### PR TITLE
fix(frontend): curl fallback for +Variable/+Resource in bash sandbox mode

### DIFF
--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -39,6 +39,7 @@
 	import { createEventDispatcher, untrack } from 'svelte'
 	import { sendUserToast } from '$lib/toast'
 	import { getScriptByPath, scriptLangToEditorLang } from '$lib/scripts'
+	import { bashRunsInCustomImage } from '$lib/script_helpers'
 	import Toggle from './Toggle.svelte'
 
 	import {
@@ -673,10 +674,13 @@
 			}
 			editor.insertAtCursor(`v, _ := wmill.GetVariable("${path}")`)
 		} else if (lang == 'bash') {
-			const code = editor.getCode()
-			if (code.includes('# sandbox') || code.includes('# docker')) {
+			if (bashRunsInCustomImage(editor.getCode())) {
+				// Custom image: no wmill CLI. Fall back to curl, then busybox wget
+				// (the default `# sandbox alpine:latest` image ships wget, not curl).
+				// get_value returns a JSON-quoted string, so strip the outer quotes
+				// to match the `jq -r .value` output of the non-sandbox branch.
 				editor.insertAtCursor(
-					`curl -s -H "Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/variables/get_value/${path}"`
+					`{ curl -sf -H "Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/variables/get_value/${path}" 2>/dev/null || wget -qO- --header="Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/variables/get_value/${path}"; } | sed 's/^"//;s/"$//'`
 				)
 			} else {
 				editor.insertAtCursor(`wmill variable get ${path} --json | jq -r .value`)
@@ -758,10 +762,12 @@ string ${windmillPathToCamelCaseName(path)} = await client.GetStringAsync(uri);
 			}
 			editor.insertAtCursor(`r, _ := wmill.GetResource("${path}")`)
 		} else if (lang == 'bash') {
-			const code = editor.getCode()
-			if (code.includes('# sandbox') || code.includes('# docker')) {
+			if (bashRunsInCustomImage(editor.getCode())) {
+				// Custom image: no wmill CLI. Fall back to curl, then busybox wget
+				// (the default `# sandbox alpine:latest` image ships wget, not curl).
+				// get_value_interpolated returns JSON, matching the `jq .value` branch.
 				editor.insertAtCursor(
-					`curl -s -H "Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/resources/get_value_interpolated/${path}"`
+					`curl -sf -H "Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/resources/get_value_interpolated/${path}" 2>/dev/null || wget -qO- --header="Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/resources/get_value_interpolated/${path}"`
 				)
 			} else {
 				editor.insertAtCursor(`wmill resource get ${path} --json | jq .value`)

--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -673,7 +673,14 @@
 			}
 			editor.insertAtCursor(`v, _ := wmill.GetVariable("${path}")`)
 		} else if (lang == 'bash') {
-			editor.insertAtCursor(`wmill variable get ${path} --json | jq -r .value`)
+			const code = editor.getCode()
+			if (code.includes('# sandbox') || code.includes('# docker')) {
+				editor.insertAtCursor(
+					`curl -s -H "Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/variables/get_value/${path}"`
+				)
+			} else {
+				editor.insertAtCursor(`wmill variable get ${path} --json | jq -r .value`)
+			}
 		} else if (lang == 'powershell') {
 			editor.insertAtCursor(`$Headers = @{\n"Authorization" = "Bearer $Env:WM_TOKEN"`)
 			editor.arrowDown()
@@ -751,7 +758,14 @@ string ${windmillPathToCamelCaseName(path)} = await client.GetStringAsync(uri);
 			}
 			editor.insertAtCursor(`r, _ := wmill.GetResource("${path}")`)
 		} else if (lang == 'bash') {
-			editor.insertAtCursor(`wmill resource get ${path} --json | jq .value`)
+			const code = editor.getCode()
+			if (code.includes('# sandbox') || code.includes('# docker')) {
+				editor.insertAtCursor(
+					`curl -s -H "Authorization: Bearer $WM_TOKEN" "$BASE_INTERNAL_URL/api/w/$WM_WORKSPACE/resources/get_value_interpolated/${path}"`
+				)
+			} else {
+				editor.insertAtCursor(`wmill resource get ${path} --json | jq .value`)
+			}
 		} else if (lang == 'powershell') {
 			editor.insertAtCursor(`$Headers = @{\n"Authorization" = "Bearer $Env:WM_TOKEN"`)
 			editor.arrowDown()
@@ -962,7 +976,8 @@ JsonNode ${windmillPathToCamelCaseName(path)} = JsonNode.Parse(await client.GetS
 			// after an unterminated one produces invalid SQL. The separator starts on
 			// its own line so the `;` cannot land inside a trailing line comment.
 			const existing = editor?.getCode() ?? ''
-			const sep = existing.trim() === '' ? '' : endsWithUnterminatedStatement(existing) ? '\n;\n\n' : '\n\n'
+			const sep =
+				existing.trim() === '' ? '' : endsWithUnterminatedStatement(existing) ? '\n;\n\n' : '\n\n'
 			editor?.append(sep + sql + '\n')
 		}}
 	/>

--- a/frontend/src/lib/script_helpers.test.ts
+++ b/frontend/src/lib/script_helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { bashRunsInCustomImage } from './script_helpers'
+
+// bashRunsInCustomImage decides whether the +Variable/+Resource pickers insert a
+// curl/wget snippet (custom image, no wmill CLI) or the wmill CLI snippet. It must
+// stay in sync with the worker's BashAnnotations grammar
+// (backend/windmill-common/src/worker.rs): leading comment lines only, `# sandbox
+// <image>` or bare `# docker` select a container; a bare `# sandbox` does not.
+
+describe('bashRunsInCustomImage', () => {
+	it('true for `# sandbox <image>` (spaced and compact)', () => {
+		expect(bashRunsInCustomImage('# sandbox alpine:latest\necho hi')).toBe(true)
+		expect(bashRunsInCustomImage('#sandbox   python:3.12-slim\n')).toBe(true)
+	})
+
+	it('true for a bare `# docker` annotation', () => {
+		expect(bashRunsInCustomImage('# docker\necho hi')).toBe(true)
+	})
+
+	it('true when the sandbox line follows other leading comments (default template)', () => {
+		expect(bashRunsInCustomImage('# shellcheck shell=bash\n# sandbox alpine:latest\necho hi')).toBe(
+			true
+		)
+	})
+
+	it('false for a bare `# sandbox` (nsjail-bash on the worker, wmill available)', () => {
+		expect(bashRunsInCustomImage('# sandbox\necho hi')).toBe(false)
+	})
+
+	it('false for prose comments that merely contain the words', () => {
+		expect(bashRunsInCustomImage('# sandboxed run below\necho hi')).toBe(false)
+		expect(bashRunsInCustomImage('# runs in a docker container\necho hi')).toBe(false)
+	})
+
+	it('false when the annotation is not on a leading comment line', () => {
+		expect(bashRunsInCustomImage('echo hi\n# sandbox alpine')).toBe(false)
+		expect(bashRunsInCustomImage('msg="$1" # docker')).toBe(false)
+	})
+
+	it('false for a plain script with no annotations', () => {
+		expect(bashRunsInCustomImage('# shellcheck shell=bash\necho hi')).toBe(false)
+	})
+})

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -1435,6 +1435,30 @@ export const INITIAL_CODE = {
 	// for related places search: ADD_NEW_LANG
 }
 
+/**
+ * Whether a bash script body runs inside a custom container image that does not
+ * ship the `wmill` CLI (nor `jq`), namely `# sandbox <image>` or `# docker`. In
+ * that case editor snippets must fall back to a plain HTTP client instead of `wmill`.
+ *
+ * Mirrors the worker's annotation grammar (backend/windmill-common/src/worker.rs,
+ * `BashAnnotations`): only leading comment lines are scanned, stopping at the first
+ * non-comment line. A bare `# sandbox` (no image) is the nsjail-bash modifier that
+ * still runs on the worker rootfs where `wmill` is available, so it is excluded.
+ */
+export function bashRunsInCustomImage(code: string): boolean {
+	for (const line of code.split('\n')) {
+		const trimmed = line.trim()
+		if (trimmed === '') continue
+		if (!trimmed.startsWith('#')) break
+		const tokens = trimmed.slice(1).trim().split(/\s+/)
+		// `# sandbox <image>` selects a container; bare `# sandbox` does not.
+		if (tokens[0] === 'sandbox' && tokens[1]) return true
+		// `# docker` (v1 daemon runtime) runs in the referenced image, no wmill.
+		if (tokens[0] === 'docker' && tokens.length === 1) return true
+	}
+	return false
+}
+
 export function isInitialCode(content: string): boolean {
 	for (const lang of Object.values(INITIAL_CODE)) {
 		for (const code of Object.values(lang)) {


### PR DESCRIPTION
## Summary

In a bash script that runs inside a custom container image (`# sandbox <image>` or `# docker`), the body has no `wmill` CLI, so the `+Variable` / `+Resource` picker snippets (`wmill variable get …` / `wmill resource get …`) fail. This inserts a plain HTTP snippet in that case, using the `BASE_INTERNAL_URL`, `WM_TOKEN`, and `WM_WORKSPACE` env vars that are available inside sandbox (confirmed in `bash_executor.rs` / `docker_v2.rs`).

## Changes

- `frontend/src/lib/script_helpers.ts`: new `bashRunsInCustomImage(code)` helper that mirrors the worker's `BashAnnotations` grammar (`backend/windmill-common/src/worker.rs`) — only leading comment lines are scanned; `# sandbox <image>` (image present) or a bare `# docker` line selects a custom container. A bare `# sandbox` is the nsjail-bash modifier (runs on the worker rootfs, `wmill` available) and is correctly excluded.
- `frontend/src/lib/components/EditorBar.svelte`: the `+Variable` / `+Resource` bash branches use the helper. In a custom image they insert a `curl` snippet with a busybox-`wget` fallback (the default `# sandbox alpine:latest` image ships `wget`, not `curl`). The variable snippet strips the surrounding quotes from `get_value`'s JSON string with `sed` so it matches the `jq -r .value` output of the non-sandbox branch; resources return JSON either way.
- `frontend/src/lib/script_helpers.test.ts`: focused unit tests for the detection grammar (spaced/compact annotations, bare `# sandbox`, prose false positives, non-leading annotations, default template).

## Notes / decisions

- **Why `curl || wget`**: no HTTP client is universal, but the default sandbox template is `alpine:latest`, whose busybox ships `wget` (not `curl`). Trying `curl` first then `wget` makes the snippet work on the default image and on images that provide `curl`. `sed` (used to unquote the variable value) is present in both busybox and coreutils.
- **Grammar parity over substring match**: the original `code.includes('# sandbox')` both missed compact annotations and fired on prose/body occurrences and on bare `# sandbox` (which keeps `wmill`). The helper mirrors the worker parser instead.

## Test plan

Verified end-to-end in the browser (bash script editor, headless Playwright):

- [x] `# sandbox alpine:latest` (after a leading `# shellcheck` line) + `+Variable` → `{ curl … || wget …; } | sed 's/^"//;s/"$//'`
- [x] `# docker` + `+Resource` → `curl … || wget …` (raw JSON, no `sed`)
- [x] Bare `# sandbox` + `+Variable` → keeps `wmill variable get … --json | jq -r .value`
- [x] Plain bash (no directive) → keeps the `wmill` snippets
- [x] `variables/get_value` returns `"myvalue"` (JSON-quoted, confirmed against the running API); `sed 's/^"//;s/"$//'` strips it to `myvalue`, matching `jq -r .value`
- [x] `npm run check:fast` clean (only a pre-existing unrelated `modern-screenshot` error in `RawAppEditor.svelte`)
- [x] `vitest run src/lib/script_helpers.test.ts` — 7 passed

### Screenshot

`# sandbox alpine:latest` + `+Variable` inserts the curl/wget snippet with the `sed` unquote (line scrolled to show the tail):

![sandbox-curl](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2215-use-curl-fallback-for-variableresource-in-bash-sandbox-mode/1784630872-sandbox-curl-v2.png)

Fixes WIN-2215

🤖 Generated with [Claude Code](https://claude.com/claude-code)