### PR TITLE
feat(git-sync): dev-workspace promotion via a toggle on the inherited repo

### DIFF
--- a/frontend/src/lib/components/git_sync/GitSyncRepositoryCard.svelte
+++ b/frontend/src/lib/components/git_sync/GitSyncRepositoryCard.svelte
@@ -33,7 +33,8 @@
 		repository = null,
 		onAdd = null,
 		isCollapsible = true,
-		showEmptyState = false
+		showEmptyState = false,
+		devPromotion = false
 	} = $props<{
 		idx?: number | null
 		isSecondary?: boolean
@@ -44,6 +45,9 @@
 		onAdd?: (() => void) | null
 		isCollapsible?: boolean
 		showEmptyState?: boolean
+		// Dev workspace: this is the single inherited repo, and promotion is a
+		// toggle on it (reuse prod's repo) rather than a separately-configured one.
+		devPromotion?: boolean
 	}>()
 
 	const gitSyncContext = getGitSyncContext()
@@ -89,6 +93,20 @@
 	}
 	function setPromotionOpenPrs(v: boolean) {
 		if (repo) repo.promotion_open_prs = v
+	}
+	// Dev-workspace promotion toggle: flips the inherited repo between sync mode
+	// (deploys to the dev branch) and promotion mode (per-item wm_deploy/** PRs to
+	// prod). Persists immediately — it's a mode switch on an already-saved repo.
+	async function setDevPromotion(v: boolean) {
+		if (!repo || idx === null) return
+		repo.use_individual_branch = v
+		if (!v) repo.group_by_folder = false
+		await gitSyncContext.saveRepository(idx)
+	}
+	async function setGroupByFolder(v: boolean) {
+		if (!repo || idx === null) return
+		repo.group_by_folder = v
+		await gitSyncContext.saveRepository(idx)
 	}
 
 	let targetBranch = $state<string | undefined>(undefined) // Default to main, will be updated when resource is available
@@ -596,6 +614,32 @@
 									Push to repo
 								</Button>
 							</div>
