### PR TITLE
feat(ai): improve data-pipeline building in AI sessions (prompt + evals + e2e)

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1484,9 +1484,15 @@
       - deploy_workspace_item
       - delete_workspace_item
   judgeChecklist:
+    # A pipeline node is DECLARATIVE: triggers are declared by `-- on <ref>`
+    # annotations (the trigger row is created separately) and a `-- materialize`
+    # output is a MANAGED write where the body is a bare SELECT that the runtime
+    # wraps in the create/replace. Do not expect a separate trigger config or a
+    # hand-written CREATE TABLE / INSERT — those would be wrong for a materialize node.
     - builds a data pipeline node as a script (not a flow)
     - marks the script as a pipeline member with the pipeline annotation in the script's comment syntax (`-- pipeline` for a DuckDB/SQL node, not `// pipeline`)
-    - declares a schedule trigger and writes its output to a managed DuckLake table
+    - declares the schedule trigger with the `-- on schedule` annotation comment (this annotation is the correct and complete way a pipeline node binds a schedule; no separate trigger configuration is expected)
+    - declares the managed DuckLake output with `-- materialize ducklake://<table>` and writes the body as a bare SELECT (materialize is a managed write, so the node correctly does NOT hand-write its own CREATE TABLE / INSERT)
     - leaves the result as an AI draft and does not deploy or save it
 
 - id: global-test-pipeline-two-node-chain
@@ -1500,6 +1506,12 @@
     maxTurns: 14
   validate:
     draftCountAtLeast: 2
+    requiredDrafts:
+      - type: script
+        pathStartsWith: f/evals/global/
+        valueIncludes:
+          - pipeline
+          - ducklake
     forbiddenDrafts:
       - type: flow
         pathStartsWith: f/evals/global/
@@ -1511,11 +1523,64 @@
       - deploy_workspace_item
       - delete_workspace_item
   judgeChecklist:
+    # Pipeline nodes are declarative: `-- on <ref>` binds inputs/triggers and
+    # `-- materialize ducklake://<table>` is a managed write whose body is a bare
+    # SELECT. Do not expect hand-written CREATE TABLE / INSERT on a materialize node.
     - creates two data pipeline nodes as scripts (not a flow) in f/evals/global
     - both scripts carry the pipeline annotation in their comment syntax (`-- pipeline` for DuckDB/SQL nodes, not `// pipeline`)
-    - the first ingests orders into a DuckLake table
-    - the second reads that same table and writes a daily rollup, wired to the first step's output asset
+    - the first ingests orders into a DuckLake table (a `-- materialize ducklake://<table>` output with a bare SELECT body is correct; no hand-written CREATE TABLE / INSERT is expected)
+    - the second reads that same table via `-- on ducklake://<that-table>` and materializes a daily rollup table, wiring it to the first step's output asset
     - leaves both as AI drafts without deploying
+
+- id: global-test-pipeline-complex-incremental
+  prompt: |-
+    Build a data pipeline in the `f/evals/global` folder for our web shop's
+    orders. It has three steps:
+    1. On a schedule, ingest the raw order CSVs under `s3://raw/orders/` into a
+       managed DuckLake table.
+    2. An incremental daily rollup: read that raw orders table and, on each run,
+       append just the current day's order count and total revenue into a second
+       DuckLake table. It should process one day at a time, not rebuild the whole
+       table every run.
+    3. A final step that reads the daily rollup table and exports the latest data
+       as a Parquet file to `s3://reports/` for the BI team.
+    Wire each step to the previous step's output so they form one pipeline. Keep
+    everything as AI drafts — don't deploy or save.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json
+  runtime:
+    maxTurns: 18
+  validate:
+    draftCountAtLeast: 3
+    requiredDrafts:
+      - type: script
+        pathStartsWith: f/evals/global/
+        valueIncludes:
+          - pipeline
+          - ducklake
+    forbiddenDrafts:
+      - type: flow
+        pathStartsWith: f/evals/global/
+  toolExpect:
+    requiredToolsUsed:
+      - write_script
+    forbiddenToolsUsed:
+      - write_flow
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    # Pipeline nodes are declarative: `-- on <ref>` binds inputs/triggers, and a
+    # DuckLake `-- materialize` output is a managed write whose body is a bare SELECT
+    # (the runtime performs the create/replace/append/merge). Do not expect a
+    # separate trigger config or hand-written CREATE TABLE / INSERT on a
+    # materialize node. S3/Parquet output is NOT materialize: the body writes it.
+    - builds the pipeline as three independent scripts (not a flow) in f/evals/global
+    - every node carries the pipeline annotation in its own comment syntax (`-- pipeline` for DuckDB/SQL nodes, not `// pipeline`)
+    - step 1 binds a schedule with `-- on schedule` and declares a managed DuckLake output with `-- materialize ducklake://<table>` and a bare SELECT body (no separate trigger config or hand-written CREATE TABLE is expected)
+    - "step 2 is incremental: each run appends only that day's rows to a second DuckLake table (`-- materialize ducklake://<table> append`) rather than rebuilding the whole table every run. Selecting the day via the `-- partitioned daily` + `{partition}` / `wm_partition(...)` idiom is the idiomatic form, but an equivalent current-day filter also satisfies this; a full-refresh/replace of the whole table does not"
+    - step 2 reads the same DuckLake table step 1 writes (via `-- on ducklake://<that-table>`), wiring it to step 1's output asset
+    - step 3 reads the daily rollup table and exports it as a Parquet file to S3
+    - does not misuse `-- materialize` for the S3 Parquet export (materialize is DuckLake-only; the S3 output is written by the script body, e.g. a DuckDB COPY or an SDK write)
+    - leaves all three nodes as AI drafts without deploying or saving
 
 - id: global-path5-create-folder-then-draft
   prompt: |-

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1576,7 +1576,7 @@
     - builds the pipeline as three independent scripts (not a flow) in f/evals/global
     - every node carries the pipeline annotation in its own comment syntax (`-- pipeline` for DuckDB/SQL nodes, not `// pipeline`)
     - step 1 binds a schedule with `-- on schedule` and declares a managed DuckLake output with `-- materialize ducklake://<table>` and a bare SELECT body (no separate trigger config or hand-written CREATE TABLE is expected)
