### PR TITLE
fix(security): add missing authentication to GET /concurrency_groups/{job_id}/key

### DIFF
--- a/backend/windmill-api-jobs/src/concurrency_groups.rs
+++ b/backend/windmill-api-jobs/src/concurrency_groups.rs
@@ -357,6 +357,7 @@ async fn get_concurrent_intervals(
 }
 
 async fn get_concurrency_key(
+    _authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path(job_id): Path<Uuid>,
 ) -> JsonResult<Option<String>> {


### PR DESCRIPTION
## Problem

The `get_concurrency_key` handler in `backend/windmill-api-jobs/src/concurrency_groups.rs` did not declare an `authed: ApiAuthed` parameter, unlike its two sibling handlers `list_concurrency_groups` and `prune_concurrency_group` in the same file.

The `/concurrency_groups` global service is registered in `backend/windmill-api/src/lib.rs` **after** the `.route_layer(from_extractor::<ApiAuthed>())`. Axum's `route_layer` only wraps routes already present at the call site, so the router-level auth layer did not cover this service. As a result, `GET /api/concurrency_groups/{job_id}/key` required **no authentication at all** — any unauthenticated network client could retrieve concurrency keys for arbitrary jobs instance-wide.

Concurrency keys can contain workspace IDs, script/flow paths, and — when custom keys use `$args[...]` templating — actual runtime argument values.

## Fix

Add `_authed: ApiAuthed` as a parameter to `get_concurrency_key` (prefixed with `_` since the value is not used in the query). This makes Axum's extractor independently enforce authentication regardless of router-level layer placement, matching the defense-in-depth pattern of the two sibling handlers.

```rust
async fn get_concurrency_key(
    _authed: ApiAuthed,
    Extension(db): Extension<DB>,
    Path(job_id): Path<Uuid>,
) -> JsonResult<Option<String>> {
```

The `ApiAuthed` import already exists. The OpenAPI spec already implies authentication is required (the endpoint does not override the global `security` scheme with `security: []`), so no spec change is needed.

## Validation

- Backend compiles cleanly under `cargo watch` (`health check completed`, no warnings/errors).
- Manual end-to-end check against the running dev backend:
  - `GET /api/concurrency_groups/{job_id}/key` **without** auth → `401` (previously `200`)
  - `GET /api/concurrency_groups/{job_id}/key` **with** a valid admin bearer token → `200` (happy path preserved)
  - Sibling `GET /api/concurrency_groups/list` → `401` without auth (unchanged reference)

Fixes WIN-2212

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures GET /api/concurrency_groups/{job_id}/key by requiring authentication, blocking unauthenticated access to concurrency keys. Addresses WIN-2212.

- **Bug Fixes**
  - Added `_authed: ApiAuthed` to `get_concurrency_key`, enforcing auth regardless of router `.route_layer` placement and aligning with sibling handlers.
  - Verified: 401 without auth, 200 with valid token; no change to other endpoints.

<sup>Written for commit 603cf1dc8cde968bd0835a7507dcabaa99f14126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

