### PR TITLE
fix(ai-chat): improve resource-type search tool description and scoring

### DIFF
--- a/backend/windmill-api-embeddings/src/lib.rs
+++ b/backend/windmill-api-embeddings/src/lib.rs
@@ -112,6 +112,26 @@ pub struct ResourceTypeResult {
     score: f32,
     schema: Option<serde_json::Value>,
 }
+
+/// Drop results whose score falls more than `max_relative_drop` below the best
+/// match, so a strong hit isn't diluted by weakly-related entries that merely
+/// clear the similarity floor. Expects `results` sorted by descending score and
+/// a positive top score (guaranteed by the caller's similarity threshold).
+#[cfg(feature = "embedding")]
+fn trim_to_top_score<T>(
+    results: Vec<T>,
+    max_relative_drop: f32,
+    score: impl Fn(&T) -> f32,
+) -> Vec<T> {
+    if results.len() <= 1 {
+        return results;
+    }
+    let top_score = score(&results[0]);
+    results
+        .into_iter()
+        .take_while(|r| (top_score - score(r)) / top_score <= max_relative_drop)
+        .collect()
+}
 #[cfg(feature = "embedding")]
 async fn query_resource_types(
     Query(query): Query<ResourceTypesQuery>,
@@ -511,15 +531,7 @@ impl EmbeddingsDb {
             })
             .collect();
 
-        let mut results = results?;
-
-        if results.len() > 1 {
-            let top_score = results[0].score;
-            results = results
-                .into_iter()
-                .take_while(|r| (top_score - r.score) / top_score <= 0.05)
-                .collect();
-        }
+        let results = trim_to_top_score(results?, 0.05, |r| r.score);
 
         Ok(results)
     }
@@ -560,7 +572,7 @@ impl EmbeddingsDb {
             Some(0.75),
         );
 
-        let results: Result<_> = results
+        let results: Result<Vec<ResourceTypeResult>> = results
             .iter()
             .map(|r| {
                 let metadata = r
@@ -582,7 +594,9 @@ impl EmbeddingsDb {
             })
             .collect();
 
-        results
+        let results = trim_to_top_score(results?, 0.05, |r| r.score);
+
+        Ok(results)
     }
 }
 
@@ -658,4 +672,32 @@ pub fn workspaced_service() -> Router {
 #[cfg(not(feature = "embedding"))]
 pub fn global_service() -> Router {
     Router::new()
+}
+
+#[cfg(all(test, feature = "embedding"))]
+mod tests {
+    use super::trim_to_top_score;
+
+    #[test]
+    fn trims_scores_more_than_5pct_below_top() {
+        // top=1.0, cutoff at 0.95: 0.96 stays (0.04 drop), 0.93 is the first
+        // beyond the cutoff so take_while stops there and drops the tail.
+        let kept = trim_to_top_score(vec![1.0f32, 0.97, 0.96, 0.93, 0.9], 0.05, |s| *s);
+        assert_eq!(kept, vec![1.0, 0.97, 0.96]);
+    }
+
+    #[test]
+    fn keeps_all_when_tightly_clustered() {
+        let kept = trim_to_top_score(vec![0.9f32, 0.89, 0.88], 0.05, |s| *s);
+        assert_eq!(kept, vec![0.9, 0.89, 0.88]);
+    }
+
+    #[test]
+    fn passes_through_zero_or_one_result() {
+        assert_eq!(
+            trim_to_top_score(Vec::<f32>::new(), 0.05, |s| *s),
+            Vec::<f32>::new()
+        );
+        assert_eq!(trim_to_top_score(vec![0.42f32], 0.05, |s| *s), vec![0.42]);
+    }
 }

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -574,7 +574,11 @@ const writeResourceSchema = resourceRequestSchema.extend({ override: draftOverri
 const writeVariableSchema = variableRequestSchema.extend({ override: draftOverrideField })
 
 const searchResourceTypesSchema = z.object({
-	query: z.string().describe('Substring to match against resource type names.'),
+	query: z
+		.string()
+		.describe(
+			'Natural-language description of the integration or capability you need, e.g. "stripe", "postgres database", or "send emails". Matched semantically against resource type names and descriptions, so describe the intent rather than guessing the exact name.'
+		),
 	limit: z
 		.number()
 		.int()


### PR DESCRIPTION
## Summary
The AI chat's `search_resource_types` tool (global/session mode) searches the workspace's **local** resource types via semantic embedding search on the backend, but two things undermined its result quality:

1. The tool schema told the LLM its `query` was a **substring match** against resource-type names. The backend actually does BERT-embedding cosine-similarity search, so this mismatch nudged the model toward literal-name guesses instead of the natural-language intent the embedding search rewards.
2. `query_resource_types` applied only the flat `0.75` similarity floor, so a query with one strong hit could still return a spread of weakly-related types. The sibling `query_hub_scripts` already trims results that fall more than 5% below the top score; that logic was inlined there and never applied to resource types.

## Changes
- **Frontend** (`frontend/src/lib/components/copilot/chat/global/core.ts`): rewrite the `search_resource_types` `query` description to describe natural-language semantic search (matched against names **and** descriptions) with examples, instead of "substring match".
- **Backend** (`backend/windmill-api-embeddings/src/lib.rs`):
  - Extract the relative top-score trim (previously inlined in `query_hub_scripts`) into a shared generic `trim_to_top_score` helper.
  - Apply it in `query_resource_types` so a strong match isn't diluted by near-floor entries; `query_hub_scripts` now calls the same helper.
  - Add unit tests pinning the 5% cutoff boundary (drop beyond cutoff, keep tightly-clustered, pass through 0/1 result).

No behavior change to the hub-script path (same trim, now shared). No new API surface, SQL, or auth path.

## Screenshots
No visible UI effect: the only frontend change is a tool-schema description string consumed by the LLM, with no rendered UI.

## Test plan
- [x] `cargo test -p windmill-api-embeddings --features embedding` — 3 `trim_to_top_score` tests pass
- [x] `cargo check -p windmill-api-embeddings --features embedding`
- [x] `npm run check` (frontend) — changed file clean (one pre-existing unrelated error in `RawAppEditor.svelte`)
- [ ] In global AI chat, ask for an integration by intent ("send emails", "postgres database"); confirm `search_resource_types` returns a tightly-clustered set and a strong single match ("stripe") isn't diluted by near-floor entries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns AI chat resource-type search with semantic intent and trims results to within 5% of the top score for tighter, more relevant matches. Prevents weak entries from diluting strong hits.

- **Bug Fixes**
  - Frontend: rewrite `search_resource_types.query` to request natural-language intent matched against resource type names and descriptions.
  - Backend: add shared `trim_to_top_score` helper and apply it in `query_resource_types` (also used by `query_hub_scripts`); add unit tests for the 5% cutoff.

<sup>Written for commit ddd1ccbb57b720cfc4af5c64f06da3b10c122ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

