### PR TITLE
fix(postgres-triggers): enforce resource-path scopes on ancillary routes

### DIFF
--- a/backend/tests/postgres_trigger_scope.rs
+++ b/backend/tests/postgres_trigger_scope.rs
@@ -1,0 +1,77 @@
+//! Regression test for the Postgres-trigger ancillary routes (slot / publication
+//! / version management) scope enforcement.
+//!
+//! The route-level middleware only checks that a token carries *some*
+//! `postgres_triggers` scope; per-resource-path enforcement is delegated to each
+//! handler. These handlers previously made no `check_scopes` call, so a token
+//! scoped to one resource path could drive slot/publication management (including
+//! the destructive `drop_slot_name`, which terminates the active backend and
+//! drops the replication slot) against any Postgres resource in the workspace.
+//!
+//! Each handler now calls `check_scopes` before touching the database, so a
+//! path-mismatched scoped token is rejected before any connection is opened —
+//! which is exactly why this test needs no real Postgres resource.
+
+use axum::{extract::Path, Extension, Json};
+use sqlx::{Pool, Postgres};
+use windmill_api_auth::ApiAuthed;
+use windmill_common::{db::UserDB, error::Error};
+use windmill_trigger_postgres::{handler, Slot};
+
+fn scoped_authed(scopes: Vec<&str>) -> ApiAuthed {
+    ApiAuthed {
+        email: "alice@windmill.dev".to_string(),
+        username: "alice".to_string(),
+        is_admin: false,
+        is_operator: false,
+        groups: vec![],
+        folders: vec![],
+        scopes: Some(scopes.into_iter().map(str::to_string).collect()),
+        username_override: None,
+        token_prefix: None,
+        read_only: false,
+    }
+}
+
+// A token scoped to `u/alice/db` must not reach a read handler for `u/bob/db`.
+#[sqlx::test]
+async fn read_handler_rejects_path_mismatched_scope(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let authed = scoped_authed(vec!["postgres_triggers:read:u/alice/db"]);
+    let user_db = UserDB::new(db.clone());
+
+    let res = handler::get_postgres_version(
+        authed,
+        Extension(db),
+        Extension(user_db),
+        Path(("test-workspace".to_string(), "u/bob/db".to_string())),
+    )
+    .await;
+
+    assert!(
+        matches!(res, Err(Error::PermissionDenied(_))),
+        "expected PermissionDenied, got {res:?}"
+    );
+    Ok(())
+}
+
+// The destructive slot-drop handler must reject a write token scoped to another path.
+#[sqlx::test]
+async fn drop_slot_rejects_path_mismatched_scope(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let authed = scoped_authed(vec!["postgres_triggers:write:u/alice/db"]);
+    let user_db = UserDB::new(db.clone());
+
+    let res = handler::drop_slot_name(
+        authed,
+        Extension(user_db),
+        Extension(db),
+        Path(("test-workspace".to_string(), "u/bob/db".to_string())),
+        Json(Slot { name: "some_slot".to_string() }),
+    )
+    .await;
+
+    assert!(
+        matches!(res, Err(Error::PermissionDenied(_))),
+        "expected PermissionDenied, got {res:?}"
+    );
+    Ok(())
+}

--- a/backend/tests/postgres_trigger_scope.rs
+++ b/backend/tests/postgres_trigger_scope.rs
@@ -1,16 +1,8 @@
-//! Regression test for the Postgres-trigger ancillary routes (slot / publication
-//! / version management) scope enforcement.
-//!
-//! The route-level middleware only checks that a token carries *some*
-//! `postgres_triggers` scope; per-resource-path enforcement is delegated to each
-//! handler. These handlers previously made no `check_scopes` call, so a token
-//! scoped to one resource path could drive slot/publication management (including
-//! the destructive `drop_slot_name`, which terminates the active backend and
-//! drops the replication slot) against any Postgres resource in the workspace.
-//!
-//! Each handler now calls `check_scopes` before touching the database, so a
-//! path-mismatched scoped token is rejected before any connection is opened —
-//! which is exactly why this test needs no real Postgres resource.
+//! Postgres-trigger ancillary handlers (slot / publication / version management)
+//! must reject a path-mismatched scoped token before opening any connection —
+//! the route-level middleware only checks the scope domain, so per-path
+//! enforcement lives in the handlers. Rejecting pre-connection is why these tests
+//! need no real Postgres resource.
 
 use axum::{extract::Path, Extension, Json};
 use sqlx::{Pool, Postgres};

