### PR TITLE
fix(triggers): apply scope-path filtering to list_triggers and fix update_trigger scope check

### DIFF
--- a/backend/windmill-trigger/src/handler.rs
+++ b/backend/windmill-trigger/src/handler.rs
@@ -6,13 +6,13 @@
  * LICENSE-AGPL for a copy of the license.
  */
 
-use crate::types::{StandardTriggerQuery, TriggerData, TriggerMode};
+use crate::types::{HasPath, StandardTriggerQuery, TriggerData, TriggerMode};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sql_builder::{bind::Bind, SqlBuilder};
 use sqlx::{FromRow, PgConnection};
 use std::fmt::Debug;
-use windmill_api_auth::{check_scopes, ApiAuthed};
+use windmill_api_auth::{build_scope_path_predicate, check_scopes, ApiAuthed};
 use windmill_common::{
     db::UserDB,
     error::{Error, JsonResult, Result},
@@ -65,6 +65,8 @@ pub trait TriggerCrud: Send + Sync + 'static {
         + Send
         + Sync
         + Unpin
+        // Path accessor so `list_triggers` can apply scoped-token filtering.
+        + HasPath
         // `'static` so the deployed trigger can be boxed into
         // `WithDraftOverlay`'s erased-serde inner (it's an owned row).
         + 'static;
@@ -662,6 +664,9 @@ async fn list_triggers<T: TriggerCrud>(
         }
     }
 
+    let allowed = build_scope_path_predicate(&authed, T::scope_domain_name(), "read");
+    triggers.retain(|t| allowed(t.trigger_path()));
+
     Ok(Json(triggers))
 }
 
@@ -715,6 +720,12 @@ async fn update_trigger<T: TriggerCrud>(
     Json(mut edit_trigger): Json<TriggerData<T::TriggerConfigRequest>>,
 ) -> Result<String> {
     let path = path.to_path();
+    // A scoped token must be allowed on both the existing path (URL) and the
+    // new path (body); checking only the latter would let it move a trigger it
+    // can't touch into its scope.
+    check_scopes(&authed, || {
+        format!("{}:write:{}", T::scope_domain_name(), &path)
+    })?;
     check_scopes(&authed, || {
         format!(
             "{}:write:{}",

--- a/backend/windmill-trigger/src/types.rs
+++ b/backend/windmill-trigger/src/types.rs
@@ -102,6 +102,28 @@ where
     pub error_handling: TriggerErrorHandling,
 }
 
+/// Path accessor for the associated `Trigger` row type, so the shared list
+/// handler can apply scoped-token path filtering without knowing the concrete
+/// row shape. The `()` OSS stub returns "" (its endpoints 404 anyway).
+pub trait HasPath {
+    fn trigger_path(&self) -> &str;
+}
+
+impl<T> HasPath for Trigger<T>
+where
+    T: for<'r> FromRow<'r, sqlx::postgres::PgRow>,
+{
+    fn trigger_path(&self) -> &str {
+        &self.base.path
+    }
+}
+
+impl HasPath for () {
+    fn trigger_path(&self) -> &str {
+        ""
+    }
+}
+
 impl<T> FromRow<'_, sqlx::postgres::PgRow> for Trigger<T>
 where
     T: for<'r> FromRow<'r, sqlx::postgres::PgRow>,


### PR DESCRIPTION
Fixes WIN-2211

## What

Brings the shared trigger CRUD handler in line with scripts, flows, apps, resources, variables and schedules for scoped-token path handling.

- **`list_triggers<T>`** now filters returned rows through `build_scope_path_predicate(&authed, T::scope_domain_name(), "read")`, applied after the draft-only append so both deployed and draft rows are covered. Previously the list endpoint ignored the token's declared scope path, unlike `get_trigger`/`create_trigger`/`delete_trigger`/`exists_trigger` which already call `check_scopes`. Covers all 10 `TriggerCrud` kinds (HTTP, WebSocket, Kafka, NATS, MQTT, SQS, GCP, Azure, Postgres, Email).
- **`update_trigger`** now checks scope against the existing path (URL param) in addition to the new path (request body). It previously only checked the body path.

## How

A small `HasPath` supertrait is added to `Self::Trigger` so the shared handler can read the row's path without each impl restating it: `Trigger<T>` returns `&base.path`, the `()` OSS stub returns `""`. This keeps the change to two files (`windmill-trigger/src/{types,handler}.rs`) rather than editing every per-kind impl.

## Validation

- `cargo check` on `windmill-trigger` and all 10 impl crates (OSS + EE variants via `--features private,enterprise`) passes.
- No SQL query changes, so no sqlx cache update.
- No frontend changes.

Following the precedent of the analogous schedules fix (#10192) and the scripts/flows/apps/resources/variables endpoints, no dedicated per-endpoint scope test is added — all rely on the shared, already-tested `build_scope_path_predicate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies path-based scope filtering to trigger listing and checks both old and new paths on update to prevent unauthorized access and moves. Fixes WIN-2211 and brings triggers in line with other scoped endpoints.

- **Bug Fixes**
  - `list_triggers<T>` now filters rows via `build_scope_path_predicate(&authed, T::scope_domain_name(), "read")` after draft overlay, across all `TriggerCrud` kinds.
  - `update_trigger` now verifies write scope on both the existing path (URL) and the new path (body).
  - Added `HasPath` on `Self::Trigger` so the list handler can read each row’s path (`Trigger<T>` returns `&base.path`, OSS stub returns "").

<sup>Written for commit f29834680253b9301da84f3686af8cc443eab26f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

