### PR TITLE
fix(worker): gate ansible socket-dir name check to unix

### DIFF
--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -103,6 +103,7 @@ fn persistent_control_path_dir(job_id: &Uuid) -> Option<String> {
 
 /// Whether `name` is one this module could have created, i.e. `Uuid::simple` (32 hex, no
 /// hyphens). Belt to the root check's braces: nothing else should ever be in there.
+#[cfg(unix)]
 fn is_persistent_control_path_dir_name(name: &str) -> bool {
     name.len() == 32 && Uuid::try_parse(name).is_ok()
 }
@@ -2693,6 +2694,7 @@ collections_path : a/col:b/col
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_is_persistent_control_path_dir_name() {
         assert!(is_persistent_control_path_dir_name(


### PR DESCRIPTION
## Summary
Fixes a Windows build failure (`-D dead-code`): `is_persistent_control_path_dir_name` in `ansible_executor.rs` is only referenced from `prepare_socket_root`, which is `#[cfg(unix)]`. On non-unix targets nothing used the function, so the dead-code lint (`-D warnings`) failed the build.

## Changes
- Gate `is_persistent_control_path_dir_name` with `#[cfg(unix)]`.
- Gate its unit test `test_is_persistent_control_path_dir_name` with `#[cfg(unix)]`, matching the unix-only reaping code it exercises.

`persistent_control_path_dir` and the guard are used from non-gated code paths, so they are unaffected.

## Test plan
- [ ] Build on a non-unix target (Windows) succeeds without the dead-code error.
- [ ] `cargo test -p windmill-worker` still runs `test_is_persistent_control_path_dir_name` on unix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated `is_persistent_control_path_dir_name` and its unit test with `#[cfg(unix)]` to fix a Windows build failure caused by dead-code linting. This matches the unix-only `prepare_socket_root`, removes unused code on non-unix targets, and keeps the test running on Unix.

<sup>Written for commit 9659cdcdafeaeac90d11c16fe8dbf6fccf2acd1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

