### PR TITLE
fix(raw-apps): bump ui_builder to 3246b18

### DIFF
--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "17406f1",
-	"sha256": "405143b5b7c9f9e789f7f25dd2a435ecf7f5344b01e517e14e505f6817281c95"
+	"version": "3246b18",
+	"sha256": "4b0be80f586bc57f91965a15bceba0a37a2ae8b727a70d8ab30d9c5e0b75f115"
 }


### PR DESCRIPTION
## Summary

Advances the pinned UI builder tarball from `17406f1` (set by #10150) to `3246b18`, current head of windmill-labs/windmill-code-ui-builder. This ships three merged PRs there:

- **windmill-labs/windmill-code-ui-builder#20** — Svelte raw apps build again. The bundler rejected any `svelte` dependency other than the exact string `5.45.2`, so apps created from the current template (`^5.55.5`, raised in #9084 for `wmill app dev` compatibility) failed to build outright. The guard now derives its bound from the bundled compiler's own version and rejects only runtimes older than it (the blank-screen direction). Apps pinned at exactly `5.45.2` get an actionable build error telling them to bump one line; deployed bundles are unaffected.
- **windmill-labs/windmill-code-ui-builder#18** — multi-select DOM inspector synced with the host chat.
- **windmill-labs/windmill-code-ui-builder#21** — the inspector's selector re-resolution no longer trips the empty-render root-lookup latch, so the "Nothing was mounted" hint still fires when a chat selection on `#root` persists across a rebuild.

The host side for the empty-render overlay already landed in #10150 and has been dormant-pinned until this bump.

## Changes

- `frontend/scripts/ui_builder_artifact.json`: `version` `17406f1` → `3246b18`, `sha256` updated to the published tarball's hash

## Test plan

- [x] `node scripts/untar_ui_builder.js` downloads, checksum-verifies, and extracts the pinned tarball cleanly
- [x] Extracted `app-preview.html` contains the empty-render detection and the #21 latch fix
- [x] Tarball behavior exercised directly in a browser: empty-render report/retract/supersede scenarios, and an A/B proving #21 (a `#root` chat selection re-pushed after a rebuild suppressed the report before the fix, fires after)
- [ ] Editor smoke test on a running stack: create a Svelte raw app from the template and confirm it builds

## Screenshots

Data-only pin bump (no windmill code change); the shipped UI was verified in a standalone browser harness as described above. The overlay UI itself was screenshotted in #10150.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the pinned UI builder artifact to bring in fixes that restore `svelte` raw app builds and improve the DOM inspector and empty-render hint. No app code changes.

- **Bug Fixes**
  - Raw `svelte` apps build again by deriving the version guard from the bundled compiler; only older runtimes are rejected.
  - Multi-select DOM inspector stays in sync with the host chat.
  - Selector re-resolution no longer suppresses the “Nothing was mounted” hint after rebuilds with a `#root` selection.

- **Dependencies**
  - Updated `frontend/scripts/ui_builder_artifact.json` to point to the new builder tarball and its `sha256`.

<sup>Written for commit 5806c8e816c0ded3e12127b36200182d15c8b026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