--- a/backend/windmill-trigger-postgres/src/handler.rs
+++ b/backend/windmill-trigger-postgres/src/handler.rs
@@ -20,7 +20,7 @@ use windmill_common::{
 };
 use windmill_git_sync::DeployedObject;
 
-use windmill_api_auth::ApiAuthed;
+use windmill_api_auth::{check_scopes, ApiAuthed};
 use windmill_trigger::{Trigger, TriggerCrud, TriggerData};
 
 use super::{
@@ -46,7 +46,8 @@ impl TriggerCrud for PostgresTrigger {
 
     const TABLE_NAME: &'static str = "postgres_trigger";
     const TRIGGER_TYPE: &'static str = "postgres";
-    const DRAFT_KIND: windmill_common::user_drafts::UserDraftItemKind = windmill_common::user_drafts::UserDraftItemKind::TriggerPostgres;
+    const DRAFT_KIND: windmill_common::user_drafts::UserDraftItemKind =
+        windmill_common::user_drafts::UserDraftItemKind::TriggerPostgres;
     const SUPPORTS_SERVER_STATE: bool = true;
     const SUPPORTS_TEST_CONNECTION: bool = true;
     const ROUTE_PREFIX: &'static str = "/postgres_triggers";
@@ -395,6 +396,10 @@ pub async fn get_postgres_version(
     Extension(user_db): Extension<UserDB>,
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
 ) -> Result<String> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:read:{}", postgres_resource_path)
+    })?;
+
     let pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db),
@@ -416,6 +421,10 @@ pub async fn list_slot_name(
     Extension(db): Extension<DB>,
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
 ) -> Result<Json<Vec<SlotList>>> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:read:{}", postgres_resource_path)
+    })?;
+
     let pg_connection: Client = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -458,6 +467,10 @@ pub async fn create_slot(
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
     Json(Slot { name }): Json<Slot>,
 ) -> Result<String> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:write:{}", postgres_resource_path)
+    })?;
+
     let pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -513,6 +526,10 @@ pub async fn drop_slot_name(
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
     Json(Slot { name }): Json<Slot>,
 ) -> Result<String> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:write:{}", postgres_resource_path)
+    })?;
+
     let pg_connection =
         get_default_pg_connection(authed, Some(user_db), &db, &postgres_resource_path, &w_id)
             .await
@@ -531,6 +548,10 @@ pub async fn list_database_publication(
     Extension(db): Extension<DB>,
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
 ) -> Result<Json<Vec<String>>> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:read:{}", postgres_resource_path)
+    })?;
+
     let pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -563,6 +584,10 @@ pub async fn get_publication_info(
     Extension(db): Extension<DB>,
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
 ) -> Result<Json<PublicationData>> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:read:{}", postgres_resource_path)
+    })?;
+
     let mut pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -604,6 +629,10 @@ pub async fn create_publication(
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
     Json(publication_data): Json<PublicationData>,
 ) -> Result<String> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:write:{}", postgres_resource_path)
+    })?;
+
     let mut pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -640,6 +669,10 @@ pub async fn delete_publication(
     Extension(db): Extension<DB>,
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
 ) -> Result<String> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:write:{}", postgres_resource_path)
+    })?;
+
     let mut pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -773,6 +806,10 @@ pub async fn alter_publication(
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
     Json(publication_data): Json<PublicationData>,
 ) -> Result<String> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:write:{}", postgres_resource_path)
