### PR TITLE
fix(embeddings): retry on failed init instead of disabling for a day

### DIFF
--- a/backend/windmill-api-embeddings/src/lib.rs
+++ b/backend/windmill-api-embeddings/src/lib.rs
@@ -607,6 +607,10 @@ pub fn load_embeddings_db(db: &Pool<Postgres>) -> () {
         tokio::spawn(async move {
             // Keep retrying model init: a transient failure here must not
             // permanently disable embeddings until the next process restart.
+            // Backoff decays to the pulling interval so an environment where it
+            // can never succeed (e.g. air-gapped, embeddings left enabled)
+            // settles into ~1 attempt/interval rather than a tight error loop.
+            let mut backoff_secs = *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS;
             loop {
                 match ModelInstance::new().await {
                     Ok(model_instance) => {
@@ -618,21 +622,26 @@ pub fn load_embeddings_db(db: &Pool<Postgres>) -> () {
                         tracing::error!(
                             "Failed to initialize model instance: {}. Retrying in {}s...",
                             e,
-                            *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS
+                            backoff_secs
                         );
-                        tokio::time::sleep(std::time::Duration::from_secs(
-                            *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS,
-                        ))
-                        .await;
+                        tokio::time::sleep(std::time::Duration::from_secs(backoff_secs)).await;
+                        backoff_secs = backoff_secs
+                            .saturating_mul(2)
+                            .min(*HUB_EMBEDDINGS_PULLING_INTERVAL_SECS);
                     }
                 }
             }
+            let mut backoff_secs = *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS;
             loop {
-                let succeeded = update_embeddings_db(&db_clone).await;
-                let sleep_secs = if succeeded {
+                let sleep_secs = if update_embeddings_db(&db_clone).await {
+                    backoff_secs = *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS;
                     *HUB_EMBEDDINGS_PULLING_INTERVAL_SECS
                 } else {
-                    *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS
+                    let secs = backoff_secs;
+                    backoff_secs = backoff_secs
+                        .saturating_mul(2)
+                        .min(*HUB_EMBEDDINGS_PULLING_INTERVAL_SECS);
+                    secs
                 };
                 tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
             }

--- a/backend/windmill-api-embeddings/src/lib.rs
+++ b/backend/windmill-api-embeddings/src/lib.rs
@@ -56,6 +56,10 @@ lazy_static::lazy_static! {
     pub static ref EMBEDDINGS_DB: Arc<RwLock<Option<EmbeddingsDb>>> = Arc::new(RwLock::new(None));
     pub static ref MODEL_INSTANCE: Arc<RwLock<Option<Arc<ModelInstance>>>> = Arc::new(RwLock::new(None));
     pub static ref HUB_EMBEDDINGS_PULLING_INTERVAL_SECS: u64 = std::env::var("HUB_EMBEDDINGS_PULLING_INTERVAL_SECS").ok().map(|x| x.parse::<u64>().ok()).flatten().unwrap_or(3600 * 24);
+    // On a failed init/refresh we retry after this short interval instead of the
+    // full pulling interval, so a transient startup error doesn't leave the
+    // embeddings DB uninitialized for a whole day.
+    pub static ref HUB_EMBEDDINGS_RETRY_INTERVAL_SECS: u64 = std::env::var("HUB_EMBEDDINGS_RETRY_INTERVAL_SECS").ok().map(|x| x.parse::<u64>().ok()).flatten().unwrap_or(60);
 }
 
 #[cfg(feature = "embedding")]
@@ -601,42 +605,58 @@ pub fn load_embeddings_db(db: &Pool<Postgres>) -> () {
     if !disable_embedding {
         let db_clone = db.clone();
         tokio::spawn(async move {
-            let model_instance = ModelInstance::new().await;
-            if let Ok(model_instance) = model_instance {
-                let mut model_instance_lock = MODEL_INSTANCE.write().await;
-                *model_instance_lock = Some(Arc::new(model_instance));
-                drop(model_instance_lock);
-                loop {
-                    update_embeddings_db(&db_clone).await;
-                    tokio::time::sleep(std::time::Duration::from_secs(
-                        *HUB_EMBEDDINGS_PULLING_INTERVAL_SECS,
-                    ))
-                    .await;
+            // Keep retrying model init: a transient failure here must not
+            // permanently disable embeddings until the next process restart.
+            loop {
+                match ModelInstance::new().await {
+                    Ok(model_instance) => {
+                        let mut model_instance_lock = MODEL_INSTANCE.write().await;
+                        *model_instance_lock = Some(Arc::new(model_instance));
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to initialize model instance: {}. Retrying in {}s...",
+                            e,
+                            *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(
+                            *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS,
+                        ))
+                        .await;
+                    }
                 }
-            } else {
-                tracing::error!(
-                    "Failed to initialize model instance: {}",
-                    model_instance.err().unwrap()
-                );
+            }
+            loop {
+                let succeeded = update_embeddings_db(&db_clone).await;
+                let sleep_secs = if succeeded {
+                    *HUB_EMBEDDINGS_PULLING_INTERVAL_SECS
+                } else {
+                    *HUB_EMBEDDINGS_RETRY_INTERVAL_SECS
+                };
+                tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
             }
         });
     }
 }
 
 #[cfg(feature = "embedding")]
-pub async fn update_embeddings_db(db: &Pool<Postgres>) -> () {
+pub async fn update_embeddings_db(db: &Pool<Postgres>) -> bool {
     if let Some(model_instance) = MODEL_INSTANCE.read().await.as_ref() {
         tracing::info!("Creating embeddings DB...");
         let new_embeddings_db = EmbeddingsDb::new(&db, model_instance.clone()).await;
         if let Err(e) = new_embeddings_db.as_ref() {
             tracing::error!("Failed to create embeddings db: {}", e);
+            false
         } else {
             let mut embeddings_db = EMBEDDINGS_DB.write().await;
             *embeddings_db = new_embeddings_db.ok();
             tracing::info!("Created embeddings DB");
+            true
         }
     } else {
         tracing::error!("Could not update embeddings DB, model instance not initialized");
+        false
     }
 }
 


### PR DESCRIPTION
## Summary
On app.windmill.dev the server continuously returned `Internal: Embeddings db not initialized` for `/query_hub_scripts` and `/query_resource_types`. The embeddings init task treated failure and success identically, so a single transient error at startup left the embeddings DB uninitialized indefinitely (or for a full day).

Two failure modes, both fixed here:

- **Model init gave up permanently.** If `ModelInstance::new()` failed (a transient HuggingFace/network error surviving its own 5 download retries), the spawned task exited for good — embeddings never came up until the next process restart.
- **Refresh loop backed off 24h on failure.** If `update_embeddings_db` (hub fetch + `fill_db`) failed, the loop still slept the full `HUB_EMBEDDINGS_PULLING_INTERVAL_SECS` (default 24h) before retrying, so a transient startup failure kept the DB down for a whole day.

## Changes
- Wrap model-instance initialization in a retry loop so a transient failure no longer permanently disables embeddings.
- `update_embeddings_db` now returns a `bool`; the refresh loop retries after `HUB_EMBEDDINGS_RETRY_INTERVAL_SECS` (new, default 60s, env-configurable) on failure instead of the full pulling interval, and only sleeps the full interval after a successful refresh.

## Test plan
- [x] `cargo check -p windmill-api-embeddings --features embedding`
- [x] `cargo check -p windmill --features embedding` (verifies the `monitor.rs` caller tolerates the new `bool` return)
- [ ] On startup with a transient hub/HF failure, confirm the DB retries within ~60s (logs: `Retrying in 60s...`) instead of staying uninitialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes embeddings init and refresh so transient errors recover quickly and the DB doesn’t stay uninitialized; adds exponential backoff so offline setups don’t spin. Keeps `/query_hub_scripts` and `/query_resource_types` working reliably.

- **Bug Fixes**
  - Add exponential backoff retry for `ModelInstance::new()` starting at `HUB_EMBEDDINGS_RETRY_INTERVAL_SECS` (default 60s), capped at `HUB_EMBEDDINGS_PULLING_INTERVAL_SECS`; backoff resets on success.
  - Make `update_embeddings_db` return `bool` and apply the same backoff in the refresh loop; sleep the full pulling interval only after a successful refresh, otherwise back off instead of waiting 24h.

<sup>Written for commit 0e9fc4ab25173cd4e4a43620aa24678537333ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

