### PR TITLE
fix(cli): stop spurious has_on_behalf_of/has_permissioned_as diffs on pull (WIN-2201)

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -1008,7 +1008,11 @@ function ZipFSElement(
             }
 
             if (stripOnBehalfOf) {
-              (flow as any).has_on_behalf_of = !!(flow as any).on_behalf_of_email;
+              // Only emit the flag when set; a `false` here is the default and
+              // would produce a spurious diff for every ownerless flow.
+              if ((flow as any).on_behalf_of_email) {
+                (flow as any).has_on_behalf_of = true;
+              }
               delete (flow as any).on_behalf_of_email;
             }
 
@@ -1293,7 +1297,11 @@ function ZipFSElement(
               parsed["codebase"] = undefined;
             }
             if (stripOnBehalfOf) {
-              parsed["has_on_behalf_of"] = !!parsed["on_behalf_of_email"];
+              // Only emit the flag when set; a `false` here is the default and
+              // would produce a spurious diff for every ownerless script.
+              if (parsed["on_behalf_of_email"]) {
+                parsed["has_on_behalf_of"] = true;
+              }
               delete parsed["on_behalf_of_email"];
             }
             // Modules are stored as files in __mod/ folder, not in metadata
@@ -1340,13 +1348,19 @@ function ZipFSElement(
               if (stripOnBehalfOf) {
                 const isSchedule = p.endsWith(".schedule.json");
                 const isTrigger = p.endsWith("_trigger.json");
+                // Only emit the flag when set; a `false` here is the default and
+                // would produce a spurious diff for every ownerless schedule/trigger.
                 if (isSchedule) {
-                  parsed["has_permissioned_as"] = !!parsed["permissioned_as"];
+                  if (parsed["permissioned_as"]) {
+                    parsed["has_permissioned_as"] = true;
+                  }
                   delete parsed["permissioned_as"];
                   delete parsed["email"];
                   delete parsed["edited_by"];
                 } else if (isTrigger) {
-                  parsed["has_permissioned_as"] = !!parsed["permissioned_as"];
+                  if (parsed["permissioned_as"]) {
+                    parsed["has_permissioned_as"] = true;
+                  }
                   delete parsed["permissioned_as"];
                   delete parsed["edited_by"];
                 }

--- a/cli/test/pull_on_behalf_of_marker.test.ts
+++ b/cli/test/pull_on_behalf_of_marker.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { withTestBackend } from "./test_backend.ts";
+import { addWorkspace } from "../workspace.ts";
+import { setClient } from "../src/core/client.ts";
+
+// Regression guard for WIN-2201: with syncBehavior v1 the pull strips
+// `on_behalf_of_email` and keeps only a boolean marker. That marker must be
+// emitted ONLY when an owner exists — writing `has_on_behalf_of: false` for the
+// (overwhelmingly common) ownerless script produced a spurious diff on every pull.
+test("pull omits has_on_behalf_of for ownerless scripts", async () => {
+  await withTestBackend(async (backend, tempDir) => {
+    await addWorkspace(
+      {
+        remote: backend.baseUrl,
+        workspaceId: backend.workspace,
+        name: "obo_marker_test",
+        token: backend.token,
+      },
+      { force: true, configDir: backend.testConfigDir },
+    );
+    setClient(backend.token, backend.baseUrl);
+
+    await writeFile(
+      `${tempDir}/wmill.yaml`,
+      `defaultTs: bun\nsyncBehavior: v1\nincludes:\n  - "**"\nexcludes: []`,
+      "utf-8",
+    );
+
+    const scriptPath = "f/test/no_owner";
+    const createResp = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/scripts/create`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          path: scriptPath,
+          content: `export async function main() { return 1; }`,
+          language: "bun",
+          summary: "no owner",
+          description: "",
+        }),
+      },
+    );
+    expect(createResp.status).toBeLessThan(300);
+
+    const pullResult = await backend.runCLICommand(
+      ["sync", "pull", "--yes"],
+      tempDir,
+      "obo_marker_test",
+    );
+    expect(pullResult.code).toEqual(0);
+
+    const meta = await readFile(`${tempDir}/${scriptPath}.script.yaml`, "utf-8");
+    expect(meta).not.toContain("has_on_behalf_of");
+    expect(meta).not.toContain("on_behalf_of_email");
+  });
+});


### PR DESCRIPTION
## Problem

`wmill sync pull` (with `syncBehavior: v1`) produced a spurious `has_on_behalf_of: false` line in the metadata of nearly every script and flow, causing endless noise in git diffs.

### Why the marker exists

With `syncBehavior: v1` the pull deliberately **strips `on_behalf_of_email`** from the committed metadata — the owner's email is user-specific and committing it causes ownership churn between whoever pulls. But on the next push the CLI still needs to know *whether the item had an owner* so it can send `preserve_on_behalf_of: true` and keep the remote ownership instead of clobbering it. Once the email is stripped, a boolean marker (`has_on_behalf_of` for scripts/flows, `has_permissioned_as` for schedules/triggers) is the only residual signal of "this has an owner."

So the marker is **not** implicit from `on_behalf_of_email` once that field is gone — but it is only meaningful when **true**. The code wrote it unconditionally as `!!<field>`, so every ownerless item (the overwhelming majority) got `...: false` written on pull.

## Fix

Emit the marker only when an owner exists. Absence of the key already means "no owner" everywhere it's read on push (`typed?.has_on_behalf_of ?? !!typed?.on_behalf_of_email` → `false`; schedules/triggers delete the marker before push and never read it), so dropping the `false` line is behavior-preserving.

Applied consistently to the four pull transforms in `cli/src/commands/sync/sync.ts`:
- scripts — `has_on_behalf_of`
- flows — `has_on_behalf_of`
- schedules — `has_permissioned_as`
- triggers — `has_permissioned_as`

Existing files that already carry a `...: false` line will show a one-time cleanup diff on the next pull (the redundant line removed), then stay stable.

## Testing

- `cli/test/pull_on_behalf_of_marker.test.ts` — new regression test: creates an ownerless script via the API, runs `sync pull` with `syncBehavior: v1`, and asserts the pulled `.script.yaml` contains neither `has_on_behalf_of` nor `on_behalf_of_email`. Verified it **fails** on the pre-fix code (received `has_on_behalf_of: false`) and **passes** with the fix.
- `bunx tsc --noEmit`: no new type errors (16 pre-existing, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop writing `has_on_behalf_of: false` and `has_permissioned_as: false` on `wmill sync pull` with `syncBehavior: v1`. Only emit these markers when true to remove noisy diffs for ownerless items. Fixes WIN-2201.

- **Bug Fixes**
  - Emit `has_on_behalf_of` / `has_permissioned_as` only when an owner exists; behavior on push is unchanged.
  - Applied to scripts, flows, schedules, and triggers; existing files may see a one-time cleanup removing redundant `false` lines.
  - Added a regression test to ensure ownerless scripts omit both the marker and `on_behalf_of_email`.

<sup>Written for commit ac3f2a8d71a6d35111d3cecc10775d949f8730dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