+    })?;
+
     let mut pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),
@@ -948,6 +985,10 @@ pub async fn create_template_script(
 ) -> Result<String> {
     let TemplateScript { postgres_resource_path, relations, language } = template_script;
 
+    check_scopes(&authed, || {
+        format!("postgres_triggers:write:{}", postgres_resource_path)
+    })?;
+
     let relations = match relations {
         Some(r) => r,
         None => {
@@ -1090,6 +1131,10 @@ pub async fn is_database_in_logical_level(
     Extension(db): Extension<DB>,
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
 ) -> error::JsonResult<bool> {
+    check_scopes(&authed, || {
+        format!("postgres_triggers:read:{}", postgres_resource_path)
+    })?;
+
     let pg_connection = get_default_pg_connection(
         authed.clone(),
         Some(user_db.clone()),


### PR DESCRIPTION
## Summary

The Postgres trigger ancillary routes in `additional_routes()` (slot management, publication management, postgres version, logical-replication-level check, template script creation) relied solely on the route-level scope middleware. That middleware validates only the scope **domain + action** (that the token carries *some* `postgres_triggers` scope) and delegates per-resource-path enforcement to each handler. These handlers made no `check_scopes` call, so a token scoped to one resource path (e.g. `postgres_triggers:write:u/alice/*`) could reach these endpoints for **any** postgres resource path in the workspace, including the destructive `drop_slot_name` (which runs `pg_terminate_backend` on the slot's active connection PID, then `pg_drop_replication_slot`).

This mirrors the fix already present in the generic trigger CRUD handlers (`create_trigger`, `get_trigger`, `update_trigger`, `delete_trigger` in `windmill-trigger/src/handler.rs`), which call `check_scopes` with path-specific scope strings.

## Changes

- Import `check_scopes` from `windmill_api_auth` in `windmill-trigger-postgres/src/handler.rs`.
- Add a `check_scopes` call at the top of each affected handler, before any `get_default_pg_connection` call:
  - **Read** (`postgres_triggers:read:{path}`): `get_postgres_version`, `list_slot_name`, `list_database_publication`, `get_publication_info`, `is_database_in_logical_level`
  - **Write** (`postgres_triggers:write:{path}`): `create_slot`, `drop_slot_name`, `create_publication`, `delete_publication`, `alter_publication`, `create_template_script`
- Add a regression test (`backend/tests/postgres_trigger_scope.rs`) that drives a read handler and the destructive `drop_slot_name` with a token scoped to a different resource path and asserts `PermissionDenied`. Because `check_scopes` runs before any connection is opened, the test needs no real Postgres resource. Verified it fails without the fix (the pre-fix handler proceeds to resource loading and returns `Not found` rather than `PermissionDenied`).

## Test plan

- [x] `cargo check -p windmill-trigger-postgres` passes
- [x] `cargo test --test postgres_trigger_scope` passes (2 tests)
- [x] Confirmed the regression test fails when the `check_scopes` call is removed
- [ ] CI review round clean

Fixes WIN-2213

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces per-resource-path scope checks on ancillary Postgres trigger routes to block cross-path access, including destructive slot/publication actions. Fixes WIN-2213 and aligns ancillary handlers with CRUD scope enforcement.

- **Bug Fixes**
  - Added `check_scopes` from `windmill_api_auth` to all ancillary handlers in `windmill-trigger-postgres` before any DB connection.
  - Applies to slot management, publication management, version/logical-level checks, and template script creation.
  - Read requires `postgres_triggers:read:{path}`; write requires `postgres_triggers:write:{path}`.

- **Tests**
  - Added `backend/tests/postgres_trigger_scope.rs` asserting `PermissionDenied` on path-mismatched tokens (including `drop_slot_name`).
  - Condensed the test module comment to state the durable “reject before DB access” constraint.

<sup>Written for commit f070f69adf5559efda4266f12714450a4d89d7ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

