### PR TITLE
refactor: custom-instance datatable connection handling

### DIFF
--- a/backend/.sqlx/query-ffbe9fe78a7fc0e95a5a29c8d17f4367ef6b6cc3de20da6ef8c98f679b832240.json
+++ b/backend/.sqlx/query-ffbe9fe78a7fc0e95a5a29c8d17f4367ef6b6cc3de20da6ef8c98f679b832240.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT value->>'replication_user_pwd' FROM global_settings WHERE name = 'custom_instance_pg_databases';",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ffbe9fe78a7fc0e95a5a29c8d17f4367ef6b6cc3de20da6ef8c98f679b832240"
+}

--- a/backend/migrations/20260716152346_custom_instance_replication_user.down.sql
+++ b/backend/migrations/20260716152346_custom_instance_replication_user.down.sql
@@ -1,0 +1,14 @@
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user') THEN
+        ALTER ROLE custom_instance_user REPLICATION;
+    END IF;
+
+    DROP ROLE IF EXISTS custom_instance_replication_user;
+
+    DELETE FROM global_settings WHERE name = 'custom_instance_replication_pwd';
+EXCEPTION
+    WHEN others THEN
+        RAISE NOTICE 'custom_instance_replication_user down-migration error, skipping: %', SQLERRM;
+END
+$$;

--- a/backend/migrations/20260716152346_custom_instance_replication_user.up.sql
+++ b/backend/migrations/20260716152346_custom_instance_replication_user.up.sql
@@ -1,0 +1,34 @@
+-- Dedicated logical-replication role used by postgres triggers on custom-instance
+-- datatables. Its password is stored server-only in global_settings.custom_instance_replication_pwd
+-- (hidden from the config surface); membership in custom_instance_user lets it manage
+-- publications on the datatable tables. custom_instance_user itself must not hold REPLICATION.
+DO $$
+DECLARE
+    pwd text;
+BEGIN
+    SELECT gen_random_uuid()::text INTO pwd;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_replication_user') THEN
+        EXECUTE format('ALTER USER custom_instance_replication_user WITH PASSWORD %L REPLICATION', pwd);
+    ELSE
+        EXECUTE format('CREATE USER custom_instance_replication_user WITH PASSWORD %L REPLICATION', pwd);
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user') THEN
+        GRANT custom_instance_user TO custom_instance_replication_user;
+        ALTER ROLE custom_instance_user NOREPLICATION;
+    END IF;
+
+    INSERT INTO global_settings (name, value)
+    VALUES ('custom_instance_replication_pwd', to_jsonb(pwd::text))
+    ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;
+
+    -- Drop any replication password an earlier iteration stored in the operator-facing row.
+    UPDATE global_settings
+    SET value = value - 'replication_user_pwd'
+    WHERE name = 'custom_instance_pg_databases';
+EXCEPTION
+    WHEN others THEN
+        RAISE NOTICE 'custom_instance_replication_user migration error, skipping: %', SQLERRM;
+END
+$$;

--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -1578,6 +1578,7 @@ async fn refresh_custom_instance_user_pwd(
 ) -> JsonResult<()> {
     require_super_admin(&db, &authed.email).await?;
     windmill_common::utils::refresh_custom_instance_user_pwd(&db).await?;
+    windmill_common::utils::refresh_custom_instance_replication_user_pwd(&db).await?;
     Ok(Json(()))
 }
 
@@ -1704,11 +1705,23 @@ async fn setup_custom_instance_pg_database_inner(
             ))
         })?;
 
+    // The replication attribute lives on a dedicated role used by postgres trigger
+    // connections. The getter creates the role (with its stored password) when the
+    // migration couldn't.
+    if let Err(e) = windmill_common::utils::get_custom_pg_instance_replication_password(db).await {
+        tracing::error!("Failed to ensure custom_instance_replication_user exists: {e:#}");
+    }
     if let Err(e) = client
