### PR TITLE
fix(extra): make the extra container runnable as a non-root UID

### DIFF
--- a/.github/workflows/publish_extra.yml
+++ b/.github/workflows/publish_extra.yml
@@ -70,54 +70,17 @@ jobs:
         run: |
           bun run docker/test_windmill_extra.ts
 
-      # Clusters that forbid root run this image under `runAsUser`. The build steps
-      # write caches as root, so only a non-root run catches dirs left unwritable.
-      - name: Start container as non-root UID
-        run: |
-          docker run -d --name windmill-extra-nonroot \
-            --user 1000 \
-            -p 4001:3001 -p 4002:3002 -p 4003:3003 \
-            -e ENABLE_LSP=true \
-            -e ENABLE_MULTIPLAYER=true \
-            -e ENABLE_DEBUGGER=true \
-            -e DEBUGGER_PORT=3003 \
-            -e REQUIRE_SIGNED_DEBUG_REQUESTS=false \
-            -e NETRC="machine example.com login user password pass" \
-            windmill-extra:test
-
-          echo "Waiting for container to initialize..."
-          sleep 10
-          docker logs windmill-extra-nonroot
-
-      - name: Run integration tests as non-root UID
-        env:
-          LSP_PORT: 4001
-          MULTIPLAYER_PORT: 4002
-          DEBUGGER_PORT: 4003
-        run: |
-          bun run docker/test_windmill_extra.ts
-
-          # The debugger installs job dependencies through the uv cache, which is
-          # where a root-owned build cache surfaces as EACCES.
-          echo "Checking dependency install works as a non-root UID..."
-          docker exec windmill-extra-nonroot bash -c \
-            'echo "{\"code\":\"import requests\\ndef main():\\n  return 1\\n\",\"language\":\"python3\"}" \
-              | windmill prepare-deps' | tee /tmp/prepare-deps.json
-          grep -q '"success":true' /tmp/prepare-deps.json
-
       - name: Show container logs on failure
         if: failure()
         run: |
-          echo "=== Container logs (root) ==="
+          echo "=== Container logs ==="
           docker logs windmill-extra-test
-          echo "=== Container logs (non-root) ==="
-          docker logs windmill-extra-nonroot || true
 
       - name: Cleanup
         if: always()
         run: |
-          docker stop windmill-extra-test windmill-extra-nonroot || true
-          docker rm windmill-extra-test windmill-extra-nonroot || true
+          docker stop windmill-extra-test || true
+          docker rm windmill-extra-test || true
 
   publish_extra:
     needs: [sleep, test_extra]

--- a/.github/workflows/publish_extra.yml
+++ b/.github/workflows/publish_extra.yml
@@ -70,17 +70,54 @@ jobs:
         run: |
           bun run docker/test_windmill_extra.ts
 
+      # Clusters that forbid root run this image under `runAsUser`. The build steps
+      # write caches as root, so only a non-root run catches dirs left unwritable.
+      - name: Start container as non-root UID
+        run: |
+          docker run -d --name windmill-extra-nonroot \
+            --user 1000 \
+            -p 4001:3001 -p 4002:3002 -p 4003:3003 \
+            -e ENABLE_LSP=true \
+            -e ENABLE_MULTIPLAYER=true \
+            -e ENABLE_DEBUGGER=true \
+            -e DEBUGGER_PORT=3003 \
+            -e REQUIRE_SIGNED_DEBUG_REQUESTS=false \
+            -e NETRC="machine example.com login user password pass" \
+            windmill-extra:test
+
+          echo "Waiting for container to initialize..."
+          sleep 10
+          docker logs windmill-extra-nonroot
+
+      - name: Run integration tests as non-root UID
+        env:
+          LSP_PORT: 4001
+          MULTIPLAYER_PORT: 4002
+          DEBUGGER_PORT: 4003
+        run: |
+          bun run docker/test_windmill_extra.ts
+
+          # The debugger installs job dependencies through the uv cache, which is
+          # where a root-owned build cache surfaces as EACCES.
+          echo "Checking dependency install works as a non-root UID..."
+          docker exec windmill-extra-nonroot bash -c \
+            'echo "{\"code\":\"import requests\\ndef main():\\n  return 1\\n\",\"language\":\"python3\"}" \
+              | windmill prepare-deps' | tee /tmp/prepare-deps.json
+          grep -q '"success":true' /tmp/prepare-deps.json
+
       - name: Show container logs on failure
         if: failure()
         run: |
