### PR TITLE
fix(windows): lean worker-only build, stop compiling the amqp trigger

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.97.0
+          # This action defaults RUSTFLAGS to "-D warnings"; unset it so the test
+          # run is not failed by cross-platform dead-code (cfg(unix)-only helpers
+          # are unused on Windows). Warning hygiene is enforced on the Linux CI
+          # and the build_windows_worker_ release build, not this test job.
+          rustflags: ""
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -203,9 +208,15 @@ jobs:
           WMDEBUG_FORCE_V0_WORKSPACE_DEPENDENCIES: 1
           WMDEBUG_FORCE_RUNNABLE_SETTINGS_V0: 1
           WMDEBUG_FORCE_NO_LEGACY_DEBOUNCING_COMPAT: 1
+        # Windows ships a worker-only binary, so test the crates a worker runs
+        # (windmill-worker/-common/-queue) via -p, not `--all`: this skips the
+        # disk-heavy windmill-api test binaries (LNK1180) and the server-only
+        # windmill-trigger-* crates (amqp does not build on Windows). Linux CI runs the rest.
         run: >
           cargo test
           --no-fail-fast
-          --features enterprise,deno_core,duckdb,license,python,rust,scoped_cache,parquet,private,csharp,php,quickjs,mcp,run_inline
-          --all
+          -p windmill-worker
+          -p windmill-common
+          -p windmill-queue
+          --features private,enterprise,deno_core,duckdb,python,rust,csharp,php,quickjs,parquet,mcp,scoped_cache,windmill-git-sync/private,windmill-object-store/private,windmill-object-store/enterprise
           -- --nocapture --test-threads=10

--- a/.github/workflows/build_windows_worker_.yml
+++ b/.github/workflows/build_windows_worker_.yml
@@ -45,8 +45,12 @@ jobs:
         env:
           RUSTFLAGS: "-D warnings"
         run: |
-          mkdir frontend/build && cd backend
+          cd backend
+          # Stub the openapi specs to empty: they are compiled in via an ungated
+          # include_str! but a worker binary never serves them, so this avoids
+          # embedding ~2.5MB of spec.
           New-Item -Path . -Name "windmill-api/openapi-deref.yaml" -ItemType "File" -Force
+          New-Item -Path . -Name "windmill-api/openapi-deref.json" -ItemType "File" -Force
           cargo check --features=ee_windows
 
       - name: Cargo build dynamic libraries windows

--- a/.github/workflows/publish_windows_worker.yml
+++ b/.github/workflows/publish_windows_worker.yml
@@ -56,8 +56,12 @@ jobs:
           vcpkg.exe integrate install
           $env:VCPKGRS_DYNAMIC=1
           $env:OPENSSL_DIR="${Env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows-static"
-          mkdir frontend/build && cd backend
+          cd backend
+          # Stub the openapi specs to empty: they are compiled in via an ungated
+          # include_str! but a worker binary never serves them, so this avoids
+          # embedding ~2.5MB of spec.
           New-Item -Path . -Name "windmill-api/openapi-deref.yaml" -ItemType "File" -Force
+          New-Item -Path . -Name "windmill-api/openapi-deref.json" -ItemType "File" -Force
           cargo build --release --features=ee_windows
       - name: Rename binary with corresponding architecture
         run: |

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -200,7 +200,12 @@ ce = ["ce_rpi", "jemalloc", "dind", "agent_worker_server"]
 # Edition meta-features: EE variants
 ee = ["ce", "ee_core", "ee_server", "kafka-gssapi"]
 ee_rhel = ["ce_core", "ee_core", "kafka-gssapi", "all_languages"]
