### PR TITLE
fix(flows): make updateFlow body path optional so AI can update flows

### DIFF
--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -165,13 +165,14 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
 
     conflicts = (path_keys & query_keys) | (path_keys & body_keys) | (query_keys & body_keys)
 
-    path_field_renames = {}
     query_field_renames = {}
     body_field_renames = {}
 
     for field in conflicts:
+        # The path parameter keeps the plain name: it identifies the item, is what a
+        # caller reaches for first, and matches the non-colliding endpoints (`getFlowByPath`
+        # takes `path`). Only the other locations carry a suffix.
         schemas_and_renames = [
-            (path_params_schema, path_keys, '__path', path_field_renames),
             (query_params_schema, query_keys, '__query', query_field_renames),
             (body_schema, body_keys, '__body', body_field_renames),
         ]
@@ -209,7 +210,7 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
             if isinstance(prop, dict):
                 existing_desc = prop.get('description', '').rstrip('. ')
                 prop['description'] = (
-                    f"{existing_desc}. Defaults to `{field}__path` when omitted; "
+                    f"{existing_desc}. Defaults to `{field}` when omitted; "
                     f"set it only to change the {field}."
                 ).lstrip('. ')
 
@@ -217,7 +218,7 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
     path_params_schema = path_params_schema if path_params_schema and path_params_schema.get('properties') else None
     query_params_schema = query_params_schema if query_params_schema and query_params_schema.get('properties') else None
 
-    return (path_params_schema, query_params_schema, body_schema, path_field_renames, query_field_renames, body_field_renames)
+    return (path_params_schema, query_params_schema, body_schema, query_field_renames, body_field_renames)
 
 # Cache for loaded external files
 _external_file_cache: Dict[str, Dict[str, Any]] = {}
@@ -469,7 +470,7 @@ export const mcpEndpointTools: EndpointTool[] = [];
         method = tool['method'].upper()
 
         # Generate separate schemas
-        path_params_schema, query_params_schema, body_schema, path_field_renames, query_field_renames, body_field_renames = extract_separate_schemas(
+        path_params_schema, query_params_schema, body_schema, query_field_renames, body_field_renames = extract_separate_schemas(
             tool['parameters'], tool['requestBody'], spec, tool['required_fields'], base_path,
             tool.get('include_fields'), tool.get('opaque_fields'), tool.get('include_query_params')
         )
@@ -478,7 +479,6 @@ export const mcpEndpointTools: EndpointTool[] = [];
         path_params_ts = json.dumps(path_params_schema, indent=8) if path_params_schema else "undefined"
         query_params_ts = json.dumps(query_params_schema, indent=8) if query_params_schema else "undefined"
         body_schema_ts = json.dumps(body_schema, indent=8) if body_schema else "undefined"
-        path_field_renames_ts = json.dumps(path_field_renames, indent=8) if path_field_renames else "undefined"
         query_field_renames_ts = json.dumps(query_field_renames, indent=8) if query_field_renames else "undefined"
         body_field_renames_ts = json.dumps(body_field_renames, indent=8) if body_field_renames else "undefined"
 
@@ -492,7 +492,6 @@ export const mcpEndpointTools: EndpointTool[] = [];
         pathParamsSchema: {path_params_ts},
         queryParamsSchema: {query_params_ts},
         bodySchema: {body_schema_ts},
-        pathFieldRenames: {path_field_renames_ts},
         queryFieldRenames: {query_field_renames_ts},
         bodyFieldRenames: {body_field_renames_ts}
     }}"""
@@ -513,7 +512,6 @@ export interface EndpointTool {{
     pathParamsSchema?: object;
     queryParamsSchema?: object;
     bodySchema?: object;
-    pathFieldRenames?: Record<string, string>;
     queryFieldRenames?: Record<string, string>;
     bodyFieldRenames?: Record<string, string>;
 }}
@@ -545,7 +543,7 @@ pub fn all_tools() -> Vec<EndpointTool> {{
         method = tool['method'].upper()
 
         # Generate separate schemas
-        path_params_schema, query_params_schema, body_schema, path_field_renames, query_field_renames, body_field_renames = extract_separate_schemas(
+        path_params_schema, query_params_schema, body_schema, query_field_renames, body_field_renames = extract_separate_schemas(
             tool['parameters'], tool['requestBody'], spec, tool['required_fields'], base_path,
             tool.get('include_fields'), tool.get('opaque_fields'), tool.get('include_query_params')
         )
@@ -553,7 +551,6 @@ pub fn all_tools() -> Vec<EndpointTool> {{
         path_params_rust = schema_to_rust_value(path_params_schema)
         query_params_rust = schema_to_rust_value(query_params_schema)
         body_schema_rust = schema_to_rust_value(body_schema)
-        path_field_renames_rust = schema_to_rust_value(path_field_renames if path_field_renames else None)
         query_field_renames_rust = schema_to_rust_value(query_field_renames if query_field_renames else None)
         body_field_renames_rust = schema_to_rust_value(body_field_renames if body_field_renames else None)
 
@@ -567,7 +564,6 @@ pub fn all_tools() -> Vec<EndpointTool> {{
         path_params_schema: {path_params_rust},
         query_params_schema: {query_params_rust},
         body_schema: {body_schema_rust},
-        path_field_renames: {path_field_renames_rust},
         query_field_renames: {query_field_renames_rust},
         body_field_renames: {body_field_renames_rust},
     }}"""

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -200,8 +200,7 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
 
         # A body field colliding with a same-named path parameter (`path` on the update
         # endpoints) holds the new value and differs only when moving the item, so it must
-        # stay optional: `same_named_path_param_value` (windmill-api/src/mcp/utils.rs)
-        # fills it from the path parameter when the caller omits it.
+        # stay optional; the server defaults it from the URL path when the caller omits it.
         if field in path_keys and field in body_keys and body_schema:
             body_name = field + '__body'
             if 'required' in body_schema:

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -197,6 +197,22 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
                 # Store the reverse mapping: renamed -> original
                 renames_map[new_name] = field
 
