### PR TITLE
fix(resources): apply resource_type changes on update (git-sync pull) — Fixes GIT-932

### DIFF
--- a/backend/windmill-api-integration-tests/tests/resources.rs
+++ b/backend/windmill-api-integration-tests/tests/resources.rs
@@ -276,8 +276,7 @@ async fn test_resource_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     assert_eq!(body["description"], "Updated description");
 
     // --- update (resource_type) ---
-    // Guards GIT-932: switching a resource's type (e.g. via git-sync pull) must
-    // actually persist; EditResource previously dropped resource_type silently.
+    // An update that only changes resource_type must persist it.
     let resp = authed(client().post(resource_url(port, "update", "u/test-user/new_resource")))
         .json(&json!({"resource_type": "mcp_server"}))
         .send()

--- a/backend/windmill-api-integration-tests/tests/resources.rs
+++ b/backend/windmill-api-integration-tests/tests/resources.rs
@@ -275,6 +275,20 @@ async fn test_resource_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     let body = resp.json::<serde_json::Value>().await?;
     assert_eq!(body["description"], "Updated description");
 
+    // --- update (resource_type) ---
+    // Guards GIT-932: switching a resource's type (e.g. via git-sync pull) must
+    // actually persist; EditResource previously dropped resource_type silently.
+    let resp = authed(client().post(resource_url(port, "update", "u/test-user/new_resource")))
+        .json(&json!({"resource_type": "mcp_server"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = authed_get(port, "get", "u/test-user/new_resource").await;
+    let body = resp.json::<serde_json::Value>().await?;
+    assert_eq!(body["resource_type"], "mcp_server");
+
     // --- update_value ---
     let resp = authed(client().post(resource_url(
         port,

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -184,6 +184,7 @@ struct EditResource {
     path: Option<String>,
     description: Option<String>,
     value: Option<Box<RawValue>>,
+    resource_type: Option<String>,
     labels: Option<Vec<String>>,
     ws_specific: Option<bool>,
 }
@@ -1712,6 +1713,9 @@ async fn update_resource(
     }
     if let Some(nvalue) = &ns.value {
         sqlb.set_str("value", nvalue.to_string());
+    }
+    if let Some(nrt) = &ns.resource_type {
+        sqlb.set_str("resource_type", nrt);
     }
     if let Some(ndesc) = ns.description {
         sqlb.set_str("description", ndesc);


### PR DESCRIPTION
## Problem

Fixes GIT-932.

Switching a resource between two resource types in git and pulling back into the workspace did **not** update the resource's type in the workspace, leaving git and the workspace out of sync. Deleting the resource in git afterwards then failed on pull (the resource of the "new" type couldn't be found), forcing a manual recreate-with-original-type cleanup.

## Root cause

The `EditResource` request body is declared in `backend/windmill-api/openapi.yaml` **with** a `resource_type` field ("The new resource_type to be associated with the resource"), and the generated CLI client (`cli/gen/types.gen.ts`) sends it. But the backend's Rust `EditResource` struct (`windmill-store/src/resources.rs`) **omitted** the field, so serde silently dropped it and `update_resource` never touched `resource.resource_type`.

`wmill sync` (the mechanism behind git-sync "Pull from repo") pushes changed resources through this exact `POST /resources/update/{path}` endpoint, so a changed `resource_type` in git was accepted and reported as success while being discarded server-side.

The spec/CLI have declared this field since #6329; there was never a matching backend implementation.

## Fix

- Add `resource_type: Option<String>` to the backend `EditResource` struct.
- Persist it in the `UPDATE resource` statement when present.

This matches the already-published OpenAPI contract; no spec or client regeneration needed.

## Validation

- **Backend** rebuilt cleanly under `cargo watch` and restarted healthy.
- **End-to-end against the running API**: created a resource of type `git932_type_a`, called `POST /resources/update/{path}` with `{"resource_type":"git932_type_b"}`, and confirmed `get` now reports `git932_type_b` (previously it stayed `git932_type_a`).
- **Regression test**: added a `resource_type`-change assertion to `test_resource_endpoints` in `windmill-api-integration-tests/tests/resources.rs`. The integration-test crate typechecks clean (`cargo check -p windmill-api-integration-tests --tests`).

No frontend changes (backend-only API fix), so no UI screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `resource_type` changes on resource update and git-sync pull so type changes made in git persist in the workspace. Fixes GIT-932 and prevents pull errors after switching types.

- **Bug Fixes**
  - Include `resource_type` in backend `EditResource` and persist it in `update_resource`, aligning with the OpenAPI/CLI contract.
  - Add an integration test asserting `POST /resources/update/{path}` updates `resource_type`; refine the test comment for long-term clarity.

<sup>Written for commit c10bd7d6683191510f5befa3489ae09ae09819e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

