### PR TITLE
feat(worker-tags): add `*` fork marker to workspace-scoped custom tags

### DIFF
--- a/backend/.sqlx/query-be21088e8b88e01b50a544f220e27d1e30b63c946a4eb640e55850100c3edd3c.json
+++ b/backend/.sqlx/query-be21088e8b88e01b50a544f220e27d1e30b63c946a4eb640e55850100c3edd3c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace (id, name, owner, parent_workspace_id)\n         VALUES ($1, $1, 'test-user', 'test-workspace')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "be21088e8b88e01b50a544f220e27d1e30b63c946a4eb640e55850100c3edd3c"
+}

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -5340,7 +5340,7 @@ async fn test_duckdb_ffi(db: Pool<Postgres>) -> anyhow::Result<()> {
 #[sqlx::test(fixtures("base"))]
 async fn test_flow_substep_tag_availability_check(db: Pool<Postgres>) -> anyhow::Result<()> {
     use windmill_common::worker::{
-        CustomTags, SpecificTagData, SpecificTagType, CUSTOM_TAGS_PER_WORKSPACE,
+        CustomTags, SpecificTagData, SpecificTagType, WorkspaceMatcher, CUSTOM_TAGS_PER_WORKSPACE,
     };
 
     initialize_tracing().await;
@@ -5354,7 +5354,10 @@ async fn test_flow_substep_tag_availability_check(db: Pool<Postgres>) -> anyhow:
             "restricted-tag".to_string(),
             SpecificTagData {
                 tag_type: SpecificTagType::NoneExcept,
-                workspaces: vec!["other-workspace".to_string()],
+                workspaces: vec![WorkspaceMatcher {
+                    id: "other-workspace".to_string(),
+                    include_forks: false,
+                }],
             },
         )]),
     }));

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -5338,6 +5338,7 @@ async fn test_duckdb_ffi(db: Pool<Postgres>) -> anyhow::Result<()> {
 /// This validates that `check_tag_available_for_workspace_internal` is properly called
 /// when pushing jobs from worker_flow.
 #[sqlx::test(fixtures("base"))]
+#[serial]
 async fn test_flow_substep_tag_availability_check(db: Pool<Postgres>) -> anyhow::Result<()> {
     use windmill_common::worker::{
         CustomTags, SpecificTagData, SpecificTagType, WorkspaceMatcher, CUSTOM_TAGS_PER_WORKSPACE,
@@ -5402,6 +5403,61 @@ async fn test_flow_substep_tag_availability_check(db: Pool<Postgres>) -> anyhow:
     );
 
     // Clean up: reset custom tags
+    CUSTOM_TAGS_PER_WORKSPACE.store(std::sync::Arc::new(CustomTags::default()));
+
+    Ok(())
+}
+
+/// The `*` fork marker only grants through a real `parent_workspace_id` lineage lookup, which the
+/// parse-level unit tests cannot reach: they hand `applies_to_workspace` a synthetic chain, so a
+/// regression in the lookup or in the `is_fork_scoped()` gate that skips it would pass them.
+#[sqlx::test(fixtures("base"))]
+#[serial]
+async fn test_fork_marker_tag_admission_through_lineage(db: Pool<Postgres>) -> anyhow::Result<()> {
+    use windmill_common::jobs::check_tag_available_for_workspace_internal;
+    use windmill_common::worker::{CustomTags, CUSTOM_TAGS_PER_WORKSPACE};
+
+    initialize_tracing().await;
+
+    // The ancestor chain is cached process-wide by workspace id, so use one no other test takes.
+    let fork = "wm-fork-tagmarker";
+    sqlx::query!(
+        "INSERT INTO workspace (id, name, owner, parent_workspace_id)
+         VALUES ($1, $1, 'test-user', 'test-workspace')",
+        fork
+    )
+    .execute(&db)
+    .await?;
+
+    CUSTOM_TAGS_PER_WORKSPACE.store(std::sync::Arc::new(CustomTags::from(vec![
+        "forky(test-workspace*)".to_string(),
+        "bare(test-workspace)".to_string(),
+    ])));
+
+    // test2 is not a superadmin, who would bypass the scope check entirely.
+    let email = "test2@windmill.dev";
+
+    for (w_id, tag) in [("test-workspace", "bare"), ("test-workspace", "forky")] {
+        assert!(
+            check_tag_available_for_workspace_internal(&db, w_id, tag, email, None)
+                .await
+                .is_ok(),
+            "{tag} should be available in the workspace it names"
+        );
+    }
+    assert!(
+        check_tag_available_for_workspace_internal(&db, fork, "forky", email, None)
+            .await
+            .is_ok(),
+        "a `*` tag must be granted to a fork through its parent lineage"
+    );
+    assert!(
+        check_tag_available_for_workspace_internal(&db, fork, "bare", email, None)
+            .await
+            .is_err(),
+        "an unmarked tag must not reach a fork of the workspace it names"
+    );
+
     CUSTOM_TAGS_PER_WORKSPACE.store(std::sync::Arc::new(CustomTags::default()));
 
     Ok(())

--- a/backend/windmill-api-workers/src/lib.rs
+++ b/backend/windmill-api-workers/src/lib.rs
@@ -162,6 +162,21 @@ async fn exists_workers_with_tags(
         let has_devops_role = require_devops_role(&db, &authed.email).await.is_ok();
         if !has_devops_role {
             if let Some(ref workspace) = tags_query.workspace {
+                // This route is global, so the workspace is an unauthorized query param: check
+                // membership before reading its lineage, which would otherwise disclose whether
+                // an arbitrary workspace descends from one named by a `tag(parent*)` rule.
+                let is_member = sqlx::query_scalar!(
+                    "SELECT EXISTS(SELECT 1 FROM usr WHERE workspace_id = $1 AND email = $2 AND NOT disabled)",
+                    workspace,
+                    &authed.email
+                )
+                .fetch_one(&db)
+                .await?
+                .unwrap_or(false);
+                if !is_member {
+                    return Ok(Json(std::collections::HashMap::new()));
+                }
+
                 // Filter to only tags visible in this workspace
                 let chain = workspace_with_fork_ancestors(&db, workspace).await?;
                 let custom_tags = CUSTOM_TAGS_PER_WORKSPACE.load();

--- a/backend/windmill-api-workers/src/lib.rs
+++ b/backend/windmill-api-workers/src/lib.rs
@@ -21,6 +21,7 @@ use windmill_common::{
     jobs::{HIDE_WORKERS_FOR_NON_ADMINS, TAGS_ARE_SENSITIVE},
     utils::{paginate, Pagination},
     worker::{ALL_TAGS, CUSTOM_TAGS_PER_WORKSPACE, DEFAULT_TAGS, DEFAULT_TAGS_PER_WORKSPACE},
+    workspaces::workspace_with_fork_ancestors,
     DB,
 };
 
@@ -162,8 +163,9 @@ async fn exists_workers_with_tags(
         if !has_devops_role {
             if let Some(ref workspace) = tags_query.workspace {
                 // Filter to only tags visible in this workspace
+                let chain = workspace_with_fork_ancestors(&db, workspace).await?;
                 let custom_tags = CUSTOM_TAGS_PER_WORKSPACE.load();
-                let allowed_tags = custom_tags.to_string_vec(Some(workspace.clone()));
+                let allowed_tags = custom_tags.to_string_vec(Some(&chain));
                 tags.retain(|t| allowed_tags.contains(t));
             } else {
                 // No workspace provided and not superadmin - return empty
@@ -222,10 +224,12 @@ async fn get_custom_tags(
 
 async fn get_custom_tags_for_workspace(
     _authed: ApiAuthed,
+    Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
 ) -> JsonResult<Vec<String>> {
+    let chain = workspace_with_fork_ancestors(&db, &w_id).await?;
     let tags_o = CUSTOM_TAGS_PER_WORKSPACE.load();
-    let all_tags = tags_o.to_string_vec(Some(w_id));
+    let all_tags = tags_o.to_string_vec(Some(&chain));
     Ok(Json(all_tags))
 }
 

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -20,6 +20,7 @@ use crate::{
     users::username_to_permissioned_as,
     utils::{StripPath, HTTP_CLIENT},
     worker::{to_raw_value, CUSTOM_TAGS_PER_WORKSPACE, WINDMILL_DIR},
+    workspaces::workspace_with_fork_ancestors,
     FlowVersionInfo, ScriptHashInfo, Tag,
 };
 
@@ -343,8 +344,8 @@ lazy_static::lazy_static! {
     ).unwrap_or(false);
 }
 
-pub async fn check_tag_available_for_workspace_internal<'c>(
-    db: impl sqlx::PgExecutor<'c>,
+pub async fn check_tag_available_for_workspace_internal(
+    db: &DB,
     w_id: &str,
     tag: &str,
     email: &str,
@@ -361,7 +362,14 @@ pub async fn check_tag_available_for_workspace_internal<'c>(
     if custom_tags_per_w.global.contains(&tag.to_string()) {
         is_tag_in_workspace_custom_tags = true;
     } else if let Some(specific_tag) = custom_tags_per_w.specific.get(tag) {
-        is_tag_in_workspace_custom_tags = specific_tag.applies_to_workspace(w_id);
+        // Only a fork-scoped tag can match through the lineage, so every other tag keeps the
+        // ancestor lookup off the push path entirely.
+        let chain = if specific_tag.is_fork_scoped() {
+            workspace_with_fork_ancestors(db, w_id).await?
+        } else {
+            vec![w_id.to_string()]
+        };
+        is_tag_in_workspace_custom_tags = specific_tag.applies_to_workspace(&chain);
     }
 
     match is_tag_in_scope_tags {

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -52,10 +52,10 @@ impl CustomTags {
                 let tag_name = cap.get(1).unwrap().as_str().to_string();
                 let workspace_str = cap.get(2).unwrap().as_str();
                 let tag_type = SpecificTagType::from_regex_string(workspace_str);
-                let workspaces: Vec<String> = workspace_str
+                let workspaces: Vec<WorkspaceMatcher> = workspace_str
                     .split(tag_type.corresponding_separator())
                     .filter(|s| !s.is_empty())
-                    .map(str::to_string)
+                    .map(WorkspaceMatcher::parse)
                     .collect();
                 if workspaces.is_empty() {
                     tracing::warn!("Ignoring tag `{}` with empty exclusion/inclusion list", e);
@@ -70,11 +70,13 @@ impl CustomTags {
         Self { global, specific }
     }
 
-    pub fn to_string_vec(&self, filter_with_workspace: Option<String>) -> Vec<String> {
-        let specific = if let Some(workspace) = filter_with_workspace {
+    /// `filter_with_workspace` is the workspace's id chain (see [`SpecificTagData::applies_to_workspace`]);
+    /// `None` re-emits the authored `tag(ws1+ws2)` strings for the settings editor.
+    pub fn to_string_vec(&self, filter_with_workspace: Option<&[String]>) -> Vec<String> {
+        let specific = if let Some(chain) = filter_with_workspace {
             self.specific
                 .iter()
-                .filter(|(_, tag_data)| tag_data.applies_to_workspace(&workspace))
+                .filter(|(_, tag_data)| tag_data.applies_to_workspace(chain))
                 .map(|(tag, _)| tag.clone())
                 .collect::<Vec<String>>()
         } else {
@@ -82,7 +84,12 @@ impl CustomTags {
                 .iter()
                 .map(|(tag, tag_data)| {
                     let separator = tag_data.tag_type.corresponding_separator();
-                    let mut workspaces = tag_data.workspaces.join(&*separator.to_string());
+                    let mut workspaces = tag_data
+                        .workspaces
+                        .iter()
+                        .map(|w| w.to_string())
+                        .collect::<Vec<_>>()
+                        .join(&*separator.to_string());
                     if tag_data.tag_type == SpecificTagType::AllExcluding {
                         // the AllExcluding tag syntax has a leading separator
                         workspaces.insert(0, separator);
@@ -95,18 +102,77 @@ impl CustomTags {
         all_tags.into_iter().chain(specific.into_iter()).collect()
     }
 }
+
+/// Marker suffixed to a workspace id inside a custom tag's scope (`mytag(prod*)`) to extend the
+/// entry to that workspace's forks. `*` cannot appear in a workspace id (the `proper_id` check
+/// constraint restricts them to `^\w+(-\w+)*$`), so it can never collide with a real id.
+pub const FORK_SCOPE_MARKER: char = '*';
+
+/// One workspace entry in a custom tag's scope. Bare (`prod`) matches that workspace only;
+/// with the [`FORK_SCOPE_MARKER`] (`prod*`) it also matches its forks, transitively.
+///
+/// The marker is opt-in in BOTH scope forms so that no existing tag string changes meaning:
+/// `sensitive(^prod)` keeps excluding only `prod` itself, and `sensitive(^prod*)` is how you
+/// exclude its forks too.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceMatcher {
+    pub id: String,
+    pub include_forks: bool,
+}
+
+impl WorkspaceMatcher {
+    fn parse(entry: &str) -> Self {
+        match entry.strip_suffix(FORK_SCOPE_MARKER) {
+            Some(id) => Self { id: id.to_string(), include_forks: true },
+            None => Self { id: entry.to_string(), include_forks: false },
+        }
+    }
+
+    fn matches(&self, workspace_id: &str, fork_ancestors: &[String]) -> bool {
+        workspace_id == self.id
+            || (self.include_forks && fork_ancestors.iter().any(|a| *a == self.id))
+    }
+}
+
+impl std::fmt::Display for WorkspaceMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.id)?;
+        if self.include_forks {
+            f.write_str(FORK_SCOPE_MARKER.encode_utf8(&mut [0u8; 4]))?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SpecificTagData {
     pub tag_type: SpecificTagType,
-    pub workspaces: Vec<String>,
+    pub workspaces: Vec<WorkspaceMatcher>,
 }
 
 impl SpecificTagData {
-    pub fn applies_to_workspace(&self, workspace_id: &str) -> bool {
+    /// `chain` is the workspace itself followed by its fork ancestors, nearest-first, as built by
+    /// `workspaces::workspace_with_fork_ancestors`. Pass a single-element slice when
+    /// [`Self::is_fork_scoped`] is false: the ancestors cannot affect the outcome then.
+    pub fn applies_to_workspace(&self, chain: &[String]) -> bool {
+        let Some((workspace_id, fork_ancestors)) = chain.split_first() else {
+            return false;
+        };
+        let matched = self
+            .workspaces
+            .iter()
+            .any(|w| w.matches(workspace_id, fork_ancestors));
         match self.tag_type {
-            SpecificTagType::AllExcluding => !self.workspaces.contains(&workspace_id.to_string()),
-            SpecificTagType::NoneExcept => self.workspaces.contains(&workspace_id.to_string()),
+            SpecificTagType::AllExcluding => !matched,
+            SpecificTagType::NoneExcept => matched,
         }
+    }
+
+    /// Whether any entry carries the fork marker, i.e. whether resolving the workspace's fork
+    /// lineage can change what [`Self::applies_to_workspace`] returns. Lets hot callers skip the
+    /// lineage lookup for the (overwhelmingly common) fork-agnostic tag.
+    pub fn is_fork_scoped(&self) -> bool {
+        self.workspaces.iter().any(|w| w.include_forks)
     }
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -295,12 +361,14 @@ lazy_static::lazy_static! {
     //    ^([\w-]+)         # Group 1: tag name
     //    \(                # Literal '('
     //    (                 # Group 2: the full workspace list
-    //      (?:[\w-]+\+)*[\w-]+     # NoneExcept pattern: ws1+ws2
-    //      |                      # OR
-    //      (?:\^[\w-]+)+          # AllExcluding pattern: ^ws1^ws2
+    //      (?:[\w-]+\*?\+)*[\w-]+\*?   # NoneExcept pattern: ws1+ws2*
+    //      |                          # OR
+    //      (?:\^[\w-]+\*?)+           # AllExcluding pattern: ^ws1^ws2*
     //    )
     //    \)$               # Closing ')'
-    static ref CUSTOM_TAG_REGEX: Regex = Regex::new(r"^([\w-]+)\(((?:[\w-]+\+)*[\w-]+|(?:\^[\w-]+)+)\)$").unwrap();
+    //
+    // The optional `*` after each workspace id is the fork marker, see [`WorkspaceMatcher`].
+    static ref CUSTOM_TAG_REGEX: Regex = Regex::new(r"^([\w-]+)\(((?:[\w-]+\*?\+)*[\w-]+\*?|(?:\^[\w-]+\*?)+)\)$").unwrap();
 
     pub static ref DISABLE_BUNDLING: bool = std::env::var("DISABLE_BUNDLING")
     .ok()
@@ -2332,6 +2400,19 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    fn matcher(id: &str) -> WorkspaceMatcher {
+        WorkspaceMatcher { id: id.to_string(), include_forks: false }
+    }
+
+    fn fork_matcher(id: &str) -> WorkspaceMatcher {
+        WorkspaceMatcher { id: id.to_string(), include_forks: true }
+    }
+
+    /// A workspace id chain: the workspace itself, then its fork ancestors nearest-first.
+    fn chain(ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
     #[test]
     fn test_bash_sandbox_image_annotation() {
         // `# sandbox <image>` selects the container runtime and returns the image.
@@ -2430,14 +2511,14 @@ mod tests {
             "feat".to_string(),
             SpecificTagData {
                 tag_type: SpecificTagType::NoneExcept,
-                workspaces: vec!["ws1".to_string(), "ws2".to_string()],
+                workspaces: vec![matcher("ws1"), matcher("ws2")],
             },
         );
         expected.insert(
             "hotfix".to_string(),
             SpecificTagData {
                 tag_type: SpecificTagType::AllExcluding,
-                workspaces: vec!["ws3".to_string(), "ws4".to_string()],
+                workspaces: vec![matcher("ws3"), matcher("ws4")],
             },
         );
 
@@ -2480,7 +2561,7 @@ mod tests {
 
         let data = tags.specific.get("urgent").unwrap();
         assert_eq!(data.tag_type, SpecificTagType::NoneExcept);
-        assert_eq!(data.workspaces, vec!["ws1", "ws2"]);
+        assert_eq!(data.workspaces, vec![matcher("ws1"), matcher("ws2")]);
     }
 
     #[test]
@@ -2493,7 +2574,7 @@ mod tests {
 
         let data = tags.specific.get("legacy").unwrap();
         assert_eq!(data.tag_type, SpecificTagType::AllExcluding);
-        assert_eq!(data.workspaces, vec!["ws1", "ws2"]);
+        assert_eq!(data.workspaces, vec![matcher("ws1"), matcher("ws2")]);
     }
 
     #[test]
@@ -2510,10 +2591,10 @@ mod tests {
         let input = vec!["urgent(ws1+ws2)".to_string()];
         let tags = CustomTags::from(input);
 
-        let output = tags.to_string_vec(Some("ws1".to_string()));
+        let output = tags.to_string_vec(Some(&chain(&["ws1"])));
         assert_eq!(output, vec!["urgent"]);
 
-        let output_none = tags.to_string_vec(Some("ws3".to_string()));
+        let output_none = tags.to_string_vec(Some(&chain(&["ws3"])));
         assert!(output_none.is_empty());
     }
 
@@ -2522,10 +2603,10 @@ mod tests {
         let input = vec!["legacy(^ws1^ws2)".to_string()];
         let tags = CustomTags::from(input);
 
-        let output = tags.to_string_vec(Some("ws3".to_string()));
+        let output = tags.to_string_vec(Some(&chain(&["ws3"])));
         assert_eq!(output, vec!["legacy"]);
 
-        let output_excluded = tags.to_string_vec(Some("ws1".to_string()));
+        let output_excluded = tags.to_string_vec(Some(&chain(&["ws1"])));
         assert!(output_excluded.is_empty());
     }
 
@@ -2541,6 +2622,68 @@ mod tests {
         let mut result = tags.to_string_vec(None);
         result.sort();
         assert_eq!(result, vec!["foo", "legacy(^ws1^ws2)", "urgent(ws1+ws2)"]);
+    }
+
+    #[test]
+    fn test_fork_marker_parses_and_round_trips() {
+        let tags = CustomTags::from(vec![
+            "urgent(prod*+ws2)".to_string(),
+            "legacy(^prod*)".to_string(),
+        ]);
+
+        let urgent = tags.specific.get("urgent").unwrap();
+        assert_eq!(
+            urgent.workspaces,
+            vec![fork_matcher("prod"), matcher("ws2")]
+        );
+        assert!(urgent.is_fork_scoped());
+
+        let legacy = tags.specific.get("legacy").unwrap();
+        assert_eq!(legacy.workspaces, vec![fork_matcher("prod")]);
+
+        // The settings editor re-emits what it parsed; dropping `*` here would silently widen
+        // an excluding tag / narrow an including one on every save.
+        let mut result = tags.to_string_vec(None);
+        result.sort();
+        assert_eq!(result, vec!["legacy(^prod*)", "urgent(prod*+ws2)"]);
+    }
+
+    #[test]
+    fn test_fork_marker_extends_none_except_to_forks_only_when_present() {
+        let fork = chain(&["wm-fork-x", "prod"]);
+        let nested = chain(&["wm-fork-y", "wm-fork-x", "prod"]);
+
+        let marked = CustomTags::from(vec!["urgent(prod*)".to_string()]);
+        let marked = marked.specific.get("urgent").unwrap();
+        assert!(marked.applies_to_workspace(&chain(&["prod"])));
+        assert!(marked.applies_to_workspace(&fork));
+        assert!(marked.applies_to_workspace(&nested));
+        assert!(!marked.applies_to_workspace(&chain(&["wm-fork-z", "other"])));
+
+        // Without the marker a fork must NOT inherit the parent's tag.
+        let unmarked = CustomTags::from(vec!["urgent(prod)".to_string()]);
+        let unmarked = unmarked.specific.get("urgent").unwrap();
+        assert!(unmarked.applies_to_workspace(&chain(&["prod"])));
+        assert!(!unmarked.applies_to_workspace(&fork));
+        // Gates the ancestor lookup, so a wrong answer here silently disables the marker.
+        assert!(!unmarked.is_fork_scoped());
+    }
+
+    #[test]
+    fn test_fork_marker_extends_all_excluding_to_forks_only_when_present() {
+        let fork = chain(&["wm-fork-x", "prod"]);
+
+        // Pre-existing exclusions keep their exact meaning: only `prod` itself is excluded.
+        let unmarked = CustomTags::from(vec!["legacy(^prod)".to_string()]);
+        let unmarked = unmarked.specific.get("legacy").unwrap();
+        assert!(!unmarked.applies_to_workspace(&chain(&["prod"])));
+        assert!(unmarked.applies_to_workspace(&fork));
+
+        let marked = CustomTags::from(vec!["legacy(^prod*)".to_string()]);
+        let marked = marked.specific.get("legacy").unwrap();
+        assert!(!marked.applies_to_workspace(&chain(&["prod"])));
+        assert!(!marked.applies_to_workspace(&fork));
+        assert!(marked.applies_to_workspace(&chain(&["other"])));
     }
 
     #[test]

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -114,7 +114,7 @@ pub const FORK_SCOPE_MARKER: char = '*';
 /// The marker is opt-in in BOTH scope forms so that no existing tag string changes meaning:
 /// `sensitive(^prod)` keeps excluding only `prod` itself, and `sensitive(^prod*)` is how you
 /// exclude its forks too.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct WorkspaceMatcher {
     pub id: String,
     pub include_forks: bool,
@@ -141,6 +141,14 @@ impl std::fmt::Display for WorkspaceMatcher {
             f.write_str(FORK_SCOPE_MARKER.encode_utf8(&mut [0u8; 4]))?;
         }
         Ok(())
+    }
+}
+
+/// Renders the authored `prod` / `prod*` form rather than the struct fields: `CustomTags` is
+/// `{:?}`-dumped into the "tag is not in the allowed CUSTOM_TAGS" error operators see.
+impl std::fmt::Debug for WorkspaceMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.to_string(), f)
     }
 }
 

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -1394,10 +1394,11 @@ pub async fn fork_ancestor_chain(db: &crate::DB, w_id: &str) -> Result<Vec<Strin
 /// `w_id` followed by its fork ancestors, nearest-first: the id sequence to match a
 /// workspace-scoped rule against when the rule can extend to a fork subtree.
 ///
-/// Reads lineage for any `w_id` with no authorization check, like [`fork_ancestor_chain`]. Feed
-/// the result into a scoping decision rather than returning it: callers that pass a
-/// caller-supplied id would otherwise disclose the ancestry of workspaces the caller is not a
-/// member of.
+/// Reads lineage for any `w_id` with no authorization check, like [`fork_ancestor_chain`], so the
+/// caller must already be authorized for `w_id`: routes that take it from the path get that from
+/// `ApiAuthed`, but a caller-supplied id must be membership-checked first. Otherwise even using
+/// the chain only for a scoping decision discloses whether an arbitrary workspace descends from
+/// one the rule names.
 pub async fn workspace_with_fork_ancestors(db: &crate::DB, w_id: &str) -> Result<Vec<String>> {
     let mut chain = Vec::with_capacity(4);
     chain.push(w_id.to_string());

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -1391,6 +1391,17 @@ pub async fn fork_ancestor_chain(db: &crate::DB, w_id: &str) -> Result<Vec<Strin
     Ok(chain)
 }
 
+/// `w_id` followed by its fork ancestors, nearest-first: the id sequence to match a
+/// workspace-scoped rule against when the rule can extend to a fork subtree.
+///
+/// Same authorization caveat as [`fork_ancestor_chain`].
+pub async fn workspace_with_fork_ancestors(db: &crate::DB, w_id: &str) -> Result<Vec<String>> {
+    let mut chain = Vec::with_capacity(4);
+    chain.push(w_id.to_string());
+    chain.extend(fork_ancestor_chain(db, w_id).await?);
+    Ok(chain)
+}
+
 pub async fn get_ducklake_from_db_unchecked(
     name: &str,
     w_id: &str,

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -1394,7 +1394,10 @@ pub async fn fork_ancestor_chain(db: &crate::DB, w_id: &str) -> Result<Vec<Strin
 /// `w_id` followed by its fork ancestors, nearest-first: the id sequence to match a
 /// workspace-scoped rule against when the rule can extend to a fork subtree.
 ///
-/// Same authorization caveat as [`fork_ancestor_chain`].
+/// Reads lineage for any `w_id` with no authorization check, like [`fork_ancestor_chain`]. Feed
+/// the result into a scoping decision rather than returning it: callers that pass a
+/// caller-supplied id would otherwise disclose the ancestry of workspaces the caller is not a
+/// member of.
 pub async fn workspace_with_fork_ancestors(db: &crate::DB, w_id: &str) -> Result<Vec<String>> {
     let mut chain = Vec::with_capacity(4);
     chain.push(w_id.to_string());

--- a/frontend/src/lib/components/AssignableTagsInner.svelte
+++ b/frontend/src/lib/components/AssignableTagsInner.svelte
@@ -37,8 +37,13 @@
 
 	const dispatch = createEventDispatcher()
 
-	const customTagRegex = /^([\w-]+)\(((?:[\w-]+\+)*[\w-]+|(?:\^[\w-]+)+)\)$/
+	// Mirrors CUSTOM_TAG_REGEX in backend/windmill-common/src/worker.rs — keep both in sync.
+	const customTagRegex = /^([\w-]+)\(((?:[\w-]+\*?\+)*[\w-]+\*?|(?:\^[\w-]+\*?)+)\)$/
 	const dynamicTagRegex = /\$args\[((?:\w+\.)*\w+)\]/
+
+	function formatWorkspace(w: { id: string; includeForks: boolean }) {
+		return w.includeForks ? `${w.id} (and its forks)` : w.id
+	}
 
 	let dynamicTag = $derived.by(() => {
 		let r = newTag.trim()
@@ -51,14 +56,16 @@
 		let r = newTag.trim()
 		if (r == '') return undefined
 		let matched = r.match(customTagRegex)
-		console.log(matched)
 		let tag = matched?.[1]
 		let workspaces_raw = matched?.[2]
 		let tag_type = workspaces_raw?.includes('^') ? 'exclude' : 'include'
 		if (tag_type == 'exclude') {
 			workspaces_raw = workspaces_raw?.slice(1)
 		}
-		let workspaces = workspaces_raw?.split(tag_type == 'include' ? '+' : '^')
+		let workspaces = workspaces_raw?.split(tag_type == 'include' ? '+' : '^').map((w) => {
+			const includeForks = w.endsWith('*')
+			return { id: includeForks ? w.slice(0, -1) : w, includeForks }
+		})
 		if (!workspaces_raw || workspaces_raw?.length == 0) {
 			return undefined
 		}
@@ -163,14 +170,14 @@
 				<div>
 					<b>Workspaces:</b>
 					{#if extractedCustomTag.tag_type == 'include'}
-						{extractedCustomTag.workspaces?.join(', ')}
+						{extractedCustomTag.workspaces?.map(formatWorkspace).join(', ')}
 					{:else}
-						All workspaces except {extractedCustomTag.workspaces?.join(', ')}
+						All workspaces except {extractedCustomTag.workspaces?.map(formatWorkspace).join(', ')}
 					{/if}
 				</div>
 			</div>
 		{:else if newTag.trim()}
-			{#if newTag.includes('(') || newTag.includes(')') || newTag.includes('+') || newTag.includes('^') || ((newTag.includes('.') || newTag.includes('$args[')) && !dynamicTag)}
+			{#if newTag.includes('(') || newTag.includes(')') || newTag.includes('+') || newTag.includes('^') || newTag.includes('*') || ((newTag.includes('.') || newTag.includes('$args[')) && !dynamicTag)}
 				<div class="text-2xs text-primary p-2 bg-surface-secondary rounded border">
 					<div class="font-medium mb-1 text-red-500">Invalid tag</div>
 					<div>
@@ -218,6 +225,10 @@
 			<br />{#if variant !== 'drawer'}<br />{/if}
 			To exclude 'workspace1' and 'workspace2' from a tag, use
 			<pre class="inline text-emphasis">tag(^workspace1^workspace2)</pre>
+			<br />{#if variant !== 'drawer'}<br />{/if}
+			Forks of a workspace do not get its tags. Suffix a workspace with
+			<pre class="inline text-emphasis">*</pre>
+			to also cover its forks, e.g. <pre class="inline text-emphasis">tag(workspace1*)</pre>
 			<br />{#if variant !== 'drawer'}<br />{/if}
 			For
 			<a


### PR DESCRIPTION
## Summary

Custom worker tags can be scoped to workspaces (`mytag(ws1+ws2)` = only those workspaces may use the tag; `mytag(^ws1^ws2)` = every workspace except those). Matching was a literal id comparison, so a **fork never matched its parent's scoped tag** — a workspace forked from `linux` could not use `linux-common-dev(linux)`, which is surprising when the tag names a shared dev worker group.

Inheriting unconditionally isn't right either: a restricted worker group may exist precisely to encode "only code that made it into this workspace runs on this hardware", and a fork is by definition where the code isn't reviewed yet. That distinction is a property of the worker group, not of the instance, so this adds a per-entry opt-in marker rather than a global toggle.

A `*` suffixed to a workspace id extends that entry to the workspace's forks, transitively:

```
linux-common-dev(linux*)          linux and all its forks
linux-common-dev(linux*+shared)   linux and its forks, plus exactly `shared`
sensitive(^prod*)                 everyone except prod and its forks
sensitive(^prod)                  everyone except prod itself (unchanged)
```

The marker is opt-in in **both** grammar forms, so **no existing tag string changes meaning on upgrade** — this is purely additive. `*` cannot collide with a real workspace id: the `proper_id` check constraint restricts ids to `^\w+(-\w+)*$`.

The setting itself is already instance-scoped and superadmin-only (`set_global_setting` is `require_super_admin`), so the marker adds an argument to a knob a superadmin already exclusively controls, not a new configuration surface.

## Changes

- `windmill-common/src/worker.rs`: extend `CUSTOM_TAG_REGEX` with an optional `*` per workspace id; replace `SpecificTagData.workspaces: Vec<String>` with `Vec<WorkspaceMatcher { id, include_forks }>`; `applies_to_workspace` now takes the workspace's id chain (itself + fork ancestors) instead of a single id. `WorkspaceMatcher`'s `Debug` renders the authored `prod*` form, since `CustomTags` is `{:?}`-dumped into the operator-facing "not in the allowed CUSTOM_TAGS" error.
- `windmill-common/src/workspaces.rs`: add `workspace_with_fork_ancestors`, a thin wrapper over the existing cached `fork_ancestor_chain`.
- `windmill-common/src/jobs.rs`: resolve the chain in `check_tag_available_for_workspace_internal`, but **only when the tag actually carries a marker** (`is_fork_scoped()`), so no DB lookup is added to the job-push path for anyone not using the feature. Its first parameter narrows from `impl PgExecutor` to `&DB`; all four call sites already passed a `&DB`.
- `windmill-api-workers/src/lib.rs`: resolve the chain in the per-workspace tag listing and in `exists_workers_with_tags`.
- `AssignableTagsInner.svelte`: mirror the regex, spell the marker out in the live preview ("linux (and its forks)"), flag a stray `*` as an invalid tag, document the syntax.

## Screenshots

![tag-fork-marker-include](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/custom-tags-in-forks/1784296580-tag-fork-marker-include.png)

![tag-fork-marker-exclude](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/custom-tags-in-forks/1784296583-tag-fork-marker-exclude.png)

## Test plan

- [x] `cargo test -p windmill-common --lib worker::tests` — 35 pass, including 3 new: marker parse + round-trip (a dropped `*` would silently rewrite an operator's security config on every save), and marker-vs-unmarked behaviour in both grammar forms including a nested fork.
- [x] `cargo test --test worker test_fork_marker_tag_admission_through_lineage` — new integration test pinning admission through a real `parent_workspace_id` row. Mutation-checked: neutering `is_fork_scoped()` makes it fail as intended, so it is not vacuous.
- [x] Full `cargo check` and frontend `npm run check:fast` clean.
- [x] Exercised against a running server with a parent, a fork, a fork-of-fork and an unrelated workspace, **as a non-superadmin** (superadmins bypass the tag check entirely). Both the listing endpoint and job-push enforcement agree in all cells:

  | tag | parent | fork | fork-of-fork | unrelated |
  |---|---|---|---|---|
  | `bare(tagparent)` | allowed | **denied** | denied | denied |
  | `forky(tagparent*)` | allowed | **allowed** | **allowed** | denied |
  | `excl(^tagparent)` | denied | allowed | allowed | allowed |
  | `exclforky(^tagparent*)` | denied | **denied** | denied | allowed |

- [x] UI verified in-browser: preview renders per-entry fork annotation; saved badges round-trip `forky(tagparent*)` with the marker intact.

## Follow-ups (not in this PR)

- The `*` syntax should be documented on the `worker_groups` docs page (separate `windmilldocs` repo).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `*` fork marker to workspace-scoped custom worker tags so tags can include or exclude a workspace’s forks transitively. Also tightens the global tags route by requiring workspace membership before resolving fork lineage.

- New Features
  - Extend tag grammar to `tag(ws1*+ws2)` and `tag(^ws1*^ws2)` to include/exclude forks.
  - Matching uses the workspace id chain only for fork-scoped tags; `check_tag_available_for_workspace_internal` resolves lineage via `workspace_with_fork_ancestors` only when needed.
  - `get_custom_tags_for_workspace` and `exists_workers_with_tags` now filter using the id chain; `CustomTags::to_string_vec` accepts a chain and round-trips `prod*`.
  - UI mirrors the regex, previews “and its forks,” flags stray `*`, and updates the help text.

- Bug Fixes
  - Gate fork-lineage lookup in `exists_workers_with_tags` on workspace membership to avoid disclosing ancestry; non-members get an empty result.
  - Add `sqlx` offline cache for the fork-marker test INSERT to keep `SQLX_OFFLINE=true` CI green.

<sup>Written for commit ec60b972c9ffb1c29ba64fce9ce4f4a3f7f1d092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

