### PR TITLE
feat: display openai reasoning summaries in ai chat

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -643,7 +643,9 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 											: aiChatManager.currentReasoningActive &&
 												  !aiChatManager.currentReply &&
 												  !aiChatManager.currentReasoning
-												? 'Thinking'
+												? aiChatManager.reasoningHiddenForCurrentModel
+													? 'Thinking (hidden, OpenAI org not verified)'
+													: 'Thinking'
 												: undefined}
 								/>
 							{/if}

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -643,9 +643,7 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 											: aiChatManager.currentReasoningActive &&
 												  !aiChatManager.currentReply &&
 												  !aiChatManager.currentReasoning
-												? aiChatManager.reasoningHiddenForCurrentModel
-													? 'Thinking (hidden, OpenAI org not verified)'
-													: 'Thinking'
+												? (aiChatManager.reasoningHiddenIndicatorLabel ?? 'Thinking')
 												: undefined}
 								/>
 							{/if}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -327,18 +327,23 @@ export class AIChatManager {
 	currentReasoning = $state<string>('')
 	currentReasoningActive = $state<boolean>(false)
 	// The provider reasons but refuses to stream summaries (unverified OpenAI
-	// organization) — drives the discreet "Thinking (hidden)" indicator.
-	reasoningSummaryUnavailable = $state<boolean>(false)
+	// organization) — drives the discreet "Thinking (hidden)" indicator. Keyed
+	// by workspace:provider like the chat-loop fallback cache, so the hint never
+	// carries over to a provider or workspace whose summaries work.
+	private reasoningSummaryUnavailableFor = $state<string | undefined>(undefined)
 
-	/** Whether the live "Thinking" indicator should hint that thinking stays
-	 * hidden. Gated on the current provider: switching to a provider that does
-	 * stream thinking must not carry the hint over. */
+	private reasoningSummaryKey(provider: string): string {
+		return `${this.operatingWorkspace ?? ''}:${provider}`
+	}
+
+	/** Whether the live "Thinking" indicator should hint that thinking stays hidden. */
 	get reasoningHiddenForCurrentModel(): boolean {
-		if (!this.reasoningSummaryUnavailable) {
+		if (this.reasoningSummaryUnavailableFor === undefined) {
 			return false
 		}
-		const provider = getCurrentModel().provider
-		return provider === 'openai' || provider === 'azure_openai'
+		return (
+			this.reasoningSummaryUnavailableFor === this.reasoningSummaryKey(getCurrentModel().provider)
+		)
 	}
 	// Smooths the provider's bursty delivery into continuous typing by revealing
 	// buffered text a slice per frame. The reply and the reasoning/thinking stream
@@ -1724,7 +1729,7 @@ export class AIChatManager {
 	}
 
 	private notifyReasoningSummaryUnavailable = () => {
-		this.reasoningSummaryUnavailable = true
+		this.reasoningSummaryUnavailableFor = this.reasoningSummaryKey(getCurrentModel().provider)
 		if (getLocalSetting(REASONING_SUMMARY_WARNED_STORAGE_KEY) !== 'true') {
 			storeLocalSetting(REASONING_SUMMARY_WARNED_STORAGE_KEY, 'true')
 			sendUserToast(REASONING_SUMMARY_UNAVAILABLE_MESSAGE, 'warning', [], undefined, 10000)

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -153,6 +153,11 @@ const AI_AUTONOMY_MODE_STORAGE_KEY = 'ai-chat-autonomy-mode'
 const LEGACY_AUTO_ACCEPT_TOOL_CONFIRMATIONS_STORAGE_KEY = 'ai-chat-yolo-mode'
 const WEB_SEARCH_ERROR_HINT =
 	'Web search is unavailable for this provider/model/key. Disable web search in workspace settings and try again.'
+// The full explanation is shown once per browser; afterwards the hidden
+// thinking is only hinted at discreetly in the typing indicator.
+const REASONING_SUMMARY_WARNED_STORAGE_KEY = 'ai-chat-reasoning-summary-unverified-warned'
+const REASONING_SUMMARY_UNAVAILABLE_MESSAGE =
+	'This model is reasoning, but your OpenAI organization is not verified to generate reasoning summaries, so its thinking stays hidden. To display it, verify your organization in the OpenAI platform settings (Settings > General), then reload this page.'
 
 export enum AIMode {
 	SCRIPT = 'script',
@@ -321,6 +326,20 @@ export class AIChatManager {
 	currentReply = $state<string>('')
 	currentReasoning = $state<string>('')
 	currentReasoningActive = $state<boolean>(false)
+	// The provider reasons but refuses to stream summaries (unverified OpenAI
+	// organization) — drives the discreet "Thinking (hidden)" indicator.
+	reasoningSummaryUnavailable = $state<boolean>(false)
+
+	/** Whether the live "Thinking" indicator should hint that thinking stays
+	 * hidden. Gated on the current provider: switching to a provider that does
+	 * stream thinking must not carry the hint over. */
+	get reasoningHiddenForCurrentModel(): boolean {
+		if (!this.reasoningSummaryUnavailable) {
+			return false
+		}
+		const provider = getCurrentModel().provider
+		return provider === 'openai' || provider === 'azure_openai'
+	}
 	// Smooths the provider's bursty delivery into continuous typing by revealing
 	// buffered text a slice per frame. The reply and the reasoning/thinking stream
 	// each get their own reveal (independent buffers, both append to their own
@@ -1704,6 +1723,14 @@ export class AIChatManager {
 		}
 	}
 
+	private notifyReasoningSummaryUnavailable = () => {
+		this.reasoningSummaryUnavailable = true
+		if (getLocalSetting(REASONING_SUMMARY_WARNED_STORAGE_KEY) !== 'true') {
+			storeLocalSetting(REASONING_SUMMARY_WARNED_STORAGE_KEY, 'true')
+			sendUserToast(REASONING_SUMMARY_UNAVAILABLE_MESSAGE, 'warning', [], undefined, 10000)
+		}
+	}
+
 	private chatRequest = async ({
 		messages,
 		abortController,
@@ -1723,6 +1750,7 @@ export class AIChatManager {
 		systemMessage?: ChatCompletionSystemMessageParam
 		onWebSearchUnavailable?: () => void
 	}) => {
+		const onReasoningSummaryUnavailable = () => this.notifyReasoningSummaryUnavailable()
 		try {
 			// Use JS getters so runChatLoop re-reads tools/helpers/systemMessage/modelProvider
 			// on each iteration. This is critical for changeModeTool (Navigator → Script/Flow)
@@ -1772,6 +1800,7 @@ export class AIChatManager {
 					this.skipResponsesApi = true
 				},
 				onWebSearchUnavailable,
+				onReasoningSummaryUnavailable,
 				getPendingUserMessage: () => {
 					const pendingPrompt = this.pendingPrompt
 					if (!pendingPrompt) return undefined

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -156,8 +156,18 @@ const WEB_SEARCH_ERROR_HINT =
 // The full explanation is shown once per browser; afterwards the hidden
 // thinking is only hinted at discreetly in the typing indicator.
 const REASONING_SUMMARY_WARNED_STORAGE_KEY = 'ai-chat-reasoning-summary-unverified-warned'
-const REASONING_SUMMARY_UNAVAILABLE_MESSAGE =
-	'This model is reasoning, but your OpenAI organization is not verified to generate reasoning summaries, so its thinking stays hidden. To display it, verify your organization in the OpenAI platform settings (Settings > General), then reload this page.'
+
+function providerDisplayName(provider: string): string {
+	return provider === 'azure_openai' ? 'Azure OpenAI' : 'OpenAI'
+}
+
+function reasoningSummaryUnavailableMessage(provider: string): string {
+	const verifyHint =
+		provider === 'azure_openai'
+			? 'To display it, verify your organization with your provider, then reload this page.'
+			: 'To display it, verify your organization in the OpenAI platform settings (Settings > General), then reload this page.'
+	return `This model is reasoning, but your ${providerDisplayName(provider)} organization is not verified to generate reasoning summaries, so its thinking stays hidden. ${verifyHint}`
+}
 
 export enum AIMode {
 	SCRIPT = 'script',
@@ -329,21 +339,26 @@ export class AIChatManager {
 	// The provider reasons but refuses to stream summaries (unverified OpenAI
 	// organization) — drives the discreet "Thinking (hidden)" indicator. Keyed
 	// by workspace:provider like the chat-loop fallback cache, so the hint never
-	// carries over to a provider or workspace whose summaries work.
-	private reasoningSummaryUnavailableFor = $state<string | undefined>(undefined)
+	// carries over to a provider or workspace whose summaries work. A list, not
+	// a scalar: several workspace/provider pairs can be unavailable at once, and
+	// the chat loop only notifies on first detection per pair.
+	private reasoningSummaryUnavailableFor = $state<string[]>([])
 
 	private reasoningSummaryKey(provider: string): string {
 		return `${this.operatingWorkspace ?? ''}:${provider}`
 	}
 
-	/** Whether the live "Thinking" indicator should hint that thinking stays hidden. */
-	get reasoningHiddenForCurrentModel(): boolean {
-		if (this.reasoningSummaryUnavailableFor === undefined) {
-			return false
+	/** Label for the live "Thinking" indicator when thinking stays hidden for
+	 * the current workspace/provider, undefined otherwise. */
+	get reasoningHiddenIndicatorLabel(): string | undefined {
+		if (this.reasoningSummaryUnavailableFor.length === 0) {
+			return undefined
 		}
-		return (
-			this.reasoningSummaryUnavailableFor === this.reasoningSummaryKey(getCurrentModel().provider)
-		)
+		const provider = getCurrentModel().provider
+		if (!this.reasoningSummaryUnavailableFor.includes(this.reasoningSummaryKey(provider))) {
+			return undefined
+		}
+		return `Thinking (hidden, ${providerDisplayName(provider)} org not verified)`
 	}
 	// Smooths the provider's bursty delivery into continuous typing by revealing
 	// buffered text a slice per frame. The reply and the reasoning/thinking stream
@@ -1729,10 +1744,14 @@ export class AIChatManager {
 	}
 
 	private notifyReasoningSummaryUnavailable = () => {
-		this.reasoningSummaryUnavailableFor = this.reasoningSummaryKey(getCurrentModel().provider)
+		const provider = getCurrentModel().provider
+		const key = this.reasoningSummaryKey(provider)
+		if (!this.reasoningSummaryUnavailableFor.includes(key)) {
+			this.reasoningSummaryUnavailableFor = [...this.reasoningSummaryUnavailableFor, key]
+		}
 		if (getLocalSetting(REASONING_SUMMARY_WARNED_STORAGE_KEY) !== 'true') {
 			storeLocalSetting(REASONING_SUMMARY_WARNED_STORAGE_KEY, 'true')
-			sendUserToast(REASONING_SUMMARY_UNAVAILABLE_MESSAGE, 'warning', [], undefined, 10000)
+			sendUserToast(reasoningSummaryUnavailableMessage(provider), 'warning', [], undefined, 10000)
 		}
 	}
 

--- a/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
@@ -50,12 +50,14 @@ function createConfig({
 	workspace,
 	modelProvider = { provider: 'openai', model: 'gpt-4.1' },
 	callbacks = createCallbacks(),
-	onWebSearchUnavailable
+	onWebSearchUnavailable,
+	onReasoningSummaryUnavailable
 }: {
 	workspace: string
 	modelProvider?: ReasoningProviderModel
 	callbacks?: ChatLoopConfig['callbacks']
 	onWebSearchUnavailable?: ChatLoopConfig['onWebSearchUnavailable']
+	onReasoningSummaryUnavailable?: ChatLoopConfig['onReasoningSummaryUnavailable']
 }): ChatLoopConfig {
 	const messages: ChatCompletionMessageParam[] = [{ role: 'user', content: 'search this' }]
 
@@ -73,7 +75,8 @@ function createConfig({
 		},
 		workspace,
 		maxIterations: 1,
-		onWebSearchUnavailable
+		onWebSearchUnavailable,
+		onReasoningSummaryUnavailable
 	}
 }
 
@@ -288,6 +291,76 @@ describe('runChatLoop web search fallback', () => {
 
 		expect(mocks.getAnthropicCompletion).toHaveBeenCalledTimes(1)
 		expect(callbacks.setToolStatus).not.toHaveBeenCalled()
+	})
+})
+
+describe('runChatLoop reasoning summary fallback', () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+		mocks.providerSupportsWebSearch.mockReturnValue(false)
+		mocks.resolveRequestReasoning.mockReturnValue('high')
+		mocks.parseOpenAIResponsesCompletion.mockResolvedValue({
+			shouldContinue: false,
+			tokenUsage
+		})
+	})
+
+	it('retries once without the summary on the unverified-org error and caches per workspace/provider', async () => {
+		const onReasoningSummaryUnavailable = vi.fn()
+		const workspace = `workspace-${randomUUID()}`
+		const modelProvider: ReasoningProviderModel = { provider: 'openai', model: 'gpt-5.1' }
+
+		mocks.getOpenAIResponsesCompletion
+			.mockRejectedValueOnce(
+				Object.assign(
+					new Error('Your organization must be verified to generate reasoning summaries.'),
+					{
+						status: 400,
+						param: 'reasoning.summary',
+						code: 'unsupported_value',
+						error: { type: 'invalid_request_error' }
+					}
+				)
+			)
+			.mockResolvedValue({})
+
+		await runChatLoop(createConfig({ workspace, modelProvider, onReasoningSummaryUnavailable }))
+
+		expect(mocks.getOpenAIResponsesCompletion).toHaveBeenCalledTimes(2)
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[0][3]).toEqual(
+			expect.objectContaining({ reasoningSummary: true })
+		)
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[1][3]).toEqual(
+			expect.objectContaining({ reasoningSummary: false })
+		)
+		expect(onReasoningSummaryUnavailable).toHaveBeenCalledTimes(1)
+		expect(mocks.getCompletion).not.toHaveBeenCalled()
+
+		// Cached: a later run in the same workspace skips the summary outright,
+		// but a different model on the same provider shares the cache entry.
+		await runChatLoop(
+			createConfig({
+				workspace,
+				modelProvider: { provider: 'openai', model: 'o3' }
+			})
+		)
+
+		expect(mocks.getOpenAIResponsesCompletion).toHaveBeenCalledTimes(3)
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[2][3]).toEqual(
+			expect.objectContaining({ reasoningSummary: false })
+		)
+	})
+
+	it('does not request a summary when reasoning is off', async () => {
+		mocks.resolveRequestReasoning.mockReturnValue(undefined)
+		mocks.getOpenAIResponsesCompletion.mockResolvedValue({})
+		const workspace = `workspace-${randomUUID()}`
+
+		await runChatLoop(createConfig({ workspace }))
+
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[0][3]).toEqual(
+			expect.objectContaining({ reasoningSummary: false })
+		)
 	})
 })
 

--- a/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
@@ -354,6 +354,57 @@ describe('runChatLoop reasoning summary fallback', () => {
 		)
 	})
 
+	it('composes with the web-search fallback when the errors arrive web-search first', async () => {
+		mocks.providerSupportsWebSearch.mockReturnValue(true)
+		const onReasoningSummaryUnavailable = vi.fn()
+		const onWebSearchUnavailable = vi.fn()
+		const workspace = `workspace-${randomUUID()}`
+		const modelProvider: ReasoningProviderModel = { provider: 'openai', model: 'gpt-5.1' }
+
+		mocks.getOpenAIResponsesCompletion
+			.mockRejectedValueOnce(
+				Object.assign(new Error("Hosted tool 'web_search' is not supported with this model"), {
+					status: 400,
+					error: { type: 'invalid_request_error' }
+				})
+			)
+			.mockRejectedValueOnce(
+				Object.assign(
+					new Error('Your organization must be verified to generate reasoning summaries.'),
+					{
+						status: 400,
+						param: 'reasoning.summary',
+						code: 'unsupported_value',
+						error: { type: 'invalid_request_error' }
+					}
+				)
+			)
+			.mockResolvedValue({})
+
+		await runChatLoop(
+			createConfig({
+				workspace,
+				modelProvider,
+				onReasoningSummaryUnavailable,
+				onWebSearchUnavailable
+			})
+		)
+
+		expect(mocks.getOpenAIResponsesCompletion).toHaveBeenCalledTimes(3)
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[0][3]).toEqual(
+			expect.objectContaining({ webSearch: true, reasoningSummary: true })
+		)
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[1][3]).toEqual(
+			expect.objectContaining({ webSearch: false, reasoningSummary: true })
+		)
+		expect(mocks.getOpenAIResponsesCompletion.mock.calls[2][3]).toEqual(
+			expect.objectContaining({ webSearch: false, reasoningSummary: false })
+		)
+		expect(onWebSearchUnavailable).toHaveBeenCalledTimes(1)
+		expect(onReasoningSummaryUnavailable).toHaveBeenCalledTimes(1)
+		expect(mocks.getCompletion).not.toHaveBeenCalled()
+	})
+
 	it('does not request a summary when reasoning is explicitly off via a disable token', async () => {
 		// gpt-5.1+ reasoning is turned off with the explicit 'none' effort on the
 		// wire, while the effective reasoning resolves to undefined.

--- a/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
 	parseOpenAIResponsesCompletion: vi.fn(),
 	getAnthropicCompletion: vi.fn(),
 	parseAnthropicCompletion: vi.fn(),
-	resolveRequestReasoning: vi.fn()
+	resolveRequestReasoning: vi.fn(),
+	resolveEffectiveReasoning: vi.fn()
 }))
 
 vi.mock('../lib', () => ({
@@ -22,7 +23,8 @@ vi.mock('../lib', () => ({
 }))
 
 vi.mock('../reasoningRegistry', () => ({
-	resolveRequestReasoning: mocks.resolveRequestReasoning
+	resolveRequestReasoning: mocks.resolveRequestReasoning,
+	resolveEffectiveReasoning: mocks.resolveEffectiveReasoning
 }))
 
 vi.mock('./openai-responses', () => ({
@@ -299,6 +301,7 @@ describe('runChatLoop reasoning summary fallback', () => {
 		vi.resetAllMocks()
 		mocks.providerSupportsWebSearch.mockReturnValue(false)
 		mocks.resolveRequestReasoning.mockReturnValue('high')
+		mocks.resolveEffectiveReasoning.mockReturnValue('high')
 		mocks.parseOpenAIResponsesCompletion.mockResolvedValue({
 			shouldContinue: false,
 			tokenUsage
@@ -351,15 +354,20 @@ describe('runChatLoop reasoning summary fallback', () => {
 		)
 	})
 
-	it('does not request a summary when reasoning is off', async () => {
-		mocks.resolveRequestReasoning.mockReturnValue(undefined)
+	it('does not request a summary when reasoning is explicitly off via a disable token', async () => {
+		// gpt-5.1+ reasoning is turned off with the explicit 'none' effort on the
+		// wire, while the effective reasoning resolves to undefined.
+		mocks.resolveRequestReasoning.mockReturnValue('none')
+		mocks.resolveEffectiveReasoning.mockReturnValue(undefined)
 		mocks.getOpenAIResponsesCompletion.mockResolvedValue({})
 		const workspace = `workspace-${randomUUID()}`
 
-		await runChatLoop(createConfig({ workspace }))
+		await runChatLoop(
+			createConfig({ workspace, modelProvider: { provider: 'openai', model: 'gpt-5.1' } })
+		)
 
 		expect(mocks.getOpenAIResponsesCompletion.mock.calls[0][3]).toEqual(
-			expect.objectContaining({ reasoningSummary: false })
+			expect.objectContaining({ reasoningEffort: 'none', reasoningSummary: false })
 		)
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/chatLoop.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.ts
@@ -6,7 +6,11 @@ import type {
 	ChatCompletionUserMessageParam
 } from 'openai/resources/chat/completions.mjs'
 import { getCompletion, parseOpenAICompletion, providerSupportsWebSearch } from '../lib'
-import { resolveRequestReasoning, type ReasoningProviderModel } from '../reasoningRegistry'
+import {
+	resolveEffectiveReasoning,
+	resolveRequestReasoning,
+	type ReasoningProviderModel
+} from '../reasoningRegistry'
 import { getAnthropicCompletion, parseAnthropicCompletion } from './anthropic'
 import { usesAnthropicMessagesApi } from '../modelConfig'
 import { getOpenAIResponsesCompletion, parseOpenAIResponsesCompletion } from './openai-responses'
@@ -335,8 +339,12 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 
 		if (isOpenAI) {
 			const reasoningSummaryCacheKey = getReasoningSummaryCacheKey(workspace, modelProvider)
+			// Gate on the effective (not request) reasoning: an explicit off resolves
+			// to a truthy disable token like 'none' on the request side, and asking
+			// for a summary on a non-reasoning request would 400 on unverified orgs.
 			let reasoningSummary =
-				!!reasoningEffort && !unsupportedReasoningSummaryCache.has(reasoningSummaryCacheKey)
+				resolveEffectiveReasoning(modelProvider) !== undefined &&
+				!unsupportedReasoningSummaryCache.has(reasoningSummaryCacheKey)
 
 			const runOpenAIResponses = async (useWebSearch: boolean): Promise<boolean> => {
 				const completion = await getOpenAIResponsesCompletion(

--- a/frontend/src/lib/components/copilot/chat/chatLoop.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.ts
@@ -374,55 +374,47 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 
 			let useCompletionsApi = skipResponsesApi
 			if (!skipResponsesApi) {
-				try {
-					if (!(await runOpenAIResponses(webSearch))) {
-						break
-					}
-				} catch (err) {
-					let fallbackError = err
-					if (reasoningSummary && shouldRetryWithoutReasoningSummary(err)) {
-						markReasoningSummaryUnsupported(
-							reasoningSummaryCacheKey,
-							err,
-							onReasoningSummaryUnavailable
-						)
-						reasoningSummary = false
-						try {
-							if (!(await runOpenAIResponses(webSearch))) {
-								break
-							}
-							continue
-						} catch (retryErr) {
-							fallbackError = retryErr
+				// Retry the Responses call disabling whichever optional feature the
+				// provider rejected (reasoning summary, web search) in the order the
+				// errors arrive — a turn can hit both, either one first. Each retry
+				// permanently disables one feature, so this loops at most twice.
+				let useWebSearch = webSearch
+				let outcome: 'break' | 'continue' | undefined
+				let fallbackError: unknown
+				while (outcome === undefined) {
+					try {
+						outcome = (await runOpenAIResponses(useWebSearch)) ? 'continue' : 'break'
+					} catch (err) {
+						if (reasoningSummary && shouldRetryWithoutReasoningSummary(err)) {
+							markReasoningSummaryUnsupported(
+								reasoningSummaryCacheKey,
+								err,
+								onReasoningSummaryUnavailable
+							)
+							reasoningSummary = false
+						} else if (useWebSearch && shouldRetryWithoutWebSearch(err)) {
+							markWebSearchUnsupported(webSearchCacheKey, err, config.onWebSearchUnavailable)
+							useWebSearch = false
+						} else {
+							fallbackError = err
+							break
 						}
 					}
-					if (webSearch && shouldRetryWithoutWebSearch(fallbackError)) {
-						markWebSearchUnsupported(
-							webSearchCacheKey,
-							fallbackError,
-							config.onWebSearchUnavailable
-						)
-						try {
-							if (!(await runOpenAIResponses(false))) {
-								break
-							}
-							continue
-						} catch (retryErr) {
-							fallbackError = retryErr
-						}
-					}
-
-					console.warn(
-						'OpenAI Responses API failed, falling back to Completions API:',
-						fallbackError
-					)
-					const errorMessage = getErrorText(fallbackError)
-					if (errorMessage.includes('Responses API is not enabled')) {
-						skipResponsesApi = true
-						onSkipResponsesApi?.()
-					}
-					useCompletionsApi = true
 				}
+				if (outcome === 'break') {
+					break
+				}
+				if (outcome === 'continue') {
+					continue
+				}
+
+				console.warn('OpenAI Responses API failed, falling back to Completions API:', fallbackError)
+				const errorMessage = getErrorText(fallbackError)
+				if (errorMessage.includes('Responses API is not enabled')) {
+					skipResponsesApi = true
+					onSkipResponsesApi?.()
+				}
+				useCompletionsApi = true
 			}
 
 			if (useCompletionsApi) {

--- a/frontend/src/lib/components/copilot/chat/chatLoop.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.ts
@@ -48,6 +48,12 @@ export interface ChatLoopConfig {
 	skipResponsesApi?: boolean
 	onSkipResponsesApi?: () => void
 	onWebSearchUnavailable?: () => void
+	/**
+	 * Called when the provider refuses to generate reasoning summaries (OpenAI
+	 * gates them behind organization verification). The request is retried
+	 * without summaries, so reasoning happens but stays hidden.
+	 */
+	onReasoningSummaryUnavailable?: () => void
 	/** Return a pending user message to inject between iterations, or undefined. */
 	getPendingUserMessage?: () => ChatCompletionUserMessageParam | undefined
 	/**
@@ -107,8 +113,22 @@ export function truncateToToolPairedPrefix(
 const unsupportedWebSearchCache = new Set<string>()
 const WEB_SEARCH_UNAVAILABLE_STATUS_CODES = new Set([400, 403, 404])
 
+// Reasoning-summary availability is an org-level property of the provider
+// credentials (OpenAI organization verification), not of the model — key by
+// workspace + provider. In-memory on purpose: a page reload re-probes, so a
+// freshly verified organization starts getting summaries again.
+const unsupportedReasoningSummaryCache = new Set<string>()
+const REASONING_SUMMARY_UNAVAILABLE_STATUS_CODES = new Set([400, 403])
+
 function getWebSearchCacheKey(workspace: string, modelProvider: ReasoningProviderModel): string {
 	return [workspace, modelProvider.provider, modelProvider.model].join(':')
+}
+
+function getReasoningSummaryCacheKey(
+	workspace: string,
+	modelProvider: ReasoningProviderModel
+): string {
+	return [workspace, modelProvider.provider].join(':')
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -193,6 +213,44 @@ function shouldRetryWithoutWebSearch(err: unknown): boolean {
 	return status === undefined || WEB_SEARCH_UNAVAILABLE_STATUS_CODES.has(status)
 }
 
+function getErrorParam(err: unknown): string | undefined {
+	if (!isRecord(err)) {
+		return undefined
+	}
+	const candidates = [err.param]
+	if (isRecord(err.error)) {
+		candidates.push(err.error.param)
+	}
+	return candidates.find((param): param is string => typeof param === 'string')
+}
+
+// Unverified OpenAI organizations get a 400 on the reasoning.summary param
+// ("Your organization must be verified to generate reasoning summaries").
+function shouldRetryWithoutReasoningSummary(err: unknown): boolean {
+	const status = getErrorStatus(err)
+	if (status !== undefined && !REASONING_SUMMARY_UNAVAILABLE_STATUS_CODES.has(status)) {
+		return false
+	}
+	if (getErrorParam(err) === 'reasoning.summary') {
+		return true
+	}
+	const message = getErrorText(err).toLowerCase()
+	return (
+		message.includes('reasoning.summary') ||
+		/verified to (?:generate|stream) reasoning summar/.test(message)
+	)
+}
+
+function markReasoningSummaryUnsupported(
+	cacheKey: string,
+	err: unknown,
+	onReasoningSummaryUnavailable?: () => void
+) {
+	unsupportedReasoningSummaryCache.add(cacheKey)
+	console.warn('Reasoning summaries unavailable; retrying without them:', err)
+	onReasoningSummaryUnavailable?.()
+}
+
 function markWebSearchUnsupported(
 	cacheKey: string,
 	err: unknown,
@@ -212,6 +270,7 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 		workspace,
 		maxIterations,
 		onSkipResponsesApi,
+		onReasoningSummaryUnavailable,
 		getPendingUserMessage,
 		onBeforeIteration
 	} = config
@@ -275,6 +334,10 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 		const parseOptions = { workspace, provider: modelProvider.provider }
 
 		if (isOpenAI) {
+			const reasoningSummaryCacheKey = getReasoningSummaryCacheKey(workspace, modelProvider)
+			let reasoningSummary =
+				!!reasoningEffort && !unsupportedReasoningSummaryCache.has(reasoningSummaryCacheKey)
+
 			const runOpenAIResponses = async (useWebSearch: boolean): Promise<boolean> => {
 				const completion = await getOpenAIResponsesCompletion(
 					messageParams,
@@ -284,7 +347,8 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 						forceModelProvider: modelProvider,
 						openaiClient: clients.openai,
 						webSearch: useWebSearch,
-						reasoningEffort
+						reasoningEffort,
+						reasoningSummary
 					}
 				)
 				const continueCompletion = await parseOpenAIResponsesCompletion(
@@ -308,8 +372,28 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 					}
 				} catch (err) {
 					let fallbackError = err
-					if (webSearch && shouldRetryWithoutWebSearch(err)) {
-						markWebSearchUnsupported(webSearchCacheKey, err, config.onWebSearchUnavailable)
+					if (reasoningSummary && shouldRetryWithoutReasoningSummary(err)) {
+						markReasoningSummaryUnsupported(
+							reasoningSummaryCacheKey,
+							err,
+							onReasoningSummaryUnavailable
+						)
+						reasoningSummary = false
+						try {
+							if (!(await runOpenAIResponses(webSearch))) {
+								break
+							}
+							continue
+						} catch (retryErr) {
+							fallbackError = retryErr
+						}
+					}
+					if (webSearch && shouldRetryWithoutWebSearch(fallbackError)) {
+						markWebSearchUnsupported(
+							webSearchCacheKey,
+							fallbackError,
+							config.onWebSearchUnavailable
+						)
 						try {
 							if (!(await runOpenAIResponses(false))) {
 								break

--- a/frontend/src/lib/components/copilot/chat/openai-responses.ts
+++ b/frontend/src/lib/components/copilot/chat/openai-responses.ts
@@ -159,6 +159,7 @@ export async function getOpenAIResponsesCompletion(
 		openaiClient?: OpenAI
 		webSearch?: boolean
 		reasoningEffort?: string
+		reasoningSummary?: boolean
 	}
 ) {
 	const { provider, config } = getProviderAndCompletionConfig({
@@ -173,6 +174,13 @@ export async function getOpenAIResponsesCompletion(
 		'responses',
 		options?.reasoningEffort
 	)
+
+	// Reasoning summaries make the model's thinking renderable in the chat, but
+	// OpenAI rejects the request (400 on reasoning.summary) for organizations
+	// that haven't completed verification — callers opt in and fall back.
+	if (options?.reasoningSummary && responsesConfig.reasoning) {
+		responsesConfig.reasoning = { ...responsesConfig.reasoning, summary: 'auto' }
+	}
 
 	// Enable OpenAI's built-in web search tool. The proxy forwards the body
 	// verbatim, so this reaches OpenAI as a native server-side tool.
@@ -289,6 +297,20 @@ export async function parseOpenAIResponsesCompletion(
 	runner.on('response.output_text.delta', (event) => {
 		callbacks.onNewToken(event.delta)
 		textContent += event.delta
+	})
+
+	// Stream the reasoning summary (present when the request asked for
+	// reasoning.summary) into the thinking display. Summaries arrive as
+	// separate parts; join them as paragraphs.
+	let reasoningSummaryParts = 0
+	runner.on('response.reasoning_summary_part.added', () => {
+		reasoningSummaryParts++
+		if (reasoningSummaryParts > 1) {
+			callbacks.onReasoningDelta?.('\n\n')
+		}
+	})
+	runner.on('response.reasoning_summary_text.delta', (event) => {
+		callbacks.onReasoningDelta?.(event.delta)
 	})
 
 	// Handle new output items (including function calls)


### PR DESCRIPTION
## Summary

The AI chat now requests reasoning summaries (`reasoning.summary: "auto"`) on the OpenAI Responses API, so OpenAI reasoning models stream their thinking into the same expandable "Thinking" block that Anthropic models already use.

OpenAI rejects that parameter with a 400 (`param: "reasoning.summary"`, `code: "unsupported_value"`) for organizations that have not completed [organization verification](https://help.openai.com/en/articles/10910291-api-organization-verification). The chat loop handles this gracefully instead of failing the turn:

- On that specific error, it retries once without the summary and caches unavailability per workspace + provider (in-memory, so a page reload re-probes and a freshly verified org starts getting summaries again).
- The first time it happens, a warning toast explains that the thinking stays hidden and how to fix it (once per browser, persisted in localStorage).
- On every later reasoning turn, the live typing indicator discreetly reads "Thinking (hidden, OpenAI org not verified)" instead of "Thinking". The hint is scoped to the exact workspace + provider that failed, so switching model, provider, or workspace never carries it over.

## Changes

- `openai-responses.ts`: optional `reasoningSummary` request flag; stream `response.reasoning_summary_text.delta` into the existing `onReasoningDelta` callback (summary parts joined as paragraphs).
- `chatLoop.ts`: unverified-org detection (status 400/403 + `param === 'reasoning.summary'` or message match), retry-once-without-summary rung ordered before the web-search retry and the Completions fallback, workspace+provider unavailability cache, `onReasoningSummaryUnavailable` callback. The summary is only requested when reasoning is effectively on (an explicit off resolves to a truthy disable token like `none` on the wire and must not request a summary).
- `AIChatManager.svelte.ts`: one-time warning toast, hidden-thinking state keyed by workspace+provider.
- `AIChatDisplay.svelte`: discreet "Thinking (hidden, OpenAI org not verified)" indicator label.
- `chatLoop.test.ts`: pins retry-once + caching on the unverified-org error, and that no summary is requested when reasoning is off via a disable token.

## Test plan

- [x] `chatLoop` unit tests (18/18) and `npm run check` (0 errors); full copilot vitest suite has only pre-existing failures (verified identical with the change stashed)
- [x] Browser-verified all three flows against a fetch-layer stub of the AI proxy replaying OpenAI's real error/stream shapes: first failure (toast + hidden indicator + retried request without `summary`), subsequent turn (single summary-less request, no toast, discreet indicator only), verified org (summary streams into the expandable Thinking block)
- [ ] Live verification with a real OpenAI resource: verified org shows the thinking block; unverified org gets the toast once, then the discreet indicator, and turns still complete

## Screenshots

First failure on an unverified org (warning toast + hidden-thinking indicator):

![ai-first-failure-toast](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-40a12153/1784191990-ai-first-failure-toast.png)

Subsequent reasoning turn (discreet indicator only, no toast):

![ai-thinking-hidden](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-40a12153/1784191992-ai-thinking-hidden.png)

Verified org: reasoning summary streamed into the expandable Thinking block:

![ai-thinking-visible-expanded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-40a12153/1784191993-ai-thinking-visible-expanded.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display OpenAI reasoning summaries in the chat by streaming them into the expandable Thinking block. If the org isn’t verified, turns still complete and the UI hints that thinking is hidden; this composes cleanly with web‑search fallback.

- **New Features**
  - Request `reasoning.summary: "auto"` on the OpenAI Responses API when reasoning is enabled; stream `response.reasoning_summary_text.delta` into the Thinking block.
  - On `reasoning.summary` 400/403, retry once without summaries, cache unavailability per workspace+provider (in‑memory), and show a one‑time warning toast; later turns display “Thinking (hidden, OpenAI/Azure OpenAI org not verified)” scoped to the active workspace+provider.
  - Compose fallbacks when both web search and summaries are rejected (in either error order); don’t request summaries when reasoning is effectively off (e.g., `none`). Unit tests cover retry, caching, ordering, and explicit‑off cases.

<sup>Written for commit adef255aa545a78ec71e33b952908f256a86ce80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

