### PR TITLE
fix(python,windows): cross-platform cross-process wheel-install lock

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -16378,6 +16378,7 @@ dependencies = [
  "dotenv",
  "eventsource-stream",
  "flume",
+ "fs4",
  "futures",
  "gcp_auth",
  "git-version",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -588,6 +588,7 @@ rust_decimal = { version = "^1", features = ["db-postgres", "serde-float"]}
 jsonwebtoken = "8.3.0"
 pem = "3.0.1"
 nix = { version = "0.27.1", features = ["process", "signal"] }
+fs4 = "0.13"
 tinyvector = { git = "https://github.com/windmill-labs/tinyvector", rev = "20823b94c20f2b9093f318badd24026cf54dcc85" }
 hf-hub = "0.4.3"
 tokenizers = "0.14.1"

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -115,9 +115,11 @@ hmac.workspace = true
 pem = { workspace = true, optional = true }
 rsa = { workspace = true, optional = true }
 urlencoding.workspace = true
-# `fs` adds flock(2) for the cross-process Python install lock (shared cache mounts);
 # `user` adds geteuid(2) to verify ownership of the ansible socket-dir root
 nix = { workspace = true, features = ["fs", "user"] }
+# Cross-platform advisory file lock (flock on unix, LockFileEx on windows) for the
+# cross-process Python install lock into shared wheel-cache dirs.
+fs4 = { workspace = true }
 bytes.workspace = true
 reqwest.workspace = true
 reqwest-middleware.workspace = true

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -116,7 +116,7 @@ pem = { workspace = true, optional = true }
 rsa = { workspace = true, optional = true }
 urlencoding.workspace = true
 # `user` adds geteuid(2) to verify ownership of the ansible socket-dir root
-nix = { workspace = true, features = ["fs", "user"] }
+nix = { workspace = true, features = ["user"] }
 # Cross-platform advisory file lock (flock on unix, LockFileEx on windows) for the
 # cross-process Python install lock into shared wheel-cache dirs.
 fs4 = { workspace = true }

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -2832,11 +2832,12 @@ pub async fn handle_python_reqs(
             };
 
             // Cross-process advisory lock. Best-effort: if the filesystem doesn't
-            // support flock we log and proceed — verify_wheel_record + job retry
-            // still guard correctness, just without the dedup.
-            #[cfg(unix)]
+            // support locking we log and proceed — verify_wheel_record + job retry
+            // still guard correctness, just without the dedup. Cross-platform
+            // (flock on unix, LockFileEx on windows) so agents sharing a wheel-cache
+            // dir on a Windows host serialize just as they do on unix.
             let _venv_file_lock: Option<std::fs::File> = {
-                use std::os::unix::io::AsRawFd;
+                use fs4::fs_std::FileExt;
                 let lock_path = format!("{venv_p}.lock");
                 if let Some(parent) = std::path::Path::new(&lock_path).parent() {
                     let _ = std::fs::create_dir_all(parent);
@@ -2844,17 +2845,17 @@ pub async fn handle_python_reqs(
                 match std::fs::OpenOptions::new().create(true).write(true).open(&lock_path) {
                     Ok(f) => {
                         // Bounded wait: a holder that crashes releases the lock (the
-                        // kernel drops it on fd close), but a live-but-stuck holder
+                        // OS drops it on handle close), but a live-but-stuck holder
                         // (e.g. uv wedged on a hung mount) would otherwise block us
                         // forever. After the cap, proceed degraded rather than hang —
                         // verify_wheel_record + retry still guard correctness.
                         const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(300);
                         let waited_since = std::time::Instant::now();
                         loop {
-                            match nix::fcntl::flock(f.as_raw_fd(), nix::fcntl::FlockArg::LockExclusiveNonblock) {
-                                Ok(()) => break Some(f),
-                                // EWOULDBLOCK == EAGAIN on Linux: another holder has the lock.
-                                Err(nix::errno::Errno::EWOULDBLOCK) => {
+                            match f.try_lock_exclusive() {
+                                Ok(true) => break Some(f),
+                                // Another holder has the lock.
+                                Ok(false) => {
                                     if waited_since.elapsed() >= MAX_WAIT {
                                         tracing::warn!(
                                             workspace_id = %w_id,
@@ -2876,7 +2877,7 @@ pub async fn handle_python_reqs(
                                 Err(e) => {
                                     tracing::warn!(
                                         workspace_id = %w_id,
-                                        "could not flock {lock_path}, proceeding without cross-process install lock: {e}"
+                                        "could not lock {lock_path}, proceeding without cross-process install lock: {e}"
                                     );
                                     break Some(f);
                                 }
@@ -3782,14 +3783,14 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn test_venv_file_lock_excludes_across_descriptions() {
-        // The cross-process layer: flock on a sibling `.lock` excludes a second
-        // independent open file description (i.e. another worker process) while
-        // held, and frees it on close. Mirrors the loop in handle_python_reqs.
-        use nix::fcntl::{flock, FlockArg};
-        use std::os::unix::io::AsRawFd;
+        // The cross-process layer: an advisory lock on a sibling `.lock` excludes a
+        // second independent open file handle (i.e. another worker process) while
+        // held, and frees it on close. Mirrors the loop in handle_python_reqs and
+        // must hold on every platform (flock on unix, LockFileEx on windows) — a
+        // Windows host running several agents against one wheel cache relies on it.
+        use fs4::fs_std::FileExt;
 
         let dir = std::env::temp_dir().join("wm_venv_lock_test");
         std::fs::create_dir_all(&dir).unwrap();
@@ -3800,24 +3801,28 @@ mod tests {
             .write(true)
             .open(&lock_path)
             .unwrap();
-        flock(f1.as_raw_fd(), FlockArg::LockExclusiveNonblock).unwrap();
+        assert!(
+            f1.try_lock_exclusive().unwrap(),
+            "first holder must acquire the lock"
+        );
 
-        // A second descriptor (stand-in for another process) cannot take it.
+        // A second handle (stand-in for another process) cannot take it.
         let f2 = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
             .open(&lock_path)
             .unwrap();
-        assert_eq!(
-            flock(f2.as_raw_fd(), FlockArg::LockExclusiveNonblock),
-            Err(nix::errno::Errno::EWOULDBLOCK),
+        assert!(
+            !f2.try_lock_exclusive().unwrap(),
             "a second holder must be blocked while the lock is held"
         );
 
         // Releasing the first lets the second acquire it.
         drop(f1);
-        flock(f2.as_raw_fd(), FlockArg::LockExclusiveNonblock)
-            .expect("lock must be acquirable once the holder releases it");
+        assert!(
+            f2.try_lock_exclusive().unwrap(),
+            "lock must be acquirable once the holder releases it"
+        );
 
         drop(f2);
         let _ = std::fs::remove_file(&lock_path);


### PR DESCRIPTION
## Problem

Self-hosted workers running in **agent mode on Windows hosts** intermittently fail Python env installs when multiple jobs run concurrently on the same host. Errors seen in the field:

```
[!] cached wheel for pendulum==3.2.0 failed integrity check, reinstalling: no .dist-info directory in .../python_3_13/pendulum==3.2.0
Wheel RECORD verification failed after install of pendulum==3.2.0: read RECORD ... The system cannot find the file specified. (os error 2). Aborting to avoid publishing a corrupt cache entry.
error: Failed to install: pendulum-3.2.0-...whl
  Caused by: failed to rename file from ...\.tmpEQeyCg\__init__.py to ...\__init__.py: The system cannot find the file specified. (os error 2)
```

They correlate with several agents (e.g. 7 agents on one host) installing the **same package at the same time**.

## Root cause

Windmill serializes concurrent installs into a shared wheel-cache dir with two layers: an in-process `tokio::Mutex` per target dir, and a **cross-process advisory file lock** on a sibling `<venv>.lock` (added in #9787). Multiple agents on one host are **separate processes** sharing one per-user cache dir (`.../Temp/windmill/cache/python_<v>/`), so only the cross-process layer protects them.

That cross-process layer was gated `#[cfg(unix)]` and called `nix::fcntl::flock` directly — so **on Windows it did nothing**. Concurrent `uv pip install --target <shared dir>` runs then clobber each other's atomic renames, producing the `os error 2` / missing-`RECORD` / missing-`dist-info` failures above.

## Fix

Replace the unix-only `flock` with [`fs4`](https://crates.io/crates/fs4)'s cross-platform advisory lock (already in the dependency tree via tantivy):

- **Unix**: `fs4` calls `flock(2)` via `rustix` — behavior is identical to the code it replaces (whole-file advisory lock, released on handle close / process death, would-block → retry loop).
- **Windows**: `fs4` uses `LockFileEx(LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY)`, released by the OS on handle close / process crash — so co-located agents now serialize per-package installs into the shared cache instead of corrupting it.

The bounded 300s wait, kill-signal cancellation, and best-effort degraded fallback are all preserved. `verify_wheel_record` + job retry remain the correctness backstop.

## Testing

- `cargo check -p windmill-worker --features python,quickjs` — clean (only pre-existing warnings)
- `cargo test -p windmill-worker --features python,quickjs venv_` — 3/3 pass, including `test_venv_file_lock_excludes_across_descriptions`, which is now un-gated from `#[cfg(unix)]` and exercises the actual `fs4` path so it covers Windows semantics too.

## Note on config

No config change is required to benefit from this fix. As a separate operational mitigation, agents on the same host that use **distinct cache directories** would also avoid the contention entirely, but the intended design is a shared cache with correct locking, which this restores on Windows.

Fixes WIN-2225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Python wheel-cache corruption on Windows by adding a cross-process, cross-platform install lock. Concurrent agents now serialize installs into the shared cache instead of clobbering files (fixes WIN-2225).

- **Bug Fixes**
  - Replace unix-only `flock` with `fs4` advisory file lock (flock on Unix, `LockFileEx` on Windows).
  - Preserve 300s bounded wait and degraded fallback; Unix behavior unchanged.
  - Un-gate the lock test to run on all platforms, covering Windows semantics.

- **Dependencies**
  - Add `fs4@0.13` to the workspace and `windmill-worker`.
  - Drop the `nix` `fs` feature from `windmill-worker` (now using `fs4` for locking).

<sup>Written for commit efbd32e30369c621907880c962c41b8786a4645b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

