### PR TITLE
fix(migrations): grant zombie_job_counter to windmill roles

### DIFF
--- a/backend/migrations/20260716151337_grant_zombie_job_counter_to_windmill_roles.down.sql
+++ b/backend/migrations/20260716151337_grant_zombie_job_counter_to_windmill_roles.down.sql
@@ -1,0 +1,2 @@
+REVOKE ALL ON zombie_job_counter FROM windmill_user;
+REVOKE ALL ON zombie_job_counter FROM windmill_admin;

--- a/backend/migrations/20260716151337_grant_zombie_job_counter_to_windmill_roles.up.sql
+++ b/backend/migrations/20260716151337_grant_zombie_job_counter_to_windmill_roles.up.sql
@@ -1,0 +1,14 @@
+-- The zombie_job_counter table (migration 20250205131522) was created relying on
+-- ALTER DEFAULT PRIVILEGES to grant access to windmill_user and windmill_admin.
+-- Those default privileges only apply to objects created by the role that set
+-- them (migration 20250205131523), so deployments whose migration runner is a
+-- different role leave zombie_job_counter ungranted. The table used to be
+-- reached only through ON DELETE CASCADE, which bypasses caller permissions,
+-- but 20260625092813_drop_v2_job_side_table_cascades replaced that cascade with
+-- an explicit DELETE in delete_jobs (windmill-common/src/jobs.rs) which runs as
+-- the invoking role and fails with "permission denied for table
+-- zombie_job_counter". Grant explicitly to guarantee access regardless of who
+-- ran the migrations (same fix as notify_event in 20260619091631,
+-- script_trigger in 20260619112847 and dispatch_event in 20260701080313).
+GRANT ALL ON zombie_job_counter TO windmill_user;
+GRANT ALL ON zombie_job_counter TO windmill_admin;


### PR DESCRIPTION
Fixes WIN-2195

## Problem

The `zombie_job_counter` table (migration `20250205131522`) never received an explicit GRANT to `windmill_user` / `windmill_admin`. The generic `GRANT ALL ON ALL TABLES` in `20250205131523` is wrapped in an `EXCEPTION WHEN OTHERS` handler that silently swallows failures, and the `ALTER DEFAULT PRIVILEGES` it sets only applies to objects created by the same role that set the defaults. In external-database deployments where the migration runner differs from the init-script runner, the table ends up ungranted.

This was invisible while `zombie_job_counter` was only touched via `ON DELETE CASCADE`, which bypasses caller permissions. `20260625092813_drop_v2_job_side_table_cascades` replaced those cascades with explicit DELETEs in `delete_jobs()` (`windmill-common/src/jobs.rs:493`), which run as the invoking role and surface the missing GRANT as `permission denied for table zombie_job_counter`.

Same pattern already fixed for `notify_event` (`20260619091631`), `script_trigger` (`20260619112847`) and `dispatch_event` (`20260701080313`).

## Fix

New reversible migration `20260716151337_grant_zombie_job_counter_to_windmill_roles` granting ALL on the table to both roles. The table has no sequence, so unlike the `dispatch_event` fix no sequence grants are needed.

## Validation

Reproduced the failure and the fix end-to-end against the dev database:

| Step | Result |
|---|---|
| Apply `.down.sql` (simulates the ungranted external-DB state) | `REVOKE` |
| `set role windmill_user; delete from zombie_job_counter ...` | `ERROR: permission denied for table zombie_job_counter` — the exact reported error |
| Apply `.up.sql` | `GRANT` |
| Same DELETE as `windmill_user` | `DELETE 0` |
| Same DELETE as `windmill_admin` | `DELETE 0` |

Final `\dp zombie_job_counter` matches the pre-test privileges (`windmill_user=arwdDxtm`, `windmill_admin=arwdDxtm`), confirming the up migration is a faithful restore and the down migration reverses cleanly. No SQLx queries changed, so the offline cache needs no refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2195 by adding a migration that explicitly grants ALL on `zombie_job_counter` to `windmill_user` and `windmill_admin`. This fixes “permission denied for table zombie_job_counter” after cascades were replaced with explicit DELETEs in external DB setups.

- **Migration**
  - Adds `20260716151337_grant_zombie_job_counter_to_windmill_roles` with up/down scripts to ensure the table is granted for both roles across deployments.
  - Reversible. No sequence grants needed.

<sup>Written for commit 634545538a08b77a87fce08ffb587cb418a3579b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

