### PR TITLE
feat(windows): enable ruby and rlang on the windows worker

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -176,7 +176,7 @@ ruby = ["windmill-worker/ruby"]
 rlang = ["windmill-worker/rlang"]
 all_languages = ["python", "deno_core", "rust", "mysql", "oracledb", "duckdb", "mssql-kerberos", "bigquery", "csharp", "nu", "php", "java", "ruby", "rlang"]
 # For windows we have another set of languages enabled
-all_languages_windows = ["python", "deno_core", "rust", "mysql", "oracledb", "duckdb", "mssql-winauth", "bigquery", "csharp", "nu", "php", "java"]
+all_languages_windows = ["python", "deno_core", "rust", "mysql", "oracledb", "duckdb", "mssql-winauth", "bigquery", "csharp", "nu", "php", "java", "ruby", "rlang"]
 # Edition meta-features: shared groups
 run_inline = ["windmill-api/run_inline"]
 oss_core = [


### PR DESCRIPTION
## Summary
Brings the Windows worker's language set to parity with Linux by enabling `ruby` and `rlang`. Previously `all_languages_windows` omitted them; now the only intentional difference from `all_languages` is `mssql-winauth` vs `mssql-kerberos` (the correct per-OS integrated-auth backend).

## Rationale
For nearly every language, the Rust worker binary only carries a **parser** plus an executor that shells out — the actual runtime (CPython, Node/Bun, PHP, .NET, JDK, R, Ruby) is a host/Dockerfile concern, not linked into the binary. Enabling a language flips on a small parser crate.

- `windmill-parser-ruby` and `windmill-parser-r` are dependency-free pure-Rust crates → negligible build-time and binary-size cost, no platform-specific deps.
- The executors are already Windows-aware: `ruby_executor.rs` and `r_executor.rs` both contain `#[cfg(windows)]` branches. They were written to compile and run on Windows; they simply weren't wired into the Windows feature set.
- If the Ruby/R runtime isn't installed on the host, a job degrades gracefully to a runtime "command not found", identical to any other missing runtime.

The dominant compile-time/binary costs on Windows (V8 via `deno_core`, Oracle Instant Client via `oracledb`, the nushell parser via `nu`) are already paid for in the existing `ee_windows` build, so the marginal cost of these two parser-only languages is rounding error.

## Changes
- `backend/Cargo.toml`: add `ruby` and `rlang` to `all_languages_windows`.

## Test plan
- [ ] Windows worker build (`cargo build --release --features=ee_windows`) compiles.
- [ ] A Ruby or R script dispatched to a Windows worker with the runtime installed executes.
- [ ] The same script with the runtime absent fails with a clear runtime error rather than crashing the worker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `ruby` and `rlang` on the Windows worker by adding them to `all_languages_windows` in `backend/Cargo.toml`. This brings parity with Linux; the only remaining difference is `mssql-winauth` vs `mssql-kerberos`.

<sup>Written for commit 605c990a4b439efa1892311b92b4c5fdaf1f78bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