-          echo "=== Container logs ==="
+          echo "=== Container logs (root) ==="
           docker logs windmill-extra-test
+          echo "=== Container logs (non-root) ==="
+          docker logs windmill-extra-nonroot || true
 
       - name: Cleanup
         if: always()
         run: |
-          docker stop windmill-extra-test || true
-          docker rm windmill-extra-test || true
+          docker stop windmill-extra-test windmill-extra-nonroot || true
+          docker rm windmill-extra-test windmill-extra-nonroot || true
 
   publish_extra:
     needs: [sleep, test_extra]

--- a/docker/DockerfileExtra
+++ b/docker/DockerfileExtra
@@ -134,8 +134,8 @@ RUN addgroup --gid 1000 windmill && \
 # (/tmp/windmill/cache/uv) after the base already made it world-writable, leaving
 # root-owned 0755 dirs that make uv fail EACCES for a non-root UID. /pyls/.cache
 # (XDG_CACHE_HOME, incl. DENO_DIR) and /tmp/monaco are written at runtime too.
-RUN chmod -R a+rX /usr/local /pyls /debugger /multiplayer && \
-    chmod -R a+rw /tmp/windmill /pyls/.cache /tmp/monaco && \
+RUN chmod -R a+rX /usr/local /pyls /debugger /multiplayer /tmp/monaco && \
+    chmod -R a+rw /tmp/windmill /pyls/.cache && \
     find /tmp/windmill /pyls/.cache /tmp/monaco -type d -exec chmod 777 {} +
 
 # Expose all service ports

--- a/docker/DockerfileExtra
+++ b/docker/DockerfileExtra
@@ -131,9 +131,9 @@ RUN addgroup --gid 1000 windmill && \
     adduser --disabled-password --gecos "" --uid 1000 --gid 1000 windmill
 
 # The root-run installs above write into the base image's UV_CACHE_DIR
-# (/tmp/windmill/cache/uv) and XDG_CACHE_HOME (/pyls/.cache) after the base image
-# already made those world-writable, leaving root-owned 0755 dirs. uv, the LSP and
-# gopls write there at runtime, so a non-root UID needs them world-writable again.
+# (/tmp/windmill/cache/uv) after the base already made it world-writable, leaving
+# root-owned 0755 dirs that make uv fail EACCES for a non-root UID. /pyls/.cache
+# (XDG_CACHE_HOME, incl. DENO_DIR) and /tmp/monaco are written at runtime too.
 RUN chmod -R a+rX /usr/local /pyls /debugger /multiplayer && \
     chmod -R a+rw /tmp/windmill /pyls/.cache /tmp/monaco && \
     find /tmp/windmill /pyls/.cache /tmp/monaco -type d -exec chmod 777 {} +

--- a/docker/DockerfileExtra
+++ b/docker/DockerfileExtra
@@ -124,10 +124,19 @@ WORKDIR /app
 COPY docker/entrypoint-extra.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Set permissions
-RUN chmod -R a+rX /usr/local && \
-    chmod -R a+rX /pyls && \
-    chmod -R a+rX /debugger
+# Non-root 'windmill' user with UID/GID 1000 to match the app image, so
+# `runAsUser: 1000` resolves to a real account with a writable $HOME.
+# No USER directive: the image still starts as root by default.
+RUN addgroup --gid 1000 windmill && \
+    adduser --disabled-password --gecos "" --uid 1000 --gid 1000 windmill
+
+# The root-run installs above write into the base image's UV_CACHE_DIR
+# (/tmp/windmill/cache/uv) and XDG_CACHE_HOME (/pyls/.cache) after the base image
+# already made those world-writable, leaving root-owned 0755 dirs. uv, the LSP and
+# gopls write there at runtime, so a non-root UID needs them world-writable again.
+RUN chmod -R a+rX /usr/local /pyls /debugger /multiplayer && \
+    chmod -R a+rw /tmp/windmill /pyls/.cache /tmp/monaco && \
+    find /tmp/windmill /pyls/.cache /tmp/monaco -type d -exec chmod 777 {} +
 
 # Expose all service ports
 EXPOSE 3000 3001 3002 3003

