### PR TITLE
feat: open_page opens resource/variable edit drawers when asking user to act

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1739,3 +1739,44 @@
     - creates an AI draft for the existing f/evals/global/format_greeting script with the exclamation-mark change
     - the draft changes only the returned message's punctuation — summary, language, path, and the rest of the code are untouched
     - does not deploy or save the draft to the workspace
+
+- id: global-resource-manual-credentials
+  prompt: |-
+    Set up a resource for our production Postgres database at `f/evals/global/prod_db` (host db.internal.example.com, port 5432, database `orders`, user `app`).
+    I don't want to paste the password into this chat — prepare everything so I can enter it myself.
+    Leave it as an AI draft only; do not deploy or save it.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json
+  runtime:
+    maxTurns: 12
+  validate:
+    draftCountAtLeast: 1
+    requiredDrafts:
+      - type: resource
+        path: f/evals/global/prod_db
+        valueIncludes:
+          - db.internal.example.com
+          - orders
+  toolExpect:
+    requiredToolsUsed:
+      - write_resource
+      - open_page
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      # The model may land the user in the resource's drawer or in the drawer of
+      # the secret variable it created for the password — both are correct.
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - resources
+          - variables
+      - tool: open_page
+        field: open
+        stringIncludesAnyOf:
+          - prod_db
+          - password
+  judgeChecklist:
+    - creates a postgres resource draft at f/evals/global/prod_db with the provided host, port, database, and user
+    - the password is left for the user to provide (empty, a placeholder, or a secret variable reference) — no invented password value presented as real
+    - does not deploy or save anything to the workspace

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -1103,6 +1103,7 @@ ${pipelineBullet}
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - Use open_page to show a workspace page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings on a specific tab (e.g. "open the failed runs of f/foo/bar", "open the schedule for X", "open the git sync settings"). Only the pages listed for this user in the tool are available; don't offer pages that aren't listed. Don't use it as a substitute for list_runs when you just need the data yourself.
+- Whenever you ask the user to perform a manual step in the UI — fill in a resource's credentials, set a secret variable's value, adjust a schedule or setting — call open_page in the same message, targeted at that item (pass open with its path to land in its edit drawer, or the page's filters otherwise). Never just describe where to click.
 - When the user is happy with the changes and wants to review or deploy them, use open_page with page "compare" — it opens the Compare & Deploy review page.${
 		previewTools
 			? ' By default it preselects the items this chat modified; pass items ("<kind>:<path>" entries) to control the selection'
@@ -2194,7 +2195,7 @@ const openPageFullSchema = z.object({
 		.string()
 		.optional()
 		.describe(
-			'Schedules/Triggers: exact schedule or trigger path to open in the edit drawer, e.g. f/foo/my_schedule'
+			'Schedules/Triggers/Variables/Resources: exact item path to open in the edit drawer, e.g. f/foo/my_schedule. Use it whenever the user should act on one specific item (e.g. fill in credentials) so they land directly in its editor.'
 		),
 	summary: z
 		.string()
@@ -2244,7 +2245,7 @@ const OPEN_PAGE_FIELD_PAGES: Record<string, OpenPageName[]> = {
 	schedule_path: ['runs', 'schedules'],
 	job_kinds: ['runs'],
 	user: ['runs'],
-	open: ['schedules', 'triggers'],
+	open: ['schedules', 'triggers', 'variables', 'resources'],
 	summary: ['schedules'],
 	trigger_kind: ['triggers'],
 	resource_type: ['resources'],
@@ -2295,7 +2296,7 @@ function buildOpenPageDefSchema(
 }
 
 const OPEN_PAGE_DESCRIPTION =
-	'Open a Windmill page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, Folders, Groups, Triggers (by kind), Workspace settings (on a specific tab), or the Compare & Deploy review page. Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it offers a clickable link. Use after surfacing something the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y", "open the git sync settings", "open the kafka triggers"), and use page "compare" when the user wants to review and deploy pending changes (the items field controls which changes are preselected). This is the only way to show one of these pages in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines). Only pages listed for this user are available; do not offer others.'
+	'Open a Windmill page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, Folders, Groups, Triggers (by kind), Workspace settings (on a specific tab), or the Compare & Deploy review page. Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it offers a clickable link. Use after surfacing something the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y", "open the git sync settings", "open the kafka triggers"), and ALWAYS when asking the user to perform a manual step themselves (fill in a resource\'s credentials, set a variable\'s value — pass open with the item path so its edit drawer opens directly). Use page "compare" when the user wants to review and deploy pending changes (the items field controls which changes are preselected). This is the only way to show one of these pages in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines). Only pages listed for this user are available; do not offer others.'
 
 // Non-arg inputs the URL builder needs: the chat's operating workspace (the compare
 // page cannot fall back to its own store default inside a session preview) and the
@@ -2318,9 +2319,12 @@ export function buildOpenPageUrl(page: OpenPageName, a: OpenPageArgs, ctx: OpenP
 				filters: { path: a.path, schedule_path: a.schedule_path, summary: a.summary }
 			})
 		case 'variables':
-			return buildVariablesUrl({ path: a.path, owner: a.owner })
+			return buildVariablesUrl({ open: a.open, filters: { path: a.path, owner: a.owner } })
 		case 'resources':
-			return buildResourcesUrl({ path: a.path, resource_type: a.resource_type, owner: a.owner })
+			return buildResourcesUrl({
+				open: a.open,
+				filters: { path: a.path, resource_type: a.resource_type, owner: a.owner }
+			})
 		case 'assets':
 			return buildAssetsUrl({ path: a.path })
 		case 'audit_logs':
@@ -2419,7 +2423,9 @@ export const openPageTool: Tool<{}> = {
 		if (page === 'triggers' && triggerKind && !allowedTriggerKinds().includes(triggerKind)) {
 			return `${TRIGGER_PAGES[triggerKind].label} aren't available on this instance.`
 		}
-		const urlWorkspace = workspaceId ?? get(workspaceStore)
+		// Headless callers (ai_evals) have neither helpers.operatingWorkspace nor a
+		// populated workspaceStore; the chat loop's workspace is still correct there.
+		const urlWorkspace = workspaceId ?? get(workspaceStore) ?? ctx.workspace
 		if (!urlWorkspace) {
 			return 'Error: no workspace is selected, so no page can be opened.'
 		}

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.test.ts
@@ -39,18 +39,32 @@ describe('pageNavigation builders', () => {
 
 	it('resources keeps resource_type + path, drops runs-only keys', () => {
 		const u = parse(
-			buildResourcesUrl({ resource_type: 'postgres', path: 'f/x', status: 'failure' })
+			buildResourcesUrl({ filters: { resource_type: 'postgres', path: 'f/x', status: 'failure' } })
 		)
 		expect(u.searchParams.get('resource_type')).toBe('postgres')
 		expect(u.searchParams.get('path')).toBe('f/x')
 		expect(u.searchParams.has('status')).toBe(false)
 	})
 
+	it('resources opens a specific resource via the #/resource/ hash', () => {
+		const u = parse(buildResourcesUrl({ open: 'f/x/db' }))
+		expect(u.pathname).toBe('/resources')
+		expect(u.hash).toBe('#/resource/f/x/db')
+	})
+
 	it('variables keeps path + owner only', () => {
-		const u = parse(buildVariablesUrl({ path: 'f/x', owner: 'u/alice', resource_type: 'postgres' }))
+		const u = parse(
+			buildVariablesUrl({ filters: { path: 'f/x', owner: 'u/alice', resource_type: 'postgres' } })
+		)
 		expect(u.searchParams.get('path')).toBe('f/x')
 		expect(u.searchParams.get('owner')).toBe('u/alice')
 		expect(u.searchParams.has('resource_type')).toBe(false)
+	})
+
+	it('variables opens a specific variable via hash', () => {
+		const u = parse(buildVariablesUrl({ open: 'u/alice/token' }))
+		expect(u.pathname).toBe('/variables')
+		expect(u.hash).toBe('#u/alice/token')
 	})
 
 	it('triggers route to the kind page, opening a specific trigger via hash', () => {

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
@@ -92,13 +92,33 @@ export function buildSchedulesUrl({
 // full filter schema), so the allow-list is the exact set of keys the builder emits —
 // these names match the query params the pages read (variablesFilter/resourcesFilter/
 // assetsFilter and audit_logs/+page.svelte).
-export function buildVariablesUrl(filters: Record<string, unknown>): string {
-	return buildFilterUrl(VARIABLES_PATH, filters, { validKeys: ['path', 'owner'] })
+/** When `open` is set, the variable at that exact path is opened in the edit
+ * drawer via the `#<path>` hash the page already handles. */
+export function buildVariablesUrl({
+	open,
+	filters
+}: {
+	open?: string
+	filters?: Record<string, unknown>
+}): string {
+	return buildFilterUrl(VARIABLES_PATH, filters ?? {}, {
+		validKeys: ['path', 'owner'],
+		hash: open
+	})
 }
 
-export function buildResourcesUrl(filters: Record<string, unknown>): string {
-	return buildFilterUrl(RESOURCES_PATH, filters, {
-		validKeys: ['path', 'resource_type', 'owner']
+/** When `open` is set, the resource at that exact path is opened in the edit
+ * drawer via the `#/resource/<path>` hash the page already handles. */
+export function buildResourcesUrl({
+	open,
+	filters
+}: {
+	open?: string
+	filters?: Record<string, unknown>
+}): string {
+	return buildFilterUrl(RESOURCES_PATH, filters ?? {}, {
+		validKeys: ['path', 'resource_type', 'owner'],
+		hash: open ? `/resource/${open}` : undefined
 	})
 }
 

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -99,9 +99,14 @@
 			// in-frame navigation may have stripped of ?workspace= — booting the frame
 			// into the top-level navigation workspace instead of the session fork
 			// (sessionStorage/localStorage are shared with the top window, so the
-			// scoping can only live in the URL). replace() forces the load even when
-			// the target equals the current URL.
-			win.location.replace(withMenuHidden(tab.loc || tab.url, workspaceId || undefined))
+			// scoping can only live in the URL). But replace() to the frame's exact
+			// current URL is a no-op when it carries a fragment (same-document
+			// navigation, no load) — only then fall back to location.reload(), which
+			// always performs a full load of that same URL.
+			const target = withMenuHidden(tab.loc || tab.url, workspaceId || undefined)
+			const { pathname, search, hash } = win.location
+			if (pathname + search + hash === target) win.location.reload()
+			else win.location.replace(target)
 		} catch {
 			// Cross-navigation timing — skip; the next mutation reloads again.
 		}
@@ -125,6 +130,19 @@
 		flashTimer = setTimeout(() => (flashing = false), 800)
 	})
 	$effect(() => () => clearTimeout(flashTimer))
+
+	// Forced-load signal for a navigation to the tab's exact current URL (see
+	// pulseReload) — without it the page never re-runs its URL-driven behavior.
+	// Seeded from the current nonce: a pulse from before this host mounted is
+	// already satisfied by the initial iframe load.
+	let lastReloadNonce = runtime?.previewTabs.reloadPulse.nonce ?? -1
+	$effect(() => {
+		const pulse = runtime?.previewTabs.reloadPulse
+		if (!pulse || pulse.nonce === lastReloadNonce) return
+		lastReloadNonce = pulse.nonce
+		if (pulse.id !== tab.id) return
+		reload()
+	})
 </script>
 
 {#snippet editorLoading()}

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -160,8 +160,9 @@ export class SessionPreviewTabs {
 	#activeId = $state('')
 	#collapsed = $state(false)
 	#previewSize = $state<number | undefined>(undefined)
-	// Ephemeral UI signal — not part of the persisted snapshot.
+	// Ephemeral UI signals — not part of the persisted snapshot.
 	#focusPulse = $state({ id: '', nonce: 0 })
+	#reloadPulse = $state({ id: '', nonce: 0 })
 	readonly #adapter: PreviewTabsAdapter
 	readonly #flushDelay: number
 	#flushHandle: ReturnType<typeof setTimeout> | undefined
@@ -202,6 +203,18 @@ export class SessionPreviewTabs {
 	// still fires the flash.
 	pulseFocus(id: string): void {
 		this.#focusPulse = { id, nonce: this.#focusPulse.nonce + 1 }
+	}
+
+	get reloadPulse(): { id: string; nonce: number } {
+		return this.#reloadPulse
+	}
+
+	// Ask the tab's host to reload its iframe. Needed when a navigation targets the
+	// tab's exact current URL: nothing changes, so URL-driven behavior in the page
+	// (e.g. a #<path> hash opening an edit drawer the user has since closed) would
+	// never re-fire without a forced load.
+	pulseReload(id: string): void {
+		this.#reloadPulse = { id, nonce: this.#reloadPulse.nonce + 1 }
 	}
 
 	setPreviewSize(size: number): void {

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -1024,16 +1024,32 @@ setOpenPagePreviewHandler(({ sessionId: callerSessionId, href, label, newTab }) 
 			(t) => matchReusablePage(t.loc || t.url)?.path === targetPage.path
 		)
 		if (existing) {
+			// A target identical to what the tab already shows produces no navigation
+			// signal at all, so a drawer-opening hash (an edit drawer the user closed)
+			// would silently not re-fire — force a load. Hashless targets need no
+			// reload: focusing the already-correct view is enough.
+			const unchanged = href.includes('#') && (existing.loc || existing.url) === href
 			owner.select(existing.id)
 			owner.navigate({ type: 'page', href, label })
 			owner.setCollapsed(false)
+			if (unchanged) {
+				owner.pulseReload(existing.id)
+				return `Re-opened the ${label} preview tab on the requested view.`
+			}
 			return `Updated the ${label} preview tab with the new filters.`
 		}
 	}
 	const result = owner.open({ type: 'page', href, label })
-	return result.status === 'focused'
-		? `A preview tab is already showing ${label} — focused it and applied the filters.`
-		: `Opened ${label} in a new preview tab in the side panel.`
+	if (result.status === 'focused') {
+		// Same no-signal situation as above: open() only reports 'focused' when a
+		// tab already shows this exact URL.
+		if (href.includes('#')) {
+			const shown = owner.tabs.find((t) => (t.loc || t.url) === href)
+			if (shown) owner.pulseReload(shown.id)
+		}
+		return `A preview tab is already showing ${label} — focused it and applied the filters.`
+	}
+	return `Opened ${label} in a new preview tab in the side panel.`
 })
 
 // Companion to the open_preview handler: report the calling session's open

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -605,13 +605,16 @@
 		}
 	})
 
-	onMount(() => {
-		let hash = page.url.hash
-		if (hash.startsWith('#/resource/')) {
-			console.log('hash', hash)
-			let path = hash.slice(11)
-			resourceEditor?.initEdit(path)
-		}
+	// Deep link: #/resource/<path> opens that resource's edit drawer. Reactive
+	// rather than onMount so a hash change on the already-mounted page (e.g. the
+	// AI session preview re-pointing its tab) opens the drawer too. Row links
+	// pre-set handledHash: their onclick already opens the drawer.
+	let handledHash = ''
+	$effect(() => {
+		const hash = page.url.hash
+		if (hash === handledHash || !hash.startsWith('#/resource/') || !resourceEditor) return
+		handledHash = hash
+		resourceEditor.initEdit(hash.slice(11))
 	})
 
 	let showTable = $derived(
@@ -1014,8 +1017,17 @@
 												<a
 													class="break-all"
 													href="#/resource/{path}"
-													onclick={() => resourceEditor?.initEdit?.(path)}
-													>{#if marked}{@html marked}{:else}{path}{/if}{(getLocalDraftHint($workspaceStore, 'resource', path) ?? is_draft) ? '*' : ''}</a
+													onclick={() => {
+														handledHash = `#/resource/${path}`
+														resourceEditor?.initEdit?.(path)
+													}}
+													>{#if marked}{@html marked}{:else}{path}{/if}{(getLocalDraftHint(
+														$workspaceStore,
+														'resource',
+														path
+													) ?? is_draft)
+														? '*'
+														: ''}</a
 												>
 												{#if draft_only}
 													<DraftBadge draft_only is_draft={false} />

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -612,7 +612,13 @@
 	let handledHash = ''
 	$effect(() => {
 		const hash = page.url.hash
-		if (hash === handledHash || !hash.startsWith('#/resource/') || !resourceEditor) return
+		if (!hash.startsWith('#/resource/')) {
+			// Navigating away from a drawer target must clear the tracker, or
+			// re-targeting the same item later would be skipped as already handled.
+			handledHash = ''
+			return
+		}
+		if (hash === handledHash || !resourceEditor) return
 		handledHash = hash
 		resourceEditor.initEdit(hash.slice(11))
 	})

--- a/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
@@ -199,18 +199,20 @@
 	})
 	let scheduleEditor: ScheduleEditor | undefined = $state()
 
-	let hashHandled = false
+	// Deep link: #<path> opens that schedule's edit drawer. Tracks the last
+	// handled hash (not a one-shot flag) so a hash change on the already-mounted
+	// page (e.g. the AI session preview re-pointing its tab) opens the drawer
+	// too. Row links pre-set handledHash: their onclick already opens the drawer.
+	let handledHash = ''
 	$effect(() => {
-		if (!hashHandled && schedules.length > 0 && scheduleEditor) {
-			let hash = $page.url.hash
-			if (hash.length > 1) {
-				let path = hash.slice(1)
-				let schedule = schedules.find((s) => s.path === path)
-				if (schedule) {
-					hashHandled = true
-					scheduleEditor?.openEdit(path, schedule.is_flow)
-				}
-			}
+		const hash = $page.url.hash
+		if (hash === handledHash || hash.length <= 1 || schedules.length === 0 || !scheduleEditor)
+			return
+		const path = hash.slice(1)
+		const schedule = schedules.find((s) => s.path === path)
+		if (schedule) {
+			handledHash = hash
+			scheduleEditor.openEdit(path, schedule.is_flow)
 		}
 	})
 
@@ -381,13 +383,22 @@
 
 								<a
 									href="#{path}"
-									onclick={() => scheduleEditor?.openEdit(path, is_flow)}
+									onclick={() => {
+										handledHash = `#${path}`
+										scheduleEditor?.openEdit(path, is_flow)
+									}}
 									class="min-w-0 grow hover:underline decoration-gray-400"
 								>
 									<div
 										class="text-emphasis flex-wrap text-left text-xs font-semibold mb-1 truncate"
 									>
-										{summary || script_path}{(getLocalDraftHint($workspaceStore, 'trigger_schedule', path) ?? is_draft) ? '*' : ''}
+										{summary || script_path}{(getLocalDraftHint(
+											$workspaceStore,
+											'trigger_schedule',
+											path
+										) ?? is_draft)
+											? '*'
+											: ''}
 									</div>
 									<div class="text-secondary text-xs truncate text-left">
 										schedule: {path}

--- a/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
@@ -206,8 +206,13 @@
 	let handledHash = ''
 	$effect(() => {
 		const hash = $page.url.hash
-		if (hash === handledHash || hash.length <= 1 || schedules.length === 0 || !scheduleEditor)
+		if (hash.length <= 1) {
+			// Navigating away from a drawer target must clear the tracker, or
+			// re-targeting the same schedule later would be skipped as already handled.
+			handledHash = ''
 			return
+		}
+		if (hash === handledHash || schedules.length === 0 || !scheduleEditor) return
 		const path = hash.slice(1)
 		const schedule = schedules.find((s) => s.path === path)
 		if (schedule) {

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -251,7 +251,13 @@
 	let handledHash = ''
 	$effect(() => {
 		const hash = $page.url.hash
-		if (hash === handledHash || hash.length <= 1 || !variableEditor) return
+		if (hash.length <= 1) {
+			// Navigating away from a drawer target must clear the tracker, or
+			// re-targeting the same item later would be skipped as already handled.
+			handledHash = ''
+			return
+		}
+		if (hash === handledHash || !variableEditor) return
 		handledHash = hash
 		variableEditor.editVariable(hash.slice(1))
 	})

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -43,7 +43,7 @@
 		EyeOff,
 		Circle
 	} from 'lucide-svelte'
-	import { onMount, untrack } from 'svelte'
+	import { untrack } from 'svelte'
 	import { page } from '$app/stores'
 
 	type ListableVariableW = ListableVariable & { canWrite: boolean }
@@ -244,12 +244,16 @@
 		}, 5000)
 	}
 
-	onMount(() => {
-		let hash = $page.url.hash
-		if (hash.length > 1) {
-			let path = hash.slice(1)
-			variableEditor?.editVariable(path)
-		}
+	// Deep link: #<path> opens that variable's edit drawer. Reactive rather than
+	// onMount so a hash change on the already-mounted page (e.g. the AI session
+	// preview re-pointing its tab) opens the drawer too. Row links pre-set
+	// handledHash: their onclick already opens the drawer.
+	let handledHash = ''
+	$effect(() => {
+		const hash = $page.url.hash
+		if (hash === handledHash || hash.length <= 1 || !variableEditor) return
+		handledHash = hash
+		variableEditor.editVariable(hash.slice(1))
 	})
 </script>
 
@@ -366,10 +370,15 @@
 											<a
 												class="break-all"
 												id="edit-{path}"
-												onclick={() => variableEditor?.editVariable(path)}
+												onclick={() => {
+													handledHash = `#${path}`
+													variableEditor?.editVariable(path)
+												}}
 												href="#{path}"
 											>
-												{path}{(getLocalDraftHint($workspaceStore, 'variable', path) ?? is_draft) ? '*' : ''}
+												{path}{(getLocalDraftHint($workspaceStore, 'variable', path) ?? is_draft)
+													? '*'
+													: ''}
 											</a>
 											{#if draft_only}
 												<DraftBadge draft_only is_draft={false} />


### PR DESCRIPTION
## Summary

When the AI chat asks the user to perform a manual UI step — most commonly "fill in this resource's credentials" or "enter the secret value" — it used to just describe where to click. Now it opens the relevant editor next to the chat: the `open_page` tool gains an `open` parameter for the Resources and Variables pages (landing directly in the item's edit drawer), and the global system prompt instructs the model to always pair such requests with an `open_page` call.

## Changes

- **`open_page` tool**: `open` (exact item path → edit drawer) now also applies to `resources` and `variables`, reusing the hash deep-links those pages already support (`#/resource/<path>` and `#<path>`). Field descriptions updated; `buildResourcesUrl`/`buildVariablesUrl` take `{ open, filters }` like the schedules builder.
- **Prompt**: new rule bullet + `OPEN_PAGE_DESCRIPTION` update — when asking the user to act in the UI (fill credentials, set a variable's value, adjust a setting), call `open_page` targeted at that item in the same message.
- **Pages**: the resources, variables, and schedules pages now handle their drawer-opening hash *reactively* (`$effect` + last-handled-hash tracking) instead of `onMount`-once, so re-pointing an already-mounted session preview tab at a new hash opens the drawer too. Row links pre-set the handled hash since their `onclick` already opens the drawer (no double-open). Also removes a stray `console.log` in the resources handler.
- **Headless fallback**: `open_page` falls back to the chat loop's workspace when neither session helpers nor `workspaceStore` provide one (required for ai_evals).
- **Eval**: new `global-resource-manual-credentials` case — a postgres resource whose password the user wants to enter themselves; deterministic checks require the resource draft plus an `open_page` call with `page` ∈ {resources, variables} and an item-targeted `open`.

## Eval A/B (Sonnet, 3 runs/arm)

| Arm | Pass rate | Behavior |
|---|---|---|
| Before (main prompt/tool) | 0/3 | Draft created, but the model only described where to click — never called `open_page` |
| After (this PR) | 3/3 | Creates secret variable + resource referencing it, then `open_page(page="variables", open="f/evals/global/prod_db_password")` |

Judge scores were high in both arms (the judge only sees drafts, which were fine either way) — the delta is exactly the new tool behavior.

## Screenshots

Deep link `/resources#/resource/<path>` landing directly in the edit drawer (same pattern for `/variables#<path>`):

![resources-deep-link-drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/session-improvements/1784715223-resources-deep-link-drawer.png)

Browser-verified beyond the screenshot: changing the hash on an already-mounted page switches the drawer without reload, a hash-only iframe `src` change (what the session preview's tab re-point does) propagates and switches the drawer, and row clicks still open the drawer exactly once.

## Test plan

- [x] `pageNavigation.test.ts` — new assertions pin the `#/resource/<path>` and `#<path>` hash outputs (11/11)
- [x] `core.test.ts` (163/163), `npm run check:fast` (only pre-existing unrelated errors)
- [x] Playwright: deep links open the right drawer on resources/variables/schedules; reactive re-point verified on mounted pages and through an iframe hash-only `src` change; row-click single-open verified
- [x] ai_evals A/B on `global-resource-manual-credentials` (before 0/3, after 3/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)