### PR TITLE
fix(ai): show the question in askUserQuestion tool-call labels

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1268,7 +1268,7 @@ export class AIChatManager {
 			if (message.role === 'tool' && message.tool_call_id === toolId && message.userQuestion) {
 				return {
 					...message,
-					content: `User answered question: ${answerSummary}`,
+					content: `Asked: ${message.userQuestion.question} — ${answerSummary}`,
 					isLoading: false,
 					userQuestion: {
 						...message.userQuestion,
@@ -2925,7 +2925,11 @@ export class AIChatManager {
 				return {
 					...message,
 					isLoading: false,
-					content: messageText,
+					// A question's card disappears once canceled, so keep the question
+					// itself readable in the collapsed header.
+					content: message.userQuestion
+						? `Asked: ${message.userQuestion.question} — ${messageText}`
+						: messageText,
 					error: messageText,
 					userQuestion: message.userQuestion
 						? { ...message.userQuestion, canceled: true }

--- a/frontend/src/lib/components/copilot/chat/anthropic.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.ts
@@ -143,7 +143,7 @@ export async function parseAnthropicCompletion(
 
 				callbacks.setToolStatus(toolId, {
 					isLoading: true,
-					content: `Calling ${toolName}...`,
+					content: tool?.streamingLabel ?? `Calling ${toolName}...`,
 					toolName,
 					isStreamingArguments: shouldStream,
 					showFade: tool?.showFade,

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -3188,7 +3188,7 @@ describe('global AI tools', () => {
 		expect(callbacks.setToolStatus).toHaveBeenLastCalledWith(
 			'test-askUserQuestion',
 			expect.objectContaining({
-				content: 'User answered question: python3',
+				content: 'Asked: Which script language should be used? — python3',
 				isLoading: false,
 				result: 'python3',
 				userQuestion: expect.objectContaining({ selectedChoices: ['python3'] })
@@ -3226,7 +3226,7 @@ describe('global AI tools', () => {
 		expect(callbacks.setToolStatus).toHaveBeenLastCalledWith(
 			'test-askUserQuestion',
 			expect.objectContaining({
-				content: 'User answered question: bun, go',
+				content: 'Asked: Which languages should be supported? — bun, go',
 				isLoading: false,
 				result: '- bun\n- go',
 				userQuestion: expect.objectContaining({ selectedChoices: ['bun', 'go'] })
@@ -3300,7 +3300,7 @@ describe('global AI tools', () => {
 		expect(callbacks.setToolStatus).toHaveBeenLastCalledWith(
 			'test-askUserQuestion',
 			expect.objectContaining({
-				content: 'User answered question: use deno instead',
+				content: 'Asked: Which script language should be used? — use deno instead',
 				result: 'use deno instead',
 				userQuestion: expect.objectContaining({ selectedChoices: ['use deno instead'] })
 			})

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2130,6 +2130,7 @@ export const globalTools: Tool<{}>[] = [
 			'askUserQuestion',
 			'Ask the user a question with proposed answers and wait for their selected or custom answer before continuing.'
 		),
+		streamingLabel: 'Asking the user a question...',
 		fn: async ({ args, toolId, toolCallbacks }) => {
 			const parsed = askUserQuestionSchema.parse(args)
 			const userQuestion = {
@@ -2139,7 +2140,7 @@ export const globalTools: Tool<{}>[] = [
 			}
 
 			toolCallbacks.setToolStatus(toolId, {
-				content: parsed.question,
+				content: `Asking user: ${parsed.question}`,
 				userQuestion,
 				isLoading: true
 			})
@@ -2159,7 +2160,7 @@ export const globalTools: Tool<{}>[] = [
 			if (!selected?.length) {
 				const message = 'Question cancelled by user'
 				toolCallbacks.setToolStatus(toolId, {
-					content: message,
+					content: `Asked: ${parsed.question} — cancelled by user`,
 					userQuestion: { ...userQuestion, canceled: true },
 					isLoading: false,
 					error: message
@@ -2173,12 +2174,13 @@ export const globalTools: Tool<{}>[] = [
 			// ("Yes, immediately") stays unambiguous to the model reading it back.
 			const answerText =
 				selected.length === 1 ? selected[0] : selected.map((c) => `- ${c}`).join('\n')
-			// The collapsed tool-header is a human glance, not model input, so the picks
-			// read as a compact comma list there instead of a stacked bullet list.
+			// The collapsed tool-header is a human glance, not model input, so it carries
+			// the question plus the picks as a compact comma list (not a bullet list) —
+			// it is the only place the exchange stays readable in the transcript.
 			const answerSummary = selected.join(', ')
 
 			toolCallbacks.setToolStatus(toolId, {
-				content: `User answered question: ${answerSummary}`,
+				content: `Asked: ${parsed.question} — ${answerSummary}`,
 				userQuestion: {
 					...userQuestion,
 					selectedChoices: selected

--- a/frontend/src/lib/components/copilot/chat/openai-responses.ts
+++ b/frontend/src/lib/components/copilot/chat/openai-responses.ts
@@ -315,7 +315,7 @@ export async function parseOpenAIResponsesCompletion(
 			callbacks.onMessageEnd()
 			callbacks.setToolStatus(`${item.id}`, {
 				isLoading: true,
-				content: `Calling ${item.name}...`,
+				content: tool?.streamingLabel ?? `Calling ${item.name}...`,
 				toolName: item.name,
 				isStreamingArguments: shouldStream,
 				showFade: tool?.showFade,

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -788,6 +788,9 @@ export interface Tool<T> {
 	autoCollapseDetails?: boolean
 	streamArguments?: boolean
 	showFade?: boolean
+	/** Header shown while the model is still streaming this call's arguments,
+	 * before `fn` runs and sets a real status. Defaults to "Calling <name>...". */
+	streamingLabel?: string
 }
 
 /** Status of a job the chat started and tracks in the jobs tray. Mirrors the

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -1176,7 +1176,7 @@ export async function parseOpenAICompletion(
 					// Display tool call with streaming parameters if enabled
 					callbacks.setToolStatus(toolCallId, {
 						isLoading: true,
-						content: `Calling ${funcName}...`,
+						content: tool?.streamingLabel ?? `Calling ${funcName}...`,
 						toolName: funcName,
 						isStreamingArguments: shouldStream,
 						showFade: tool?.showFade,


### PR DESCRIPTION
## Summary

The `askUserQuestion` AI-chat tool's collapsed tool-call header never showed the question being asked: while the model streamed the call it read `Calling askUserQuestion...`, and once answered it collapsed to `User answered question: <answer>` — so reading a transcript you could see the answer but not what was asked. Every label state now carries the question text.

## Changes

- **Answered**: header reads `Asked: <question> — <answer(s)>` in both writers of that label — the tool `fn` in `global/core.ts` and the immediate display update in `AIChatManager.handleUserQuestionAnswer` (identical strings, so no flicker between them).
- **Cancelled**: both cancel paths keep the question visible — the tool fn writes `Asked: <question> — cancelled by user`, and the generic `cancelLoadingTools` (Stop button / turn abort) special-cases question messages instead of collapsing them to a bare `Canceled`.
- **While streaming arguments**: new optional `streamingLabel` field on the `Tool` interface, honored by all three completion parsers (`lib.ts` chat-completions, `anthropic.ts`, `openai-responses.ts`); `askUserQuestion` sets it to `Asking the user a question...` instead of the technical `Calling askUserQuestion...`.
- **While pending**: status content is `Asking user: <question>` (normally hidden behind the interactive card, but correct wherever the header renders instead).
- Updated the three label assertions in `global/core.test.ts`.

## Test plan

- [x] `global/core.test.ts` (137 tests), `shared.test.ts` + `AIChatManager.test.ts` (99 tests) pass
- [x] `npm run check:fast` clean for the touched files (one pre-existing error in `utils_workspace_deploy.ts`, unrelated to this branch)
- [x] Browser-verified in an AI session (Anthropic path): asked a question, answered, and cancelled a second one — see screenshots
- [x] `local-review` and `local-review-codex` both returned "Good to merge" with no findings

## Screenshots

Question card while awaiting an answer (unchanged UI):

![asking-phase](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/question-tool-label/1784206592-asking-phase.png)

Answered — collapsed header now carries the question (`Asked: Should the deploy go to staging or production? — Staging`):

![answered-label](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/question-tool-label/1784206595-answered-label.png)

Cancelled mid-question via Stop — question stays legible (`Asked: Which color theme … — cancelled by user`):

![canceled-label](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/question-tool-label/1784206597-canceled-label.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)