### PR TITLE
refactor(frontend): reorder sidebar settings menu, move logout to user submenu

### DIFF
--- a/frontend/src/lib/components/sidebar/SettingsMenu.svelte
+++ b/frontend/src/lib/components/sidebar/SettingsMenu.svelte
@@ -136,8 +136,32 @@
 
 	// Account / instance actions gathered under one "Settings" dropdown, shared by
 	// the session rail and the global sidebar so both expose the same entry point.
-	// User sits just above Logout so the account-scoped entries read as one block.
-	const items = $derived<Item[]>([
+	// Logout lives inside the user submenu with the other account-scoped entries.
+	// Workspace- and instance-scoped entries anchor the bottom of the menu,
+	// instance settings last.
+	const workspaceInstanceItems = $derived<Item[]>([
+		...(!canManageWorkspace && !workspaceSettingsTarget
+			? [
+					{
+						displayName: 'Leave workspace',
+						icon: LogOut,
+						type: 'delete' as const,
+						action: () => (leaveWorkspaceModal = true)
+					}
+				]
+			: []),
+		// Fork deletion is a global-sidebar action on the active workspace, so keep it
+		// out of the session rail's per-target settings entry (`workspaceSettingsTarget`).
+		...(currentWsIsFork && !workspaceSettingsTarget
+			? [
+					{
+						displayName: 'Delete forked workspace',
+						icon: Trash2,
+						type: 'delete' as const,
+						action: () => deleteForkModal?.openModal()
+					}
+				]
+			: []),
 		...(canManageWorkspace
 			? [
 					workspaceSettingsTarget
@@ -163,35 +187,15 @@
 						action: () => goto(SUPERADMIN_SETTINGS_HASH)
 					}
 				]
-			: []),
-		...(!canManageWorkspace && !workspaceSettingsTarget
-			? [
-					{
-						displayName: 'Leave workspace',
-						icon: LogOut,
-						type: 'delete' as const,
-						action: () => (leaveWorkspaceModal = true)
-					}
-				]
-			: []),
-		// Fork deletion is a global-sidebar action on the active workspace, so keep it
-		// out of the session rail's per-target settings entry (`workspaceSettingsTarget`).
-		...(currentWsIsFork && !workspaceSettingsTarget
-			? [
-					{
-						displayName: 'Delete forked workspace',
-						icon: Trash2,
-						type: 'delete' as const,
-						action: () => deleteForkModal?.openModal()
-					}
-				]
-			: []),
+			: [])
+	])
+
+	const items = $derived<Item[]>([
 		{
 			displayName: 'Help',
 			icon: HelpCircle,
 			submenuItems: helpItems,
-			extra: helpPing,
-			separatorTop: true
+			extra: helpPing
 		},
 		{
 			displayName: 'Switch theme',
@@ -218,10 +222,11 @@
 								disabled: true
 							}
 						]
-					: [])
+					: []),
+				{ displayName: 'Logout', icon: LogOut, action: () => logout() }
 			]
 		},
-		{ displayName: 'Logout', icon: LogOut, action: () => logout() }
+		...workspaceInstanceItems.map((item, i) => (i === 0 ? { ...item, separatorTop: true } : item))
 	])
 
 	const logsItems = $derived<Item[]>([


### PR DESCRIPTION
## Summary

Reorders the sidebar Settings dropdown (shared by the global sidebar and the session rail) so that workspace-scoped and instance-scoped entries anchor the bottom of the menu, and moves Logout into the user submenu alongside the other account-scoped entries.

New order:
1. Help
2. Switch theme
3. User menu (email) — submenu: Account settings, cloud usage line (when applicable), **Logout**
4. — separator —
5. Workspace block: Leave workspace / Delete forked workspace (when they apply), then workspace settings, then **Instance settings** last

## Changes

- `SettingsMenu.svelte`: extracted the workspace/instance-scoped entries (Leave workspace, Delete forked workspace, workspace settings, Instance settings) into a `workspaceInstanceItems` array appended at the bottom of the menu; the separator is applied to whichever entry of that block renders first, since every entry is conditional (admin, superadmin, fork, session-rail target)
- Moved the top-level Logout item into the user submenu, after Account settings
- All existing conditional gating (`canManageWorkspace`, `workspaceSettingsTarget`, `currentWsIsFork`, `$superadmin`, cloud usage) is preserved verbatim
- `OperatorMenu.svelte` (operator-mode sidebar) has a different structure and is intentionally untouched

## Screenshots

Settings dropdown as a workspace admin/superadmin on a forked workspace, with the user submenu open:

![settings-menu-reordered](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/settings-reordering/1784198715-settings-menu-reordered.png)

## Test plan

- [x] `npm run check:fast` passes; Svelte autofixer reports no issues
- [x] Browser-verified (Playwright) as an admin/superadmin on a fork: top-level order is Help, Switch theme, user email, separator, Delete forked workspace, workspace settings, Instance settings; user submenu shows Account settings + Logout
- [ ] Verify as a non-admin member of a non-fork workspace: "Leave workspace" appears below the separator (workspace settings hidden)
- [ ] Verify from the session rail (`workspaceSettingsTarget` set): Leave workspace / Delete forked workspace stay hidden, target-workspace settings link still shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)