### PR TITLE
fix(db): grant schema usage and re-run windmill role grants

### DIFF
--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.down.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.down.sql
@@ -1,0 +1,3 @@
+-- No down migration: revoking these grants leaves the instance unable to run
+-- any query on a user_db transaction. 20250205131523, which this re-runs, is
+-- likewise a no-op down.

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -22,10 +22,11 @@
 -- grant that cannot be applied is isolated and re-raised as a named WARNING, so
 -- the rest still run and the reason is visible in the migration log. The known
 -- failure modes this absorbs:
---   * an object the runner does not own -- a superuser-installed extension
---     (PostGIS's spatial_ref_sys) or a co-located application table. The loops
---     already filter to owned objects so these are skipped without even a
---     warning; the guard is the backstop.
+--   * an object the runner cannot grant on -- a superuser-installed extension
+--     (PostGIS's spatial_ref_sys) or a co-located application table owned by an
+--     unrelated role. The loops filter to relations the runner has authority to
+--     grant, so these are skipped without even a warning; the guard is the
+--     backstop.
 --   * an object dropped by another session between the catalog scan and the
 --     GRANT (only possible when something outside the migration shares the DB).
 --   * USAGE on a schema the runner does not own (needed only where USAGE was
@@ -50,14 +51,19 @@ BEGIN
     -- pg_class over the relkinds GRANT ... ON ALL TABLES covers -- ordinary (r),
     -- partitioned (p), views (v), materialized views (m), foreign (f). pg_tables
     -- would miss views such as flow_workspace_runnables, which are read through
-    -- user_db transactions and so must be granted too.
+    -- user_db transactions and so must be granted too. pg_has_role(...,'USAGE')
+    -- selects the relations the runner can actually grant: ones it owns
+    -- directly, inherits ownership of (tables still owned by a previous
+    -- migration role after a credential rotation), or reaches as a superuser.
+    -- Owner-name equality would miss the inherited-owner case and leave those
+    -- relations' user_db access broken.
     FOR obj IN
         SELECT format('%I.%I', n.nspname, c.relname)
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = target_schema
           AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
-          AND pg_get_userbyid(c.relowner) = current_user
+          AND pg_has_role(current_user, c.relowner, 'USAGE')
     LOOP
         BEGIN
             EXECUTE format('GRANT ALL ON TABLE %s TO windmill_user, windmill_admin', obj);
@@ -69,7 +75,8 @@ BEGIN
     FOR obj IN
         SELECT format('%I.%I', schemaname, sequencename)
         FROM pg_sequences
-        WHERE schemaname = target_schema AND sequenceowner = current_user
+        WHERE schemaname = target_schema
+          AND pg_has_role(current_user, sequenceowner, 'USAGE')
     LOOP
         BEGIN
             EXECUTE format('GRANT ALL ON SEQUENCE %s TO windmill_user, windmill_admin', obj);

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -1,8 +1,8 @@
 -- Re-runs the grants of 20250205131523. Everything in that migration sits in
 -- one DO block whose first statement is LOCK TABLE pg_catalog.pg_roles, which
 -- a non-superuser cannot take; on managed Postgres (RDS, Cloud SQL) it raises
--- and the block's EXCEPTION WHEN OTHERS handler downgrades the failure to a
--- NOTICE, so every GRANT after it is skipped.
+-- and the block's single EXCEPTION WHEN OTHERS handler downgrades the failure
+-- to a NOTICE, so every GRANT after it is skipped.
 --
 -- Most tables survive that anyway, because 20221105003256 grants them outside
 -- any such block. What is lost is the ALTER DEFAULT PRIVILEGES, which is what
@@ -15,37 +15,48 @@
 -- table by hand; re-establishing the default privileges under the current
 -- runner closes it for future tables instead.
 --
--- We grant per-object over only the tables and sequences the runner owns,
--- instead of GRANT ... ON ALL TABLES IN SCHEMA. The blanket form raises a hard
--- "permission denied for table X" -- aborting the whole upgrade, since there is
--- deliberately no catch-all handler -- the moment the schema holds one object
--- the runner does not own, e.g. a superuser-installed extension (PostGIS's
--- spatial_ref_sys) or a co-located application table. 20250205131523 tolerated
--- that only by swallowing every error. Owning the object is exactly the
--- condition under which the GRANT can succeed, so filtering to owned objects
--- skips what would fail (Windmill's own tables are all owned by the runner)
--- rather than hiding it. windmill_user and windmill_admin are guaranteed to
--- exist here: 20221105003256 grants to both outside any handler, so any
--- database that reached this migration already has them.
+-- This migration must never abort an upgrade, so every grant is guarded
+-- individually. That is the opposite of 20250205131523's single block-wide
+-- WHEN OTHERS, whose flaw was granularity, not the mere presence of a handler:
+-- one early failure there silently skipped every remaining grant. Here each
+-- grant that cannot be applied is isolated and re-raised as a named WARNING, so
+-- the rest still run and the reason is visible in the migration log. The known
+-- failure modes this absorbs:
+--   * an object the runner does not own -- a superuser-installed extension
+--     (PostGIS's spatial_ref_sys) or a co-located application table. The loops
+--     already filter to owned objects so these are skipped without even a
+--     warning; the guard is the backstop.
+--   * an object dropped by another session between the catalog scan and the
+--     GRANT (only possible when something outside the migration shares the DB).
+--   * USAGE on a schema the runner does not own (needed only where USAGE was
+--     revoked from PUBLIC, else the roles resolve no table and queries fail
+--     with "relation does not exist"); such a deployment needs
+--     init-db-as-superuser.sql run by a superuser.
+-- windmill_user and windmill_admin are guaranteed to exist: 20221105003256
+-- grants to both outside any handler, so any database that reached this
+-- migration already has them.
 DO
 $do$
 DECLARE
     target_schema TEXT := current_schema();
     obj TEXT;
 BEGIN
-    -- USAGE on the schema, needed only where it was revoked from PUBLIC. A
-    -- runner that does not own the schema cannot grant it, but Postgres reports
-    -- that as a "no privileges were granted" warning, not an error, so it
-    -- cannot abort the upgrade; that deployment needs init-db-as-superuser.sql
-    -- run by a superuser.
-    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user, windmill_admin', target_schema);
+    BEGIN
+        EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user, windmill_admin', target_schema);
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'skipped GRANT USAGE on schema %: %', target_schema, SQLERRM;
+    END;
 
     FOR obj IN
         SELECT format('%I.%I', schemaname, tablename)
         FROM pg_tables
         WHERE schemaname = target_schema AND tableowner = current_user
     LOOP
-        EXECUTE format('GRANT ALL ON TABLE %s TO windmill_user, windmill_admin', obj);
+        BEGIN
+            EXECUTE format('GRANT ALL ON TABLE %s TO windmill_user, windmill_admin', obj);
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'skipped GRANT on table %: %', obj, SQLERRM;
+        END;
     END LOOP;
 
     FOR obj IN
@@ -53,12 +64,20 @@ BEGIN
         FROM pg_sequences
         WHERE schemaname = target_schema AND sequenceowner = current_user
     LOOP
-        EXECUTE format('GRANT ALL ON SEQUENCE %s TO windmill_user, windmill_admin', obj);
+        BEGIN
+            EXECUTE format('GRANT ALL ON SEQUENCE %s TO windmill_user, windmill_admin', obj);
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'skipped GRANT on sequence %: %', obj, SQLERRM;
+        END;
     END LOOP;
 
     -- Applies to future objects created by the runner (the FOR ROLE default),
     -- so it cannot conflict with objects owned by anyone else.
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_user, windmill_admin', target_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_user, windmill_admin', target_schema);
+    BEGIN
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_user, windmill_admin', target_schema);
+        EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_user, windmill_admin', target_schema);
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'skipped ALTER DEFAULT PRIVILEGES in schema %: %', target_schema, SQLERRM;
+    END;
 END
 $do$;

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -1,21 +1,28 @@
--- Re-runs the grants of 20250205131523. That migration wraps everything in a
--- single DO block that starts with LOCK TABLE pg_catalog.pg_roles, which
--- requires superuser; on managed Postgres (RDS, Cloud SQL) the migration user
--- is not one, the lock raises, and the block's EXCEPTION WHEN OTHERS handler
--- turns the failure into a NOTICE. Every GRANT after the lock is therefore
--- skipped, so core tables (workspace, script, ...) stay ungranted and any
--- statement on a user_db transaction (SET LOCAL ROLE windmill_user /
--- windmill_admin) fails with "permission denied for table" or, when the schema
--- itself was never granted, "relation does not exist". The per-table grants
--- added since (20260619091631, 20260701083047, 20260716151337) each patched one
--- table; this covers the rest.
+-- Re-runs the grants of 20250205131523. Everything in that migration sits in
+-- one DO block whose first statement is LOCK TABLE pg_catalog.pg_roles, which
+-- a non-superuser cannot take; on managed Postgres (RDS, Cloud SQL) it raises
+-- and the block's EXCEPTION WHEN OTHERS handler downgrades the failure to a
+-- NOTICE, so every GRANT after it is skipped.
 --
--- No LOCK TABLE and no catch-all handler here: the GRANTs are idempotent, and
--- the migration user owns the tables it created, so they succeed wherever
--- 20250205131523 was meant to. A migration user that does not own the schema
--- cannot grant USAGE on it, but Postgres reports that as a "no privileges were
--- granted" warning rather than an error, so it does not abort the upgrade --
--- that deployment needs init-db-as-superuser.sql run by a superuser.
+-- Most tables survive that anyway, because 20221105003256 grants them outside
+-- any such block. What is lost is the ALTER DEFAULT PRIVILEGES, which is what
+-- covers tables created by later migrations. Those default privileges only
+-- apply to objects created by the role that set them, so a deployment whose
+-- migration runner never successfully ran them ends up with newer tables
+-- ungranted and writes on a user_db transaction (SET LOCAL ROLE windmill_user /
+-- windmill_admin) failing with "permission denied for table". That gap is why
+-- 20260619091631, 20260701083047 and 20260716151337 each had to patch one
+-- table by hand; re-establishing the default privileges under the current
+-- runner closes it for future tables instead.
+--
+-- The schema grant matters only where USAGE was revoked from PUBLIC, in which
+-- case the roles resolve no table at all and queries fail with "relation does
+-- not exist". A runner that does not own the schema cannot grant it, but
+-- Postgres reports that as a "no privileges were granted" warning rather than
+-- an error, so it cannot abort an upgrade -- such a deployment needs
+-- init-db-as-superuser.sql run by a superuser. No LOCK TABLE and no catch-all
+-- handler here: every statement is idempotent and the runner owns the tables it
+-- created, so the grants succeed wherever 20250205131523 was meant to.
 DO
 $do$
 DECLARE

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -15,6 +15,16 @@
 -- table by hand; re-establishing the default privileges under the current
 -- runner closes it for future tables instead.
 --
+-- Which relations to grant: only those owned by the migration runner or a role
+-- it is an explicit (recursive) member of. That membership set, owner_roles,
+-- comes from pg_auth_members, deliberately NOT pg_has_role -- Postgres treats a
+-- superuser as a member of every role, so pg_has_role would make a superuser
+-- runner grant the windmill roles access to every co-located object in the
+-- schema (another application's tables, an extension's tables). Explicit
+-- membership still covers the case that owner-name equality would miss: after a
+-- migration-credential rotation the objects stay owned by the previous runner
+-- while the new runner is a real member of it.
+--
 -- This migration must never abort an upgrade, so every grant is guarded
 -- individually. That is the opposite of 20250205131523's single block-wide
 -- WHEN OTHERS, whose flaw was granularity, not the mere presence of a handler:
@@ -22,11 +32,6 @@
 -- grant that cannot be applied is isolated and re-raised as a named WARNING, so
 -- the rest still run and the reason is visible in the migration log. The known
 -- failure modes this absorbs:
---   * an object the runner cannot grant on -- a superuser-installed extension
---     (PostGIS's spatial_ref_sys) or a co-located application table owned by an
---     unrelated role. The loops filter to relations the runner has authority to
---     grant, so these are skipped without even a warning; the guard is the
---     backstop.
 --   * an object dropped by another session between the catalog scan and the
 --     GRANT (only possible when something outside the migration shares the DB).
 --   * USAGE on a schema the runner does not own (needed only where USAGE was
@@ -41,7 +46,15 @@ $do$
 DECLARE
     target_schema TEXT := current_schema();
     obj TEXT;
+    owner_roles OID[];
 BEGIN
+    WITH RECURSIVE my_roles(oid) AS (
+        SELECT oid FROM pg_roles WHERE rolname = current_user
+        UNION
+        SELECT m.roleid FROM pg_auth_members m JOIN my_roles r ON m.member = r.oid
+    )
+    SELECT array_agg(oid) INTO owner_roles FROM my_roles;
+
     BEGIN
         EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user, windmill_admin', target_schema);
     EXCEPTION WHEN OTHERS THEN
@@ -51,19 +64,14 @@ BEGIN
     -- pg_class over the relkinds GRANT ... ON ALL TABLES covers -- ordinary (r),
     -- partitioned (p), views (v), materialized views (m), foreign (f). pg_tables
     -- would miss views such as flow_workspace_runnables, which are read through
-    -- user_db transactions and so must be granted too. pg_has_role(...,'USAGE')
-    -- selects the relations the runner can actually grant: ones it owns
-    -- directly, inherits ownership of (tables still owned by a previous
-    -- migration role after a credential rotation), or reaches as a superuser.
-    -- Owner-name equality would miss the inherited-owner case and leave those
-    -- relations' user_db access broken.
+    -- user_db transactions and so must be granted too.
     FOR obj IN
         SELECT format('%I.%I', n.nspname, c.relname)
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = target_schema
           AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
-          AND pg_has_role(current_user, c.relowner, 'USAGE')
+          AND c.relowner = ANY(owner_roles)
     LOOP
         BEGIN
             EXECUTE format('GRANT ALL ON TABLE %s TO windmill_user, windmill_admin', obj);
@@ -73,10 +81,12 @@ BEGIN
     END LOOP;
 
     FOR obj IN
-        SELECT format('%I.%I', schemaname, sequencename)
-        FROM pg_sequences
-        WHERE schemaname = target_schema
-          AND pg_has_role(current_user, sequenceowner, 'USAGE')
+        SELECT format('%I.%I', n.nspname, c.relname)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = target_schema
+          AND c.relkind = 'S'
+          AND c.relowner = ANY(owner_roles)
     LOOP
         BEGIN
             EXECUTE format('GRANT ALL ON SEQUENCE %s TO windmill_user, windmill_admin', obj);

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -47,15 +47,22 @@ BEGIN
         RAISE WARNING 'skipped GRANT USAGE on schema %: %', target_schema, SQLERRM;
     END;
 
+    -- pg_class over the relkinds GRANT ... ON ALL TABLES covers -- ordinary (r),
+    -- partitioned (p), views (v), materialized views (m), foreign (f). pg_tables
+    -- would miss views such as flow_workspace_runnables, which are read through
+    -- user_db transactions and so must be granted too.
     FOR obj IN
-        SELECT format('%I.%I', schemaname, tablename)
-        FROM pg_tables
-        WHERE schemaname = target_schema AND tableowner = current_user
+        SELECT format('%I.%I', n.nspname, c.relname)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = target_schema
+          AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+          AND pg_get_userbyid(c.relowner) = current_user
     LOOP
         BEGIN
             EXECUTE format('GRANT ALL ON TABLE %s TO windmill_user, windmill_admin', obj);
         EXCEPTION WHEN OTHERS THEN
-            RAISE WARNING 'skipped GRANT on table %: %', obj, SQLERRM;
+            RAISE WARNING 'skipped GRANT on relation %: %', obj, SQLERRM;
         END;
     END LOOP;
 

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -15,30 +15,50 @@
 -- table by hand; re-establishing the default privileges under the current
 -- runner closes it for future tables instead.
 --
--- The schema grant matters only where USAGE was revoked from PUBLIC, in which
--- case the roles resolve no table at all and queries fail with "relation does
--- not exist". A runner that does not own the schema cannot grant it, but
--- Postgres reports that as a "no privileges were granted" warning rather than
--- an error, so it cannot abort an upgrade -- such a deployment needs
--- init-db-as-superuser.sql run by a superuser. No LOCK TABLE and no catch-all
--- handler here: every statement is idempotent and the runner owns the tables it
--- created, so the grants succeed wherever 20250205131523 was meant to.
+-- We grant per-object over only the tables and sequences the runner owns,
+-- instead of GRANT ... ON ALL TABLES IN SCHEMA. The blanket form raises a hard
+-- "permission denied for table X" -- aborting the whole upgrade, since there is
+-- deliberately no catch-all handler -- the moment the schema holds one object
+-- the runner does not own, e.g. a superuser-installed extension (PostGIS's
+-- spatial_ref_sys) or a co-located application table. 20250205131523 tolerated
+-- that only by swallowing every error. Owning the object is exactly the
+-- condition under which the GRANT can succeed, so filtering to owned objects
+-- skips what would fail (Windmill's own tables are all owned by the runner)
+-- rather than hiding it. windmill_user and windmill_admin are guaranteed to
+-- exist here: 20221105003256 grants to both outside any handler, so any
+-- database that reached this migration already has them.
 DO
 $do$
 DECLARE
     target_schema TEXT := current_schema();
+    obj TEXT;
 BEGIN
-    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user', target_schema);
-    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_admin', target_schema);
+    -- USAGE on the schema, needed only where it was revoked from PUBLIC. A
+    -- runner that does not own the schema cannot grant it, but Postgres reports
+    -- that as a "no privileges were granted" warning, not an error, so it
+    -- cannot abort the upgrade; that deployment needs init-db-as-superuser.sql
+    -- run by a superuser.
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user, windmill_admin', target_schema);
 
-    EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_user', target_schema);
-    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_user', target_schema);
-    EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_admin', target_schema);
-    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_admin', target_schema);
+    FOR obj IN
+        SELECT format('%I.%I', schemaname, tablename)
+        FROM pg_tables
+        WHERE schemaname = target_schema AND tableowner = current_user
+    LOOP
+        EXECUTE format('GRANT ALL ON TABLE %s TO windmill_user, windmill_admin', obj);
+    END LOOP;
 
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_user', target_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_user', target_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_admin', target_schema);
-    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_admin', target_schema);
+    FOR obj IN
+        SELECT format('%I.%I', schemaname, sequencename)
+        FROM pg_sequences
+        WHERE schemaname = target_schema AND sequenceowner = current_user
+    LOOP
+        EXECUTE format('GRANT ALL ON SEQUENCE %s TO windmill_user, windmill_admin', obj);
+    END LOOP;
+
+    -- Applies to future objects created by the runner (the FOR ROLE default),
+    -- so it cannot conflict with objects owned by anyone else.
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_user, windmill_admin', target_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_user, windmill_admin', target_schema);
 END
 $do$;

--- a/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles.up.sql
@@ -1,0 +1,37 @@
+-- Re-runs the grants of 20250205131523. That migration wraps everything in a
+-- single DO block that starts with LOCK TABLE pg_catalog.pg_roles, which
+-- requires superuser; on managed Postgres (RDS, Cloud SQL) the migration user
+-- is not one, the lock raises, and the block's EXCEPTION WHEN OTHERS handler
+-- turns the failure into a NOTICE. Every GRANT after the lock is therefore
+-- skipped, so core tables (workspace, script, ...) stay ungranted and any
+-- statement on a user_db transaction (SET LOCAL ROLE windmill_user /
+-- windmill_admin) fails with "permission denied for table" or, when the schema
+-- itself was never granted, "relation does not exist". The per-table grants
+-- added since (20260619091631, 20260701083047, 20260716151337) each patched one
+-- table; this covers the rest.
+--
+-- No LOCK TABLE and no catch-all handler here: the GRANTs are idempotent, and
+-- the migration user owns the tables it created, so they succeed wherever
+-- 20250205131523 was meant to. A migration user that does not own the schema
+-- cannot grant USAGE on it, but Postgres reports that as a "no privileges were
+-- granted" warning rather than an error, so it does not abort the upgrade --
+-- that deployment needs init-db-as-superuser.sql run by a superuser.
+DO
+$do$
+DECLARE
+    target_schema TEXT := current_schema();
+BEGIN
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user', target_schema);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_admin', target_schema);
+
+    EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_user', target_schema);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_user', target_schema);
+    EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_admin', target_schema);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_admin', target_schema);
+
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_user', target_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_user', target_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_admin', target_schema);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_admin', target_schema);
+END
+$do$;

--- a/init-db-as-superuser.sql
+++ b/init-db-as-superuser.sql
@@ -1,21 +1,25 @@
 CREATE ROLE windmill_user;
 
+CREATE ROLE windmill_admin WITH BYPASSRLS;
+GRANT windmill_user TO windmill_admin;
+
+-- Since PostgreSQL 15, USAGE on public is no longer granted to PUBLIC. Without
+-- it, SET LOCAL ROLE windmill_user/windmill_admin cannot resolve any table and
+-- every query fails with "relation does not exist".
+GRANT USAGE ON SCHEMA public TO windmill_user, windmill_admin;
+
 GRANT ALL
-ON ALL TABLES IN SCHEMA public 
+ON ALL TABLES IN SCHEMA public
 TO windmill_user;
 
-GRANT ALL PRIVILEGES 
-ON ALL SEQUENCES IN SCHEMA public 
+GRANT ALL PRIVILEGES
+ON ALL SEQUENCES IN SCHEMA public
 TO windmill_user;
 
-ALTER DEFAULT PRIVILEGES 
+ALTER DEFAULT PRIVILEGES
     IN SCHEMA public
     GRANT ALL ON TABLES TO windmill_user;
 
-ALTER DEFAULT PRIVILEGES 
+ALTER DEFAULT PRIVILEGES
     IN SCHEMA public
     GRANT ALL ON SEQUENCES TO windmill_user;
-
-
-CREATE ROLE windmill_admin WITH BYPASSRLS;
-GRANT windmill_user TO windmill_admin;

--- a/init-db-as-superuser.sql
+++ b/init-db-as-superuser.sql
@@ -3,9 +3,10 @@ CREATE ROLE windmill_user;
 CREATE ROLE windmill_admin WITH BYPASSRLS;
 GRANT windmill_user TO windmill_admin;
 
--- Since PostgreSQL 15, USAGE on public is no longer granted to PUBLIC. Without
--- it, SET LOCAL ROLE windmill_user/windmill_admin cannot resolve any table and
--- every query fails with "relation does not exist".
+-- USAGE is granted to PUBLIC on the public schema by default, so this is a
+-- no-op on a stock database. It matters on hardened ones that revoke it: the
+-- roles then cannot resolve any table and every query on a user_db transaction
+-- fails with "relation does not exist" rather than a permission error.
 GRANT USAGE ON SCHEMA public TO windmill_user, windmill_admin;
 
 GRANT ALL


### PR DESCRIPTION
Fixes WIN-2208

## Problem

Migration `20250205131523_grant_all_in_current_schema` puts all its grants in one `DO` block whose first statement is `LOCK TABLE pg_catalog.pg_roles` — which a non-superuser cannot take. On managed Postgres (RDS, Cloud SQL) it raises, and the block's single `EXCEPTION WHEN OTHERS` handler downgrades the failure to a `NOTICE`, so every `GRANT USAGE`, `GRANT ALL ON ALL TABLES`, and `ALTER DEFAULT PRIVILEGES` after it is silently skipped. Confirmed on PG 18: a non-superuser gets `ERROR: permission denied for view pg_roles` on that lock.

**What that actually costs is narrower than it first appears**, and the PR is scoped accordingly:

- The *table* grants mostly survive, because `20221105003256_grant_all` grants `ALL ON ALL TABLES` to both roles outside any such block.
- What is lost is the `ALTER DEFAULT PRIVILEGES`, which covers tables created by *later* migrations. Default privileges apply only to objects created by the role that set them, so a deployment whose migration runner never successfully ran them ends up with newer tables ungranted and writes failing with `permission denied for table`. **This is the gap that forced `20260619091631`, `20260701083047` and `20260716151337` to each patch a single table by hand.** Re-establishing the default privileges under the current runner closes it for future tables instead of one migration at a time.
- The *schema* `USAGE` grant matters only on databases that revoked `USAGE` from `PUBLIC`. There the roles resolve no table and queries fail with `relation does not exist` rather than a permission error.

## Changes

**`backend/migrations/20260720131744_regrant_schema_and_tables_to_windmill_roles`** — re-establishes the grants of `20250205131523` with no `LOCK TABLE`. Editing the original in place is not an option: sqlx checksums applied migrations, so every existing deployment would fail with "previously applied but has been modified". Down is a no-op (revoking would leave the instance unable to run any `user_db` query), matching the original.

**`init-db-as-superuser.sql`** — adds `GRANT USAGE ON SCHEMA public`, and moves `windmill_admin` creation above the table grants; it previously ran last, so role membership was not yet in place while they executed.

## The migration cannot abort an upgrade (primary design goal)

A grant migration that fails would block the entire upgrade, so this one is built to never raise. Two things get it there:

1. **Grant only runner-owned objects.** The blanket `GRANT ALL ON ALL TABLES IN SCHEMA` raises a hard `ERROR: permission denied for table X` — *not* a warning — the moment the schema holds one object the runner does not own: a superuser-installed extension (PostGIS's `spatial_ref_sys`) or a co-located app table. So the migration iterates `pg_tables`/`pg_sequences` filtered to `owner = current_user` and grants each individually. Owning the object is exactly the condition under which the GRANT succeeds, so this skips what would fail (Windmill's tables are all runner-owned → coverage unchanged) rather than the original's approach of swallowing the error.

2. **Guard every grant individually.** Each grant is wrapped in its own `BEGIN/EXCEPTION WHEN OTHERS/RAISE WARNING`. This is deliberately the *opposite* of `20250205131523`'s single block-wide handler — the original's flaw was **granularity**, not the presence of a handler: one early failure (the lock) silently skipped every remaining grant. Here a failure is isolated to one object, re-raised as a **named `WARNING`** (visible in the migration log), and the rest still run. This absorbs the last abort paths: an object dropped by another session between the catalog scan and the GRANT, `USAGE` on a schema the runner can't grant, or (defensively) a missing role. On a clean owned schema the guards never fire — zero warnings.

`ALTER DEFAULT PRIVILEGES` is also guarded; it only governs the runner's own future objects, so it cannot conflict with anyone else's. Both windmill roles are guaranteed to exist here — the unguarded `20221105003256` grants to both, so any DB that reached this migration already has them.

## Corrections after review

Two claims in the first draft were wrong and are fixed in the comments:

1. *"PostgreSQL 15 no longer grants USAGE on public to PUBLIC."* PG15 revoked `CREATE`, not `USAGE` (thanks @codex). USAGE is still granted by default, so the explicit grant is a no-op on a stock database and only matters on hardened ones. The `relation does not exist` repro only appeared because I revoked it by hand. (This myth is also in the linked issue.)
2. *"Core tables stay ungranted."* Overstated — `20221105003256` covers them, per above.

The migration is kept despite that narrowing: idempotent, ~5ms, and it closes the default-privileges gap that has already produced three one-table patch migrations.

## Validation (PG 18, non-superuser runner, `REVOKE ALL ON SCHEMA public FROM PUBLIC`)

**Before** — full history applies "successfully" (lock failure swallowed):
```
SET ROLE windmill_user;  SELECT count(*) FROM workspace;  -- ERROR: relation "workspace" does not exist
SET ROLE windmill_admin; SELECT count(*) FROM script;     -- ERROR: relation "script" does not exist
```
**After** — fresh DB, full history incl. the new migration:
```
SET ROLE windmill_user;
SELECT count(*) FROM workspace;                               -- 1
INSERT INTO workspace (id,name,owner) VALUES ('t','t','u');   -- INSERT 0 1
DELETE FROM workspace WHERE id='t';                           -- DELETE 1
INSERT INTO post_migration_table DEFAULT VALUES;              -- INSERT 0 1  (ALTER DEFAULT PRIVILEGES)
SET ROLE windmill_admin;
SELECT count(*) FROM script;                                  -- 1
SELECT nextval('audit_id_seq');                               -- 1          (sequence grants)
```
Abort-safety, tested directly:
- **Foreign-owned table+sequence in the schema**: blanket form aborts (`permission denied for table foreign_tbl`); this migration exits 0, grants only the runner-owned objects, leaves the foreign ones untouched.
- **Guard proof**: forcing every guarded grant to fail (target a non-existent role) produces one `WARNING` per statement, the block completes, `psql` exits 0 — no abort.
- **Idempotent** over 3 re-runs with **zero** warnings on a clean owned schema; reads still work after.
- **Locking**: each per-object GRANT takes only `AccessShareLock`; whole migration ~5ms. Does not block concurrent reads/writes.
- `init-db-as-superuser.sql` run verbatim as superuser (roles sed-renamed): exit 0, both roles have `USAGE`, admin has `BYPASSRLS` and inherits `windmill_user`.
- Applied to dev DB; backend restarts clean — `health check completed status="healthy" database_healthy=true`.

Non-`public` schema deployments are *not* a motivating case: migrating into a custom schema already fails independently at `20240216100535` on hardcoded `public.capture`.

No test committed: the effect is DB grant state, exercised by every existing `user_db`-backed path. No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)