### PR TITLE
fix(monitor): diagnose zombie-flow OOM on the transition worker, not q.worker

### DIFF
--- a/backend/.sqlx/query-856697038686ec82f1925f70c57d41e538012b79637c9c0dcd29345ded09f699.json
+++ b/backend/.sqlx/query-856697038686ec82f1925f70c57d41e538012b79637c9c0dcd29345ded09f699.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH ref AS (\n            SELECT worker_instance, worker_group FROM worker_ping WHERE worker = $1 LIMIT 1\n        )\n        SELECT\n            wp.worker AS \"worker!\",\n            wp.ping_at AS \"ping_at!\",\n            wp.memory_usage,\n            wp.wm_memory_usage,\n            wp.memory AS memory_total,\n            wp.worker_group,\n            wp.worker_instance,\n            EXTRACT(EPOCH FROM (wp.ping_at - $2::timestamptz))::float8 AS ping_delta_secs\n        FROM worker_ping wp, ref\n        WHERE wp.worker <> $1\n            AND (\n                (ref.worker_instance IS NOT NULL AND wp.worker_instance = ref.worker_instance)\n                OR (ref.worker_group IS NOT NULL AND wp.worker_group = ref.worker_group)\n            )\n            AND wp.ping_at >= $2::timestamptz - interval '5 seconds'\n            AND wp.ping_at <= $2::timestamptz + interval '15 seconds'\n        ORDER BY ABS(EXTRACT(EPOCH FROM (wp.ping_at - $2::timestamptz))) ASC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "worker!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "ping_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "memory_usage",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "wm_memory_usage",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "memory_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "worker_group",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "worker_instance",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "ping_delta_secs",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "856697038686ec82f1925f70c57d41e538012b79637c9c0dcd29345ded09f699"
+}

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -4864,6 +4864,87 @@ WHERE concurrency_id IN (SELECT concurrency_id FROM rows_to_delete)  RETURNING c
     Ok(())
 }
 
