### PR TITLE
fix(forks): show workspace settings link in sidebar for fork creators

### DIFF
--- a/frontend/src/lib/components/sidebar/SettingsMenu.svelte
+++ b/frontend/src/lib/components/sidebar/SettingsMenu.svelte
@@ -29,7 +29,7 @@
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import ConfirmationModal from '../common/confirmationModal/ConfirmationModal.svelte'
 	import DeleteForkedWorkspaceModal from './DeleteForkedWorkspaceModal.svelte'
-	import { workspaceIsFork } from '$lib/utils/workspaceHierarchy'
+	import { workspaceIsFork, isForkOwner } from '$lib/utils/workspaceHierarchy'
 	import DarkModeObserver from '../DarkModeObserver.svelte'
 	import DiscordIcon from '../icons/brands/Discord.svelte'
 	import MenuLink from './MenuLink.svelte'
@@ -69,7 +69,9 @@
 	} = $props()
 
 	const currentWs = $derived($userWorkspaces?.find((w) => w.id === $workspaceStore))
-	const canManageWorkspace = $derived($userStore?.is_admin || $superadmin)
+	const canManageWorkspace = $derived(
+		$userStore?.is_admin || $superadmin || isForkOwner(currentWs, $userStore?.email)
+	)
 	// Fork/dev workspaces are detected by their parent link, not the `wm-fork-` id prefix.
 	const currentWsIsFork = $derived(workspaceIsFork($workspaceStore, $userWorkspaces ?? []))
 

--- a/frontend/src/lib/components/sidebar/SettingsMenu.svelte
+++ b/frontend/src/lib/components/sidebar/SettingsMenu.svelte
@@ -69,17 +69,23 @@
 	} = $props()
 
 	const currentWs = $derived($userWorkspaces?.find((w) => w.id === $workspaceStore))
-	const canManageWorkspace = $derived(
-		$userStore?.is_admin || $superadmin || isForkOwner(currentWs, $userStore?.email)
-	)
-	// Fork/dev workspaces are detected by their parent link, not the `wm-fork-` id prefix.
-	const currentWsIsFork = $derived(workspaceIsFork($workspaceStore, $userWorkspaces ?? []))
 
 	const settingsTargetWs = $derived(
 		workspaceSettingsTarget
 			? $userWorkspaces?.find((w) => w.id === workspaceSettingsTarget)
 			: undefined
 	)
+
+	// The fork-owner grant must be checked against the workspace the settings entry
+	// actually points at — the session target when in session mode, else the active
+	// workspace — otherwise ownership of the wrong workspace could hide the entry or
+	// expose a dead link to a fork the user doesn't own.
+	const settingsWs = $derived(workspaceSettingsTarget ? settingsTargetWs : currentWs)
+	const canManageWorkspace = $derived(
+		$userStore?.is_admin || $superadmin || isForkOwner(settingsWs, $userStore?.email)
+	)
+	// Fork/dev workspaces are detected by their parent link, not the `wm-fork-` id prefix.
+	const currentWsIsFork = $derived(workspaceIsFork($workspaceStore, $userWorkspaces ?? []))
 
 	let leaveWorkspaceModal = $state(false)
 	let deleteForkModal = $state<DeleteForkedWorkspaceModal>()

--- a/frontend/src/lib/components/sidebar/SidebarContent.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarContent.svelte
@@ -4,6 +4,7 @@
 		superadmin,
 		usedTriggerKinds,
 		userStore,
+		userWorkspaces,
 		workspaceStore,
 		isCriticalAlertsUIOpen,
 		enterpriseLicense,
@@ -11,6 +12,7 @@
 		tutorialsToDo,
 		skippedAll
 	} from '$lib/stores'
+	import { isForkOwner } from '$lib/utils/workspaceHierarchy'
 	import { syncTutorialsTodos } from '$lib/tutorialUtils'
 	import { SIDEBAR_SHOW_SCHEDULES } from '$lib/consts'
 	import {
@@ -400,6 +402,12 @@
 			return !page.url.pathname.includes(link.href) && !$usedTriggerKinds.includes(link.kind)
 		})
 	)