+        # A body field colliding with a same-named path parameter (`path` on the update
+        # endpoints) holds the new value and differs only when moving the item, so it must
+        # stay optional: `same_named_path_param_value` (windmill-api/src/mcp/utils.rs)
+        # fills it from the path parameter when the caller omits it.
+        if field in path_keys and field in body_keys and body_schema:
+            body_name = field + '__body'
+            if 'required' in body_schema:
+                body_schema['required'] = [r for r in body_schema['required'] if r != body_name]
+            prop = body_schema['properties'].get(body_name)
+            if isinstance(prop, dict):
+                existing_desc = prop.get('description', '').rstrip('. ')
+                prop['description'] = (
+                    f"{existing_desc}. Defaults to `{field}__path` when omitted; "
+                    f"set it only to change the {field}."
+                ).lstrip('. ')
+
     # Return None for empty schemas
     path_params_schema = path_params_schema if path_params_schema and path_params_schema.get('properties') else None
     query_params_schema = query_params_schema if query_params_schema and query_params_schema.get('properties') else None

--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -47,7 +47,7 @@ use windmill_common::HUB_BASE_URL;
 use windmill_common::{
     db::UserDB,
     error::{self, to_anyhow, Error, JsonResult, Result},
-    flows::{Flow, FlowWithStarred, ListFlowQuery, ListableFlow, NewFlow},
+    flows::{EditFlow, Flow, FlowWithStarred, ListFlowQuery, ListableFlow, NewFlow},
     jobs::JobPayload,
     schedule::Schedule,
     utils::{http_get_from_hub, not_found_if_none, paginate, Pagination, RunnableKind, StripPath},
@@ -1007,7 +1007,7 @@ async fn update_flow(
     Extension(db): Extension<DB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, flow_path)): Path<(String, StripPath)>,
-    Json(nf): Json<NewFlow>,
+    Json(ef): Json<EditFlow>,
 ) -> Result<String> {
     if authed.is_operator {
         return Err(Error::NotAuthorized(
@@ -1015,6 +1015,8 @@ async fn update_flow(
         ));
     }
     let flow_path = flow_path.to_path();
+    // The URL identifies the flow being updated; the body path is only needed to rename.
+    let nf = ef.into_new_flow(flow_path);
     check_scopes(&authed, || format!("flows:write:{}", flow_path))?;
 
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10775,7 +10775,7 @@ paths:
           application/json:
             schema:
               allOf:
-                - $ref: "#/components/schemas/OpenFlowWPath"
+                - $ref: "#/components/schemas/EditFlow"
                 - type: object
                   properties:
                     deployment_message:
@@ -29097,6 +29097,37 @@ components:
                 type: string
           required:
             - path
+    # Like OpenFlowWPath but `path` is optional: on update the flow is identified by
+    # the URL, so the body path is only needed to rename it. Kept as a separate schema
+    # (rather than making OpenFlowWPath.path optional) so createFlow still requires path.
+    EditFlow:
+      allOf:
+        - $ref: "../../openflow.openapi.yaml#/components/schemas/OpenFlow"
+        - type: object
+          properties:
+            path:
+              type: string
+            tag:
+              type: string
+            ws_error_handler_muted:
+              type: boolean
+            priority:
+              type: integer
+            dedicated_worker:
+              type: boolean
+            timeout:
+              type: number
+            visible_to_runner_only:
+              type: boolean
+            on_behalf_of_email:
+              type: string
+            preserve_on_behalf_of:
+              type: boolean
+              description: "When true and the caller is a member of the 'wm_deployers' group, preserves the original on_behalf_of_email value instead of overwriting it."
+            labels:
+              type: array
+              items:
+                type: string
 
     FlowPreview:
       type: object

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -26,7 +26,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         ]
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -54,7 +53,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         ]
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -124,7 +122,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 "description"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -147,7 +144,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
 })),
         query_params_schema: None,
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -160,13 +156,12 @@ pub fn all_tools() -> Vec<EndpointTool> {
         path_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 })),
         query_params_schema: Some(serde_json::json!({
@@ -205,12 +200,9 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the variable (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "The path to the variable (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         }
-})),
-        path_field_renames: Some(serde_json::json!({
-        "path__path": "path"
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -253,7 +245,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -307,7 +298,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -362,7 +352,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 "resource_type"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -385,7 +374,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
 })),
         query_params_schema: None,
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -398,13 +386,12 @@ pub fn all_tools() -> Vec<EndpointTool> {
         path_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 })),
         query_params_schema: None,
@@ -433,12 +420,9 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the resource (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "The path to the resource (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         }
-})),
-        path_field_renames: Some(serde_json::json!({
-        "path__path": "path"
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -473,7 +457,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -535,7 +518,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -548,7 +530,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         path_params_schema: None,
         query_params_schema: None,
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -646,7 +627,6 @@ pub fn all_tools() -> Vec<EndpointTool> {
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -699,7 +679,6 @@ Creates a new version of an existing script when called with the same path and t
                 "language"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -722,7 +701,6 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_params_schema: None,
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -754,7 +732,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -789,7 +766,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -816,7 +792,6 @@ Creates a new version of an existing script when called with the same path and t
         "description": "The arguments to pass to the script or flow",
         "additionalProperties": true
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -886,7 +861,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -921,7 +895,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -967,7 +940,6 @@ Creates a new version of an existing script when called with the same path and t
         ],
         "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -980,13 +952,12 @@ Creates a new version of an existing script when called with the same path and t
         path_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 })),
         query_params_schema: None,
@@ -1015,7 +986,7 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "(body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         },
         "required": [
@@ -1023,9 +994,6 @@ Creates a new version of an existing script when called with the same path and t
                 "value"
         ],
         "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
-})),
-        path_field_renames: Some(serde_json::json!({
-        "path__path": "path"
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -1060,7 +1028,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1098,7 +1065,6 @@ Creates a new version of an existing script when called with the same path and t
                 "policy"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1111,13 +1077,12 @@ Creates a new version of an existing script when called with the same path and t
         path_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 })),
         query_params_schema: None,
