### PR TITLE
fix(ai-sessions): show preview chip on write tools, not open_preview

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -97,7 +97,7 @@
 			</button>
 		{/snippet}
 
-		<!-- Discrete preview chip for an item a tool created/updated/opened, pinned to
+		<!-- Discrete preview chip for an item a tool created/updated, pinned to
 		     the right of the header row. Rendered inline (not gated on expand) so it
 		     stays visible after the tool collapses. -->
 		{#if showPreviewChip && message.previewCard}

--- a/frontend/src/lib/components/copilot/chat/ToolPreviewCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolPreviewCard.svelte
@@ -35,5 +35,7 @@
 	endIcon={{ icon: PanelRight }}
 	wrapperClasses="shrink-0"
 >
-	Preview
+	<!-- The chip renders inside the tool row's font-mono scope; the label is UI text.
+	     (font-main, not font-sans — this Tailwind config only defines main/mono.) -->
+	<span class="font-main">Preview</span>
 </Button>

--- a/frontend/src/lib/components/copilot/chat/ToolPreviewCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolPreviewCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { PanelRight } from 'lucide-svelte'
+	import { Button } from '$lib/components/common'
 	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
 	import { runToolDisplayAction } from './createdResourceActions.svelte'
 	import { openItemPreviewAction, type PreviewCardKind } from './shared'
@@ -10,12 +11,7 @@
 
 	let { card }: Props = $props()
 
-	// RowIcon has no 'pipeline' kind — a pipeline is a folder graph, shown with the
-	// data-pipeline icon.
-	const iconKind = $derived(card.kind === 'pipeline' ? 'data_pipeline' : card.kind)
-	const kindLabel = $derived(
-		card.kind === 'raw_app' ? 'app' : card.kind === 'pipeline' ? 'pipeline' : card.kind
-	)
+	const kindLabel = $derived(card.kind === 'raw_app' ? 'app' : card.kind)
 
 	let opening = $state(false)
 	async function open() {
@@ -29,17 +25,15 @@
 	}
 </script>
 
-<button
-	type="button"
-	onclick={open}
+<Button
+	variant="default"
+	unifiedSize="2xs"
 	disabled={opening}
 	title="Open {kindLabel} preview: {card.path}"
-	class="group shrink-0 inline-flex items-center gap-1.5 rounded-md border border-light bg-surface pl-1.5 pr-2 py-1 transition-colors hover:bg-surface-hover disabled:opacity-60"
+	onClick={open}
+	startIcon={{ icon: RowIcon, props: { kind: card.kind, size: 12 } }}
+	endIcon={{ icon: PanelRight }}
+	wrapperClasses="shrink-0"
 >
-	<span class="inline-flex shrink-0">
-		<RowIcon kind={iconKind} size={12} />
-	</span>
-	<span class="inline-flex items-center gap-1 text-2xs text-tertiary group-hover:text-secondary">
-		Preview <PanelRight size={11} />
-	</span>
-</button>
+	Preview
+</Button>

--- a/frontend/src/lib/components/copilot/chat/ToolPreviewCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolPreviewCard.svelte
@@ -2,6 +2,7 @@
 	import { PanelRight } from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
 	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
+	import type { IconType } from '$lib/utils'
 	import { runToolDisplayAction } from './createdResourceActions.svelte'
 	import { openItemPreviewAction, type PreviewCardKind } from './shared'
 
@@ -31,7 +32,7 @@
 	disabled={opening}
 	title="Open {kindLabel} preview: {card.path}"
 	onClick={open}
-	startIcon={{ icon: RowIcon, props: { kind: card.kind, size: 12 } }}
+	startIcon={{ icon: RowIcon as unknown as IconType, props: { kind: card.kind, size: 12 } }}
 	endIcon={{ icon: PanelRight }}
 	wrapperClasses="shrink-0"
 >

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -3260,18 +3260,7 @@ export const globalTools: Tool<{}>[] = [
 		),
 		fn: async (ctx) => {
 			const parsed = openPreviewSchema.parse(ctx.args)
-			const sessionId = sessionIdFromCtx(ctx)
-			const { opened, message } = openSessionPreview(parsed, sessionId)
-			// Surface the same discrete card the write tools show, so the user can
-			// re-open/focus the preview later from the tool call. Only when the tool
-			// actually opened the preview (not for a refused open, e.g. a gated
-			// pipeline), and only in a session.
-			if (sessionId && opened) {
-				ctx.toolCallbacks.setToolStatus(ctx.toolId, {
-					previewCard: { kind: parsed.kind, path: parsed.path }
-				})
-			}
-			return message
+			return openSessionPreview(parsed, sessionIdFromCtx(ctx))
 		}
 	},
 	{
@@ -3485,6 +3474,9 @@ type WriteDraftCtx = {
 	// reloads the preview of the session that issued the deploy — not the
 	// UI-active one. Undefined for the global side-panel chat.
 	sessionId?: string
+	// Present when the ctx is the raw tool `fn` context — session chats carry
+	// their id here (see SessionToolHelpers / sessionIdFromCtx).
+	helpers?: unknown
 }
 
 // Sessions are the only context where `open_preview` makes sense — the global
@@ -3560,25 +3552,18 @@ export function setOpenPreviewHandler(handler: OpenPreviewHandler | undefined): 
 	openPreviewHandler = handler
 }
 
