### PR TITLE
feat(frontend): wire topBar.path and editablePath customUi in FlowBuilder (WIN-2200)

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1129,17 +1129,21 @@
 					: 'max-h-12'}"
 			>
 				<div class="flex flex-row items-center gap-2 min-w-0">
-					<div class="min-w-0 overflow-hidden">
-						<EditorHeader
-							bind:summary={flowStore.val.summary}
-							bind:path={$pathStore}
-							savedPath={initialPath}
-							onBehalfOfEmail={$savedOnBehalfOfEmail}
-							hidePath={condensedHeader}
-							workspaceId={autosaveWorkspace}
-							onNavigate={(item) => onNavigate?.(item)}
-						/>
-					</div>
+					{#if customUi?.topBar?.path != false}
+						<div class="min-w-0 overflow-hidden">
+							<EditorHeader
+								bind:summary={flowStore.val.summary}
+								bind:path={$pathStore}
+								savedPath={initialPath}
+								onBehalfOfEmail={$savedOnBehalfOfEmail}
+								summaryEditable={customUi?.topBar?.editableSummary != false}
+								pathEditable={customUi?.topBar?.editablePath != false}
+								hidePath={condensedHeader}
+								workspaceId={autosaveWorkspace}
+								onNavigate={(item) => onNavigate?.(item)}
+							/>
+						</div>
+					{/if}
 					{#if opWorkspace && indicatorPath !== undefined}
 						<AutosaveIndicator
 							workspace={opWorkspace}

--- a/frontend/src/lib/components/custom_ui.ts
+++ b/frontend/src/lib/components/custom_ui.ts
@@ -3,6 +3,7 @@ import type { SupportedLanguage } from '$lib/common'
 export type FlowBuilderWhitelabelCustomUi = {
 	topBar?: {
 		path?: boolean
+		editablePath?: boolean
 		export?: boolean
 		history?: boolean
 		aiBuilder?: boolean

--- a/frontend/src/lib/components/flows/content/FlowSettings.svelte
+++ b/frontend/src/lib/components/flows/content/FlowSettings.svelte
@@ -137,7 +137,7 @@
 				<!-- prettier-ignore -->
 				<LabelsInput bind:labels={(flowStore.val as any).labels} class="-mt-4" />
 
-				{#if !noEditor}
+				{#if !noEditor && customUi?.topBar?.editablePath != false}
 					<Label label="Path">
 						<Path
 							autofocus={false}


### PR DESCRIPTION
## Summary

The `FlowBuilderWhitelabelCustomUi` type defined `topBar.path` but `FlowBuilder` never read it, and the FlowSettings Path field had no customUi gate. This wires those options through, mirroring the existing ScriptBuilder whitelabel pattern.

- `custom_ui.ts`: add `editablePath?: boolean` to `FlowBuilderWhitelabelCustomUi.topBar`.
- `FlowBuilder.svelte`: wrap the `EditorHeader` block in `{#if customUi?.topBar?.path != false}` and pass `pathEditable={customUi?.topBar?.editablePath != false}` (plus `summaryEditable`, wiring the pre-existing-but-unused `editableSummary` flag) — matching ScriptBuilder.
- `FlowSettings.svelte`: gate the Path `<Label>` section on `customUi?.topBar?.editablePath != false` so it hides when path editing is disabled.

Defaults are `!= false`, so non-whitelabel flows are unaffected — the topbar path header and settings Path field still render as before.

Fixes WIN-2200

## Validation

- `npm run check:fast` — clean on the three changed files (the only reported error is a pre-existing unrelated `modern-screenshot` module-resolution issue in `RawAppEditor.svelte`, untouched here).
- Manually exercised the flow editor via Playwright: default `customUi` ({}) still renders both the topbar **Edit path** button and the Settings **Path** field, confirming no regression to the standard (non-whitelabel) flow builder.

## Screenshots

Default flow builder (no customUi override) — path header and Path settings field both present:

![flow-default-path-visible](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2200-wire-topbarpath-and-editablepath-customui-options-in/1784360408-flow-default-path-visible.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired `FlowBuilder` to respect whitelabel `customUi.topBar.path`, `editablePath`, and `editableSummary`, matching `ScriptBuilder`. Addresses WIN-2200; default behavior remains unchanged.

- **New Features**
  - Added `editablePath?: boolean` to `FlowBuilderWhitelabelCustomUi.topBar`.
  - Conditionally render `EditorHeader` based on `topBar.path`.
  - Pass `pathEditable` and `summaryEditable` to `EditorHeader`.
  - Hide Flow Settings “Path” when `topBar.editablePath` is false.

<sup>Written for commit 7e17b8c9f7e13c3562fe287b1af800c68f78a21b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

