### PR TITLE
fix(ansible): keep persistent-connection socket path under the AF_UNIX limit

### DIFF
--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -115,8 +115,9 @@ hmac.workspace = true
 pem = { workspace = true, optional = true }
 rsa = { workspace = true, optional = true }
 urlencoding.workspace = true
-# `fs` adds flock(2) for the cross-process Python install lock (shared cache mounts)
-nix = { workspace = true, features = ["fs"] }
+# `fs` adds flock(2) for the cross-process Python install lock (shared cache mounts);
+# `user` adds geteuid(2) to verify ownership of the ansible socket-dir root
+nix = { workspace = true, features = ["fs", "user"] }
 bytes.workspace = true
 reqwest.workspace = true
 reqwest-middleware.workspace = true

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -55,6 +55,96 @@ const WINDMILL_ANSIBLE_PASSWORD_FILENAME: &str = ".windmill.ansible_vault_passwo
 
 const DELEGATE_GIT_REPO_TARGET: &str = "delegate_git_repository";
 
+/// Root for the per-job dir in which ansible's persistent-connection plugins
+/// (`network_cli`, `httpapi`, `netconf`) bind their unix socket, named after a digest of
+/// the connection. `sockaddr_un.sun_path` caps the whole socket path at 107 bytes, which
+/// the job dir alone already exhausts, so this root must stay short and cannot live under
+/// `ANSIBLE_HOME` (which Windmill pins into the job dir).
+const PERSISTENT_CONTROL_PATH_ROOT: &str = "/tmp/wm-pc";
+
+/// Socket dir for `job_id`. Per-job on purpose: socket names hash host+credentials, so
+/// concurrent jobs sharing a dir would reuse each other's connection daemon.
+fn persistent_control_path_dir(job_id: &Uuid) -> String {
+    format!("{PERSISTENT_CONTROL_PATH_ROOT}/{}", job_id.simple())
+}
+
+/// Removes the job's socket dir on the way out. It lives outside `job_dir`, so the
+/// worker's job-dir sweep does not cover it.
+struct PersistentControlPathGuard(String);
+
+impl Drop for PersistentControlPathGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Claim the socket-dir root at worker start, then reap dirs left behind by workers that
+/// died before their guard could run.
+#[cfg(unix)]
+pub async fn prepare_persistent_control_path_root() {
+    // A play holds its socket dir for as long as it runs, touching the mtime only when
+    // connections open, so anything younger than the longest permitted job may still be
+    // live — including on another worker sharing this host.
+    let stale_after = std::time::Duration::from_secs(
+        windmill_common::worker::MAX_TIMEOUT.saturating_add(24 * 60 * 60),
+    );
+    prepare_socket_root(PERSISTENT_CONTROL_PATH_ROOT, stale_after).await
+}
+
+/// SECURITY: the root sits in a world-writable `/tmp`, so a local user could pre-plant it
+/// as a symlink and turn the sweep's `remove_dir_all` into arbitrary directory deletion as
+/// the worker's uid. `symlink_metadata` reports the link's own type without following it,
+/// so `is_dir()` holds only for a real directory. Creating the root 0700 up front is what
+/// keeps it ours: in a sticky `/tmp` only the owner may replace an entry.
+#[cfg(unix)]
+async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
+    use std::os::unix::fs::DirBuilderExt;
+
+    match tokio::fs::symlink_metadata(root).await {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if let Err(e) = tokio::fs::DirBuilder::new()
+                .recursive(true)
+                .mode(0o700)
+                .create(root)
+                .await
+            {
+                tracing::error!(
+                    "Failed to create ansible persistent-connection socket root at {root}: {e:?}"
+                );
+            }
+            return;
+        }
+        Ok(meta) if meta.is_dir() => {}
+        Ok(_) => {
+            tracing::error!(
+                "Refusing to sweep ansible persistent-connection socket root: {root} exists \
+                 but is not a directory (possibly a symlink planted by another local user). \
+                 Ansible network playbooks on this host will fail until it is removed."
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::error!("Failed to stat ansible socket root at {root}: {e:?}");
+            return;
+        }
+    }
+
+    let Ok(mut entries) = tokio::fs::read_dir(root).await else {
+        return;
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        // `DirEntry::metadata` does not traverse symlinks, so a planted link is never
+        // followed here either.
+        let stale = match entry.metadata().await.and_then(|m| m.modified()) {
+            Ok(modified) => modified.elapsed().is_ok_and(|e| e > stale_after),
+            Err(_) => false,
+        };
+        if stale {
+            let _ = tokio::fs::remove_dir_all(entry.path()).await;
+        }
+    }
+}
+
 lazy_static::lazy_static! {
     static ref TEMPLATE_RE: regex::Regex = regex::Regex::new(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}").unwrap();
 }
@@ -903,6 +993,7 @@ pub fn create_ansible_cfg(
     reqs: Option<&AnsibleRequirements>,
     job_dir: &str,
     vault_password_file_exists: bool,
+    job_id: &Uuid,
 ) -> error::Result<()> {
     let mut passwords_cfg = String::new();
     if vault_password_file_exists {
@@ -922,6 +1013,7 @@ pub fn create_ansible_cfg(
             passwords_cfg.push_str(&format!("vault_identity_list = {password_files}\n"));
         }
     }
+    let control_path_dir = persistent_control_path_dir(job_id);
     let ansible_cfg_content = format!(
         r#"
 [defaults]
@@ -931,6 +1023,8 @@ home={job_dir}/.ansible
 local_tmp={job_dir}/.ansible/tmp
 remote_tmp={job_dir}/.ansible/tmp
 {passwords_cfg}
+[persistent_connection]
+control_path_dir = {control_path_dir}
 "#
     );
 
@@ -978,6 +1072,31 @@ fn parse_ansible_cfg_path_list(content: &str, key: &str) -> Option<Vec<String>> 
     None
 }
 
+/// Whether `section` declares `key` in an ansible.cfg. Same deliberately minimal
+/// parsing as [`parse_ansible_cfg_path_list`], for a scalar key in a named section.
+fn ansible_cfg_declares(content: &str, section: &str, key: &str) -> bool {
+    let mut in_section = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_section = trimmed[1..trimmed.len() - 1]
+                .trim()
+                .eq_ignore_ascii_case(section);
+            continue;
+        }
+        if !in_section || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+        let sep = trimmed.find('=').into_iter().chain(trimmed.find(':')).min();
+        if let Some(sep) = sep {
+            if trimmed[..sep].trim().eq_ignore_ascii_case(key) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Prepend Windmill's dependency install dir to the repo cfg's declared path list.
 /// Relative entries from the repo cfg are resolved against `cfg_dir` to match how
 /// ansible resolves them relative to the config file's own directory.
@@ -1006,6 +1125,7 @@ async fn build_ansible_cfg_override_envs(
     job_dir: &str,
     vault_password_file_exists: bool,
     reqs: Option<&AnsibleRequirements>,
+    job_id: &Uuid,
 ) -> error::Result<Vec<(String, String)>> {
     let mut envs = vec![
         ("ANSIBLE_CONFIG".to_string(), cfg_path.to_string()),
@@ -1052,6 +1172,15 @@ async fn build_ansible_cfg_override_envs(
             "Failed to read delegated ansible.cfg at `{cfg_path}`: {e}"
         ))
     })?;
+
+    // Persistent-connection socket dir: only a default. Unlike ANSIBLE_HOME this value is
+    // not runtime-bound, so a repo that picks its own dir keeps it.
+    if !ansible_cfg_declares(&cfg_content, "persistent_connection", "control_path_dir") {
+        envs.push((
+            "ANSIBLE_PERSISTENT_CONTROL_PATH_DIR".to_string(),
+            persistent_control_path_dir(job_id),
+        ));
+    }
 
     envs.push((
         "ANSIBLE_ROLES_PATH".to_string(),
@@ -1606,7 +1735,8 @@ pub async fn handle_ansible_job(
         None => false,
     };
 
-    create_ansible_cfg(reqs.as_ref(), job_dir, vault_password_file_exists)?;
+    create_ansible_cfg(reqs.as_ref(), job_dir, vault_password_file_exists, &job.id)?;
+    let _control_path_guard = PersistentControlPathGuard(persistent_control_path_dir(&job.id));
 
     // When the run delegates to a git repo that ships its own ansible.cfg, that
     // file becomes the effective config (ansible loads exactly one config file and
@@ -1628,6 +1758,7 @@ pub async fn handle_ansible_job(
                 job_dir,
                 vault_password_file_exists,
                 reqs.as_ref(),
+                &job.id,
             )
             .await?
         }
@@ -2027,10 +2158,34 @@ mod tests {
             vault_id: vec!["dev@vault_pass.txt".to_string()],
             ..Default::default()
         };
-        create_ansible_cfg(Some(&reqs), job_dir, false).unwrap();
+        create_ansible_cfg(Some(&reqs), job_dir, false, &Uuid::new_v4()).unwrap();
         let cfg = std::fs::read_to_string(dir.path().join("ansible.cfg")).unwrap();
         assert!(cfg.contains("vault_identity_list = dev@vault_pass.txt"));
         assert!(!cfg.contains("library"));
+    }
+
+    /// The socket ansible binds under `control_path_dir` must fit `sun_path` (107
+    /// usable bytes), which the job dir alone blows past — hence a short dir outside
+    /// `ANSIBLE_HOME`.
+    #[test]
+    fn test_create_ansible_cfg_control_path_dir_fits_af_unix_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_dir = dir.path().to_str().unwrap();
+        let job_id = Uuid::new_v4();
+        create_ansible_cfg(None, job_dir, false, &job_id).unwrap();
+
+        let cfg = std::fs::read_to_string(dir.path().join("ansible.cfg")).unwrap();
+        let control_path_dir = persistent_control_path_dir(&job_id);
+        assert!(cfg.contains("[persistent_connection]"));
+        assert!(cfg.contains(&format!("control_path_dir = {control_path_dir}")));
+        assert!(!control_path_dir.starts_with(job_dir));
+
+        // dir + `/` + socket name, budgeted at a full 40-char sha1 (ansible truncates
+        // it far shorter today, but a custom control path may not).
+        assert!(
+            control_path_dir.len() + 1 + 40 <= 107,
+            "socket path would exceed sun_path: {control_path_dir}"
+        );
     }
 
     #[test]
@@ -2042,7 +2197,7 @@ mod tests {
             ..Default::default()
         };
         // Defense-in-depth boundary: a poisoned entry must error before any config is written.
-        assert!(create_ansible_cfg(Some(&reqs), job_dir, false).is_err());
+        assert!(create_ansible_cfg(Some(&reqs), job_dir, false, &Uuid::new_v4()).is_err());
         assert!(!dir.path().join("ansible.cfg").exists());
     }
 
@@ -2161,7 +2316,7 @@ collections_path : a/col:b/col
         std::fs::write(repo.join("play.yml"), play).unwrap();
 
         // Windmill's own generated cfg (the negative-control config that exists today).
