### PR TITLE
feat(prompts): prefer Bun over Deno for TypeScript runtime selection

### DIFF
--- a/cli/src/guidance/core.ts
+++ b/cli/src/guidance/core.ts
@@ -74,7 +74,7 @@ You are a helpful assistant that can help with Windmill scripts, flows, apps, an
 
 ## Script Writing Guide
 
-You MUST use the \`write-script-<language>\` skill to write or modify scripts in the language specified by the user. Use bun by default.
+You MUST use the \`write-script-<language>\` skill to write or modify scripts in the language specified by the user. Use bun by default. For TypeScript, always prefer bun (\`write-script-bun\`) over deno unless the script specifically requires the Deno runtime.
 For Workflow-as-Code scripts, use the \`write-workflow-as-code\` skill.
 
 ## Flow Writing Guide

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -10,10 +10,10 @@ export const SKILLS: SkillMetadata[] = [
   { name: "write-script-ansible", description: "MUST use when writing Ansible playbooks.", languageKey: "ansible" },
   { name: "write-script-bash", description: "MUST use when writing Bash scripts.", languageKey: "bash" },
   { name: "write-script-bigquery", description: "MUST use when writing BigQuery queries.", languageKey: "bigquery" },
-  { name: "write-script-bun", description: "MUST use when writing Bun/TypeScript scripts.", languageKey: "bun" },
+  { name: "write-script-bun", description: "MUST use when writing TypeScript scripts. Bun is the default and preferred TypeScript runtime — pick it for TypeScript unless the script specifically needs Deno.", languageKey: "bun" },
   { name: "write-script-bunnative", description: "MUST use when writing Bun Native scripts. The script must start with //native to run on the native worker.", languageKey: "bunnative" },
   { name: "write-script-csharp", description: "MUST use when writing C# scripts.", languageKey: "csharp" },
-  { name: "write-script-deno", description: "MUST use when writing Deno/TypeScript scripts.", languageKey: "deno" },
+  { name: "write-script-deno", description: "Use ONLY when a TypeScript script specifically requires the Deno runtime (Deno stdlib or deno.land URL imports). For all other TypeScript, use write-script-bun instead.", languageKey: "deno" },
   { name: "write-script-duckdb", description: "MUST use when writing DuckDB queries.", languageKey: "duckdb" },
   { name: "write-script-go", description: "MUST use when writing Go scripts.", languageKey: "go" },
   { name: "write-script-graphql", description: "MUST use when writing GraphQL queries.", languageKey: "graphql" },
@@ -374,7 +374,7 @@ being buffered, bypassing the 10000-row return cap.
 `,
   "write-script-bun": `---
 name: write-script-bun
-description: MUST use when writing Bun/TypeScript scripts.
+description: MUST use when writing TypeScript scripts. Bun is the default and preferred TypeScript runtime — pick it for TypeScript unless the script specifically needs Deno.
 ---
 
 ## CLI Commands
@@ -424,7 +424,7 @@ Use \`wmill resource-type list --schema\` to discover available resource types.
 
 # TypeScript (Bun)
 
-Bun runtime with full npm ecosystem and fastest execution.
+Bun runtime with full npm ecosystem and fastest execution. **Bun is the default and preferred TypeScript runtime** — choose it for any TypeScript script unless there is a major reason to use Deno for that specific use-case.
 
 ## Structure
 
@@ -1994,7 +1994,7 @@ public class Script
 `,
   "write-script-deno": `---
 name: write-script-deno
-description: MUST use when writing Deno/TypeScript scripts.
+description: Use ONLY when a TypeScript script specifically requires the Deno runtime (Deno stdlib or deno.land URL imports). For all other TypeScript, use write-script-bun instead.
 ---
 
 ## CLI Commands
@@ -2045,6 +2045,8 @@ Use \`wmill resource-type list --schema\` to discover available resource types.
 # TypeScript (Deno)
 
 Deno runtime with npm support via \`npm:\` prefix and native Deno libraries.
+
+**Prefer Bun (\`write-script-bun\`) for TypeScript.** Only use Deno when the script specifically requires the Deno runtime — Deno's standard library or \`deno.land\` URL imports that have no npm equivalent. For all other TypeScript, use Bun instead.
 
 ## Structure
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3729,7 +3729,7 @@ being buffered, bypassing the 10000-row return cap.
 
 export const LANG_BUN = `# TypeScript (Bun)
 
