### PR TITLE
fix(docker): bump slim image Python to 3.12.13 to ship current pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,13 +245,9 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11 --compile-bytecode
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-# Upgrade the bundled pip in each real runtime (skip uv's version-alias symlinks). -e fails the build if any upgrade fails.
-RUN set -eux; \
-    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
-        if [ -x "$runtime/bin/python" ]; then \
-            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
-        fi; \
-    done
+# Upgrade the bundled pip to the pinned version (the RUN fails the build if the pin can't be installed).
+RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python 3.11 --system --break-system-packages --upgrade "pip==$PIP_VERSION"
+RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python $LATEST_STABLE_PY --system --break-system-packages --upgrade "pip==$PIP_VERSION"
 
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,8 +151,6 @@ ARG features=""
 # 2. Change LATEST_STABLE_PY in dockerfile
 # 3. Change #[default] annotation for PyVersion in backend
 ARG LATEST_STABLE_PY=3.12
-# Pinned pip for uv-managed runtimes: the bundled pip lags, so upgrade it explicitly.
-ARG PIP_VERSION=26.1.2
 ENV UV_PYTHON_INSTALL_DIR=/tmp/windmill/cache/py_runtime
 ENV UV_PYTHON_PREFERENCE=only-managed
 
@@ -245,9 +243,6 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11 --compile-bytecode
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-# Upgrade the bundled pip to the pinned version (the RUN fails the build if the pin can't be installed).
-RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python 3.11 --system --break-system-packages --upgrade "pip==$PIP_VERSION"
-RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python $LATEST_STABLE_PY --system --break-system-packages --upgrade "pip==$PIP_VERSION"
 
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,6 +151,8 @@ ARG features=""
 # 2. Change LATEST_STABLE_PY in dockerfile
 # 3. Change #[default] annotation for PyVersion in backend
 ARG LATEST_STABLE_PY=3.12
+# Pinned pip for uv-managed runtimes: the bundled pip lags, so upgrade it explicitly.
+ARG PIP_VERSION=26.1.2
 ENV UV_PYTHON_INSTALL_DIR=/tmp/windmill/cache/py_runtime
 ENV UV_PYTHON_PREFERENCE=only-managed
 
@@ -243,6 +245,13 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11 --compile-bytecode
 RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
+# Upgrade the bundled pip in each real runtime (skip uv's version-alias symlinks). -e fails the build if any upgrade fails.
+RUN set -eux; \
+    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
+        if [ -x "$runtime/bin/python" ]; then \
+            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
+        fi; \
+    done
 
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -26,9 +26,7 @@ RUN make
 FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
-ARG LATEST_STABLE_PY=3.12.12
-# Pinned pip for uv-managed runtimes: the bundled pip lags, so upgrade it explicitly.
-ARG PIP_VERSION=26.1.2
+ARG LATEST_STABLE_PY=3.12.13
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -64,8 +62,6 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-# Upgrade the bundled pip to the pinned version (the RUN fails the build if the pin can't be installed).
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python $LATEST_STABLE_PY --system --break-system-packages --upgrade "pip==$PIP_VERSION"
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -27,6 +27,8 @@ FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
 ARG LATEST_STABLE_PY=3.12.12
+# Pinned pip for uv-managed runtimes: the bundled pip lags, so upgrade it explicitly.
+ARG PIP_VERSION=26.1.2
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -62,6 +64,13 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
+# Upgrade the bundled pip in each real runtime (skip uv's version-alias symlinks). -e fails the build if any upgrade fails.
+RUN set -eux; \
+    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
+        if [ -x "$runtime/bin/python" ]; then \
+            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
+        fi; \
+    done
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -64,13 +64,8 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-# Upgrade the bundled pip in each real runtime (skip uv's version-alias symlinks). -e fails the build if any upgrade fails.
-RUN set -eux; \
-    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
-        if [ -x "$runtime/bin/python" ]; then \
-            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
-        fi; \
-    done
+# Upgrade the bundled pip to the pinned version (the RUN fails the build if the pin can't be installed).
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python $LATEST_STABLE_PY --system --break-system-packages --upgrade "pip==$PIP_VERSION"
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -26,9 +26,7 @@ RUN make
 FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