-        create_ansible_cfg(None, job_dir, false).unwrap();
+        create_ansible_cfg(None, job_dir, false, &Uuid::new_v4()).unwrap();
 
         let playbook = format!("{DELEGATE_GIT_REPO_TARGET}/play.yml");
         let run = |envs: Vec<(String, String)>| {
@@ -2185,10 +2340,15 @@ collections_path : a/col:b/col
 
         // With the override: ANSIBLE_CONFIG points at the repo cfg and roles_path
         // is honored, so the role runs.
-        let envs =
-            build_ansible_cfg_override_envs(cfg_path.to_str().unwrap(), job_dir, false, None)
-                .await
-                .unwrap();
+        let envs = build_ansible_cfg_override_envs(
+            cfg_path.to_str().unwrap(),
+            job_dir,
+            false,
+            None,
+            &Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
         let after = run(envs);
         let stdout = String::from_utf8_lossy(&after.stdout);
         assert!(
@@ -2213,7 +2373,8 @@ collections_path : a/col:b/col
             vault_id: vec!["dev@vault_pass.txt".to_string()],
             ..Default::default()
         };
-        let envs = build_ansible_cfg_override_envs(cfg_path, job_dir, true, Some(&reqs))
+        let job_id = Uuid::new_v4();
+        let envs = build_ansible_cfg_override_envs(cfg_path, job_dir, true, Some(&reqs), &job_id)
             .await
             .unwrap();
         let map: std::collections::HashMap<_, _> = envs.into_iter().collect();
@@ -2221,6 +2382,11 @@ collections_path : a/col:b/col
         assert_eq!(
             map.get("ANSIBLE_CONFIG").map(|s| s.as_str()),
             Some(cfg_path)
+        );
+        // The repo cfg declares no control_path_dir, so Windmill's short default applies.
+        assert_eq!(
+            map.get("ANSIBLE_PERSISTENT_CONTROL_PATH_DIR"),
+            Some(&persistent_control_path_dir(&job_id))
         );
         assert_eq!(
             map.get("ANSIBLE_HOME"),
@@ -2261,14 +2427,140 @@ collections_path : a/col:b/col
         // are not silently dropped when the env override replaces the cfg value.
         std::fs::write(&cfg_path, "[defaults]\ncollections_paths = my_cols\n").unwrap();
 
-        let envs =
-            build_ansible_cfg_override_envs(cfg_path.to_str().unwrap(), job_dir, false, None)
-                .await
-                .unwrap();
+        let envs = build_ansible_cfg_override_envs(
+            cfg_path.to_str().unwrap(),
+            job_dir,
+            false,
+            None,
+            &Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
         let map: std::collections::HashMap<_, _> = envs.into_iter().collect();
         assert_eq!(
             map.get("ANSIBLE_COLLECTIONS_PATH"),
             Some(&format!("{job_dir}:{}/my_cols", repo_dir.to_str().unwrap()))
         );
+    }
+
+    #[tokio::test]
+    async fn test_build_ansible_cfg_override_envs_keeps_user_control_path_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_dir = dir.path().to_str().unwrap();
+        let repo_dir = dir.path().join(DELEGATE_GIT_REPO_TARGET);
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        let cfg_path = repo_dir.join("ansible.cfg");
+        std::fs::write(
+            &cfg_path,
+            "[defaults]\nroles_path = my_roles\n\n[persistent_connection]\ncontrol_path_dir = /tmp/my_pc\n",
+        )
+        .unwrap();
+
+        let envs = build_ansible_cfg_override_envs(
+            cfg_path.to_str().unwrap(),
+            job_dir,
+            false,
+            None,
+            &Uuid::new_v4(),
+        )
+        .await
+        .unwrap();
+        let map: std::collections::HashMap<_, _> = envs.into_iter().collect();
+        assert_eq!(map.get("ANSIBLE_PERSISTENT_CONTROL_PATH_DIR"), None);
+    }
+
+    #[cfg(unix)]
+    fn backdate(path: &std::path::Path, age: std::time::Duration) {
+        let times = std::fs::FileTimes::new().set_modified(std::time::SystemTime::now() - age);
+        std::fs::File::open(path).unwrap().set_times(times).unwrap();
+    }
+
+    /// The sweep only reaps what no live job can own: a play may hold its socket dir for
+    /// the whole of MAX_TIMEOUT without touching the mtime again.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_sweeps_only_stale_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("wm-pc");
+        std::fs::create_dir(&root).unwrap();
+
+        let stale = root.join("stale-job");
+        let live = root.join("live-job");
+        std::fs::create_dir(&stale).unwrap();
+        std::fs::create_dir(&live).unwrap();
+        backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
+        backdate(&live, std::time::Duration::from_secs(12 * 60 * 60));
+
+        prepare_socket_root(
+            root.to_str().unwrap(),
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .await;
+
+        assert!(!stale.exists(), "dir older than the cutoff must be reaped");
+        assert!(live.exists(), "a dir a live job may still own must be kept");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_creates_root_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("wm-pc");
+        prepare_socket_root(root.to_str().unwrap(), std::time::Duration::from_secs(1)).await;
+
+        let meta = std::fs::metadata(&root).unwrap();
+        assert!(meta.is_dir());
+        // Owning the root 0700 is what stops another local user replacing it later.
+        assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+    }
+
+    /// A symlinked root must never be swept: `remove_dir_all` through it would delete
+    /// whatever the link points at, as the worker's uid.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_refuses_symlinked_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let victim = dir.path().join("victim");
+        let victim_child = victim.join("precious");
+        std::fs::create_dir_all(&victim_child).unwrap();
+        backdate(&victim_child, std::time::Duration::from_secs(48 * 60 * 60));
+
+        let root = dir.path().join("wm-pc");
+        std::os::unix::fs::symlink(&victim, &root).unwrap();
+
+        prepare_socket_root(
+            root.to_str().unwrap(),
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .await;
+
+        assert!(
+            victim_child.exists(),
+            "sweep must not follow a symlinked root"
+        );
+    }
+
+    #[test]
+    fn test_ansible_cfg_declares_scoped_to_section() {
+        let cfg = "\
+[defaults]
+control_path_dir = /wrong/section
+
+[persistent_connection]
+# control_path_dir = /commented
+connect_timeout = 30
+";
+        assert!(!ansible_cfg_declares(
+            cfg,
+            "persistent_connection",
+            "control_path_dir"
+        ));
+        assert!(ansible_cfg_declares(
+            cfg,
+            "persistent_connection",
+            "connect_timeout"
+        ));
     }
 }

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -60,23 +60,26 @@ const DELEGATE_GIT_REPO_TARGET: &str = "delegate_git_repository";
 /// same job dir is fine.
 const AF_UNIX_PATH_LIMIT: usize = 107;
 
-lazy_static::lazy_static! {
-    /// Root for the per-job dir in which ansible's persistent-connection plugins
-    /// (`network_cli`, `httpapi`, `netconf`) bind their unix socket, named after a digest
-    /// of the connection. `sockaddr_un.sun_path` caps the whole socket path at 107 bytes,
-    /// which the job dir alone already exhausts, so the socket dir must stay short and
-    /// cannot live under `ANSIBLE_HOME` (which Windmill pins into the job dir).
-    ///
-    /// Rooted directly at `/tmp`, whose sticky bit is what stops another uid renaming our
-    /// root away — the property [`prepare_socket_root`] needs from a parent. Notably NOT
-    /// under `WINDMILL_DIR`: the shipped image chmods that tree to a non-sticky 0777 so any
-    /// UID can write it (`Dockerfile`, "Make directories world-accessible for any UID"),
-    /// which is exactly the parent an attacker can swap entries in. Default `/tmp/wm-pc`
-    /// leaves 84 of the 107 bytes at full socket length; override if `/tmp` is unsuitable.
-    static ref PERSISTENT_CONTROL_PATH_ROOT: String =
-        std::env::var("WINDMILL_ANSIBLE_CONTROL_PATH_ROOT")
-            .unwrap_or_else(|_| "/tmp/wm-pc".to_string());
-}
+/// Root for the per-job dir in which ansible's persistent-connection plugins
+/// (`network_cli`, `httpapi`, `netconf`) bind their unix socket, named after a digest of the
+/// connection. `sockaddr_un.sun_path` caps the whole socket path at [`AF_UNIX_PATH_LIMIT`],
+/// which the job dir alone already exhausts, so the socket dir must stay short and cannot
+/// live under `ANSIBLE_HOME` (which Windmill pins into the job dir).
+///
+/// Fixed, and directly under `/tmp`, for two reasons that are easy to undo by accident:
+/// `/tmp`'s sticky bit is what stops another uid renaming our root away, the one property
+/// [`prepare_socket_root`] needs from a parent; and every component of a fixed path is one
+/// nobody can point elsewhere, so trusting the root does not mean trusting an ancestor
+/// chain. Notably NOT under `WINDMILL_DIR`: the shipped image chmods that tree to a
+/// non-sticky 0777 so any UID can write it (`Dockerfile`, "Make directories
+/// world-accessible for any UID"), which is exactly the parent an attacker can swap entries
+/// in.
+const PERSISTENT_CONTROL_PATH_ROOT: &str = "/tmp/wm-pc";
+
+/// The budget this whole change exists to protect: root + `/` + a 32-char job uuid + `/` +
+/// a socket name, allowing a full 40-char sha1 (ansible truncates it far shorter today, but
+/// a custom control path may not).
+const _: () = assert!(PERSISTENT_CONTROL_PATH_ROOT.len() + 1 + 32 + 1 + 40 <= AF_UNIX_PATH_LIMIT);
 
 /// Cleared when the root cannot be trusted (see [`prepare_socket_root`]), which makes jobs
 /// stop naming it and fall back to ansible's own `{ANSIBLE_HOME}/pc` default — inside the
@@ -92,11 +95,11 @@ static SOCKET_ROOT_TRUSTED: std::sync::atomic::AtomicBool =
 fn persistent_control_path_dir(job_id: &Uuid) -> Option<String> {
     SOCKET_ROOT_TRUSTED
         .load(std::sync::atomic::Ordering::Relaxed)
-        .then(|| format!("{}/{}", &*PERSISTENT_CONTROL_PATH_ROOT, job_id.simple()))
+        .then(|| format!("{PERSISTENT_CONTROL_PATH_ROOT}/{}", job_id.simple()))
 }
 
 /// Whether `name` is one this module could have created, i.e. `Uuid::simple` (32 hex, no
-/// hyphens). The gate for deleting anything under the configurable root.
+/// hyphens). Belt to the root check's braces: nothing else should ever be in there.
 fn is_persistent_control_path_dir_name(name: &str) -> bool {
     name.len() == 32 && Uuid::try_parse(name).is_ok()
 }
@@ -115,26 +118,13 @@ impl Drop for PersistentControlPathGuard {
 /// died before their guard could run.
 #[cfg(unix)]
 pub async fn prepare_persistent_control_path_root() {
-    let root = &*PERSISTENT_CONTROL_PATH_ROOT;
-    // An overridden root can be long enough to put the budget back out of reach; the
-    // playbook-side error is opaque, so say so once at startup instead.
-    let longest_socket_path = root.len() + 1 + 32 + 1 + 40;
-    if longest_socket_path > AF_UNIX_PATH_LIMIT {
-        tracing::warn!(
-            "WINDMILL_ANSIBLE_CONTROL_PATH_ROOT is long enough that ansible \
-             persistent-connection sockets under {root} may reach {longest_socket_path} \
-             bytes, over the AF_UNIX limit of {AF_UNIX_PATH_LIMIT}; network playbooks may \
-             fail with `AF_UNIX path too long`."
-        );
-    }
-
     // A play holds its socket dir for as long as it runs, touching the mtime only when
     // connections open, so anything younger than the longest permitted job may still be
     // live — including on another worker sharing this host.
     let stale_after = std::time::Duration::from_secs(
         windmill_common::worker::MAX_TIMEOUT.saturating_add(24 * 60 * 60),
     );
-    prepare_socket_root(root, stale_after).await
+    prepare_socket_root(PERSISTENT_CONTROL_PATH_ROOT, stale_after).await
 }
 
 /// Reject a root that another local user could control, and mark it untrusted so jobs stop
@@ -222,9 +212,9 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
         return;
     };
     while let Ok(Some(entry)) = entries.next_entry().await {
-        // Only reap what we could have created. The root is configurable, so it may well
-        // be a directory holding things that are not ours, and a recursive delete of
-        // whatever happens to be old in there is not a mistake worth risking.
+        // Only reap what we could have created. Nothing else should ever be in a root we
+        // made 0700 ourselves, but this is a recursive delete running as the worker's uid:
+        // cheap to bound by name, expensive to get wrong.
         if !entry
             .file_name()
             .to_str()
@@ -2608,8 +2598,8 @@ collections_path : a/col:b/col
     }
 
     /// The sweep only reaps what no live job can own: a play may hold its socket dir for
-    /// the whole of MAX_TIMEOUT without touching the mtime again. And since the root is
-    /// configurable, it only ever touches names it could have created itself.
+    /// the whole of MAX_TIMEOUT without touching the mtime again. And it only ever touches
+    /// names it could have created itself.
     #[cfg(unix)]
     #[tokio::test]
     async fn test_prepare_socket_root_sweeps_only_stale_dirs() {
@@ -2734,18 +2724,17 @@ collections_path : a/col:b/col
         );
     }
 
