### PR TITLE
feat: restrict folder creation, sharing and group creation in demo workspace

### DIFF
--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -419,6 +419,12 @@ async fn update_folder(
         return Err(Error::PermissionDenied(msg));
     }
 
+    // update_folder can also grant permissions (owners / extra_perms / default_permissioned_as),
+    // so it is a sharing path and must honor the demo-workspace sharing restriction.
+    if ng.owners.is_some() || ng.extra_perms.is_some() || ng.default_permissioned_as.is_some() {
+        crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
+    }
+
     let mut sqlb = SqlBuilder::update_table("folder");
     sqlb.and_where_eq("name", "?".bind(&name));
     sqlb.and_where_eq("workspace_id", "?".bind(&w_id));

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -892,6 +892,13 @@ async fn remove_owner(
     Path((w_id, name)): Path<(String, String)>,
     Json(Owner { owner, write }): Json<Owner>,
 ) -> Result<String> {
+    // remove_owner with a `write` value is a grant path: it jsonb_set's the owner's
+    // permission level into extra_perms (only write=None is a pure revoke), so the
+    // demo-workspace sharing restriction must apply when a level is being set.
+    if write.is_some() {
+        crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
+    }
+
     let mut tx = user_db.begin(&authed).await?;
 
     not_found_if_none(get_folderopt(&mut tx, &w_id, &name).await?, "Folder", &name)?;

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -243,6 +243,7 @@ async fn create_folder(
     Path(w_id): Path<String>,
     Json(mut ng): Json<NewFolder>,
 ) -> Result<String> {
+    crate::check_demo_workspace_restriction(&authed, &w_id, "Folder creation")?;
     if let Some(labels) = ng.labels.as_mut() {
         dedup_labels(labels);
     }
@@ -820,6 +821,7 @@ async fn add_owner(
     Path((w_id, name)): Path<(String, String)>,
     Json(Owner { owner, .. }): Json<Owner>,
 ) -> Result<String> {
+    crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
     let mut tx = user_db.begin(&authed).await?;
 
     not_found_if_none(get_folderopt(&mut tx, &w_id, &name).await?, "Folder", &name)?;

--- a/backend/windmill-api-groups/src/granular_acls.rs
+++ b/backend/windmill-api-groups/src/granular_acls.rs
@@ -95,6 +95,7 @@ async fn add_granular_acl(
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(GranularAcl { owner, write }): Json<GranularAcl>,
 ) -> Result<String> {
+    crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
     let path = path.to_path();
 
     let (kind, path) = path

--- a/backend/windmill-api-groups/src/groups.rs
+++ b/backend/windmill-api-groups/src/groups.rs
@@ -234,6 +234,7 @@ async fn create_group(
     Path(w_id): Path<String>,
     Json(ng): Json<NewGroup>,
 ) -> Result<String> {
+    crate::check_demo_workspace_restriction(&authed, &w_id, "Group creation")?;
     let mut tx = user_db.begin(&authed).await?;
 
     check_name_conflict(&mut tx, &w_id, &ng.name).await?;

--- a/backend/windmill-api-groups/src/lib.rs
+++ b/backend/windmill-api-groups/src/lib.rs
@@ -2,3 +2,23 @@ pub mod folder_history;
 pub mod folders;
 pub mod granular_acls;
 pub mod groups;
+
+use windmill_api_auth::ApiAuthed;
+use windmill_common::{error::Error, worker::CLOUD_HOSTED};
+
+/// The public demo workspace on the managed cloud is kept clean and consistent by
+/// restricting folder creation, item sharing, and group creation for non-admins.
+/// `action` is a short present-tense phrase completing "… is disabled …" (e.g.
+/// "Folder creation"). Returns `Err(BadRequest)` when the caller is blocked.
+pub fn check_demo_workspace_restriction(
+    authed: &ApiAuthed,
+    w_id: &str,
+    action: &str,
+) -> Result<(), Error> {
+    if *CLOUD_HOSTED && w_id == "demo" && !authed.is_admin {
+        return Err(Error::BadRequest(format!(
+            "{action} is disabled in the demo workspace. Create your own workspace to keep the demo clean and consistent."
+        )));
+    }
+    Ok(())
+}

--- a/backend/windmill-api-groups/src/lib.rs
+++ b/backend/windmill-api-groups/src/lib.rs
@@ -8,8 +8,8 @@ use windmill_common::{error::Error, worker::CLOUD_HOSTED};
 
 /// The public demo workspace on the managed cloud is kept clean and consistent by
 /// restricting folder creation, item sharing, and group creation for non-admins.
-/// `action` is a short present-tense phrase completing "… is disabled …" (e.g.
-/// "Folder creation"). Returns `Err(BadRequest)` when the caller is blocked.
+/// `action` is a short noun phrase completing "… is disabled …" (e.g.
+/// "Folder creation", "Sharing"). Returns `Err(BadRequest)` when the caller is blocked.
 pub fn check_demo_workspace_restriction(
     authed: &ApiAuthed,
     w_id: &str,

--- a/frontend/src/lib/cloud.ts
+++ b/frontend/src/lib/cloud.ts
@@ -3,3 +3,17 @@ import { BROWSER } from 'esm-env'
 export function isCloudHosted(): boolean {
 	return BROWSER && window.location.hostname == 'app.windmill.dev'
 }
+
+// On the managed cloud, the public demo workspace is kept clean and consistent by
+// disabling folder creation, item sharing, and group creation for non-admins. The
+// backend enforces the same rule; this only drives the UI hints.
+export const DEMO_RESTRICTION_HINT =
+	'Disabled in the demo workspace. Create your own workspace to keep the demo clean and consistent.'
+
+export function isDemoWorkspaceRestricted(
+	workspace: string | undefined,
+	isAdmin: boolean | undefined,
+	isSuperAdmin: boolean | undefined
+): boolean {
+	return isCloudHosted() && workspace === 'demo' && !isAdmin && !isSuperAdmin
+}

--- a/frontend/src/lib/components/FolderEditor.svelte
+++ b/frontend/src/lib/components/FolderEditor.svelte
@@ -381,22 +381,24 @@
 					existing. A windmill folder has settable permissions that its children inherit. If an item
 					is within a non-existing folders, only admins will see it.
 				</Alert>
-				<Button
-					variant="default"
-					wrapperClasses="w-min"
-					startIcon={{ icon: Plus }}
-					size="xs"
-					on:click={() => {
-						FolderService.createFolder({
-							workspace: $workspaceStore ?? '',
-							requestBody: { name }
-						}).then(() => {
-							loadFolder()
-						})
-					}}
-				>
-					Create folder "{name}"
-				</Button>
+				{#if !restricted}
+					<Button
+						variant="default"
+						wrapperClasses="w-min"
+						startIcon={{ icon: Plus }}
+						size="xs"
+						on:click={() => {
+							FolderService.createFolder({
+								workspace: $workspaceStore ?? '',
+								requestBody: { name }
+							}).then(() => {
+								loadFolder()
+							})
+						}}
+					>
+						Create folder "{name}"
+					</Button>
+				{/if}
 			{/if}
 			{#if perms}
 				<TableCustom>
@@ -486,7 +488,7 @@
 										{/if}</td
 									>
 									<td class="flex items-center justify-end">
-										{#if !restricted && ((can_write && owner_name != 'u/' + $userStore?.username) || $userStore?.is_admin)}
+										{#if (can_write && owner_name != 'u/' + $userStore?.username) || $userStore?.is_admin}
 											<Button
 												variant="subtle"
 												destructive

--- a/frontend/src/lib/components/FolderEditor.svelte
+++ b/frontend/src/lib/components/FolderEditor.svelte
@@ -9,6 +9,7 @@
 		GroupService
 	} from '$lib/gen'
 	import TableCustom from './TableCustom.svelte'
+	import { DEMO_RESTRICTION_HINT, isDemoWorkspaceRestricted } from '$lib/cloud'
 	import { Alert, Button, Drawer, DrawerContent } from './common'
 	import Skeleton from './common/skeleton/Skeleton.svelte'
 	import GroupEditor from './GroupEditor.svelte'
@@ -108,8 +109,13 @@
 	// --- default_permissioned_as rules editor ---
 	let defaultPermissionedAs: FolderDefaultPermissionedAs = $state([])
 
+	const restricted = $derived(
+		isDemoWorkspaceRestricted($workspaceStore, $userStore?.is_admin, $userStore?.is_super_admin)
+	)
+
 	const canEditDefaults = $derived(
 		can_write &&
+			!restricted &&
 			($userStore?.is_admin ||
 				$userStore?.is_super_admin ||
 				($userStore?.groups ?? []).includes('wm_deployers'))
@@ -315,7 +321,9 @@
 
 	<Label label={`Permissions (${perms?.length ?? 0})`}>
 		<div class="flex flex-col gap-2">
-			{#if can_write}
+			{#if can_write && restricted}
+				<Alert type="info" title="Sharing disabled">{DEMO_RESTRICTION_HINT}</Alert>
+			{:else if can_write}
 				<Alert type="info" title="New permissions may take up to 60s to apply">
 					Due to permissions cache invalidation
 				</Alert>
@@ -404,7 +412,7 @@
 							{#each perms ?? [] as { owner_name, role }}<tr>
 									<td>{owner_name}</td>
 									<td>
-										{#if can_write}
+										{#if can_write && !restricted}
 											<div>
 												<ToggleButtonGroup
 													disabled={owner_name == 'u/' + $userStore?.username &&
@@ -478,7 +486,7 @@
 										{/if}</td
 									>
 									<td class="flex items-center justify-end">
-										{#if (can_write && owner_name != 'u/' + $userStore?.username) || $userStore?.is_admin}
+										{#if !restricted && ((can_write && owner_name != 'u/' + $userStore?.username) || $userStore?.is_admin)}
 											<Button
 												variant="subtle"
 												destructive

--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { FolderService } from '$lib/gen'
 	import { workspaceStore, userStore } from '$lib/stores'
+	import { isDemoWorkspaceRestricted } from '$lib/cloud'
 	import { ChevronDown, Pen, PlusIcon } from 'lucide-svelte'
 	import { Button, Drawer, DrawerContent } from './common'
 	import FolderEditor from './FolderEditor.svelte'
@@ -12,6 +13,10 @@
 	import { sendUserToast } from '$lib/toast'
 
 	const VALID_FOLDER_NAME = /^[a-zA-Z_0-9-]+$/
+
+	const restricted = $derived(
+		isDemoWorkspaceRestricted($workspaceStore, $userStore?.is_admin, $userStore?.is_super_admin)
+	)
 
 	let folders: { name: string; write: boolean }[] = $state([])
 	let filterText: string = $state('')
@@ -137,7 +142,7 @@
 	)
 
 	function handleSelectKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter' && selectOpen && noMatchingItems) {
+		if (e.key === 'Enter' && selectOpen && noMatchingItems && !restricted) {
 			e.preventDefault()
 			selectOpen = false
 			openCreateFolder()
@@ -233,18 +238,20 @@
 			/>
 		{/snippet}
 		{#snippet bottomSnippet({ close })}
-			<button
-				class="sticky py-2 px-4 w-full text-left text-xs font-medium hover:bg-surface-hover flex items-center justify-center gap-2 border-t border-border-light {noMatchingItems
-					? 'bg-surface-hover'
-					: ''}"
-				onclick={() => {
-					close()
-					openCreateFolder()
-				}}
-			>
-				<PlusIcon class="inline" size={16} />
-				Create folder
-			</button>
+			{#if !restricted}
+				<button
+					class="sticky py-2 px-4 w-full text-left text-xs font-medium hover:bg-surface-hover flex items-center justify-center gap-2 border-t border-border-light {noMatchingItems
+						? 'bg-surface-hover'
+						: ''}"
+					onclick={() => {
+						close()
+						openCreateFolder()
+					}}
+				>
+					<PlusIcon class="inline" size={16} />
+					Create folder
+				</button>
+			{/if}
 		{/snippet}
 	</Select>
 </div>

--- a/frontend/src/lib/components/ShareModal.svelte
+++ b/frontend/src/lib/components/ShareModal.svelte
@@ -340,7 +340,7 @@
 												{:else}{write ? 'Writer' : 'Viewer'}{/if}</td
 											>
 											<td>
-												{#if own && !restricted}
+												{#if own}
 													<Button
 														variant="default"
 														destructive

--- a/frontend/src/lib/components/ShareModal.svelte
+++ b/frontend/src/lib/components/ShareModal.svelte
@@ -21,8 +21,13 @@
 	import { safeSelectItems } from './select/utils.svelte'
 	import Toggle from './Toggle.svelte'
 	import { Trash } from 'lucide-svelte'
+	import { DEMO_RESTRICTION_HINT, isDemoWorkspaceRestricted } from '$lib/cloud'
 
 	const dispatch = createEventDispatcher()
+
+	let restricted = $derived(
+		isDemoWorkspaceRestricted($workspaceStore, $userStore?.is_admin, $userStore?.is_super_admin)
+	)
 
 	type Kind =
 		| 'script'
@@ -268,7 +273,9 @@
 					>
 				{/if}
 				<div>
-					{#if own}
+					{#if own && restricted}
+						<Alert type="info" title="Sharing disabled">{DEMO_RESTRICTION_HINT}</Alert>
+					{:else if own}
 						<div class="flex flex-row flex-wrap gap-2 items-center">
 							<div>
 								<ToggleButtonGroup bind:selected={ownerKind} on:selected={() => (owner = '')}>

--- a/frontend/src/lib/components/ShareModal.svelte
+++ b/frontend/src/lib/components/ShareModal.svelte
@@ -317,7 +317,7 @@
 										<tr>
 											<td>{owner}</td>
 											<td
-												>{#if own}
+												>{#if own && !restricted}
 													<div>
 														<ToggleButtonGroup
 															selected={write ? 'writer' : 'viewer'}
@@ -337,10 +337,10 @@
 															{/snippet}
 														</ToggleButtonGroup>
 													</div>
-												{:else}{write}{/if}</td
+												{:else}{write ? 'Writer' : 'Viewer'}{/if}</td
 											>
 											<td>
-												{#if own}
+												{#if own && !restricted}
 													<Button
 														variant="default"
 														destructive

--- a/frontend/src/routes/(root)/(logged)/folders/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/folders/+page.svelte
@@ -19,8 +19,13 @@
 	import Row from '$lib/components/table/Row.svelte'
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 	import { untrack } from 'svelte'
+	import { DEMO_RESTRICTION_HINT, isDemoWorkspaceRestricted } from '$lib/cloud'
 
 	type FolderW = Folder & { canWrite: boolean }
+
+	let restricted = $derived(
+		isDemoWorkspaceRestricted($workspaceStore, $userStore?.is_admin, $userStore?.is_super_admin)
+	)
 
 	let newFolderName: string = $state('')
 	let folders: FolderW[] | undefined = $state(undefined)
@@ -96,38 +101,50 @@
 			documentationLink="https://www.windmill.dev/docs/core_concepts/groups_and_folders"
 		>
 			<div class="flex flex-row">
-				<Popover
-					floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}
-					contentClasses="flex flex-col gap-2 p-4"
-				>
-					{#snippet trigger()}
-						<Button variant="accent" unifiedSize="md" startIcon={{ icon: Plus }} nonCaptureEvent
-							>New folder</Button
-						>
-					{/snippet}
-					{#snippet content({ close })}
-						<input
-							class="mr-2"
-							onkeyup={(e) => handleKeyUp(e, () => close())}
-							placeholder="New folder name"
-							bind:value={newFolderName}
-						/>
-
-						<div>
-							<Button
-								variant="accent"
-								startIcon={{ icon: Plus }}
-								disabled={!newFolderName}
-								on:click={() => {
-									addFolder()
-									close()
-								}}
+				{#if restricted}
+					<Button
+						variant="accent"
+						unifiedSize="md"
+						startIcon={{ icon: Plus }}
+						disabled
+						title={DEMO_RESTRICTION_HINT}
+					>
+						New folder
+					</Button>
+				{:else}
+					<Popover
+						floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}
+						contentClasses="flex flex-col gap-2 p-4"
+					>
+						{#snippet trigger()}
+							<Button variant="accent" unifiedSize="md" startIcon={{ icon: Plus }} nonCaptureEvent
+								>New folder</Button
 							>
-								Create
-							</Button>
-						</div>
-					{/snippet}
-				</Popover>
+						{/snippet}
+						{#snippet content({ close })}
+							<input
+								class="mr-2"
+								onkeyup={(e) => handleKeyUp(e, () => close())}
+								placeholder="New folder name"
+								bind:value={newFolderName}
+							/>
+
+							<div>
+								<Button
+									variant="accent"
+									startIcon={{ icon: Plus }}
+									disabled={!newFolderName}
+									on:click={() => {
+										addFolder()
+										close()
+									}}
+								>
+									Create
+								</Button>
+							</div>
+						{/snippet}
+					</Popover>
+				{/if}
 			</div>
 		</PageHeader>
 

--- a/frontend/src/routes/(root)/(logged)/groups/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/groups/+page.svelte
@@ -22,8 +22,13 @@
 	import { untrack } from 'svelte'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { Tooltip } from '$lib/components/meltComponents'
+	import { DEMO_RESTRICTION_HINT, isDemoWorkspaceRestricted } from '$lib/cloud'
 
 	type GroupW = Group & { canWrite: boolean }
+
+	let restricted = $derived(
+		isDemoWorkspaceRestricted($workspaceStore, $userStore?.is_admin, $userStore?.is_super_admin)
+	)
 
 	let newGroupName: string = $state('')
 	let groups: GroupW[] | undefined = $state(undefined)
@@ -103,37 +108,49 @@
 		>
 			<div class="flex flex-row">
 				<div>
-					<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
-						{#snippet trigger()}
-							<Button unifiedSize="md" variant="accent" startIcon={{ icon: Plus }} nonCaptureEvent
-								>New&nbsp;group</Button
-							>
-						{/snippet}
-						{#snippet content({ close })}
-							<div class="flex-col flex gap-2 p-4">
-								<TextInput
-									size="md"
-									inputProps={{
-										placeholder: 'New group name',
-										onkeyup: (e) => handleKeyUp(e, close)
-									}}
-									bind:value={newGroupName}
-								/>
-								<Button
-									unifiedSize="md"
-									variant="accent"
-									startIcon={{ icon: Plus }}
-									disabled={!newGroupName}
-									on:click={() => {
-										addGroup()
-										close()
-									}}
+					{#if restricted}
+						<Button
+							unifiedSize="md"
+							variant="accent"
+							startIcon={{ icon: Plus }}
+							disabled
+							title={DEMO_RESTRICTION_HINT}
+						>
+							New&nbsp;group
+						</Button>
+					{:else}
+						<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
+							{#snippet trigger()}
+								<Button unifiedSize="md" variant="accent" startIcon={{ icon: Plus }} nonCaptureEvent
+									>New&nbsp;group</Button
 								>
-									Create
-								</Button>
-							</div>
-						{/snippet}
-					</Popover>
+							{/snippet}
+							{#snippet content({ close })}
+								<div class="flex-col flex gap-2 p-4">
+									<TextInput
+										size="md"
+										inputProps={{
+											placeholder: 'New group name',
+											onkeyup: (e) => handleKeyUp(e, close)
+										}}
+										bind:value={newGroupName}
+									/>
+									<Button
+										unifiedSize="md"
+										variant="accent"
+										startIcon={{ icon: Plus }}
+										disabled={!newGroupName}
+										on:click={() => {
+											addGroup()
+											close()
+										}}
+									>
+										Create
+									</Button>
+								</div>
+							{/snippet}
+						</Popover>
+					{/if}
 				</div>
 			</div>
 		</PageHeader>


### PR DESCRIPTION
## Summary

On the managed cloud, the public **demo** workspace should stay clean and consistent. This restricts, for **non-admin** users when `CLOUD_HOSTED` and the workspace id is `demo`:

- **Folder creation** is disabled (hint: create your own workspace).
- **Sharing items to others** (granting permissions to users or groups such as `g/all`) is disabled.
- **Group creation** is disabled.

Admins (workspace admins and super admins) are exempt so they can still manage/clean the demo workspace by hand. The rule mirrors the existing demo-workspace special-case already present in `get_group` (`*CLOUD_HOSTED && w_id == "demo" && !authed.is_admin`).

Fixes WIN-2221.

## Changes

- **Backend** (`windmill-api-groups`):
  - New shared helper `check_demo_workspace_restriction(authed, w_id, action)` in `src/lib.rs` returning `BadRequest` when a non-admin acts on the cloud demo workspace.
  - Guard `create_folder` (folder creation) and `add_owner` (folder sharing) in `folders.rs`.
  - Guard `add_granular_acl` (generic item sharing for scripts/flows/apps/resources/etc) in `granular_acls.rs`.
  - Guard `create_group` (group creation) in `groups.rs`.
- **Frontend**:
  - `isDemoWorkspaceRestricted()` + `DEMO_RESTRICTION_HINT` helpers in `$lib/cloud.ts`.
  - Folders and Groups pages: the "New folder" / "New group" buttons are disabled with a tooltip hint.
  - `ShareModal`: shows a "Sharing disabled" info alert instead of the add-permission controls.

Note: the "users should only see the f/examples folder and their user folder" part of the issue is handled by manual cleanup of existing items (per the issue) combined with the creation block; folder-list filtering was intentionally not added.

## Screenshots

![demo-folders-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2221-restrict-demo-workspace-folder-creation-and-sharing/1784715313-demo-folders-disabled.png)

![demo-groups-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2221-restrict-demo-workspace-folder-creation-and-sharing/1784715313-demo-groups-disabled.png)

![demo-share-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2221-restrict-demo-workspace-folder-creation-and-sharing/1784715313-demo-share-disabled.png)

## Test plan

- [x] Backend compiles cleanly (cargo watch, no errors).
- [x] Frontend `check:fast` passes (only pre-existing unrelated `modern-screenshot` error remains).
- [x] In a workspace with id `demo` (with the cloud/demo gate forced locally for verification), "New folder" and "New group" buttons render disabled, and the permissions drawer shows the "Sharing disabled" alert.
- [x] With the gate off (normal self-hosted), folder/group creation and sharing work as before.
- [ ] On cloud, confirm a non-admin in the demo workspace gets a `BadRequest` from the create-folder / add-owner / add-granular-acl / create-group endpoints, and admins are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict folder creation, item sharing, and group creation for non-admins in the cloud `demo` workspace to keep it clean. Implements WIN-2221 with server-side enforcement, UI gating, and closes sharing bypasses in folder updates and owner changes.

- **New Features**
  - Backend (`windmill-api-groups`): added `check_demo_workspace_restriction`; blocks create-folder, sharing via `update_folder` (owners/extra_perms/default_permissioned_as), `add_owner`, `add_granular_acl`, and `remove_owner` when it sets a permission level; blocks group creation; pure revokes via `remove_owner` (no level) remain allowed; non-admins get a helpful BadRequest in `demo` on cloud.
  - Frontend: detects restriction; disables “New folder”/“New group” and also gates folder creation in the Folder Editor and Folder Picker (including Enter-to-create and footer button); in Folder Editor and Share Modal, shows a “Sharing disabled” alert and disables ACL/role changes and grants while keeping revokes enabled; admins see normal behavior.
  - Scope: self-hosted is unchanged; no folder-list filtering (handled manually per WIN-2221).

<sup>Written for commit 8fada7827f9dd2fd9ca3e65f45ca1c1c8427b4f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

