### PR TITLE
fix(worker): mount /dev/shm as tmpfs in the Docker v2 nsjail sandbox

### DIFF
--- a/backend/windmill-worker/nsjail/run.docker.config.proto
+++ b/backend/windmill-worker/nsjail/run.docker.config.proto
@@ -77,6 +77,13 @@ mount {
     is_bind: true
 }
 
+mount {
+    dst: "/dev/shm"
+    fstype: "tmpfs"
+    rw: true
+    is_bind: false
+}
+
 # Host DNS config layered over the image's /etc so name resolution works on the
 # job's network (mandatory:false: some minimal images have no /etc files to shadow).
 mount {


### PR DESCRIPTION
## Problem

The Docker v2 nsjail config template (`backend/windmill-worker/nsjail/run.docker.config.proto`) did not mount `/dev/shm`. `generate_rootfs_mounts()` in `docker_v2.rs` skips the `dev` directory from the image rootfs, expecting the nsjail profile to provide the necessary `/dev/*` entries. The profile provided `/dev/null`, `/dev/zero`, `/dev/random`, and `/dev/urandom`, but omitted `/dev/shm`.

This caused any program needing POSIX shared memory (Ansible multiprocessing, Python multiprocessing, Chromium, ...) to fail with `No such file or directory: /dev/shm`.

## Fix

Add a `/dev/shm` tmpfs mount block after the existing `/dev/urandom` bind mount, matching the pattern already used in `run.ansible.config.proto` and `run.python3.config.proto`:

```
mount {
    dst: "/dev/shm"
    fstype: "tmpfs"
    rw: true
    is_bind: false
}
```

## Scope

- `backend/windmill-worker/nsjail/run.docker.config.proto`

Fixes WIN-2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount /dev/shm as a tmpfs in the Docker v2 nsjail sandbox to restore POSIX shared memory and stop failures in Ansible/Python multiprocessing and Chromium. Aligns the Docker profile with the Ansible and Python nsjail configs and fixes WIN-2216.

<sup>Written for commit 5d686319b0f5571eaa4c41c0c699f5d2dcac9230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

