### PR TITLE
fix(ai-sessions): remove collaborator presence badge from session preview (WIN-2222)

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -34,7 +34,7 @@
 	import DeployOverrideConfirmationModal from '$lib/components/common/confirmationModal/DeployOverrideConfirmationModal.svelte'
 	import AIChangesWarningModal from '$lib/components/copilot/chat/flow/AIChangesWarningModal.svelte'
 
-	import { createRawSnippet, setContext, untrack } from 'svelte'
+	import { createRawSnippet, getContext, setContext, untrack } from 'svelte'
 	import { writable } from 'svelte/store'
 	import CenteredPage from './CenteredPage.svelte'
 	import { Button } from './common'
@@ -201,6 +201,12 @@
 		draftTriggersModalOpen = false
 		confirmDeploymentCallback(selectedTriggers)
 	}
+
+	// Inside an AI session pane (SessionEditorTarget injects an aiChatManager via
+	// context) the collaborator presence badge is spurious: the editor is embedded
+	// in the shared /sessions URL under the session's own workspace identity, so
+	// presence keyed on that URL leaks a phantom self-badge. Hide it here.
+	const inSessionPane = !!getContext('aiChatManager')
 
 	function hasAIChanges(): boolean {
 		return aiChatManager.flowAiChatHelpers?.hasPendingChanges() ?? false
@@ -1173,7 +1179,7 @@
 					{/if}
 				</div>
 				<div class="flex flex-row gap-2 items-center shrink-0">
-					{#if $enterpriseLicense && !newFlow}
+					{#if $enterpriseLicense && !newFlow && !inSessionPane}
 						<Awareness />
 					{/if}
 					<div class="relative">

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1976,7 +1976,7 @@
 				<!-- Separator -->
 				<div class="flex-1"></div>
 
-				{#if $enterpriseLicense && initialPath != ''}
+				{#if $enterpriseLicense && initialPath != '' && !inSessionPane}
 					<Awareness />
 				{/if}
 

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -1076,7 +1076,7 @@
 			/>
 		</div>
 	{/if}
-	{#if $enterpriseLicense && $appPath != ''}
+	{#if $enterpriseLicense && $appPath != '' && !inSessionPane}
 		<div class="shrink-0">
 			<Awareness />
 		</div>

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -841,7 +841,7 @@
 		{/if}
 	</div>
 
-	{#if $enterpriseLicense && appPath != ''}
+	{#if $enterpriseLicense && appPath != '' && !inSessionPane}
 		<div class="shrink-0">
 			<Awareness />
 		</div>


### PR DESCRIPTION
## Problem

In the AI session **preview**, a collaborator/presence avatar badge shows up on a brand-new draft even though no one is co-editing and per-document Multiplayer is off. The badge shown is the current user's own avatar. On the normal `/scripts/edit` (and equivalent) pages the same editor shows no such badge.

## Root cause

Windmill has an always-on, workspace-wide **presence** layer (`MultiplayerMenu.svelte`, the sidebar "Live activity") that auto-connects whenever an EE license is present — independent of the per-document Multiplayer toggle. It broadcasts each user's `window.location.pathname` into `awarenessStore`.

`Awareness.svelte` (in each editor's header) renders every `awarenessStore` entry whose stored path matches the current `window.location.pathname`, minus yourself:

```js
Object.entries($awarenessStore).filter(([a, b]) => b == url && a != $userStore?.username)
//                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ self-filter
```

- **Normal editor page:** the only entry matching the URL is your own, and the `a != $userStore?.username` self-filter removes it; genuine co-editors on the same item are rare. So the badge slot is empty — matching what users see.
- **Session preview:** the badge appears because the **self-filter breaks**. `$userStore` is scoped to the *active* workspace, but the session preview operates on a *different* (root/fork) workspace where your username differs (or `$userStore` isn't set in that context). So `"ruben" != <active-workspace username / undefined>` is `true`, your own presence entry is no longer recognized as you, and it leaks through against the shared `/sessions` shell URL as a phantom "collaborator." (`sessions/WorkspaceFamilyPicker.svelte` has an explicit comment about the active-workspace `$userStore` vs the session's root/fork identity.)

Either way the badge is meaningless in the preview — nobody is co-editing the draft.

## Fix

Suppress `<Awareness />` whenever the editor runs inside the session pane, reusing the existing `inSessionPane` context flag (derived from the `aiChatManager` context that `SessionEditorTarget` injects — and which is set *only* there, so the guard is a no-op in the standalone editors).

Applied to every editor that renders the badge and can be embedded in a session preview:
- `ScriptBuilder.svelte` (scripts — the originally reported surface)
- `FlowBuilder.svelte` (flows) — added the `inSessionPane` flag (`getContext('aiChatManager')`)
- `apps/editor/AppEditorHeader.svelte` (apps) — reused existing flag
- `raw_apps/RawAppEditorHeader.svelte` (raw apps) — reused existing flag

```diff
-{#if $enterpriseLicense && <path-guard>}
+{#if $enterpriseLicense && <path-guard> && !inSessionPane}
 	<Awareness />
 {/if}
```

## Validation

- `npm run check:fast` — clean for all changed files (the one reported error, `modern-screenshot` missing in `RawAppEditor.svelte`, is pre-existing and unrelated — that file is not touched here).
- The presence layer and `<Awareness />` only activate under an **EE license**, and this CE dev environment has no EE license and no AI provider configured, so the live session-preview flow can't be exercised here to capture a before/after screenshot. Diagnosis is from the code paths; each change is a one-line guard on a session-pane-only context flag, so behavior is unchanged everywhere except inside the session preview, where the badge is now hidden.

Fixes WIN-2222