@@ -1138,12 +1103,9 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "(body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         }
-})),
-        path_field_renames: Some(serde_json::json!({
-        "path__path": "path"
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -1173,7 +1135,6 @@ Creates a new version of an existing script when called with the same path and t
         "description": "The arguments to pass to the script or flow",
         "additionalProperties": true
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1268,7 +1229,6 @@ Creates a new version of an existing script when called with the same path and t
                 "language"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1389,7 +1349,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1556,7 +1515,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1595,7 +1553,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1627,7 +1584,6 @@ Creates a new version of an existing script when called with the same path and t
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -1840,7 +1796,6 @@ You should get the schema of the script or flow before creating the schedule to 
                 "args"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -2046,7 +2001,6 @@ You should get the schema of the script or flow before updating the schedule to 
                 "args"
         ]
 })),
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -2069,7 +2023,6 @@ You should get the schema of the script or flow before updating the schedule to 
 })),
         query_params_schema: None,
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -2101,7 +2054,6 @@ You should get the schema of the script or flow before updating the schedule to 
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -2167,7 +2119,6 @@ You should get the schema of the script or flow before updating the schedule to 
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     },
@@ -2197,7 +2148,6 @@ You should get the schema of the script or flow before updating the schedule to 
         "required": []
 })),
         body_schema: None,
-        path_field_renames: None,
         query_field_renames: None,
         body_field_renames: None,
     }

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -205,7 +205,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the variable (body parameter)"
+                        "description": "The path to the variable (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         }
 })),
@@ -433,7 +433,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the resource (body parameter)"
+                        "description": "The path to the resource (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         }
 })),
@@ -1015,13 +1015,12 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter)"
+                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         },
         "required": [
                 "summary",
-                "value",
-                "path__body"
+                "value"
         ],
         "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
 })),
