### PR TITLE
fix(frontend): fall back to createFlow when the update target does not exist

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -413,7 +413,22 @@
 			// loadingSave = false // del
 			// return
 
-			if (newFlow) {
+			// `newFlow` comes from the embedder, and updating a path that has no
+			// deployed flow 404s. Confirm with the server before taking the update
+			// branch so a first deploy still lands.
+			let isNewFlow = newFlow
+			if (!isNewFlow) {
+				try {
+					isNewFlow =
+						initialPath === '' ||
+						!(await FlowService.existsFlowByPath({ workspace: opWorkspace!, path: initialPath }))
+				} catch (err) {
+					// Unreachable check: keep the caller's intent rather than failing the deploy.
+					console.error('Could not check flow existence', err)
+				}
+			}
+
+			if (isNewFlow) {
 				await FlowService.createFlow({
 					workspace: opWorkspace!,
 					requestBody: {


### PR DESCRIPTION
Fixes WIN-2206

## Problem

Deploying a new flow from the whitelabel SDK fails with:

```
The flow could not be saved: Not found: Flow not found at name f/exabeam/no_trigger/no_trigger/testwithoutsave (flows.rs:1048)
```

`FlowBuilder.saveFlow` picks its endpoint solely from the `newFlow` prop: true → `POST /flows/create`, false → `PUT /flows/update/{initialPath}`. `update_flow` reads `dependency_job` from the `flow` table and `not_found_if_none`s when there is no row, which is exactly this error.

So the embedder is deploying a never-deployed flow while the builder sits in the `newFlow={false}` branch. `newFlow: boolean` is required in `FlowBuilderProps`, so the Svelte layer can't silently drop it — this points at the private react-sdk wrapper not forwarding the prop (same class of gap as the earlier `onTestJob` one), which isn't fixable in this repo.

To be explicit: **if an embedder passes `newFlow` correctly, this error cannot occur.** This PR does not change that; it stops the deploy path from trusting a caller-supplied flag for something the server already knows.

## Change

Before taking the update branch, confirm with `GET /flows/exists/{path}` — which queries the same `flow` table `update_flow` reads — and create instead when nothing is deployed there.

- No behavior change when `newFlow` is true: no extra request, straight to create.
- No behavior change for the full-page editor, where `newFlow` is derived from the server's `no_deployed` and is already accurate.
- If the existence check itself fails, the caller's `newFlow` intent is kept rather than failing the deploy.

## Validation

Reproduced and fixed against the local dev stack using `/test_dev/sdk_flow` with `newFlow` omitted and `initialPath` pointing at an undeployed path.

**Before** (toast, matching the report — line drift only):

```
The flow could not be saved: Not found: Flow not found at name u/admin/sdk_new_flow_test (flows.rs:1050)
```

**After** — deploy succeeds; observed request sequence:

```
GET  /api/w/admins/flows/exists/u/admin/sdk_new_flow_test => 200
POST /api/w/admins/flows/create                           => 201
```

Row confirmed in the `flow` table, no error toast. The temporary edit to the test route was reverted before committing.

`npm run check:fast` is clean for this file (the one reported error is a pre-existing missing `modern-screenshot` dependency in `RawAppEditor.svelte`, unrelated).

No screenshot attached: the change is behavioral on the deploy request, and the visible UI is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2206: FlowBuilder now verifies the target path before updating and falls back to create when the update target doesn’t exist. This prevents “Flow not found” errors when the whitelabel SDK sends `newFlow=false` for an undeployed path.

- **Bug Fixes**
  - When `newFlow` is false, call GET /flows/exists/{path}; if not found or `initialPath` is empty, use create; otherwise, update.
  - No extra request when `newFlow` is true; full-page editor behavior unchanged.
  - If the existence check fails, keep the caller’s `newFlow` intent instead of failing the deploy.

<sup>Written for commit f7bcca8261cbde2ad71cb21e05c99b40006db2ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