-// `opened` distinguishes a real open (the caller may then offer a preview card)
-// from a refusal that is returned as a message rather than thrown — so the card is
-// never shown for an item the tool declined to preview (e.g. a gated pipeline).
 function openSessionPreview(
 	args: { kind: 'script' | 'flow' | 'raw_app' | 'pipeline'; path: string },
 	sessionId: string | undefined
-): { opened: boolean; message: string } {
+): string {
 	if (!openPreviewHandler) {
-		return {
-			opened: false,
-			message:
-				'Error: open_preview is only available inside an AI session. Tell the user to switch to a session to view the preview, or describe the item textually.'
-		}
+		return 'Error: open_preview is only available inside an AI session. Tell the user to switch to a session to view the preview, or describe the item textually.'
 	}
 	// open_preview only exists in sessions, so no sessionId check is needed here.
 	if (args.kind === 'pipeline' && !isSessionPipelinesEnabled()) {
-		return { opened: false, message: SESSION_PIPELINES_GATED_MESSAGE }
+		return SESSION_PIPELINES_GATED_MESSAGE
 	}
-	return { opened: true, message: openPreviewHandler({ ...args, sessionId }) }
+	return openPreviewHandler({ ...args, sessionId })
 }
 
 // Opens a workspace *page* (Runs, Schedules, …) as a page tab in the session's
@@ -3943,15 +3928,17 @@ const PREVIEW_CARD_KIND_BY_ITEM_KIND: Partial<
 }
 
 // Offer a preview card for a write that landed a previewable item. Session chats
