### PR TITLE
fix(cli): surface shared UI changes in sync push dry-run preview

### DIFF
--- a/cli/src/commands/shared_ui.ts
+++ b/cli/src/commands/shared_ui.ts
@@ -26,6 +26,54 @@ async function readDirRecursive(
   return out;
 }
 
+export type SharedUiChange =
+  | { type: "added"; path: string }
+  | { type: "edited"; path: string; before: string; after: string }
+  | { type: "deleted"; path: string };
+
+/**
+ * Diff the local <cwd>/ui/ folder against the workspace's shared UI store in
+ * the push direction (local -> remote), returning entries whose `path` is
+ * prefixed with `ui/`. This is the same comparison pushSharedUi applies, so the
+ * dry-run preview and the real push never diverge.
+ *
+ * Mirrors pushSharedUi's no-op: with no local ui/ folder there is nothing to
+ * push, so the apply is a no-op and the preview must be empty (even when the
+ * remote store is non-empty) to avoid phantom diffs the apply won't perform.
+ */
+export async function diffSharedUi(workspace: string): Promise<SharedUiChange[]> {
+  const localDir = path.join(process.cwd(), SHARED_UI_DIR);
+  if (!fs.existsSync(localDir)) {
+    return [];
+  }
+  const files = await readDirRecursive(localDir);
+
+  let remote: Record<string, string> = {};
+  try {
+    const got = await wmill.getSharedUi({ workspace });
+    remote = got.files ?? {};
+  } catch {
+    // If endpoint missing or unauthorized, treat remote as empty (the push
+    // would attempt the PUT anyway).
+  }
+
+  const changes: SharedUiChange[] = [];
+  for (const [rel, content] of Object.entries(files)) {
+    const p = `${SHARED_UI_DIR}/${rel}`;
+    if (!(rel in remote)) {
+      changes.push({ type: "added", path: p });
+    } else if (remote[rel] !== content) {
+      changes.push({ type: "edited", path: p, before: remote[rel], after: content });
+    }
+  }
+  for (const rel of Object.keys(remote)) {
+    if (!(rel in files)) {
+      changes.push({ type: "deleted", path: `${SHARED_UI_DIR}/${rel}` });
+    }
+  }
+  return changes;
+}
+
 /**
  * Push the local <cwd>/ui/ folder to the workspace's shared UI store.
  * Returns true if a push was performed, false if the folder is missing or empty.
@@ -35,25 +83,15 @@ export async function pushSharedUi(workspace: string): Promise<boolean> {
   if (!fs.existsSync(localDir)) {
     return false;
   }
-  const files = await readDirRecursive(localDir);
 
-  // Skip if no change
-  let remote: Record<string, string> = {};
-  try {
-    const got = await wmill.getSharedUi({ workspace });
-    remote = got.files ?? {};
-  } catch {
-    // If endpoint missing or unauthorized, just attempt the PUT
-  }
-
-  if (
-    Object.keys(remote).length === Object.keys(files).length &&
-    Object.entries(files).every(([k, v]) => remote[k] === v)
-  ) {
+  // Skip if no change — reuse diffSharedUi so preview and push never diverge.
+  const diff = await diffSharedUi(workspace);
+  if (diff.length === 0) {
     log.info(colors.gray("Shared UI folder up to date"));
     return false;
   }
 
+  const files = await readDirRecursive(localDir);
   await wmill.updateSharedUi({
     workspace,
     requestBody: { files },

--- a/cli/src/commands/shared_ui.ts
+++ b/cli/src/commands/shared_ui.ts
@@ -57,17 +57,20 @@ export async function diffSharedUi(workspace: string): Promise<SharedUiChange[]>
     // would attempt the PUT anyway).
   }
 
+  // Use Object.hasOwn, not `in`: a file named after an Object.prototype member
+  // (e.g. ui/toString) would otherwise register as always-present and be
+  // misdiffed.
   const changes: SharedUiChange[] = [];
   for (const [rel, content] of Object.entries(files)) {
     const p = `${SHARED_UI_DIR}/${rel}`;
-    if (!(rel in remote)) {
+    if (!Object.hasOwn(remote, rel)) {
       changes.push({ type: "added", path: p });
     } else if (remote[rel] !== content) {
       changes.push({ type: "edited", path: p, before: remote[rel], after: content });
     }
   }
   for (const rel of Object.keys(remote)) {
-    if (!(rel in files)) {
+    if (!Object.hasOwn(files, rel)) {
       changes.push({ type: "deleted", path: `${SHARED_UI_DIR}/${rel}` });
     }
   }

--- a/cli/src/commands/shared_ui.ts
+++ b/cli/src/commands/shared_ui.ts
@@ -76,7 +76,9 @@ export async function diffSharedUi(workspace: string): Promise<SharedUiChange[]>
 
 /**
  * Push the local <cwd>/ui/ folder to the workspace's shared UI store.
- * Returns true if a push was performed, false if the folder is missing or empty.
+ * Returns true if a push was performed, false if the folder is missing or
+ * already matches the remote store. Note an empty-but-existing folder still
+ * pushes an empty map (clearing the remote store) if the remote is non-empty.
  */
 export async function pushSharedUi(workspace: string): Promise<boolean> {
   const localDir = path.join(process.cwd(), SHARED_UI_DIR);

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4136,6 +4136,33 @@ export async function push(
 
   await fetchRemoteVersion(workspace);
 
+  // Shared UI (the ui/ folder) is pushed out-of-band via pushSharedUi on apply
+  // and is excluded from the file diff (isNotWmillFile), so surface its diff in
+  // the dry-run preview. Without this the "Pull from repo" preview reads "no
+  // changes" even when the apply will overwrite the shared-UI store. Folded in
+  // only for dry-run (before the count/summary below) so the apply path is
+  // unchanged (pushSharedUi still runs) and the summary count includes ui/.
+  if (opts.dryRun) {
+    try {
+      for (const c of await diffSharedUi(workspace.workspaceId)) {
+        if (c.type === "added") {
+          changes.push({ name: "added", path: c.path, content: "" });
+        } else if (c.type === "deleted") {
+          changes.push({ name: "deleted", path: c.path });
+        } else {
+          changes.push({
+            name: "edited",
+            path: c.path,
+            before: c.before,
+            after: c.after,
+          });
+        }
+      }
+    } catch (e) {
+      log.warn(`Failed to compute shared UI diff for dry-run preview: ${e}`);
+    }
+  }
+
   log.info(
     `remote (${workspace.name}) <- local: ${changes.length} changes to apply`,
   );
@@ -4198,32 +4225,6 @@ export async function push(
     }
     if (!opts.jsonOutput) {
       log.warn(msg);
-    }
-  }
-
-  // Shared UI (the ui/ folder) is pushed out-of-band via pushSharedUi on apply
-  // and is excluded from the file diff (isNotWmillFile), so surface its diff in
-  // the dry-run preview. Without this the "Pull from repo" preview reads "no
-  // changes" even when the apply will overwrite the shared-UI store. Folded in
-  // only for dry-run so the apply path is unchanged (pushSharedUi still runs).
-  if (opts.dryRun) {
-    try {
-      for (const c of await diffSharedUi(workspace.workspaceId)) {
-        if (c.type === "added") {
-          changes.push({ name: "added", path: c.path, content: "" });
-        } else if (c.type === "deleted") {
-          changes.push({ name: "deleted", path: c.path });
-        } else {
-          changes.push({
-            name: "edited",
-            path: c.path,
-            before: c.before,
-            after: c.after,
-          });
-        }
-      }
-    } catch (e) {
-      log.warn(`Failed to compute shared UI diff for dry-run preview: ${e}`);
     }
   }
 

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -28,7 +28,7 @@ import {
 } from "../../types.ts";
 import { downloadZip } from "./pull.ts";
 import { runLint, printReport, checkMissingLocks } from "../lint/lint.ts";
-import { pullSharedUi, pushSharedUi } from "../shared_ui.ts";
+import { diffSharedUi, pullSharedUi, pushSharedUi } from "../shared_ui.ts";
 import {
   pushMigrationFromDisk,
   offerToRunNewMigrations,
@@ -3494,6 +3494,9 @@ export async function gitDeploy(
 // are self-describing via their `migrations/datatable/...` path, so they get no
 // label prefix.
 function changeTypeLabel(p: string): string {
+  // Shared UI files (ui/…) are not wmill items — getTypeStrFromPath throws on
+  // them (e.g. ui/config.json). Label them directly.
+  if (p === "ui" || p.startsWith("ui/")) return "shared UI ";
   const t = getTypeStrFromPath(p);
   return t === "datatable_migration" ? "" : `${t} `;
 }
@@ -3543,7 +3546,6 @@ function prettyChanges(
         ),
       );
     } else if (change.name === "edited") {
-      const changeType = getTypeStrFromPath(change.path);
       log.info(
         colors.yellow(
           `~ ${changeTypeLabel(change.path)}` +
@@ -3553,6 +3555,12 @@ function prettyChanges(
         ),
       );
       if (change.before != change.after) {
+        // Shared UI files (ui/…) aren't wmill items; getTypeStrFromPath throws
+        // on them, so fall back to a plain diff.
+        const changeType =
+          change.path === "ui" || change.path.startsWith("ui/")
+            ? "shared_ui"
+            : getTypeStrFromPath(change.path);
         if (changeType === "encryption_key") {
           showDiff(
             redactEncryptionKey(change.before),
@@ -4190,6 +4198,32 @@ export async function push(
     }
     if (!opts.jsonOutput) {
       log.warn(msg);
+    }
+  }
+
+  // Shared UI (the ui/ folder) is pushed out-of-band via pushSharedUi on apply
+  // and is excluded from the file diff (isNotWmillFile), so surface its diff in
+  // the dry-run preview. Without this the "Pull from repo" preview reads "no
+  // changes" even when the apply will overwrite the shared-UI store. Folded in
+  // only for dry-run so the apply path is unchanged (pushSharedUi still runs).
+  if (opts.dryRun) {
+    try {
+      for (const c of await diffSharedUi(workspace.workspaceId)) {
+        if (c.type === "added") {
+          changes.push({ name: "added", path: c.path, content: "" });
+        } else if (c.type === "deleted") {
+          changes.push({ name: "deleted", path: c.path });
+        } else {
+          changes.push({
+            name: "edited",
+            path: c.path,
+            before: c.before,
+            after: c.after,
+          });
+        }
+      }
+    } catch (e) {
+      log.warn(`Failed to compute shared UI diff for dry-run preview: ${e}`);
     }
   }
 
@@ -5170,10 +5204,14 @@ export async function push(
       );
     }
   } else {
-    try {
-      await pushSharedUi(workspace.workspaceId);
-    } catch (e) {
-      log.warn(`Failed to push shared UI folder: ${e}`);
+    // Dry-run with no changes reaches here (a ui/ diff would have made changes
+    // non-empty and returned above); never mutate the remote in that case.
+    if (!opts.dryRun) {
+      try {
+        await pushSharedUi(workspace.workspaceId);
+      } catch (e) {
+        log.warn(`Failed to push shared UI folder: ${e}`);
+      }
     }
     // No changes pushed, so no new datatable migrations to run.
     if (opts.jsonOutput) {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -5206,18 +5206,27 @@ export async function push(
   } else {
     // Dry-run with no changes reaches here (a ui/ diff would have made changes
     // non-empty and returned above); never mutate the remote in that case.
+    let sharedUiPushed = false;
     if (!opts.dryRun) {
       try {
-        await pushSharedUi(workspace.workspaceId);
+        sharedUiPushed = await pushSharedUi(workspace.workspaceId);
       } catch (e) {
         log.warn(`Failed to push shared UI folder: ${e}`);
       }
     }
     // No changes pushed, so no new datatable migrations to run.
     if (opts.jsonOutput) {
+      // Shared UI is out-of-band from the file diff (total counts diffed
+      // files), but don't claim "No changes" when the ui/ store was written.
       console.log(
         JSON.stringify(
-          { success: true, message: "No changes to push", total: 0 },
+          {
+            success: true,
+            message: sharedUiPushed
+              ? "Pushed shared UI changes"
+              : "No changes to push",
+            total: 0,
+          },
           null,
           2,
         ),

--- a/cli/test/shared_ui_diff_unit.test.ts
+++ b/cli/test/shared_ui_diff_unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * Unit tests for diffSharedUi in shared_ui.ts.
- *
- * Regression guard: the git-sync "Pull from repo" preview (wmill sync push
- * --dry-run --json) folds diffSharedUi into its `changes` list so pending
- * shared-UI (ui/) changes show up in the preview instead of reading as
- * "no changes". The apply already syncs ui/ out-of-band via pushSharedUi;
- * only the dry-run was blind.
- *
- * Asserts diffSharedUi emits ui/<rel> entries when the local ui/ folder
- * differs from the remote shared-UI store, and nothing when they match.
+ * diffSharedUi must mirror pushSharedUi's apply semantics so the git-sync
+ * dry-run preview and the real apply never diverge: it emits ui/<rel> entries
+ * exactly when the local ui/ folder differs from the remote store, and nothing
+ * (including no local folder) when the apply would be a no-op.
  */
 
 import { expect, test, describe, beforeEach, afterEach, mock } from "bun:test";

--- a/cli/test/shared_ui_diff_unit.test.ts
+++ b/cli/test/shared_ui_diff_unit.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for diffSharedUi in shared_ui.ts.
+ *
+ * Regression guard: the git-sync "Pull from repo" preview (wmill sync push
+ * --dry-run --json) folds diffSharedUi into its `changes` list so pending
+ * shared-UI (ui/) changes show up in the preview instead of reading as
+ * "no changes". The apply already syncs ui/ out-of-band via pushSharedUi;
+ * only the dry-run was blind.
+ *
+ * Asserts diffSharedUi emits ui/<rel> entries when the local ui/ folder
+ * differs from the remote shared-UI store, and nothing when they match.
+ */
+
+import { expect, test, describe, beforeEach, afterEach, mock } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+let remoteFiles: Record<string, string> = {};
+
+mock.module("../gen/services.gen.ts", () => ({
+  getSharedUi: async (_args: { workspace: string }) => ({ files: remoteFiles }),
+}));
+
+const { diffSharedUi } = await import("../src/commands/shared_ui.ts");
+
+describe("diffSharedUi", () => {
+  const ws = "test-workspace";
+  let tmpDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    remoteFiles = {};
+    prevCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-shared-ui-"));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeUi(rel: string, content: string) {
+    const full = path.join(tmpDir, "ui", rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, "utf-8");
+  }
+
+  test("emits an added ui/<rel> entry when local has a file the remote lacks", async () => {
+    writeUi("theme.json", "{}");
+    const changes = await diffSharedUi(ws);
+    expect(changes).toEqual([{ type: "added", path: "ui/theme.json" }]);
+  });
+
+  test("emits an edited ui/<rel> entry when local content differs", async () => {
+    remoteFiles = { "theme.json": "{}" };
+    writeUi("theme.json", '{"a":1}');
+    const changes = await diffSharedUi(ws);
+    expect(changes).toEqual([
+      { type: "edited", path: "ui/theme.json", before: "{}", after: '{"a":1}' },
+    ]);
+  });
+
+  test("emits a deleted ui/<rel> entry when remote has a file local lacks", async () => {
+    remoteFiles = { "theme.json": "{}", "extra.json": "1" };
+    writeUi("theme.json", "{}");
+    const changes = await diffSharedUi(ws);
+    expect(changes).toEqual([{ type: "deleted", path: "ui/extra.json" }]);
+  });
+
+  test("emits nothing when local matches the remote store", async () => {
+    remoteFiles = { "theme.json": "{}" };
+    writeUi("theme.json", "{}");
+    const changes = await diffSharedUi(ws);
+    expect(changes).toEqual([]);
+  });
+
+  test("emits nothing when there is no local ui/ folder (apply is a no-op)", async () => {
+    remoteFiles = { "theme.json": "{}" };
+    const changes = await diffSharedUi(ws);
+    expect(changes).toEqual([]);
+  });
+});

--- a/cli/test/shared_ui_diff_unit.test.ts
+++ b/cli/test/shared_ui_diff_unit.test.ts
@@ -70,6 +70,20 @@ describe("diffSharedUi", () => {
     expect(changes).toEqual([]);
   });
 
+  test("diffs files named after Object.prototype members (e.g. toString)", async () => {
+    // Own-property check, not `in`: a local-only ui/toString is an add, and a
+    // remote-only ui/toString is a delete, despite Object.prototype.toString.
+    writeUi("toString", "x");
+    let changes = await diffSharedUi(ws);
+    expect(changes).toEqual([{ type: "added", path: "ui/toString" }]);
+
+    fs.rmSync(path.join(tmpDir, "ui", "toString"));
+    fs.mkdirSync(path.join(tmpDir, "ui"), { recursive: true });
+    remoteFiles = { toString: "x" };
+    changes = await diffSharedUi(ws);
+    expect(changes).toEqual([{ type: "deleted", path: "ui/toString" }]);
+  });
+
   test("emits nothing when there is no local ui/ folder (apply is a no-op)", async () => {
     remoteFiles = { "theme.json": "{}" };
     const changes = await diffSharedUi(ws);


### PR DESCRIPTION
## Summary

The git-sync "Pull from repo" preview never showed shared UI (`ui/` folder) changes, so users thought the shared-UI folder was not syncing. The apply step **does** sync it; only the preview/dry-run was blind.

The Shared UI store (`?tab=shared_ui`, backed by `workspace_shared_ui`) maps to a single top-level `ui/` folder and is handled out-of-band from the normal script/flow/app diff (`isNotWmillFile` excludes `ui/`). Round-trip is done by `pushSharedUi`/`pullSharedUi`. In `push()`, the dry-run path returns **before** `pushSharedUi` runs, so the `changes` array the modal consumes never contained a `ui/` entry and the preview read as "No changes to pull" even when the apply would overwrite the store.

## Changes

- **`cli/src/commands/shared_ui.ts`**: add exported `diffSharedUi(workspace)` returning `added`/`edited`/`deleted` `ui/<rel>` entries (push direction, local -> remote). Refactor `pushSharedUi` to reuse it so preview and apply never diverge. `diffSharedUi` mirrors `pushSharedUi`'s no-op: with no local `ui/` folder it returns `[]` (apply doesn't touch the remote in that case), so the preview never shows phantom deletes the apply won't perform.
- **`cli/src/commands/sync/sync.ts`**: fold the `diffSharedUi` result into the `changes` list in the dry-run path only (before both early returns), guarded by try/catch. They flow through the JSON contract and `prettyChanges` with no frontend change. The apply path is unchanged (`pushSharedUi` still runs on `dryRun=false`). Also: label `ui/…` paths as "shared UI" in `changeTypeLabel`/`prettyChanges` (`getTypeStrFromPath` throws on non-wmill paths like `ui/config.json`), and skip `pushSharedUi` in the zero-changes branch during a dry-run so a dry-run never mutates the remote.
- **`cli/test/shared_ui_diff_unit.test.ts`**: regression test for `diffSharedUi` (added/edited/deleted emitted when local differs; empty when matching; empty when no local `ui/`).

### Decision notes

- The `diffSharedUi` no-op guard is stricter than "local absent AND remote empty": it returns `[]` whenever the local `ui/` folder is absent (any remote), because `pushSharedUi` returns early and never deletes the remote store in that case. Matching apply exactly is what avoids a preview/apply mismatch.

## Test plan

- [x] CLI unit test: `UNIT_ONLY=1 bun test test/shared_ui_diff_unit.test.ts` (5 pass)
- [x] `bunx tsc --noEmit`: no new type errors (identical error count with/without the change; the 2 pre-existing `JSZip | TarAsZip` errors are unrelated)
- [x] End-to-end against a running backend:
  - Local `ui/theme.json` differing from an empty remote -> `sync push --dry-run --json-output` includes `{"type":"added","path":"ui/theme.json"}`, `total: 1`
  - After a real `sync push`, the store matches -> dry-run has no `ui/` entries, `total: 0`
  - Terminal (non-JSON) dry-run renders `+ shared UI ui/config.json` / `~ shared UI ui/theme.json` without the `getTypeStrFromPath` crash

Note: the full Gitea + EE git-sync e2e (driving the actual "Pull from repo" modal with Playwright) was not run here; the modal consumes the exact JSON `changes` array validated end-to-end above and the frontend is unchanged, so the fix is exercised by the CLI-level e2e.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git-sync dry-run preview so changes in the `ui/` shared UI folder are shown and counted, matching what the apply step would push. Also improves output labeling and JSON messages around shared-UI-only changes.

- **Bug Fixes**
  - Added `diffSharedUi(workspace)` and reused it in `pushSharedUi` so preview and apply stay consistent; returns no diffs when local `ui/` is missing.
  - Dry-run now folds `ui/` changes into the `changes` list and summary; pretty output labels them as “shared UI” and uses own-property checks to handle names like `ui/toString`.
  - Dry-run never calls `pushSharedUi`, avoiding remote mutations; JSON output now reports shared-UI-only pushes instead of “No changes”.
  - Added unit tests covering add/edit/delete, matching stores, no local `ui/`, and inherited-name files.

<sup>Written for commit 0c2abdbaef84fdf0bc42b3fd3a202653d44dc3b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