-ARG LATEST_STABLE_PY=3.12.12
-# Pinned pip for uv-managed runtimes: the bundled pip lags, so upgrade it explicitly.
-ARG PIP_VERSION=26.1.2
+ARG LATEST_STABLE_PY=3.12.13
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -64,8 +62,6 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-# Upgrade the bundled pip to the pinned version (the RUN fails the build if the pin can't be installed).
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python $LATEST_STABLE_PY --system --break-system-packages --upgrade "pip==$PIP_VERSION"
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -27,6 +27,8 @@ FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
 ARG LATEST_STABLE_PY=3.12.12
+# Pinned pip for uv-managed runtimes: the bundled pip lags, so upgrade it explicitly.
+ARG PIP_VERSION=26.1.2
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -62,6 +64,13 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
+# Upgrade the bundled pip in each real runtime (skip uv's version-alias symlinks). -e fails the build if any upgrade fails.
+RUN set -eux; \
+    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
+        if [ -x "$runtime/bin/python" ]; then \
+            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
+        fi; \
+    done
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -64,13 +64,8 @@ RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releas
 # under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
 # timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
 RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
-# Upgrade the bundled pip in each real runtime (skip uv's version-alias symlinks). -e fails the build if any upgrade fails.
-RUN set -eux; \
-    for runtime in $(find /tmp/build_cache/py_runtime -mindepth 1 -maxdepth 1 -type d); do \
-        if [ -x "$runtime/bin/python" ]; then \
-            uv pip install --python "$runtime/bin/python" --break-system-packages --compile-bytecode --upgrade "pip==$PIP_VERSION"; \
-        fi; \
-    done
+# Upgrade the bundled pip to the pinned version (the RUN fails the build if the pin can't be installed).
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --python $LATEST_STABLE_PY --system --break-system-packages --upgrade "pip==$PIP_VERSION"
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \


### PR DESCRIPTION
## Summary

Part of #10219 (the pip half). The concern is that uv-managed Python runtimes ship a preinstalled `pip` (python-build-standalone installs it at build time) that gets baked into the images and flagged by scanners.

Investigation showed the gap is narrower than it first appeared. With the pinned uv `0.11.24`:

| Runtime | Resolves to | Bundled pip |
|---|---|---|
| `Dockerfile` `3.11` | 3.11.15 | 26.1.2 ✅ |
| `Dockerfile` `3.12` (floating patch) | 3.12.13 | 26.1.2 ✅ |
| `DockerfileSlim*` `3.12.12` (pinned patch) | 3.12.12 | **26.0.1** ❌ |

Only the slim / EE-slim images are behind, and only because they pin the `3.12.12` patch while the full image floats to `3.12.13` (which already ships pip 26.1.2).

## Change

Bump `LATEST_STABLE_PY` `3.12.12 → 3.12.13` in `docker/DockerfileSlim` and `docker/DockerfileSlimEe`, aligning them with the patch the full image already uses. The runtime then ships pip 26.1.2 natively — no `PIP_VERSION` arg and no explicit `uv pip install` upgrade step needed.

`3.12.12` was referenced nowhere else (the backend keys off the minor version, not the patch), so this is self-contained.

## Verification

With uv 0.11.24 (the version these images pin): `uv python install 3.12.12` ships `pip 26.0.1`, `3.12.13` ships `pip 26.1.2`, `3.11.15` ships `pip 26.1.2` — so after this change every runtime in every image ships 26.1.2.

## Scope note

The `form-data@4.0.5 → 4.0.6` half of #10219 is fixed at its source (the embedded Hub-script locks) in a separate `windmill-integrations` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)