+							{#if devPromotion && !repo.isUnsavedConnection}
+								<div class="mt-2">
+									<Toggle
+										checked={repo.use_individual_branch ?? false}
+										options={{
+											right: 'Promote to prod via Git',
+											rightTooltip:
+												"Each deploy pushes a per-item wm_deploy/** branch to prod's repository and opens a pull request into its tracked branch, instead of committing to the dev branch. Reuses prod's repository — no separate setup."
+										}}
+										on:change={(e) => setDevPromotion(e.detail)}
+									/>
+									{#if repo.use_individual_branch}
+										<div class="mt-2">
+											<Toggle
+												checked={repo.group_by_folder ?? false}
+												options={{
+													right: 'One pull request per folder',
+													rightTooltip:
+														"Group a folder's items into a single wm_deploy/** branch and pull request, instead of one per item."
+												}}
+												on:change={(e) => setGroupByFolder(e.detail)}
+											/>
+										</div>
+									{/if}
+								</div>
+							{/if}
 							{#if repoMode === 'promotion' && isGithubApp}
 								<div class="mt-2">
 									<Toggle
@@ -752,22 +796,22 @@
 								{#if !isGithubApp && !loadingResourceInfo}
 									<div class="mt-2">
 										<Alert type="info" title="Instant pull recommended" size="xs">
-											Pull for this repository checks the tracked branch about every minute;
-											longer gaps make drift and merge conflicts more likely. For instant pull,
-											connect the repository through the
+											Pull for this repository checks the tracked branch about every minute; longer
+											gaps make drift and merge conflicts more likely. For instant pull, connect the
+											repository through the
 											<a
 												href="https://www.windmill.dev/docs/integrations/git_repository#github-app"
 												target="_blank"
 												class="text-blue-500 hover:underline">GitHub App</a
 											>
-											(which also lets Windmill manage pull requests), or push changes into
-											Windmill with the
+											(which also lets Windmill manage pull requests), or push changes into Windmill
+											with the
 											<a
 												href="https://www.windmill.dev/docs/advanced/git_sync#github-actions"
 												target="_blank"
 												class="text-blue-500 hover:underline">sync GitHub workflow</a
-											>. If you already push changes with a GitHub Action, keep either the
-											Action or automatic pull, not both, so they don't fight over deploys.
+											>. If you already push changes with a GitHub Action, keep either the Action or
+											automatic pull, not both, so they don't fight over deploys.
 										</Alert>
 									</div>
 								{/if}

--- a/frontend/src/lib/components/git_sync/GitSyncSection.svelte
+++ b/frontend/src/lib/components/git_sync/GitSyncSection.svelte
@@ -74,6 +74,10 @@
 	// Derived state for repository categorization
 	const primarySync = $derived(gitSyncContext?.getPrimarySyncRepository() || null)
 	const primaryPromotion = $derived(gitSyncContext?.getPrimaryPromotionRepository() || null)
+	// A dev workspace reuses the single repo it inherited from prod: whether it's
+	// currently in sync or promotion mode, it's the same one card, toggled between
+	// the two — so a dev never configures a separate promotion repo.
+	const devPrimaryRepo = $derived(isDevWorkspace ? (primarySync ?? primaryPromotion) : null)
 	const secondarySync = $derived(gitSyncContext?.getSecondarySyncRepositories() || [])
 	const secondaryPromotion = $derived(gitSyncContext?.getSecondaryPromotionRepositories() || [])
 
@@ -144,16 +148,17 @@
 			<GitSyncRepositoryCard
 				variant="primary-sync"
 				mode="sync"
-				idx={primarySync?.idx ?? null}
-				repository={primarySync?.repo ?? null}
+				idx={(isDevWorkspace ? devPrimaryRepo : primarySync)?.idx ?? null}
+				repository={(isDevWorkspace ? devPrimaryRepo : primarySync)?.repo ?? null}
 				onAdd={() => gitSyncContext.addSyncRepository()}
 				isCollapsible={false}
-				showEmptyState={primarySync?.repo === null}
+				showEmptyState={(isDevWorkspace ? devPrimaryRepo : primarySync)?.repo == null}
+				devPromotion={isDevWorkspace}
 			/>
 
 			{#if $enterpriseLicense}
-				<!-- Secondary Sync Repositories (EE only) -->
-				{#if primarySync && !primarySync.repo?.isUnsavedConnection}
+				<!-- Secondary Sync Repositories (EE only; a dev workspace has a single inherited repo) -->
+				{#if primarySync && !primarySync.repo?.isUnsavedConnection && !isDevWorkspace}
 					{#if secondarySync.length > 0 || secondarySyncExpanded}
 						<div class="mt-4">
 							<button
@@ -215,8 +220,9 @@
 					{/if}
 				{/if}
 
-				<!-- Primary Promotion Repository (EE only; dev workspaces, not throwaway forks) -->
-				{#if showPromotion}
+				<!-- Primary Promotion Repository (EE only; roots only — a dev promotes via the
+					toggle on its single inherited repo, not a separate promotion repo) -->
+				{#if showPromotion && !isDevWorkspace}
 					<div class="mt-6">
 						<GitSyncRepositoryCard
 							variant="primary-promotion"


### PR DESCRIPTION
## Summary
Follow-up to #10205 (base branch). Instead of making a dev workspace configure a **separate** promotion repository, a dev reuses the single repo it already inherited from prod: a **"Promote to prod via Git"** toggle flips that repo between sync mode (deploys commit to the dev branch) and promotion mode (per-item `wm_deploy/**` PRs into prod's tracked branch). No separate setup, and it naturally reuses prod's GitHub App installation (which the fork already clones), so the auto-PR works without extra token plumbing.

## Changes
- `GitSyncSection.svelte`: for a dev workspace, render the single inherited repo (whichever mode it's in) and hide the separate promotion card + secondary sections. Roots keep the existing sync/promotion two-section layout.
- `GitSyncRepositoryCard.svelte`: `devPromotion` prop adds a "Promote to prod via Git" toggle (flips `use_individual_branch`) with a "One pull request per folder" sub-toggle (`group_by_folder`, per-item vs per-folder). Persists immediately — it's a mode switch on an already-saved repo.

## Screenshots
Dev workspace git-sync — promotion **off** (deploys to the dev branch):

![toggle off](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-fork-promotion-toggle/1784625145-dev-promotion-toggle-off.png)

Promotion **on** (per-item `wm_deploy/**` PRs to prod, with the per-folder sub-toggle):

![toggle on](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-fork-promotion-toggle/1784625147-dev-promotion-toggle-on.png)

## Test plan
- [x] `npm run check:fast` clean for the changed components (only pre-existing main-side `DataMetric` errors remain)
- [x] Playwright: on a dev workspace that inherited prod's repo, the toggle shows; enabling it persists `use_individual_branch=true` (DB-confirmed), switches the card to promotion mode, and reveals the per-folder sub-toggle; the separate promotion card is hidden

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let dev workspaces promote to prod using a toggle on the inherited repo, removing the separate promotion repo setup. The toggle switches between syncing to the dev branch and opening `wm_deploy/**` PRs to prod.

- New Features
  - Add “Promote to prod via Git” toggle on the inherited repo in dev workspaces; no separate promotion repo.
  - Persist mode switch by updating `use_individual_branch`; add “One pull request per folder” sub-toggle via `group_by_folder`.
  - Update layout to show a single repo card in dev workspaces and hide promotion/secondary sections; root workspaces keep the existing two-section layout.

<sup>Written for commit 21cbbd07aa7a52c3573e8962d103dc2ada4475c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

