### PR TITLE
fix(ai): unbreak session chat compaction for Anthropic models

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1002,12 +1002,17 @@ export class AIChatManager {
 	): Promise<'ok' | 'empty' | 'aborted' | 'error'> => {
 		this.compacting = true
 		try {
+			// Cap the summarizer's output at the budget already reserved for the
+			// summary. Without a cap the model's default max_tokens applies, and the
+			// Anthropic SDK rejects non-streaming requests whose max_tokens implies
+			// >10 minutes of generation (~21k tokens) before anything is sent.
 			const raw = await getNonStreamingCompletion(
 				[
 					...sanitizeToolCallArguments(prefix),
 					{ role: 'user', content: getCompactionSummaryPrompt() }
 				],
-				abortController
+				abortController,
+				{ maxTokensCap: SUMMARY_OUTPUT_RESERVE_TOKENS }
 			)
 			const formatted = formatCompactSummary(raw ?? '')
 			if (!formatted) {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1143,6 +1143,9 @@ describe('AIChatManager manual compaction', () => {
 		expect(summaryReq[0].content).toBe('q1')
 		expect(summaryReq[3].content).toBe('a2')
 		expect(summaryReq[4].content).toContain('detailed summary')
+		// The summarizer's output must stay capped: without it the model default
+		// applies and the Anthropic SDK rejects the non-streaming call pre-flight.
+		expect(mocks.getNonStreamingCompletion.mock.calls[0][2]).toEqual({ maxTokensCap: 8000 })
 
 		// Nothing kept verbatim: messages collapse to just the summary user message.
 		expect(manager.messages).toHaveLength(1)

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -487,7 +487,9 @@ export async function testKey({
 	// getNonStreamingCompletion routes Anthropic-Messages-API models (native
 	// Anthropic and Claude on Azure Foundry) through the Anthropic SDK and
 	// everything else through OpenAI chat completions, so the test exercises the
-	// same request shape the feature actually sends.
+	// same request shape the feature actually sends. The cap keeps max_tokens
+	// under the Anthropic SDK's non-streaming pre-flight limit (~21k tokens),
+	// which would otherwise reject the request before it is sent.
 	await getNonStreamingCompletion(messages, abortController, {
 		apiKey,
 		workspace,
@@ -495,7 +497,8 @@ export async function testKey({
 		forceModelProvider: {
 			model: modelToTest,
 			provider: aiProvider
-		}
+		},
+		maxTokensCap: METADATA_MAX_TOKENS
 	})
 }
 


### PR DESCRIPTION
## Summary

`/compact` (and automatic summary-based compaction) in the AI session chat failed instantly for Anthropic models. The summarization request never left the browser: `runSummarization` called `getNonStreamingCompletion` without a `maxTokensCap`, so `resolveMaxTokens` fell back to the model default (64,000 output tokens for `claude-sonnet-*`/`claude-haiku-*`, 32,000 for `claude-opus-*`), and the Anthropic TS SDK rejects any non-streaming request whose `max_tokens` implies more than 10 minutes of generation (threshold ≈ 21,333 tokens) when no explicit timeout is set:

```
AnthropicError: Streaming is required for operations that may take longer than 10 minutes.
  at Anthropic.calculateNonstreamingTimeout
  at getAnthropicNonStreamingCompletion (lib.ts)
  at AIChatManager.runSummarization → compactManually
```

The user-visible symptom was a "Failed to compact the conversation" toast on `/compact`, and the automatic trigger silently falling back to drop-oldest until the circuit breaker tripped. Metadata completions were unaffected only because they already cap at `METADATA_MAX_TOKENS` (4,096).

## Changes

- `AIChatManager.runSummarization` now passes `maxTokensCap: SUMMARY_OUTPUT_RESERVE_TOKENS` (8,000) to `getNonStreamingCompletion` — the same output budget the compaction math already reserves for the summary message, and the same pattern the metadata completions use. Fixes both `/compact` and the automatic compaction trigger, which share this path.
- Unit assertion pinning the cap in the existing manual-compaction test, so a future edit can't silently drop the third argument and reintroduce the pre-flight failure (mocks don't enforce the SDK guard).

## Test plan

- [x] Reproduced the failure in a real session chat on an Anthropic workspace (`claude-sonnet-4-6`): `/compact` failed instantly with the SDK error above.
- [x] After the fix: `/compact` completes, the transcript collapses to a "Summarized earlier conversation" boundary, and a follow-up question is answered correctly from the summary alone ("how many scripts did we count earlier?" → "4 scripts") with zero console errors.
- [x] `npx vitest run src/lib/components/copilot/chat/AIChatManager.test.ts` — 65/65 pass, including the new cap assertion.
- [x] `npm run check:fast` — only pre-existing unrelated error on this branch (`listDatatableMigrations` missing from `DeployProvider`); the touched files check clean.
- [x] Local reviews (Claude branch-diff reviewer + Codex `/local-review-codex`): both "good to merge", no findings.

## Screenshots

Session chat after `/compact` on `claude-sonnet-4-6` — summary boundary in place and a follow-up answered from the summary:

![compact-fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-af91596a/1784282139-compact-fixed.png)

Also fixes the same uncapped-call pattern in `testKey` (`lib.ts`): the AI-settings "Test key" button hit the same SDK guard with Claude models. Capped at `METADATA_MAX_TOKENS` (4,096); browser-verified against a real Anthropic provider — the request now goes out with `max_tokens: 4096` and returns 200 with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