+/// Memory usage at a worker's last ping as a fraction of its cgroup limit.
+/// Takes the larger of the cgroup-wide reading and the windmill process's
+/// jemalloc resident — if only one is present, that value wins; if both are
+/// present, the larger is the more conservative (higher-signal) choice.
+fn zombie_worker_memory_pct(
+    usage: Option<i64>,
+    wm_usage: Option<i64>,
+    total: Option<i64>,
+) -> Option<f64> {
+    let total = total?;
+    if total <= 0 {
+        return None;
+    }
+    let used = usage.max(wm_usage)?;
+    Some(used as f64 / total as f64)
+}
+
+struct ZombieFlowCulprit {
+    worker: String,
+    ping_at: DateTime<Utc>,
+    memory_usage: Option<i64>,
+    wm_memory_usage: Option<i64>,
+    memory_total: Option<i64>,
+    worker_group: Option<String>,
+    worker_instance: Option<String>,
+    ping_delta_secs: Option<f64>,
+}
+
+/// Finds the worker that likely performed and dropped the flow's final state
+/// transition when `q.worker` (the outer queue-row worker) looks healthy — a
+/// different worker on the same pod/group whose *latest* ping is frozen in the
+/// `[last_ping-5s, +15s]` window (a live worker would have advanced its in-place
+/// ping past that old window, so a frozen ping there proves it has gone silent),
+/// nearest the transition. Diagnostics-only: fails soft to `None`.
+async fn find_zombie_flow_culprit_worker(
+    db: &DB,
+    q_worker: &str,
+    last_ping: DateTime<Utc>,
+) -> Option<ZombieFlowCulprit> {
+    let res = sqlx::query_as!(
+        ZombieFlowCulprit,
+        r#"
+        WITH ref AS (
+            SELECT worker_instance, worker_group FROM worker_ping WHERE worker = $1 LIMIT 1
+        )
+        SELECT
+            wp.worker AS "worker!",
+            wp.ping_at AS "ping_at!",
+            wp.memory_usage,
+            wp.wm_memory_usage,
+            wp.memory AS memory_total,
+            wp.worker_group,
+            wp.worker_instance,
+            EXTRACT(EPOCH FROM (wp.ping_at - $2::timestamptz))::float8 AS ping_delta_secs
+        FROM worker_ping wp, ref
+        WHERE wp.worker <> $1
+            AND (
+                (ref.worker_instance IS NOT NULL AND wp.worker_instance = ref.worker_instance)
+                OR (ref.worker_group IS NOT NULL AND wp.worker_group = ref.worker_group)
+            )
+            AND wp.ping_at >= $2::timestamptz - interval '5 seconds'
+            AND wp.ping_at <= $2::timestamptz + interval '15 seconds'
+        ORDER BY ABS(EXTRACT(EPOCH FROM (wp.ping_at - $2::timestamptz))) ASC
+        LIMIT 1
+        "#,
+        q_worker,
+        last_ping,
+    )
+    .fetch_optional(db)
+    .await;
+    match res {
+        Ok(culprit) => culprit,
+        Err(e) => {
+            tracing::warn!(
+                "failed to query for zombie-flow culprit worker (q_worker={q_worker}): {e:#}"
+            );
+            None
+        }
+    }
+}
+
 async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
     let flows = sqlx::query!(
         r#"
@@ -4963,18 +5044,35 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
             // worker name; this flow's recorded worker name still points at the
             // dead process whose last ping can be under 60s old, and the memory
             // signal is what lets us catch that window.
-            let memory_pct: Option<f64> = flow.worker_memory_total.and_then(|total| {
-                if total <= 0 {
-                    return None;
-                }
-                let used = flow.worker_memory_usage.max(flow.worker_wm_memory_usage)?;
-                Some(used as f64 / total as f64)
-            });
+            let memory_pct: Option<f64> = zombie_worker_memory_pct(
+                flow.worker_memory_usage,
+                flow.worker_wm_memory_usage,
+                flow.worker_memory_total,
+            );
             let oom_strong = memory_pct.is_some_and(|p| p >= 0.85);
             let oom_moderate = memory_pct.is_some_and(|p| p >= 0.60);
             let mem_pct_str = memory_pct
                 .map(|p| format!("{:.1}% of container limit", (p * 100.0).min(100.0)))
                 .unwrap_or_else(|| "memory unknown at last ping".to_string());
+
+            // When q.worker itself already shows OOM evidence the diagnosis below is
+            // already correct. Otherwise q.worker is likely a bystander (the outer
+            // queue-row worker) and the dropped transition was performed by a
+            // different worker on the same pod/group that OOM-died — go find it.
+            let q_worker_shows_oom = oom_moderate || worker_ping_stale == Some(true);
+            let culprit = if q_worker_shows_oom {
+                None
+            } else if let (Some(qw), Some(lp)) = (flow.worker.as_deref(), flow.last_ping) {
+                find_zombie_flow_culprit_worker(db, qw, lp).await
+            } else {
+                None
+            };
+            let culprit_pct = culprit.as_ref().and_then(|c| {
+                zombie_worker_memory_pct(c.memory_usage, c.wm_memory_usage, c.memory_total)
+            });
+            let culprit_pct_str =
+                culprit_pct.map(|p| format!("{:.1}% of its memory limit", (p * 100.0).min(100.0)));
+
             let worker_info = if let Some(worker_name) = flow.worker.as_deref() {
                 let mut s = format!("\nWorker handling the flow: {worker_name}");
                 match (flow.worker_group.as_deref(), flow.worker_version.as_deref()) {
@@ -5005,8 +5103,11 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                         (false, false, true) => format!(
                             "LIKELY OOM-KILLED — {mem_pct_str} at last ping (a replacement worker process may have started in the same pod under a new windmill worker name)"
                         ),
+                        (false, false, false) if culprit.is_some() => {
+                            "still pinging with healthy memory — this is NOT the worker that performed the flow's final state transition (see likely culprit worker below)".to_string()
+                        }
                         (false, false, false) => {
-                            "worker still pinging with healthy memory — likely deadlocked or blocking on the state transition".to_string()
+                            "worker still pinging with healthy memory — most likely a different worker performed and dropped the final transition (see hint); less likely: this worker deadlocked or is blocking on the state transition".to_string()
                         }
                     };
                     s.push_str(&format!("\nWorker last ping: {wp} ({age}s ago) — {status}"));
@@ -5051,20 +5152,88 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                     .to_string()
             };
 
-            let hint: String = match (worker_ping_stale, oom_moderate) {
-                (Some(_), true) => format!(
-                    "\nThis is almost certainly an OOM-kill: container memory at the worker's last ping was at {mem_pct_str}. Raise the worker memory limit (e.g. k8s `resources.limits.memory`) or reduce per-flow memory usage. Confirm via pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`)."
-                ),
-                (Some(true), false) => {
-                    "\nWorker stopped pinging and its last memory snapshot did not look high — in practice the overwhelmingly common cause here is still OOM-kill (memory may have spiked between the last ping and the kill, or never been reported). First check pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). Less likely: host failure, network partition, or a panic — check worker logs / k8s events around the last ping time.".to_string()
-                }
-                (Some(false), false) => {
-                    "\nWorker is still pinging and memory looked healthy at its last ping — most likely a deadlock or blocking call during the state transition. Capture a stack trace (e.g. via SIGQUIT) from the worker process. As a sanity check, also verify pod restart count in case a replacement worker process in the same pod has silently taken over.".to_string()
-                }
-                (None, _) => String::new(),
+            let culprit_info = if let Some(c) = culprit.as_ref() {
+                let age = (now - c.ping_at).num_seconds();
+                let rel = match c.ping_delta_secs {
+                    Some(d) if d >= 0.0 => format!("{d:.0}s after"),
+                    Some(d) => format!("{:.0}s before", -d),
+                    None => "around".to_string(),
+                };
+                let loc =
+                    if c.worker_instance.is_some() && c.worker_instance == flow.worker_instance {
+                        format!(
+                            "same pod/instance '{}'",
+                            c.worker_instance.as_deref().unwrap()
+                        )
+                    } else if let Some(g) = c.worker_group.as_deref() {
+                        format!("worker group '{g}'")
+                    } else if let Some(inst) = c.worker_instance.as_deref() {
+                        format!("instance '{inst}'")
+                    } else {
+                        "same pod/group".to_string()
+                    };
+                let mem = match culprit_pct_str.as_deref() {
+                    Some(p) => format!("was at {p}"),
+                    None => "did not report memory".to_string(),
+                };
+                let mem_detail = match (c.memory_usage, c.wm_memory_usage, c.memory_total) {
+                    (host, wm, Some(total)) => {
+                        let used = host.max(wm);
+                        match used {
+                            Some(u) => format!(
+                                " (memory at last ping: {} of {})",
+                                fmt_mb(u),
+                                fmt_mb(total)
+                            ),
+                            None => format!(" (total available: {})", fmt_mb(total)),
+                        }
+                    }
+                    _ => String::new(),
+                };
+                let q_name = flow.worker.as_deref().unwrap_or("the recorded worker");
+                format!(
+                    "\nLikely culprit worker (on {loc}): {} — last pinged {} ({age}s ago, {rel} this flow's last ping) and then stopped pinging; it {mem} at that last ping{mem_detail}. This flow's dropped state transition was most likely performed by this worker and lost to its death (most likely OOM-kill), not a deadlock on {q_name}.",
+                    c.worker, c.ping_at,
+                )
+            } else {
+                String::new()
             };
 
-            let service_logs_info = match (flow.worker_instance.as_deref(), flow.worker_last_ping) {
+            let hint: String = if let Some(c) = culprit.as_ref() {
+                let q_name = flow.worker.as_deref().unwrap_or("the recorded worker");
+                match culprit_pct {
+                    Some(p) if p >= 0.60 => format!(
+                        "\nThis is almost certainly an OOM-kill on a *different* worker: {} (on the same pod/worker group) was at {} at its last ping right around this flow's transition, then stopped pinging. The flow's recorded worker ({q_name}) looks healthy because it is not the worker that performed the dropped transition. Raise the worker memory limit (e.g. k8s `resources.limits.memory`) or reduce per-flow memory usage. Confirm via that pod's restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`).",
+                        c.worker,
+                        culprit_pct_str.as_deref().unwrap_or("a high fraction of its limit"),
+                    ),
+                    _ => format!(
+                        "\nMost likely an OOM-kill on a *different* worker: {} (on the same pod/worker group) stopped pinging right around this flow's transition ({last_ping:?}); its memory may have spiked after its last ping or not been reported. The flow's recorded worker ({q_name}) looks healthy because it did not perform the dropped transition. First check that pod's restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). Only if that worker was not OOM-killed, consider a deadlock on {q_name} and capture a stack trace (e.g. via SIGQUIT).",
+                        c.worker,
+                    ),
+                }
+            } else {
+                match (worker_ping_stale, oom_moderate) {
+                    (Some(_), true) => format!(
+                        "\nThis is almost certainly an OOM-kill: container memory at the worker's last ping was at {mem_pct_str}. Raise the worker memory limit (e.g. k8s `resources.limits.memory`) or reduce per-flow memory usage. Confirm via pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`)."
+                    ),
+                    (Some(true), false) => {
+                        "\nWorker stopped pinging and its last memory snapshot did not look high — in practice the overwhelmingly common cause here is still OOM-kill (memory may have spiked between the last ping and the kill, or never been reported). First check pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). Less likely: host failure, network partition, or a panic — check worker logs / k8s events around the last ping time.".to_string()
+                    }
+                    (Some(false), false) => {
+                        format!("\nThe flow's recorded worker is still pinging with healthy memory, but that worker is often NOT the one that performed the final state transition (in nested/subflow/forloop cases the last iteration runs on another worker). First check whether a different worker on the same pod / worker group was OOM-killed around {last_ping:?} (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`, and that pod's worker memory metrics). Only if no such worker died, treat this as a deadlock or blocking call on the recorded worker during the state transition and capture a stack trace (e.g. via SIGQUIT).")
+                    }
+                    (None, _) => String::new(),
+                }
+            };
+
+            // Pull logs for the worker (and around the time) we actually blame: the
+            // culprit's instance/last-ping when one was found, else q.worker's.
+            let (log_instance, log_ping) = match culprit.as_ref() {
+                Some(c) => (c.worker_instance.as_deref(), Some(c.ping_at)),
+                None => (flow.worker_instance.as_deref(), flow.worker_last_ping),
+            };
+            let service_logs_info = match (log_instance, log_ping) {
                 (Some(host), Some(wlp)) => {
                     let after = (wlp - chrono::Duration::seconds(90))
                         .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
@@ -5118,7 +5287,7 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
             };
 
             let reason = format!(
-                "{} was hanging in between 2 steps. Last ping: {last_ping:?} (now: {now}){worker_info}{hint}{service_logs_info}",
+                "{} was hanging in between 2 steps. Last ping: {last_ping:?} (now: {now}){worker_info}{culprit_info}{hint}{service_logs_info}",
                 if flow.is_flow_step.unwrap_or(false) && flow.parent_job.is_some() {
                     format!("Flow was cancelled because subflow {id} ({base_url}/run/{id}?workspace={workspace_id})")
                 } else {
@@ -5786,5 +5955,41 @@ mod strike_unarmed_tests {
         assert!(strike_unarmed(&mut seen, set(&["a"])).is_empty());
         assert_eq!(strike_unarmed(&mut seen, set(&["a", "b"])), vec![key("a")]);
         assert_eq!(strike_unarmed(&mut seen, set(&["b"])), vec![key("b")]);
+    }
+}
+
+#[cfg(test)]
+mod zombie_worker_memory_pct_tests {
+    use super::zombie_worker_memory_pct;
+
+    #[test]
+    fn takes_the_larger_of_the_two_readings() {
+        // Both present: the larger (higher-signal) reading wins, not either
+        // one unconditionally — a "simplify to `usage.or(wm_usage)`" refactor
+        // would silently under-report and miss OOMs.
+        let p = zombie_worker_memory_pct(Some(600), Some(900), Some(1000)).unwrap();
+        assert!((p - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn falls_back_to_whichever_reading_is_present() {
+        assert_eq!(
+            zombie_worker_memory_pct(Some(700), None, Some(1000)),
+            Some(0.7)
+        );
+        assert_eq!(
+            zombie_worker_memory_pct(None, Some(800), Some(1000)),
+            Some(0.8)
+        );
+    }
+
+    #[test]
+    fn none_when_no_usage_or_no_valid_total() {
+        assert_eq!(zombie_worker_memory_pct(None, None, Some(1000)), None);
+        assert_eq!(zombie_worker_memory_pct(Some(500), Some(500), None), None);
+        assert_eq!(
+            zombie_worker_memory_pct(Some(500), Some(500), Some(0)),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes WIN-2231.

A production flow was cancelled as a between-steps zombie with a diagnostic that told on-call to *"capture a stack trace (e.g. via SIGQUIT) — worker still pinging with healthy memory, likely deadlocked"*. That advice was wrong and cost investigation time.

**Ground truth:** the subflow was on its final forloop iteration (187/188); all 188 iterations had completed. A worker (`hql6x`) finished the last iteration, logged *"subflow is finished, updating parent flow status"* (this write set the flow's `last_ping`), then was **OOMKilled ~3s later** (k8s `lastState.terminated.reason=OOMKilled`, 1024Mi limit) — killed mid state-transition. The dropped transition left the flow's module `InProgress` with a frozen ping, so 60s later the monitor reaped it. The worker the alert *named* (`6pwsf`) was a **different, healthy** worker — it just happened to be the one recorded on the flow's outer queue row.

## Root cause

`handle_zombie_flows()` built its diagnostic by joining `worker_ping` on the flow's queue-row worker only:

```sql
LEFT JOIN worker_ping wp ON wp.worker = q.worker
```

`q.worker` is the worker on the **outer flow queue row**, which in nested / subflow / forloop cases is frequently NOT the worker that performed and dropped the final transition. So all OOM detection (`oom_strong`, `oom_moderate`, `worker_ping_stale`, `memory_pct`) ran against the wrong (healthy) worker, and the `(false,false,false)` branch confidently printed "healthy memory → deadlock → SIGQUIT".

## Changes (diagnostics only — no change to *when* a flow is cancelled)

**Change 1 — inspect the worker that actually died.** When `q.worker` looks healthy, additionally query `worker_ping` (new helper `find_zombie_flow_culprit_worker`) for a plausible culprit: a *different* worker on the same pod (`worker_instance`) or worker group whose last ping clusters around the flow's `last_ping` (within `[-5s, +15s]`) and has since gone silent — the signature of a worker OOM-killed mid state-transition. The candidate closest in time to the transition wins. If found, the message names that worker and routes to the OOM explanation, alongside (not replacing) the existing `q.worker` info. The service-log lookup also follows the culprit's instance/timestamp when one is found.

**Change 2 — stop over-weighting "deadlock".** The healthy-`q.worker` hint now leads with *"check whether a different worker on the same pod / worker group was OOM-killed around {last_ping}"*, keeping deadlock/SIGQUIT as the secondary possibility.

The extra query runs only on the rare zombie path, only when `q.worker` is not already implicating itself, and fails soft (`warn` + fall back to prior behavior) so a diagnostics failure never blocks the cancel. No migration.

## Before / after (the incident)

**Before:**
> Worker handling the flow: `wk-small-production-6pwsf` (group: small)
> Worker last ping: … (3s ago) — worker still pinging with healthy memory — likely deadlocked or blocking on the state transition
> …
> Worker is still pinging and memory looked healthy at its last ping — **most likely a deadlock or blocking call during the state transition. Capture a stack trace (e.g. via SIGQUIT)** …

**After:**
> Worker handling the flow: `wk-small-production-6pwsf` (group: small)
> Worker last ping: … (3s ago) — still pinging with healthy memory — **this is NOT the worker that performed the flow's final state transition (see likely culprit worker below)**
> **Likely culprit worker (on same pod/instance '…'): `wk-small-production-hql6x`** — last pinged … (63s ago, 2s after this flow's last ping) and then stopped pinging; it was at 96.5% of its memory limit at that last ping (memory: 988.0 MB of 1024.0 MB). This flow's dropped state transition was most likely performed by this worker and lost to its death (most likely OOM-kill), not a deadlock on `wk-small-production-6pwsf`.
> …
> **This is almost certainly an OOM-kill on a *different* worker:** `wk-small-production-hql6x` (on the same pod/worker group) was at 96.5% of its memory limit at its last ping right around this flow's transition, then stopped pinging. … Raise the worker memory limit …

## Exhaustive failure grid (is the shown message the most relevant?)

`q.worker` = worker on the outer queue row. The culprit search runs **only** when `q.worker` is not already implicating itself (not OOM-moderate and not stale) and a worker name + `last_ping` exist.

| # | `q.worker` observed state | culprit found? | Message leads with | Most relevant? |
|---|---|---|---|---|
| A | mem ≥ 0.85 (strong OOM) | not searched | `q.worker` OOM-killed at X% | ✅ q.worker is the victim |
| B | 0.60 ≤ mem < 0.85 (moderate) | not searched | `q.worker` likely OOM at X% | ✅ |
| C | ping > 60s stale, no mem evidence | not searched | `q.worker` died — most likely OOM | ✅ leads OOM; a >60s ping gap is itself a death signal so q.worker is treated as the victim |
| D | healthy (pinging, mem < 0.60) | **culprit, mem ≥ 0.60** | **culprit named, "almost certainly OOM-kill on a different worker"** | ✅ the incident — fixed |
| E | healthy | **culprit, stale-only** | **culprit named, "most likely OOM-kill on a different worker; only if not OOM, consider deadlock"** | ✅ leads OOM, deadlock hedged |
| F | healthy | none found | **"check whether a different worker on same pod/group was OOM-killed around {last_ping}; only if none, deadlock/SIGQUIT"** | ✅ improved — old code led with deadlock here (the reported bug) |
| G | no `worker_ping` row for q.worker | **culprit found** | **culprit named + OOM lead** | ✅ improved — old hint was empty |
| H | no `worker_ping` row | none found | (empty hint — no signal anywhere) | ⚪ unchanged — nothing to inspect |
| I | no worker recorded on queue row | not searched | (empty hint) | ⚪ unchanged — no anchor to search from (would need the schema migration this PR deliberately avoids) |

Cross-cutting culprit-query failure modes: **SQL error/DB blip** → `warn` + `None`, falls back to F/H/I, cancel still proceeds. **Multiple candidates** → closest-in-time wins (most likely mid-transition). **False positive** (a same-*group* worker on another pod that scaled down inside the ±window) → hedged text (`worker group 'X'` vs `same pod/instance 'X'`) and the "check pod restart count" first action is harmless and disambiguating. Only cells H and I are non-specific, and both are genuinely no-signal cases unfixable without recording the transition worker in schema.

## Test plan
- [x] `cargo build` / `cargo watch` compiles clean; `cargo clippy -p windmill` clean for `monitor.rs` (a pre-existing unrelated clippy error in `windmill-queue/src/jobs.rs:6193` is untouched by this PR)
- [x] `.sqlx` offline cache regenerated (1 new query file; 0 EE caches lost)
- [x] Unit tests for `zombie_worker_memory_pct` (max-of-two readings, single-reading fallback, `None` cases) pass
- [ ] Manual: reproduce a nested/subflow zombie where the final iteration runs on a second same-pod worker that is then OOM-killed near the flow's `last_ping`; confirm the cancellation `reason` surfaces the "Likely culprit worker" line and the service-log lookup targets the culprit's instance/time window
- [ ] Confirm behavior/wording unchanged when there is genuinely no OOM signal anywhere (rows H/I)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Diagnose zombie-flow OOM on the worker that performed the final transition, not the outer queue-row worker. Fixes WIN-2231 and avoids deadlock/SIGQUIT false-positives.

- **Bug Fixes**
  - When `q.worker` looks healthy, search `worker_ping` for a different worker on the same `worker_instance` or `worker_group` whose last ping clusters near the flow’s `last_ping` and then went silent; pick the closest-in-time candidate.
  - Show a “Likely culprit worker” line naming the worker, its ping delta, and memory; lead with “OOM on a different worker” and keep deadlock as secondary.
  - Route service-log lookups to the culprit worker’s instance/time window instead of `q.worker`.
  - Compute memory percent using the max of cgroup and process readings for stronger OOM signal.
  - Diagnostics-only on the zombie path and soft-failing; no changes to cancellation timing or schema.

<sup>Written for commit e3f11caebc069bca3105d02b6913ddd99e15314f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

