### PR TITLE
feat: make content search a full CE feature

### DIFF
--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -101,11 +101,7 @@ async fn list_search_flows(
     Path(w_id): Path<String>,
     Extension(user_db): Extension<UserDB>,
 ) -> JsonResult<Vec<SearchFlow>> {
-    #[cfg(feature = "enterprise")]
     let n = 1000;
-
-    #[cfg(not(feature = "enterprise"))]
-    let n = 3;
     let mut tx = user_db.begin(&authed).await?;
 
     let allowed = build_scope_path_predicate(&authed, "flows", "read");

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -157,11 +157,7 @@ async fn list_search_scripts(
     Extension(user_db): Extension<UserDB>,
 ) -> JsonResult<Vec<SearchScript>> {
     let mut tx = user_db.begin(&authed).await?;
-    #[cfg(feature = "enterprise")]
     let n = 10000;
-
-    #[cfg(not(feature = "enterprise"))]
-    let n = 10;
 
     let allowed = build_scope_path_predicate(&authed, "scripts", "read");
     let rows = sqlx::query_as!(

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -383,11 +383,7 @@ async fn list_search_apps(
     // apps' definitions. `check_scopes` uses ScopeDefinition::includes, where run
     // does NOT include read, so it correctly denies such tokens.
     check_scopes(&authed, || "apps:read".to_string())?;
-    #[cfg(feature = "enterprise")]
     let n = 1000;
-
-    #[cfg(not(feature = "enterprise"))]
-    let n = 3;
     let mut tx = user_db.begin(&authed).await?;
 
     let allowed = build_scope_path_predicate(&authed, "apps", "read");

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -242,11 +242,7 @@ async fn list_search_resources(
     Extension(user_db): Extension<UserDB>,
 ) -> JsonResult<Vec<SearchResource>> {
     let mut tx = user_db.begin(&authed).await?;
-    #[cfg(feature = "enterprise")]
     let n = 1000;
-
-    #[cfg(not(feature = "enterprise"))]
-    let n = 3;
 
     let allowed = build_scope_path_predicate(&authed, "resources", "read");
     let rows = sqlx::query_as!(

--- a/frontend/src/lib/components/ContentSearchInner.svelte
+++ b/frontend/src/lib/components/ContentSearchInner.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { AppService, FlowService, ResourceService, ScriptService } from '$lib/gen'
-	import { enterpriseLicense, workspaceStore } from '$lib/stores'
+	import { workspaceStore } from '$lib/stores'
 	import {
 		ArrowDown,
 		Boxes,
@@ -14,7 +14,7 @@
 	import ToggleButtonGroup from './common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from './common/toggleButton-v2/ToggleButton.svelte'
 	import FlowIcon from './home/FlowIcon.svelte'
-	import { Alert, Button } from './common'
+	import { Button } from './common'
 	import YAML from 'yaml'
 	import { twMerge } from 'tailwind-merge'
 	import ContentSearchInnerItem from './ContentSearchInnerItem.svelte'
@@ -229,16 +229,6 @@
 	</div>
 
 	<div class={twMerge('p-2')}>
-		{#if !$enterpriseLicense}
-			<div class="py-1"></div>
-
-			<Alert title="Content Search is an EE feature" type="warning">
-				Without EE, content search will only search among 10 scripts, 3 flows, 3 apps and 3
-				resources.
-			</Alert>
-			<div class="py-1"></div>
-		{/if}
-
 		{#if search.trim().length > 0}
 			<div class="flex flex-col gap-4">
 				{#if (searchKind == 'all' || searchKind == 'scripts') && filteredScriptItems?.length > 0}


### PR DESCRIPTION
## Summary

The content search (the `#` mode of the home-page `Ctrl+K` search — searches scripts/flows/apps/resources by content) was restricted on CE: the backend capped results to **10 scripts and 3 each of flows / apps / resources**, and the UI showed a `Content Search is an EE feature` warning. This makes it a **full CE feature**: the CE caps are lifted to match the previous EE limits, and the warning is removed.

Fixes WIN-2218

> Note: an earlier revision of this PR mistakenly targeted the indexer-backed *runs* search; that has been reverted. This PR only touches the content search.

## Changes

Lift the per-kind result caps in the four `list_search_*` handlers so CE gets the same limit EE always had (removing the `#[cfg(feature = "enterprise")]` / `#[cfg(not(...))]` split):

- `windmill-api-scripts` `list_search_scripts`: `10 → 10000`
- `windmill-api-flows` `list_search_flows`: `3 → 1000`
- `windmill-api` `list_search_apps`: `3 → 1000`
- `windmill-store` `list_search_resources`: `3 → 1000`

Frontend (`ContentSearchInner.svelte`):

- Removed the `Content Search is an EE feature` warning `Alert` and the now-unused `enterpriseLicense` / `Alert` imports.

No `*_ee.rs` files are touched, so there is no EE companion PR.

## Screenshots

Content search on a CE build — no more `Content Search is an EE feature` warning (the `Searching among …` counts now come from the uncapped query):

![content-search-no-ee-warning](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2218-remove-ee-restriction-from-frontend-search/1784711410-content-search-no-ee.png)

## Test plan

- [x] Backend rebuilt cleanly under the default `quickjs` (non-enterprise) feature set — the collapsed `let n = …` compiles for all feature sets.
- [x] `npm run check:fast` — no new errors in `ContentSearchInner.svelte` (one pre-existing unrelated `modern-screenshot` error in `RawAppEditor.svelte`).
- [x] Verified in browser on a CE build: opened content search (`#`), confirmed the EE warning no longer appears and results load.
- [ ] On a workspace with >10 scripts / >3 flows/apps/resources, confirm CE now returns all of them (previously capped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)