-// only (`ctx.sessionId`): the card opens the item in the side panel, which the
-// global side-panel chat has no equivalent of. `path` is the item's display path
-// (what `open_preview` takes), not its synthetic draft storage key.
+// only: the card opens the item in the side panel, which the global side-panel
+// chat has no equivalent of. `path` is the item's display path (what
+// `open_preview` takes), not its synthetic draft storage key.
 function maybeAttachPreviewCard(
 	ctx: WriteDraftCtx,
 	itemKind: DraftPersistResult['itemKind'],
 	path: string
 ): void {
-	if (!ctx.sessionId) return
+	// Write tools pass the raw tool ctx, whose session id lives in `helpers` —
+	// `ctx.sessionId` is only set by callers that thread it explicitly.
+	if (!ctx.sessionId && !sessionIdFromCtx(ctx)) return
 	const kind = PREVIEW_CARD_KIND_BY_ITEM_KIND[itemKind]
 	if (!kind) return
 	ctx.toolCallbacks.setToolStatus(ctx.toolId, { previewCard: { kind, path } })

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -515,14 +515,14 @@ export type NavigateAction = {
 	page: string
 }
 
-/** Kinds of item a session preview can host — the subset the `open_preview` tool
- * accepts. `pipeline` targets a folder graph, the rest a workspace item path. */
-export type PreviewCardKind = 'script' | 'flow' | 'raw_app' | 'pipeline'
+/** Kinds of previewable item a write tool can land — the subset of draft item
+ * kinds a session preview can host. */
+export type PreviewCardKind = 'script' | 'flow' | 'raw_app'
 
-// A discrete card shown under a tool call that created/updated/opened the preview of
-// a workspace item. Clicking it opens the item's live preview in the session side
-// panel — or focuses the tab if it is already open. The handler is registered by the
-// sessions page (the only surface with a preview panel).
+// A discrete card shown on a tool call that created or updated a workspace item.
+// Clicking it opens the item's live preview in the session side panel — or focuses
+// the tab if it is already open. The handler is registered by the sessions page
+// (the only surface with a preview panel).
 export type OpenItemPreviewAction = {
 	id: string
 	type: 'open_item_preview'
@@ -586,8 +586,8 @@ export type ToolDisplayMessage = {
 	webSearchSources?: WebSearchSource[]
 	/** Data URL of an image the tool produced (e.g. take_screenshot), shown on the card. */
 	imageUrl?: string
-	/** Workspace item this tool created/updated or opened a preview of. Rendered as a
-	 * discrete, always-visible card that opens (or focuses) the item's preview in the
+	/** Workspace item this tool created or updated. Rendered as a discrete,
+	 * always-visible card that opens (or focuses) the item's preview in the
 	 * session side panel. Set only for session chats — the side panel is their surface. */
 	previewCard?: { kind: PreviewCardKind; path: string }
 }

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -460,7 +460,7 @@
 		}
 	})
 
-	// Preview cards under create/update/open-preview tool calls dispatch here. Open
+	// Preview cards on create/update tool calls dispatch here. Open
 	// (or focus, if already shown) the item's preview in the active session's panel —
 	// the visible chat is always the active session, so `owner` is its panel. Read
 	// `owner` lazily inside the handler (not in the effect body) so this registers


### PR DESCRIPTION
## Summary

#10254 introduced a "Preview" chip on AI-session tool calls, meant to let the user open/focus an item's side-panel preview from the create/update tool that produced it. In practice the chip never appeared on write tools and only appeared on `open_preview` — the one tool where it is redundant, since that tool just opened the preview itself.

Root cause: `maybeAttachPreviewCard` gated on `ctx.sessionId`, but write tools pass the raw tool-call context, which carries the session id in `helpers` — so the guard always bailed on the write path. `open_preview` read the id correctly via `sessionIdFromCtx`, hence the inverted behavior.

## Changes

- `maybeAttachPreviewCard` falls back to `sessionIdFromCtx(ctx)` (the raw tool ctx's `helpers`), so every session-chat write that lands a previewable item (script, flow, raw app) gets the chip — creates, updates, `edit_script`, `patch_flow_json`, and the app write tools included. The global side-panel chat still gets none (`helpers.sessionId` is only set for session chats).
- Removed the chip from the `open_preview` tool and reverted `openSessionPreview` to a plain string return — the `{opened, message}` struct existed only to feed the chip.
- Dropped the now-unreachable `pipeline` kind from `PreviewCardKind` and its dead icon/label branches (writes only resolve to script/flow/raw_app).
- Rewrote `ToolPreviewCard.svelte` to use the design-system `Button` component (`variant="default"`, `unifiedSize="2xs"`, `RowIcon` via `startIcon.props`, `PanelRight` as `endIcon`) instead of a raw `<button>`.

## Screenshots

`write_script` and `edit_script` tool calls now carry the Preview chip on their header row; the `open_preview` call below them has none. Clicking the chip opens/focuses the script tab in the side panel.

![preview-chip-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/open-preview-nit/1784720329-preview-chip-final.png)

## Test plan

- [x] `npm run check:fast` clean; `shared.test.ts` 38/38 passing; svelte-autofixer reports no issues
- [x] In a real AI session (Playwright, `debug-sessions` workspace): `write_script` and `edit_script` calls show the chip; clicking it opens, then focuses, the script preview tab
- [x] `open_preview` tool call shows no chip
- [ ] Global side-panel chat (non-session) shows no chip on writes — guarded by `helpers.sessionId` only being set for session chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)
