### PR TITLE
chore(pr-skill): make review-round waiter idempotency-aware

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -139,8 +139,10 @@ A PR leaves draft **only after a clean CI review round**. Never run `gh pr ready
 
    It comments `/review` on the PR — which runs the Codex, Claude and Pi CI reviewers even on a draft — waits for the spawned `PR Review Commands` workflow run(s) to complete, then prints one verdict line per reviewer and saves the full review comments to files.
 
+   `/review` (and `/codex`) are **idempotent per head SHA**: if a running or successful review already covers the current head, they skip that agent and post nothing new — the waiter reads the existing verdict for that head, so a skipped agent is *not* a missing one. A cancelled/failed head run is re-run in place; a fresh run is launched only when nothing covers the head. So an unchanged-head re-review is a near no-op, not a new round — push a commit to get genuinely fresh reviews.
+
 2. **Judge the round.** Codex is mandatory; Claude, Pi and cubic count whenever they posted. Every review starts with one of the three `REVIEW.md` verdicts:
-   - Codex verdict missing → the round is void: comment `/codex` on the PR, wait for it the same way, and judge again.
+   - Codex verdict missing → the round is void: the waiter warns only when the head has no green Codex run (cancelled/failed/absent — not merely skipped-because-already-reviewed). Comment `/codex` on the PR, which re-runs the interrupted run in place (or launches one if none exists), wait the same way, and judge again.
    - Any **"Should address issues before merging"** → fix the P0/P1 findings (and the nits while you're there), commit, push, and start a new round (step 1).
    - Only **"Mergeable, but should ideally address nits"** and/or **"Good to merge"** → fix the nits too; a nit that is wrong or genuinely not worth fixing may instead be dismissed by replying to the review comment with your reasoning. Push nit-only fixes without starting another full round.
 

--- a/.agents/skills/pr/review-round.sh
+++ b/.agents/skills/pr/review-round.sh
@@ -79,10 +79,43 @@ while :; do
   sleep 60
 done
 
+# Head SHA at trigger time. `/review` is idempotent per head: it skips an agent a
+# running/successful review already covers, re-runs a cancelled/failed one in place on a
+# separate head-tied run, and launches fresh only when nothing covers the head. Verdict
+# reading below therefore keys off the head, not just the trigger timestamp.
+HEAD_SHA=$(retry gh api "repos/$REPO/pulls/$PR" --jq .head.sha)
+echo "Reviewing head $HEAD_SHA"
+
+# Newest non-skipped run of <workflow> tied to the head ("status conclusion"), or empty
+# when none exists. A re-run-in-place or an already-covering review resolves on such a
+# head-tied run — separate from the pr-review-commands run waited on above (a fresh
+# launch instead runs inside it, and posts after the trigger). A `skipped` run is the
+# draft/fork gate and produced no review, so it is ignored.
+head_run_state() {
+  gh run list --repo "$REPO" --workflow "$1" --commit "$HEAD_SHA" --limit 20 \
+    --json databaseId,status,conclusion \
+    --jq '[.[] | select(.conclusion != "skipped")] | sort_by(.databaseId) | last | if . then "\(.status) \(.conclusion // "-")" else empty end' 2>/dev/null || true
+}
+
+# A re-run-in-place review lands on a head-tied run that finishes after the fast
+# pr-review-commands run, so let those settle before reading verdicts.
+for wf in codex-pr-review.yml pi-pr-review.yml pr-ready-review.yml; do
+  while :; do
+    case "$(head_run_state "$wf")" in
+      ""|"completed "*) break ;;
+      *) if [ "$(date +%s)" -gt "$DEADLINE" ]; then break; fi; sleep 30 ;;
+    esac
+  done
+done
+
 OUT_DIR=$(mktemp -d -t review-round-XXXXXX)
 COMMENTS_RAW=$(retry gh api "repos/$REPO/issues/$PR/comments?per_page=100" --paginate)
+# Two views: comments from THIS round (after the trigger) and the full history. A fresh
+# launch posts after the trigger; an idempotent skip leaves the covering verdict in the
+# earlier run's comment, so fall back to history when that agent's head run is green.
 jq -s --arg t "$TRIGGER_TIME" '[.[][] | select(.created_at > $t)]' \
   <<<"$COMMENTS_RAW" > "$OUT_DIR/comments.json"
+jq -s '[.[][]]' <<<"$COMMENTS_RAW" > "$OUT_DIR/comments-all.json"
 # cubic posts through the PR reviews API, not issue comments.
 REVIEWS_RAW=$(retry gh api "repos/$REPO/pulls/$PR/reviews?per_page=100" --paginate)
 jq -s --arg t "$TRIGGER_TIME" '[.[][] | select((.submitted_at // "") > $t)]' \
@@ -90,18 +123,28 @@ jq -s --arg t "$TRIGGER_TIME" '[.[][] | select((.submitted_at // "") > $t)]' \
 
 VERDICT_RE='(Good to merge|Mergeable, but should ideally address nits|Should address issues before merging)'
 
-body_by_header() {
-  jq -r --arg h "$1" '[.[] | select(.body // "" | contains($h))] | last | .body // empty' \
-    "$OUT_DIR/comments.json"
+body_by_header() { # <file> <header-substring>
+  jq -r --arg h "$2" '[.[] | select(.body // "" | contains($h))] | last | .body // empty' "$1"
 }
-body_by_login() {
-  jq -r --arg l "$1" '[.[] | select(.user.login == $l)] | last | .body // empty' \
-    "$OUT_DIR/comments.json"
+body_by_login() { # <file> <login>
+  jq -r --arg l "$2" '[.[] | select(.user.login == $l)] | last | .body // empty' "$1"
+}
+head_ok() { [ "$(head_run_state "$1")" = "completed success" ]; }
+# Latest verdict for a reviewer: prefer this round's comment; if none and the reviewer's
+# head run succeeded (an idempotent /review skipped re-reviewing an already-green head),
+# fall back to the covering comment from the full history.
+verdict_body() { # <header|login> <value> <workflow>
+  local body
+  body=$("body_by_$1" "$OUT_DIR/comments.json" "$2")
+  if [ -z "$body" ] && head_ok "$3"; then
+    body=$("body_by_$1" "$OUT_DIR/comments-all.json" "$2")
+  fi
+  printf '%s' "$body"
 }
 report() { # <reviewer-name> <comment-body>
   local name=$1 body=$2 verdict
   if [ -z "$body" ]; then
-    echo "$name: (no review posted this round)"
+    echo "$name: (no review posted for this head)"
     return
   fi
   printf '%s\n' "$body" > "$OUT_DIR/$name.md"
@@ -110,11 +153,11 @@ report() { # <reviewer-name> <comment-body>
 }
 
 echo
-echo "=== Review round verdicts for $REPO#$PR (posted after $TRIGGER_TIME) ==="
-CODEX_BODY=$(body_by_header '## Codex Review')
+echo "=== Review round verdicts for $REPO#$PR (head $HEAD_SHA) ==="
+CODEX_BODY=$(verdict_body header '## Codex Review' codex-pr-review.yml)
 report codex "$CODEX_BODY"
-report claude "$(body_by_login 'claude[bot]')"
-report pi "$(body_by_header '## Pi Review')"
+report claude "$(verdict_body login 'claude[bot]' pr-ready-review.yml)"
+report pi "$(verdict_body header '## Pi Review' pi-pr-review.yml)"
 CUBIC_BODY=$(jq -r '[.[] | select(.user.login | test("^cubic(-dev-ai)?(\\[bot\\])?$"; "i"))] | last | .body // empty' \
   "$OUT_DIR/pr-reviews.json")
 if [ -z "$CUBIC_BODY" ]; then
@@ -125,5 +168,5 @@ report cubic "$CUBIC_BODY"
 echo
 echo "Full round output: $OUT_DIR (comments.json, pr-reviews.json, one .md per reviewer)"
 if [ -z "$CODEX_BODY" ]; then
-  echo "WARNING: Codex verdict missing - the round is incomplete. Re-trigger with a '/codex' PR comment and wait again." >&2
+  echo "WARNING: no Codex verdict for $HEAD_SHA - its head run is not green (cancelled/failed/absent, not merely skipped-because-already-reviewed). Re-trigger with a '/codex' PR comment (re-runs the interrupted run in place, or launches one) and wait again." >&2
 fi


### PR DESCRIPTION
Follow-up to #10283 (which made \`/review\` and \`/codex\` idempotent per head SHA). Updates the \`pr\` skill's review-round tooling so it stays correct under that behavior.

**\`review-round.sh\`**
- Waits for re-run-in-place reviews to settle. A \`/review\` that re-runs a cancelled/failed review does so on a separate head-tied run that outlives the fast \`PR Review Commands\` run, so the waiter now also polls the codex/pi/claude runs tied to the head SHA before reading verdicts.
- Falls back to the covering verdict for the head. When \`/review\` idempotently skips an already-green agent, no comment is posted after the trigger; the waiter now reads that agent's existing verdict for the head (from full comment history, gated on a green head run) instead of reporting it "missing".
- The "Codex verdict missing" warning now fires only when the head has no green Codex run (cancelled/failed/absent) — the case where \`/codex\` genuinely helps (re-run in place / launch).

**\`SKILL.md\`**
- Documents that \`/review\` and \`/codex\` are idempotent per head SHA: a skipped agent is not a missing one, and an unchanged-head re-review is a near no-op — push a commit for genuinely fresh reviews.

Logic verified with stubbed \`gh --jq\`: head-run parsing (skipped ignored, success/in-progress), the wait-loop state matching, and the verdict fallback (green head → prior verdict; failed head → empty/missing; fresh post-trigger → used directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the PR review waiter idempotency-aware per head SHA so skipped agents are treated as covered and verdicts come from the head’s existing run when valid. Updates `SKILL.md` to document `/review` and `/codex` idempotency and the correct judging flow.

- **Bug Fixes**
  - Head-aware waiting: polls `codex-pr-review.yml`, `pi-pr-review.yml`, and `pr-ready-review.yml` tied to the head and waits for re-run-in-place to finish before reading verdicts.
  - Verdicts: keyed to the head SHA; if an agent was skipped and the head run is green, use the existing verdict from history; otherwise report “(no review posted for this head)”.
  - Warnings/docs: only warn when there’s no green Codex run for the head; `SKILL.md` explains idempotency for `/review` and `/codex` and that unchanged-head re-reviews are near no-ops.

<sup>Written for commit d2e0528be23bed0b983e740666f2c4d8cceec002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

