### PR TITLE
fix(jobs): enforce self_approval_disabled on the UI resume path

### DIFF
--- a/backend/tests/suspend_resume.rs
+++ b/backend/tests/suspend_resume.rs
@@ -352,13 +352,10 @@ mod suspend_resume {
         Ok(())
     }
 
-    /// Test that self-approval is blocked on the UI resume endpoint (POST
-    /// /jobs/flow/resume_suspended/:job_id) when self_approval_disabled is true, even for a
-    /// user who owns the flow path.
-    ///
-    /// This is the endpoint the "Resume" button in the run detail UI calls. Its owner shortcut
-    /// used to skip the approval-condition checks entirely, so the flow owner/operator who
-    /// triggered the run could self-approve despite self_approval_disabled.
+    /// The UI "Resume" button (POST /jobs_u/flow/resume_suspended/:job_id) must reject the
+    /// triggerer approving their own self_approval_disabled step even when they own the flow
+    /// path: only admins are exempt from the self-approval restriction, so owning the runnable
+    /// does not grant the right to self-approve.
     #[cfg(feature = "enterprise")]
     #[cfg(feature = "deno_core")]
     #[sqlx::test(fixtures("base"))]
@@ -444,6 +441,107 @@ mod suspend_resume {
                     status == reqwest::StatusCode::FORBIDDEN,
                     "Self-approval via the UI resume endpoint should be blocked for the owner when \
                      self_approval_disabled=true. Expected 403 Forbidden, got {}. Response: {}",
+                    status,
+                    response.text().await.unwrap_or_default()
+                );
+            },
+            port,
+        )
+        .await;
+
+        server.close().await.unwrap();
+        Ok(())
+    }
+
+    /// self_approval_disabled must hold even when user_auth_required is not set: the worker must
+    /// persist the condition and the resume boundary must enforce it for the authenticated
+    /// triggerer. The triggerer here is a non-owner (folder path they don't own), so the owner
+    /// shortcut is not involved and this exercises the persistence + authenticated-check path.
+    #[cfg(feature = "enterprise")]
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base"))]
+    async fn test_self_approval_disabled_without_user_auth_required(
+        db: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        initialize_tracing().await;
+
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        // self_approval_disabled without user_auth_required (as a raw-flow/CLI author could set).
+        let flow_value: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "a",
+                "value": {
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": "export function main() { return 'step1'; }"
+                },
+                "suspend": {
+                    "required_events": 1,
+                    "self_approval_disabled": true
+                }
+            }, {
+                "id": "b",
+                "value": {
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": "export function main() { return 'step2 - after approval'; }"
+                }
+            }]
+        }))
+        .unwrap();
+
+        // Folder path test-user-2 does not own -> non-owner triggerer (no folders in the base
+        // fixture), so the owner shortcut is bypassed and only persistence matters here.
+        let flow = RunJob::from(JobPayload::RawFlow {
+            value: flow_value,
+            path: Some("f/system/test_persist".to_string()),
+            restarted_from: None,
+        })
+        .push_as(&db, "test-user-2", "test2@windmill.dev")
+        .await;
+
+        let queue = listen_for_queue(&db).await;
+        let db_ = db.clone();
+
+        in_test_worker(
+            &db,
+            async move {
+                let db = db_;
+
+                wait_until_flow_suspends(flow, queue, &db).await;
+
+                let token = windmill_common::auth::create_token_for_owner(
+                    &db,
+                    "test-workspace",
+                    "u/test-user-2",
+                    "test-token",
+                    100,
+                    "test2@windmill.dev",
+                    &Uuid::nil(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                let response = reqwest::Client::new()
+                    .post(format!(
+                        "http://localhost:{port}/api/w/test-workspace/jobs_u/flow/resume_suspended/{flow}"
+                    ))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Content-Type", "application/json")
+                    .body("{}")
+                    .send()
+                    .await
+                    .unwrap();
+
+                let status = response.status();
+                assert!(
+                    status == reqwest::StatusCode::FORBIDDEN,
+                    "Self-approval should be blocked when self_approval_disabled=true even without \
+                     user_auth_required. Expected 403 Forbidden, got {}. Response: {}",
                     status,
                     response.text().await.unwrap_or_default()
                 );

--- a/backend/tests/suspend_resume.rs
+++ b/backend/tests/suspend_resume.rs
@@ -352,6 +352,110 @@ mod suspend_resume {
         Ok(())
     }
 
+    /// Test that self-approval is blocked on the UI resume endpoint (POST
+    /// /jobs/flow/resume_suspended/:job_id) when self_approval_disabled is true, even for a
+    /// user who owns the flow path.
+    ///
+    /// This is the endpoint the "Resume" button in the run detail UI calls. Its owner shortcut
+    /// used to skip the approval-condition checks entirely, so the flow owner/operator who
+    /// triggered the run could self-approve despite self_approval_disabled.
+    #[cfg(feature = "enterprise")]
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base"))]
+    async fn test_self_approval_disabled_blocks_ui_resume_for_owner(
+        db: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        initialize_tracing().await;
+
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        let flow_with_self_approval_disabled: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "a",
+                "value": {
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": "export function main() { return 'step1'; }"
+                },
+                "suspend": {
+                    "required_events": 1,
+                    "user_auth_required": true,
+                    "self_approval_disabled": true
+                }
+            }, {
+                "id": "b",
+                "value": {
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": "export function main() { return 'step2 - after approval'; }"
+                }
+            }]
+        }))
+        .unwrap();
+
+        // Push as a non-admin who owns the flow path, so the owner shortcut is exercised.
+        let flow = RunJob::from(JobPayload::RawFlow {
+            value: flow_with_self_approval_disabled,
+            path: Some("u/test-user-2/test_ui_resume".to_string()),
+            restarted_from: None,
+        })
+        .push_as(&db, "test-user-2", "test2@windmill.dev")
+        .await;
+
+        let queue = listen_for_queue(&db).await;
+        let db_ = db.clone();
+
+        in_test_worker(
+            &db,
+            async move {
+                let db = db_;
+
+                wait_until_flow_suspends(flow, queue, &db).await;
+
+                let token = windmill_common::auth::create_token_for_owner(
+                    &db,
+                    "test-workspace",
+                    "u/test-user-2",
+                    "test-token",
+                    100,
+                    "test2@windmill.dev",
+                    &Uuid::nil(),
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+
+                // Resume via the UI endpoint as the owner who triggered the flow.
+                let response = reqwest::Client::new()
+                    .post(format!(
+                        "http://localhost:{port}/api/w/test-workspace/jobs_u/flow/resume_suspended/{flow}"
+                    ))
+                    .header("Authorization", format!("Bearer {token}"))
+                    .header("Content-Type", "application/json")
+                    .body("{}")
+                    .send()
+                    .await
+                    .unwrap();
+
+                let status = response.status();
+                assert!(
+                    status == reqwest::StatusCode::FORBIDDEN,
+                    "Self-approval via the UI resume endpoint should be blocked for the owner when \
+                     self_approval_disabled=true. Expected 403 Forbidden, got {}. Response: {}",
+                    status,
+                    response.text().await.unwrap_or_default()
+                );
+            },
+            port,
+        )
+        .await;
+
+        server.close().await.unwrap();
+        Ok(())
+    }
+
     /// Test that self-approval WORKS when self_approval_disabled is false (default behavior).
     ///
     /// This is the complementary test to test_self_approval_disabled_blocks_owner_resume.

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -3214,6 +3214,14 @@ async fn resume_suspended(
 
     // If logged in, check authorization rules
     if let Some(ref authed) = opt_authed {
+        let trigger_email = flow.email.as_deref().unwrap_or("");
+
+        // self_approval_disabled applies to owners too (only admins are exempt), so it is
+        // enforced before the owner shortcut below.
+        if let Some(ref ac) = approval_conditions {
+            require_not_self_approval(authed, ac, trigger_email)?;
+        }
+
         let is_admin = authed.is_admin;
         let is_owner = flow
             .script_path
@@ -3222,7 +3230,6 @@ async fn resume_suspended(
             .unwrap_or(false);
 
         if !is_admin && !is_owner {
-            let trigger_email = flow.email.as_deref().unwrap_or("");
             conditionally_require_authed_user(
                 Some(authed.clone()),
                 approval_conditions.clone(),
@@ -3361,6 +3368,12 @@ fn can_approve_step(
         Some(authed) => {
             if authed.is_admin {
                 return true;
+            }
+            // self_approval_disabled applies to owners too, so it gates the owner shortcut.
+            if let Some(ref ac) = approval_conditions {
+                if require_not_self_approval(authed, ac, trigger_email).is_err() {
+                    return false;
+                }
             }
             let is_owner = script_path
                 .map(|p| require_owner_of_path(authed, p).is_ok())
@@ -4095,6 +4108,27 @@ pub async fn get_suspended_job_flow(
     Ok(Json(SuspendedJobFlow { job: flow, approvers, view_token }).into_response())
 }
 
+/// The flow's triggerer may not approve their own suspended step when the step sets
+/// `self_approval_disabled`. Only admins are exempt: owning the runnable does not grant
+/// the right to approve your own run, so this must be enforced at every resume boundary
+/// independently of the owner shortcut (which only waives user_auth_required /
+/// user_groups_required).
+fn require_not_self_approval(
+    authed: &ApiAuthed,
+    approval_conditions: &ApprovalConditions,
+    trigger_email: &str,
+) -> error::Result<()> {
+    if approval_conditions.self_approval_disabled
+        && !authed.is_admin
+        && authed.email.eq(trigger_email)
+    {
+        return Err(Error::PermissionDenied(
+            "Self-approval is disabled for this flow step".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn conditionally_require_authed_user(
     _authed: Option<ApiAuthed>,
     approval_conditions_opt: Option<ApprovalConditions>,
@@ -4106,14 +4140,8 @@ fn conditionally_require_authed_user(
     let approval_conditions = approval_conditions_opt.unwrap();
 
     // Check self-approval independently of user_auth_required
-    if approval_conditions.self_approval_disabled {
-        if let Some(ref authed) = _authed {
-            if !authed.is_admin && authed.email.eq(_trigger_email) {
-                return Err(Error::PermissionDenied(
-                    "Self-approval is disabled for this flow step".to_string(),
-                ));
-            }
-        }
+    if let Some(ref authed) = _authed {
+        require_not_self_approval(authed, &approval_conditions, _trigger_email)?;
     }
 
     if approval_conditions.user_auth_required {

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -3192,17 +3192,9 @@ async fn resume_suspended(
     }
 
     // Check approval conditions
-    let approval_conditions = if is_wac {
-        flow.flow_status
-            .as_ref()
-            .and_then(|v| v.get("approval_conditions"))
-            .and_then(|v| serde_json::from_value::<ApprovalConditions>(v.clone()).ok())
-    } else {
-        flow.flow_status
-            .as_ref()
-            .and_then(|v| serde_json::from_value::<FlowStatus>(v.clone()).ok())
-            .and_then(|fs| fs.approval_conditions)
-    };
+    let approval_conditions = extract_approval_conditions(flow.flow_status.as_ref(), is_wac);
+
+    let trigger_email = flow.email.as_deref().unwrap_or("");
 
     if let Some(ref ac) = approval_conditions {
         if ac.user_auth_required && opt_authed.is_none() {
@@ -3214,10 +3206,9 @@ async fn resume_suspended(
 
     // If logged in, check authorization rules
     if let Some(ref authed) = opt_authed {
-        let trigger_email = flow.email.as_deref().unwrap_or("");
-
         // self_approval_disabled applies to owners too (only admins are exempt), so it is
-        // enforced before the owner shortcut below.
+        // enforced before the owner shortcut below. A token-only (anonymous) resume is treated as
+        // capability-based and intentionally not gated here; see resume_suspended_job.
         if let Some(ref ac) = approval_conditions {
             require_not_self_approval(authed, ac, trigger_email)?;
         }
@@ -3354,10 +3345,11 @@ struct ApprovalInfo {
 }
 
 /// Whether `opt_authed` is allowed to approve — and therefore view — this approval step.
-/// Mirrors the authorization performed at the resume boundary: workspace admins and owners
-/// of the runnable always qualify; otherwise the approval conditions (user_auth_required /
-/// user_groups_required / self_approval_disabled) decide. When the step does not require auth,
-/// an anonymous (token-only) caller qualifies.
+/// Mirrors the authorization performed at the resume boundary: workspace admins always qualify;
+/// self_approval_disabled then bars the triggerer even when they own the runnable; otherwise
+/// owners qualify and the remaining approval conditions (user_auth_required /
+/// user_groups_required) decide. When the step does not require auth, an anonymous (token-only)
+/// caller qualifies.
 fn can_approve_step(
     opt_authed: &Option<ApiAuthed>,
     approval_conditions: &Option<ApprovalConditions>,
@@ -3661,8 +3653,10 @@ async fn resume_suspended_job_internal(
     // Get flow info - works for step-level, flow-level, and WAC approval
     let (flow_info, is_flow_level, is_wac) = get_flow_info_for_resume(job_id, &db).await?;
 
-    // HMAC secret = full capability. Skip approval_conditions checks.
-    // Authorization rules are enforced by the new resume_suspended endpoint instead.
+    // HMAC secret = full capability. Skip approval_conditions checks: possession of the full
+    // resume URL is the authorization (it is only disclosed to intended approvers, e.g. when a
+    // step returns it). Identity-based rules, including self_approval_disabled, are enforced by
+    // the resume_suspended endpoint instead.
 
     let exists = sqlx::query_scalar!(
         r#"
@@ -4106,6 +4100,24 @@ pub async fn get_suspended_job_flow(
     let view_token = Some(format!("{flow_id}.{hmac}"));
 
     Ok(Json(SuspendedJobFlow { job: flow, approvers, view_token }).into_response())
+}
+
+/// Read the step's approval_conditions from the suspended flow status. For classic flows they
+/// live inside the deserialized `FlowStatus`; for workflow-as-code they are a top-level
+/// `approval_conditions` key in the status JSON.
+fn extract_approval_conditions(
+    flow_status: Option<&serde_json::Value>,
+    is_wac: bool,
+) -> Option<ApprovalConditions> {
+    if is_wac {
+        flow_status
+            .and_then(|v| v.get("approval_conditions"))
+            .and_then(|v| serde_json::from_value::<ApprovalConditions>(v.clone()).ok())
+    } else {
+        flow_status
+            .and_then(|v| serde_json::from_value::<FlowStatus>(v.clone()).ok())
+            .and_then(|fs| fs.approval_conditions)
+    }
 }
 
 /// The flow's triggerer may not approve their own suspended step when the step sets

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3398,10 +3398,16 @@ async fn push_next_flow_job(
             // Persist approval user groups conditions, if any. Requires runnning the InputTransform
             let required_events = suspend.required_events.unwrap() as u16;
             let user_auth_required = suspend.user_auth_required.unwrap_or(false);
-            if user_auth_required {
-                let self_approval_disabled = suspend.self_approval_disabled.unwrap_or(false);
+            let self_approval_disabled = suspend.self_approval_disabled.unwrap_or(false);
+            // self_approval_disabled must be persisted even without user_auth_required, otherwise
+            // the resume boundary sees no approval_conditions and the restriction is silently
+            // dropped. user_groups_required only applies together with user_auth_required.
+            if user_auth_required || self_approval_disabled {
                 let user_groups_required: Vec<String>;
-                if let Some(user_groups_required_as_input_transform) = suspend.user_groups_required
+                if !user_auth_required {
+                    user_groups_required = Vec::new();
+                } else if let Some(user_groups_required_as_input_transform) =
+                    suspend.user_groups_required
                 {
                     match user_groups_required_as_input_transform {
                         InputTransform::Static { value } => {


### PR DESCRIPTION
## Summary
Feedback reported that `self_approval_disabled` appears broken: an operator can click the "Resume" button in the run detail UI and the flow continues, even though they triggered the run.

The "Resume" button calls the `resume_suspended` endpoint (`POST /w/{w}/jobs_u/flow/resume_suspended/{job_id}`). Its authorization block short-circuits on `is_owner` (and `is_admin`) and **skips the approval-condition checks entirely**. So a user who owns the flow path (their personal `u/<user>/…` space, or a folder they own) — the same person who triggered the run — could self-approve despite `self_approval_disabled`. The dedicated owner endpoint (`resume_suspended_flow_as_owner`) already enforces the check for owners, so the two resume paths were inconsistent. Per the existing design, only **admins** are meant to bypass self-approval.

A second, latent gap: the worker only persisted `approval_conditions` (which carries `self_approval_disabled`) when `user_auth_required` was set. A raw-flow / CLI author who sets `self_approval_disabled` without `user_auth_required` had the restriction silently dropped at the resume boundary. (The flow-editor UI couples the two toggles, so this only affected non-UI authors.)

Fixes WIN-2223

## Changes
- Extract `require_not_self_approval` and enforce it **before** the owner shortcut in `resume_suspended` and in `can_approve_step` (so the standalone approval page also hides the button for a self-approving owner), matching `resume_suspended_flow_as_owner`. Admins remain exempt.
- Refactor `conditionally_require_authed_user` to reuse the same helper (single source of truth).
- Persist `approval_conditions` when `self_approval_disabled` is set even without `user_auth_required` (`worker_flow.rs`); `user_groups_required` still only applies together with `user_auth_required`.

## Test plan
- [x] `test_self_approval_disabled_blocks_ui_resume_for_owner` (new) — owner-triggerer resuming via the UI endpoint gets 403 when `self_approval_disabled=true` (this failed before the fix, returning 201).
- [x] `test_self_approval_disabled_blocks_owner_resume` — owner endpoint still blocks self-approval.
- [x] `test_self_approval_allowed_when_not_disabled` — self-approval allowed when the flag is off.
- [x] `test_different_user_can_approve_when_self_approval_disabled` — a different user can still approve.
- All 4 pass under `--features enterprise,deno_core,private,license`.

Pure backend change; no frontend code touched. The `user_auth_required` toggle is enterprise-gated and can't be exercised on the CE dev build, so validation is via the integration tests above rather than a browser walkthrough.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce `self_approval_disabled` on identity-based resume paths (UI “Resume” and approval page) so the triggerer can’t self-approve even if they own the flow; only admins can bypass. Fixes WIN-2223; the secret HMAC resume path stays capability-based and skips approval checks.

- **Bug Fixes**
  - Enforce `self_approval_disabled` before the owner shortcut in `resume_suspended` and `can_approve_step`, matching `resume_suspended_flow_as_owner`.
  - Keep `resume_suspended_job` (HMAC URL) and token-only resumes on `resume_suspended` capability-based; approval conditions are not applied there.
  - Persist `approval_conditions` when `self_approval_disabled` is set even without `user_auth_required`, so the restriction isn’t dropped at resume.

- **Refactors**
  - Extract `require_not_self_approval` for a single source of truth and reuse it in `conditionally_require_authed_user`.
  - Add `extract_approval_conditions` (handles WAC vs. classic) and reuse in `resume_suspended`.

<sup>Written for commit e45506560b8183ed26a1785cd831c21729f67561. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