+	// Admins, superadmins, and fork creators reach workspace settings (the latter
+	// for the fork members screen; see isForkOwner / backend authorize_fork_owner_add_user).
+	const currentWs = $derived($userWorkspaces?.find((w) => w.id === $workspaceStore))
+	const canManageWorkspace = $derived(
+		$userStore?.is_admin || $superadmin || isForkOwner(currentWs, $userStore?.email)
+	)
 	let secondaryMenuLinks = $derived([
 		// {
 		// 	label: 'Workspace',
@@ -422,7 +430,7 @@
 					aiDescription: 'Button to navigate to account settings',
 					faIcon: undefined
 				},
-				...($userStore?.is_admin || $superadmin
+				...(canManageWorkspace
 					? [
 							{
 								label: 'Workspace',

--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -30,7 +30,7 @@
 	import { workspaceAIClients } from '../copilot/lib'
 	import { twMerge } from 'tailwind-merge'
 	import type { MenubarBuilders } from '@melt-ui/svelte'
-	import { buildWorkspaceHierarchy } from '$lib/utils/workspaceHierarchy'
+	import { buildWorkspaceHierarchy, isForkOwner } from '$lib/utils/workspaceHierarchy'
 	import { canCreateFork } from '$lib/utils/editInFork'
 	import { getContrastTextColor } from '$lib/utils'
 	import { workspaceRootId } from '$lib/components/sessions/sessionScope.svelte'
@@ -167,7 +167,9 @@
 
 	// The active workspace itself (fork included) — names the settings entry.
 	const activeWorkspace = $derived($userWorkspaces?.find((w) => w.id === $workspaceStore))
-	const canManageWorkspace = $derived($userStore?.is_admin || $superadmin)
+	const canManageWorkspace = $derived(
+		$userStore?.is_admin || $superadmin || isForkOwner(activeWorkspace, $userStore?.email)
+	)
 
 	// font-normal is explicit: href-less MenuItems render as <button>, which the
 	// global stylesheet makes semibold, unlike the <a> the href entries get.

--- a/frontend/src/lib/components/sidebar/WorkspaceScopeHeader.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceScopeHeader.svelte
@@ -12,7 +12,11 @@
 	import { workspaceAIClients } from '$lib/components/copilot/lib'
 	import WorkspaceFamilyPicker from '$lib/components/sessions/WorkspaceFamilyPicker.svelte'
 	import WorkspaceScopeTrigger from '$lib/components/WorkspaceScopeTrigger.svelte'
-	import { findWorkspaceRoot, findWorkspaceDescendants } from '$lib/utils/workspaceHierarchy'
+	import {
+		findWorkspaceRoot,
+		findWorkspaceDescendants,
+		isForkOwner
+	} from '$lib/utils/workspaceHierarchy'
 	import { useForkableWorkspaces } from '$lib/utils/useForkableWorkspaces.svelte'
 
 	let { isCollapsed = false }: { isCollapsed?: boolean } = $props()
@@ -38,9 +42,11 @@
 	})
 	const rootLabel = $derived(`${forkCount} fork${forkCount === 1 ? '' : 's'}`)
 
-	// Settings link at the bottom of the picker — admin/superadmin only, scoped
-	// to the active workspace (fork or root).
-	const canManageWorkspace = $derived($userStore?.is_admin || $superadmin)
+	// Settings link at the bottom of the picker — admins, superadmins, and fork
+	// creators, scoped to the active workspace (fork or root).
+	const canManageWorkspace = $derived(
+		$userStore?.is_admin || $superadmin || isForkOwner(currentWs, $userStore?.email)
+	)
 	const settingsHref = $derived(canManageWorkspace ? `${base}/workspace_settings` : undefined)
 	const settingsLabel = $derived(`${currentWs?.name ?? effectiveId ?? 'Workspace'} settings`)
 

--- a/frontend/src/lib/utils/workspaceHierarchy.ts
+++ b/frontend/src/lib/utils/workspaceHierarchy.ts
@@ -139,6 +139,21 @@ export function workspaceIsFork(
 }
 
 /**
+ * Whether `userEmail` is the creator of a fork workspace. The fork creator gets workspace-settings
+ * access (the fork members screen) even when they are not an admin of it: forking as an ordinary
+ * developer copies their parent `usr` row, leaving them otherwise unable to bring collaborators in.
+ * Mirrors the backend `authorize_fork_owner_add_user` grant.
+ */
+export function isForkOwner(
+	workspace: UserWorkspace | undefined,
+	userEmail: string | null | undefined
+): boolean {
+	return (
+		Boolean(workspace?.parent_workspace_id) && !!userEmail && workspace?.created_by === userEmail
+	)
+}
+
+/**
  * The canonical dev workspace of a prod workspace, if any (at most one per prod). Used to redirect
  * edits from a locked prod workspace into its dev workspace. Disabled dev workspaces are excluded:
  * redirecting edits to one the user can't select would be a dead end.


### PR DESCRIPTION
## Problem

PR #10166 added a fork-creator membership grant and a `ForkMemberSettings` UI on the workspace settings page, gated by `canAdmin || isForkOwner`. But every sidebar entry point to `/workspace_settings` stayed gated on `is_admin || superadmin` alone, so a **non-admin fork creator had no UI path to the page** — it worked only via direct URL navigation.

Affected guards:
- `SettingsMenu.svelte` — `canManageWorkspace`
- `SidebarContent.svelte` — inline `$userStore?.is_admin || $superadmin`
- `WorkspaceMenu.svelte` — `canManageWorkspace`
- `WorkspaceScopeHeader.svelte` — `canManageWorkspace`

## Fix

Widen the four sidebar guards to also admit fork owners. The fork-owner check is extracted into a shared `isForkOwner()` helper in `workspaceHierarchy.ts`, mirroring the check already used on `workspace_settings/+page.svelte` and the backend `authorize_fork_owner_add_user` grant:

```ts
Boolean(workspace?.parent_workspace_id) && !!userEmail && workspace?.created_by === userEmail
```

`created_by` is `workspace.owner` (the fork creator's email) as returned by the workspaces list API. No backend changes needed.

The guard stays correctly scoped: it opens only for the fork's creator on their own fork, not for every non-admin member (verified below).

## Validation

- `npm run check:fast` — passes (0 svelte warnings; the one pre-existing `modern-screenshot` module error in `RawAppEditor.svelte` is unrelated).
- Manual browser test with a **non-admin, non-superadmin** user (`dev`) who owns a fork (`wm-fork-test`, parent `testparent`), where `dev` is only a developer on both. Verified the settings link now appears in all three interactive sidebar surfaces on the fork, and does **not** appear on the parent workspace where `dev` is a non-owner. (`SidebarContent`'s `secondaryMenuLinks` variant is the legacy off-canvas drawer — `pointer-events-none` / `-translate-x-full`, effectively unreachable — but uses the identical `canManageWorkspace` derived and compiles clean.)

## Screenshots

`SettingsMenu` on the fork — **Test Fork settings** now shown to the non-admin fork owner:

![fork-settings-menu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2210-fixforks-show-workspace-settings-link-in-sidebar-for-fork/1784566800-fork-settings-menu.png)

`WorkspaceScopeHeader` family picker — **Test Fork settings** link at the bottom:

![fork-family-picker](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2210-fixforks-show-workspace-settings-link-in-sidebar-for-fork/1784566800-fork-family-picker.png)

`WorkspaceMenu` — **Test Fork settings**:

![fork-workspace-menu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2210-fixforks-show-workspace-settings-link-in-sidebar-for-fork/1784566800-fork-workspace-menu.png)

Control — same non-admin user on the **parent** workspace (non-owner): no settings entry, only "Leave workspace":

![parent-no-settings-control](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2210-fixforks-show-workspace-settings-link-in-sidebar-for-fork/1784566800-parent-no-settings-control.png)

Fixes WIN-2210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the workspace settings link in the sidebar for fork creators. Non-admin fork owners can now access `/workspace_settings` on their forks; fixes WIN-2210.

- **Bug Fixes**
  - Expanded sidebar guards to include fork creators in SettingsMenu, SidebarContent, WorkspaceMenu, and WorkspaceScopeHeader; in SettingsMenu the fork-owner check now uses the settings entry’s target workspace in session mode to avoid hidden or dead links.
  - Added `isForkOwner(workspace, userEmail)` in `workspaceHierarchy.ts` and used it across the sidebar. The check is scoped to the fork creator on their own fork and mirrors the backend grant.

<sup>Written for commit e4f05a826671109b47918531f26c8ef5817c8c21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

