### PR TITLE
fix: manual resource type sync fetches from hub first, cache as fallback

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -1989,10 +1989,10 @@ async fn sync_cached_resource_types(
     // on-disk cache is only a fallback for when the hub is unreachable (airgapped
     // installs / network error); refreshing it is left to the daily cache-rt cron and
     // the startup sync in main.rs, which own the offline path.
-    let resource_types = match fetch_resource_types_from_hub().await {
+    let (resource_types, from_hub) = match fetch_resource_types_from_hub().await {
         Ok(types) => {
             tracing::info!("Fetched {} resource types live from the hub", types.len());
-            types
+            (types, true)
         }
         Err(hub_err) => {
             tracing::warn!(
@@ -2000,28 +2000,19 @@ async fn sync_cached_resource_types(
             );
             match tokio::fs::read_to_string(&cache_path).await {
                 Ok(content) => {
-                    serde_json::from_str::<Vec<CachedResourceType>>(&content).map_err(|e| {
-                        error::Error::InternalErr(format!(
-                            "Failed to parse cached resource types: {}",
-                            e
-                        ))
-                    })?
+                    let parsed = serde_json::from_str::<Vec<CachedResourceType>>(&content)
+                        .map_err(|e| {
+                            error::Error::InternalErr(format!(
+                                "Failed to parse cached resource types: {}",
+                                e
+                            ))
+                        })?;
+                    (parsed, false)
                 }
                 Err(_) => return Err(hub_err),
             }
         }
     };
-
-    // Targeted refresh: if a specific type was requested and the hub does not know it,
-    // surface an explicit not-found instead of a silent "Synced 0".
-    if let Some(name) = name.as_deref() {
-        if !resource_types.iter().any(|rt| rt.name == name) {
-            return Err(error::Error::NotFound(format!(
-                "resource type '{}' not found on the hub",
-                name
-            )));
-        }
-    }
 
     let mut synced_count = 0;
 
@@ -2052,6 +2043,23 @@ async fn sync_cached_resource_types(
         .await?;
 
         synced_count += 1;
+    }
+
+    // If a specific type was requested and is still absent after syncing, surface an
+    // explicit not-found instead of a silent "Synced 0". Word it by source so the
+    // cache-fallback path does not claim it checked the hub.
+    if let Some(name) = name.as_deref() {
+        if !resource_types.iter().any(|rt| rt.name == name) {
+            let source = if from_hub {
+                "on the hub"
+            } else {
+                "in the cached resource types (hub unreachable)"
+            };
+            return Err(error::Error::NotFound(format!(
+                "resource type '{}' not found {}",
+                name, source
+            )));
+        }
     }
 
     Ok(format!(

--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -32,11 +32,9 @@ use windmill_common::DB;
 use ee_oss::validate_license_key;
 use windmill_common::usernames::generate_instance_username_for_all_users;
 
-#[cfg(feature = "enterprise")]
-use axum::extract::Query;
 use axum::{
     body::Body,
-    extract::{Extension, Path},
+    extract::{Extension, Path, Query},
     response::Response,
     routing::{get, post},
     Json, Router,
@@ -1972,25 +1970,62 @@ async fn fetch_resource_types_from_hub() -> error::Result<Vec<CachedResourceType
         .collect())
 }
 
+#[derive(serde::Deserialize)]
+struct SyncResourceTypesQuery {
+    name: Option<String>,
+}
+
 async fn sync_cached_resource_types(
     Extension(db): Extension<DB>,
     authed: ApiAuthed,
+    Query(SyncResourceTypesQuery { name }): Query<SyncResourceTypesQuery>,
 ) -> error::Result<String> {
     require_super_admin(&db, &authed.email).await?;
 
     use windmill_common::worker::HUB_RT_CACHE_DIR;
     let cache_path = format!("{}/resource_types.json", *HUB_RT_CACHE_DIR);
 
-    let cached_types = match tokio::fs::read_to_string(&cache_path).await {
-        Ok(content) => serde_json::from_str::<Vec<CachedResourceType>>(&content).map_err(|e| {
-            error::Error::InternalErr(format!("Failed to parse cached resource types: {}", e))
-        })?,
-        Err(_) => fetch_resource_types_from_hub().await?,
+    // Manual sync is hub-first so it lands newly-published hub types on demand. The
+    // on-disk cache is only a fallback for when the hub is unreachable (airgapped
+    // installs / network error); refreshing it is left to the daily cache-rt cron and
+    // the startup sync in main.rs, which own the offline path.
+    let resource_types = match fetch_resource_types_from_hub().await {
+        Ok(types) => {
+            tracing::info!("Fetched {} resource types live from the hub", types.len());
+            types
+        }
+        Err(hub_err) => {
+            tracing::warn!(
+                "Live hub fetch failed ({hub_err}), falling back to on-disk cache at {cache_path}"
+            );
+            match tokio::fs::read_to_string(&cache_path).await {
+                Ok(content) => {
+                    serde_json::from_str::<Vec<CachedResourceType>>(&content).map_err(|e| {
+                        error::Error::InternalErr(format!(
+                            "Failed to parse cached resource types: {}",
+                            e
+                        ))
+                    })?
+                }
+                Err(_) => return Err(hub_err),
+            }
+        }
     };
+
+    // Targeted refresh: if a specific type was requested and the hub does not know it,
+    // surface an explicit not-found instead of a silent "Synced 0".
+    if let Some(name) = name.as_deref() {
+        if !resource_types.iter().any(|rt| rt.name == name) {
+            return Err(error::Error::NotFound(format!(
+                "resource type '{}' not found on the hub",
+                name
+            )));
+        }
+    }
 
     let mut synced_count = 0;
 
-    for rt in &cached_types {
+    for rt in &resource_types {
         let exists: Option<bool> = sqlx::query_scalar!(
             "SELECT EXISTS(SELECT 1 FROM resource_type WHERE workspace_id = 'admins' AND name = $1 AND schema IS NOT DISTINCT FROM $2 AND description IS NOT DISTINCT FROM $3)",
             &rt.name,
@@ -2022,7 +2057,7 @@ async fn sync_cached_resource_types(
     Ok(format!(
         "Synced {} resource types ({} unchanged)",
         synced_count,
-        cached_types.len() - synced_count
+        resource_types.len() - synced_count
     ))
 }
 

--- a/frontend/src/lib/components/ApiConnectForm.svelte
+++ b/frontend/src/lib/components/ApiConnectForm.svelte
@@ -231,7 +231,7 @@
 		>No corresponding resource type found in your workspace for {resourceType}. Define the value in
 		JSON directly</p
 	>
-	<SyncResourceTypes {onSynced} />
+	<SyncResourceTypes {resourceType} {onSynced} />
 {/if}
 {#if notFound || viewJsonSchema}
 	{#if !emptyString(error)}<span class="text-red-400 text-xs mb-1 flex flex-row-reverse"

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -1075,7 +1075,7 @@
 					<p class="text-red-500 dark:text-red-400 text-xs">
 						Resource type '{resourceType}' not found in your workspace
 					</p>
-					<SyncResourceTypes onSynced={getResourceTypeInfo} />
+					<SyncResourceTypes {resourceType} onSynced={getResourceTypeInfo} />
 				</div>
 			{/if}
 			{#if registryCcCapable()}

--- a/frontend/src/lib/components/ResourceForm.svelte
+++ b/frontend/src/lib/components/ResourceForm.svelte
@@ -296,7 +296,7 @@
 					<p class="text-red-500 dark:text-red-400 text-xs">
 						Resource type '{resource_type}' not found in your workspace
 					</p>
-					<SyncResourceTypes onSynced={() => onLoadResourceType?.()} />
+					<SyncResourceTypes resourceType={resource_type} onSynced={() => onLoadResourceType?.()} />
 					<p class="italic text-secondary text-xs"> Define the value in JSON directly </p>
 				</div>
 			{/if}

--- a/frontend/src/lib/components/SyncResourceTypes.svelte
+++ b/frontend/src/lib/components/SyncResourceTypes.svelte
@@ -6,13 +6,19 @@
 
 	interface Props {
 		onSynced?: () => void
+		// When set, the endpoint returns an explicit not-found error if the hub does
+		// not know this type (the sync itself still refreshes the whole list).
+		resourceType?: string
 	}
 
-	let { onSynced = undefined }: Props = $props()
+	let { onSynced = undefined, resourceType = undefined }: Props = $props()
 
 	let hubRtSync = usePromise(
 		async () => {
-			const res = await fetch('/api/settings/sync_cached_resource_types', { method: 'POST' })
+			const url = resourceType
+				? `/api/settings/sync_cached_resource_types?name=${encodeURIComponent(resourceType)}`
+				: '/api/settings/sync_cached_resource_types'
+			const res = await fetch(url, { method: 'POST' })
 			if (!res.ok) {
 				const body = await res.text()
 				throw new Error(body || res.statusText)


### PR DESCRIPTION
## Summary

The superadmin **"Synchronize resource types"** button
(`POST /api/settings/sync_cached_resource_types`) was **cache-first**: it read the
on-disk `hub_rt/resource_types.json` cache and only hit the hub when *no* cache file
existed. That cache is refreshed by an external daily `cache-rt` cron, so a
brand-new hub type (e.g. `amqp`, added this week) could not be pulled on demand,
clicking sync replayed the stale cache, returned `Synced 0 resource types
(266 unchanged)`, and the type never landed in the `admins` workspace. The UI then
kept showing *"Resource type 'amqp' not found in your workspace"* even after the
superadmin clicked sync. Deleting the cache file was the only workaround.

This makes the **manual** endpoint **hub-first with the cache as a genuine fallback**,
and lets the frontend request a specific type by name so the not-found call-to-action
becomes deterministic.

## Changes

- **Hub-first manual sync** (`windmill-api-settings`): the handler now fetches the live
  list from the hub and upserts it into `admins`. It falls back to reading the on-disk
  cache **only** when the live hub fetch fails (airgapped install / network error),
  logging which path it took.
- **Targeted by-name refresh**: the endpoint accepts an optional `?name=<type>` query
  param. When a specific type is requested and is still absent from the hub after syncing,
  it returns an explicit `404 resource type '<name>' not found on the hub` instead of a
  silent `Synced 0`. The no-name (global) call works exactly as before.
- **Frontend**: `SyncResourceTypes.svelte` gains an optional `resourceType` prop and
  appends `?name=` when set. The three not-found sites (`ResourceForm`, `AppConnectInner`,
  `ApiConnectForm`) pass the specific type in scope; the global instance-settings button
  and the browse-all connect step stay name-less.

## Left unchanged (intentional)

The **startup / offline** path is still cache-based: `cache_hub_resource_types()`
(the `cache-rt` CLI subcommand that *writes* the cache), `sync_cached_resource_types(db)`,
and its `SYNC_CACHED_RT` gate in `backend/src/main.rs`. Airgapped installs and the daily
cron rely on the cache, so only the manual HTTP endpoint changed. **The manual endpoint
does not write the cache** — refreshing it stays owned by the cron / startup path, which
avoids adding a non-atomic write (and a partial-response overwrite) to the offline
fallback. The startup sync is upsert-only, so a manually-synced type is never lost to a
stale cache on restart. The endpoint stays `require_super_admin`-gated.

## Screenshots

Reproduced with a **stale cache present** (266 types, `amqp` excluded) and `amqp` removed
from `admins`. Opening an `amqp` resource shows the not-found branch; clicking sync issues
`POST …/sync_cached_resource_types?name=amqp`, the endpoint fetches live from the hub, and
the form resolves to the full `amqp` schema. Verified the on-disk cache file is left
byte-for-byte unchanged by the manual sync.

Not-found branch with the by-type sync button:

![rt-notfound-sync](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-manual-rt-sync-hub-first/1784756753-rt-notfound-sync.png)

Resolved form after the hub-first sync landed `amqp`:

![rt-resolved-amqp](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-manual-rt-sync-hub-first/1784756756-rt-resolved-amqp.png)

## Test plan

- [x] `cargo check -p windmill-api-settings` (default features) passes
- [x] `npm run check:fast` clean for the touched files; svelte autofixer clean
- [x] Stale cache present + `amqp` missing → endpoint now syncs `amqp` (was `Synced 0`), and the on-disk cache file is left untouched (md5 identical before/after)
- [x] `?name=amqp` (present) → `200`; `?name=<bogus>` → `404 resource type '<bogus>' not found on the hub`
- [x] UI: not-found sync button posts `?name=amqp`, form resolves to the amqp schema; global button still posts name-less