-Bun runtime with full npm ecosystem and fastest execution.
+Bun runtime with full npm ecosystem and fastest execution. **Bun is the default and preferred TypeScript runtime** — choose it for any TypeScript script unless there is a major reason to use Deno for that specific use-case.
 
 ## Structure
 
@@ -4015,6 +4015,8 @@ public class Script
 export const LANG_DENO = `# TypeScript (Deno)
 
 Deno runtime with npm support via \`npm:\` prefix and native Deno libraries.
+
+**Prefer Bun (\`write-script-bun\`) for TypeScript.** Only use Deno when the script specifically requires the Deno runtime — Deno's standard library or \`deno.land\` URL imports that have no npm equivalent. For all other TypeScript, use Bun instead.
 
 ## Structure
 

--- a/system_prompts/auto-generated/script.md
+++ b/system_prompts/auto-generated/script.md
@@ -215,7 +215,7 @@ being buffered, bypassing the 10000-row return cap.
 
 # TypeScript (Bun)
 
-Bun runtime with full npm ecosystem and fastest execution.
+Bun runtime with full npm ecosystem and fastest execution. **Bun is the default and preferred TypeScript runtime** — choose it for any TypeScript script unless there is a major reason to use Deno for that specific use-case.
 
 ## Structure
 
@@ -501,6 +501,8 @@ public class Script
 # TypeScript (Deno)
 
 Deno runtime with npm support via `npm:` prefix and native Deno libraries.
+
+**Prefer Bun (`write-script-bun`) for TypeScript.** Only use Deno when the script specifically requires the Deno runtime — Deno's standard library or `deno.land` URL imports that have no npm equivalent. For all other TypeScript, use Bun instead.
 
 ## Structure
 

--- a/system_prompts/auto-generated/skills/write-script-bun/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-bun/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-script-bun
-description: MUST use when writing Bun/TypeScript scripts.
+description: MUST use when writing TypeScript scripts. Bun is the default and preferred TypeScript runtime — pick it for TypeScript unless the script specifically needs Deno.
 ---
 
 ## CLI Commands
@@ -50,7 +50,7 @@ Use `wmill resource-type list --schema` to discover available resource types.
 
 # TypeScript (Bun)
 
-Bun runtime with full npm ecosystem and fastest execution.
+Bun runtime with full npm ecosystem and fastest execution. **Bun is the default and preferred TypeScript runtime** — choose it for any TypeScript script unless there is a major reason to use Deno for that specific use-case.
 
 ## Structure
 

--- a/system_prompts/auto-generated/skills/write-script-deno/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-deno/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-script-deno
-description: MUST use when writing Deno/TypeScript scripts.
+description: Use ONLY when a TypeScript script specifically requires the Deno runtime (Deno stdlib or deno.land URL imports). For all other TypeScript, use write-script-bun instead.
 ---
 
 ## CLI Commands
@@ -51,6 +51,8 @@ Use `wmill resource-type list --schema` to discover available resource types.
 # TypeScript (Deno)
 
 Deno runtime with npm support via `npm:` prefix and native Deno libraries.
+
+**Prefer Bun (`write-script-bun`) for TypeScript.** Only use Deno when the script specifically requires the Deno runtime — Deno's standard library or `deno.land` URL imports that have no npm equivalent. For all other TypeScript, use Bun instead.
 
 ## Structure
 

--- a/system_prompts/languages/bun.md
+++ b/system_prompts/languages/bun.md
@@ -1,6 +1,6 @@
 # TypeScript (Bun)
 
-Bun runtime with full npm ecosystem and fastest execution.
+Bun runtime with full npm ecosystem and fastest execution. **Bun is the default and preferred TypeScript runtime** — choose it for any TypeScript script unless there is a major reason to use Deno for that specific use-case.
 
 ## Structure
 

--- a/system_prompts/languages/deno.md
+++ b/system_prompts/languages/deno.md
@@ -2,6 +2,8 @@
 
 Deno runtime with npm support via `npm:` prefix and native Deno libraries.
 
+**Prefer Bun (`write-script-bun`) for TypeScript.** Only use Deno when the script specifically requires the Deno runtime — Deno's standard library or `deno.land` URL imports that have no npm equivalent. For all other TypeScript, use Bun instead.
+
 ## Structure
 
 Export a single **async** function called `main`:

--- a/system_prompts/utils.py
+++ b/system_prompts/utils.py
@@ -86,13 +86,13 @@ CLI_EXCLUDED_FIELDS = [
 LANGUAGE_METADATA = {
     'bun': {
         'name': 'TypeScript (Bun)',
-        'description': 'MUST use when writing Bun/TypeScript scripts.',
-        'use_cases': 'TypeScript automation, npm packages, data processing, API integrations'
+        'description': 'MUST use when writing TypeScript scripts. Bun is the default and preferred TypeScript runtime — pick it for TypeScript unless the script specifically needs Deno.',
+        'use_cases': 'TypeScript automation, npm packages, data processing, API integrations — the default choice for TypeScript'
     },
     'deno': {
         'name': 'TypeScript (Deno)',
-        'description': 'MUST use when writing Deno/TypeScript scripts.',
-        'use_cases': 'TypeScript with Deno stdlib, secure sandboxed execution'
+        'description': 'Use ONLY when a TypeScript script specifically requires the Deno runtime (Deno stdlib or deno.land URL imports). For all other TypeScript, use write-script-bun instead.',
+        'use_cases': 'TypeScript that specifically needs the Deno runtime (Deno stdlib or deno.land imports); prefer Bun otherwise'
     },
     # 'nativets' is intentionally omitted: it is a legacy duplicate of
     # 'bunnative' (a Bun script with a leading //native marker). No


### PR DESCRIPTION
## What & why

Fixes WIN-2220.

Updates the AI prompting instructions so that **when deciding which runtime to use for a TypeScript script, the model always picks Bun** unless there is a major reason to use Deno for that specific use-case (Deno stdlib or `deno.land` URL imports with no npm equivalent).

Before this change, the two TypeScript skill descriptions read as equally valid defaults:

- `write-script-bun` → "MUST use when writing Bun/TypeScript scripts."
- `write-script-deno` → "MUST use when writing Deno/TypeScript scripts."

For a generic "write a TypeScript script" request there was no signal telling the model which to choose. The behavioral defaults in the global AI chat already coerce Deno to Bun; this change makes the *prompting/guidance layer* consistent with that, everywhere the runtime is selectable.

## Changes

Source-of-truth edits:

- `system_prompts/utils.py` — `LANGUAGE_METADATA` for `bun`/`deno` (skill descriptions + use-cases): Bun is now the default/preferred TypeScript runtime; Deno is marked as the exception.
- `system_prompts/languages/bun.md` — notes Bun is the default and preferred TypeScript runtime.
- `system_prompts/languages/deno.md` — notes to prefer Bun and use Deno only when the runtime is specifically required.
- `cli/src/guidance/core.ts` — script-writing guide now says to prefer `write-script-bun` over deno for TypeScript.

Regenerated via `python system_prompts/generate.py`:

- `system_prompts/auto-generated/` (`prompts.ts`, `script.md`, `skills/write-script-bun/SKILL.md`, `skills/write-script-deno/SKILL.md`)
- `cli/src/guidance/skills.gen.ts`

These generated files are consumed by both the CLI agent skills and the frontend copilot (via the `$system_prompts` alias), so the preference propagates to every prompt surface where a TypeScript runtime is chosen.

## Validation

- Ran `python system_prompts/generate.py`; the regenerated artifacts are committed. `prompts.d.ts` was unchanged (only string values changed, no structural drift).
- Verified `cli/src/guidance/skills.gen.ts` and `system_prompts/auto-generated/prompts.ts` parse cleanly with esbuild.
- Confirmed no tests assert the previous description strings.

No Rust or runtime-logic changes; this is prompt/guidance content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Bun the default TypeScript runtime across all prompts and skills; use Deno only when explicitly required (Deno stdlib or deno.land imports). Aligns runtime selection across CLI and copilot and fixes WIN-2220.

- **Refactors**
  - Updated `system_prompts/utils.py` and language docs to prefer Bun; mark Deno as an exception.
  - Changed `cli/src/guidance/core.ts` to prefer `write-script-bun` over `write-script-deno` for TypeScript.
  - Regenerated auto-generated prompts and skills (`system_prompts/auto-generated/*`, `cli/src/guidance/skills.gen.ts`); no runtime logic changes.

<sup>Written for commit d935bcf2de6ff8e53901cb75954e97794f17c976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

