### PR TITLE
fix(schedules): apply scope-path filtering to schedule list endpoints

### DIFF
--- a/backend/windmill-api-schedule/src/lib.rs
+++ b/backend/windmill-api-schedule/src/lib.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 use sql_builder::{prelude::Bind, SqlBuilder};
 use sqlx::{Postgres, Transaction};
 use std::str::FromStr;
-use windmill_api_auth::{check_scopes, maybe_refresh_folders, require_super_admin, ApiAuthed};
+use windmill_api_auth::{
+    build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_super_admin, ApiAuthed,
+};
 use windmill_audit::audit_oss::audit_log;
 use windmill_audit::ActionKind;
 use windmill_common::DB;
@@ -911,6 +913,9 @@ async fn list_schedule(
         }
     }
 
+    let allowed = build_scope_path_predicate(&authed, "schedules", "read");
+    rows.retain(|r| allowed(&r.path));
+
     Ok(Json(rows))
 }
 
@@ -958,7 +963,10 @@ async fn list_schedule_with_jobs(
     .fetch_all(&mut *tx)
     .await?;
     tx.commit().await?;
-    Ok(Json(rows))
+    let allowed = build_scope_path_predicate(&authed, "schedules", "read");
+    Ok(Json(
+        rows.into_iter().filter(|r| allowed(&r.path)).collect(),
+    ))
 }
 
 // SELECT id, title AS item_title, t.tag_array


### PR DESCRIPTION
Fixes WIN-2204

## Problem

`list_schedule` (`GET /w/{ws}/schedules/list`) and `list_schedule_with_jobs` (`GET /w/{ws}/schedules/list_with_jobs`) did not apply scope-path filtering. A token restricted to `schedules:read:<prefix>/*` could enumerate every schedule in the workspace through either endpoint, including paths, target script paths, cron expressions, and recent job outcomes, bypassing its declared scope.

The single-item `get_schedule` handler already calls `check_scopes`, and every other domain's list endpoint (scripts, flows, apps, resources, variables) applies `build_scope_path_predicate` post-fetch. Schedules was the only one missing it.

## Fix

Apply `build_scope_path_predicate(&authed, "schedules", "read")` to the rows returned by both handlers, mirroring `apps.rs:587`, `scripts.rs:346`, `flows.rs:227`, `resources.rs:379`, `variables.rs:218`.

In `list_schedule` the filter runs after the draft-only append block, so synthesized draft rows are filtered too, not just DB rows.

Unscoped tokens and tag-filter-only tokens are unaffected: the predicate returns `true` for every path unless the token carries at least one non-`if_jobs:filter_tags:` scope.

## Validation

- `cargo check -p windmill-api-schedule` clean, `cargo fmt` applied.
- End-to-end against the local dev backend with two seeded schedules (`f/allowed/s1`, `f/other/s2`) and a token scoped to `schedules:read:f/allowed/*`:

| request | token | result |
|---|---|---|
| `/schedules/list` | admin | `['f/allowed/s1', 'f/other/s2']` |
| `/schedules/list` | scoped | `['f/allowed/s1']` |
| `/schedules/list_with_jobs` | scoped | `['f/allowed/s1']` |
| `/schedules/get/f/other/s2` | scoped | `403` (already correct) |

Before the change both list endpoints returned both paths for the scoped token.

## Tests

No test added. `build_scope_path_predicate` already has unit coverage in `windmill-api-auth` (exact-path, wildcard-subtree, unscoped, tag-filter-only), and no domain has a handler-level integration test for scope-filtered listings, so a new one here would need substantial fixtures to assert what the predicate's own tests already pin. Verified manually as above instead.

## Known limitation

Filtering runs after the SQL `LIMIT/OFFSET`, so a scoped token can receive a short or empty page when out-of-scope rows sort ahead of allowed ones (reproducible with an explicit small `per_page`; `DEFAULT_PER_PAGE` is 1000). This is the same post-fetch shape every other domain uses, and it is fail-closed: it can hide authorized rows from a scoped token, never expose unauthorized ones. Pushing scope into the SQL predicate is a cross-cutting change to the shared pattern and is left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied scope-path filtering to schedule list endpoints so tokens scoped to `schedules:read:<prefix>/*` only see permitted schedules. Fixes WIN-2204.

- **Bug Fixes**
  - Added `build_scope_path_predicate(&authed, "schedules", "read")` from `windmill-api-auth` to `list_schedule` and `list_schedule_with_jobs`.
  - In `list_schedule`, filtering runs after draft rows are appended, so both draft and DB rows are filtered.
  - Unscoped and tag-filter-only tokens remain unaffected.

<sup>Written for commit 1abb0c6bfc31b4611b72d1156b275e56f1390023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