-    /// The default root must hang off a parent whose sticky bit protects it. Notably not
+    /// The root must hang off a parent whose sticky bit protects it. Notably not
     /// `WINDMILL_DIR`: the shipped image chmods that whole tree to a non-sticky 0777 so any
     /// UID can write it, which would make the root untrusted and silently disable this fix
     /// in the standard image while every local test still passed.
     #[test]
-    fn test_default_control_path_root_hangs_off_tmp_not_windmill_dir() {
-        let root = &*PERSISTENT_CONTROL_PATH_ROOT;
+    fn test_control_path_root_hangs_off_tmp_not_windmill_dir() {
         assert_eq!(
-            std::path::Path::new(root).parent(),
+            std::path::Path::new(PERSISTENT_CONTROL_PATH_ROOT).parent(),
             Some(std::path::Path::new("/tmp"))
         );
-        assert!(!root.starts_with(&*windmill_common::worker::WINDMILL_DIR));
+        assert!(!PERSISTENT_CONTROL_PATH_ROOT.starts_with(&*windmill_common::worker::WINDMILL_DIR));
     }
 
     /// A parent that others can write (and that is not sticky) lets them rename the root

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -16,7 +16,7 @@ use windmill_common::{
     git_sync_oss::{prepend_token_to_github_url, sanitize_git_url},
     worker::{
         is_allowed_file_location, split_python_requirements, to_raw_value, write_file,
-        write_file_at_user_defined_location, Connection, PyVAlias, WINDMILL_DIR, WORKER_CONFIG,
+        write_file_at_user_defined_location, Connection, PyVAlias, WORKER_CONFIG,
     },
 };
 use windmill_queue::MiniPulledJob;
@@ -55,6 +55,11 @@ const WINDMILL_ANSIBLE_PASSWORD_FILENAME: &str = ".windmill.ansible_vault_passwo
 
 const DELEGATE_GIT_REPO_TARGET: &str = "delegate_git_repository";
 
+/// Usable bytes in `sockaddr_un.sun_path` (108 minus the NUL). An ABI constant, not a
+/// filesystem limit — which is why only the socket breaks while every regular file in the
+/// same job dir is fine.
+const AF_UNIX_PATH_LIMIT: usize = 107;
+
 lazy_static::lazy_static! {
     /// Root for the per-job dir in which ansible's persistent-connection plugins
     /// (`network_cli`, `httpapi`, `netconf`) bind their unix socket, named after a digest
@@ -62,11 +67,15 @@ lazy_static::lazy_static! {
     /// which the job dir alone already exhausts, so the socket dir must stay short and
     /// cannot live under `ANSIBLE_HOME` (which Windmill pins into the job dir).
     ///
-    /// Rooted at `WINDMILL_DIR` rather than a fresh `/tmp` name: the worker already
-    /// creates and owns it (job dirs live there), so this adds no new squattable path,
-    /// and an operator whose `/tmp` is unsuitable can move it with the same env var.
-    /// Default `/tmp/windmill/pc` leaves 90 of the 107 bytes at full socket length.
-    static ref PERSISTENT_CONTROL_PATH_ROOT: String = format!("{}/pc", &*WINDMILL_DIR);
+    /// Rooted directly at `/tmp`, whose sticky bit is what stops another uid renaming our
+    /// root away — the property [`prepare_socket_root`] needs from a parent. Notably NOT
+    /// under `WINDMILL_DIR`: the shipped image chmods that tree to a non-sticky 0777 so any
+    /// UID can write it (`Dockerfile`, "Make directories world-accessible for any UID"),
+    /// which is exactly the parent an attacker can swap entries in. Default `/tmp/wm-pc`
+    /// leaves 84 of the 107 bytes at full socket length; override if `/tmp` is unsuitable.
+    static ref PERSISTENT_CONTROL_PATH_ROOT: String =
+        std::env::var("WINDMILL_ANSIBLE_CONTROL_PATH_ROOT")
+            .unwrap_or_else(|_| "/tmp/wm-pc".to_string());
 }
 
 /// Cleared when the root cannot be trusted (see [`prepare_socket_root`]), which makes jobs
@@ -101,14 +110,15 @@ impl Drop for PersistentControlPathGuard {
 #[cfg(unix)]
 pub async fn prepare_persistent_control_path_root() {
     let root = &*PERSISTENT_CONTROL_PATH_ROOT;
-    // A custom WINDMILL_DIR can be long enough to put the budget back out of reach; the
-    // playbook error is opaque, so say so once at startup instead.
+    // An overridden root can be long enough to put the budget back out of reach; the
+    // playbook-side error is opaque, so say so once at startup instead.
     let longest_socket_path = root.len() + 1 + 32 + 1 + 40;
-    if longest_socket_path > 107 {
+    if longest_socket_path > AF_UNIX_PATH_LIMIT {
         tracing::warn!(
-            "WINDMILL_DIR is long enough that ansible persistent-connection sockets under \
-             {root} may exceed the {longest_socket_path}-byte AF_UNIX limit of 107; \
-             network playbooks may fail with `AF_UNIX path too long`."
+            "WINDMILL_ANSIBLE_CONTROL_PATH_ROOT is long enough that ansible \
+             persistent-connection sockets under {root} may reach {longest_socket_path} \
+             bytes, over the AF_UNIX limit of {AF_UNIX_PATH_LIMIT}; network playbooks may \
+             fail with `AF_UNIX path too long`."
         );
     }
 
@@ -1106,12 +1116,6 @@ remote_tmp={job_dir}/.ansible/tmp
     Ok(())
 }
 
-/// Read a colon-separated path list (e.g. `roles_path`, `collections_path`) from
-/// the `[defaults]` section of an ansible.cfg. Returns the raw entries as written,
-/// unresolved. Deliberately minimal: no inline-comment or continuation handling,
-/// which ansible's configparser also does not apply to these values. `key` and `=`
-/// or `:` as the delimiter are both matched (Python configparser accepts either),
-/// with the value itself split on `:` (`os.pathsep`).
 /// The section a header line opens, if it is one. Mirrors configparser's `SECTCRE`
 /// (`\[(?P<header>.+)\]`, matched not fullmatched, `.+` greedy): the name runs to the
 /// *last* `]`, and anything after it — an inline comment, say — is ignored.
@@ -1121,6 +1125,12 @@ fn parse_ansible_cfg_section_header(trimmed: &str) -> Option<&str> {
     Some(rest[..end].trim())
 }
 
+/// Read a colon-separated path list (e.g. `roles_path`, `collections_path`) from
+/// the `[defaults]` section of an ansible.cfg. Returns the raw entries as written,
+/// unresolved. Deliberately minimal: no inline-comment or continuation handling,
+/// which ansible's configparser also does not apply to these values. `key` and `=`
+/// or `:` as the delimiter are both matched (Python configparser accepts either),
+/// with the value itself split on `:` (`os.pathsep`).
 fn parse_ansible_cfg_path_list(content: &str, key: &str) -> Option<Vec<String>> {
     let mut in_defaults = false;
     for line in content.lines() {
@@ -2264,7 +2274,7 @@ mod tests {
         // dir + `/` + socket name, budgeted at a full 40-char sha1 (ansible truncates
         // it far shorter today, but a custom control path may not).
         assert!(
-            control_path_dir.len() + 1 + 40 <= 107,
+            control_path_dir.len() + 1 + 40 <= AF_UNIX_PATH_LIMIT,
             "socket path would exceed sun_path: {control_path_dir}"
         );
     }
@@ -2683,6 +2693,20 @@ collections_path : a/col:b/col
             stale.exists(),
             "must not sweep a root that others can write to"
         );
+    }
+
+    /// The default root must hang off a parent whose sticky bit protects it. Notably not
+    /// `WINDMILL_DIR`: the shipped image chmods that whole tree to a non-sticky 0777 so any
+    /// UID can write it, which would make the root untrusted and silently disable this fix
+    /// in the standard image while every local test still passed.
+    #[test]
+    fn test_default_control_path_root_hangs_off_tmp_not_windmill_dir() {
+        let root = &*PERSISTENT_CONTROL_PATH_ROOT;
+        assert_eq!(
+            std::path::Path::new(root).parent(),
+            Some(std::path::Path::new("/tmp"))
+        );
+        assert!(!root.starts_with(&*windmill_common::worker::WINDMILL_DIR));
     }
 
     /// A parent that others can write (and that is not sticky) lets them rename the root

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -69,10 +69,21 @@ lazy_static::lazy_static! {
     static ref PERSISTENT_CONTROL_PATH_ROOT: String = format!("{}/pc", &*WINDMILL_DIR);
 }
 
-/// Socket dir for `job_id`. Per-job on purpose: socket names hash host+credentials, so
-/// concurrent jobs sharing a dir would reuse each other's connection daemon.
-fn persistent_control_path_dir(job_id: &Uuid) -> String {
-    format!("{}/{}", &*PERSISTENT_CONTROL_PATH_ROOT, job_id.simple())
+/// Cleared when the root cannot be trusted (see [`prepare_socket_root`]), which makes jobs
+/// stop naming it and fall back to ansible's own `{ANSIBLE_HOME}/pc` default — inside the
+/// job dir, so worker-owned. Network playbooks then fail on the path length as they did
+/// before this dir existed, which beats handing an attacker the socket a device session
+/// runs over. Defaults to trusted: the check runs at worker start, before any job.
+static SOCKET_ROOT_TRUSTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(true);
+
+/// Socket dir for `job_id`, or `None` when the root is untrusted. Per-job on purpose:
+/// socket names hash host+credentials, so concurrent jobs sharing a dir would reuse each
+/// other's connection daemon.
+fn persistent_control_path_dir(job_id: &Uuid) -> Option<String> {
+    SOCKET_ROOT_TRUSTED
+        .load(std::sync::atomic::Ordering::Relaxed)
+        .then(|| format!("{}/{}", &*PERSISTENT_CONTROL_PATH_ROOT, job_id.simple()))
 }
 
 /// Removes the job's socket dir on the way out. It lives outside `job_dir`, so the
@@ -110,16 +121,48 @@ pub async fn prepare_persistent_control_path_root() {
     prepare_socket_root(root, stale_after).await
 }
 
-/// SECURITY: the root's parent is typically under a world-writable `/tmp`, so a local user
-/// could pre-plant the root and thereby own the parent of every job's socket dir — enough
-/// to swap dirs under a live job, or to redirect the sweep's path-based `remove_dir_all`
-/// through a symlink planted after the check. Only a real directory that we own and that
-/// nobody else can write is trusted; anything else is left strictly alone.
-/// `symlink_metadata` reports the link's own type without following it, so `is_dir()`
-/// holds only for a real directory.
+/// Reject a root that another local user could control, and mark it untrusted so jobs stop
+/// naming it. Returns without sweeping in that case.
+///
+/// SECURITY: the root sits under `WINDMILL_DIR`, typically in a world-writable `/tmp`, so a
+/// local user who wins the race to create it owns the parent of every job's socket dir —
+/// enough to hand ansible a socket of their choosing (a device session, credentials and
+/// all, runs over it), or to swap in a symlink after the check below and redirect the
+/// sweep's path-based `remove_dir_all` onto a target of their choosing, as the worker's
+/// uid. Three things must hold: the root is a real directory (`symlink_metadata` reports
+/// the link's own type without following it, so `is_dir()` cannot be satisfied by a
+/// symlink), we own it and nobody else can write it, and its parent cannot be used to
+/// replace it — which needs the parent either not writable by others, or sticky, since the
+/// sticky bit is exactly what stops a non-owner renaming an entry out of a shared dir.
 #[cfg(unix)]
 async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let untrusted = |reason: String| {
+        tracing::error!(
+            "Refusing to use the ansible persistent-connection socket root at {root}: {reason}. \
+             Ansible network playbooks on this host will keep failing with `AF_UNIX path too \
+             long` until this is resolved."
+        );
+        SOCKET_ROOT_TRUSTED.store(false, std::sync::atomic::Ordering::Relaxed);
+    };
+
+    if let Some(parent) = std::path::Path::new(root).parent() {
+        match tokio::fs::symlink_metadata(parent).await {
+            Ok(meta) => {
+                let mode = meta.permissions().mode();
+                if mode & 0o022 != 0 && mode & 0o1000 == 0 {
+                    return untrusted(format!(
+                        "its parent {} is writable by other users and not sticky (mode={:o}), \
+                         so they could replace the root",
+                        parent.display(),
+                        mode & 0o7777
+                    ));
+                }
+            }
+            Err(e) => return untrusted(format!("cannot stat its parent: {e}")),
+        }
+    }
 
     match tokio::fs::symlink_metadata(root).await {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -129,38 +172,29 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
                 .create(root)
                 .await
             {
-                tracing::error!(
-                    "Failed to create ansible persistent-connection socket root at {root}: {e:?}"
-                );
+                untrusted(format!("it could not be created: {e}"));
             }
             return;
         }
         Ok(meta) if meta.is_dir() => {
             let mode = meta.permissions().mode();
             if meta.uid() != nix::unistd::Uid::effective().as_raw() || mode & 0o022 != 0 {
-                tracing::error!(
-                    "Refusing to use the ansible persistent-connection socket root at {root}: \
-                     it already exists but is not owned by this worker or is writable by \
-                     others (uid={}, mode={:o}). Remove it to restore ansible network \
-                     playbooks on this host.",
+                return untrusted(format!(
+                    "it already exists but is not owned by this worker or is writable by \
+                     others (uid={}, mode={:o})",
                     meta.uid(),
-                    mode & 0o7777,
-                );
-                return;
+                    mode & 0o7777
+                ));
             }
         }
         Ok(_) => {
-            tracing::error!(
-                "Refusing to use the ansible persistent-connection socket root at {root}: it \
-                 exists but is not a directory (possibly a symlink planted by another local \
-                 user). Remove it to restore ansible network playbooks on this host."
-            );
-            return;
+            return untrusted(
+                "it exists but is not a directory (possibly a symlink planted by another \
+                 local user)"
+                    .to_string(),
+            )
         }
-        Err(e) => {
-            tracing::error!("Failed to stat ansible socket root at {root}: {e:?}");
-            return;
-        }
+        Err(e) => return untrusted(format!("it could not be stat'd: {e}")),
     }
 
     let Ok(mut entries) = tokio::fs::read_dir(root).await else {
@@ -1047,7 +1081,9 @@ pub fn create_ansible_cfg(
             passwords_cfg.push_str(&format!("vault_identity_list = {password_files}\n"));
         }
     }
-    let control_path_dir = persistent_control_path_dir(job_id);
+    let persistent_cfg = persistent_control_path_dir(job_id)
+        .map(|dir| format!("[persistent_connection]\ncontrol_path_dir = {dir}\n"))
+        .unwrap_or_default();
     let ansible_cfg_content = format!(
         r#"
 [defaults]
@@ -1057,9 +1093,7 @@ home={job_dir}/.ansible
 local_tmp={job_dir}/.ansible/tmp
 remote_tmp={job_dir}/.ansible/tmp
 {passwords_cfg}
-[persistent_connection]
-control_path_dir = {control_path_dir}
-"#
+{persistent_cfg}"#
     );
 
     write_file(job_dir, "ansible.cfg", &ansible_cfg_content)?;
@@ -1073,14 +1107,21 @@ control_path_dir = {control_path_dir}
 /// which ansible's configparser also does not apply to these values. `key` and `=`
 /// or `:` as the delimiter are both matched (Python configparser accepts either),
 /// with the value itself split on `:` (`os.pathsep`).
+/// The section a header line opens, if it is one. Mirrors configparser's `SECTCRE`
+/// (`\[(?P<header>.+)\]`, matched not fullmatched, `.+` greedy): the name runs to the
+/// *last* `]`, and anything after it — an inline comment, say — is ignored.
+fn parse_ansible_cfg_section_header(trimmed: &str) -> Option<&str> {
+    let rest = trimmed.strip_prefix('[')?;
+    let end = rest.rfind(']')?;
+    Some(rest[..end].trim())
+}
+
 fn parse_ansible_cfg_path_list(content: &str, key: &str) -> Option<Vec<String>> {
     let mut in_defaults = false;
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with('[') && trimmed.ends_with(']') {
-            in_defaults = trimmed[1..trimmed.len() - 1]
-                .trim()
-                .eq_ignore_ascii_case("defaults");
+        if let Some(section) = parse_ansible_cfg_section_header(trimmed) {
+            in_defaults = section.eq_ignore_ascii_case("defaults");
             continue;
         }
         if !in_defaults || trimmed.starts_with('#') || trimmed.starts_with(';') {
@@ -1112,10 +1153,8 @@ fn ansible_cfg_declares(content: &str, section: &str, key: &str) -> bool {
     let mut in_section = false;
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with('[') && trimmed.ends_with(']') {
-            in_section = trimmed[1..trimmed.len() - 1]
-                .trim()
-                .eq_ignore_ascii_case(section);
+        if let Some(header) = parse_ansible_cfg_section_header(trimmed) {
+            in_section = header.eq_ignore_ascii_case(section);
             continue;
         }
         if !in_section || trimmed.starts_with('#') || trimmed.starts_with(';') {
@@ -1210,10 +1249,9 @@ async fn build_ansible_cfg_override_envs(
     // Persistent-connection socket dir: only a default. Unlike ANSIBLE_HOME this value is
     // not runtime-bound, so a repo that picks its own dir keeps it.
     if !ansible_cfg_declares(&cfg_content, "persistent_connection", "control_path_dir") {
-        envs.push((
-            "ANSIBLE_PERSISTENT_CONTROL_PATH_DIR".to_string(),
-            persistent_control_path_dir(job_id),
-        ));
+        if let Some(dir) = persistent_control_path_dir(job_id) {
+            envs.push(("ANSIBLE_PERSISTENT_CONTROL_PATH_DIR".to_string(), dir));
+        }
     }
 
     envs.push((
@@ -1770,7 +1808,7 @@ pub async fn handle_ansible_job(
     };
 
     create_ansible_cfg(reqs.as_ref(), job_dir, vault_password_file_exists, &job.id)?;
-    let _control_path_guard = PersistentControlPathGuard(persistent_control_path_dir(&job.id));
+    let _control_path_guard = persistent_control_path_dir(&job.id).map(PersistentControlPathGuard);
 
     // When the run delegates to a git repo that ships its own ansible.cfg, that
     // file becomes the effective config (ansible loads exactly one config file and
@@ -2206,10 +2244,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let job_dir = dir.path().to_str().unwrap();
         let job_id = Uuid::new_v4();
+        let flag = TrustFlag::lock();
+        flag.set(true);
         create_ansible_cfg(None, job_dir, false, &job_id).unwrap();
 
         let cfg = std::fs::read_to_string(dir.path().join("ansible.cfg")).unwrap();
-        let control_path_dir = persistent_control_path_dir(&job_id);
+        let control_path_dir = persistent_control_path_dir(&job_id).unwrap();
         assert!(cfg.contains("[persistent_connection]"));
         assert!(cfg.contains(&format!("control_path_dir = {control_path_dir}")));
         // The whole point: the socket dir must escape the job dir, whose length is what
@@ -2410,6 +2450,8 @@ collections_path : a/col:b/col
             ..Default::default()
         };
         let job_id = Uuid::new_v4();
+        let flag = TrustFlag::lock();
+        flag.set(true);
         let envs = build_ansible_cfg_override_envs(cfg_path, job_dir, true, Some(&reqs), &job_id)
             .await
             .unwrap();
@@ -2422,7 +2464,7 @@ collections_path : a/col:b/col
         // The repo cfg declares no control_path_dir, so Windmill's short default applies.
         assert_eq!(
             map.get("ANSIBLE_PERSISTENT_CONTROL_PATH_DIR"),
-            Some(&persistent_control_path_dir(&job_id))
+            persistent_control_path_dir(&job_id).as_ref()
         );
         assert_eq!(
             map.get("ANSIBLE_HOME"),
@@ -2505,6 +2547,29 @@ collections_path : a/col:b/col
         assert_eq!(map.get("ANSIBLE_PERSISTENT_CONTROL_PATH_DIR"), None);
     }
 
+    /// `SOCKET_ROOT_TRUSTED` is process-global and cargo runs tests in parallel: hold this
+    /// while reading or flipping it, and the default is restored on the way out.
+    struct TrustFlag(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+    impl TrustFlag {
+        fn lock() -> Self {
+            static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+            Self(LOCK.lock().unwrap_or_else(|e| e.into_inner()))
+        }
+        fn set(&self, trusted: bool) {
+            SOCKET_ROOT_TRUSTED.store(trusted, std::sync::atomic::Ordering::Relaxed);
+        }
+        fn get(&self) -> bool {
+            SOCKET_ROOT_TRUSTED.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    impl Drop for TrustFlag {
+        fn drop(&mut self) {
+            SOCKET_ROOT_TRUSTED.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
     #[cfg(unix)]
     fn backdate(path: &std::path::Path, age: std::time::Duration) {
         let times = std::fs::FileTimes::new().set_modified(std::time::SystemTime::now() - age);
@@ -2527,6 +2592,7 @@ collections_path : a/col:b/col
         backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
         backdate(&live, std::time::Duration::from_secs(12 * 60 * 60));
 
+        let _flag = TrustFlag::lock();
         prepare_socket_root(
             root.to_str().unwrap(),
             std::time::Duration::from_secs(24 * 60 * 60),
@@ -2544,6 +2610,7 @@ collections_path : a/col:b/col
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("wm-pc");
+        let _flag = TrustFlag::lock();
         prepare_socket_root(root.to_str().unwrap(), std::time::Duration::from_secs(1)).await;
 
         let meta = std::fs::metadata(&root).unwrap();
@@ -2569,6 +2636,7 @@ collections_path : a/col:b/col
         std::fs::create_dir(&stale).unwrap();
         backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
 
+        let _flag = TrustFlag::lock();
         prepare_socket_root(
             root.to_str().unwrap(),
             std::time::Duration::from_secs(24 * 60 * 60),
@@ -2579,6 +2647,79 @@ collections_path : a/col:b/col
             stale.exists(),
             "must not sweep a root that others can write to"
         );
+    }
+
+    /// A parent that others can write (and that is not sticky) lets them rename the root
+    /// away and drop a symlink in its place after the checks — so the root cannot be
+    /// trusted no matter how it currently looks.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_refuses_writable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("windmill");
+        let root = parent.join("pc");
+        std::fs::create_dir_all(&root).unwrap();
+        let stale = root.join("stale-job");
+        std::fs::create_dir(&stale).unwrap();
+        backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let flag = TrustFlag::lock();
+        flag.set(true);
+        prepare_socket_root(
+            root.to_str().unwrap(),
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .await;
+
+        assert!(stale.exists(), "must not sweep under a replaceable parent");
+        assert!(
+            !flag.get(),
+            "an untrusted root must be marked so jobs stop naming it"
+        );
+    }
+
+    /// A sticky parent (like /tmp itself) is fine: the sticky bit is what stops a
+    /// non-owner renaming our root out of it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_accepts_sticky_world_writable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("windmill");
+        let root = parent.join("pc");
+        std::fs::create_dir_all(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o1777)).unwrap();
+
+        let flag = TrustFlag::lock();
+        flag.set(true);
+        prepare_socket_root(
+            root.to_str().unwrap(),
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .await;
+
+        assert!(root.is_dir(), "root must be created under a sticky parent");
+        assert!(flag.get());
+    }
+
+    /// Fail closed: when the root is untrusted the cfg must not name it, so ansible falls
+    /// back to its own `{ANSIBLE_HOME}/pc` default inside the worker-owned job dir.
+    #[test]
+    fn test_create_ansible_cfg_omits_untrusted_control_path_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_dir = dir.path().to_str().unwrap();
+
+        let flag = TrustFlag::lock();
+        flag.set(false);
+        create_ansible_cfg(None, job_dir, false, &Uuid::new_v4()).unwrap();
+
+        let cfg = std::fs::read_to_string(dir.path().join("ansible.cfg")).unwrap();
+        assert!(!cfg.contains("control_path_dir"));
+        assert!(!cfg.contains("[persistent_connection]"));
     }
 
     /// A symlinked root must never be swept: `remove_dir_all` through it would delete
@@ -2595,6 +2736,7 @@ collections_path : a/col:b/col
         let root = dir.path().join("wm-pc");
         std::os::unix::fs::symlink(&victim, &root).unwrap();
 
+        let _flag = TrustFlag::lock();
         prepare_socket_root(
             root.to_str().unwrap(),
             std::time::Duration::from_secs(24 * 60 * 60),
@@ -2604,6 +2746,30 @@ collections_path : a/col:b/col
         assert!(
             victim_child.exists(),
             "sweep must not follow a symlinked root"
+        );
+    }
+
+    /// configparser matches `\[(?P<header>.+)\]` without anchoring the end of the line, so
+    /// a header with anything trailing it is still that section — and missing it here
+    /// would silently override the user's own control_path_dir.
+    #[test]
+    fn test_ansible_cfg_section_header_with_trailing_text() {
+        assert_eq!(
+            parse_ansible_cfg_section_header("[persistent_connection] ; note"),
+            Some("persistent_connection")
+        );
+        assert_eq!(parse_ansible_cfg_section_header("not a header"), None);
+        // Greedy `.+` runs to the last `]`.
+        assert_eq!(parse_ansible_cfg_section_header("[a]b]"), Some("a]b"));
+
+        assert!(ansible_cfg_declares(
+            "[persistent_connection] ; note\ncontrol_path_dir = /tmp/mine\n",
+            "persistent_connection",
+            "control_path_dir"
+        ));
+        assert_eq!(
+            parse_ansible_cfg_path_list("[defaults] # note\nroles_path = my_roles\n", "roles_path"),
+            Some(vec!["my_roles".to_string()])
         );
     }
 

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -127,13 +127,14 @@ pub async fn prepare_persistent_control_path_root() {
 /// SECURITY: the root sits under `WINDMILL_DIR`, typically in a world-writable `/tmp`, so a
 /// local user who wins the race to create it owns the parent of every job's socket dir —
 /// enough to hand ansible a socket of their choosing (a device session, credentials and
-/// all, runs over it), or to swap in a symlink after the check below and redirect the
-/// sweep's path-based `remove_dir_all` onto a target of their choosing, as the worker's
-/// uid. Three things must hold: the root is a real directory (`symlink_metadata` reports
-/// the link's own type without following it, so `is_dir()` cannot be satisfied by a
-/// symlink), we own it and nobody else can write it, and its parent cannot be used to
-/// replace it — which needs the parent either not writable by others, or sticky, since the
-/// sticky bit is exactly what stops a non-owner renaming an entry out of a shared dir.
+/// all, runs over it), or to swap in a symlink and redirect the sweep's path-based
+/// `remove_dir_all` onto a target of their choosing, as the worker's uid. Three things must
+/// hold: the root is a real directory (`symlink_metadata` reports the link's own type
+/// without following it, so `is_dir()` cannot be satisfied by a symlink), we own it and
+/// nobody else can write it, and its parent cannot be used to replace it — which needs the
+/// parent either not writable by others, or sticky, since the sticky bit is exactly what
+/// stops a non-owner renaming an entry out of a shared dir. The root is validated after the
+/// create attempt, never before: anything else races whoever creates it first.
 #[cfg(unix)]
 async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -148,7 +149,13 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
     };
 
     if let Some(parent) = std::path::Path::new(root).parent() {
-        match tokio::fs::symlink_metadata(parent).await {
+        // The worker's own dir, but a fresh install may not have created it yet.
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            return untrusted(format!("its parent {} is unusable: {e}", parent.display()));
+        }
+        // Resolved, not `symlink_metadata`: what matters is the mode of the directory the
+        // entries actually live in, and a symlinked parent is normal (macOS `/tmp`).
+        match tokio::fs::metadata(parent).await {
             Ok(meta) => {
                 let mode = meta.permissions().mode();
                 if mode & 0o022 != 0 && mode & 0o1000 == 0 {
@@ -164,24 +171,23 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
         }
     }
 
+    // Non-recursive on purpose: `recursive` reports success for a path that already
+    // exists, which under a sticky parent (where others may still *create* the
+    // not-yet-existing `pc`, only not rename ours away) would hand us whatever another uid
+    // raced into place. Create-or-EEXIST, then validate whatever is actually there.
+    match tokio::fs::DirBuilder::new().mode(0o700).create(root).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return untrusted(format!("it could not be created: {e}")),
+    }
+
     match tokio::fs::symlink_metadata(root).await {
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            if let Err(e) = tokio::fs::DirBuilder::new()
-                .recursive(true)
-                .mode(0o700)
-                .create(root)
-                .await
-            {
-                untrusted(format!("it could not be created: {e}"));
-            }
-            return;
-        }
         Ok(meta) if meta.is_dir() => {
             let mode = meta.permissions().mode();
             if meta.uid() != nix::unistd::Uid::effective().as_raw() || mode & 0o022 != 0 {
                 return untrusted(format!(
-                    "it already exists but is not owned by this worker or is writable by \
-                     others (uid={}, mode={:o})",
+                    "it is not owned by this worker or is writable by others (uid={}, \
+                     mode={:o})",
                     meta.uid(),
                     mode & 0o7777
                 ));
@@ -189,8 +195,7 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
         }
         Ok(_) => {
             return untrusted(
-                "it exists but is not a directory (possibly a symlink planted by another \
-                 local user)"
+                "it is not a directory (possibly a symlink planted by another local user)"
                     .to_string(),
             )
         }
@@ -2610,13 +2615,44 @@ collections_path : a/col:b/col
 
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path().join("wm-pc");
-        let _flag = TrustFlag::lock();
+        let flag = TrustFlag::lock();
+        flag.set(true);
         prepare_socket_root(root.to_str().unwrap(), std::time::Duration::from_secs(1)).await;
 
         let meta = std::fs::metadata(&root).unwrap();
         assert!(meta.is_dir());
         // Owning the root 0700 is what stops another local user replacing it later.
         assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+        assert!(flag.get(), "a root we created ourselves is trusted");
+    }
+
+    /// The root must be validated *after* the create attempt, not before: under a sticky
+    /// parent another uid may still win the race to create the not-yet-existing `pc`
+    /// (sticky stops them renaming ours away, not creating it first), and a create that
+    /// tolerates `AlreadyExists` would otherwise hand us their directory unchecked.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_validates_raced_creation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("windmill");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o1777)).unwrap();
+
+        // Stand in for the racer's dir: present before we look, and not exclusively ours.
+        let root = parent.join("pc");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let flag = TrustFlag::lock();
+        flag.set(true);
+        prepare_socket_root(root.to_str().unwrap(), std::time::Duration::from_secs(1)).await;
+
+        assert!(
+            !flag.get(),
+            "a root raced into place under a sticky parent must not be trusted"
+        );
     }
 
     /// A root we do not exclusively own may have been pre-planted by another local user,

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -95,6 +95,12 @@ fn persistent_control_path_dir(job_id: &Uuid) -> Option<String> {
         .then(|| format!("{}/{}", &*PERSISTENT_CONTROL_PATH_ROOT, job_id.simple()))
 }
 
+/// Whether `name` is one this module could have created, i.e. `Uuid::simple` (32 hex, no
+/// hyphens). The gate for deleting anything under the configurable root.
+fn is_persistent_control_path_dir_name(name: &str) -> bool {
+    name.len() == 32 && Uuid::try_parse(name).is_ok()
+}
+
 /// Removes the job's socket dir on the way out. It lives outside `job_dir`, so the
 /// worker's job-dir sweep does not cover it.
 struct PersistentControlPathGuard(String);
@@ -134,8 +140,8 @@ pub async fn prepare_persistent_control_path_root() {
 /// Reject a root that another local user could control, and mark it untrusted so jobs stop
 /// naming it. Returns without sweeping in that case.
 ///
-/// SECURITY: the root sits under `WINDMILL_DIR`, typically in a world-writable `/tmp`, so a
-/// local user who wins the race to create it owns the parent of every job's socket dir —
+/// SECURITY: the root sits in a world-writable `/tmp`, so a local user who wins the race to
+/// create it owns the parent of every job's socket dir —
 /// enough to hand ansible a socket of their choosing (a device session, credentials and
 /// all, runs over it), or to swap in a symlink and redirect the sweep's path-based
 /// `remove_dir_all` onto a target of their choosing, as the worker's uid. Three things must
@@ -216,6 +222,16 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
         return;
     };
     while let Ok(Some(entry)) = entries.next_entry().await {
+        // Only reap what we could have created. The root is configurable, so it may well
+        // be a directory holding things that are not ours, and a recursive delete of
+        // whatever happens to be old in there is not a mistake worth risking.
+        if !entry
+            .file_name()
+            .to_str()
+            .is_some_and(is_persistent_control_path_dir_name)
+        {
+            continue;
+        }
         // `DirEntry::metadata` does not traverse symlinks, so a planted link is never
         // followed here either.
         let stale = match entry.metadata().await.and_then(|m| m.modified()) {
@@ -2592,7 +2608,8 @@ collections_path : a/col:b/col
     }
 
     /// The sweep only reaps what no live job can own: a play may hold its socket dir for
-    /// the whole of MAX_TIMEOUT without touching the mtime again.
+    /// the whole of MAX_TIMEOUT without touching the mtime again. And since the root is
+    /// configurable, it only ever touches names it could have created itself.
     #[cfg(unix)]
     #[tokio::test]
     async fn test_prepare_socket_root_sweeps_only_stale_dirs() {
@@ -2600,12 +2617,15 @@ collections_path : a/col:b/col
         let root = dir.path().join("wm-pc");
         std::fs::create_dir(&root).unwrap();
 
-        let stale = root.join("stale-job");
-        let live = root.join("live-job");
-        std::fs::create_dir(&stale).unwrap();
-        std::fs::create_dir(&live).unwrap();
+        let stale = root.join(Uuid::new_v4().simple().to_string());
+        let live = root.join(Uuid::new_v4().simple().to_string());
+        let foreign = root.join("someone-elses-data");
+        for p in [&stale, &live, &foreign] {
+            std::fs::create_dir(p).unwrap();
+        }
         backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
         backdate(&live, std::time::Duration::from_secs(12 * 60 * 60));
+        backdate(&foreign, std::time::Duration::from_secs(48 * 60 * 60));
 
         let _flag = TrustFlag::lock();
         prepare_socket_root(
@@ -2616,6 +2636,23 @@ collections_path : a/col:b/col
 
         assert!(!stale.exists(), "dir older than the cutoff must be reaped");
         assert!(live.exists(), "a dir a live job may still own must be kept");
+        assert!(
+            foreign.exists(),
+            "a stale dir we never created must be left alone"
+        );
+    }
+
+    #[test]
+    fn test_is_persistent_control_path_dir_name() {
+        assert!(is_persistent_control_path_dir_name(
+            &Uuid::new_v4().simple().to_string()
+        ));
+        // Hyphenated form is not what we create, so it is not ours to delete.
+        assert!(!is_persistent_control_path_dir_name(
+            &Uuid::new_v4().to_string()
+        ));
+        assert!(!is_persistent_control_path_dir_name("someone-elses-data"));
+        assert!(!is_persistent_control_path_dir_name(""));
     }
 
     #[cfg(unix)]
@@ -2678,7 +2715,9 @@ collections_path : a/col:b/col
         std::fs::create_dir(&root).unwrap();
         std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o777)).unwrap();
 
-        let stale = root.join("stale-job");
+        // UUID-named, so survival proves the trust check stopped the sweep rather than the
+        // name filter.
+        let stale = root.join(Uuid::new_v4().simple().to_string());
         std::fs::create_dir(&stale).unwrap();
         backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
 
@@ -2721,7 +2760,9 @@ collections_path : a/col:b/col
         let parent = dir.path().join("windmill");
         let root = parent.join("pc");
         std::fs::create_dir_all(&root).unwrap();
-        let stale = root.join("stale-job");
+        // UUID-named, so survival proves the trust check stopped the sweep rather than the
+        // name filter.
+        let stale = root.join(Uuid::new_v4().simple().to_string());
         std::fs::create_dir(&stale).unwrap();
         backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
         std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
@@ -2789,7 +2830,9 @@ collections_path : a/col:b/col
     async fn test_prepare_socket_root_refuses_symlinked_root() {
         let dir = tempfile::tempdir().unwrap();
         let victim = dir.path().join("victim");
-        let victim_child = victim.join("precious");
+        // UUID-named, so survival proves the symlink was not followed rather than the name
+        // filter sparing it.
+        let victim_child = victim.join(Uuid::new_v4().simple().to_string());
         std::fs::create_dir_all(&victim_child).unwrap();
         backdate(&victim_child, std::time::Duration::from_secs(48 * 60 * 60));
 

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -16,7 +16,7 @@ use windmill_common::{
     git_sync_oss::{prepend_token_to_github_url, sanitize_git_url},
     worker::{
         is_allowed_file_location, split_python_requirements, to_raw_value, write_file,
-        write_file_at_user_defined_location, Connection, PyVAlias, WORKER_CONFIG,
+        write_file_at_user_defined_location, Connection, PyVAlias, WINDMILL_DIR, WORKER_CONFIG,
     },
 };
 use windmill_queue::MiniPulledJob;
@@ -55,17 +55,24 @@ const WINDMILL_ANSIBLE_PASSWORD_FILENAME: &str = ".windmill.ansible_vault_passwo
 
 const DELEGATE_GIT_REPO_TARGET: &str = "delegate_git_repository";
 
-/// Root for the per-job dir in which ansible's persistent-connection plugins
-/// (`network_cli`, `httpapi`, `netconf`) bind their unix socket, named after a digest of
-/// the connection. `sockaddr_un.sun_path` caps the whole socket path at 107 bytes, which
-/// the job dir alone already exhausts, so this root must stay short and cannot live under
-/// `ANSIBLE_HOME` (which Windmill pins into the job dir).
-const PERSISTENT_CONTROL_PATH_ROOT: &str = "/tmp/wm-pc";
+lazy_static::lazy_static! {
+    /// Root for the per-job dir in which ansible's persistent-connection plugins
+    /// (`network_cli`, `httpapi`, `netconf`) bind their unix socket, named after a digest
+    /// of the connection. `sockaddr_un.sun_path` caps the whole socket path at 107 bytes,
+    /// which the job dir alone already exhausts, so the socket dir must stay short and
+    /// cannot live under `ANSIBLE_HOME` (which Windmill pins into the job dir).
+    ///
+    /// Rooted at `WINDMILL_DIR` rather than a fresh `/tmp` name: the worker already
+    /// creates and owns it (job dirs live there), so this adds no new squattable path,
+    /// and an operator whose `/tmp` is unsuitable can move it with the same env var.
+    /// Default `/tmp/windmill/pc` leaves 90 of the 107 bytes at full socket length.
+    static ref PERSISTENT_CONTROL_PATH_ROOT: String = format!("{}/pc", &*WINDMILL_DIR);
+}
 
 /// Socket dir for `job_id`. Per-job on purpose: socket names hash host+credentials, so
 /// concurrent jobs sharing a dir would reuse each other's connection daemon.
 fn persistent_control_path_dir(job_id: &Uuid) -> String {
-    format!("{PERSISTENT_CONTROL_PATH_ROOT}/{}", job_id.simple())
+    format!("{}/{}", &*PERSISTENT_CONTROL_PATH_ROOT, job_id.simple())
 }
 
 /// Removes the job's socket dir on the way out. It lives outside `job_dir`, so the
@@ -82,23 +89,37 @@ impl Drop for PersistentControlPathGuard {
 /// died before their guard could run.
 #[cfg(unix)]
 pub async fn prepare_persistent_control_path_root() {
+    let root = &*PERSISTENT_CONTROL_PATH_ROOT;
+    // A custom WINDMILL_DIR can be long enough to put the budget back out of reach; the
+    // playbook error is opaque, so say so once at startup instead.
+    let longest_socket_path = root.len() + 1 + 32 + 1 + 40;
+    if longest_socket_path > 107 {
+        tracing::warn!(
+            "WINDMILL_DIR is long enough that ansible persistent-connection sockets under \
+             {root} may exceed the {longest_socket_path}-byte AF_UNIX limit of 107; \
+             network playbooks may fail with `AF_UNIX path too long`."
+        );
+    }
+
     // A play holds its socket dir for as long as it runs, touching the mtime only when
     // connections open, so anything younger than the longest permitted job may still be
     // live — including on another worker sharing this host.
     let stale_after = std::time::Duration::from_secs(
         windmill_common::worker::MAX_TIMEOUT.saturating_add(24 * 60 * 60),
     );
-    prepare_socket_root(PERSISTENT_CONTROL_PATH_ROOT, stale_after).await
+    prepare_socket_root(root, stale_after).await
 }
 
-/// SECURITY: the root sits in a world-writable `/tmp`, so a local user could pre-plant it
-/// as a symlink and turn the sweep's `remove_dir_all` into arbitrary directory deletion as
-/// the worker's uid. `symlink_metadata` reports the link's own type without following it,
-/// so `is_dir()` holds only for a real directory. Creating the root 0700 up front is what
-/// keeps it ours: in a sticky `/tmp` only the owner may replace an entry.
+/// SECURITY: the root's parent is typically under a world-writable `/tmp`, so a local user
+/// could pre-plant the root and thereby own the parent of every job's socket dir — enough
+/// to swap dirs under a live job, or to redirect the sweep's path-based `remove_dir_all`
+/// through a symlink planted after the check. Only a real directory that we own and that
+/// nobody else can write is trusted; anything else is left strictly alone.
+/// `symlink_metadata` reports the link's own type without following it, so `is_dir()`
+/// holds only for a real directory.
 #[cfg(unix)]
 async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
-    use std::os::unix::fs::DirBuilderExt;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     match tokio::fs::symlink_metadata(root).await {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -114,12 +135,25 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
             }
             return;
         }
-        Ok(meta) if meta.is_dir() => {}
+        Ok(meta) if meta.is_dir() => {
+            let mode = meta.permissions().mode();
+            if meta.uid() != nix::unistd::Uid::effective().as_raw() || mode & 0o022 != 0 {
+                tracing::error!(
+                    "Refusing to use the ansible persistent-connection socket root at {root}: \
+                     it already exists but is not owned by this worker or is writable by \
+                     others (uid={}, mode={:o}). Remove it to restore ansible network \
+                     playbooks on this host.",
+                    meta.uid(),
+                    mode & 0o7777,
+                );
+                return;
+            }
+        }
         Ok(_) => {
             tracing::error!(
-                "Refusing to sweep ansible persistent-connection socket root: {root} exists \
-                 but is not a directory (possibly a symlink planted by another local user). \
-                 Ansible network playbooks on this host will fail until it is removed."
+                "Refusing to use the ansible persistent-connection socket root at {root}: it \
+                 exists but is not a directory (possibly a symlink planted by another local \
+                 user). Remove it to restore ansible network playbooks on this host."
             );
             return;
         }
@@ -2178,6 +2212,8 @@ mod tests {
         let control_path_dir = persistent_control_path_dir(&job_id);
         assert!(cfg.contains("[persistent_connection]"));
         assert!(cfg.contains(&format!("control_path_dir = {control_path_dir}")));
+        // The whole point: the socket dir must escape the job dir, whose length is what
+        // blows the budget.
         assert!(!control_path_dir.starts_with(job_dir));
 
         // dir + `/` + socket name, budgeted at a full 40-char sha1 (ansible truncates
@@ -2514,6 +2550,35 @@ collections_path : a/col:b/col
         assert!(meta.is_dir());
         // Owning the root 0700 is what stops another local user replacing it later.
         assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+    }
+
+    /// A root we do not exclusively own may have been pre-planted by another local user,
+    /// who then controls the parent of every job's socket dir — and could swap a symlink
+    /// in after this check, redirecting the sweep's path-based `remove_dir_all`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_refuses_world_writable_root() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("wm-pc");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let stale = root.join("stale-job");
+        std::fs::create_dir(&stale).unwrap();
+        backdate(&stale, std::time::Duration::from_secs(48 * 60 * 60));
+
+        prepare_socket_root(
+            root.to_str().unwrap(),
+            std::time::Duration::from_secs(24 * 60 * 60),
+        )
+        .await;
+
+        assert!(
+            stale.exists(),
+            "must not sweep a root that others can write to"
+        );
     }
 
     /// A symlinked root must never be swept: `remove_dir_all` through it would delete

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -190,10 +190,16 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
     match tokio::fs::symlink_metadata(root).await {
         Ok(meta) if meta.is_dir() => {
             let mode = meta.permissions().mode();
-            if meta.uid() != nix::unistd::Uid::effective().as_raw() || mode & 0o022 != 0 {
+            // Trusted means usable as well as safe: without owner rwx ansible cannot create
+            // its per-job dir, and a trusted-but-unusable root would hand every network
+            // playbook a permission error instead of the working fallback.
+            if meta.uid() != nix::unistd::Uid::effective().as_raw()
+                || mode & 0o022 != 0
+                || mode & 0o700 != 0o700
+            {
                 return untrusted(format!(
-                    "it is not owned by this worker or is writable by others (uid={}, \
-                     mode={:o})",
+                    "it is not owned by this worker, is writable by others, or is not \
+                     writable by us (uid={}, mode={:o})",
                     meta.uid(),
                     mode & 0o7777
                 ));
@@ -2692,6 +2698,28 @@ collections_path : a/col:b/col
         );
     }
 
+    /// Safe but unusable is still not trusted: ansible cannot create its per-job dir under
+    /// a root we cannot write, and naming it anyway would swap the working fallback for a
+    /// permission error on every network playbook.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_prepare_socket_root_refuses_unwritable_root() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("wm-pc");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let flag = TrustFlag::lock();
+        flag.set(true);
+        prepare_socket_root(root.to_str().unwrap(), std::time::Duration::from_secs(1)).await;
+
+        assert!(!flag.get(), "a root we cannot write must not be trusted");
+        // Let the tempdir clean itself up.
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
     /// A root we do not exclusively own may have been pre-planted by another local user,
     /// who then controls the parent of every job's socket dir — and could swap a symlink
     /// in after this check, redirecting the sweep's path-based `remove_dir_all`.
@@ -2724,17 +2752,16 @@ collections_path : a/col:b/col
         );
     }
 
-    /// The root must hang off a parent whose sticky bit protects it. Notably not
-    /// `WINDMILL_DIR`: the shipped image chmods that whole tree to a non-sticky 0777 so any
-    /// UID can write it, which would make the root untrusted and silently disable this fix
-    /// in the standard image while every local test still passed.
+    /// The root must hang off `/tmp`, whose sticky bit is what protects it. The trap this
+    /// guards: the shipped image chmods the whole `WINDMILL_DIR` tree to a non-sticky 0777
+    /// so any UID can write it, so parenting the root there would make it untrusted and
+    /// silently disable this fix in the standard image while every local test still passed.
     #[test]
-    fn test_control_path_root_hangs_off_tmp_not_windmill_dir() {
+    fn test_control_path_root_hangs_off_tmp() {
         assert_eq!(
             std::path::Path::new(PERSISTENT_CONTROL_PATH_ROOT).parent(),
             Some(std::path::Path::new("/tmp"))
         );
-        assert!(!PERSISTENT_CONTROL_PATH_ROOT.starts_with(&*windmill_common::worker::WINDMILL_DIR));
     }
 
     /// A parent that others can write (and that is not sticky) lets them rename the root

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -158,10 +158,6 @@ async fn prepare_socket_root(root: &str, stale_after: std::time::Duration) {
     };
 
     if let Some(parent) = std::path::Path::new(root).parent() {
-        // The worker's own dir, but a fresh install may not have created it yet.
-        if let Err(e) = tokio::fs::create_dir_all(parent).await {
-            return untrusted(format!("its parent {} is unusable: {e}", parent.display()));
-        }
         // Resolved, not `symlink_metadata`: what matters is the mode of the directory the
         // entries actually live in, and a symlinked parent is normal (macOS `/tmp`).
         match tokio::fs::metadata(parent).await {

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -76,6 +76,9 @@ const AF_UNIX_PATH_LIMIT: usize = 107;
 /// in.
 const PERSISTENT_CONTROL_PATH_ROOT: &str = "/tmp/wm-pc";
 
+/// Ansible's env var for `[persistent_connection] control_path_dir`.
+const ANSIBLE_CONTROL_PATH_DIR_ENV: &str = "ANSIBLE_PERSISTENT_CONTROL_PATH_DIR";
+
 /// The budget this whole change exists to protect: root + `/` + a 32-char job uuid + `/` +
 /// a socket name, allowing a full 40-char sha1 (ansible truncates it far shorter today, but
 /// a custom control path may not).
@@ -1226,6 +1229,7 @@ async fn build_ansible_cfg_override_envs(
     vault_password_file_exists: bool,
     reqs: Option<&AnsibleRequirements>,
     job_id: &Uuid,
+    job_envs: &HashMap<String, String>,
 ) -> error::Result<Vec<(String, String)>> {
     let mut envs = vec![
         ("ANSIBLE_CONFIG".to_string(), cfg_path.to_string()),
@@ -1274,10 +1278,14 @@ async fn build_ansible_cfg_override_envs(
     })?;
 
     // Persistent-connection socket dir: only a default. Unlike ANSIBLE_HOME this value is
-    // not runtime-bound, so a repo that picks its own dir keeps it.
-    if !ansible_cfg_declares(&cfg_content, "persistent_connection", "control_path_dir") {
+    // not runtime-bound, so a repo that picks its own dir keeps it — and so does a job that
+    // sets the env var itself, which these overrides are applied after and would otherwise
+    // silently outrank.
+    if !ansible_cfg_declares(&cfg_content, "persistent_connection", "control_path_dir")
+        && !job_envs.contains_key(ANSIBLE_CONTROL_PATH_DIR_ENV)
+    {
         if let Some(dir) = persistent_control_path_dir(job_id) {
-            envs.push(("ANSIBLE_PERSISTENT_CONTROL_PATH_DIR".to_string(), dir));
+            envs.push((ANSIBLE_CONTROL_PATH_DIR_ENV.to_string(), dir));
         }
     }
 
@@ -1858,6 +1866,7 @@ pub async fn handle_ansible_job(
                 vault_password_file_exists,
                 reqs.as_ref(),
                 &job.id,
+                &envs,
             )
             .await?
         }
@@ -2171,6 +2180,10 @@ async fn get_resource_or_variable_content(
 mod tests {
     use super::*;
 
+    fn no_job_envs() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
     fn args_from_json(v: serde_json::Value) -> HashMap<String, Box<RawValue>> {
         let serde_json::Value::Object(map) = v else {
             panic!("expected object");
@@ -2449,6 +2462,7 @@ collections_path : a/col:b/col
             false,
             None,
             &Uuid::new_v4(),
+            &no_job_envs(),
         )
         .await
         .unwrap();
@@ -2479,9 +2493,16 @@ collections_path : a/col:b/col
         let job_id = Uuid::new_v4();
         let flag = TrustFlag::lock();
         flag.set(true);
-        let envs = build_ansible_cfg_override_envs(cfg_path, job_dir, true, Some(&reqs), &job_id)
-            .await
-            .unwrap();
+        let envs = build_ansible_cfg_override_envs(
+            cfg_path,
+            job_dir,
+            true,
+            Some(&reqs),
+            &job_id,
+            &no_job_envs(),
+        )
+        .await
+        .unwrap();
         let map: std::collections::HashMap<_, _> = envs.into_iter().collect();
 
         assert_eq!(
@@ -2538,6 +2559,7 @@ collections_path : a/col:b/col
             false,
             None,
             &Uuid::new_v4(),
+            &no_job_envs(),
         )
         .await
         .unwrap();
@@ -2545,6 +2567,42 @@ collections_path : a/col:b/col
         assert_eq!(
             map.get("ANSIBLE_COLLECTIONS_PATH"),
             Some(&format!("{job_dir}:{}/my_cols", repo_dir.to_str().unwrap()))
+        );
+    }
+
+    /// These overrides are applied after the job's own env, so a default that ignores what
+    /// the job set would silently outrank it. Not runtime-bound, so the job wins.
+    #[tokio::test]
+    async fn test_build_ansible_cfg_override_envs_keeps_job_env_control_path_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_dir = dir.path().to_str().unwrap();
+        let repo_dir = dir.path().join(DELEGATE_GIT_REPO_TARGET);
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        let cfg_path = repo_dir.join("ansible.cfg");
+        // Cfg is silent on control_path_dir; the job env is not.
+        std::fs::write(&cfg_path, "[defaults]\nroles_path = my_roles\n").unwrap();
+
+        let job_envs = HashMap::from([(
+            ANSIBLE_CONTROL_PATH_DIR_ENV.to_string(),
+            "/tmp/job-picked".to_string(),
+        )]);
+
+        let flag = TrustFlag::lock();
+        flag.set(true);
+        let envs = build_ansible_cfg_override_envs(
+            cfg_path.to_str().unwrap(),
+            job_dir,
+            false,
+            None,
+            &Uuid::new_v4(),
+            &job_envs,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !envs.iter().any(|(k, _)| k == ANSIBLE_CONTROL_PATH_DIR_ENV),
+            "must not override a control_path_dir the job set itself"
         );
     }
 
@@ -2567,6 +2625,7 @@ collections_path : a/col:b/col
             false,
             None,
             &Uuid::new_v4(),
+            &no_job_envs(),
         )
         .await
         .unwrap();

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -2006,6 +2006,9 @@ pub async fn run_worker(
 
     create_directory_async(&worker_dir).await;
 
+    #[cfg(all(feature = "python", unix))]
+    crate::ansible_executor::prepare_persistent_control_path_root().await;
+
     if is_sandboxing_enabled() {
         let _ = write_file(
             &worker_dir,

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -2468,7 +2468,7 @@ async fn ansible_dep(
 
     let ansible_lockfile;
 
-    create_ansible_cfg(Some(&reqs), job_dir, false)?;
+    create_ansible_cfg(Some(&reqs), job_dir, false, job_id)?;
 
     if let Some(collections) = reqs.roles_and_collections.as_ref() {
         install_galaxy_collections(


### PR DESCRIPTION
## Summary

Ansible network playbooks (`nxos` and anything else on `network_cli` / `httpapi` /
`netconf`) fail on their first task with:

```
  File ".../ansible/cli/scripts/ansible_connection_cli_stub.py", line 104, in start
    self.sock.bind(self.socket_path)
OSError: AF_UNIX path too long
[ERROR]: Task failed: AF_UNIX path too long
```

Persistent-connection plugins fork a daemon that holds the device session open across
tasks and talk to it over a unix socket. When a process binds a unix socket the kernel
stores the path in `sockaddr_un.sun_path`, a fixed 108-byte array (107 usable). That is
an ABI constant, not a filesystem limit — which is why only the socket breaks while
regular files in the same directory are fine, and why only network playbooks hit it.

Ansible derives the socket dir from `PERSISTENT_CONTROL_PATH_DIR`, defaulting to
`{ANSIBLE_HOME}/pc`, and Windmill pins `ANSIBLE_HOME` into the ephemeral job dir. The
budget, with a real job dir:

```
/tmp/windmill/ag-agent-msypt-initial-standard-1-qRRyi/019f6db4-...-28c8c50e4fb0   90
+ /.ansible/pc/                                                                  103
+ socket name                                                                    143   (limit: 107)
```

36 bytes over before ansible writes anything of its own; the job dir alone spends 90 of
the 107, and the UUID in it is 36, so shorter worker names would not save it. Pinning
home into the job dir is right for tmp files, roles and collections — it just drags the
socket dir along, and the socket dir is the one thing with a 107-byte ceiling.

This decouples the socket dir from `ANSIBLE_HOME` and defaults it to `/tmp/wm-pc/<job uuid>`,
leaving a worst-case socket path of 85 bytes. It stays per-job: socket names hash
host+credentials, so a shared dir would let concurrent jobs to the same device reuse each
other's connection daemon across job boundaries.

## Changes

- `create_ansible_cfg` writes `[persistent_connection] control_path_dir`. This covers the
  nsjail path too, since the jail loads our generated cfg as `/tmp/ansible.cfg`.
- `build_ansible_cfg_override_envs` also exports `ANSIBLE_PERSISTENT_CONTROL_PATH_DIR`,
  because on the `delegate_to_git_repo` path the user's own cfg is the one ansible reads
  (it loads exactly one config file and does not merge). **The user override wins**: unlike
  `ANSIBLE_HOME` this value is not runtime-bound, so the env var is only set when the
  user's cfg does not already declare `[persistent_connection] control_path_dir`. New
  `ansible_cfg_declares` helper mirrors the existing `parse_ansible_cfg_path_list` shape.
- Cleanup: the socket dir lives outside `job_dir`, so the job-dir sweep does not cover it.
  A Drop guard removes it on every exit path, and the worker reaps dirs left by workers
  that died before their guard ran.

Rooted directly at `/tmp` rather than under `WINDMILL_DIR`: `/tmp` is sticky (`1777`), and the
sticky bit is exactly what stops another uid renaming our root away — the property the trust
check needs from a parent. `WINDMILL_DIR` looked like the safer home (the worker already owns
it) but is the opposite: the shipped image runs `find ${APP} /tmp/windmill -type d -exec chmod
777 {} +` so any UID can write that tree, which is precisely the replaceable parent an attacker
wants. Sticky-ing `/tmp/windmill` instead was rejected because `clean_cache` does
`remove_dir_all(/tmp/windmill/cache)`, and a sticky parent would make that fail with EPERM when
the runtime UID differs from the build-time root that created it.

The root is a fixed constant with no env override. An override was tried and removed: it made
every ancestor of the root operator-supplied (and so potentially attacker-replaceable), and it
turned the startup sweep into a recursive delete over a directory that might hold things we
never created. Both hazards exist only if the path is configurable, and nothing asked for the
knob. Being fixed also lets the socket-path budget be a compile-time assert — a root that would
reintroduce this bug no longer builds.

The startup sweep only reaps dirs older than `MAX_TIMEOUT` + 24h (not a flat 24h): workers
sharing a host share this root, a play may hold its socket dir for the whole of a job's
permitted lifetime without touching the mtime again, and `MAX_TIMEOUT` defaults to 7 days
self-hosted. It also refuses any root that is not a real directory we own and that nobody
else can write, since `remove_dir_all` through a planted symlink would delete whatever it
points at as the worker's uid.

## Out of scope (flagging, not fixing)

Under nsjail, `create_ansible_cfg` is called with the **host** `job_dir`, so the cfg
mounted at `/tmp/ansible.cfg` says `home=/tmp/windmill/wk-.../<uuid>/.ansible` — a path
that does not exist inside the jail, where job_dir is mounted at `/tmp`. Ansible just
recreates that deep tree in the jail's tmpfs, so it works by accident at the same
excessive length. This PR resolves the socket symptom there too (the jail's `/tmp` is
jail-private, so the short path is created and torn down with the jail), but the
host-path-inside-jail behavior looks unintended and deserves its own change.

## Test plan

Verified end-to-end **through Windmill**, not just against ansible standalone. The reported
failure needs a long job dir, so the worker was given a 26-char `WORKER_GROUP`, yielding
`wk-initial-standard-network-1-rub-wuioi` (39 chars) and a **90-char job dir** — the same shape
as the reported `ag-agent-msypt-initial-standard-1-qRRyi`. At that length ansible's default
socket path needs 113 bytes against the 107 limit.

**Before/after, same worker, same playbook** (a `network_cli` play against an unreachable
device; the connection failing at *dial* rather than at *bind* is the pass condition):

| | Result |
|---|---|
| Fix active | no `AF_UNIX` error; reaches `Unable to connect to port 59999 on 127.0.0.1` |
| Fix disabled (negative control) | `[ERROR]: Task failed: AF_UNIX path too long` |

The negative control was produced by making the root untrusted (`chmod 0777 /tmp/wm-pc`), which
drives the fail-closed path: the worker logs `Refusing to use the ansible persistent-connection
socket root at /tmp/wm-pc: ... (uid=1000, mode=777)`, the cfg omits the section, ansible falls
back to `{ANSIBLE_HOME}/pc`, and the original bug reproduces in-product. So the bug is real at
this job-dir length, this change is what prevents it, and the documented degradation behaves as
described.

**Observed in a real job:**

- cfg Windmill generated: `control_path_dir = /tmp/wm-pc/019f70081a3017356117fec7fa42846b`
- socket dir live *during* the run: `/tmp/wm-pc/019f7008.../` holding ansible's
  `.ansible_pc_lock_41bc85d4f2`
- after the job: `/tmp/wm-pc` empty — the Drop guard reaped it
- worker startup: root created `mode=700 owner=rfiszel`

**nsjail path** (`DISABLE_NSJAIL=false`, standalone worker, 90-char job dir): `run.config.proto`
present so the jail was genuinely used; the cfg mounted at `/tmp/ansible.cfg` carries the short
`control_path_dir`; no `AF_UNIX` error; task reaches the device-dial stage. The host's
`/tmp/wm-pc` stays empty because the jail's `/tmp` is private (tmpfs, or a bind under `job_dir`),
so the socket lives and dies with the jail and the host-side guard correctly no-ops.

**Automated / static:**

- `cargo test -p windmill-worker --features python --lib ansible` — 34 passed. Covers the
  generated cfg's short `control_path_dir` and that it escapes the job dir; the `sun_path`
  budget; omission when the root is untrusted; delegate-path precedence in both directions for
  the repo cfg *and* the job env; section-header parsing with trailing comments; and the root
  checks (stale vs live sweep, foreign names left alone, symlinked root, world-writable root,
  writable parent, sticky parent accepted, raced creation, unwritable root).
  Each new guard was confirmed non-vacuous by reverting it and watching its test fail.
- The socket-path budget is a **compile-time** assert: a root that would reintroduce this bug
  fails to build (`error[E0080]: evaluation panicked: assertion failed`).
- `cargo check -p windmill-worker` without `python` — the `#[cfg]`-gated startup hook compiles.
- `nix`'s `user` feature is a no-op off-unix (`nix/src/lib.rs` is `#![cfg(unix)]`, so the crate
  is empty on Windows) and the `Uid` call is inside a `#[cfg(unix)]` fn — noted because Windows
  CI only runs on tags, not PRs.
- `cargo fmt` clean for all touched files.

---
## Summary by cubic
Fixes “AF_UNIX path too long” in Ansible network playbooks by moving persistent-connection sockets to `/tmp/wm-pc/<job-uuid>` with strict trust checks, safe fallback, and scoped cleanup. Also drops the unused parent-creation step now that the root lives under sticky `/tmp`.

- **Bug Fixes**
  - Set `[persistent_connection] control_path_dir` in the generated ansible.cfg to keep socket paths under the 107‑byte AF_UNIX limit.
  - When delegating to a repo ansible.cfg, export `ANSIBLE_PERSISTENT_CONTROL_PATH_DIR` only if the repo doesn’t declare `control_path_dir` and the job didn’t set the env itself (parser accepts section headers with trailing comments; case‑insensitive).
  - Root the socket dir at sticky `/tmp` (`/tmp/wm-pc`), validate after create that it’s a real dir we own and can use (uid matches, mode 0700, not writable by others), require a safe parent (sticky or not world‑writable), and refuse a symlinked root. Sweep only stale, UUID‑named dirs older than `MAX_TIMEOUT + 24h`. Prepare/sweep at worker startup; per‑job dirs are cleaned via a Drop guard.
  - Fail closed on an untrusted or unusable root: omit `control_path_dir` and the env override so Ansible falls back to `{ANSIBLE_HOME}/pc` inside the job dir.

- **Dependencies**
  - Enable `nix` crate `user` feature to verify ownership of the socket root.

<sup>Written for commit 59c40dbe34dca8adcd246224fe8d3384c7a70dd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


