### PR TITLE
chore(schedules): lower reconciler re-arm back-off cap to 8 passes

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -3391,9 +3391,10 @@ const SCHEDULE_REARM_ALERT_THRESHOLD: u32 = 3;
 
 /// Cap on the exponential back-off (in reconcile passes) between re-arm retries of
 /// a schedule that keeps failing. Without a back-off a permanently-failing push
-/// retries every pass forever; the delay grows 2, 4, 8, … up to this cap and
-/// resets the moment the schedule re-arms.
-const SCHEDULE_REARM_MAX_BACKOFF_PASSES: u32 = 32;
+/// retries every pass forever; the delay grows 2, 4, 8 and holds at this cap, and
+/// resets the moment the schedule re-arms. Kept small so a schedule fixed out of
+/// band (the UI/API re-arms immediately) still auto-recovers within a few passes.
+const SCHEDULE_REARM_MAX_BACKOFF_PASSES: u32 = 8;
 
 /// State for a schedule that keeps failing to re-arm: paces retries and drives the
 /// one-time visibility so the loop is neither hot nor silent.


### PR DESCRIPTION
## Summary

Follow-up to #10179 (WIN-2198), which merged with the reconciler re-arm back-off cap at 32 passes.

The exponential back-off between reconciler re-arm retries of a persistently-failing schedule (bad stored cron/timezone/args, lapsed license) grows 2, 4, 8, … and held at **32 passes** — ~2.7h at the default 5-min reconcile cadence. That's longer than necessary for **passive** auto-recovery: a schedule fixed out of band (a license renewed, a cron corrected directly in the DB) would wait up to ~2.7h for the next re-arm attempt.

This lowers the cap to **8 passes** (~40min), still cutting the retry rate sharply versus the every-pass loop the back-off replaced, but recovering much sooner after an out-of-band fix. Fixes made through the UI/API re-arm immediately (that path pushes directly) and are unaffected either way.

## Changes

- `backend/src/monitor.rs`: `SCHEDULE_REARM_MAX_BACKOFF_PASSES` 32 → 8 (one constant + its doc comment).

## Test plan

- [x] Pure `u32` literal value change to an existing, tested constant (validated live in #10179's e2e at the higher cap; behavior is identical bar the cap value). No new queries, no API/type impact.
- [ ] CI green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lower the reconciler re-arm backoff cap from 32 to 8 passes so schedules fixed out of band auto-recover faster (worst case drops from ~2.7h to ~40min at the default 5‑min cadence) while still avoiding hot loops. Addresses WIN-2198; UI/API edits still re-arm immediately and are unchanged.

<sup>Written for commit 4518ac6243b425f6d2876abb2b0ef79f69269efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

