### PR TITLE
fix(tutorials): repair broken frontend tutorials after UI redesigns

### DIFF
--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -565,7 +565,7 @@
 {:else}
 	<div class="w-full h-screen flex flex-col" bind:clientWidth={innerWidth}>
 		<!-- Header and filters -->
-		<div class="flex flex-row items-start w-full px-4 gap-3 py-4 flex-wrap">
+		<div id="runs-filters-bar" class="flex flex-row items-start w-full px-4 gap-3 py-4 flex-wrap">
 			<div class="flex flex-row items-center gap-6">
 				<h1
 					class={twMerge(
@@ -772,11 +772,11 @@
 		</div>
 
 		<!-- Graph -->
-		<div class="p-2 px-4 bg-surface-tertiary mx-4 border rounded-md">
+		<div id="runs-chart" class="p-2 px-4 bg-surface-tertiary mx-4 border rounded-md">
 			<div class="relative z-10 mb-2 flex gap-2">
 				<Tabs bind:selected={graph}>
-					<Tab value="RunChart" label="Duration" />
-					<Tab value="ConcurrencyChart" label="Concurrency">
+					<Tab value="RunChart" label="Duration" id="runs-chart-duration-tab" />
+					<Tab value="ConcurrencyChart" label="Concurrency" id="runs-chart-concurrency-tab">
 						{#snippet extra()}
 							{#if warnJobLimit}
 								<Tooltip Icon={TriangleAlertIcon}>{warnJobLimitMsg}</Tooltip>

--- a/frontend/src/lib/components/tutorials/RunsTutorial.svelte
+++ b/frontend/src/lib/components/tutorials/RunsTutorial.svelte
@@ -6,7 +6,14 @@
 	import { workspaceStore, userStore } from '$lib/stores'
 	import { wait } from '$lib/utils'
 	import { waitJob } from '$lib/components/waitJob'
-	import { DELAY_SHORT, DELAY_MEDIUM, DELAY_LONG, createFakeCursor, animateCursorToElementAndClick, animateFakeCursorClick } from './utils'
+	import {
+		DELAY_SHORT,
+		DELAY_MEDIUM,
+		DELAY_LONG,
+		createFakeCursor,
+		animateCursorToElementAndClick,
+		animateFakeCursorClick
+	} from './utils'
 	import { goto } from '$app/navigation'
 	import { base } from '$lib/base'
 	import { sendUserToast } from '$lib/toast'
@@ -38,7 +45,8 @@
 						id: 'hello',
 						value: {
 							type: 'rawscript',
-							content: 'export async function main() {\n  return {\n    message: "Hello from the Runs tutorial!",\n    timestamp: new Date().toISOString()\n  };\n}',
+							content:
+								'export async function main() {\n  return {\n    message: "Hello from the Runs tutorial!",\n    timestamp: new Date().toISOString()\n  };\n}',
 							language: 'bun',
 							input_transforms: {}
 						},
@@ -80,7 +88,8 @@
 						id: 'error',
 						value: {
 							type: 'rawscript',
-							content: 'export async function main() {\n  throw new Error("Intentional error for tutorial - this demonstrates how failed jobs appear in the runs list");\n}',
+							content:
+								'export async function main() {\n  throw new Error("Intentional error for tutorial - this demonstrates how failed jobs appear in the runs list");\n}',
 							language: 'bun',
 							input_transforms: {}
 						},
@@ -103,7 +112,7 @@
 		}
 
 		await FlowService.createFlow({
-					workspace: $workspaceStore!,
+			workspace: $workspaceStore!,
 			requestBody: flow
 		})
 
@@ -126,88 +135,101 @@
 
 	function getTutorialSteps(driver: any): DriveStep[] {
 		return [
-		{
-			popover: {
-				title: 'Welcome to your Monitoring Dashboard!',
-				description: "<p>Before we dive in, let's define a key term: a Job. A &quot;Job&quot; is simply a single run of a script or flow. Every time you run code, Windmill creates a Job to track if it succeeded or failed, how long it took, and what the results were.</p><p style='margin-top: 12px;'>In this tutorial, we will explore:</p><ul style='margin-top: 8px; padding-left: 20px;'><li style='margin-bottom: 8px;'><svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' style='color: #22c55e; display: inline-block; vertical-align: middle; margin-right: 6px;'><circle cx='12' cy='12' r='10'/><path d='m9 12 2 2 4-4'/></svg>A successful job execution.</li><li style='margin-bottom: 8px;'><svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' style='color: #ef4444; display: inline-block; vertical-align: middle; margin-right: 6px;'><circle cx='12' cy='12' r='10'/><path d='m12 8v4'/><path d='m12 16h.01'/></svg>A failed job execution.</li><li><svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' style='color: #3b82f6; display: inline-block; vertical-align: middle; margin-right: 6px;'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>How to filter your monitoring view.</li></ul>",
-				onNextClick: () => {
-					driver.moveNext()
-				},
-				onPrevClick: () => {
-					sendUserToast('Previous is not available for this step', true, [], undefined, 3000)
+			{
+				popover: {
+					title: 'Welcome to your Monitoring Dashboard!',
+					description:
+						"<p>Before we dive in, let's define a key term: a Job. A &quot;Job&quot; is simply a single run of a script or flow. Every time you run code, Windmill creates a Job to track if it succeeded or failed, how long it took, and what the results were.</p><p style='margin-top: 12px;'>In this tutorial, we will explore:</p><ul style='margin-top: 8px; padding-left: 20px;'><li style='margin-bottom: 8px;'><svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' style='color: #22c55e; display: inline-block; vertical-align: middle; margin-right: 6px;'><circle cx='12' cy='12' r='10'/><path d='m9 12 2 2 4-4'/></svg>A successful job execution.</li><li style='margin-bottom: 8px;'><svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' style='color: #ef4444; display: inline-block; vertical-align: middle; margin-right: 6px;'><circle cx='12' cy='12' r='10'/><path d='m12 8v4'/><path d='m12 16h.01'/></svg>A failed job execution.</li><li><svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' style='color: #3b82f6; display: inline-block; vertical-align: middle; margin-right: 6px;'><circle cx='11' cy='11' r='8'/><path d='m21 21-4.35-4.35'/></svg>How to filter your monitoring view.</li></ul>",
+					onNextClick: () => {
+						driver.moveNext()
+					},
+					onPrevClick: () => {
+						sendUserToast('Previous is not available for this step', true, [], undefined, 3000)
+					}
 				}
-			}
-		},
+			},
 			{
 				element: '#runs-table-wrapper',
 				onHighlighted: async () => {
 					step2Complete = false
 					await wait(DELAY_MEDIUM)
-					
+
 					// Find all jobs
 					const allJobRows = Array.from(
 						document.querySelectorAll('#runs-table-wrapper .cursor-pointer')
 					) as HTMLElement[]
-					
+
 					// Find successful job (green badge/check icon) - first one that's not failed
-					const successfulJobRow = allJobRows.find((el) => {
-						const hasRedBadge = el.querySelector('[class*="bg-red"], [class*="text-red"]')
-						const hasGreenBadge = el.querySelector('[class*="bg-green"], [class*="text-green"]')
-						return !hasRedBadge && hasGreenBadge !== null
-					}) || allJobRows[0]
+					const successfulJobRow =
+						allJobRows.find((el) => {
+							const hasRedBadge = el.querySelector('[class*="bg-red"], [class*="text-red"]')
+							const hasGreenBadge = el.querySelector('[class*="bg-green"], [class*="text-green"]')
+							return !hasRedBadge && hasGreenBadge !== null
+						}) || allJobRows[0]
 
 					if (successfulJobRow) {
 						// Create cursor
 						const cursor = createFakeCursor()
-						
+
 						// Click on successful job
 						await animateCursorToElementAndClick(cursor, successfulJobRow)
-						
+
 						// Wait for navigation to job details page
 						await wait(DELAY_LONG)
-						
+
 						// Navigate back to runs page using SvelteKit navigation
 						await goto(`${base}/runs?tutorial=runs-tutorial`, { replaceState: true })
 						await wait(DELAY_LONG)
-						
+
 						// Remove the cursor
 						cursor.remove()
 						step2Complete = true
 					}
 				},
 				popover: {
-					title: 'Exploring successful job runs <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: #22c55e; display: inline-block; vertical-align: middle;"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>',
+					title:
+						'Exploring successful job runs <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: #22c55e; display: inline-block; vertical-align: middle;"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>',
 					description:
-						'Let\'s click on a successful job to see how to inspect a completed execution.',
+						"Let's click on a successful job to see how to inspect a completed execution.",
 					side: 'bottom',
 					onNextClick: async () => {
 						if (!step2Complete) {
-							sendUserToast('Please wait for the job click to complete...', false, [], undefined, 3000)
+							sendUserToast(
+								'Please wait for the job click to complete...',
+								false,
+								[],
+								undefined,
+								3000
+							)
 							return
 						}
 						// Click on the successful job again (without showing cursor)
-						const successfulJobRow = Array.from(
-							document.querySelectorAll('#runs-table-wrapper .cursor-pointer')
-						).find((el) => {
-							const hasRedBadge = el.querySelector('[class*="bg-red"], [class*="text-red"]')
-							const hasGreenBadge = el.querySelector('[class*="bg-green"], [class*="text-green"]')
-							return !hasRedBadge && hasGreenBadge !== null
-						}) as HTMLElement || Array.from(
-							document.querySelectorAll('#runs-table-wrapper .cursor-pointer')
-						)[0] as HTMLElement
-						
+						const successfulJobRow =
+							(Array.from(document.querySelectorAll('#runs-table-wrapper .cursor-pointer')).find(
+								(el) => {
+									const hasRedBadge = el.querySelector('[class*="bg-red"], [class*="text-red"]')
+									const hasGreenBadge = el.querySelector(
+										'[class*="bg-green"], [class*="text-green"]'
+									)
+									return !hasRedBadge && hasGreenBadge !== null
+								}
+							) as HTMLElement) ||
+							(Array.from(
+								document.querySelectorAll('#runs-table-wrapper .cursor-pointer')
+							)[0] as HTMLElement)
+
 						if (successfulJobRow) {
 							successfulJobRow.click()
 							await wait(DELAY_SHORT)
-							
+
 							// Wait for navigation to job details page
 							await wait(DELAY_LONG)
-							
+
 							// Navigate back to runs page using SvelteKit navigation
 							await goto(`${base}/runs?tutorial=runs-tutorial`, { replaceState: true })
 							await wait(DELAY_LONG)
 						}
-						
+
 						driver.moveNext()
 					},
 					onPrevClick: () => {
@@ -220,12 +242,12 @@
 				onHighlighted: async () => {
 					step3Complete = false
 					await wait(DELAY_MEDIUM)
-					
+
 					// Find all jobs
 					const allJobRows = Array.from(
 						document.querySelectorAll('#runs-table-wrapper .cursor-pointer')
 					) as HTMLElement[]
-					
+
 					// Find failed job (red badge/X icon)
 					const failedJobRow = allJobRows.find((el) => {
 						const badge = el.querySelector('[class*="bg-red"], [class*="text-red"]')
@@ -235,30 +257,36 @@
 					if (failedJobRow) {
 						// Create cursor
 						const cursor = createFakeCursor()
-						
+
 						// Click on failed job
 						await animateCursorToElementAndClick(cursor, failedJobRow)
-						
+
 						// Wait for navigation to job details page
 						await wait(DELAY_LONG)
-						
+
 						// Navigate back to runs page using SvelteKit navigation
 						await goto(`${base}/runs?tutorial=runs-tutorial`, { replaceState: true })
 						await wait(DELAY_LONG)
-						
+
 						// Remove the cursor
 						cursor.remove()
 						step3Complete = true
 					}
 				},
 				popover: {
-					title: 'Exploring failed job runs <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: #ef4444; display: inline-block; vertical-align: middle;"><circle cx="12" cy="12" r="10"/><path d="m12 8v4"/><path d="m12 16h.01"/></svg>',
-					description:
-						'Now let\'s click on a failed job to see how to inspect a failed execution.',
+					title:
+						'Exploring failed job runs <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: #ef4444; display: inline-block; vertical-align: middle;"><circle cx="12" cy="12" r="10"/><path d="m12 8v4"/><path d="m12 16h.01"/></svg>',
+					description: "Now let's click on a failed job to see how to inspect a failed execution.",
 					side: 'bottom',
 					onNextClick: async () => {
 						if (!step3Complete) {
-							sendUserToast('Please wait for the job click to complete...', false, [], undefined, 3000)
+							sendUserToast(
+								'Please wait for the job click to complete...',
+								false,
+								[],
+								undefined,
+								3000
+							)
 							return
 						}
 						// Click on the failed job again (without showing cursor)
@@ -268,19 +296,19 @@
 							const badge = el.querySelector('[class*="bg-red"], [class*="text-red"]')
 							return badge !== null
 						}) as HTMLElement
-						
+
 						if (failedJobRow) {
 							failedJobRow.click()
 							await wait(DELAY_SHORT)
-							
+
 							// Wait for navigation to job details page
 							await wait(DELAY_LONG)
-							
+
 							// Navigate back to runs page using SvelteKit navigation
 							await goto(`${base}/runs?tutorial=runs-tutorial`, { replaceState: true })
 							await wait(DELAY_LONG)
 						}
-						
+
 						driver.moveNext()
 					},
 					onPrevClick: () => {
@@ -289,7 +317,7 @@
 				}
 			},
 			{
-				element: 'div.p-2.px-4.pt-8.w-full.border-b',
+				element: '#runs-chart',
 				popover: {
 					title: 'Visual run history',
 					description:
@@ -304,15 +332,15 @@
 				}
 			},
 			{
-				element: 'div.p-2.px-4.pt-8.w-full.border-b',
+				element: '#runs-chart',
 				onHighlighted: async () => {
 					step5Complete = false
 					await wait(DELAY_MEDIUM)
-					// Find the button with data-value="ConcurrencyChart"
+					// Switch to the Concurrency chart tab
 					const concurrencyButton = document.querySelector(
-						'button[data-value="ConcurrencyChart"]'
+						'#runs-chart-concurrency-tab'
 					) as HTMLElement
-					
+
 					if (concurrencyButton) {
 						await animateFakeCursorClick(concurrencyButton)
 						await wait(DELAY_MEDIUM)
@@ -326,7 +354,13 @@
 					side: 'bottom',
 					onNextClick: () => {
 						if (!step5Complete) {
-							sendUserToast('Please wait for the chart switch to complete...', false, [], undefined, 3000)
+							sendUserToast(
+								'Please wait for the chart switch to complete...',
+								false,
+								[],
+								undefined,
+								3000
+							)
 							return
 						}
 						driver.moveNext()
@@ -337,11 +371,11 @@
 				}
 			},
 			{
-				element: 'div.flex.flex-row.items-start.w-full.border-b.px-4.gap-8',
+				element: '#status',
 				onHighlighted: async () => {
 					step6Complete = false
 					await wait(DELAY_MEDIUM)
-					
+
 					// Find the success and failure filter buttons
 					const successButton = document.querySelector(
 						'button[data-value="success"]'
@@ -349,18 +383,18 @@
 					const failureButton = document.querySelector(
 						'button[data-value="failure"]'
 					) as HTMLElement
-					
+
 					if (successButton && failureButton) {
 						// Create cursor once for both clicks
 						const cursor = createFakeCursor()
-						
+
 						// Click on failure button first
 						await animateCursorToElementAndClick(cursor, failureButton)
 						await wait(DELAY_MEDIUM)
-						
+
 						// Click on success button
 						await animateCursorToElementAndClick(cursor, successButton)
-						
+
 						// Remove the cursor
 						cursor.remove()
 						await wait(DELAY_MEDIUM)
@@ -374,7 +408,13 @@
 					side: 'bottom',
 					onNextClick: () => {
 						if (!step6Complete) {
-							sendUserToast('Please wait for the filter clicks to complete...', false, [], undefined, 3000)
+							sendUserToast(
+								'Please wait for the filter clicks to complete...',
+								false,
+								[],
+								undefined,
+								3000
+							)
 							return
 						}
 						driver.moveNext()
@@ -385,11 +425,11 @@
 				}
 			},
 			{
-				element: 'div.flex.flex-row.gap-4.items-center.px-2.py-1.grow-0.justify-between',
+				element: '#runs-filters-bar',
 				popover: {
 					title: 'More filtering options',
 					description:
-						'Even more filters are available to help you find exactly what you\'re looking for. Explore the additional filtering options to refine your search.',
+						"Even more filters are available to help you find exactly what you're looking for. Explore the additional filtering options to refine your search.",
 					side: 'bottom',
 					onNextClick: () => {
 						driver.moveNext()
@@ -415,14 +455,13 @@
 		]
 	}
 
-
 	// Cleanup function to delete tutorial flows
 	async function cleanupTutorialFlows() {
 		// Don't delete flows if user is an operator (they don't have permission)
 		if ($userStore?.operator) {
 			return
 		}
-		
+
 		for (const flowPath of tutorialFlowPaths) {
 			try {
 				await FlowService.deleteFlowByPath({
@@ -441,22 +480,19 @@
 		try {
 			const successfulFlowPath = await createTutorialFlow()
 			const brokenFlowPath = await createBrokenFlow()
-			
+
 			// Store flow paths for cleanup
 			tutorialFlowPaths = [successfulFlowPath, brokenFlowPath]
-			
+
 			// Run both flows in parallel
-			await Promise.all([
-				runFlowAndWait(successfulFlowPath),
-				runFlowAndWait(brokenFlowPath)
-			])
-			
+			await Promise.all([runFlowAndWait(successfulFlowPath), runFlowAndWait(brokenFlowPath)])
+
 			// Wait a bit for jobs to appear
 			await wait(DELAY_LONG)
 		} catch (error) {
 			console.error('Error creating/running tutorial flows:', error)
 		}
-		
+
 		tutorial?.runTutorial()
 	}
 </script>

--- a/frontend/src/lib/components/tutorials/app/BackgroundRunnablesTutorial.svelte
+++ b/frontend/src/lib/components/tutorials/app/BackgroundRunnablesTutorial.svelte
@@ -73,7 +73,7 @@
 						setTimeout(() => {
 							driver.moveNext()
 
-							updateProgress(5)
+							updateProgress(index)
 						})
 					}
 				}

--- a/frontend/src/lib/components/tutorials/app/ConnectionTutorial.svelte
+++ b/frontend/src/lib/components/tutorials/app/ConnectionTutorial.svelte
@@ -116,7 +116,7 @@
 				title: 'Connection done',
 				description: 'You can now see the email output connected to the text component input',
 				onNextClick: () => {
-					updateProgress(6)
+					updateProgress(index)
 
 					setTimeout(() => {
 						driver.moveNext()

--- a/frontend/src/lib/components/tutorials/workspace/WorkspaceOnboardingTutorial.svelte
+++ b/frontend/src/lib/components/tutorials/workspace/WorkspaceOnboardingTutorial.svelte
@@ -27,7 +27,7 @@
 
 <Tutorial
 	bind:this={tutorial}
-	index={index}
+	{index}
 	name="workspace-onboarding"
 	tainted={false}
 	on:skipAll
@@ -39,15 +39,7 @@
 					description:
 						"Let's take a quick tour! We will show you the main sections of your workspace.",
 					onNextClick: () => {
-						// Wait a bit to ensure the page is fully rendered before moving to next step
-						setTimeout(() => {
-							const button = document.querySelector('#create-script-button') as HTMLElement | null
-							if (button) {
-								driver.moveNext()
-							} else {
-								alert('Could not find the Create Script button. Please make sure you are on the home page.')
-							}
-						}, 100)
+						driver.moveNext()
 					}
 				}
 			},
@@ -55,45 +47,29 @@
 				popover: {
 					title: 'Create your first script',
 					description:
-						'<img src="/languages.png" alt="Programming Languages" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>Scripts turn code into tools. Write in Python, TypeScript, Go, Bash, SQL and more. Run them manually, on schedule, or via webhooks.</p>',
+						'<img src="/languages.png" alt="Programming Languages" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>Open the <strong>New</strong> menu to create a script. Scripts turn code into tools. Write in Python, TypeScript, Go, Bash, SQL and more. Run them manually, on schedule, or via webhooks.</p>',
 					onNextClick: async () => {
-						// Move to the next step (Create Flow button)
-						setTimeout(() => {
-							const button = document.querySelector('#create-flow-button') as HTMLElement | null
-							if (button) {
-								driver.moveNext()
-							} else {
-								alert('Could not find the Create Flow button. Please make sure you are on the home page.')
-							}
-						}, 100)
+						driver.moveNext()
 					}
 				},
-				element: '#create-script-button',
+				element: '#create-new-button'
 			},
 			{
 				popover: {
 					title: 'Create your first flow',
 					description:
-						'<img src="/flow.png" alt="Flow" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>Flows orchestrate multiple scripts. Chain them together with branching, loops, and error handling to build complex workflows.</p>',
+						'<img src="/flow.png" alt="Flow" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>The same <strong>New</strong> menu lets you create a flow. Flows orchestrate multiple scripts. Chain them together with branching, loops, and error handling to build complex workflows.</p>',
 					onNextClick: async () => {
-						// Move to the next step (Create App button)
-						setTimeout(() => {
-							const button = document.querySelector('#create-app-button') as HTMLElement | null
-							if (button) {
-								driver.moveNext()
-							} else {
-								alert('Could not find the Create App button. Please make sure you are on the home page.')
-							}
-						}, 100)
+						driver.moveNext()
 					}
 				},
-				element: '#create-flow-button',
+				element: '#create-new-button'
 			},
 			{
 				popover: {
 					title: 'Create your first app',
 					description:
-						'<img src="/app.png" alt="App" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>Apps are custom UIs built with drag-and-drop. Combine tables, forms, charts, and buttons that trigger your scripts and flows.. That\'s it for the tour!</p><p style="margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(128,128,128,0.3); font-size: 0.9em; opacity: 0.9;"><strong>💡 Want to learn more?</strong> Access more tutorials from the <strong>Tutorials</strong> page in the main menu or in the <strong>Help</strong> submenu.</p>',
+						'<img src="/app.png" alt="App" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>And from the <strong>New</strong> menu you can also create an app. Apps are custom UIs built with drag-and-drop. Combine tables, forms, charts, and buttons that trigger your scripts and flows. That\'s it for the tour!</p><p style="margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(128,128,128,0.3); font-size: 0.9em; opacity: 0.9;"><strong>💡 Want to learn more?</strong> Access more tutorials from the <strong>Tutorials</strong> page in the main menu or in the <strong>Help</strong> submenu.</p>',
 					onNextClick: async () => {
 						// Mark tutorial as complete
 						updateProgress(index)
@@ -105,7 +81,7 @@
 						}
 					}
 				},
-				element: '#create-app-button',
+				element: '#create-new-button'
 			}
 		]
 

--- a/frontend/src/lib/components/tutorials/workspace/WorkspaceOnboardingTutorial.svelte
+++ b/frontend/src/lib/components/tutorials/workspace/WorkspaceOnboardingTutorial.svelte
@@ -38,7 +38,12 @@
 					title: 'Welcome to your Windmill workspace! 🎉',
 					description:
 						"Let's take a quick tour! We will show you the main sections of your workspace.",
-					onNextClick: () => {
+					onNextClick: async () => {
+						// The New menu button mounts once an async permission check resolves, so
+						// wait for it before highlighting it in the next step.
+						for (let i = 0; i < 20 && !document.querySelector('#create-new-button'); i++) {
+							await new Promise((resolve) => setTimeout(resolve, 100))
+						}
 						driver.moveNext()
 					}
 				}
@@ -48,7 +53,7 @@
 					title: 'Create your first script',
 					description:
 						'<img src="/languages.png" alt="Programming Languages" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>Open the <strong>New</strong> menu to create a script. Scripts turn code into tools. Write in Python, TypeScript, Go, Bash, SQL and more. Run them manually, on schedule, or via webhooks.</p>',
-					onNextClick: async () => {
+					onNextClick: () => {
 						driver.moveNext()
 					}
 				},
@@ -59,7 +64,7 @@
 					title: 'Create your first flow',
 					description:
 						'<img src="/flow.png" alt="Flow" style="width: 100%; max-width: 400px; margin-bottom: 12px; border-radius: 8px; display: block; margin-left: auto; margin-right: auto;" /><p>The same <strong>New</strong> menu lets you create a flow. Flows orchestrate multiple scripts. Chain them together with branching, loops, and error handling to build complex workflows.</p>',
-					onNextClick: async () => {
+					onNextClick: () => {
 						driver.moveNext()
 					}
 				},


### PR DESCRIPTION
## Summary

Fixes WIN-2217. Every frontend interactive tutorial (driver.js tours) was tested end-to-end; several were broken because the underlying UI was redesigned out from under their DOM selectors, and two marked the wrong tutorial complete. All 7 tutorials now run to completion and record the correct progress bit.

Tutorials tested (all now pass, verified via Playwright + `tutorial_progress` bitmask):
- `workspace-onboarding` (idx 1) — **was broken**
- `flow-live-tutorial` (idx 2) — ok
- `troubleshoot-flow` (idx 3) — ok
- `runs-tutorial` (idx 7) — **was broken**
- `workspace-onboarding-operator` (idx 6) — ok
- `backgroundrunnables` (idx 4) — **wrong progress bit**
- `connection` (idx 5) — **wrong progress bit**

## Changes

- **`workspace-onboarding`** (`WorkspaceOnboardingTutorial.svelte`): the home page replaced the separate `#create-script-button` / `#create-flow-button` / `#create-app-button` with a single `#create-new-button` dropdown, so step 1's `onNextClick` couldn't find the next anchor and blocked the tour with a "Could not find the Create Script button" alert. Retargeted all element steps to `#create-new-button`, dropped the fragile `setTimeout`+`alert` lookups, and reworded the popovers to reference the unified **New** menu.
- **`runs-tutorial`** (`RunsTutorial.svelte` + `RunsPage.svelte`): the runs page was rebuilt, so the chart/filter class selectors and the removed `button[data-value="ConcurrencyChart"]` no longer matched — step 5 hard-blocked (its `onHighlighted` never set `step5Complete`). Added stable anchors to `RunsPage.svelte` (`#runs-filters-bar`, `#runs-chart`, and Tab ids `#runs-chart-duration-tab` / `#runs-chart-concurrency-tab`) and pointed the tutorial steps 4–7 at them.
- **`backgroundrunnables`** (`BackgroundRunnablesTutorial.svelte`): final step called `updateProgress(5)` (the *connection* tutorial's bit) instead of `updateProgress(index)` — completing it never marked itself done and falsely marked connection done. Fixed to `updateProgress(index)`.
- **`connection`** (`ConnectionTutorial.svelte`): same bug — called `updateProgress(6)` (the *operator onboarding* bit). Fixed to `updateProgress(index)`.

## Notes / out of scope

- `+page.svelte` auto-launches workspace onboarding guarded on `$tutorialsToDo.includes(8)`, but no tutorial has index 8 (max is 7), so that auto-popup never fires. Left unchanged since making it fire changes broad home-page UX; flagging for a product decision.
- `ExpressionEvaluationTutorial.svelte` exists but is not registered in any router or `config.ts` (unreachable dead code); left untouched.

## Screenshots

Each tutorial driven to its final step in a real browser:

**workspace-onboarding** — now spotlights the redesigned **New** menu
![workspace-onboarding](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2217-test-and-fix-all-broken-frontend-tutorials/1784711682-workspace-onboarding.png)

**flow-live-tutorial** — wire-up + test step runs green
![flow-step5](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2217-test-and-fix-all-broken-frontend-tutorials/1784711684-flow-step5.png)

**troubleshoot-flow** — intentional error surfaced for review
![troubleshoot-step4](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2217-test-and-fix-all-broken-frontend-tutorials/1784711687-troubleshoot-step4.png)

**connection** — text component input connected to app context
![connection-done](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2217-test-and-fix-all-broken-frontend-tutorials/1784711689-connection-done.png)

## Test plan

- [x] Each tutorial launched via its URL param and stepped to the final "complete" popover in a real browser (Playwright)
- [x] `tutorial_progress` bitmask verified after each: bits 1–7 all set, and `backgroundrunnables`/`connection` now set their own bit (4/5) rather than 5/6
- [x] `npm run check:fast` clean on all touched files (one pre-existing unrelated error in `RawAppEditor.svelte` re: `modern-screenshot`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2217 by repairing all 7 frontend tutorials broken by recent UI changes. Each tutorial now completes and records the correct progress bit.

- **Bug Fixes**
  - Workspace onboarding: retarget steps to `#create-new-button` and wait for it to mount; removed timeouts/alerts.
  - Runs tutorial: added stable anchors in `RunsPage.svelte` (`#runs-filters-bar`, `#runs-chart`, `#runs-chart-duration-tab`, `#runs-chart-concurrency-tab`) and updated steps; fixed chart/tab and filter steps.
  - Background Runnables: write progress with `updateProgress(index)` instead of hardcoded 5.
  - Connection tutorial: write progress with `updateProgress(index)` instead of hardcoded 6.

<sup>Written for commit 39789cccaa1bcde07021861f3c0af291db885357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

