### PR TITLE
fix: preserve trigger metadata when restarting a flow

### DIFF
--- a/backend/.sqlx/query-47d41e53c8346c683b87997dd9c0dbadfa139d7c3d04e43111f88d438c6fed37.json
+++ b/backend/.sqlx/query-47d41e53c8346c683b87997dd9c0dbadfa139d7c3d04e43111f88d438c6fed37.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                                flow_status->>'step' = '0'\n                                AND flow_status->'restarted_from' IS NULL\n                                AND (\n                                    jsonb_array_length(flow_status->'modules') = 0\n                                    OR flow_status->'modules'->0->>'type' = 'WaitingForPriorSteps'\n                                    OR (\n                                        flow_status->'modules'->0->>'type' = 'Failure'\n                                        AND flow_status->'modules'->0->>'job' = $1\n                                    )\n                                )\n                            FROM v2_job_completed WHERE id = $2 AND workspace_id = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "47d41e53c8346c683b87997dd9c0dbadfa139d7c3d04e43111f88d438c6fed37"
+}

--- a/backend/.sqlx/query-b34615d144bc4430ed4a4e4957dac19e139d35dd6658630e8439fd143fe73df0.json
+++ b/backend/.sqlx/query-b34615d144bc4430ed4a4e4957dac19e139d35dd6658630e8439fd143fe73df0.json
@@ -1,0 +1,81 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                j.runnable_path as script_path, j.args AS \"args: sqlx::types::Json<HashMap<String, Box<RawValue>>>\",\n                j.tag AS \"tag!\", j.priority,\n                j.trigger, j.trigger_kind AS \"trigger_kind: windmill_common::jobs::JobTriggerKind\"\n            FROM v2_job j\n            WHERE j.id = $1 and j.workspace_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "script_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "args: sqlx::types::Json<HashMap<String, Box<RawValue>>>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "tag!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "priority",
+        "type_info": "Int2"
+      },
+      {
+        "ordinal": 4,
+        "name": "trigger",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "trigger_kind: windmill_common::jobs::JobTriggerKind",
+        "type_info": {
+          "Custom": {
+            "name": "job_trigger_kind",
+            "kind": {
+              "Enum": [
+                "webhook",
+                "http",
+                "websocket",
+                "kafka",
+                "email",
+                "nats",
+                "schedule",
+                "app",
+                "ui",
+                "postgres",
+                "sqs",
+                "gcp",
+                "mqtt",
+                "nextcloud",
+                "google",
+                "ci_test",
+                "github",
+                "azure",
+                "asset",
+                "freshness"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "b34615d144bc4430ed4a4e4957dac19e139d35dd6658630e8439fd143fe73df0"
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -5126,7 +5126,8 @@ pub async fn restart_flow(
     let completed_job = sqlx::query!(
             "SELECT
                 j.runnable_path as script_path, j.args AS \"args: sqlx::types::Json<HashMap<String, Box<RawValue>>>\",
-                j.tag AS \"tag!\", j.priority
+                j.tag AS \"tag!\", j.priority,
+                j.trigger, j.trigger_kind AS \"trigger_kind: windmill_common::jobs::JobTriggerKind\"
             FROM v2_job j
             WHERE j.id = $1 and j.workspace_id = $2",
             job_id,
@@ -5150,6 +5151,12 @@ pub async fn restart_flow(
         .unwrap_or_else(|| PushArgs::from(&ehm));
 
     let scheduled_for = run_query.get_scheduled_for(&db).await?;
+
+    // Keep the original run's trigger metadata (e.g. its schedule) so the
+    // restarted run stays associated with it in the runs list.
+    let trigger = completed_job
+        .trigger_kind
+        .map(|kind| TriggerMetadata::new(completed_job.trigger.clone(), kind));
 
     let (top_branch_chosen, nested_chain) = resolve_nested_restart(
         &db,
@@ -5198,7 +5205,7 @@ pub async fn restart_flow(
         Some(&authed.clone().into()),
         false,
         None,
-        None,
+        trigger,
         run_query.suspended_mode,
     )
     .await?;

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -1301,7 +1301,9 @@ async fn commit_completed_job<T: Serialize + Send + Sync + ValidableJson>(
                 // terminal attempt can drive handlers) but `parent_job` is set —
                 // they must not each push the next cron tick (the root already
                 // did), so gate next-tick on a top-level (`parent_job IS NULL`)
-                // occurrence.
+                // occurrence. Restarted runs (`restarted_from` set) also carry
+                // the trigger but are not occurrences either — they must not
+                // arm the next tick.
                 let schedule_next_tick = completed_job.parent_job.is_none()
                     && (!completed_job.is_flow()
                         || from_cache
@@ -1309,6 +1311,7 @@ async fn commit_completed_job<T: Serialize + Send + Sync + ValidableJson>(
                             && sqlx::query_scalar!(
                                 "SELECT
                                 flow_status->>'step' = '0'
+                                AND flow_status->'restarted_from' IS NULL
                                 AND (
                                     jsonb_array_length(flow_status->'modules') = 0
                                     OR flow_status->'modules'->0->>'type' = 'WaitingForPriorSteps'

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -2864,11 +2864,15 @@ pub async fn handle_flow(
         .with_context(|| "Unable to parse flow status")?;
 
     let schedule_path = flow_job.schedule_path();
+    // Restarted runs keep their schedule trigger metadata but are not genuine
+    // schedule occurrences: they must not arm the next cron tick (the original
+    // occurrence already did, and a restart must not resurrect a cancelled one).
     if !flow_job.is_flow_step()
         && status.retry.fail_count == 0
         && schedule_path.is_some()
         && flow_job.runnable_path.is_some()
         && status.step == 0
+        && status.restarted_from.is_none()
     {
         let schedule_path = schedule_path.as_ref().unwrap();
 
@@ -3223,7 +3227,13 @@ async fn push_next_flow_job(
     }
 
     if matches!(step, Step::Step { idx: 0, .. }) {
-        if !flow_job.is_flow_step() && flow_job.schedule_path().is_some() {
+        // no_flow_overlap only skips genuine schedule occurrences: a restarted
+        // run carries the schedule trigger metadata but was explicitly
+        // requested by a user, so it always runs.
+        if !flow_job.is_flow_step()
+            && flow_job.schedule_path().is_some()
+            && status.restarted_from.is_none()
+        {
             let schedule_path = flow_job.schedule_path();
             let no_flow_overlap = sqlx::query_scalar!(
                 "SELECT no_flow_overlap FROM schedule WHERE path = $1 AND workspace_id = $2",


### PR DESCRIPTION
## Summary

Fixes WIN-2192.

When a flow originally triggered by a schedule (or any other trigger) was restarted via the restart-at-step API, the new run was pushed with `trigger = None`, so it showed up as a manual run in the Runs list and lost its association with the original schedule. `restart_flow` now reads `trigger`/`trigger_kind` from the original `v2_job` row and forwards them as `TriggerMetadata` to `push()` — mirroring what the native-retry path already does.

Because `trigger`/`trigger_kind` are not display-only (the scheduler machinery derives `schedule_path()` from them), the second commit ensures a restarted run is never treated as a genuine schedule *occurrence* for tick-arming purposes:

- `handle_flow`'s flow-start next-tick push is skipped when `flow_status.restarted_from` is set — a restart from the first step can no longer arm a duplicate/resurrected cron tick.
- The completion-path next-tick push (flows failed/cancelled before `handle_flow`) gets the same `restarted_from IS NULL` gate in its SQL check.
- The `no_flow_overlap` self-skip is bypassed for restarted runs: a restart explicitly requested by a user always runs instead of silently completing with "not allowed to overlap" (which is the pre-existing behavior, since restarts previously carried no schedule metadata).

## Intentional semantic choices (please push back if undesired)

- **Schedule completion handlers (`on_failure`/`on_success`/`on_recovery`) now fire for restarted runs** of scheduled flows, and such runs count toward the schedule's occurrence tracking. This mirrors the native-retry precedent (terminal attempt drives handlers) and means a failing restart alerts the schedule owner. If restarts should be handler-silent, the completion path needs an additional `restarted_from` gate.
- **A running restarted run counts toward `no_flow_overlap`** for the schedule's genuine next tick (the tick skips itself while the restart is running) — consistent with no-overlap semantics for the same flow.
- **Edge cases inherited from schedule metadata**: a queued (not yet running) restarted run matches `clear_schedule`'s deletion query on schedule edit/disable, and a restart pushed with a future `scheduled_for` is rejected by the cancel endpoint's future-tick guard until it starts. Both require exotic API usage (restarts normally start immediately) and are left as is.

## Changes

- `backend/windmill-api/src/jobs.rs`: `restart_flow` fetches `trigger`/`trigger_kind` from the original job and passes `TriggerMetadata` to `push()` instead of `None`.
- `backend/windmill-worker/src/worker_flow.rs`: gate the flow-start schedule next-tick push and the `no_flow_overlap` self-skip on `status.restarted_from.is_none()`.
- `backend/windmill-queue/src/jobs.rs`: gate the completion-path next-tick SQL check on `flow_status->'restarted_from' IS NULL`.
- `backend/.sqlx/`: regenerated offline caches for the two modified queries (EE caches preserved per the update-sqlx safe procedure — zero net deletions vs main).

## Validation

- `cargo sqlx prepare --workspace -- --workspace --features all_sqlx_features` compiles the workspace cleanly.
- `SQLX_OFFLINE=true cargo check --features quickjs,enterprise` passes (what CI runs).
- Local review (branch-diff-reviewer subagent) ran; its P1 about schedule-occurrence side effects is addressed by the second commit / documented above. The Codex local pass could not run (`gpt-5.6-sol` unsupported with the locally available auth).

## Manual testing (EE build, `--features quickjs,enterprise`)

- Created a two-step identity flow with an every-5s schedule; after completed scheduled runs, called `POST /api/w/test/jobs/restart/f/{job_id}` at a mid step and at the first step: both restarted runs completed successfully and carry `trigger = f/test/restart_meta_schedule`, `trigger_kind = schedule` in `v2_job`.
- Enabled-schedule + step-0 restart: exactly one queued tick before and after (no duplicate push).
- Tick-resurrection scenario: with the schedule enabled and its queued tick removed, a step-0 restart completed without re-arming a tick (before the gate it would have pushed one).
- UI: the restarted runs show "Triggered by: f/test/restart_meta_schedule" in the Runs list, and the run detail page shows the Schedule association (screenshots below).

## Screenshots

Runs list — the restarted runs (top entries) keep the schedule association instead of appearing as manual runs:

![runs_list](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/win-2192-preserve-schedule-trigger-metadata-when-restarting-a-flow/1784704829-runs_list.png)

Restarted run detail — Schedule field and "Edit schedule" button present:

![restarted_run_detail](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/win-2192-preserve-schedule-trigger-metadata-when-restarting-a-flow/1784704830-restarted_run_detail.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EYDimx858zPR7qA24qw3J