### PR TITLE
fix: prevent u16 underflow in suspend count causing permanent flow deadlock

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3566,7 +3566,7 @@ async fn push_next_flow_job(
                         count: required_events,
                         job: last
                     }),
-                    (required_events - resume_messages.len() as u16) as i32,
+                    (required_events.saturating_sub(resume_messages.len() as u16)) as i32,
                     Duration::from_secs(
                         suspend.timeout.map(|t| t.into()).unwrap_or_else(|| 30 * 60)
                     ) as Duration,


### PR DESCRIPTION
## Problem

In `worker_flow.rs`, the suspend event count is computed as:

```rust
(required_events - resume_messages.len() as u16) as i32
```

When extra `resume_messages` arrive concurrently and `resume_messages.len()` exceeds `required_events`, this `u16` subtraction wraps around to ~65535. The resulting value is written to the database as the suspend counter, causing the flow to wait for 65K+ events that will never arrive, permanently deadlocking the workflow.

## Fix

Replace the wrapping subtraction with `saturating_sub()`:

```rust
(required_events.saturating_sub(resume_messages.len() as u16)) as i32
```

When the subtraction would underflow, `saturating_sub()` returns 0 instead, correctly indicating that no additional events are needed.

## Impact

- Fixes flows that get stuck indefinitely under concurrent resume pressure
- Zero behavioral change in the normal case (when `resume_messages.len() < required_events`)
- Single-line change, no risk of regression

---

Supersedes #10248, which bundled an unrelated `windmill-dep-map` change. This is the isolated single-line suspend fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a wraparound bug in the suspend event count that could jump to ~65k when extra resume messages arrive, causing flows to deadlock. Uses `saturating_sub` to clamp the count to 0 when resumes exceed required events.

<sup>Written for commit 4de7b76e57f0cb5dd31ac229f465467473e19bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