-    - "step 2 is incremental: each run appends only that day's rows to a second DuckLake table (`-- materialize ducklake://<table> append`) rather than rebuilding the whole table every run. Selecting the day via the `-- partitioned daily` + `{partition}` / `wm_partition(...)` idiom is the idiomatic form, but an equivalent current-day filter also satisfies this; a full-refresh/replace of the whole table does not"
+    - "step 2 is incremental: each run adds only that day's rows to a second DuckLake table rather than rebuilding the whole table every run (e.g. an `append` or `key=<col>` merge materialize mode, not a full replace). Selecting the day via the `-- partitioned daily` + `{partition}` / `wm_partition(...)` idiom is the idiomatic form, but an equivalent current-day filter also satisfies this; a full-refresh/replace of the whole table does not"
     - step 2 reads the same DuckLake table step 1 writes (via `-- on ducklake://<that-table>`), wiring it to step 1's output asset
     - step 3 reads the daily rollup table and exports it as a Parquet file to S3
     - does not misuse `-- materialize` for the S3 Parquet export (materialize is DuckLake-only; the S3 output is written by the script body, e.g. a DuckDB COPY or an SDK write)

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -26,6 +26,18 @@ async function seedScript(page: Page, path: string, content: string, summary: st
 }
 
 test.describe('Pipeline editor', () => {
+	// Track what the test seeds so afterAll can remove it (keeps the shared dev/CI
+	// instance from accumulating a folder + scripts per run).
+	let seeded: { folder: string; scripts: string[] } | undefined
+
+	test.afterAll(async ({ request }) => {
+		if (!seeded) return
+		for (const path of seeded.scripts) {
+			await request.post(`/api/w/${WORKSPACE}/scripts/delete/p/${path}`).catch(() => {})
+		}
+		await request.delete(`/api/w/${WORKSPACE}/folders/delete/${seeded.folder}`).catch(() => {})
+	})
+
 	test('derives the DAG from annotated pipeline scripts', async ({ page }, testInfo) => {
 		const suffix = uniqueSuffix(testInfo.project.name)
 		const folder = `pipeline_e2e_${suffix}`
@@ -33,6 +45,7 @@ test.describe('Pipeline editor', () => {
 		const daily = `f/${folder}/orders_daily`
 		const ordersTbl = `main/orders_${suffix}`
 		const dailyTbl = `main/orders_daily_${suffix}`
+		seeded = { folder, scripts: [ingest, daily] }
 
 		// Folder may already exist from a prior run; only fail on the seeds.
 		await page.request.post(`/api/w/${WORKSPACE}/folders/create`, { data: { name: folder } })
@@ -73,6 +86,10 @@ test.describe('Pipeline editor', () => {
 
 		// The lineage edges are derived purely from the annotations: the CSV read,
 		// the two materialize outputs, and the downstream `-- on <ducklake>` input.
+		// Two of these resolve asynchronously after the initial graph fetch (the
+		// s3 read is detected from the SQL body at deploy time; the missing-schedule
+		// edge is synthesized client-side by the page's per-script annotation sweep),
+		// so a cold-CI failure here points at that async timing, not a missing edge.
 		const edges = [
 			`Edge from asset:s3object:raw/orders/*.csv to script:${ingest}`,
 			`Edge from script:${ingest} to asset:ducklake:${ordersTbl}`,

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -75,27 +75,23 @@ test.describe('Pipeline editor', () => {
 
 		await page.goto(`/pipeline/${folder}`)
 
-		// Header summary: two scripts render as pipeline members.
 		await expect(page.getByRole('heading', { name: 'Pipeline', level: 1 })).toBeVisible()
 		await expect(page.getByText('2 scripts', { exact: false })).toBeVisible()
 
-		// Both script nodes render (the node label may truncate a long path, so match
-		// the leaf name; the full paths are asserted on the edge labels below).
+		// A long path truncates in the node label, so match the leaf name; the full
+		// paths are asserted on the edge labels below.
 		await expect(page.getByText('orders_ingest').first()).toBeVisible()
 		await expect(page.getByText('orders_daily').first()).toBeVisible()
 
-		// The lineage edges are derived purely from the annotations: the CSV read,
-		// the two materialize outputs, and the downstream `-- on <ducklake>` input.
-		// Two of these resolve asynchronously after the initial graph fetch (the
-		// s3 read is detected from the SQL body at deploy time; the missing-schedule
-		// edge is synthesized client-side by the page's per-script annotation sweep),
-		// so a cold-CI failure here points at that async timing, not a missing edge.
+		// Two edges resolve asynchronously after the initial graph fetch (the s3 read
+		// is detected from the SQL body at deploy time; the missing-schedule edge is
+		// synthesized client-side by the page's per-script annotation sweep), so a
+		// cold-CI failure here points at that async timing, not a missing edge.
 		const edges = [
 			`Edge from asset:s3object:raw/orders/*.csv to script:${ingest}`,
 			`Edge from script:${ingest} to asset:ducklake:${ordersTbl}`,
 			`Edge from asset:ducklake:${ordersTbl} to script:${daily}`,
 			`Edge from script:${daily} to asset:ducklake:${dailyTbl}`,
-			// `-- on schedule` with no schedule trigger row still wires a missing-trigger edge.
 			`Edge from trigger:schedule:missing:${ingest} to script:${ingest}`
 		]
 		for (const name of edges) {

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, Page } from '@playwright/test'
+
+// The pipeline surface an AI session builds into: session pipeline tools emit
+// annotated scripts (`-- pipeline`, `-- on <asset>`, `-- materialize <asset>`),
+// and the /pipeline/<folder> editor derives the lineage DAG from those
+// annotations alone. This test seeds the scripts an AI-built DuckLake pipeline
+// would produce and asserts the editor renders every derived node, asset, and
+// edge (including the missing-schedule-trigger edge): a deterministic check of
+// the graph the AI session relies on, without a live model in the loop.
+
+const WORKSPACE = 'admins'
+
+declare const process: any
+
+function uniqueSuffix(project: string): string {
+	// Per-project suffix so the three browser projects don't collide on the
+	// shared dev instance when Playwright runs them in parallel.
+	return `${process.env.TEST_UNIQUE_ID ?? 'local'}_${project}`
+}
+
+async function seedScript(page: Page, path: string, content: string, summary: string) {
+	const res = await page.request.post(`/api/w/${WORKSPACE}/scripts/create`, {
+		data: { path, summary, description: '', content, language: 'duckdb', schema: {} }
+	})
+	expect(res.ok(), `seed ${path}: ${res.status()} ${await res.text()}`).toBeTruthy()
+}
+
+test.describe('Pipeline editor', () => {
+	test('derives the DAG from annotated pipeline scripts', async ({ page }, testInfo) => {
+		const suffix = uniqueSuffix(testInfo.project.name)
+		const folder = `pipeline_e2e_${suffix}`
+		const ingest = `f/${folder}/orders_ingest`
+		const daily = `f/${folder}/orders_daily`
+		const ordersTbl = `main/orders_${suffix}`
+		const dailyTbl = `main/orders_daily_${suffix}`
+
+		// Folder may already exist from a prior run; only fail on the seeds.
+		await page.request.post(`/api/w/${WORKSPACE}/folders/create`, { data: { name: folder } })
+
+		await seedScript(
+			page,
+			ingest,
+			[
+				'-- pipeline',
+				'-- on schedule',
+				`-- materialize ducklake://${ordersTbl}`,
+				"SELECT * FROM read_csv('s3://raw/orders/*.csv')"
+			].join('\n'),
+			'Ingest orders'
+		)
+		await seedScript(
+			page,
+			daily,
+			[
+				'-- pipeline',
+				`-- on ducklake://${ordersTbl}`,
+				`-- materialize ducklake://${dailyTbl}`,
+				`SELECT date_trunc('day', ts) AS day, count(*) AS n FROM ducklake.${ordersTbl.replace('/', '.')} GROUP BY 1`
+			].join('\n'),
+			'Daily rollup'
+		)
+
+		await page.goto(`/pipeline/${folder}`)
+
+		// Header summary: two scripts render as pipeline members.
+		await expect(page.getByRole('heading', { name: 'Pipeline', level: 1 })).toBeVisible()
+		await expect(page.getByText('2 scripts', { exact: false })).toBeVisible()
+
+		// Both script nodes render (the node label may truncate a long path, so match
+		// the leaf name; the full paths are asserted on the edge labels below).
+		await expect(page.getByText('orders_ingest').first()).toBeVisible()
+		await expect(page.getByText('orders_daily').first()).toBeVisible()
+
+		// The lineage edges are derived purely from the annotations: the CSV read,
+		// the two materialize outputs, and the downstream `-- on <ducklake>` input.
+		const edges = [
+			`Edge from asset:s3object:raw/orders/*.csv to script:${ingest}`,
+			`Edge from script:${ingest} to asset:ducklake:${ordersTbl}`,
+			`Edge from asset:ducklake:${ordersTbl} to script:${daily}`,
+			`Edge from script:${daily} to asset:ducklake:${dailyTbl}`,
+			// `-- on schedule` with no schedule trigger row still wires a missing-trigger edge.
+			`Edge from trigger:schedule:missing:${ingest} to script:${ingest}`
+		]
+		for (const name of edges) {
+			// Edges are SVG <g> groups (no visible box of their own), so assert they
+			// are rendered into the graph rather than in-viewport visible.
+			await expect(page.getByRole('group', { name, exact: true }).first()).toBeAttached()
+		}
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/ducklakeTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/ducklakeTools.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listMock } = vi.hoisted(() => ({ listMock: vi.fn() }))
+
+vi.mock('./shared', () => ({
+	createToolDef: (_schema: unknown, name: string, description: string) => ({
+		type: 'function',
+		function: { name, description, parameters: {} }
+	})
+}))
+
+vi.mock('$lib/gen', () => ({
+	WorkspaceService: { listDucklakes: listMock }
+}))
+
+import { getDucklakeTools } from './ducklakeTools'
+
+function createToolCallbacks() {
+	return { setToolStatus: vi.fn(), removeToolStatus: vi.fn() }
+}
+
+function run(name: string, args: Record<string, unknown> = {}) {
+	const tool = getDucklakeTools().find((entry) => entry.def.function.name === name)
+	if (!tool) throw new Error(`${name} tool not found`)
+	return tool.fn({
+		args,
+		workspace: 'test-workspace',
+		helpers: {},
+		toolCallbacks: createToolCallbacks(),
+		toolId: `tool-${name}`
+	})
+}
+
+beforeEach(() => listMock.mockReset())
+
+describe('list_ducklakes', () => {
+	it('returns the configured catalog names', async () => {
+		listMock.mockResolvedValue(['main', 'analytics'])
+		const result = await run('list_ducklakes')
+		expect(listMock).toHaveBeenCalledWith({ workspace: 'test-workspace' })
+		expect(JSON.parse(result)).toEqual({ ducklakes: ['main', 'analytics'] })
+	})
+
+	it('explains the storage prerequisite with role-appropriate steps when none exist', async () => {
+		listMock.mockResolvedValue([])
+		const result = await run('list_ducklakes')
+		expect(result).toContain('No DuckLake catalogs are configured')
+		expect(result).toContain('Workspace settings → Object Storage')
+		expect(result).toContain('ask a workspace admin')
+		// Drafting is not blocked: the message must say the scripts can still be drafted.
+		expect(result).toContain('still draft the pipeline scripts')
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/ducklakeTools.ts
+++ b/frontend/src/lib/components/copilot/chat/ducklakeTools.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod'
+import { WorkspaceService } from '$lib/gen'
+import { createToolDef, type Tool } from './shared'
+
+/**
+ * Workspace-scoped DuckLake readiness tool, the pipeline counterpart to
+ * `list_datatables` in `datatableTools.ts`.
+ *
+ * A data pipeline materializes DuckLake tables and reads/writes S3 assets, which
+ * only work once the workspace has object storage + a DuckLake catalog
+ * configured. This tool lets the chat detect that prerequisite (and warn with
+ * role-appropriate next steps) instead of silently producing a pipeline that
+ * cannot run. It is a plain read gated only by workspace membership, so it needs
+ * no app context and belongs in the global tool set.
+ */
+
+/** List the names of the DuckLake catalogs configured in the workspace. */
+export async function listDucklakes(workspace: string): Promise<string[]> {
+	return await WorkspaceService.listDucklakes({ workspace })
+}
+
+const NO_DUCKLAKES_CONFIGURED_MESSAGE =
+	'No DuckLake catalogs are configured in this workspace. A data pipeline that materializes DuckLake tables or reads/writes S3 assets cannot run until object storage and a DuckLake catalog are set up. ' +
+	'You can still draft the pipeline scripts, but tell the user how to enable it by role: a workspace admin adds object storage under Workspace settings → Object Storage (S3/Azure/GCS), then a DuckLake catalog on top of it; a user without admin rights should ask a workspace admin. ' +
+	"Do not assume a default 'main' DuckLake exists."
+
+const listDucklakesSchema = z.object({})
+const listDucklakesToolDef = createToolDef(
+	listDucklakesSchema,
+	'list_ducklakes',
+	'List the DuckLake catalogs configured in this workspace, by name. Call this before building or deploying a data pipeline that materializes DuckLake tables or reads/writes S3 assets: if it returns none, the workspace has no object storage + DuckLake configured and the pipeline cannot run until a workspace admin sets it up. Returns names only.'
+)
+
+/** The workspace DuckLake tools, for registration in global mode. */
+export function getDucklakeTools(): Tool<{}>[] {
+	return [
+		{
+			def: listDucklakesToolDef,
+			fn: async ({ workspace, toolId, toolCallbacks }) => {
+				toolCallbacks.setToolStatus(toolId, { content: 'Listing DuckLake catalogs...' })
+				try {
+					const ducklakes = await listDucklakes(workspace)
+					if (ducklakes.length === 0) {
+						toolCallbacks.setToolStatus(toolId, {
+							content:
+								'No DuckLake configured — set up object storage + DuckLake in workspace settings'
+						})
+						return NO_DUCKLAKES_CONFIGURED_MESSAGE
+					}
+					toolCallbacks.setToolStatus(toolId, {
+						content: `Listed ${ducklakes.length} DuckLake catalog(s)`
+					})
+					return JSON.stringify({ ducklakes }, null, 2)
+				} catch (e) {
+					const errorMsg = `Error listing DuckLake catalogs: ${e instanceof Error ? e.message : String(e)}`
+					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
+					return errorMsg
+				}
+			}
+		}
+	]
+}

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -96,6 +96,7 @@ import { searchDocsTool, readDocsPageTool } from '../docs/core'
 import { createDbSchemaTool } from '../script/core'
 import type { ContextElement } from '../context'
 import { getDatatableTools } from '../datatableTools'
+import { getDucklakeTools } from '../ducklakeTools'
 import { fileTools } from '../files/fileTools'
 import type { AttachedFilesStore } from '../files/attachedFiles.svelte'
 import { artifactTools } from '../artifacts/artifactTools'
@@ -3493,6 +3494,8 @@ export const globalTools: Tool<{}>[] = [
 	},
 	// Workspace-scoped datatable tools (unrestricted: no whitelist, no creation policy)
 	...getDatatableTools(),
+	// Workspace DuckLake readiness (storage prerequisite check for pipelines)
+	...getDucklakeTools(),
 	// Read-only tools over files the user attached to the conversation
 	...fileTools,
 	// Search + call access to the backend API endpoint catalog, for operations

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -755,6 +755,24 @@ export const PIPELINE_BASE = `# Data pipeline authoring
 
 A **data pipeline** is NOT a flow. A flow is one runnable that orchestrates steps internally. A data pipeline is a set of **independent scripts**, each deployed on its own, that form a DAG by reading and writing shared **storage assets** (DuckLake tables, data tables, S3 objects, volumes, resources) and by declaring execution **triggers**. The pipeline is visualized and edited at \`/pipeline/<folder>\`; every node is a normal workspace script that happens to carry pipeline annotations. When the user asks for a "data pipeline" (or to "ingest / transform / materialize" data across steps), build pipeline-annotated scripts — do NOT build a flow.
 
+## Default to DuckDB + DuckLake
+
+A pipeline node that produces a table should almost always be a **\`duckdb\`** node that materializes its output into a **DuckLake** table with \`// materialize ducklake://<name>/<table>\` (write the body as a bare \`SELECT\` and let the runtime do the write). DuckLake is the default lakehouse store for pipelines and is the shape the pipeline editor is built around, so prefer it unless the work specifically calls for something else:
+
+- \`postgresql\` / data tables — only for row-level, OLTP-style mutations against an existing Postgres data table (frequent single-row upserts/updates, transactional reads an app queries live).
+- \`bun\` / \`python3\` — only for non-tabular work that doesn't map to SQL: calling an external API, wrangling files, arbitrary glue. When such a node still produces tabular data for downstream steps, land it in DuckLake (write it with the wmill SDK / ducklake helpers) rather than inventing a parallel store.
+
+Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lake would do; a consistent DuckLake lakehouse is the goal.
+
+## Storage prerequisites
+
+A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and \`s3://\` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake configured (you can confirm with the \`list_ducklakes\` workspace endpoint), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
+
+- a workspace **admin** sets it up in Workspace settings → Object Storage (add an S3/Azure/GCS storage), then adds a DuckLake catalog on top of it;
+- anyone **without admin rights** should ask a workspace admin to configure object storage + a DuckLake catalog.
+
+Never hand back a DuckLake pipeline that cannot run without flagging the missing storage and pointing to who sets it up.
+
 ## What makes a script a pipeline node
 
 A script joins the pipeline when its source begins with the \`pipeline\` annotation as a top-of-file comment, **written in the script's own comment syntax** — \`//\` for TS/JS (bun), \`--\` for SQL (DuckDB/Postgres), \`#\` for Python/Bash. So it's \`-- pipeline\` in a DuckDB node, \`# pipeline\` in a Python node, \`// pipeline\` in a bun node. Every annotation below uses that same prefix (the \`//\` shown is the TS form). All other wiring is expressed as annotation comments near the top of the file:
@@ -784,7 +802,7 @@ A script joins the pipeline when its source begins with the \`pipeline\` annotat
 ## How to build one in chat
 
 1. Put every node in the **same folder**: \`f/<folder>/<name>\`. The folder is the pipeline.
-2. Author each node as a **script draft** with \`write_script\` (or \`edit_script\`), language chosen for the work: \`duckdb\` or \`postgresql\` for SQL-shaped data work, \`bun\`/\`python3\` for general transforms. SQL-heavy lakehouse steps usually use \`duckdb\`.
+2. Author each node as a **script draft** with \`write_script\` (or \`edit_script\`). Default to \`duckdb\` materializing into DuckLake (see "Default to DuckDB + DuckLake" above); pick \`postgresql\`, \`bun\`, or \`python3\` only when that section says the work calls for it.
 3. Start each body with \`// pipeline\`, then the \`// on\` input declarations, then the transform that writes the output.
 4. **Chain nodes by asset URI**: read an upstream node's output asset, then \`// on <that-same-uri>\` in the downstream node so the edge forms. Reuse exact asset paths from existing nodes rather than inventing parallel ones.
 5. Leave nodes as drafts unless the user asks to deploy. A pipeline only "runs" once its scripts are deployed and their triggers exist.

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -757,9 +757,9 @@ A **data pipeline** is NOT a flow. A flow is one runnable that orchestrates step
 
 ## Default to DuckDB + DuckLake
 
-A pipeline node that produces a table should almost always be a **\`duckdb\`** node that materializes its output into a **DuckLake** table with \`// materialize ducklake://<name>/<table>\` (write the body as a bare \`SELECT\` and let the runtime do the write). DuckLake is the default lakehouse store for pipelines and is the shape the pipeline editor is built around, so prefer it unless the work specifically calls for something else:
+A pipeline node that produces a table should almost always be a **\`duckdb\`** node that materializes its output into a **DuckLake** table with \`-- materialize ducklake://<name>/<table>\` (in a DuckDB node the annotation uses SQL \`--\` comment syntax; write the body as a bare \`SELECT\` and let the runtime do the write). DuckLake is the default lakehouse store for pipelines and is the shape the pipeline editor is built around, so prefer it unless the work specifically calls for something else:
 
-- \`postgresql\` / data tables — only for row-level, OLTP-style mutations against an existing Postgres data table (frequent single-row upserts/updates, transactional reads an app queries live).
+- \`postgresql\` / data tables — only for row-level, OLTP-style mutations against an existing Postgres data table (frequent single-row upserts/updates, transactional reads that an app queries live).
 - \`bun\` / \`python3\` — only for non-tabular work that doesn't map to SQL: calling an external API, wrangling files, arbitrary glue. When such a node still produces tabular data for downstream steps, land it in DuckLake (write it with the wmill SDK / ducklake helpers) rather than inventing a parallel store.
 
 Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lake would do; a consistent DuckLake lakehouse is the goal.

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -766,7 +766,7 @@ Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lak
 
 ## Storage prerequisites
 
-A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and \`s3://\` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake catalog configured (set up under Workspace settings → Object Storage), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
+A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and \`s3://\` assets can't be materialized or read without it. Check with the \`list_ducklakes\` tool before you build (it returns the configured DuckLake catalogs, or none). Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if \`list_ducklakes\` returns none (or the user hits "storage not configured" errors), say so and give the right next step **by role**:
 
 - a workspace **admin** sets it up in Workspace settings → Object Storage (add an S3/Azure/GCS storage), then adds a DuckLake catalog on top of it;
 - anyone **without admin rights** should ask a workspace admin to configure object storage + a DuckLake catalog.

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -766,7 +766,7 @@ Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lak
 
 ## Storage prerequisites
 
-A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and \`s3://\` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake configured (you can confirm with the \`list_ducklakes\` workspace endpoint), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
+A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and \`s3://\` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake catalog configured (set up under Workspace settings → Object Storage), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
 
 - a workspace **admin** sets it up in Workspace settings → Object Storage (add an S3/Azure/GCS storage), then adds a DuckLake catalog on top of it;
 - anyone **without admin rights** should ask a workspace admin to configure object storage + a DuckLake catalog.

--- a/system_prompts/base/pipeline-base.md
+++ b/system_prompts/base/pipeline-base.md
@@ -13,7 +13,7 @@ Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lak
 
 ## Storage prerequisites
 
-A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and `s3://` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake catalog configured (set up under Workspace settings → Object Storage), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
+A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and `s3://` assets can't be materialized or read without it. Check with the `list_ducklakes` tool before you build (it returns the configured DuckLake catalogs, or none). Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if `list_ducklakes` returns none (or the user hits "storage not configured" errors), say so and give the right next step **by role**:
 
 - a workspace **admin** sets it up in Workspace settings → Object Storage (add an S3/Azure/GCS storage), then adds a DuckLake catalog on top of it;
 - anyone **without admin rights** should ask a workspace admin to configure object storage + a DuckLake catalog.

--- a/system_prompts/base/pipeline-base.md
+++ b/system_prompts/base/pipeline-base.md
@@ -4,9 +4,9 @@ A **data pipeline** is NOT a flow. A flow is one runnable that orchestrates step
 
 ## Default to DuckDB + DuckLake
 
-A pipeline node that produces a table should almost always be a **`duckdb`** node that materializes its output into a **DuckLake** table with `// materialize ducklake://<name>/<table>` (write the body as a bare `SELECT` and let the runtime do the write). DuckLake is the default lakehouse store for pipelines and is the shape the pipeline editor is built around, so prefer it unless the work specifically calls for something else:
+A pipeline node that produces a table should almost always be a **`duckdb`** node that materializes its output into a **DuckLake** table with `-- materialize ducklake://<name>/<table>` (in a DuckDB node the annotation uses SQL `--` comment syntax; write the body as a bare `SELECT` and let the runtime do the write). DuckLake is the default lakehouse store for pipelines and is the shape the pipeline editor is built around, so prefer it unless the work specifically calls for something else:
 
-- `postgresql` / data tables — only for row-level, OLTP-style mutations against an existing Postgres data table (frequent single-row upserts/updates, transactional reads an app queries live).
+- `postgresql` / data tables — only for row-level, OLTP-style mutations against an existing Postgres data table (frequent single-row upserts/updates, transactional reads that an app queries live).
 - `bun` / `python3` — only for non-tabular work that doesn't map to SQL: calling an external API, wrangling files, arbitrary glue. When such a node still produces tabular data for downstream steps, land it in DuckLake (write it with the wmill SDK / ducklake helpers) rather than inventing a parallel store.
 
 Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lake would do; a consistent DuckLake lakehouse is the goal.

--- a/system_prompts/base/pipeline-base.md
+++ b/system_prompts/base/pipeline-base.md
@@ -13,7 +13,7 @@ Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lak
 
 ## Storage prerequisites
 
-A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and `s3://` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake configured (you can confirm with the `list_ducklakes` workspace endpoint), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
+A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and `s3://` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake catalog configured (set up under Workspace settings → Object Storage), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
 
 - a workspace **admin** sets it up in Workspace settings → Object Storage (add an S3/Azure/GCS storage), then adds a DuckLake catalog on top of it;
 - anyone **without admin rights** should ask a workspace admin to configure object storage + a DuckLake catalog.

--- a/system_prompts/base/pipeline-base.md
+++ b/system_prompts/base/pipeline-base.md
@@ -2,6 +2,24 @@
 
 A **data pipeline** is NOT a flow. A flow is one runnable that orchestrates steps internally. A data pipeline is a set of **independent scripts**, each deployed on its own, that form a DAG by reading and writing shared **storage assets** (DuckLake tables, data tables, S3 objects, volumes, resources) and by declaring execution **triggers**. The pipeline is visualized and edited at `/pipeline/<folder>`; every node is a normal workspace script that happens to carry pipeline annotations. When the user asks for a "data pipeline" (or to "ingest / transform / materialize" data across steps), build pipeline-annotated scripts — do NOT build a flow.
 
+## Default to DuckDB + DuckLake
+
+A pipeline node that produces a table should almost always be a **`duckdb`** node that materializes its output into a **DuckLake** table with `// materialize ducklake://<name>/<table>` (write the body as a bare `SELECT` and let the runtime do the write). DuckLake is the default lakehouse store for pipelines and is the shape the pipeline editor is built around, so prefer it unless the work specifically calls for something else:
+
+- `postgresql` / data tables — only for row-level, OLTP-style mutations against an existing Postgres data table (frequent single-row upserts/updates, transactional reads an app queries live).
+- `bun` / `python3` — only for non-tabular work that doesn't map to SQL: calling an external API, wrangling files, arbitrary glue. When such a node still produces tabular data for downstream steps, land it in DuckLake (write it with the wmill SDK / ducklake helpers) rather than inventing a parallel store.
+
+Do not spread a pipeline across postgres, S3, and DuckLake when one DuckLake lake would do; a consistent DuckLake lakehouse is the goal.
+
+## Storage prerequisites
+
+A DuckLake pipeline only runs once the workspace has **object storage** (S3 / Azure Blob / GCS) **and a DuckLake catalog** configured — DuckLake tables and `s3://` assets can't be materialized or read without it. Drafting the annotated scripts does not require storage, but the pipeline can't ingest, materialize, or read its assets until it exists. So if the workspace has no object storage / DuckLake configured (you can confirm with the `list_ducklakes` workspace endpoint), or the user hits "storage not configured" errors, say so and give the right next step **by role**:
+
+- a workspace **admin** sets it up in Workspace settings → Object Storage (add an S3/Azure/GCS storage), then adds a DuckLake catalog on top of it;
+- anyone **without admin rights** should ask a workspace admin to configure object storage + a DuckLake catalog.
+
+Never hand back a DuckLake pipeline that cannot run without flagging the missing storage and pointing to who sets it up.
+
 ## What makes a script a pipeline node
 
 A script joins the pipeline when its source begins with the `pipeline` annotation as a top-of-file comment, **written in the script's own comment syntax** — `//` for TS/JS (bun), `--` for SQL (DuckDB/Postgres), `#` for Python/Bash. So it's `-- pipeline` in a DuckDB node, `# pipeline` in a Python node, `// pipeline` in a bun node. Every annotation below uses that same prefix (the `//` shown is the TS form). All other wiring is expressed as annotation comments near the top of the file:
@@ -31,7 +49,7 @@ A script joins the pipeline when its source begins with the `pipeline` annotatio
 ## How to build one in chat
 
 1. Put every node in the **same folder**: `f/<folder>/<name>`. The folder is the pipeline.
-2. Author each node as a **script draft** with `write_script` (or `edit_script`), language chosen for the work: `duckdb` or `postgresql` for SQL-shaped data work, `bun`/`python3` for general transforms. SQL-heavy lakehouse steps usually use `duckdb`.
+2. Author each node as a **script draft** with `write_script` (or `edit_script`). Default to `duckdb` materializing into DuckLake (see "Default to DuckDB + DuckLake" above); pick `postgresql`, `bun`, or `python3` only when that section says the work calls for it.
 3. Start each body with `// pipeline`, then the `// on` input declarations, then the transform that writes the output.
 4. **Chain nodes by asset URI**: read an upstream node's output asset, then `// on <that-same-uri>` in the downstream node so the edge forms. Reuse exact asset paths from existing nodes rather than inventing parallel ones.
 5. Leave nodes as drafts unless the user asks to deploy. A pipeline only "runs" once its scripts are deployed and their triggers exist.


### PR DESCRIPTION
## Summary

Fixes WIN-2229. Investigation into how AI sessions build data pipelines, the tools available to them, and the e2e coverage, plus the concrete improvements it produced: two prompt fixes, an eval-fidelity fix, a new complex-pipeline eval, and a deterministic browser e2e.

### How pipelines get built from a session today (and what's gated)

- A data pipeline is a DAG of independent annotated scripts (`-- pipeline`, `-- on <ref>`, `-- materialize <asset>`) in one folder, wired by storage assets. It is not a flow.
- The global/session chat builds pipelines with the generic `write_script` draft tools plus `get_instructions subject: pipeline` (guidance from `system_prompts/base/pipeline-base.md` -> `getPipelinePrompt`). The graph-aware tools (`build_pipeline_node`, `get_pipeline_graph`, `test_pipeline_node`) only activate when a `/pipeline/<folder>` editor is open.
- **Pipeline building inside AI sessions is disabled by default** (alpha): gated behind `localStorage.wm_dev_session_pipelines='1'` (`global/pipelineGate.ts`). By default the session prompt tells the user pipelines are alpha and "will be handled by the chat soon," `get_instructions subject: pipeline` returns the gated message, and the session preview router won't route pipeline previews. The standalone global side-panel chat and the `/pipeline` editor keep pipeline support, and the eval harness exercises the ungated path — so **the evals are the model-in-the-loop e2e for AI-built pipelines**.

### Findings that drove the changes

1. **The LLM judge grades pipelines with a flow mental model.** `global-test-pipeline-create-node` produced the textbook-correct node (a bare `SELECT` under `-- pipeline` / `-- on schedule` / `-- materialize ducklake://...`), passed every deterministic check, and still failed on the judge (72 < 80): it penalized `-- on schedule` for not being a "real" trigger config and `-- materialize` + bare SELECT for not being a hand-written `CREATE TABLE`/`INSERT` — exactly the contract, inverted. The judge has no pipeline domain context.
2. **No DuckDB/materialize steer.** The prompt was neutral ("duckdb or postgresql ... bun/python3 for general transforms"), not a default toward DuckLake materialization.
3. **No storage-readiness awareness.** Datatables have a `list_datatables` tool + a blocking-prerequisite prompt ("if none configured, tell the user to set one up in workspace settings and stop"). DuckLake/object-store pipelines had **no** equivalent: nothing about storage readiness in the prompt, and no `list_ducklakes`/object-storage tool wired into the chat. So a session would draft a DuckLake pipeline that cannot run and never tell the user storage must be configured.

## Changes

- **`list_ducklakes` chat tool** (`frontend/.../ducklakeTools.ts`, wired into the global tool set): the pipeline counterpart to `list_datatables`. Lists the workspace's configured DuckLake catalogs; when none exist it returns an actionable message (drafting still allowed, but the pipeline can't run until storage is set up, with role-appropriate next steps). This gives the chat a real storage-readiness signal instead of a blind advisory. In the eval run all three cases called it unprompted before/while building.
- **`system_prompts/base/pipeline-base.md`** (+ regenerated `auto-generated/prompts.ts`):
  - "Default to DuckDB + DuckLake": a node that produces a table should default to `duckdb` materializing into DuckLake; use postgres/data-tables only for OLTP-style row mutations and bun/python only for non-tabular glue (and still land tabular output in DuckLake).
  - "Storage prerequisites": a DuckLake pipeline needs workspace object storage + a DuckLake catalog. Check with `list_ducklakes`; when none is configured (or the user hits storage errors), warn and give role-appropriate next steps (admin: Workspace settings -> Object Storage, then a DuckLake catalog; non-admin: ask an admin). Drafting is not blocked, so it does not regress the build path.
- **`ai_evals/cases/global.yaml`**:
  - Rewrote the `judgeChecklist` items across all three `global-test-pipeline-*` cases to encode the declarative contract inline (trigger = `-- on` annotation; `-- materialize` = bare SELECT with no hand-written DDL; S3/Parquet is not materialize). This is the eval-fidelity fix for finding 1.
  - Added `global-test-pipeline-complex-incremental`: a three-node DuckLake pipeline (scheduled ingest that materializes raw orders, an incremental partitioned daily rollup that appends one day per run, a Parquet-to-S3 export). Deterministic checks stay narrow; semantics live in the judge checklist. The incremental item grades behavior (append one day, no full rebuild) and accepts either the `-- partitioned daily` / `{partition}` idiom or an equivalent current-day filter.
  - Hardened `global-test-pipeline-two-node-chain`: previously only `draftCountAtLeast: 2` + "no flow"; now also requires a pipeline-annotated DuckLake script draft at the folder.
- **`frontend/e2e/pipeline.spec.ts`** (new): a deterministic Playwright e2e. Seeds the annotated scripts an AI-built DuckLake pipeline would produce (via the API), then asserts the `/pipeline/<folder>` editor derives the full lineage DAG from the annotations alone: both pipeline-member script nodes, the DuckLake/S3 asset nodes, all four data edges, and the missing-schedule-trigger edge.

## Screenshots

The e2e asserts the graph the editor derives from the seeded annotations:

![pipeline-graph](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2229-investigate-improving-building-data-pipelines-in-ai-sessions/1784757541-pipeline-graph.png)

(The only `frontend/` change is this test spec; it has no visible-UI effect of its own.)

## Test plan

Ran the pipeline cases against `sonnet` through the local backend AI proxy, judge `claude-sonnet-4-6`.

- [x] `bun test core/` in `ai_evals` -> 76 pass (case schema valid); prompts regenerated (`generate.py`), diff limited to `prompts.ts`.
- [x] Judge-context fix: `create-node` went from judge 72 with all deterministic checks green (the false negative) to grading correctly (97-100).
- [x] Prompt A/B (before -> after, 3 cases x2 runs): pass rate 66.7% -> 83.3%, no build-case regression (create-node 2/2, two-node 2/2), finalContext 34255 -> 34894 (+639, the guidance tax). The single remaining complex failure is a genuine model error (wrote `-- materialize s3://...parquet`), which the checklist is meant to catch.
- [x] `list_ducklakes` tool: unit test (`ducklakeTools.test.ts`) passes; live endpoint verified; re-ran the three pipeline cases with the tool wired in and all three called it unprompted, still built the drafts (no regression, create-node judge 100 / two-node 92), finalContext +~205 tokens.
- [x] Browser e2e: `BASE_URL=http://localhost:3260 SKIP_HUB_SYNC=true npx playwright test pipeline.spec.ts --project=chromium` -> 1 passed.

## Follow-ups (not in this PR)

- A deterministic eval for the warn-behavior needs the harness to seed "no DuckLake configured" (it currently can't); the `list_ducklakes` tool now makes the check real, but pinning the warn-message in an eval is deferred.
- Wiring the graph-aware pipeline tools into sessions (behind the alpha gate) so session pipeline builds get canvas seeding and `get_pipeline_graph`, rather than plain script drafts.