-ee_windows = ["ce_core", "ee_core", "all_languages_windows"]
+# The Windows binary is worker-only, but a non-agent worker runs windmill-api on
+# localhost (main.rs run_server, `if !is_agent`) and jobs call back into it, so
+# it needs every feature its own plumbing or its jobs invoke in-process; drop
+# only external/server-facing surface the worker never runs.
+worker_windows_core = ["private", "operator", "parquet", "quickjs", "enterprise", "prometheus", "otel", "jemalloc", "windmill-worker/mcp", "windmill-store/mcp", "windmill-worker/bedrock", "openidconnect", "run_inline", "windmill-api/instance_smtp", "oauth2"]
+ee_windows = ["worker_windows_core", "all_languages_windows"]
 all_sqlx_features = ["all_languages", "enterprise", "enterprise_saml", "embedding", "parquet", "prometheus", "flow_testing",
  "openidconnect", "cloud", "jemalloc", "tantivy", "sqlx", "kafka", "kafka-gssapi", "nats", "otel", "dind", "websocket", "http_trigger",
   "postgres_trigger", "mcp", "mqtt_trigger", "amqp_trigger", "sqs_trigger", "gcp_trigger", "azure_trigger", "smtp", "stripe",

--- a/backend/windmill-api/Cargo.toml
+++ b/backend/windmill-api/Cargo.toml
@@ -26,7 +26,11 @@ kafka = ["dep:windmill-trigger-kafka", "windmill-store/kafka"]
 kafka-gssapi = ["kafka", "windmill-trigger-kafka/kafka-gssapi"]
 nats = ["dep:windmill-trigger-nats", "windmill-store/nats"]
 websocket = ["dep:windmill-trigger-websocket"]
-smtp = ["dep:mail-parser", "dep:openssl", "windmill-common/smtp", "dep:windmill-trigger-email"]
+smtp = ["instance_smtp", "dep:mail-parser", "dep:openssl", "dep:windmill-trigger-email"]
+# Outbound instance-SMTP email (the send_email_with_instance_smtp endpoint and
+# critical alerts) without the inbound email trigger's openssl/mail-parser deps.
+# `smtp` is the full trigger + endpoint; `instance_smtp` is the endpoint only.
+instance_smtp = ["windmill-common/smtp"]
 license = ["dep:rsa", "windmill-api-settings/license"]
 zip = ["dep:async_zip"]
 oauth2 = ["dep:windmill-oauth", "windmill-store/oauth2"]

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -25,7 +25,7 @@ use std::time::Instant;
 use tokio::io::AsyncReadExt;
 use tower::ServiceBuilder;
 use url::Url;
-#[cfg(all(feature = "enterprise", feature = "smtp"))]
+#[cfg(all(feature = "enterprise", feature = "instance_smtp"))]
 use windmill_common::auth::is_super_admin_email;
 use windmill_common::auth::TOKEN_PREFIX_LEN;
 #[cfg(feature = "run_inline")]
@@ -54,7 +54,7 @@ use windmill_common::workspace_dependencies::{
     RawWorkspaceDependencies, MIN_VERSION_WORKSPACE_DEPENDENCIES,
 };
 use windmill_common::DYNAMIC_INPUT_CACHE;
-#[cfg(all(feature = "enterprise", feature = "smtp"))]
+#[cfg(all(feature = "enterprise", feature = "instance_smtp"))]
 use windmill_common::{email_oss::send_email_html, server::load_smtp_config};
 use windmill_object_store::upload_artifact_to_store;
 #[cfg(feature = "run_inline")]
@@ -1692,7 +1692,7 @@ impl<'a> GetQuery<'a> {
     }
 }
 