--- a/docker/entrypoint-extra.sh
+++ b/docker/entrypoint-extra.sh
@@ -21,14 +21,17 @@ cleanup() {
 
 trap cleanup SIGTERM SIGINT
 
-# An arbitrary non-root UID gets HOME=/ and cannot write the image's 0700 /root,
-# so redirect $HOME somewhere writable before anything writes under it (netrc
-# below, plus bun/npm/go caches in the services). Left alone when running as root.
-if [ ! -w "${HOME:-/root}" ]; then
-    echo "[entrypoint] HOME=${HOME:-/root} is not writable for UID $(id -u), using HOME=/tmp/windmill-home"
-    export HOME=/tmp/windmill-home
+# An arbitrary non-root UID gets HOME=/ and cannot write the image's 0700 /root, so
+# redirect $HOME before anything writes under it (netrc below, plus the bun/npm/go
+# caches in the services). Keep the fallback UID-scoped: a leftover dir from a
+# different UID on a shared /tmp is not writable. Root keeps HOME=/root.
+HOME="${HOME:-/root}"
+if [ ! -w "$HOME" ]; then
+    echo "[entrypoint] HOME=$HOME is not writable for UID $(id -u), using HOME=/tmp/windmill-home-$(id -u)"
+    HOME="/tmp/windmill-home-$(id -u)"
     mkdir -p "$HOME"
 fi
+export HOME
 
 # Setup NETRC if provided (for LSP)
 if [ -n "$NETRC" ]; then

--- a/docker/entrypoint-extra.sh
+++ b/docker/entrypoint-extra.sh
@@ -21,16 +21,26 @@ cleanup() {
 
 trap cleanup SIGTERM SIGINT
 
-# Setup NETRC if provided (for LSP)
-if [ -n "$NETRC" ]; then
-    echo "$NETRC" > /root/.netrc
-    chmod 600 /root/.netrc
+# An arbitrary non-root UID gets HOME=/ and cannot write the image's 0700 /root,
+# so redirect $HOME somewhere writable before anything writes under it (netrc
+# below, plus bun/npm/go caches in the services). Left alone when running as root.
+if [ ! -w "${HOME:-/root}" ]; then
+    echo "[entrypoint] HOME=${HOME:-/root} is not writable for UID $(id -u), using HOME=/tmp/windmill-home"
+    export HOME=/tmp/windmill-home
+    mkdir -p "$HOME"
 fi
 
-# Setup cache directory for LSP
-if [ -d /root/.cache ]; then
-    export XDG_CACHE_HOME=/root/.cache
-    cp -r /pyls/.cache /root/.cache 2>/dev/null || true
+# Setup NETRC if provided (for LSP)
+if [ -n "$NETRC" ]; then
+    echo "$NETRC" > "$HOME/.netrc"
+    chmod 600 "$HOME/.netrc"
+fi
+
+# Setup cache directory for LSP (falls back to the image's world-writable
+# XDG_CACHE_HOME=/pyls/.cache when $HOME/.cache isn't mounted)
+if [ -d "$HOME/.cache" ]; then
+    export XDG_CACHE_HOME="$HOME/.cache"
+    cp -r /pyls/.cache "$HOME/.cache" 2>/dev/null || true
 fi
 
 # Setup Monaco temp directory for LSP


### PR DESCRIPTION
## Summary

Reported by a user running under a cluster policy that forbids root: the debugger in `windmill-extra` fails with permission errors because cache directories are owned by root. They confirmed it still reproduces on v1.746.0, and that mounting an `emptyDir` over `/tmp/windmill/cache` works around it.

**Root cause.** The base image (`windmill-ee-slim`) sets `UV_CACHE_DIR=/tmp/windmill/cache/uv` and `XDG_CACHE_HOME=/pyls/.cache`, and ends with a pass that makes `/tmp/windmill` world-writable "for arbitrary UID support". `DockerfileExtra` then runs `uv pip install` **after** that pass, as root, so uv repopulates its own cache and leaves ~320 root-owned `0755` dirs behind. Verified against the published image — a non-root UID hits exactly the reported failure:

```
uv venv failed: Failed to install seed packages into virtual environment
  Caused by: Failed to write to the client cache
  Caused by: Permission denied (os error 13)
    at path "/tmp/windmill/cache/uv/simple-v21/pypi/.tmpWxWzTi"
```

That call is `windmill prepare-deps`, which the debugger spawns to install job dependencies — hence "the debugger doesn't work rootless". The `emptyDir` workaround works precisely because it replaces the root-owned cache with an empty writable one.

Two adjacent rootless bugs in the same image, found while verifying:

- `/pyls/.cache` (`XDG_CACHE_HOME`, incl. `DENO_DIR`) is root-owned `0755` — the LSP can't write its cache.
- The entrypoint wrote `$NETRC` to the `0700` `/root` under `set -e`, so setting `NETRC` **killed the container at startup** for any non-root UID.

The user also correctly noted the extra container has no `windmill` user: the app image creates uid/gid 1000, the slim base it builds on doesn't, so `runAsUser: 1000` had no account and no writable `$HOME`.

No helm chart change is needed — this removes the reason for the volume workaround. (The chart lives in `windmill-helm-charts`; if you'd still like the volume hooks for other reasons, that's a separate PR.)

## Changes

- `docker/DockerfileExtra`: re-apply the base image's cache convention to `/tmp/windmill` and `/pyls/.cache` **after** the root-run installs (`chmod -R a+rw` + `777` dirs, same idiom as `DockerfileSlimEe:69`/`:121`, which already ships 666 cache files by design — so this restores the base's posture rather than widening it). `/tmp/monaco` holds `node_modules` code rather than cache, so it gets `a+rX` files with `777` dirs: enough for the `go.mod`/`ruff.toml` written into it at runtime, without making the code world-writable.
- `docker/DockerfileExtra`: create the `windmill` uid/gid 1000 account, matching `Dockerfile:333`. No `USER` directive, so the image still starts as root by default. With the passwd entry, `runAsUser: 1000` resolves to a real user with a writable `/home/windmill`.
- `docker/entrypoint-extra.sh`: redirect `$HOME` to `/tmp/windmill-home-$(id -u)` when it isn't writable, before anything writes under it. Root is unaffected. UID-scoped so a leftover dir from another UID on a shared `/tmp` can't reintroduce the same startup death.

## Test plan

Verified locally against a **full source build** of `DockerfileExtra` (not layered on the published image), so both new `RUN` steps are proven to execute. CI is unchanged and covers the root path only, so the non-root evidence below is local:

- [x] **Before**: `prepare-deps` as uid 1000 fails with the EACCES above; as root it succeeds → confirms ownership, not logic
- [x] **After** — all four services start and `prepare-deps` returns `"success":true` as:
  - [x] root (default) — no `$HOME` redirect, netrc still at `/root/.netrc`, behavior unchanged
  - [x] `--user 1000` — resolves to `windmill`, `HOME=/home/windmill`
  - [x] `--user 4567:0` (arbitrary UID, OpenShift-style) — redirect fires
- [x] 0 non-writable dirs remain under the cache paths for a non-root UID
- [x] `NETRC` set no longer kills startup; lands `0600` in the writable HOME
- [x] Full CI smoke suite (`docker/test_windmill_extra.ts`) passes **7/7 as `--user 1000`**, including real DAP *Python execution* and *breakpoint support* sessions — the reported scenario, working rootless
- [x] Negative control: the same `prepare-deps` check returns `"success":false` on the current published image and `"success":true` on this build, confirming the failure is real and fixed
- [x] Regressions caught in review and fixed: unset `HOME` leaked netrc to `/.netrc`; root-created `/tmp/windmill-home` on a shared `/tmp` re-broke non-root startup
- [x] `shellcheck -S warning` clean, `docker build --check` clean

Note: `publish_extra.yml` builds and smoke-tests this image on tag releases only, as root. Non-root remains covered by the manual verification above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `windmill-extra` image runnable as a non-root UID by fixing cache and HOME handling so the debugger and LSP work without root. The previously added non-root CI smoke test has been removed.

- **Bug Fixes**
  - Dockerfile: add `windmill` user (UID/GID 1000); re-apply permissions after root installs so `/tmp/windmill` and `/pyls/.cache` are world-writable; keep `/tmp/monaco` code read-only (`a+rX` files, `777` dirs) for metadata writes.
  - Entrypoint: redirect unwritable `$HOME` to `/tmp/windmill-home-$(id -u)`; write `$NETRC` to `$HOME/.netrc`; prefer `$HOME/.cache` for `XDG_CACHE_HOME` and fall back to `/pyls/.cache`.

- **Refactors**
  - CI: revert the non-root smoke run; keep the root-only smoke test.

<sup>Written for commit b49c2a8e9737b6c5764e31b69d85059d2614f679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