-        .batch_execute(&format!("ALTER ROLE custom_instance_user REPLICATION;"))
+        .batch_execute(
+            "ALTER ROLE custom_instance_replication_user REPLICATION;
+             GRANT custom_instance_user TO custom_instance_replication_user;
+             ALTER ROLE custom_instance_user NOREPLICATION;",
+        )
         .await
     {
-        tracing::error!("Failed to grant replication permission to custom_instance_user: {e:#}");
+        tracing::error!(
+            "Failed to grant replication permission to custom_instance_replication_user: {e:#}"
+        );
     }
 
     logs.grant_permissions = "OK".to_string();

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -1330,7 +1330,7 @@ paths:
 
   /settings/refresh_custom_instance_user_pwd:
     post:
-      summary: Refreshes the password for the custom_instance_user
+      summary: Refreshes the passwords for the custom_instance_user and the custom_instance_replication_user (used by postgres triggers)
       operationId: refreshCustomInstanceUserPwd
       tags:
         - setting

--- a/backend/windmill-api/src/live_migrations.rs
+++ b/backend/windmill-api/src/live_migrations.rs
@@ -19,6 +19,30 @@ pub async fn custom_migrations(migrator: &mut CustomMigrator) -> Result<(), Erro
         tracing::error!("Could not apply flow versioning fix migration: {err:#}");
     }
 
+    if let Err(err) = normalize_custom_instance_user_attributes(migrator).await {
+        tracing::error!("Could not normalize custom_instance_user attributes: {err:#}");
+    }
+
+    Ok(())
+}
+
+// Converged on every boot, not once: the one-shot migration swallows errors (it must not
+// abort startup without superuser), and an older instance sharing the cluster can re-add
+// the attribute. REPLICATION belongs only on custom_instance_replication_user.
+async fn normalize_custom_instance_user_attributes(
+    migrator: &mut CustomMigrator,
+) -> Result<(), Error> {
+    let has_replication = sqlx::query_scalar::<_, bool>(
+        "SELECT rolreplication FROM pg_roles WHERE rolname = 'custom_instance_user'",
+    )
+    .fetch_optional(migrator.connection())
+    .await?;
+    if has_replication == Some(true) {
+        sqlx::query("ALTER ROLE custom_instance_user NOREPLICATION")
+            .execute(migrator.connection())
+            .await?;
+        tracing::info!("Normalized custom_instance_user attributes");
+    }
     Ok(())
 }
 

--- a/backend/windmill-common/src/global_settings.rs
+++ b/backend/windmill-common/src/global_settings.rs
@@ -165,6 +165,11 @@ pub const AGENT_WORKER_BLOCKED_SETTINGS: &[&str] = &[
     INSTANCE_EVENTS_WEBHOOK_SETTING,
     OTEL_SETTING,
     OTEL_TRACING_PROXY_SETTING,
+    // Custom-instance DB credentials: `custom_instance_pg_databases` holds `user_pwd`,
+    // `custom_instance_replication_pwd` holds the REPLICATION-role password. Agent workers
+    // resolve datatable connections through the dedicated datatable endpoints, never these.
+    "custom_instance_pg_databases",
+    "custom_instance_replication_pwd",
 ];
 
 /// Whether an agent worker may read the given global setting over HTTP.