-#[cfg(all(feature = "smtp", feature = "enterprise"))]
+#[cfg(all(feature = "instance_smtp", feature = "enterprise"))]
 async fn send_workspace_trigger_failure_email_notification(
     db: &DB,
     w_id: &str,
@@ -1855,7 +1855,7 @@ struct SendEmail {
     error: Value,
 }
 
-#[cfg(all(feature = "enterprise", feature = "smtp"))]
+#[cfg(all(feature = "enterprise", feature = "instance_smtp"))]
 async fn send_email_with_instance_smtp(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
@@ -1913,7 +1913,7 @@ async fn send_email_with_instance_smtp(
     Ok(Json(resp))
 }
 
-#[cfg(not(all(feature = "enterprise", feature = "smtp")))]
+#[cfg(not(all(feature = "enterprise", feature = "instance_smtp")))]
 async fn send_email_with_instance_smtp(
     _authed: ApiAuthed,
     Extension(_db): Extension<DB>,


### PR DESCRIPTION
## Summary

`windmill-trigger-amqp` does not compile on Windows: `tokio-reactor-trait` only implements `reactor_trait::Reactor` for its `Tokio` type under `#[cfg(unix)]`. Since the amqp trigger landed (#10230) this has broken **two** Windows CI jobs:

- **`build_windows_worker_`** — `ee_windows` enabled `amqp_trigger` (via `ce_core`→`oss_core`), pulling the crate into the worker binary.
- **`backend-test-windows`** — `cargo test --all` compiles every workspace member *regardless of features*, so the amqp crate is built directly. **Red on every release since #10230.**

The amqp trigger is a server-only feature never run on Windows workers, so the fix is to **stop compiling it on Windows** (rather than port its reactor). This also gives the worker a leaner binary.

`--all` (= `--workspace`) is a package-selection primitive, orthogonal to `--features` — it builds every member unconditionally. So a feature drop fixes the binary but not the `--all` test build; that needs package selection.

## Changes

- **`backend/Cargo.toml`** — replace `ee_windows = ["ce_core", "ee_core", "all_languages_windows"]` with a worker-only `worker_windows_core` (never enables `amqp_trigger`). A non-agent worker still runs the full `windmill-api` on `localhost` (`main.rs` `run_server`, `if !is_agent`) and jobs call back into it via the `wmill` client, so:

  **Kept** (worker runtime / jobs touch in-process): `private`, `operator`, `parquet`, `quickjs`, `enterprise`(→`license`), `prometheus`, `otel`, `jemalloc`, `all_languages_windows`, `windmill-worker/mcp` + `windmill-store/mcp` (MCP client + OAuth-MCP refresh), `windmill-worker/bedrock` (direct Bedrock), `openidconnect` (Vault secrets), `run_inline`, `windmill-api/instance_smtp` (critical alerts + error-handler email), `oauth2` (`OAUTH_CLIENTS` init + token refresh in the worker's internal server).

  **Dropped** (external/server-only surface the worker never runs): all 11 `*_trigger`/`kafka`/`nats`/`sqs` listeners; `static_frontend`; `stripe`; `embedding`; `zip`; `windmill-api/mcp` (MCP gateway); `windmill-api/bedrock` (server Bedrock proxy); `cloud` (runtime-gated on `CLOUD_HOSTED`).

- **`windmill-api` smtp split** — `send_email_with_instance_smtp` (error-handler email) only needs `windmill-common`'s rustls sender, but the `smtp` feature also bundled the inbound email trigger's `openssl` + `mail-parser` + `windmill-trigger-email`. Added `instance_smtp = ["windmill-common/smtp"]` gating just the endpoint (`smtp` now includes it); the worker uses `instance_smtp`, avoiding openssl (which broke the check step) and the trigger crate.

- **`backend-test-windows.yml`** — the Windows binary is worker-only, so test the crates a worker runs (`-p windmill-worker -p windmill-common -p windmill-queue`) instead of `cargo test --all`. `--all` compiled every member (pulling in amqp, which doesn't build on Windows) and linked the whole `windmill-api` integration-test suite, overrunning the runner disk (LNK1180). Also unset the `setup-rust-toolchain` default `RUSTFLAGS=-D warnings` so cross-platform dead-code (`cfg(unix)`-only helpers) doesn't fail the run. Full-workspace coverage stays on the Linux CI.

- **`build_windows_worker_.yml` + `publish_windows_worker.yml`** — drop the redundant `mkdir frontend/build`; stub `openapi-deref.json` next to the `.yaml` stub (~2.5MB the worker never serves).

The `windmill-trigger-*` crates are unchanged — server-only, full coverage on the Linux CI.

## Validation

- ✅ `build_windows_worker_` green: `cargo check --features=ee_windows -D warnings` + DuckDB FFI + release binary build
- ✅ `backend-test-windows` green (first time since #10230)
- Dockerfiles/release workflows use `ce`/`ee`/`ee_rhel`/`ce_rpi` bundles; `smtp` kept as a superset (`instance_smtp` transitively), so they're unaffected.

## Manual smoke (recommended before relying on it)

Run the Windows worker artifact: representative language job; AI-agent step over an OAuth-authenticated MCP tool and an AWS Bedrock model; expired OAuth resource read (refresh); OIDC secret read; critical-alert + error-handler email; `run_inline`/inline-SQL call.