### PR TITLE
fix: keep job ping alive while materializing (s3object) SQL args

### DIFF
--- a/backend/windmill-worker/src/bigquery_executor.rs
+++ b/backend/windmill-worker/src/bigquery_executor.rs
@@ -398,32 +398,49 @@ pub async fn do_bigquery(
     // Materialize any `(s3object)` args into JSON text and rewrite the arg type to
     // STRING. The user wraps the parameter with `JSON_EXTRACT_ARRAY(@p)` (or similar)
     // in their SQL.
-    for arg in sig.iter_mut() {
-        if arg.otyp.as_deref() != Some("s3object") {
-            continue;
-        }
-        let raw = bigquery_args.remove(&arg.name).unwrap_or(Value::Null);
-        if matches!(raw, Value::Null) {
-            return Err(Error::BadRequest(format!(
-                "Missing S3Object value for arg `{}`",
-                arg.name
-            )));
-        }
-        let s3_obj: windmill_types::s3::S3Object = serde_json::from_value(raw).map_err(|e| {
-            Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
-        })?;
-        let json_text =
-            crate::sql_s3_input::fetch_s3object_as_json_text(client, &job.workspace_id, &s3_obj)
-                .await
-                .map_err(|e| {
-                    Error::ExecutionErr(format!(
-                        "Failed to fetch S3 object for arg `{}`: {e}",
-                        arg.name
-                    ))
+    let materialize_f = async {
+        for arg in sig.iter_mut() {
+            if arg.otyp.as_deref() != Some("s3object") {
+                continue;
+            }
+            let raw = bigquery_args.remove(&arg.name).unwrap_or(Value::Null);
+            if matches!(raw, Value::Null) {
+                return Err(Error::BadRequest(format!(
+                    "Missing S3Object value for arg `{}`",
+                    arg.name
+                )));
+            }
+            let s3_obj: windmill_types::s3::S3Object =
+                serde_json::from_value(raw).map_err(|e| {
+                    Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
                 })?;
-        bigquery_args.insert(arg.name.clone(), Value::String(json_text));
-        arg.otyp = Some("string".to_string());
-    }
+            let json_text = crate::sql_s3_input::fetch_s3object_as_json_text(
+                client,
+                &job.workspace_id,
+                &s3_obj,
+            )
+            .await
+            .map_err(|e| {
+                Error::ExecutionErr(format!(
+                    "Failed to fetch S3 object for arg `{}`: {e}",
+                    arg.name
+                ))
+            })?;
+            bigquery_args.insert(arg.name.clone(), Value::String(json_text));
+            arg.otyp = Some("string".to_string());
+        }
+        Ok(())
+    };
+    crate::sql_s3_input::materialize_under_job_poller(
+        job,
+        conn,
+        mem_peak,
+        canceled_by,
+        worker_name,
+        occupancy_metrics,
+        materialize_f,
+    )
+    .await?;
 
     let reserved_variables =
         get_reserved_variables(job, &client.token, conn, parent_runnable_path).await?;

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -223,30 +223,43 @@ pub async fn do_mssql(
 
     // Materialize any `(s3object)` args into JSON text. tiberius binds the resulting
     // String as nvarchar(max), which is exactly the input type for `OPENJSON(@P)`.
-    for arg in sig.iter() {
-        if arg.otyp.as_deref() != Some("s3object") {
-            continue;
-        }
-        let raw = mssql_args.remove(&arg.name).unwrap_or(Value::Null);
-        if matches!(raw, Value::Null) {
-            return Err(Error::BadRequest(format!(
-                "Missing S3Object value for arg `{}`",
-                arg.name
-            )));
-        }
-        let s3_obj: S3Object = serde_json::from_value(raw).map_err(|e| {
-            Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
-        })?;
-        let json_text = fetch_s3object_as_json_text(authed_client, &job.workspace_id, &s3_obj)
-            .await
-            .map_err(|e| {
-                Error::ExecutionErr(format!(
-                    "Failed to fetch S3 object for arg `{}`: {e}",
+    let materialize_f = async {
+        for arg in sig.iter() {
+            if arg.otyp.as_deref() != Some("s3object") {
+                continue;
+            }
+            let raw = mssql_args.remove(&arg.name).unwrap_or(Value::Null);
+            if matches!(raw, Value::Null) {
+                return Err(Error::BadRequest(format!(
+                    "Missing S3Object value for arg `{}`",
                     arg.name
-                ))
+                )));
+            }
+            let s3_obj: S3Object = serde_json::from_value(raw).map_err(|e| {
+                Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
             })?;
-        mssql_args.insert(arg.name.clone(), Value::String(json_text));
-    }
+            let json_text = fetch_s3object_as_json_text(authed_client, &job.workspace_id, &s3_obj)
+                .await
+                .map_err(|e| {
+                    Error::ExecutionErr(format!(
+                        "Failed to fetch S3 object for arg `{}`: {e}",
+                        arg.name
+                    ))
+                })?;
+            mssql_args.insert(arg.name.clone(), Value::String(json_text));
+        }
+        Ok(())
+    };
+    crate::sql_s3_input::materialize_under_job_poller(
+        job,
+        conn,
+        mem_peak,
+        canceled_by,
+        worker_name,
+        occupancy_metrics,
+        materialize_f,
+    )
+    .await?;
 
     let reserved_variables =
         get_reserved_variables(job, &authed_client.token, conn, parent_runnable_path).await?;

--- a/backend/windmill-worker/src/mysql_executor.rs
+++ b/backend/windmill-worker/src/mysql_executor.rs
@@ -228,31 +228,48 @@ pub async fn do_mysql(
 
     // Materialize any `(s3object)` args into JSON text. mysql_async binds strings as
     // VARBINARY/TEXT, which MySQL's `JSON_TABLE`/`JSON_EXTRACT` accept directly.
-    for arg in sig.iter() {
-        if arg.otyp.as_deref() != Some("s3object") {
-            continue;
-        }
-        let raw = job_args.remove(&arg.name).unwrap_or(Value::Null);
-        if matches!(raw, Value::Null) {
-            return Err(Error::BadRequest(format!(
-                "Missing S3Object value for arg `{}`",
-                arg.name
-            )));
-        }
-        let s3_obj: windmill_types::s3::S3Object = serde_json::from_value(raw).map_err(|e| {
-            Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
-        })?;
-        let json_text =
-            crate::sql_s3_input::fetch_s3object_as_json_text(client, &job.workspace_id, &s3_obj)
-                .await
-                .map_err(|e| {
-                    Error::ExecutionErr(format!(
-                        "Failed to fetch S3 object for arg `{}`: {e}",
-                        arg.name
-                    ))
+    let materialize_f = async {
+        for arg in sig.iter() {
+            if arg.otyp.as_deref() != Some("s3object") {
+                continue;
+            }
+            let raw = job_args.remove(&arg.name).unwrap_or(Value::Null);
+            if matches!(raw, Value::Null) {
+                return Err(Error::BadRequest(format!(
+                    "Missing S3Object value for arg `{}`",
+                    arg.name
+                )));
+            }
+            let s3_obj: windmill_types::s3::S3Object =
+                serde_json::from_value(raw).map_err(|e| {
+                    Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
                 })?;
-        job_args.insert(arg.name.clone(), Value::String(json_text));
-    }
+            let json_text = crate::sql_s3_input::fetch_s3object_as_json_text(
+                client,
+                &job.workspace_id,
+                &s3_obj,
+            )
+            .await
+            .map_err(|e| {
+                Error::ExecutionErr(format!(
+                    "Failed to fetch S3 object for arg `{}`: {e}",
+                    arg.name
+                ))
+            })?;
+            job_args.insert(arg.name.clone(), Value::String(json_text));
+        }
+        Ok(())
+    };
+    crate::sql_s3_input::materialize_under_job_poller(
+        job,
+        conn,
+        mem_peak,
+        canceled_by,
+        worker_name,
+        occupancy_metrics,
+        materialize_f,
+    )
+    .await?;
 
     let reserved_variables =
         get_reserved_variables(job, &client.token, conn, parent_runnable_path).await?;

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -768,7 +768,22 @@ pub async fn do_postgresql(
     // Materialize any `(s3object)` args into JSON text and rebind them as `jsonb` so
     // `otyp_to_pg_type` picks the right binding. Must run before the param map is
     // built below.
-    materialize_s3object_args(&mut sig.args, &mut pg_args, client, &job.workspace_id).await?;
+    let materialize_f =
+        materialize_s3object_args(&mut sig.args, &mut pg_args, client, &job.workspace_id);
+    if run_inline {
+        materialize_f.await?;
+    } else {
+        crate::sql_s3_input::materialize_under_job_poller(
+            job,
+            conn,
+            mem_peak,
+            canceled_by,
+            worker_name,
+            occupancy_metrics,
+            materialize_f,
+        )
+        .await?;
+    }
 
     let reserved_variables =
         get_reserved_variables(job, &client.token, conn, parent_runnable_path).await?;

--- a/backend/windmill-worker/src/snowflake_executor.rs
+++ b/backend/windmill-worker/src/snowflake_executor.rs
@@ -550,35 +550,48 @@ pub async fn do_snowflake(
         let sig = parse_snowflake_sig(query)
             .map_err(|x| Error::ExecutionErr(x.to_string()))?
             .args;
-        for arg in sig.iter() {
-            if arg.otyp.as_deref() != Some("s3object") {
-                continue;
-            }
-            let raw = snowflake_args.remove(&arg.name).unwrap_or(Value::Null);
-            if matches!(raw, Value::Null) {
-                return Err(Error::BadRequest(format!(
-                    "Missing S3Object value for arg `{}`",
-                    arg.name
-                )));
-            }
-            let s3_obj: windmill_types::s3::S3Object =
-                serde_json::from_value(raw).map_err(|e| {
-                    Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
+        let materialize_f = async {
+            for arg in sig.iter() {
+                if arg.otyp.as_deref() != Some("s3object") {
+                    continue;
+                }
+                let raw = snowflake_args.remove(&arg.name).unwrap_or(Value::Null);
+                if matches!(raw, Value::Null) {
+                    return Err(Error::BadRequest(format!(
+                        "Missing S3Object value for arg `{}`",
+                        arg.name
+                    )));
+                }
+                let s3_obj: windmill_types::s3::S3Object =
+                    serde_json::from_value(raw).map_err(|e| {
+                        Error::ExecutionErr(format!("Invalid S3Object for arg `{}`: {e}", arg.name))
+                    })?;
+                let json_text = crate::sql_s3_input::fetch_s3object_as_json_text(
+                    client,
+                    &job.workspace_id,
+                    &s3_obj,
+                )
+                .await
+                .map_err(|e| {
+                    Error::ExecutionErr(format!(
+                        "Failed to fetch S3 object for arg `{}`: {e}",
+                        arg.name
+                    ))
                 })?;
-            let json_text = crate::sql_s3_input::fetch_s3object_as_json_text(
-                client,
-                &job.workspace_id,
-                &s3_obj,
-            )
-            .await
-            .map_err(|e| {
-                Error::ExecutionErr(format!(
-                    "Failed to fetch S3 object for arg `{}`: {e}",
-                    arg.name
-                ))
-            })?;
-            snowflake_args.insert(arg.name.clone(), Value::String(json_text));
-        }
+                snowflake_args.insert(arg.name.clone(), Value::String(json_text));
+            }
+            Ok(())
+        };
+        crate::sql_s3_input::materialize_under_job_poller(
+            job,
+            conn,
+            mem_peak,
+            canceled_by,
+            worker_name,
+            occupancy_metrics,
+            materialize_f,
+        )
+        .await?;
     }
 
     let inline_db_res_path = parse_db_resource(&query);

--- a/backend/windmill-worker/src/sql_s3_input.rs
+++ b/backend/windmill-worker/src/sql_s3_input.rs
@@ -11,8 +11,50 @@
 //! executor binds the bare `s3://...` URI instead.
 
 use anyhow::Context;
+use std::future::Future;
 use windmill_common::client::AuthedClient;
+use windmill_common::error;
+use windmill_common::worker::Connection;
+use windmill_queue::{CanceledBy, MiniPulledJob};
 use windmill_types::s3::S3Object;
+
+use crate::common::OccupancyMetrics;
+use crate::handle_child::run_future_with_polling_update_job_poller;
+
+/// Run the `(s3object)` materialisation step under the job poller.
+///
+/// Downloading and decoding the file can take minutes on large inputs. The poller
+/// is what refreshes `v2_job_runtime.ping`, so without it the zombie monitor
+/// restarts the job after `ZOMBIE_JOB_TIMEOUT`, and since the restart cannot
+/// signal this phase, each retry stacks another concurrent download+decode on the
+/// same worker until it OOMs. It also gives this phase cancellation and the job
+/// timeout, neither of which it would otherwise honour.
+pub(crate) async fn materialize_under_job_poller<T, Fut>(
+    job: &MiniPulledJob,
+    conn: &Connection,
+    mem_peak: &mut i32,
+    canceled_by: &mut Option<CanceledBy>,
+    worker_name: &str,
+    occupancy_metrics: &mut OccupancyMetrics,
+    fut: Fut,
+) -> error::Result<T>
+where
+    Fut: Future<Output = error::Result<T>>,
+{
+    run_future_with_polling_update_job_poller(
+        job.id,
+        job.timeout,
+        conn,
+        mem_peak,
+        canceled_by,
+        fut,
+        worker_name,
+        &job.workspace_id,
+        &mut Some(occupancy_metrics),
+        Box::pin(futures::stream::once(async { 0 })),
+    )
+    .await
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum InputFormat {

--- a/backend/windmill-worker/src/sql_s3_input.rs
+++ b/backend/windmill-worker/src/sql_s3_input.rs
@@ -23,12 +23,16 @@ use crate::handle_child::run_future_with_polling_update_job_poller;
 
 /// Run the `(s3object)` materialisation step under the job poller.
 ///
-/// Downloading and decoding the file can take minutes on large inputs. The poller
-/// is what refreshes `v2_job_runtime.ping`, so without it the zombie monitor
-/// restarts the job after `ZOMBIE_JOB_TIMEOUT`, and since the restart cannot
-/// signal this phase, each retry stacks another concurrent download+decode on the
-/// same worker until it OOMs. It also gives this phase cancellation and the job
-/// timeout, neither of which it would otherwise honour.
+/// The poller is what refreshes `v2_job_runtime.ping`. Downloading and decoding the
+/// file can take minutes on large inputs, so running it unpolled leaves the ping
+/// stale and the zombie monitor restarts the job after `ZOMBIE_JOB_TIMEOUT`. The
+/// restart has no way to signal this phase, so the orphaned download keeps running
+/// concurrently with the retry.
+///
+/// This gives the phase its own `job.timeout` budget, on top of the one the query
+/// phase gets: a job can therefore occupy a worker for up to twice its timeout.
+/// That is deliberate — materialisation is otherwise unbounded — so don't collapse
+/// the two without giving this phase a budget of its own.
 pub(crate) async fn materialize_under_job_poller<T, Fut>(
     job: &MiniPulledJob,
     conn: &Connection,
@@ -54,6 +58,18 @@ where
         Box::pin(futures::stream::once(async { 0 })),
     )
     .await
+    .map_err(|e| match e {
+        // The poller labels its timeout arm as a query timeout, which would point
+        // the user at their SQL rather than at the input file. Relabelling on the
+        // message is best-effort: if it stops matching, the error is merely as
+        // unhelpful as it was before.
+        error::Error::ExecutionErr(m) if m.starts_with("Query timeout") => {
+            error::Error::ExecutionErr(format!(
+                "Timed out downloading and decoding the (s3object) argument: {m}"
+            ))
+        }
+        e => e,
+    })
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

Native SQL scripts that declare an `(s3object)` input argument could fail with:

```
ExecutionErr: Job timed out after no ping from job since 1970-01-01 00:00:00 UTC
(ZOMBIE_JOB_TIMEOUT: 60, reason: "RestartLimit (3)").
This likely means that the job died on worker wk-native-..., OOM are a common reason for worker crashes.
```

The worker was neither dead nor OOM. `(s3object)` args are materialized (downloaded from S3, decoded, bound as a JSON-text parameter) *before* `run_future_with_polling_update_job_poller` wraps the query. That poller is the only thing refreshing `v2_job_runtime.ping` for native SQL jobs, which have no child process and so never reach the `handle_child` ping loop. During the whole download and decode the ping went stale, and once it passed `ZOMBIE_JOB_TIMEOUT` (60s) the monitor restarted the job three times and gave up with `RestartLimit (3)`.

The `1970-01-01` in the error is a red herring: the monitor nulls the ping when it declares a zombie, and `last_ping.unwrap_or_default()` renders `None` as the epoch. It is not evidence of a dead worker.

The restarts also could not signal the in-flight attempt, so each retry ran a second download+decode concurrently with the orphaned one, which is a plausible route to the genuine OOM crashes that follow.

## Changes

- Add `materialize_under_job_poller` in `sql_s3_input.rs`, which runs the materialization under the existing job poller. This reuses the poller rather than adding a bespoke ping task, so the phase also gains cancellation and a timeout, neither of which it honoured before.
- Wrap the materialization step in all five executors that support `(s3object)` inputs: pg, mysql, bigquery, snowflake, mssql. (OracleDB has no `(s3object)` input path.) Loop bodies are unchanged apart from being moved into an async block.
- `pg_executor` keeps its `run_inline` bypass, mirroring how `run_inline` already skips the poller for the query phase.
- Relabel a materialization timeout, which the shared poller would otherwise report as `Query timeout`, pointing users at their SQL instead of the input file.
- Docs (companion PR in windmilldocs): correct the `(s3object)` size limits. The page claimed the path is "tested up to roughly 500 MB", which is not achievable on Postgres.

## Docs correction

The size guidance was wrong in a way that led users into this bug. What bounds the path is the size of the *decoded JSON*, not the file in S3, and the ceiling is the database's:

- Postgres rejects a `jsonb` whose array elements exceed 256 MB (`total size of jsonb array elements exceeds the maximum of 268435455 bytes`); past ~1 GB it drops the connection.
- Measured: a 15 MB Parquet file of 3M short rows decodes to ~156 MB of JSON. A 25 MB / 5M-row file already exceeds the Postgres cap.

So a 500 MB Parquet file can never go through `jsonb_to_recordset`, no matter how the ping bug is fixed. The docs now say this and point at DuckDB (which reads Parquet from S3 natively) for large-file pipelines.

## Test plan

Reproduced and verified end to end against a local native worker pool (`wk-native-*`, `tag=postgresql`, matching the reported setup), with filesystem-backed object storage and default `ZOMBIE_JOB_TIMEOUT=60`.

**Before** (25M-row Parquet, the reported script) - ping ages unrefreshed and the job is yanked to another worker:

```
t=5s   ping_age=5    worker=wk-native-rub-ihfXL
t=65s  ping_age=65   worker=wk-native-rub-ihfXL   <- past ZOMBIE_JOB_TIMEOUT
t=71s  ping_age=1    worker=wk-native-rub-ZCoaP   <- zombie restart
```

producing the reported log line verbatim: `Restarted job after not receiving job's ping for too long the last ping at ... (2/3 attempts)`, and `zombie_job_counter = 1`.

**After** - ping stays fresh throughout materialization, job stays on one worker, `zombie_job_counter` has no row.

- [x] Same 25M-row job: 0 zombie restarts (was 1+, escalating to `RestartLimit (3)`); fails only on the real Postgres size ceiling, which is now documented
- [x] 3M-row / 15 MB Parquet (~156 MB JSON, within the supported envelope): `success`, 0 zombie restarts
- [x] 200k-row Parquet (regression): `success`, 0 zombie restarts
- [x] Plain Postgres script with no `(s3object)` arg (regression): `success`, 0 zombie restarts
- [x] `cargo check -p windmill-worker` and `cargo check -p windmill-worker --features parquet,private,mysql,mssql,bigquery`

No test committed: asserting the fix requires a live connection, a real job row and a slow S3 fetch to observe `v2_job_runtime.ping` advancing across a 60s window, which is the elaborate-fixture/flaky case AGENTS.md says to skip rather than ship ceremonially. The executor loops are behavior-preserving and compile-checked.

## Known limitations / follow-ups

- **Detached decodes on cancel.** The parquet/CSV decoders run under `spawn_blocking`, which tokio cannot abort. On cancellation or timeout the future is dropped but the decode runs to completion holding its buffers. This is a property of the decoder rather than something introduced here, and it is strictly better than before, when zombie restarts stacked those decodes up to three deep. Making the decode abortable is a larger change.
- **A second unpinged window remains** for payloads that are already impossible. Serializing a very large materialized parameter into the PG wire format is synchronous CPU work inside the query future, which starves the poller task in the `select!`. It only bites above the 256 MB Postgres ceiling, so it is unreachable within the supported envelope.
- **Per-phase timeout budget.** Materialization now gets its own `job.timeout` on top of the query phase's, so a job can occupy a worker for up to 2x its timeout. Deliberate and documented on the helper: materialization was previously unbounded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zombie restarts for native SQL jobs when materializing `(s3object)` inputs by keeping the job ping fresh during download/decode. Materialization now runs under the job poller with cancellation and its own timeout to prevent false `ZOMBIE_JOB_TIMEOUT` errors and concurrent orphaned retries.

- **Bug Fixes**
  - Added `materialize_under_job_poller` in `sql_s3_input.rs` using `run_future_with_polling_update_job_poller`.
  - Applied to `pg`, `mysql`, `bigquery`, `snowflake`, and `mssql` executors; `pg` still bypasses when `run_inline`.
  - Relabeled materialization timeouts to point to `(s3object)` download/decode instead of query timeouts.
  - Gave materialization its own `job.timeout` budget (query phase keeps its own) by design.

<sup>Written for commit 77222a24ecfb7f331203814da56ef1e955ebdbf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