@@ -1139,7 +1138,7 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter)"
+                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         }
 })),

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -295,7 +295,6 @@ impl McpBackend for WindmillBackend {
             workspace_id,
             args_map,
             &endpoint_tool.path_params_schema,
-            &endpoint_tool.path_field_renames,
         )?;
         let query_string = build_query_string(
             args_map,
@@ -314,7 +313,6 @@ impl McpBackend for WindmillBackend {
             &endpoint_tool.body_schema,
             &endpoint_tool.body_field_renames,
             &endpoint_tool.path_params_schema,
-            &endpoint_tool.path_field_renames,
             &endpoint_tool.query_params_schema,
         );
 

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -314,6 +314,7 @@ impl McpBackend for WindmillBackend {
             &endpoint_tool.body_schema,
             &endpoint_tool.body_field_renames,
             &endpoint_tool.path_params_schema,
+            &endpoint_tool.path_field_renames,
             &endpoint_tool.query_params_schema,
         );
 

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -295,7 +295,7 @@ pub async fn get_hub_script_schema(path: &str, db: &DB) -> Result<Option<Schema>
 // ============================================================================
 
 /// Look up the original field name from a field_renames map.
-/// field_renames maps renamed_key -> original_key (e.g. {"path__path": "path"}).
+/// field_renames maps renamed_key -> original_key (e.g. {"path__body": "path"}).
 fn get_original_name(renamed_key: &str, field_renames: &Option<Value>) -> String {
     field_renames
         .as_ref()
@@ -373,20 +373,17 @@ pub fn substitute_path_params(
     workspace_id: &str,
     args_map: &serde_json::Map<String, Value>,
     path_schema: &Option<Value>,
-    path_field_renames: &Option<Value>,
 ) -> BackendResult<String> {
     let mut path_template = path.replace("{workspace}", workspace_id);
 
     if let Some(schema) = path_schema {
         if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
             for (param_name, _) in props {
-                // param_name may be renamed (e.g. "path__path"), get original for URL placeholder
-                let original_name = get_original_name(param_name, path_field_renames);
-                let placeholder = format!("{{{}}}", original_name);
+                let placeholder = format!("{{{}}}", param_name);
                 match args_map.get(param_name) {
                     Some(param_value) => {
                         if let Some(str_val) = param_value.as_str() {
-                            validate_path_param_value(&original_name, str_val)?;
+                            validate_path_param_value(param_name, str_val)?;
                             path_template = path_template.replace(&placeholder, str_val);
                         }
                     }
@@ -451,7 +448,7 @@ pub fn build_query_string(
     }
 }
 
-/// Value of the path parameter whose original (un-mangled) name is `original_name`.
+/// Value of the path parameter named `original_name`.
 ///
 /// A same-named body field is optional and clients routinely omit it, but the API still
 /// requires the key in the body and rejects the request without it.
@@ -459,15 +456,13 @@ fn same_named_path_param_value<'a>(
     original_name: &str,
     args_map: &'a serde_json::Map<String, Value>,
     path_params_schema: &Option<Value>,
-    path_field_renames: &Option<Value>,
 ) -> Option<&'a Value> {
     path_params_schema
         .as_ref()?
         .get("properties")?
         .as_object()?
-        .keys()
-        .find(|param_name| get_original_name(param_name, path_field_renames) == original_name)
-        .and_then(|param_name| args_map.get(param_name))
+        .contains_key(original_name)
+        .then(|| args_map.get(original_name))?
 }
 
 /// Build request body from arguments
@@ -477,7 +472,6 @@ pub fn build_request_body(
     body_schema: &Option<Value>,
     body_field_renames: &Option<Value>,
     path_params_schema: &Option<Value>,
-    path_field_renames: &Option<Value>,
     query_params_schema: &Option<Value>,
 ) -> Option<Value> {
     if method == "GET" {
@@ -534,13 +528,8 @@ pub fn build_request_body(
             // counterpart keep their null, which the API reads as absent anyway.
             let value = match arg {
                 Some(value) if !value.is_null() => Some(value),
-                _ => same_named_path_param_value(
-                    &original_name,
-                    args_map,
-                    path_params_schema,
-                    path_field_renames,
-                )
-                .or(arg),
+                _ => same_named_path_param_value(&original_name, args_map, path_params_schema)
+                    .or(arg),
             }?;
             Some((original_name, value.clone()))
         })
@@ -675,16 +664,8 @@ mod tests {
         .unwrap()
         .clone();
 
-        let body = build_request_body(
-            "POST",
-            &args,
-            &body_schema,
-            &None,
-            &path_schema,
-            &None,
-            &None,
-        )
-        .expect("passthrough body should be built");
+        let body = build_request_body("POST", &args, &body_schema, &None, &path_schema, &None)
+            .expect("passthrough body should be built");
         let obj = body.as_object().unwrap();
         assert_eq!(obj.get("name"), Some(&json!("alice")));
         assert_eq!(obj.get("count"), Some(&json!(3)));
@@ -706,8 +687,7 @@ mod tests {
             .as_object()
             .unwrap()
             .clone();
-        let body =
-            build_request_body("POST", &args, &body_schema, &None, &None, &None, &None).unwrap();
+        let body = build_request_body("POST", &args, &body_schema, &None, &None, &None).unwrap();
         let obj = body.as_object().unwrap();
         assert_eq!(obj.get("value"), Some(&json!("x")));
         assert!(
@@ -716,16 +696,15 @@ mod tests {
         );
     }
 
-    // updateFlow-shaped: `path` exists both as a path parameter and as a required
-    // body field, so both are exposed under mangled names.
-    fn update_flow_schemas() -> (Option<Value>, Option<Value>, Option<Value>, Option<Value>) {
+    // updateFlow-shaped: `path` is both a path parameter and a body field. The path
+    // parameter keeps the plain name; only the body side is mangled.
+    fn update_flow_schemas() -> (Option<Value>, Option<Value>, Option<Value>) {
         (
             Some(json!({
                 "type": "object",
-                "properties": { "path__path": { "type": "string" } },
-                "required": ["path__path"]
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"]
             })),
-            Some(json!({ "path__path": "path" })),
             Some(json!({
                 "type": "object",
                 "properties": {
@@ -741,11 +720,11 @@ mod tests {
 
     #[test]
     fn build_request_body_defaults_body_path_to_path_param() {
-        let (path_schema, path_renames, body_schema, body_renames) = update_flow_schemas();
+        let (path_schema, body_schema, body_renames) = update_flow_schemas();
         // Omitted entirely, and explicitly nulled: clients do both.
         for args in [
-            json!({ "path__path": "f/team/my_flow", "summary": "s", "value": {} }),
-            json!({ "path__path": "f/team/my_flow", "path__body": null, "summary": "s", "value": {} }),
+            json!({ "path": "f/team/my_flow", "summary": "s", "value": {} }),
+            json!({ "path": "f/team/my_flow", "path__body": null, "summary": "s", "value": {} }),
         ] {
             let args = args.as_object().unwrap().clone();
             let body = build_request_body(
@@ -754,7 +733,6 @@ mod tests {
                 &body_schema,
                 &body_renames,
                 &path_schema,
-                &path_renames,
                 &None,
             )
             .expect("body should be built");
@@ -768,9 +746,9 @@ mod tests {
 
     #[test]
     fn build_request_body_keeps_explicit_body_path() {
-        let (path_schema, path_renames, body_schema, body_renames) = update_flow_schemas();
+        let (path_schema, body_schema, body_renames) = update_flow_schemas();
         let args: serde_json::Map<String, Value> = json!({
-            "path__path": "f/team/my_flow",
+            "path": "f/team/my_flow",
             "path__body": "f/team/renamed_flow",
             "summary": "s",
             "value": {}
@@ -785,7 +763,6 @@ mod tests {
             &body_schema,
             &body_renames,
             &path_schema,
-            &path_renames,
             &None,
         )
         .expect("body should be built");
@@ -800,9 +777,7 @@ mod tests {
     fn build_request_body_get_has_no_body() {
         let body_schema = Some(json!({ "type": "object", "additionalProperties": true }));
         let args: serde_json::Map<String, Value> = json!({ "a": 1 }).as_object().unwrap().clone();
-        assert!(
-            build_request_body("GET", &args, &body_schema, &None, &None, &None, &None).is_none()
-        );
+        assert!(build_request_body("GET", &args, &body_schema, &None, &None, &None).is_none());
     }
 
     #[test]
@@ -868,7 +843,6 @@ mod tests {
             "dev",
             &args,
             &path_schema,
-            &None,
         );
         assert!(
             result.is_err(),
@@ -890,7 +864,6 @@ mod tests {
             "dev",
             &args,
             &path_schema,
-            &None,
         )
         .expect("legitimate path should substitute");
         assert_eq!(result, "/w/dev/scripts/get/p/u/alice/my_script");

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -698,7 +698,7 @@ mod tests {
     fn build_request_body_maps_body_path_alias_for_rename() {
         // The mangled body field carries the *new* path when renaming; it must reach the
         // API under its original name `path`. (An omitted `path__body` is intentionally
-        // absent from the body — the server defaults it from the URL path parameter.)
+        // absent from the body; the server defaults it from the URL path parameter.)
         let (path_schema, body_schema, body_renames) = update_flow_schemas();
         let args: serde_json::Map<String, Value> = json!({
             "path": "f/team/my_flow",

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -451,6 +451,28 @@ pub fn build_query_string(
     }
 }
 
+/// Look up the argument supplied for the path parameter whose original (un-mangled)
+/// name is `original_name`.
+///
+/// A body field and a path parameter sharing an original name are exposed to the client
+/// under distinct mangled names (`path__body` / `path__path`), and the body field is
+/// optional. Callers routinely send only `path__path`, which must still produce a body
+/// carrying `path` — the API requires it and rejects the request otherwise.
+fn same_named_path_param_value<'a>(
+    original_name: &str,
+    args_map: &'a serde_json::Map<String, Value>,
+    path_params_schema: &Option<Value>,
+    path_field_renames: &Option<Value>,
+) -> Option<&'a Value> {
+    path_params_schema
+        .as_ref()?
+        .get("properties")?
+        .as_object()?
+        .keys()
+        .find(|param_name| get_original_name(param_name, path_field_renames) == original_name)
+        .and_then(|param_name| args_map.get(param_name))
+}
+
 /// Build request body from arguments
 pub fn build_request_body(
     method: &str,
@@ -458,6 +480,7 @@ pub fn build_request_body(
     body_schema: &Option<Value>,
     body_field_renames: &Option<Value>,
     path_params_schema: &Option<Value>,
+    path_field_renames: &Option<Value>,
     query_params_schema: &Option<Value>,
 ) -> Option<Value> {
     if method == "GET" {
@@ -506,11 +529,23 @@ pub fn build_request_body(
     let body_map: serde_json::Map<String, Value> = props
         .keys()
         .filter_map(|param_name| {
-            args_map.get(param_name).map(|value| {
-                // Use the original name as the key in the request body
-                let original_name = get_original_name(param_name, body_field_renames);
-                (original_name, value.clone())
-            })
+            // Use the original name as the key in the request body
+            let original_name = get_original_name(param_name, body_field_renames);
+            let arg = args_map.get(param_name);
+            // An explicit null is treated as "not supplied" for the fallback only:
+            // clients commonly null out optional fields. Fields without a path
+            // counterpart keep their null, which the API reads as absent anyway.
+            let value = match arg {
+                Some(value) if !value.is_null() => Some(value),
+                _ => same_named_path_param_value(
+                    &original_name,
+                    args_map,
+                    path_params_schema,
+                    path_field_renames,
+                )
+                .or(arg),
+            }?;
+            Some((original_name, value.clone()))
         })
         .collect();
 
@@ -643,8 +678,16 @@ mod tests {
         .unwrap()
         .clone();
 
-        let body = build_request_body("POST", &args, &body_schema, &None, &path_schema, &None)
-            .expect("passthrough body should be built");
+        let body = build_request_body(
+            "POST",
+            &args,
+            &body_schema,
+            &None,
+            &path_schema,
+            &None,
+            &None,
+        )
+        .expect("passthrough body should be built");
         let obj = body.as_object().unwrap();
         assert_eq!(obj.get("name"), Some(&json!("alice")));
         assert_eq!(obj.get("count"), Some(&json!(3)));
@@ -666,7 +709,8 @@ mod tests {
             .as_object()
             .unwrap()
             .clone();
-        let body = build_request_body("POST", &args, &body_schema, &None, &None, &None).unwrap();
+        let body =
+            build_request_body("POST", &args, &body_schema, &None, &None, &None, &None).unwrap();
         let obj = body.as_object().unwrap();
         assert_eq!(obj.get("value"), Some(&json!("x")));
         assert!(
@@ -675,11 +719,93 @@ mod tests {
         );
     }
 
+    // updateFlow-shaped: `path` exists both as a path parameter and as a required
+    // body field, so both are exposed under mangled names.
+    fn update_flow_schemas() -> (Option<Value>, Option<Value>, Option<Value>, Option<Value>) {
+        (
+            Some(json!({
+                "type": "object",
+                "properties": { "path__path": { "type": "string" } },
+                "required": ["path__path"]
+            })),
+            Some(json!({ "path__path": "path" })),
+            Some(json!({
+                "type": "object",
+                "properties": {
+                    "summary": { "type": "string" },
+                    "value": { "type": "object" },
+                    "path__body": { "type": "string" }
+                },
+                "required": ["summary", "value"]
+            })),
+            Some(json!({ "path__body": "path" })),
+        )
+    }
+
+    #[test]
+    fn build_request_body_defaults_body_path_to_path_param() {
+        let (path_schema, path_renames, body_schema, body_renames) = update_flow_schemas();
+        // Omitted entirely, and explicitly nulled: clients do both.
+        for args in [
+            json!({ "path__path": "f/team/my_flow", "summary": "s", "value": {} }),
+            json!({ "path__path": "f/team/my_flow", "path__body": null, "summary": "s", "value": {} }),
+        ] {
+            let args = args.as_object().unwrap().clone();
+            let body = build_request_body(
+                "POST",
+                &args,
+                &body_schema,
+                &body_renames,
+                &path_schema,
+                &path_renames,
+                &None,
+            )
+            .expect("body should be built");
+            assert_eq!(
+                body.as_object().unwrap().get("path"),
+                Some(&json!("f/team/my_flow")),
+                "an absent path__body must default to the path parameter"
+            );
+        }
+    }
+
+    #[test]
+    fn build_request_body_keeps_explicit_body_path() {
+        let (path_schema, path_renames, body_schema, body_renames) = update_flow_schemas();
+        let args: serde_json::Map<String, Value> = json!({
+            "path__path": "f/team/my_flow",
+            "path__body": "f/team/renamed_flow",
+            "summary": "s",
+            "value": {}
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let body = build_request_body(
+            "POST",
+            &args,
+            &body_schema,
+            &body_renames,
+            &path_schema,
+            &path_renames,
+            &None,
+        )
+        .expect("body should be built");
+        assert_eq!(
+            body.as_object().unwrap().get("path"),
+            Some(&json!("f/team/renamed_flow")),
+            "an explicit path__body renames the item and must win"
+        );
+    }
+
     #[test]
     fn build_request_body_get_has_no_body() {
         let body_schema = Some(json!({ "type": "object", "additionalProperties": true }));
         let args: serde_json::Map<String, Value> = json!({ "a": 1 }).as_object().unwrap().clone();
-        assert!(build_request_body("GET", &args, &body_schema, &None, &None, &None).is_none());
+        assert!(
+            build_request_body("GET", &args, &body_schema, &None, &None, &None, &None).is_none()
+        );
     }
 
     #[test]

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -451,13 +451,10 @@ pub fn build_query_string(
     }
 }
 
-/// Look up the argument supplied for the path parameter whose original (un-mangled)
-/// name is `original_name`.
+/// Value of the path parameter whose original (un-mangled) name is `original_name`.
 ///
-/// A body field and a path parameter sharing an original name are exposed to the client
-/// under distinct mangled names (`path__body` / `path__path`), and the body field is
-/// optional. Callers routinely send only `path__path`, which must still produce a body
-/// carrying `path` — the API requires it and rejects the request otherwise.
+/// A same-named body field is optional and clients routinely omit it, but the API still
+/// requires the key in the body and rejects the request without it.
 fn same_named_path_param_value<'a>(
     original_name: &str,
     args_map: &'a serde_json::Map<String, Value>,

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -448,23 +448,6 @@ pub fn build_query_string(
     }
 }
 
-/// Value of the path parameter named `original_name`.
-///
-/// A same-named body field is optional and clients routinely omit it, but the API still
-/// requires the key in the body and rejects the request without it.
-fn same_named_path_param_value<'a>(
-    original_name: &str,
-    args_map: &'a serde_json::Map<String, Value>,
-    path_params_schema: &Option<Value>,
-) -> Option<&'a Value> {
-    path_params_schema
-        .as_ref()?
-        .get("properties")?
-        .as_object()?
-        .contains_key(original_name)
-        .then(|| args_map.get(original_name))?
-}
-
 /// Build request body from arguments
 pub fn build_request_body(
     method: &str,
@@ -520,18 +503,11 @@ pub fn build_request_body(
     let body_map: serde_json::Map<String, Value> = props
         .keys()
         .filter_map(|param_name| {
-            // Use the original name as the key in the request body
-            let original_name = get_original_name(param_name, body_field_renames);
-            let arg = args_map.get(param_name);
-            // An explicit null is treated as "not supplied" for the fallback only:
-            // clients commonly null out optional fields. Fields without a path
-            // counterpart keep their null, which the API reads as absent anyway.
-            let value = match arg {
-                Some(value) if !value.is_null() => Some(value),
-                _ => same_named_path_param_value(&original_name, args_map, path_params_schema)
-                    .or(arg),
-            }?;
-            Some((original_name, value.clone()))
+            args_map.get(param_name).map(|value| {
+                // Use the original name as the key in the request body
+                let original_name = get_original_name(param_name, body_field_renames);
+                (original_name, value.clone())
+            })
         })
         .collect();
 
@@ -719,33 +695,10 @@ mod tests {
     }
 
     #[test]
-    fn build_request_body_defaults_body_path_to_path_param() {
-        let (path_schema, body_schema, body_renames) = update_flow_schemas();
-        // Omitted entirely, and explicitly nulled: clients do both.
-        for args in [
-            json!({ "path": "f/team/my_flow", "summary": "s", "value": {} }),
-            json!({ "path": "f/team/my_flow", "path__body": null, "summary": "s", "value": {} }),
-        ] {
-            let args = args.as_object().unwrap().clone();
-            let body = build_request_body(
-                "POST",
-                &args,
-                &body_schema,
-                &body_renames,
-                &path_schema,
-                &None,
-            )
-            .expect("body should be built");
-            assert_eq!(
-                body.as_object().unwrap().get("path"),
-                Some(&json!("f/team/my_flow")),
-                "an absent path__body must default to the path parameter"
-            );
-        }
-    }
-
-    #[test]
-    fn build_request_body_keeps_explicit_body_path() {
+    fn build_request_body_maps_body_path_alias_for_rename() {
+        // The mangled body field carries the *new* path when renaming; it must reach the
+        // API under its original name `path`. (An omitted `path__body` is intentionally
+        // absent from the body — the server defaults it from the URL path parameter.)
         let (path_schema, body_schema, body_renames) = update_flow_schemas();
         let args: serde_json::Map<String, Value> = json!({
             "path": "f/team/my_flow",
@@ -769,7 +722,7 @@ mod tests {
         assert_eq!(
             body.as_object().unwrap().get("path"),
             Some(&json!("f/team/renamed_flow")),
-            "an explicit path__body renames the item and must win"
+            "path__body must be sent as `path` so a rename takes effect"
         );
     }
 

--- a/backend/windmill-mcp/src/server/endpoints.rs
+++ b/backend/windmill-mcp/src/server/endpoints.rs
@@ -21,7 +21,6 @@ pub struct EndpointTool {
     pub path_params_schema: Option<serde_json::Value>,
     pub query_params_schema: Option<serde_json::Value>,
     pub body_schema: Option<serde_json::Value>,
-    pub path_field_renames: Option<serde_json::Value>,
     pub query_field_renames: Option<serde_json::Value>,
     pub body_field_renames: Option<serde_json::Value>,
 }
@@ -215,7 +214,6 @@ mod tests {
                 "required": []
             })),
             body_schema: None,
-            path_field_renames: None,
             query_field_renames: None,
             body_field_renames: None,
         }

--- a/backend/windmill-types/src/flows.rs
+++ b/backend/windmill-types/src/flows.rs
@@ -1286,13 +1286,11 @@ mod tests {
 
     #[test]
     fn edit_flow_defaults_path_from_url_and_renames_when_given() {
-        // Omitted body path: update in place at the URL path (GIT-925 — a body
-        // without `path` used to fail deserialization on the required NewFlow.path).
+        // An omitted body path resolves to the URL path; an explicit body path renames.
         let ef: EditFlow =
             serde_json::from_value(json!({ "summary": "s", "value": { "modules": [] } })).unwrap();
         assert_eq!(ef.into_new_flow("f/team/my_flow").path, "f/team/my_flow");
 
-        // Explicit body path: rename to it.
         let ef: EditFlow = serde_json::from_value(
             json!({ "path": "f/team/renamed", "summary": "s", "value": { "modules": [] } }),
         )

--- a/backend/windmill-types/src/flows.rs
+++ b/backend/windmill-types/src/flows.rs
@@ -145,6 +145,57 @@ impl NewFlow {
     }
 }
 
+/// Body for updating an existing flow. Mirrors `NewFlow`, but `path` is optional: the
+/// flow to update is identified by the URL, so the body only needs `path` to rename it.
+/// This matches the `EditVariable` / `EditResource` / `EditApp` convention and lets a
+/// caller update in place without restating the path.
+#[derive(Debug, Deserialize)]
+pub struct EditFlow {
+    #[serde(default)]
+    pub path: Option<String>,
+    pub summary: String,
+    pub description: Option<String>,
+    #[serde(deserialize_with = "validate_flow_value")]
+    pub value: Box<RawValue>,
+    pub schema: Option<Schema>,
+    pub tag: Option<String>,
+    pub dedicated_worker: Option<bool>,
+    pub timeout: Option<i32>,
+    pub deployment_message: Option<String>,
+    pub visible_to_runner_only: Option<bool>,
+    pub on_behalf_of_email: Option<String>,
+    pub preserve_on_behalf_of: Option<bool>,
+    pub ws_error_handler_muted: Option<bool>,
+    #[serde(default)]
+    pub labels: Option<Vec<String>>,
+    #[serde(default)]
+    pub skip_draft_deletion: Option<bool>,
+}
+
+impl EditFlow {
+    /// Resolve into a `NewFlow`, defaulting the target path to `current_path` (the flow's
+    /// URL path) when the body omits it. A body `path` that differs renames the flow.
+    pub fn into_new_flow(self, current_path: &str) -> NewFlow {
+        NewFlow {
+            path: self.path.unwrap_or_else(|| current_path.to_string()),
+            summary: self.summary,
+            description: self.description,
+            value: self.value,
+            schema: self.schema,
+            tag: self.tag,
+            dedicated_worker: self.dedicated_worker,
+            timeout: self.timeout,
+            deployment_message: self.deployment_message,
+            visible_to_runner_only: self.visible_to_runner_only,
+            on_behalf_of_email: self.on_behalf_of_email,
+            preserve_on_behalf_of: self.preserve_on_behalf_of,
+            ws_error_handler_muted: self.ws_error_handler_muted,
+            labels: self.labels,
+            skip_draft_deletion: self.skip_draft_deletion,
+        }
+    }
+}
+
 fn validate_retry(retry: &Retry, module_id: &str) -> anyhow::Result<()> {
     if retry.exponential.attempts > 0 && retry.exponential.seconds == 0 {
         return Err(anyhow::anyhow!(
@@ -1232,6 +1283,22 @@ pub fn add_virtual_items_if_necessary(modules: &mut Vec<FlowModule>) {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn edit_flow_defaults_path_from_url_and_renames_when_given() {
+        // Omitted body path: update in place at the URL path (GIT-925 — a body
+        // without `path` used to fail deserialization on the required NewFlow.path).
+        let ef: EditFlow =
+            serde_json::from_value(json!({ "summary": "s", "value": { "modules": [] } })).unwrap();
+        assert_eq!(ef.into_new_flow("f/team/my_flow").path, "f/team/my_flow");
+
+        // Explicit body path: rename to it.
+        let ef: EditFlow = serde_json::from_value(
+            json!({ "path": "f/team/renamed", "summary": "s", "value": { "modules": [] } }),
+        )
+        .unwrap();
+        assert_eq!(ef.into_new_flow("f/team/my_flow").path, "f/team/renamed");
+    }
 
     #[test]
     fn flow_value_ignores_notes_and_groups() {

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -215,7 +215,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the variable (body parameter)"
+                        "description": "The path to the variable (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         }
 },
@@ -443,7 +443,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the resource (body parameter)"
+                        "description": "The path to the resource (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         }
 },
@@ -1024,13 +1024,12 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter)"
+                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         },
         "required": [
                 "summary",
-                "value",
-                "path__body"
+                "value"
         ],
         "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
 },
@@ -1148,7 +1147,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter)"
+                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
                 }
         }
 },

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -10,7 +10,6 @@ export interface EndpointTool {
     pathParamsSchema?: object;
     queryParamsSchema?: object;
     bodySchema?: object;
-    pathFieldRenames?: Record<string, string>;
     queryFieldRenames?: Record<string, string>;
     bodyFieldRenames?: Record<string, string>;
 }
@@ -36,7 +35,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         ]
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -64,7 +62,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         ]
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -134,7 +131,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "description"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -157,7 +153,6 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         queryParamsSchema: undefined,
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -170,13 +165,12 @@ export const mcpEndpointTools: EndpointTool[] = [
         pathParamsSchema: {
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 },
         queryParamsSchema: {
@@ -215,12 +209,9 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the variable (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "The path to the variable (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         }
-},
-        pathFieldRenames: {
-        "path__path": "path"
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -263,7 +254,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -317,7 +307,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -372,7 +361,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "resource_type"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -395,7 +383,6 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         queryParamsSchema: undefined,
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -408,13 +395,12 @@ export const mcpEndpointTools: EndpointTool[] = [
         pathParamsSchema: {
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 },
         queryParamsSchema: undefined,
@@ -443,12 +429,9 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "The path to the resource (body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "The path to the resource (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         }
-},
-        pathFieldRenames: {
-        "path__path": "path"
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -483,7 +466,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -545,7 +527,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -558,7 +539,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         pathParamsSchema: undefined,
         queryParamsSchema: undefined,
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -656,7 +636,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -708,7 +687,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "language"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -731,7 +709,6 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         queryParamsSchema: undefined,
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -763,7 +740,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -798,7 +774,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -825,7 +800,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "description": "The arguments to pass to the script or flow",
         "additionalProperties": true
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -895,7 +869,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -930,7 +903,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -976,7 +948,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         ],
         "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -989,13 +960,12 @@ export const mcpEndpointTools: EndpointTool[] = [
         pathParamsSchema: {
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 },
         queryParamsSchema: undefined,
@@ -1024,7 +994,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "(body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         },
         "required": [
@@ -1032,9 +1002,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "value"
         ],
         "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
-},
-        pathFieldRenames: {
-        "path__path": "path"
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -1069,7 +1036,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1107,7 +1073,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "policy"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1120,13 +1085,12 @@ export const mcpEndpointTools: EndpointTool[] = [
         pathParamsSchema: {
         "type": "object",
         "properties": {
-                "path__path": {
-                        "type": "string",
-                        "description": "(path parameter)"
+                "path": {
+                        "type": "string"
                 }
         },
         "required": [
-                "path__path"
+                "path"
         ]
 },
         queryParamsSchema: undefined,
@@ -1147,12 +1111,9 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "path__body": {
                         "type": "string",
-                        "description": "(body parameter). Defaults to `path__path` when omitted; set it only to change the path."
+                        "description": "(body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
         }
-},
-        pathFieldRenames: {
-        "path__path": "path"
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -1182,7 +1143,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "description": "The arguments to pass to the script or flow",
         "additionalProperties": true
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1277,7 +1237,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "language"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1398,7 +1357,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1565,7 +1523,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1604,7 +1561,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1636,7 +1592,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -1846,7 +1801,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "args"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -2049,7 +2003,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "args"
         ]
 },
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -2072,7 +2025,6 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         queryParamsSchema: undefined,
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -2104,7 +2056,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -2170,7 +2121,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
@@ -2200,7 +2150,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "required": []
 },
         bodySchema: undefined,
-        pathFieldRenames: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     }


### PR DESCRIPTION
## Summary

Fixes GIT-925. The MCP `updateFlow` tool (and any client hitting `POST /flows/update/{path}` without a body `path`) failed with:

```
HTTP 422: Failed to deserialize the JSON body into the target type: missing field `path`
```

### Root cause

`update_flow` deserializes its body as `Json<NewFlow>`, and `NewFlow.path` is a **required** `String`. `NewFlow` is shared with `createFlow`, where `path` genuinely is required (there is no URL to take it from). But on update, the flow to change is already identified by the URL `{path}`, so the body `path` is only needed to *rename*. A client that updated a flow in place, sending a body without `path`, was rejected by serde before the handler ran.

`updateFlow` was the only in-place update endpoint to break outright: `updateVariable`, `updateResource`, and `updateApp` already take an **optional** body `path` (`EditVariable` / `EditResource` / `EditApp`), so they tolerated its absence and kept the existing path. `updateFlow` reusing the create struct was the odd one out.

### Fix (server-side, covers every client)

Add an `EditFlow` request struct that mirrors `NewFlow` but with `path: Option<String>`, and have `update_flow` default the body path from the URL when it is omitted (`into_new_flow`). This matches the existing `Edit*` convention and fixes the 422 at the API layer for the MCP tool, the in-app AI chat, and raw HTTP alike. `createFlow` is untouched and still requires `path`.

A body `path` that differs from the URL still renames the flow, exactly as before.

### MCP schema cleanup (same PR)

While here, the MCP endpoint-tool generator no longer name-mangles the *path* side of a field collision. `path` collides with the body field on the four `.../update/{path}` tools, and the generator used to expose it to the model as `path__path`. Now the path parameter keeps its plain name (identical to `getFlowByPath`), and only the body side becomes an optional `path__body` (used to rename). The now-dead `path_field_renames` plumbing is removed from the generator, the `EndpointTool` struct, the TS interface, and `substitute_path_params`; it was never part of the openapi `EndpointTool` schema, so generated types are unchanged.

## Changes

- `windmill-types/src/flows.rs`: add `EditFlow` (optional `path`) + `into_new_flow(url_path)`.
- `windmill-api-flows/src/flows.rs`: `update_flow` takes `Json<EditFlow>` and defaults the path from the URL.
- `generate_mcp_endpoints_tools/generate_mcp_tools.py`: never suffix the path side of a collision; drop the colliding body field from `required`; remove `path_field_renames` emission.
- `windmill-api/src/mcp/{utils,core}.rs`, `windmill-mcp/src/server/endpoints.rs`: remove the dead `path_field_renames` plumbing and the interim MCP body-path fallback (the server now owns defaulting), simplifying `build_request_body` and `substitute_path_params`.
- Regenerated `windmill-api/src/mcp/auto_generated_endpoints.rs` and `frontend/src/lib/mcpEndpointTools.ts`. The frontend file is generated data (consumed for `method` and by the AI-chat tool builder); no visible UI effect, so no screenshots.

## In-app AI chat

The in-app AI chat's API mode (`copilot/chat/api/apiTools.ts`) builds these requests in the browser. Its **in-place** updates are now fixed by the server change (it posts a body without `path`, which the server defaults from the URL). Renaming a flow *from the chat* is still unsupported (that path posts `path__body`, which the chat does not map back to `path`), and is left as a small follow-up (needs `body_field_renames` mirrored in TS). Out of scope here; only verifiable with an AI provider configured.

## Test plan

Server-side behavior verified end-to-end via raw HTTP on a plain `--features quickjs` backend (no `mcp` feature needed):

- [x] **Repro**: pre-fix, `POST /flows/update/{path}` with a body lacking `path` returns `422 ... missing field 'path'`.
- [x] After: same call returns 200 and updates in place.
- [x] Body with a different `path` renames the flow (old path 404s, new path carries the update).
- [x] Body with `path: null` (the LLM/chat shape) returns 200 and defaults from the URL.

MCP round-trip verified with `--features quickjs,mcp` against the live MCP server:

- [x] `updateFlow` with only `path` + `summary` + `value` returns 200 (server defaults the body path; MCP no longer fills it).
- [x] `updateFlow` with `path__body` renames the flow.
- [x] Tool schema advertises `required: [path, summary, value]`; no `path__path` anywhere in the repo.

- [x] `cargo test -p windmill-types --lib flows::` (13 passed, incl. the new `EditFlow` default/rename test), `cargo test -p windmill-api --features mcp --lib mcp::utils` (17 passed), `cargo check -p windmill-api --features mcp` clean, generator re-run byte-stable.