### PR TITLE
fix(frontend): limit compare & deploy rows to the active direction

### DIFF
--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -910,22 +910,18 @@
 	// Trigger and schedule rows now flow through `comparison.diffs` like every
 	// other deployable kind — the backend's `compareWorkspaces` populates them
 	// from `workspace_diff`, with runtime fields ignored by `compare_two_*`.
-	let deployableItems = $derived.by(() => {
-		return (comparison?.diffs ?? [])
-			.filter((diff) => {
-				const key = getItemKey(diff)
-				const isSelectable = selectableDiffs.includes(diff)
-				const isDeployedAndIrrelevant =
-					deploymentStatus[key]?.status === 'deployed' && !isSelectable
-				return !isDeployedAndIrrelevant
-			})
-			.map((diff) => ({
-				key: getItemKey(diff),
-				path: diff.path,
-				kind: diff.kind as Kind,
-				diff
-			}))
-	})
+	// Rows are limited to the active direction (conflicts are ahead AND behind,
+	// so they show in both): an opposite-direction-only row would render as an
+	// unexplained disabled line. The other direction stays visible through the
+	// toggle badge counts and the behind/hidden alerts.
+	let deployableItems = $derived(
+		selectableDiffs.map((diff) => ({
+			key: getItemKey(diff),
+			path: diff.path,
+			kind: diff.kind as Kind,
+			diff
+		}))
+	)
 
 	let ciTestResults = $state<Record<string, CiTestResult[]>>({})
 
@@ -1049,10 +1045,9 @@
 	<div class="flex flex-col gap-4">
 		<div class="bg-surface-tertiary p-4 rounded-md border">
 			<WorkspaceDeployLayout
-				items={nothingToAct ? [] : deployableItems}
+				items={deployableItems}
 				{selectedItems}
 				{deploymentStatus}
-				selectablePredicate={(item) => selectableDiffs.some((d) => getItemKey(d) === item.key)}
 				{allSelected}
 				onToggleItem={(item) => toggleKey(item.key)}
 				onSelectAll={selectAll}
@@ -1109,9 +1104,6 @@
 									</div>
 								{/if}
 								<div class="flex items-center gap-2 text-sm">
-									<Badge color="transparent">
-										{comparison.summary.total_diffs} total items
-									</Badge>
 									<Badge color="transparent">
 										{selectableDiffs.length}
 										{mergeIntoParent ? 'deployable' : 'updateable'}
@@ -1277,7 +1269,6 @@
 						<span class="text-tertiary mx-1">&rarr;</span>
 						<span class="text-secondary">{diff.path}</span>
 					{:else}
-						{@const isSelectable = selectableDiffs.includes(diff)}
 						{@const oldSummary = mergeIntoParent
 							? summaryCache[key]?.parent
 							: summaryCache[key]?.current}
@@ -1293,7 +1284,7 @@
 							{editUrl}
 							{oldSummary}
 							{newSummary}
-							renamed={oldSummary != newSummary && isSelectable && existsInBothWorkspaces}
+							renamed={oldSummary != newSummary && existsInBothWorkspaces}
 						/>
 					{/if}
 				{/snippet}


### PR DESCRIPTION
## Summary
The Compare & Deploy page rendered every item from the workspace comparison in both directions: the "Deploy to parent" view also listed behind-only (update-direction) items, and the "Update current" view listed ahead-only items — all as greyed-out, non-selectable rows with no explanation of why they can't be acted on. This PR limits the list to the direction being viewed, so each view shows exactly the rows it can act on.

Conflict items (ahead **and** behind) still appear in both views since they are actionable either way, and awareness of the other direction is preserved by the toggle's per-direction counts ("Deploy to X (9)" / "Update current (4)") and the existing "fork is behind parent" alert.

## Changes
- `deployableItems` is now built from `selectableDiffs` (the direction-filtered set) instead of all `comparison.diffs`; just-deployed rows keep their "Deployed" badge until the comparison refresh drops them, exactly as before
- Removed the `selectablePredicate` prop passed to `WorkspaceDeployLayout` and the `isSelectable` check in the row summary — both are always true now that every rendered row is selectable
- Removed the "N total items" badge: it counted both directions, which would contradict the filtered list; the remaining "N deployable/updateable" badge matches the visible rows and the toggle labels carry each direction's count

## Test plan
- [x] `npm run check` passes (0 errors)
- [x] Fork with 9 ahead-only + 4 behind-only items: deploy view lists exactly the 9 deployable rows, update view exactly the 4 updateable rows (screenshots below)
- [x] Fork with a conflict item (ahead and behind): the conflict row and its badge appear in both views; ahead-only items stay out of the update view
- [x] Direction with zero actionable items still renders the explanatory empty-state message (unchanged `nothingToAct` path)

## Screenshots
"Deploy to parent" view — only the 9 deployable items (the 4 behind-only items no longer show as disabled rows):

![deploy-to-parent-view](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/compare-nit/1784628631-deploy-to-parent-view.png)

"Update current" view — only the 4 updateable items:

![update-current-view](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/compare-nit/1784628634-update-current-view.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)