### PR TITLE
feat(ai): expose get_db_schema tool in global chat

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1533,3 +1533,31 @@
     - saves the plan as a markdown artifact via create_artifact rather than only replying inline
     - the artifact content has a title, a one-line summary, and three or four bullet steps for onboarding
     - does not create a flow or script draft yet
+
+- id: global-dbschema1-postgres-resource-tables
+  prompt: |-
+    I have a postgres resource at f/data/reports_pg in this workspace.
+    What tables does that database have?
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_empty.json
+  runtime:
+    maxTurns: 12
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - get_db_schema
+    forbiddenToolsUsed:
+      - write_script
+      - write_resource
+      - test_run_script
+      - deploy_workspace_item
+    toolCallArgs:
+      - tool: get_db_schema
+        field: resourcePath
+        stringIncludesAnyOf:
+          - f/data/reports_pg
+  skipJudge: true
+  judgeChecklist:
+    - fetches the schema through get_db_schema with the resource path f/data/reports_pg
+    - when the lookup fails, tells the user instead of inventing table names
+    - does not write scripts or resources to answer a read-only question

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2716,9 +2716,11 @@ export const globalTools: Tool<{}>[] = [
 			)
 		}
 	},
-	createDbSchemaTool<{}>(
-		'Fetch the schema (tables and columns) of a database resource by its path. Supports postgresql, mysql, ms_sql_server, snowflake, bigquery and duckdb resources.'
-	),
+	createDbSchemaTool<{}>({
+		description:
+			'Fetch the schema (tables and columns) of a database resource by its path. Supports postgresql, mysql, ms_sql_server, snowflake and bigquery resources.',
+		updateEditorCache: false
+	}),
 	{
 		def: createToolDef(
 			readFlowModuleCodeSchema,

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -78,6 +78,7 @@ import {
 	type ToolDisplayAction
 } from '../shared'
 import { searchDocsTool, readDocsPageTool } from '../docs/core'
+import { createDbSchemaTool } from '../script/core'
 import type { ContextElement } from '../context'
 import { getDatatableTools } from '../datatableTools'
 import { fileTools } from '../files/fileTools'
@@ -916,6 +917,7 @@ Rules:
 - Use discard_local_draft to remove a draft, including the matching open editor draft. Use delete_workspace_item only to delete a deployed workspace item.
 - Variable values are never readable. For secrets, create a secret variable and reference it from resources as "$var:path/to/variable".
 - Use search_resource_types before write_resource.
+- Use get_db_schema with a database resource path to fetch its tables and columns before writing SQL (or a script querying that database).
 - Use get_instructions before writing scripts, flows, resources, or apps. For scripts, pass the target language.
 - A "data pipeline" is NOT a flow: it is a DAG of independent scripts in one folder, wired by storage assets (DuckLake/data tables/S3) and triggers via top-of-file \`pipeline\` / \`on <ref>\` annotation comments written in each script's comment syntax (\`--\` for SQL, \`#\` for Python/Bash, \`//\` for TS — a \`//\` line in a SQL node is a syntax error). When the user asks for a data pipeline (or to ingest/transform/materialize data across steps), call get_instructions with subject "pipeline" and build annotated script drafts — do not build a flow.
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
@@ -2714,6 +2716,9 @@ export const globalTools: Tool<{}>[] = [
 			)
 		}
 	},
+	createDbSchemaTool<{}>(
+		'Fetch the schema (tables and columns) of a database resource by its path. Supports postgresql, mysql, ms_sql_server, snowflake, bigquery and duckdb resources.'
+	),
 	{
 		def: createToolDef(
 			readFlowModuleCodeSchema,

--- a/frontend/src/lib/components/copilot/chat/script/core.ts
+++ b/frontend/src/lib/components/copilot/chat/script/core.ts
@@ -460,10 +460,15 @@ export const resourceTypeTool: Tool<ScriptChatHelpers> = {
 	}
 }
 
-// Generic DB schema tool factory that can be used by both script and flow modes
-export function createDbSchemaTool<T>(): Tool<T> {
+// Generic DB schema tool factory shared by the script, flow and global modes
+export function createDbSchemaTool<T>(description?: string): Tool<T> {
 	return {
-		def: DB_SCHEMA_FUNCTION_DEF,
+		def: description
+			? {
+					...DB_SCHEMA_FUNCTION_DEF,
+					function: { ...DB_SCHEMA_FUNCTION_DEF.function, description }
+				}
+			: DB_SCHEMA_FUNCTION_DEF,
 		fn: async ({ args, workspace, toolCallbacks, toolId }) => {
 			if (!args.resourcePath) {
 				throw new Error('Database path not provided')

--- a/frontend/src/lib/components/copilot/chat/script/core.ts
+++ b/frontend/src/lib/components/copilot/chat/script/core.ts
@@ -1,7 +1,6 @@
 import { ResourceService, JobService } from '$lib/gen/services.gen'
 import type { AIProvider, AIProviderModel, ResourceType, ScriptLang } from '$lib/gen/types.gen'
 import { capitalize, isObject, toCamel } from '$lib/utils'
-import { get } from 'svelte/store'
 import { compile, phpCompile, pythonCompile } from '../../utils'
 import type {
 	ChatCompletionSystemMessageParam,
@@ -461,7 +460,10 @@ export const resourceTypeTool: Tool<ScriptChatHelpers> = {
 }
 
 // Generic DB schema tool factory shared by the script, flow and global modes
-export function createDbSchemaTool<T>(description?: string): Tool<T> {
+export function createDbSchemaTool<T>(
+	opts: { description?: string; updateEditorCache?: boolean } = {}
+): Tool<T> {
+	const { description, updateEditorCache = true } = opts
 	return {
 		def: description
 			? {
@@ -480,23 +482,24 @@ export function createDbSchemaTool<T>(description?: string): Tool<T> {
 				workspace: workspace,
 				path: args.resourcePath
 			})
-			const newDbSchemas = {
-				[args.resourcePath]: await getDbSchemas(
-					resource.resource_type,
-					args.resourcePath,
-					workspace,
-					(error) => {
-						console.error(error)
-					}
-				)
-			}
-			dbSchemas.update((schemas) => ({ ...schemas, ...newDbSchemas }))
-			const dbs = get(dbSchemas)
-			const db = dbs[args.resourcePath]
-			if (!db) {
+			const dbSchema = await getDbSchemas(
+				resource.resource_type,
+				args.resourcePath,
+				workspace,
+				(error) => {
+					console.error(error)
+				}
+			)
+			if (!dbSchema) {
 				throw new Error('Database not found')
 			}
-			const stringSchema = await formatDBSchema(db)
+			// The dbSchemas store is an editor cache keyed by resource path with no
+			// workspace dimension: a chat that may operate on a different workspace than
+			// the navigation one (global/session) must not write into it.
+			if (updateEditorCache) {
+				dbSchemas.update((schemas) => ({ ...schemas, [args.resourcePath]: dbSchema }))
+			}
+			const stringSchema = await formatDBSchema(dbSchema)
 			toolCallbacks.setToolStatus(toolId, {
 				content: 'Retrieved database schema for ' + args.resourcePath
 			})


### PR DESCRIPTION
## Summary
Makes the `get_db_schema` tool — previously only available in the script and flow chat modes (and only when a DB context element was attached) — available to the global chat and AI sessions. The model can now fetch a database resource's tables/columns before writing SQL against it, instead of guessing.

## Changes
- `global/core.ts`: register the shared `createDbSchemaTool` factory in `globalTools` (offered to both session chats and the regular global side-panel chat), with a global-mode description that spells out what the tool does and which resource types it supports (postgresql, mysql, ms_sql_server, snowflake, bigquery — the types `getDbSchemas` actually has introspection scripts for).
- `global/core.ts`: add a system-prompt rule instructing the model to call `get_db_schema` before writing SQL against a database resource.
- `script/core.ts`: `createDbSchemaTool` now takes an options object — `description` overrides the tool description, and `updateEditorCache: false` skips writing the fetched schema into the shared `dbSchemas` store. That store is keyed by resource path with no workspace dimension, so a session chat operating on a fork workspace must not write into it (it would poison the schema cache used by editors in the navigation workspace). Script and flow modes keep their existing behavior (context-gated tool, terse description, cache write).
- `ai_evals/cases/global.yaml`: new case `global-dbschema1-postgres-resource-tables` pinning tool availability and selection — asks for the tables of a named postgres resource and deterministically requires a `get_db_schema` call with that resource path (and no script/resource writes).

## ai_evals A/B (sonnet, 8 global cases)
Before = `main`, after = this branch, same cases/model/backend:

| case | before | after |
|---|---|---|
| test1-script-create | pass | pass |
| test8-human-script-infer-path-language | pass | pass |
| test15-human-postgres-resource | pass | fail* |
| test19-datatable-not-configured | pass | pass |
| test22-datatable-inspect-columns | pass | pass |
| test23-datatable-query-select | pass | pass |
| test27-list-recent-runs | pass | pass |
| **dbschema1-postgres-resource-tables (new)** | **fail (tool absent)** | **pass** |

\* `test15` is pre-existing flakiness, not a regression: re-runs show the identical failure signature on both arms (main 2/3, branch 1/3 — the model sometimes drafts to `f/evals/global_db_password` instead of `f/evals/global/...`; a path-shape miss unrelated to this change). Datatable cases confirm the model does not confuse `get_db_schema` with the datatable tools. Context-window cost of the new tool schema + prompt rule: ~130–150 tokens per iteration (uniform across cases, e.g. final context 27729 → 27859 on test19).

## Test plan
- [x] `npm run check:fast` — no new errors (one pre-existing unrelated error in `utils_workspace_deploy.ts`)
- [x] Browser-verified: session chat request payload includes `get_db_schema` with the new description and the system-prompt rule
- [x] End-to-end: asked a session chat for the tables of a postgresql resource — the tool fetched and returned the real schema (see screenshot), including after the cache-skip refactor
- [x] `ai_evals` before/after A/B on global mode (results above)

## Screenshots
![global-chat-get-db-schema](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/db-resource-schema/1784545035-global-chat-get-db-schema.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)