### PR TITLE
fix(scripts): populate auto_kind from draft JSON for draft-only scripts

### DIFF
--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -417,11 +417,19 @@ async fn list_scripts(
             // A draft-only pipeline node (`// pipeline`) has no deployed row to carry
             // auto_kind, so compute it from the draft content — mirroring the create
             // path — so the home page folds it into its pipeline like a deployed member.
+            // Otherwise fall back to the `auto_kind` the frontend saved into the draft
+            // (e.g. `lib` for scripts without a `main`); the content-derived pipeline
+            // annotation keeps priority since it mirrors the deploy-time computation.
             let auto_kind = v
                 .get("content")
                 .and_then(|s| s.as_str())
                 .filter(|c| parse_pipeline_annotations(c).in_pipeline)
-                .map(|_| "pipeline".to_string());
+                .map(|_| "pipeline".to_string())
+                .or_else(|| {
+                    v.get("auto_kind")
+                        .and_then(|s| s.as_str())
+                        .map(|s| s.to_string())
+                });
             rows.push(ListableScript {
                 hash: ScriptHash(0),
                 path: row.path,


### PR DESCRIPTION
## Problem

The scripts list endpoint (`/api/w/{workspace}/scripts/list?include_draft_only=true`) only populated `auto_kind` for the `pipeline` case for draft-only scripts. Library scripts (no `main` function) that are draft-only always came back with `auto_kind: null`, even though the frontend saves `auto_kind: "lib"` into the draft JSON. This made it impossible to distinguish library draft-only scripts from regular ones without a separate per-script API call.

## Fix

In `backend/windmill-api-scripts/src/scripts.rs`, after the existing content-derived pipeline check, fall back to reading `auto_kind` from the draft JSON value. The pipeline annotation keeps priority since it mirrors the deploy-time computation; everything else (`lib`, etc.) is read straight from the value the frontend already persists (`ScriptBuilder.svelte`).

## Validation

- Backend recompiled cleanly under `cargo watch` and reported healthy.
- Exercised end-to-end against the running dev backend:
  - Created a draft-only library script via `POST /drafts/update/script/...` with `auto_kind: "lib"`.
  - `GET /scripts/list?include_draft_only=true` now returns `auto_kind: "lib"` for that script (previously `null`).
  - Cleaned up the test draft.

Fixes WIN-2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate auto_kind for draft-only scripts in `/api/w/{workspace}/scripts/list?include_draft_only=true` by falling back to the draft JSON when not a pipeline. Restores correct `auto_kind: "lib"` for library drafts and fixes WIN-2199.

- **Bug Fixes**
  - Keep content-derived `pipeline` detection as priority.
  - Otherwise read `auto_kind` from the draft value saved by the frontend.

<sup>Written for commit e582e6ba259aa226485f8598a1b52202b410f9ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

