### PR TITLE
fix(docker): update cached runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -244,8 +244,11 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11 --compile-bytecode
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-RUN for python in /tmp/build_cache/py_runtime/*/bin/python; do \
-    uv pip install --python "$python" --system --break-system-packages --upgrade "pip==$PIP_VERSION"; \
+RUN set -eux; \
+    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
+        if [ -x "$runtime/bin/python" ]; then \
+            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
+        fi; \
     done
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,7 @@ ARG features=""
 # 2. Change LATEST_STABLE_PY in dockerfile
 # 3. Change #[default] annotation for PyVersion in backend
 ARG LATEST_STABLE_PY=3.12
+ARG PIP_VERSION=26.1.2
 ENV UV_PYTHON_INSTALL_DIR=/tmp/windmill/cache/py_runtime
 ENV UV_PYTHON_PREFERENCE=only-managed
 
@@ -243,6 +244,9 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11 --compile-bytecode
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
+RUN for python in /tmp/build_cache/py_runtime/*/bin/python; do \
+    uv pip install --python "$python" --system --break-system-packages --upgrade "pip==$PIP_VERSION"; \
+    done
 
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -336,7 +336,12 @@ async fn cache_hub_scripts(file_path: Option<String>) -> anyhow::Result<()> {
                         "Hub script {path} returned a malformed lockfile (does not start with a package.json object), skipping prebundling"
                     );
                 } else {
-                    let install_lock = bun_cache_install_lock(&lock)?;
+                    let install_lock = bun_cache_install_lock(&lock).unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "Failed to apply dependency overrides for Hub script {path}, using the original lockfile: {e:#}"
+                        );
+                        Cow::Borrowed(lock.as_str())
+                    });
                     let _ = windmill_worker::prepare_job_dir(&install_lock, &job_dir).await?;
                     let envs = windmill_worker::get_common_bun_proc_envs(None).await;
                     if let Err(e) = windmill_worker::install_bun_lockfile(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,6 +19,7 @@ use monitor::{
 use rand::Rng;
 use sqlx::{Pool, Postgres};
 use std::{
+    borrow::Cow,
     collections::HashMap,
     fs::{create_dir_all, DirBuilder},
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -335,7 +336,8 @@ async fn cache_hub_scripts(file_path: Option<String>) -> anyhow::Result<()> {
                         "Hub script {path} returned a malformed lockfile (does not start with a package.json object), skipping prebundling"
                     );
                 } else {
-                    let _ = windmill_worker::prepare_job_dir(&lock, &job_dir).await?;
+                    let install_lock = bun_cache_install_lock(&lock)?;
+                    let _ = windmill_worker::prepare_job_dir(&install_lock, &job_dir).await?;
                     let envs = windmill_worker::get_common_bun_proc_envs(None).await;
                     if let Err(e) = windmill_worker::install_bun_lockfile(
                         &mut 0,
@@ -383,6 +385,74 @@ async fn cache_hub_scripts(file_path: Option<String>) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+fn bun_cache_install_lock(lock: &str) -> anyhow::Result<Cow<'_, str>> {
+    const BUN_LOCK_MARKER: &str = "//bun.lock\n";
+    const FORM_DATA_OVERRIDE: &str = "4.0.6";
+
+    if !lock.contains("form-data@4.0.5\"") {
+        return Ok(Cow::Borrowed(lock));
+    }
+
+    let (package_json, bun_lock) = lock
+        .split_once(BUN_LOCK_MARKER)
+        .context("Bun Hub script lockfile is missing its lock marker")?;
+    let mut package: serde_json::Value = serde_json::from_str(package_json)
+        .context("Bun Hub script lockfile has an invalid package.json")?;
+    let package = package
+        .as_object_mut()
+        .context("Bun Hub script package.json must be an object")?;
+    let overrides = package
+        .entry("overrides")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("Bun Hub script package.json overrides must be an object")?;
+    overrides.insert(
+        "form-data".to_string(),
+        serde_json::Value::String(FORM_DATA_OVERRIDE.to_string()),
+    );
+
+    Ok(Cow::Owned(format!(
+        "{}\n{BUN_LOCK_MARKER}{bun_lock}",
+        serde_json::to_string_pretty(&package)?
+    )))
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::bun_cache_install_lock;
+    use std::borrow::Cow;
+
+    #[test]
+    fn bun_cache_install_lock_overrides_vulnerable_transitive_dependency() {
+        let lock = r#"{
+  "dependencies": {
+    "@slack/web-api": "latest"
+  }
+}
+//bun.lock
+{
+  "packages": {
+    "form-data": ["form-data@4.0.5"]
+  }
+}"#;
+
+        let updated = bun_cache_install_lock(lock).unwrap();
+
+        assert!(updated.contains(r#""form-data": "4.0.6""#));
+        assert!(updated.contains(r#""form-data": ["form-data@4.0.5"]"#));
+    }
+
+    #[test]
+    fn bun_cache_install_lock_leaves_unaffected_locks_unchanged() {
+        let lock = "{\"dependencies\":{}}\n//bun.lock\n{}";
+
+        let updated = bun_cache_install_lock(lock).unwrap();
+
+        assert!(matches!(updated, Cow::Borrowed(_)));
+        assert_eq!(updated, lock);
+    }
 }
 
 /// Raw resource type from hub API (schema is a JSON string)

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -63,8 +63,11 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-RUN for python in /tmp/build_cache/py_runtime/*/bin/python; do \
-    uv pip install --python "$python" --system --break-system-packages --upgrade "pip==$PIP_VERSION"; \
+RUN set -eux; \
+    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
+        if [ -x "$runtime/bin/python" ]; then \
+            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
+        fi; \
     done
 
 # Copy to final location with world-writable permissions for arbitrary UID support

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -27,6 +27,7 @@ FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
 ARG LATEST_STABLE_PY=3.12.12
+ARG PIP_VERSION=26.1.2
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -62,6 +63,9 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
+RUN for python in /tmp/build_cache/py_runtime/*/bin/python; do \
+    uv pip install --python "$python" --system --break-system-packages --upgrade "pip==$PIP_VERSION"; \
+    done
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -63,8 +63,11 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-RUN for python in /tmp/build_cache/py_runtime/*/bin/python; do \
-    uv pip install --python "$python" --system --break-system-packages --upgrade "pip==$PIP_VERSION"; \
+RUN set -eux; \
+    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
+        if [ -x "$runtime/bin/python" ]; then \
+            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
+        fi; \
     done
 
 # Copy to final location with world-writable permissions for arbitrary UID support

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -27,6 +27,7 @@ FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
 ARG LATEST_STABLE_PY=3.12.12
+ARG PIP_VERSION=26.1.2
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -62,6 +63,9 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
+RUN for python in /tmp/build_cache/py_runtime/*/bin/python; do \
+    uv pip install --python "$python" --system --break-system-packages --upgrade "pip==$PIP_VERSION"; \
+    done
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \


### PR DESCRIPTION
## Summary

Fixes #10219.

Refresh two dependencies embedded in Windmill runtime images so new images do not retain fixable package vulnerabilities:

- upgrade `pip` from the version bundled by uv-managed Python to `26.1.2`
- override stale Hub-script locks from `form-data` 4.0.5 to 4.0.6 while building the Bun package cache and prebundles

## Changes

- Add a pinned `PIP_VERSION` build argument to the full, slim, and EE slim images and upgrade every real uv-managed Python runtime after `uv python install`.
- Fail the image build if any runtime upgrade fails, compile the upgraded package bytecode, and avoid duplicate work through uv's version symlinks.
- Add a cache-only Bun lock transformation for immutable Hub script locks that still resolve `form-data@4.0.5`.
- Keep the original Hub lock as the prebundle cache key, so runtime lookup continues to find the prebuilt bundle while its installed contents use 4.0.6.
- Fall back to an individual script's original lockfile when its override cannot be transformed, preserving the cache pass for remaining Hub scripts.
- Add unit coverage for affected and unaffected Hub locks.

## Validation

- Docker BuildKit checks complete for `Dockerfile`, `docker/DockerfileSlim`, and `docker/DockerfileSlimEe`; their reported warnings are pre-existing instructions outside this diff.
- Applied the final uv command to `ghcr.io/windmill-labs/windmill-ee-slim:1.763.0`; exactly one real managed runtime is selected, it reports `pip 26.1.2`, and uv byte-compiles 395 files.
- Applied the override to the current Slack Hub lock and ran Bun install; both `node_modules/form-data/package.json` and the regenerated text lock report 4.0.6, and a subsequent frozen install succeeds.
- Targeted `rustfmt` and `git diff --check` pass.
- The focused Rust test build was attempted, but local compilation is blocked before the changed tests by the unavailable configured PostgreSQL host and missing local `cmake` for `rdkafka-sys`; CI should exercise the included unit tests.
