### PR TITLE
feat(ai): extract prompt cache token usage from OpenAI and Azure providers

### DIFF
--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -517,12 +517,8 @@ impl QueryBuilder for OpenAIQueryBuilder {
         let mut parser = OpenAIResponsesSSEParser::new(stream_event_sink);
         parser.parse_events(response).await?;
 
-        // Convert OpenAI Responses usage to TokenUsage.
-        // cached_tokens is a subset of input_tokens, so total/prompt already account for it.
-        let usage = parser.usage.map(|u| {
-            TokenUsage::new(u.input_tokens, u.output_tokens, u.total_tokens)
-                .with_cache(u.input_tokens_details.and_then(|d| d.cached_tokens), None)
-        });
+        // Convert OpenAI Responses usage to TokenUsage
+        let usage = parser.usage.map(|u| u.to_token_usage());
 
         Ok(ParsedResponse::Text {
             content: if parser.accumulated_content.is_empty() {

--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -517,10 +517,12 @@ impl QueryBuilder for OpenAIQueryBuilder {
         let mut parser = OpenAIResponsesSSEParser::new(stream_event_sink);
         parser.parse_events(response).await?;
 
-        // Convert OpenAI Responses usage to TokenUsage
-        let usage = parser
-            .usage
-            .map(|u| TokenUsage::new(u.input_tokens, u.output_tokens, u.total_tokens));
+        // Convert OpenAI Responses usage to TokenUsage.
+        // cached_tokens is a subset of input_tokens, so total/prompt already account for it.
+        let usage = parser.usage.map(|u| {
+            TokenUsage::new(u.input_tokens, u.output_tokens, u.total_tokens)
+                .with_cache(u.input_tokens_details.and_then(|d| d.cached_tokens), None)
+        });
 
         Ok(ParsedResponse::Text {
             content: if parser.accumulated_content.is_empty() {

--- a/backend/windmill-ai/src/providers/other.rs
+++ b/backend/windmill-ai/src/providers/other.rs
@@ -268,9 +268,12 @@ impl QueryBuilder for OtherQueryBuilder {
             stream_event_processor.send(event, &mut events_str).await?;
         }
 
-        // Convert OpenAI Chat Completions usage to TokenUsage
-        let usage = openai_usage
-            .map(|u| TokenUsage::new(u.prompt_tokens, u.completion_tokens, u.total_tokens));
+        // Convert OpenAI Chat Completions usage to TokenUsage.
+        // cached_tokens is a subset of prompt_tokens, so total/prompt already account for it.
+        let usage = openai_usage.map(|u| {
+            TokenUsage::new(u.prompt_tokens, u.completion_tokens, u.total_tokens)
+                .with_cache(u.prompt_tokens_details.and_then(|d| d.cached_tokens), None)
+        });
 
         Ok(ParsedResponse::Text {
             content: if accumulated_content.is_empty() {

--- a/backend/windmill-ai/src/providers/other.rs
+++ b/backend/windmill-ai/src/providers/other.rs
@@ -268,12 +268,8 @@ impl QueryBuilder for OtherQueryBuilder {
             stream_event_processor.send(event, &mut events_str).await?;
         }
 
-        // Convert OpenAI Chat Completions usage to TokenUsage.
-        // cached_tokens is a subset of prompt_tokens, so total/prompt already account for it.
-        let usage = openai_usage.map(|u| {
-            TokenUsage::new(u.prompt_tokens, u.completion_tokens, u.total_tokens)
-                .with_cache(u.prompt_tokens_details.and_then(|d| d.cached_tokens), None)
-        });
+        // Convert OpenAI Chat Completions usage to TokenUsage
+        let usage = openai_usage.map(|u| u.to_token_usage());
 
         Ok(ParsedResponse::Text {
             content: if accumulated_content.is_empty() {

--- a/backend/windmill-ai/src/sse.rs
+++ b/backend/windmill-ai/src/sse.rs
@@ -44,6 +44,14 @@ pub struct OpenAIChoice {
     pub delta: Option<OpenAIChoiceDelta>,
 }
 
+/// Nested prompt token details returned by the Chat Completions API.
+/// `cached_tokens` is the portion of `prompt_tokens` served from cache (a subset, not additive).
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct OpenAIPromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: Option<i32>,
+}
+
 /// OpenAI Chat Completions API usage information (from final chunk with stream_options.include_usage)
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct OpenAIChatUsage {
@@ -53,6 +61,8 @@ pub struct OpenAIChatUsage {
     pub completion_tokens: Option<i32>,
     #[serde(default)]
     pub total_tokens: Option<i32>,
+    #[serde(default)]
+    pub prompt_tokens_details: Option<OpenAIPromptTokensDetails>,
 }
 
 #[derive(Deserialize)]
@@ -684,6 +694,14 @@ pub struct OpenAIUrlCitationEvent {
     pub title: Option<String>,
 }
 
+/// Nested input token details returned by the Responses API.
+/// `cached_tokens` is the portion of `input_tokens` served from cache (a subset, not additive).
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct OpenAIInputTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: Option<i32>,
+}
+
 /// OpenAI Responses API usage information
 #[derive(Deserialize, Debug, Clone)]
 pub struct OpenAIResponsesUsage {
@@ -693,6 +711,8 @@ pub struct OpenAIResponsesUsage {
     pub output_tokens: Option<i32>,
     #[serde(default)]
     pub total_tokens: Option<i32>,
+    #[serde(default)]
+    pub input_tokens_details: Option<OpenAIInputTokensDetails>,
 }
 
 /// OpenAI Responses API response object (from response.completed event)

--- a/backend/windmill-ai/src/sse.rs
+++ b/backend/windmill-ai/src/sse.rs
@@ -948,6 +948,33 @@ mod tests {
     }
 
     #[test]
+    fn openai_chat_usage_parses_cached_prompt_tokens() {
+        // Payload shape returned by OpenAI and Azure OpenAI Chat Completions.
+        // cached_tokens lives under prompt_tokens_details and is a subset of prompt_tokens.
+        let usage: OpenAIChatUsage = serde_json::from_str(
+            r#"{"prompt_tokens":4819,"completion_tokens":1,"total_tokens":4820,"prompt_tokens_details":{"cached_tokens":4736,"audio_tokens":0}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            usage.prompt_tokens_details.and_then(|d| d.cached_tokens),
+            Some(4736)
+        );
+    }
+
+    #[test]
+    fn openai_responses_usage_parses_cached_input_tokens() {
+        // Payload shape returned by the OpenAI Responses API.
+        let usage: OpenAIResponsesUsage = serde_json::from_str(
+            r#"{"input_tokens":4819,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":4736},"output_tokens":2,"total_tokens":4821}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            usage.input_tokens_details.and_then(|d| d.cached_tokens),
+            Some(4736)
+        );
+    }
+
+    #[test]
     fn openai_delta_parses_reasoning_content() {
         // DeepSeek and similar stream reasoning under `reasoning_content`.
         let delta: OpenAIChoiceDelta =

--- a/backend/windmill-ai/src/sse.rs
+++ b/backend/windmill-ai/src/sse.rs
@@ -13,7 +13,7 @@ use crate::{
         AnthropicExtraContent, ExtraContent, GoogleExtraContent, OpenAIFunction, OpenAIToolCall,
     },
     query_builder::StreamEventSink,
-    types::StreamingEvent,
+    types::{StreamingEvent, TokenUsage},
 };
 
 #[derive(Deserialize)]
@@ -63,6 +63,22 @@ pub struct OpenAIChatUsage {
     pub total_tokens: Option<i32>,
     #[serde(default)]
     pub prompt_tokens_details: Option<OpenAIPromptTokensDetails>,
+}
+
+impl OpenAIChatUsage {
+    /// cached_tokens is a subset of prompt_tokens, so input/total are reported as-is
+    /// and only recorded as cache_read for reporting.
+    pub fn to_token_usage(self) -> TokenUsage {
+        TokenUsage::new(
+            self.prompt_tokens,
+            self.completion_tokens,
+            self.total_tokens,
+        )
+        .with_cache(
+            self.prompt_tokens_details.and_then(|d| d.cached_tokens),
+            None,
+        )
+    }
 }
 
 #[derive(Deserialize)]
@@ -715,6 +731,17 @@ pub struct OpenAIResponsesUsage {
     pub input_tokens_details: Option<OpenAIInputTokensDetails>,
 }
 
+impl OpenAIResponsesUsage {
+    /// cached_tokens is a subset of input_tokens, so input/total are reported as-is
+    /// and only recorded as cache_read for reporting.
+    pub fn to_token_usage(self) -> TokenUsage {
+        TokenUsage::new(self.input_tokens, self.output_tokens, self.total_tokens).with_cache(
+            self.input_tokens_details.and_then(|d| d.cached_tokens),
+            None,
+        )
+    }
+}
+
 /// OpenAI Responses API response object (from response.completed event)
 #[derive(Deserialize, Debug)]
 pub struct OpenAIResponsesResponse {
@@ -948,30 +975,31 @@ mod tests {
     }
 
     #[test]
-    fn openai_chat_usage_parses_cached_prompt_tokens() {
+    fn openai_chat_usage_maps_cached_prompt_tokens() {
         // Payload shape returned by OpenAI and Azure OpenAI Chat Completions.
-        // cached_tokens lives under prompt_tokens_details and is a subset of prompt_tokens.
+        // cached_tokens lives under prompt_tokens_details and is a subset of prompt_tokens,
+        // so it must land in cache_read while input/total stay as the provider reported them.
         let usage: OpenAIChatUsage = serde_json::from_str(
             r#"{"prompt_tokens":4819,"completion_tokens":1,"total_tokens":4820,"prompt_tokens_details":{"cached_tokens":4736,"audio_tokens":0}}"#,
         )
         .unwrap();
-        assert_eq!(
-            usage.prompt_tokens_details.and_then(|d| d.cached_tokens),
-            Some(4736)
-        );
+        let token_usage = usage.to_token_usage();
+        assert_eq!(token_usage.cache_read_input_tokens, Some(4736));
+        assert_eq!(token_usage.input_tokens, Some(4819));
+        assert_eq!(token_usage.total_tokens, Some(4820));
     }
 
     #[test]
-    fn openai_responses_usage_parses_cached_input_tokens() {
+    fn openai_responses_usage_maps_cached_input_tokens() {
         // Payload shape returned by the OpenAI Responses API.
         let usage: OpenAIResponsesUsage = serde_json::from_str(
             r#"{"input_tokens":4819,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":4736},"output_tokens":2,"total_tokens":4821}"#,
         )
         .unwrap();
-        assert_eq!(
-            usage.input_tokens_details.and_then(|d| d.cached_tokens),
-            Some(4736)
-        );
+        let token_usage = usage.to_token_usage();
+        assert_eq!(token_usage.cache_read_input_tokens, Some(4736));
+        assert_eq!(token_usage.input_tokens, Some(4819));
+        assert_eq!(token_usage.total_tokens, Some(4821));
     }
 
     #[test]

--- a/frontend/src/lib/components/copilot/chat/tokenUsage.ts
+++ b/frontend/src/lib/components/copilot/chat/tokenUsage.ts
@@ -70,12 +70,15 @@ export function anthropicUsageToChatTokenUsage(
 	}
 }
 
+// Unlike Anthropic, OpenAI's input_tokens already includes cached tokens
+// (input_tokens_details.cached_tokens is a subset), so it must not be added again.
 export function openAIResponsesUsageToChatTokenUsage(
 	usage:
 		| {
 				input_tokens?: number | null
 				output_tokens?: number | null
 				total_tokens?: number | null
+				input_tokens_details?: { cached_tokens?: number | null } | null
 		  }
 		| null
 		| undefined
@@ -90,12 +93,15 @@ export function openAIResponsesUsageToChatTokenUsage(
 	}
 }
 
+// Unlike Anthropic, OpenAI's prompt_tokens already includes cached tokens
+// (prompt_tokens_details.cached_tokens is a subset), so it must not be added again.
 export function openAICompletionsUsageToChatTokenUsage(
 	usage:
 		| {
 				prompt_tokens?: number | null
 				completion_tokens?: number | null
 				total_tokens?: number | null
+				prompt_tokens_details?: { cached_tokens?: number | null } | null
 		  }
 		| null
 		| undefined


### PR DESCRIPTION
## What & why

Fixes WIN-2207.

The `OpenAIChatUsage` and `OpenAIResponsesUsage` structs only parsed basic token counts and dropped the nested cache token details that OpenAI (and Azure OpenAI) return. As a result the usage conversions for the Chat Completions and Responses paths never populated `cache_read_input_tokens`, unlike the Anthropic and Bedrock providers.

## Changes

**Backend**
- `sse.rs`: add `OpenAIPromptTokensDetails` / `OpenAIInputTokensDetails` and the optional `prompt_tokens_details` / `input_tokens_details` fields.
- `providers/other.rs` (Chat Completions) and `providers/openai.rs` (Responses): populate cache tokens via `.with_cache(cached_tokens, None)`.

**Frontend**
- `tokenUsage.ts`: no math change on purpose. OpenAI's `prompt_tokens`/`input_tokens` **already include** cached tokens (cached is a subset), so `total`/`prompt` are already correct — adding cached would double-count. Added the optional cache fields to the type signatures and a clarifying comment so a future reader doesn't "fix" it to mirror the Anthropic conversion (where `input_tokens` *excludes* cache and the addition is required).

## Judgment call

Issue item 5 proposed adding cache tokens into the frontend prompt total "mirroring Anthropic". That is correct for Anthropic but would double-count for OpenAI, whose reported prompt already includes the cached portion. The backend behaves the same way: `cache_read_input_tokens` is recorded as a subset of `input_tokens` for reporting, and `total`/`input` are left unchanged.

## Validation
- `cargo check -p windmill-ai` — clean.
- `svelte-check` — no new errors in the touched files.
- No user-visible UI behavior change (frontend math intentionally unchanged), so no browser exercise was applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse and record OpenAI/Azure prompt cache token usage so `cache_read_input_tokens` is populated without changing totals. Fixes WIN-2207 and aligns OpenAI/Azure reporting with Anthropic/Bedrock; adds regression tests to pin deserialization and mapping.

- **Bug Fixes**
  - Backend: Add nested prompt/input token detail structs and fields; implement `to_token_usage()` on OpenAI Chat/Responses usage and switch providers to call it to map cached tokens into `TokenUsage`.
  - Frontend: Add optional cache detail fields to usage types; keep math unchanged to avoid double-counting since OpenAI totals already include cached tokens.
  - Tests: Add regression tests for `cached_tokens` paths and the `to_token_usage()` mapping to ensure `cache_read_input_tokens` is set while input/total remain unchanged.

<sup>Written for commit adcb33cdf61ce45143bc2b8537fadd53f314e93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

