### PR TITLE
chore(git-sync): bump hub scripts to windmill-cli@1.762.3

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -167,12 +167,12 @@ pub enum ObjectType {
     DatatableMigration,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28786/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28790/sync-script-to-git-repo-windmill";
 
 /// Hub script that applies a repository's state back into a workspace
 /// (the repo → Windmill / "pull" direction). Same script the UI runs from
 /// `PullWorkspaceModal` with `pull: true`; the slug's `:` is percent-encoded.
-pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28787/git-sync%3A-init-repository-windmill";
+pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28789/git-sync%3A-init-repository-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,6 +1,6 @@
 {
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28787/git-sync%3A-init-repository-windmill",
+	"gitInitRepo": "hub/28789/git-sync%3A-init-repository-windmill",
 	"slackErrorHandler": "hub/28241/workspace-or-schedule-error-handler-slack",
 	"emailErrorHandler": "hub/19795/workspace-or-error-handler-email",
 	"slackRecoveryHandler": "hub/28239/slack/schedule-recovery-handler-slack",


### PR DESCRIPTION
## Summary

The git-sync hub scripts were republished on hub.windmill.dev, pinning `windmill-cli@1.762.3` (up from `1.753.1-gitsync.0` for the sync script and `1.703.3` for the init-repository script). This bumps the hub version-id pins in the backend and frontend to the newly published versions so auto-managed repositories pick up the new CLI.

Hub scripts are immutable per version-id, so a republish mints a new incrementing id rather than overwriting — the pins have to move.

## Changes

- `LATEST_GIT_SYNC_SCRIPT_PATH`: `hub/28786` → `hub/28790` (Sync script to Git repo, ask 6943)
- `GIT_SYNC_PULL_SCRIPT_PATH`: `hub/28787` → `hub/28789` (Git-sync: init repository, ask 13952)
- `hubPaths.json` `gitInitRepo`: `hub/28787` → `hub/28789` (same init-repository script)
- `gitSyncTest` (`hub/28184`, Git repo test read write) left unchanged — already the latest version.

## Verification

- Confirmed latest version ids via `hub.windmill.dev/searchData` (28790 sync, 28789 init, 28184 test).
- Fetched `/raw/28789` and `/raw/28790` — both import `windmill-cli@1.762.3`, confirmed published on npm.
- The `git-sync-test.yml` CI e2e triggers on `backend/windmill-common/src/workspaces.rs` changes, so this PR runs the full git-sync integration suite against the new scripts.

No visible UI effect (`hubPaths.json` is a data file mapping logical names to hub script paths); screenshots N/A.

## Test plan

- [ ] `git-sync-test.yml` CI e2e passes (exercises the new hub scripts end-to-end via Gitea)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped git-sync hub script pins to versions that use `windmill-cli@1.762.3`, so auto-managed repositories run the latest CLI. No UI changes.

- **Dependencies**
  - `LATEST_GIT_SYNC_SCRIPT_PATH`: `hub/28786` → `hub/28790`
  - `GIT_SYNC_PULL_SCRIPT_PATH` and `hubPaths.json.gitInitRepo`: `hub/28787` → `hub/28789`
  - `gitSyncTest` unchanged (already latest)

<sup>Written for commit aa0279bf796d21c2fa6c30ebf661d4a7a5fc00d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