@@ -381,6 +386,8 @@ mod tests {
             INSTANCE_EVENTS_WEBHOOK_SETTING,
             OTEL_SETTING,
             OTEL_TRACING_PROXY_SETTING,
+            "custom_instance_pg_databases",
+            "custom_instance_replication_pwd",
         ] {
             assert!(
                 !is_setting_readable_by_agent_worker(key),

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -776,7 +776,10 @@ pub enum DucklakeCatalogResourceType {
 // Custom instance PG databases
 // ---------------------------------------------------------------------------
 
-/// Custom PostgreSQL databases managed by the instance.
+/// Custom PostgreSQL databases managed by the instance. `user_pwd` is operator-configurable
+/// (resolved from a Kubernetes secretKeyRef by the EE operator); `databases` is runtime
+/// setup status. The replication-role password lives in a separate hidden setting
+/// (`custom_instance_replication_pwd`), never in this operator-facing config row.
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "instance_config_schema", derive(schemars::JsonSchema))]
 pub struct CustomInstancePgDatabases {
@@ -945,6 +948,7 @@ pub const PROTECTED_SETTINGS: &[&str] = &[
     "ducklake_user_pg_pwd",
     "ducklake_settings",
     "custom_instance_pg_databases",
+    "custom_instance_replication_pwd",
     "uid",
     "rsa_keys",
     "jwt_secret",
@@ -966,6 +970,10 @@ pub const HIDDEN_SETTINGS: &[&str] = &[
     // every bulk InstanceSettings save via `GlobalSettings::extra`. Hiding it
     // on read + rejecting it in `diff_global_settings` breaks that loop.
     "worker_configs",
+    // Auto-generated password for the REPLICATION role used by postgres triggers.
+    // Server-only (written by setup/refresh via direct SQL), never operator-authored —
+    // hidden so the config machinery can't read, rewrite, or drop it.
+    "custom_instance_replication_pwd",
 ];
 
 /// Top-level settings whose entire value is sensitive and must be fully redacted in logs.
@@ -976,6 +984,7 @@ const SENSITIVE_SETTINGS: &[&str] = &[
     "hub_api_secret",
     "license_key",
     "ducklake_user_pg_pwd",
+    "custom_instance_replication_pwd",
     "pip_index_url",
     "pip_extra_index_url",
     "npm_config_registry",
@@ -1000,6 +1009,7 @@ const NESTED_SENSITIVE_FIELDS: &[(&str, &[&str])] = &[
         "object_store_cache_config",
         &["secret_key", "serviceAccountKey"],
     ),
+    ("custom_instance_pg_databases", &["user_pwd"]),
 ];
 
 fn redact_json_value(value: &serde_json::Value) -> serde_json::Value {
@@ -1024,10 +1034,7 @@ fn mask_nested_sensitive(key: &str, value: &serde_json::Value) -> serde_json::Va
         }
     }
     // Settings that are maps-of-objects where each child has a sensitive sub-field.
-    const NESTED_MAP_SENSITIVE: &[(&str, &str)] = &[
-        ("oauths", "secret"),
-        ("custom_instance_pg_databases", "user_pwd"),
-    ];
+    const NESTED_MAP_SENSITIVE: &[(&str, &str)] = &[("oauths", "secret")];
     for &(parent_key, child_field) in NESTED_MAP_SENSITIVE {
         if key == parent_key {
             if let serde_json::Value::Object(entries) = value {
@@ -1142,14 +1149,13 @@ pub fn diff_global_settings(
     let mut previous_values = BTreeMap::new();
     let mut unchanged_count: usize = 0;
     for (key, desired_value) in desired {
-        // `worker_configs` is a legacy ghost: worker configs belong in the
-        // `config` table with a `worker__` prefix. If a client PUT carries a
-        // top-level `worker_configs` key (it flattens into
-        // `GlobalSettings::extra` on deserialize), drop it here instead of
-        // letting it resurrect a stale `global_settings` row.
-        if key == "worker_configs" {
+        // Hidden settings are server-managed and never driven by config: they are
+        // filtered out on read (`from_db`) and must be ignored on write too, so a client
+        // PUT that flattened one into `GlobalSettings::extra` can't resurrect or clobber
+        // the row (e.g. `worker_configs`, or the custom-instance credentials/status).
+        if HIDDEN_SETTINGS.contains(&key.as_str()) {
             tracing::warn!(
-                "Ignoring 'worker_configs' in global_settings diff: worker configs must be written to the config table (worker__ prefix), not global_settings"
+                "Ignoring hidden setting '{key}' in global_settings diff (server-managed, not configurable)"
             );
             continue;
         }
@@ -2367,34 +2373,63 @@ mod tests {
     }
 
     #[test]
-    fn custom_instance_pg_databases_roundtrips() {
+    fn custom_instance_replication_pwd_is_isolated_from_config() {
+        // The replication-role password is server-only: written by setup/refresh via direct
+        // SQL, never operator-authored. It must stay out of the declarative config surface
+        // (hidden on read) and be undeletable, so config sync can't read, rewrite, or drop it.
+        assert!(HIDDEN_SETTINGS.contains(&"custom_instance_replication_pwd"));
+        assert!(PROTECTED_SETTINGS.contains(&"custom_instance_replication_pwd"));
+        assert!(SENSITIVE_SETTINGS.contains(&"custom_instance_replication_pwd"));
+
+        // A stray desired value (e.g. flattened into `extra`) is ignored, not upserted.
+        let mut desired = BTreeMap::new();
+        desired.insert(
+            "custom_instance_replication_pwd".to_string(),
+            serde_json::json!("attacker-set"),
+        );
+        let diff = diff_global_settings(&BTreeMap::new(), &desired, ApplyMode::Merge);
+        assert!(
+            diff.upserts.is_empty(),
+            "hidden setting must not be upserted"
+        );
+
+        // A current value is never deleted by a Replace that omits it.
+        let mut current = BTreeMap::new();
+        current.insert(
+            "custom_instance_replication_pwd".to_string(),
+            serde_json::json!("live"),
+        );
+        let diff = diff_global_settings(&current, &BTreeMap::new(), ApplyMode::Replace);
+        assert!(
+            !diff
+                .deletes
+                .contains(&"custom_instance_replication_pwd".to_string()),
+            "hidden setting must not be deleted"
+        );
+    }
+
+    #[test]
+    fn custom_instance_pg_databases_roundtrips_and_redacts_user_pwd() {
+        // user_pwd stays operator-configurable (EE secretKeyRef); databases is runtime status.
         let json = r#"{
             "user_pwd": "secret123",
-            "databases": {
-                "mydb": {
-                    "logs": {
-                        "super_admin": "OK",
-                        "database_credentials": "OK",
-                        "valid_dbname": "OK",
-                        "created_database": "OK",
-                        "db_connect": "OK",
-                        "grant_permissions": "OK"
-                    },
-                    "success": true,
-                    "tag": "production"
-                }
-            }
+            "databases": { "mydb": { "success": true, "tag": "production" } }
         }"#;
         let pg: CustomInstancePgDatabases = serde_json::from_str(json).unwrap();
         assert_eq!(
             pg.user_pwd.as_ref().and_then(|v| v.as_literal()),
             Some("secret123")
         );
-        let db = &pg.databases["mydb"];
-        assert!(db.success);
-        assert_eq!(db.tag.as_deref(), Some("production"));
-        assert_eq!(db.logs.super_admin, "OK");
-        assert_eq!(db.logs.grant_permissions, "OK");
+        assert!(pg.databases["mydb"].success);
+
+        let out = format_setting_value(
+            "custom_instance_pg_databases",
+            &serde_json::json!({ "user_pwd": "user-plaintext-password" }),
+        );
+        assert!(
+            !out.contains("user-plaintext-password"),
+            "user_pwd leaked: {out}"
+        );
     }
 
     #[test]

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -1044,6 +1044,92 @@ pub async fn get_custom_pg_instance_password(db: &DB) -> Result<String> {
     )
 }
 
+const REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL: &str = r#"
+    DO $$
+        DECLARE
+            pwd text;
+        BEGIN
+            SELECT gen_random_uuid()::text INTO pwd;
+
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_replication_user') THEN
+                EXECUTE format('ALTER USER custom_instance_replication_user WITH PASSWORD %L REPLICATION', pwd);
+            ELSE
+                EXECUTE format('CREATE USER custom_instance_replication_user WITH PASSWORD %L REPLICATION', pwd);
+            END IF;
+
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user') THEN
+                GRANT custom_instance_user TO custom_instance_replication_user;
+                ALTER ROLE custom_instance_user NOREPLICATION;
+            END IF;
+
+            INSERT INTO global_settings (name, value)
+            VALUES ('custom_instance_replication_pwd', to_jsonb(pwd::text))
+            ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;
+        END
+        $$;
+"#;
+
+const REPLICATION_PWD_READ_SQL: &str =
+    "SELECT value #>> '{}' FROM global_settings WHERE name = 'custom_instance_replication_pwd'";
+
+/// (Re)create `custom_instance_replication_user` with a fresh password. This role is
+/// used by postgres trigger connections on custom-instance datatables; membership in
+/// `custom_instance_user` lets it manage publications on the datatable tables.
+///
+/// Authorization: rotates a stored database credential and performs no authorization
+/// itself — callers MUST restrict this to superadmin or internal server paths.
+pub async fn refresh_custom_instance_replication_user_pwd(db: &DB) -> Result<()> {
+    sqlx::query(REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Authorization: returns a stored database credential and performs no authorization
+/// itself — callers MUST restrict this to superadmin or internal server paths (mirrors
+/// [`get_custom_pg_instance_password`]).
+pub async fn get_custom_pg_instance_replication_password(db: &DB) -> Result<String> {
+    // Fast path: already provisioned by the migration.
+    if let Some(pwd) = sqlx::query_scalar::<_, Option<String>>(REPLICATION_PWD_READ_SQL)
+        .fetch_optional(db)
+        .await?
+        .flatten()
+    {
+        return Ok(pwd);
+    }
+    // Self-heal when the role-creating migration was swallowed. The advisory lock + re-check
+    // serialize concurrent workers: otherwise two callers both rotate, and the second
+    // rotation invalidates the password the first already returned. Rotating and reading in
+    // one locked transaction keeps the decision atomic.
+    let mut tx = db.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext('custom_instance_replication_pwd'))")
+        .execute(&mut *tx)
+        .await?;
+    if let Some(pwd) = sqlx::query_scalar::<_, Option<String>>(REPLICATION_PWD_READ_SQL)
+        .fetch_optional(&mut *tx)
+        .await?
+        .flatten()
+    {
+        tx.commit().await?;
+        return Ok(pwd);
+    }
+    sqlx::query(REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL)
+        .execute(&mut *tx)
+        .await?;
+    let pwd = sqlx::query_scalar::<_, Option<String>>(REPLICATION_PWD_READ_SQL)
+        .fetch_optional(&mut *tx)
+        .await?
+        .flatten()
+        .ok_or_else(|| {
+            Error::BadRequest(
+                "Custom instance replication user password not found, did you run migrations ?"
+                    .to_string(),
+            )
+        })?;
+    tx.commit().await?;
+    Ok(pwd)
+}
+
 /// Convert a JSON string to a `Box<RawValue>` without validation.
 ///
 /// # Safety

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -9,7 +9,7 @@ use crate::{
     error::{self, to_anyhow, Error, Result},
     get_database_url,
     secret_backend::{get_secret_value, is_external_stored_value},
-    utils::get_custom_pg_instance_password,
+    utils::{get_custom_pg_instance_password, get_custom_pg_instance_replication_password},
     variables::{build_crypt, decrypt},
     PgDatabase, DB,
 };
@@ -1045,6 +1045,32 @@ pub async fn get_datatable_resource_from_db_unchecked(
     w_id: &str,
     name: &str,
 ) -> Result<serde_json::Value> {
+    get_datatable_resource_inner(db, w_id, name, false).await
+}
+
+/// Same as [`get_datatable_resource_from_db_unchecked`] but for postgres trigger
+/// connections: custom-instance datatables resolve to
+/// `custom_instance_replication_user` rather than `custom_instance_user`. BYO-postgres
+/// datatables resolve to the user's own resource unchanged; configuring it for
+/// replication there is the user's responsibility.
+///
+/// Authorization: like its `_unchecked` sibling, returns resolved connection
+/// credentials and performs no authorization — callers MUST have already authorized
+/// access to the datatable (e.g. the trigger's own create-time check).
+pub async fn get_datatable_replication_resource_from_db_unchecked(
+    db: &DB,
+    w_id: &str,
+    name: &str,
+) -> Result<serde_json::Value> {
+    get_datatable_resource_inner(db, w_id, name, true).await
+}
+
+async fn get_datatable_resource_inner(
+    db: &DB,
+    w_id: &str,
+    name: &str,
+    replication: bool,
+) -> Result<serde_json::Value> {
     let datatables = sqlx::query_scalar!(
         r#"
             SELECT ws.datatable->'datatables' AS datatables
@@ -1068,8 +1094,13 @@ pub async fn get_datatable_resource_from_db_unchecked(
     {
         let mut pg_creds = PgDatabase::parse_uri(&get_database_url().await?.as_str().await)?;
         pg_creds.dbname = datatable.database.resource_path.clone();
-        pg_creds.user = Some("custom_instance_user".to_string());
-        pg_creds.password = Some(get_custom_pg_instance_password(&db).await?);
+        if replication {
+            pg_creds.user = Some("custom_instance_replication_user".to_string());
+            pg_creds.password = Some(get_custom_pg_instance_replication_password(&db).await?);
+        } else {
+            pg_creds.user = Some("custom_instance_user".to_string());
+            pg_creds.password = Some(get_custom_pg_instance_password(&db).await?);
+        }
         serde_json::to_value(&pg_creds)
             .map_err(|e| Error::internal_err(format!("Error serializing pg creds: {}", e)))?
     } else {

--- a/backend/windmill-trigger-postgres/src/lib.rs
+++ b/backend/windmill-trigger-postgres/src/lib.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue;
 use sqlx::FromRow;
 use windmill_api_auth::ApiAuthed;
-use windmill_common::workspaces::get_datatable_resource_from_db_unchecked;
+use windmill_common::workspaces::get_datatable_replication_resource_from_db_unchecked;
 use windmill_common::{
     db::UserDB,
     error::{to_anyhow, Error, Result},
@@ -382,8 +382,10 @@ pub async fn resolve_postgres_resource(
     w_id: &str,
 ) -> Result<Postgres> {
     if let Some(datatable_name) = postgres_resource_path.strip_prefix("datatable://") {
+        // Trigger connections (publication/slot management + logical replication) run
+        // as the dedicated replication user on custom-instance databases.
         let resource_value =
-            get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
+            get_datatable_replication_resource_from_db_unchecked(db, w_id, datatable_name).await?;
         serde_json::from_value::<Postgres>(resource_value).map_err(|e| Error::SerdeJson {
             error: e,
             location: "resolve_postgres_resource".to_string(),

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -2571,15 +2571,57 @@ async fn transform_attach_datatable(
         }
         Connection::Sql(db) => get_datatable_resource_from_db_unchecked(db, w_id, name).await?,
     };
-    let db_type = "postgres";
 
     if let Some(pwd) = db_resource.get("password").and_then(|p| p.as_str()) {
         hidden_passwords.lock().unwrap().push(pwd.to_string());
     }
 
-    Ok(Some(
-        db_resource_to_attach_statements(db_resource, alias_name, db_type, None).await?,
-    ))
+    Ok(Some(pg_secret_attach_statements(db_resource, alias_name)?))
+}
+
+// Secret names must be plain identifiers; the hash keeps two aliases distinct even
+// when sanitizing maps them to the same string.
+fn datatable_secret_name(alias: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let sanitized: String = alias
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let hash = &Sha256::digest(alias.as_bytes())[..4];
+    format!(
+        "__wm_datatable_{sanitized}_{:08x}",
+        u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]])
+    )
+}
+
+/// ATTACH a datatable's postgres database through a DuckDB TEMPORARY SECRET holding
+/// the connection parameters; only sslmode rides in the ATTACH string.
+fn pg_secret_attach_statements(db_resource: Value, alias_name: &str) -> Result<Vec<String>> {
+    let res: PgDatabase = serde_json::from_value(db_resource)?;
+    // Escape single quotes: each field is embedded in a single-quoted DuckDB literal,
+    // so an unescaped quote would break out of the CREATE SECRET statement.
+    let esc = |s: &str| s.replace('\'', "''");
+    // The postgres secret type has no sslmode parameter, so it goes in the ATTACH
+    // string; only the libpq values PgDatabase::to_uri collapses to are forwarded.
+    let sslmode = match res.sslmode.as_deref() {
+        Some("disable") => "disable",
+        Some("require") | Some("verify-ca") | Some("verify-full") => "require",
+        _ => "prefer",
+    };
+    let secret_name = datatable_secret_name(alias_name);
+    Ok(vec![
+        "INSTALL postgres;".to_string(),
+        "LOAD postgres;".to_string(),
+        format!(
+            "CREATE OR REPLACE TEMPORARY SECRET {secret_name} (TYPE postgres, HOST '{}', PORT {}, DATABASE '{}', USER '{}', PASSWORD '{}');",
+            esc(&res.host),
+            res.port.unwrap_or(5432),
+            esc(&res.dbname),
+            esc(res.user.as_deref().unwrap_or("postgres")),
+            esc(res.password.as_deref().unwrap_or("")),
+        ),
+        format!("ATTACH 'sslmode={sslmode}' AS {alias_name} (TYPE postgres, SECRET {secret_name});"),
+    ])
 }
 
 async fn transform_s3_uris(query: &str) -> Result<String> {
@@ -3714,6 +3756,63 @@ mod tests {
         assert!(result.starts_with("postgres://"));
         assert!(result.contains("@localhost:5432/test"));
         assert!(result.contains("sslmode=prefer"));
+    }
+
+    #[test]
+    fn test_pg_secret_attach_statements() {
+        let db_resource = json!({
+            "host": "localhost",
+            "port": 5433,
+            "user": "custom_instance_user",
+            "password": "it's-secret",
+            "dbname": "wm_datatables",
+            "sslmode": "require"
+        });
+        let stmts = pg_secret_attach_statements(db_resource, "dt").unwrap();
+        assert_eq!(stmts[0], "INSTALL postgres;");
+        assert_eq!(stmts[1], "LOAD postgres;");
+        let secret_name = datatable_secret_name("dt");
+        assert_eq!(
+            stmts[2],
+            format!(
+                "CREATE OR REPLACE TEMPORARY SECRET {secret_name} (TYPE postgres, HOST 'localhost', PORT 5433, DATABASE 'wm_datatables', USER 'custom_instance_user', PASSWORD 'it''s-secret');"
+            )
+        );
+        assert_eq!(
+            stmts[3],
+            format!("ATTACH 'sslmode=require' AS dt (TYPE postgres, SECRET {secret_name});")
+        );
+    }
+
+    #[test]
+    fn test_pg_secret_attach_statements_sslmode_whitelist() {
+        for (input, expected) in [
+            (Some("allow"), "prefer"),
+            (Some("verify-full"), "require"),
+            (Some("disable"), "disable"),
+            (Some("unknown-value"), "prefer"),
+            (None, "prefer"),
+        ] {
+            let mut db_resource = json!({ "host": "h", "dbname": "d" });
+            if let Some(s) = input {
+                db_resource["sslmode"] = json!(s);
+            }
+            let stmts = pg_secret_attach_statements(db_resource, "dt").unwrap();
+            assert!(
+                stmts[3].starts_with(&format!("ATTACH 'sslmode={expected}'")),
+                "sslmode {input:?} → {}",
+                stmts[3]
+            );
+        }
+    }
+
+    #[test]
+    fn test_datatable_secret_name_sanitizes_and_disambiguates() {
+        let a = datatable_secret_name("a.b");
+        let b = datatable_secret_name("a_b");
+        assert!(a.starts_with("__wm_datatable_a_b_"));
+        assert_ne!(a, b);
+        assert!(a.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'));
     }
 
     #[test]

--- a/frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte
@@ -165,14 +165,17 @@
 									title: 'Grant permissions to custom_instance_user',
 									status: status?.logs.grant_permissions,
 									description:
-										'Gives custom_instance_user the required permissions to use the database. custom_instance_user is already created during a migration and has an auto-generated password stored in global_settings.custom_instance_pg_databases.user_pwd. These are the commands : \n\n' +
+										'Gives custom_instance_user the required permissions to use the database. custom_instance_user is already created during a migration and has an auto-generated password stored in global_settings.custom_instance_pg_databases.user_pwd. Postgres triggers use custom_instance_replication_user (password in global_settings.custom_instance_replication_pwd). These are the commands : \n\n' +
 										`GRANT CONNECT ON DATABASE "${dbname}" TO custom_instance_user;\n` +
 										'GRANT USAGE ON SCHEMA public TO custom_instance_user;\n' +
 										'GRANT CREATE ON SCHEMA public TO custom_instance_user;\n' +
 										`GRANT CREATE ON DATABASE "${dbname}" TO custom_instance_user;\n` +
 										'ALTER DEFAULT PRIVILEGES IN SCHEMA public \n' +
 										'  	GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES\n    TO custom_instance_user;\n' +
-										'ALTER ROLE custom_instance_user CREATEROLE;'
+										'ALTER ROLE custom_instance_user CREATEROLE;\n' +
+										'ALTER ROLE custom_instance_replication_user REPLICATION;\n' +
+										'GRANT custom_instance_user TO custom_instance_replication_user;\n' +
+										'ALTER ROLE custom_instance_user NOREPLICATION;'
 								}
 							],
 							status?.error ?? undefined
@@ -185,11 +188,13 @@
 							endIcon={{ icon: InfoIcon }}
 							onClick={async () => {
 								await SettingService.refreshCustomInstanceUserPwd()
-								sendUserToast('custom_instance_user password refreshed')
-							}}>Refresh custom_instance_user password</Button
+								sendUserToast('custom instance user passwords refreshed')
+							}}>Refresh custom instance passwords</Button
 						>
 						{#snippet text()}
-							Try this if there is an issue with your custom instance database password.
+							Try this if there is an issue with your custom instance database passwords. Rotates
+							both custom_instance_user and the custom_instance_replication_user used by postgres
+							triggers.
 						{/snippet}
 					</Tooltip>
 				{/if}


### PR DESCRIPTION
## Summary

Refactors how custom-instance data tables establish their Postgres connections, in two independent places:

- **DuckDB executor** — data tables are attached through a DuckDB `TEMPORARY SECRET` carrying the connection parameters, instead of an inline connection string in the `ATTACH` statement. Only `sslmode` is passed in the attach string.
- **Postgres triggers** — triggers on custom-instance data tables now connect through a dedicated `custom_instance_replication_user` role (with its own auto-generated password stored in `global_settings.custom_instance_pg_databases.replication_user_pwd`) rather than `custom_instance_user`. BYO-Postgres data tables are unchanged.

A migration provisions the new role and grants it membership in `custom_instance_user`; server boot normalizes `custom_instance_user`'s role attributes to converge if the one-shot migration couldn't apply (it swallows errors so it never aborts startup).



## Changes

- `duckdb_executor.rs`: `transform_attach_datatable` now emits `CREATE OR REPLACE TEMPORARY SECRET` + `ATTACH ... (TYPE postgres, SECRET ...)`; sslmode whitelisted to disable/require/prefer. Unit tests added.
- New migration `custom_instance_replication_user` (+ down) provisioning the role.
- `windmill-common/utils.rs`: `refresh_custom_instance_replication_user_pwd` + `get_custom_pg_instance_replication_password` (self-heals the role on first use).
- `windmill-common/workspaces.rs`: `get_datatable_replication_resource_from_db_unchecked` resolves the replication role for instance-type data tables.
- `windmill-trigger-postgres/lib.rs`: `datatable://` resolution uses the replication resource.
- `windmill-api-settings/lib.rs`: DB setup provisions the replication role and normalizes attributes.
- `windmill-api/live_migrations.rs`: boot-time attribute normalization.
- Frontend: add `replication_user_pwd` to the instance-settings redaction list; update the custom-instance DB wizard step text.
- SQLx offline cache regenerated (EE-safe procedure, zero net deletions).

## Test plan

- [x] `cargo test -p windmill-worker --features duckdb pg_secret` — secret-attach unit tests pass
- [x] `cargo check` on all touched crates; `npm run check:fast`
- [x] Postgres trigger on a custom-instance data table: publication/slot owned by the replication role, walsender authenticates as it, insert → job fires (verified on a `postgres_trigger` build)
- [x] Boot-time normalization: manually drift the attribute, restart, confirm it re-converges
- [ ] DuckDB job doing `ATTACH 'datatable://...'` end-to-end through the worker (SQL shape + redaction verified via duckdb CLI + unit tests; live-worker job run still pending)
- [x] Upgrade path: existing trigger created before this change keeps firing after migration

## Notes

No screenshots: the two frontend edits are a redaction-list entry (no visible UI change) and one wizard description string; both live on settings pages that display sensitive instance/DB values, which must not be captured to the public screenshot repo.