### PR TITLE
feat: surface workspace-script advanced settings in flow editor

### DIFF
--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -662,6 +662,7 @@
 
 	const previewArgsStore = $state({ val: {} })
 	const scriptEditorDrawer = writable(undefined)
+	const workspaceScriptSettingsDrawer = writable(undefined)
 	const history = initHistory(flowStore.val)
 	const stepsInputArgs = new StepsInputArgs()
 	const selectionManager = new SelectionManager()
@@ -687,6 +688,7 @@
 		selectionManager,
 		previewArgs: previewArgsStore,
 		scriptEditorDrawer,
+		workspaceScriptSettingsDrawer,
 		flowEditorDrawer: writable(undefined),
 		history,
 		pathStore: pathStore,

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -40,6 +40,7 @@
 	import { Button } from './common'
 	import FlowEditor from './flows/FlowEditor.svelte'
 	import ScriptEditorDrawer from './flows/content/ScriptEditorDrawer.svelte'
+	import WorkspaceScriptSettingsDrawer from './flows/content/WorkspaceScriptSettingsDrawer.svelte'
 	import FlowEditorDrawer from './flows/content/FlowEditorDrawer.svelte'
 	import { dfs as dfsApply } from './flows/dfs'
 	import FlowImportExportMenu from './flows/header/FlowImportExportMenu.svelte'
@@ -540,6 +541,9 @@
 
 	const previewArgsStore = $state({ val: untrack(() => initialArgs) })
 	const scriptEditorDrawer = writable<ScriptEditorDrawer | undefined>(undefined)
+	const workspaceScriptSettingsDrawer = writable<WorkspaceScriptSettingsDrawer | undefined>(
+		undefined
+	)
 	const flowEditorDrawer = writable<FlowEditorDrawer | undefined>(undefined)
 	const history = initHistory(untrack(() => flowStore).val)
 	const pathStore = writable<string>(untrack(() => pathStoreInit) ?? initialPath)
@@ -589,6 +593,7 @@
 		currentEditor: writable(undefined),
 		previewArgs: previewArgsStore,
 		scriptEditorDrawer,
+		workspaceScriptSettingsDrawer,
 		flowEditorDrawer,
 		history,
 		flowStateStore: untrack(() => flowStateStore),
@@ -1139,6 +1144,7 @@
 		<FlowYamlEditor bind:drawer={yamlEditorDrawer} />
 		<FlowImportExportMenu bind:drawer={jsonViewerDrawer} />
 		<ScriptEditorDrawer bind:this={$scriptEditorDrawer} />
+		<WorkspaceScriptSettingsDrawer bind:this={$workspaceScriptSettingsDrawer} />
 		<FlowEditorDrawer bind:this={$flowEditorDrawer} />
 
 		<div bind:this={flowBuilderRoot} class="flex flex-col h-full">

--- a/frontend/src/lib/components/ScriptAdvancedSettings.svelte
+++ b/frontend/src/lib/components/ScriptAdvancedSettings.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+	import { createBubbler } from 'svelte/legacy'
+	import Section from '$lib/components/Section.svelte'
+	import Label from '$lib/components/Label.svelte'
+	import Toggle from '$lib/components/Toggle.svelte'
+	import Tooltip from '$lib/components/Tooltip.svelte'
+	import Alert from '$lib/components/common/alert/Alert.svelte'
+	import { SecondsInput } from '$lib/components/common'
+	import WorkerTagPicker from '$lib/components/WorkerTagPicker.svelte'
+	import DebounceLimit from '$lib/components/flows/DebounceLimit.svelte'
+	import { enterpriseLicense } from '$lib/stores'
+	import { isCloudHosted } from '$lib/cloud'
+	import type { Schema } from '$lib/common'
+	import type { ScriptAdvancedSettingsFields } from './scriptSettings'
+
+	const bubble = createBubbler()
+
+	interface Props {
+		script: ScriptAdvancedSettingsFields
+		// Workspace to read worker tags from (defaults to $workspaceStore inside the picker).
+		workspaceId?: string | undefined
+	}
+
+	let { script = $bindable(), workspaceId = undefined }: Props = $props()
+</script>
+
+<div class="flex flex-col gap-8">
+	<Section label="Worker group tag (queue)">
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/core_concepts/worker_groups">
+				The script will be executed on a worker configured to listen to this worker group tag
+				(queue). For instance, you could setup an "highmem", or "gpu" tag.
+			</Tooltip>
+		{/snippet}
+		<WorkerTagPicker bind:tag={script.tag} {workspaceId} />
+	</Section>
+
+	<Section label="Concurrency limits" eeOnly>
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/core_concepts/concurrency_limits">
+				Allowed concurrency within a given timeframe
+			</Tooltip>
+		{/snippet}
+		<Toggle
+			size="sm"
+			checked={Boolean(script.concurrent_limit)}
+			on:change={() => {
+				if (script.concurrent_limit && script.concurrent_limit != undefined) {
+					script.concurrent_limit = undefined
+					script.concurrency_time_window_s = undefined
+					script.concurrency_key = undefined
+				} else {
+					script.concurrent_limit = 1
+				}
+			}}
+			options={{ right: 'Concurrency limits' }}
+		/>
+		{#if Boolean(script.concurrent_limit)}
+			<div class="flex flex-col gap-4 mt-2">
+				<Label label="Max number of executions within the time window">
+					<div class="flex flex-row gap-2 max-w-sm whitespace-nowrap">
+						<input
+							disabled={!$enterpriseLicense}
+							bind:value={script.concurrent_limit}
+							type="number"
+						/>
+					</div>
+				</Label>
+				<Label label="Time window in seconds">
+					<SecondsInput
+						disabled={!$enterpriseLicense}
+						bind:seconds={script.concurrency_time_window_s}
+					/>
+				</Label>
+				<Label label="Custom concurrency key (optional)">
+					{#snippet header()}
+						<Tooltip
+							documentationLink="https://www.windmill.dev/docs/core_concepts/concurrency_limits#custom-concurrency-key"
+						>
+							Concurrency keys are global, you can have them be workspace specific using the
+							variable `$workspace`. You can also use an argument's value using `$args[name_of_arg]`</Tooltip
+						>
+					{/snippet}
+					<input
+						disabled={!$enterpriseLicense}
+						type="text"
+						bind:value={script.concurrency_key}
+						placeholder={`$workspace/script/${script.path ?? ''}-$args[foo]`}
+					/>
+				</Label>
+			</div>
+		{/if}
+	</Section>
+
+	<Section label="Cache">
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/core_concepts/caching">
+				Cache the results for each possible inputs
+			</Tooltip>
+		{/snippet}
+		<div class="flex gap-2 shrink flex-col">
+			<Toggle
+				size="sm"
+				bind:checked={() => !!script.cache_ttl, (v) => (script.cache_ttl = v ? 300 : undefined)}
+				options={{ right: 'Cache the results for each possible inputs' }}
+			/>
+			{#if script.cache_ttl}
+				<div class="text-2xs text-secondary">How long to keep the cache valid</div>
+				<SecondsInput bind:seconds={script.cache_ttl} />
+				<Toggle
+					size="2xs"
+					bind:checked={
+						() => script.cache_ignore_s3_path, (v) => (script.cache_ignore_s3_path = v || undefined)
+					}
+					options={{
+						right: 'Ignore S3 Object paths for caching purposes',
+						rightTooltip:
+							'If two S3 objects passed as input have the same content, they will hit the same cache entry, regardless of their path.'
+					}}
+				/>
+			{/if}
+		</div>
+	</Section>
+
+	<Section label="Timeout">
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/script_editor/settings#timeout">
+				Add a custom timeout for this script
+			</Tooltip>
+		{/snippet}
+		<div class="flex gap-2 shrink flex-col">
+			<Toggle
+				size="sm"
+				checked={Boolean(script.timeout)}
+				on:change={() => {
+					if (script.timeout && script.timeout != undefined) {
+						script.timeout = undefined
+					} else {
+						script.timeout = 300
+					}
+				}}
+				options={{ right: 'Add a custom timeout for this script' }}
+			/>
+			{#if Boolean(script.timeout)}
+				<span class="text-xs font-semibold text-emphasis leading-none mt-2">Timeout duration</span>
+				<SecondsInput bind:seconds={script.timeout} />
+			{/if}
+		</div>
+	</Section>
+
+	<Section label="Debouncing">
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/core_concepts/job_debouncing">
+				Debounce Jobs
+			</Tooltip>
+		{/snippet}
+		<DebounceLimit
+			size="sm"
+			bind:debounce_delay_s={script.debounce_delay_s}
+			bind:debounce_key={script.debounce_key}
+			bind:debounce_args_to_accumulate={script.debounce_args_to_accumulate}
+			bind:max_total_debouncing_time={script.max_total_debouncing_time}
+			bind:max_total_debounces_amount={script.max_total_debounces_amount}
+			schema={script.schema as Schema}
+			placeholder={`$workspace/script/${script.path ?? ''}-$args[foo]`}
+		/>
+	</Section>
+
+	<Section label="Perpetual script">
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/script_editor/perpetual_scripts">
+				Restart the script upon ending unless cancelled
+			</Tooltip>
+		{/snippet}
+		<Toggle
+			size="sm"
+			checked={Boolean(script.restart_unless_cancelled)}
+			on:change={() => {
+				script.restart_unless_cancelled = script.restart_unless_cancelled ? undefined : true
+			}}
+			options={{ right: 'Restart upon ending unless cancelled' }}
+		/>
+	</Section>
+
+	<Section label="Dedicated workers" eeOnly>
+		{#snippet header()}
+			<Tooltip documentationLink="https://www.windmill.dev/docs/core_concepts/dedicated_workers">
+				In this mode, the script is meant to be run on dedicated workers that run the script at
+				native speed. Can reach &gt;1500rps per dedicated worker. Only available on enterprise
+				edition and for Python3, Deno, Bun and Bunnative.
+			</Tooltip>
+		{/snippet}
+		<Toggle
+			disabled={!$enterpriseLicense ||
+				isCloudHosted() ||
+				(script.language != 'bun' &&
+					script.language != 'bunnative' &&
+					script.language != 'python3' &&
+					script.language != 'deno')}
+			size="sm"
+			checked={Boolean(script.dedicated_worker)}
+			on:change={() => {
+				script.dedicated_worker = script.dedicated_worker ? undefined : true
+			}}
+			options={{ right: 'Script is run on dedicated workers' }}
+		/>
+		{#if script.dedicated_worker}
+			<div class="py-2">
+				<Alert type="info" title="Require dedicated workers">
+					A worker group needs to be configured to listen to this script. Select it in the dedicated
+					workers section of the worker group configuration.
+				</Alert>
+			</div>
+		{/if}
+	</Section>
+
+	<Section label="Delete after completion">
+		{#snippet header()}
+			<Tooltip
+				documentationLink="https://www.windmill.dev/docs/script_editor/settings#delete-after-use"
+			>
+				The logs, arguments and results of the job will be completely deleted from Windmill after
+				the specified delay once it is complete. Set to 0 for immediate deletion. The deletion is
+				irreversible. This settings ONLY applies when the script is used within a flow or triggered
+				synchronously.
+				{#if !$enterpriseLicense}
+					This option is only available on Windmill Enterprise Edition.
+				{/if}
+			</Tooltip>
+		{/snippet}
+		<div class="flex gap-2 shrink flex-col">
+			<Toggle
+				disabled={!$enterpriseLicense}
+				size="sm"
+				checked={script.delete_after_secs != null}
+				on:change={() => {
+					script.delete_after_secs = script.delete_after_secs != null ? undefined : 0
+				}}
+				options={{ right: 'Delete logs, arguments and results after completion' }}
+			/>
+			{#if script.delete_after_secs != null}
+				<SecondsInput bind:seconds={script.delete_after_secs} disabled={!$enterpriseLicense} />
+			{/if}
+		</div>
+	</Section>
+
+	{#if !isCloudHosted()}
+		<Section label="High priority script" eeOnly>
+			{#snippet header()}
+				<Tooltip
+					documentationLink="https://www.windmill.dev/docs/core_concepts/jobs#high-priority-jobs"
+				>
+					Jobs from script labeled as high priority take precedence over the other jobs when in the
+					jobs queue.
+					{#if !$enterpriseLicense}This is a feature only available on enterprise edition.{/if}
+				</Tooltip>
+			{/snippet}
+			<Toggle
+				disabled={!$enterpriseLicense || isCloudHosted()}
+				size="sm"
+				checked={script.priority !== undefined && script.priority > 0}
+				on:change={() => {
+					script.priority = script.priority ? undefined : 100
+				}}
+				options={{ right: 'Label as high priority' }}
+			>
+				{#snippet right()}
+					<input
+						type="number"
+						class="!w-16 ml-4"
+						disabled={script.priority === undefined}
+						bind:value={script.priority}
+						onfocus={bubble('focus')}
+						onchange={() => {
+							if (script.priority && script.priority > 100) {
+								script.priority = 100
+							} else if (script.priority && script.priority < 0) {
+								script.priority = 0
+							}
+						}}
+					/>
+				{/snippet}
+			</Toggle>
+		</Section>
+	{/if}
+</div>

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -87,6 +87,7 @@
 	import DefaultScripts from './DefaultScripts.svelte'
 	import { getContext, onMount, setContext, tick, untrack } from 'svelte'
 	import EditorHeader from './EditorHeader.svelte'
+	import ScriptSettingsBadges from './ScriptSettingsBadges.svelte'
 	import AutosaveIndicator from './AutosaveIndicator.svelte'
 	import LabelsInput from './LabelsInput.svelte'
 
@@ -1969,6 +1970,15 @@
 							{loadedFromDraft}
 							{othersDraftsCount}
 							{onOpenOthersDrafts}
+						/>
+					{/if}
+					{#if !condensedHeader}
+						<ScriptSettingsBadges
+							settings={script}
+							onclick={() => {
+								selectedTab = 'runtime'
+								metadataOpen = true
+							}}
 						/>
 					{/if}
 				</div>

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1973,12 +1973,17 @@
 						/>
 					{/if}
 					{#if !condensedHeader}
+						{@const canOpenRuntime =
+							customUi?.topBar?.settings != false &&
+							customUi?.settingsPanel?.disableRuntime !== true}
 						<ScriptSettingsBadges
 							settings={script}
-							onclick={() => {
-								selectedTab = 'runtime'
-								metadataOpen = true
-							}}
+							onclick={canOpenRuntime
+								? () => {
+										selectedTab = 'runtime'
+										metadataOpen = true
+									}
+								: undefined}
 						/>
 					{/if}
 				</div>

--- a/frontend/src/lib/components/ScriptSettingsBadges.svelte
+++ b/frontend/src/lib/components/ScriptSettingsBadges.svelte
@@ -31,6 +31,7 @@
 					icon={{ icon: badge.icon, position: 'left' }}
 					clickable={Boolean(onclick)}
 					onclick={onclick ? () => onclick?.(badge.key) : undefined}
+					aria-label={`${badge.label}: ${badge.detail}`}
 				/>
 				{#snippet text()}
 					<span class="font-semibold">{badge.label}</span> — {badge.detail}

--- a/frontend/src/lib/components/ScriptSettingsBadges.svelte
+++ b/frontend/src/lib/components/ScriptSettingsBadges.svelte
@@ -22,18 +22,18 @@
 {#if badges.length > 0}
 	<div class="flex flex-row flex-wrap gap-1 items-center">
 		{#each badges as badge (badge.key)}
-			<Popover placement="bottom">
+			<!-- Icon-only chips to save space in crowded top bars; the label and current
+				value are shown in the hover popover. -->
+			<Popover notClickable placement="bottom">
 				<Badge
 					color="blue"
 					{small}
 					icon={{ icon: badge.icon, position: 'left' }}
 					clickable={Boolean(onclick)}
 					onclick={onclick ? () => onclick?.(badge.key) : undefined}
-				>
-					{badge.label}
-				</Badge>
+				/>
 				{#snippet text()}
-					{badge.detail}
+					<span class="font-semibold">{badge.label}</span> — {badge.detail}
 				{/snippet}
 			</Popover>
 		{/each}

--- a/frontend/src/lib/components/ScriptSettingsBadges.svelte
+++ b/frontend/src/lib/components/ScriptSettingsBadges.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import Badge from '$lib/components/common/badge/Badge.svelte'
+	import Popover from '$lib/components/Popover.svelte'
+	import {
+		getActiveScriptSettingsBadges,
+		type ScriptAdvancedSettingsFields
+	} from './scriptSettings'
+
+	interface Props {
+		settings: ScriptAdvancedSettingsFields | undefined
+		// When provided, badges become clickable and call this with the badge key
+		// (e.g. to open the settings drawer focused on that section).
+		onclick?: (key: string) => void
+		small?: boolean
+	}
+
+	let { settings, onclick, small = true }: Props = $props()
+
+	let badges = $derived(getActiveScriptSettingsBadges(settings))
+</script>
+
+{#if badges.length > 0}
+	<div class="flex flex-row flex-wrap gap-1 items-center">
+		{#each badges as badge (badge.key)}
+			<Popover placement="bottom">
+				<Badge
+					color="blue"
+					{small}
+					icon={{ icon: badge.icon, position: 'left' }}
+					clickable={Boolean(onclick)}
+					onclick={onclick ? () => onclick?.(badge.key) : undefined}
+				>
+					{badge.label}
+				</Badge>
+				{#snippet text()}
+					{badge.detail}
+				{/snippet}
+			</Popover>
+		{/each}
+	</div>
+{/if}

--- a/frontend/src/lib/components/flows/content/FlowModuleCache.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleCache.svelte
@@ -6,12 +6,25 @@
 
 	import type { FlowModule } from '$lib/gen'
 	import { SecondsInput } from '../../common'
+	import WorkspaceScriptSettingInfo from './WorkspaceScriptSettingInfo.svelte'
 
 	interface Props {
 		flowModule: FlowModule
+		// For workspace-script steps: the cache_ttl currently set on the referenced
+		// script, and a shortcut to edit it. Undefined for inline/subflow steps.
+		workspaceScriptCacheTtl?: number | undefined
+		loadingWorkspaceScript?: boolean
+		canEditWorkspaceScript?: boolean
+		onEditWorkspaceScript?: () => void
 	}
 
-	let { flowModule = $bindable() }: Props = $props()
+	let {
+		flowModule = $bindable(),
+		workspaceScriptCacheTtl = undefined,
+		loadingWorkspaceScript = false,
+		canEditWorkspaceScript = false,
+		onEditWorkspaceScript
+	}: Props = $props()
 
 	let isCacheEnabled = $derived(Boolean(flowModule.cache_ttl))
 </script>
@@ -25,10 +38,20 @@
 		</Tooltip>
 	{/snippet}
 
-	{#if flowModule.value.type != 'rawscript'}
+	{#if flowModule.value.type == 'script'}
+		<WorkspaceScriptSettingInfo
+			label="Cache"
+			active={workspaceScriptCacheTtl != undefined}
+			valueText={workspaceScriptCacheTtl != undefined
+				? `Cached for ${workspaceScriptCacheTtl}s`
+				: undefined}
+			loading={loadingWorkspaceScript}
+			canEdit={canEditWorkspaceScript}
+			onEdit={onEditWorkspaceScript}
+		/>
+	{:else if flowModule.value.type != 'rawscript'}
 		<p class="text-xs text-secondary">
-			The cache settings need to be set in the referenced script/flow settings directly. Cache for
-			hub scripts is not available yet.
+			The cache settings need to be set in the referenced flow settings directly.
 		</p>
 	{:else}
 		<Toggle

--- a/frontend/src/lib/components/flows/content/FlowModuleCache.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleCache.svelte
@@ -16,6 +16,7 @@
 		loadingWorkspaceScript?: boolean
 		workspaceScriptError?: string | undefined
 		canEditWorkspaceScript?: boolean
+		workspaceScriptNoEditReason?: string | undefined
 		onEditWorkspaceScript?: () => void
 	}
 
@@ -25,6 +26,7 @@
 		loadingWorkspaceScript = false,
 		workspaceScriptError = undefined,
 		canEditWorkspaceScript = false,
+		workspaceScriptNoEditReason = undefined,
 		onEditWorkspaceScript
 	}: Props = $props()
 
@@ -50,6 +52,7 @@
 			loading={loadingWorkspaceScript}
 			error={workspaceScriptError}
 			canEdit={canEditWorkspaceScript}
+			noEditReason={workspaceScriptNoEditReason}
 			onEdit={onEditWorkspaceScript}
 		/>
 	{:else if flowModule.value.type != 'rawscript'}

--- a/frontend/src/lib/components/flows/content/FlowModuleCache.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleCache.svelte
@@ -14,6 +14,7 @@
 		// script, and a shortcut to edit it. Undefined for inline/subflow steps.
 		workspaceScriptCacheTtl?: number | undefined
 		loadingWorkspaceScript?: boolean
+		workspaceScriptError?: string | undefined
 		canEditWorkspaceScript?: boolean
 		onEditWorkspaceScript?: () => void
 	}
@@ -22,6 +23,7 @@
 		flowModule = $bindable(),
 		workspaceScriptCacheTtl = undefined,
 		loadingWorkspaceScript = false,
+		workspaceScriptError = undefined,
 		canEditWorkspaceScript = false,
 		onEditWorkspaceScript
 	}: Props = $props()
@@ -46,6 +48,7 @@
 				? `Cached for ${workspaceScriptCacheTtl}s`
 				: undefined}
 			loading={loadingWorkspaceScript}
+			error={workspaceScriptError}
 			canEdit={canEditWorkspaceScript}
 			onEdit={onEditWorkspaceScript}
 		/>

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -204,6 +204,16 @@
 			customUi?.scriptEdit != false &&
 			$workspaceScriptSettingsDrawer != undefined
 	)
+	// Explains why settings can't be edited from here, matching the specific gate that failed.
+	let workspaceScriptNoEditReason = $derived(
+		flowModule.value.type !== 'script' || canEditWorkspaceScriptSettings
+			? undefined
+			: flowModule.value.path?.startsWith('hub/')
+				? 'Hub scripts cannot be edited from here.'
+				: flowModule.value.hash != undefined
+					? 'Steps pinned to a specific version cannot be edited from here.'
+					: 'Editing script settings is not available in this editor.'
+	)
 	// Non-positive concurrent_limit / cache_ttl are treated as unset by the runtime (legacy rows).
 	let referencedConcurrentLimit = $derived(
 		referencedScriptSettings.settings?.concurrent_limit != undefined &&
@@ -1330,6 +1340,7 @@
 															loading={referencedScriptSettings.loading}
 															error={referencedScriptSettings.error}
 															canEdit={canEditWorkspaceScriptSettings}
+															noEditReason={workspaceScriptNoEditReason}
 															onEdit={openWorkspaceScriptSettings}
 														/>
 													{:else}
@@ -1408,6 +1419,7 @@
 														loadingWorkspaceScript={referencedScriptSettings.loading}
 														workspaceScriptError={referencedScriptSettings.error}
 														canEditWorkspaceScript={canEditWorkspaceScriptSettings}
+														{workspaceScriptNoEditReason}
 														onEditWorkspaceScript={openWorkspaceScriptSettings}
 													/>
 												</div>

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -1292,7 +1292,7 @@
 																placeholder={`$workspace/script/${$pathStore}-$args[foo]`}
 															/>
 														</Label>
-													{:else}
+													{:else if flowModule.value.type == 'script'}
 														<WorkspaceScriptSettingInfo
 															label="Concurrency limit"
 															active={referencedScriptSettings.settings?.concurrent_limit !=
@@ -1314,6 +1314,11 @@
 															canEdit={canEditWorkspaceScriptSettings}
 															onEdit={openWorkspaceScriptSettings}
 														/>
+													{:else}
+														<Alert type="warning" title="Limitation" size="xs">
+															The concurrency limit of a referenced flow is only settable in the
+															flow settings directly.
+														</Alert>
 													{/if}
 												</Section>
 											{:else if advancedSelected === 'runtime' && advancedRuntimeSelected === 'timeout'}

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -204,7 +204,6 @@
 			customUi?.scriptEdit != false &&
 			$workspaceScriptSettingsDrawer != undefined
 	)
-	// Explains why settings can't be edited from here, matching the specific gate that failed.
 	let workspaceScriptNoEditReason = $derived(
 		flowModule.value.type !== 'script' || canEditWorkspaceScriptSettings
 			? undefined

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -201,6 +201,13 @@
 			flowModule.value.hash == undefined &&
 			customUi?.scriptEdit != false
 	)
+	// Non-positive concurrent_limit is treated as unset by the runtime (legacy rows).
+	let referencedConcurrentLimit = $derived(
+		referencedScriptSettings.settings?.concurrent_limit != undefined &&
+			referencedScriptSettings.settings.concurrent_limit > 0
+			? referencedScriptSettings.settings.concurrent_limit
+			: undefined
+	)
 	function openWorkspaceScriptSettings() {
 		if (flowModule.value.type !== 'script') return
 		$workspaceScriptSettingsDrawer?.openDrawer(
@@ -1300,16 +1307,12 @@
 													{:else if flowModule.value.type == 'script'}
 														<WorkspaceScriptSettingInfo
 															label="Concurrency limit"
-															active={referencedScriptSettings.settings?.concurrent_limit !=
-																undefined}
-															valueText={referencedScriptSettings.settings?.concurrent_limit !=
-															undefined
-																? `Max ${referencedScriptSettings.settings.concurrent_limit} execution${
-																		referencedScriptSettings.settings.concurrent_limit === 1
-																			? ''
-																			: 's'
+															active={referencedConcurrentLimit != undefined}
+															valueText={referencedConcurrentLimit != undefined
+																? `Max ${referencedConcurrentLimit} execution${
+																		referencedConcurrentLimit === 1 ? '' : 's'
 																	}${
-																		referencedScriptSettings.settings.concurrency_time_window_s !=
+																		referencedScriptSettings.settings?.concurrency_time_window_s !=
 																		undefined
 																			? ` within ${referencedScriptSettings.settings.concurrency_time_window_s}s`
 																			: ''

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -194,12 +194,15 @@
 		() => opWs
 	)
 	// Hub scripts, hash-pinned steps, and embeddings that disable script editing
-	// can't have their settings edited from here.
+	// can't have their settings edited from here. The drawer must also be mounted:
+	// local-dev editors (Dev.svelte / flows/dev) provide the context store but never
+	// render the drawer, so editing there would be a no-op — keep values read-only.
 	let canEditWorkspaceScriptSettings = $derived(
 		flowModule.value.type === 'script' &&
 			!flowModule.value.path?.startsWith('hub/') &&
 			flowModule.value.hash == undefined &&
-			customUi?.scriptEdit != false
+			customUi?.scriptEdit != false &&
+			$workspaceScriptSettingsDrawer != undefined
 	)
 	// Non-positive concurrent_limit / cache_ttl are treated as unset by the runtime (legacy rows).
 	let referencedConcurrentLimit = $derived(

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -193,11 +193,13 @@
 		() => (flowModule.value.type === 'script' ? flowModule.value.hash : undefined),
 		() => opWs
 	)
-	// Hub scripts and hash-pinned steps can't have their settings edited from here.
+	// Hub scripts, hash-pinned steps, and embeddings that disable script editing
+	// can't have their settings edited from here.
 	let canEditWorkspaceScriptSettings = $derived(
 		flowModule.value.type === 'script' &&
 			!flowModule.value.path?.startsWith('hub/') &&
-			flowModule.value.hash == undefined
+			flowModule.value.hash == undefined &&
+			customUi?.scriptEdit != false
 	)
 	function openWorkspaceScriptSettings() {
 		if (flowModule.value.type !== 'script') return
@@ -801,6 +803,9 @@
 								flowModule.value.hash = await getLatestHashForScript(flowModule.value.path, opWs)
 							}
 							forceReload++
+							// Keep the surfaced concurrency/cache values and badges in sync after
+							// a settings/code save from the header (path/hash may be unchanged).
+							await referencedScriptSettings.reload()
 							await reload(flowModule)
 						}
 						if (flowModule.value.type == 'flow') {

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -55,6 +55,10 @@
 	import { type Job } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { checkIfParentLoop } from '../utils.svelte'
+	import { useWorkspaceScriptSettings } from '../useWorkspaceScriptSettings.svelte'
+	import ScriptSettingsBadges from '$lib/components/ScriptSettingsBadges.svelte'
+	import { getActiveScriptSettingsBadges } from '$lib/components/scriptSettings'
+	import WorkspaceScriptSettingInfo from './WorkspaceScriptSettingInfo.svelte'
 	import ModulePreviewResultViewer from '$lib/components/ModulePreviewResultViewer.svelte'
 	import LogViewer from '$lib/components/LogViewer.svelte'
 	import DisplayResult from '$lib/components/DisplayResult.svelte'
@@ -95,7 +99,8 @@
 		saveDraft,
 		customUi,
 		executionCount,
-		opWorkspace
+		opWorkspace,
+		workspaceScriptSettingsDrawer
 	} = getContext<FlowEditorContext>('FlowEditorContext')
 
 	const selectedId = $derived(selectionManager.getSelectedId())
@@ -179,6 +184,32 @@
 
 	let assets = $derived((flowModule.value.type === 'rawscript' && flowModule.value.assets) || [])
 	const flowGraphAssetsCtx = getContext<FlowGraphAssetContext | undefined>('FlowGraphAssetContext')
+
+	// For workspace-script steps, load the referenced script's advanced settings so
+	// the delegating settings tabs (concurrency, cache, ...) can show current values
+	// and offer an "Edit script settings" shortcut instead of a bare warning.
+	const referencedScriptSettings = useWorkspaceScriptSettings(
+		() => (flowModule.value.type === 'script' ? flowModule.value.path : undefined),
+		() => (flowModule.value.type === 'script' ? flowModule.value.hash : undefined),
+		() => opWs
+	)
+	// Hub scripts and hash-pinned steps can't have their settings edited from here.
+	let canEditWorkspaceScriptSettings = $derived(
+		flowModule.value.type === 'script' &&
+			!flowModule.value.path?.startsWith('hub/') &&
+			flowModule.value.hash == undefined
+	)
+	function openWorkspaceScriptSettings() {
+		if (flowModule.value.type !== 'script') return
+		$workspaceScriptSettingsDrawer?.openDrawer(
+			flowModule.value.path,
+			flowModule.value.hash,
+			async () => {
+				await referencedScriptSettings.reload()
+				forceReload++
+			}
+		)
+	}
 
 	// UI Intent handling for AI tool control
 	useUiIntent(`flow-${flowModule.id}`, {
@@ -991,6 +1022,16 @@
 						{:else if flowModule.value.type === 'script'}
 							{#if !noEditor && (customUi?.hubCode != false || !flowModule?.value?.path?.startsWith('hub/'))}
 								<div class="border-t">
+									{#if referencedScriptSettings.settings && getActiveScriptSettingsBadges(referencedScriptSettings.settings).length > 0}
+										<div class="flex flex-row items-center gap-2 px-2 pt-2 flex-wrap">
+											<ScriptSettingsBadges
+												settings={referencedScriptSettings.settings}
+												onclick={canEditWorkspaceScriptSettings
+													? openWorkspaceScriptSettings
+													: undefined}
+											/>
+										</div>
+									{/if}
 									{#key forceReload}
 										<FlowModuleScript
 											bind:tag={workspaceScriptTag}
@@ -1252,11 +1293,27 @@
 															/>
 														</Label>
 													{:else}
-														<Alert type="warning" title="Limitation" size="xs">
-															The concurrency limit of a workspace script is only settable in the
-															script metadata itself. For hub scripts, this feature is non available
-															yet.
-														</Alert>
+														<WorkspaceScriptSettingInfo
+															label="Concurrency limit"
+															active={referencedScriptSettings.settings?.concurrent_limit !=
+																undefined}
+															valueText={referencedScriptSettings.settings?.concurrent_limit !=
+															undefined
+																? `Max ${referencedScriptSettings.settings.concurrent_limit} execution${
+																		referencedScriptSettings.settings.concurrent_limit === 1
+																			? ''
+																			: 's'
+																	}${
+																		referencedScriptSettings.settings.concurrency_time_window_s !=
+																		undefined
+																			? ` within ${referencedScriptSettings.settings.concurrency_time_window_s}s`
+																			: ''
+																	}`
+																: undefined}
+															loading={referencedScriptSettings.loading}
+															canEdit={canEditWorkspaceScriptSettings}
+															onEdit={openWorkspaceScriptSettings}
+														/>
 													{/if}
 												</Section>
 											{:else if advancedSelected === 'runtime' && advancedRuntimeSelected === 'timeout'}
@@ -1322,7 +1379,13 @@
 												</div>
 											{:else if advancedSelected === 'cache'}
 												<div>
-													<FlowModuleCache bind:flowModule />
+													<FlowModuleCache
+														bind:flowModule
+														workspaceScriptCacheTtl={referencedScriptSettings.settings?.cache_ttl}
+														loadingWorkspaceScript={referencedScriptSettings.loading}
+														canEditWorkspaceScript={canEditWorkspaceScriptSettings}
+														onEditWorkspaceScript={openWorkspaceScriptSettings}
+													/>
 												</div>
 											{:else if advancedSelected === 'early-stop'}
 												<FlowModuleEarlyStop bind:flowModule />

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -201,11 +201,17 @@
 			flowModule.value.hash == undefined &&
 			customUi?.scriptEdit != false
 	)
-	// Non-positive concurrent_limit is treated as unset by the runtime (legacy rows).
+	// Non-positive concurrent_limit / cache_ttl are treated as unset by the runtime (legacy rows).
 	let referencedConcurrentLimit = $derived(
 		referencedScriptSettings.settings?.concurrent_limit != undefined &&
 			referencedScriptSettings.settings.concurrent_limit > 0
 			? referencedScriptSettings.settings.concurrent_limit
+			: undefined
+	)
+	let referencedCacheTtl = $derived(
+		referencedScriptSettings.settings?.cache_ttl != undefined &&
+			referencedScriptSettings.settings.cache_ttl > 0
+			? referencedScriptSettings.settings.cache_ttl
 			: undefined
 	)
 	function openWorkspaceScriptSettings() {
@@ -1319,6 +1325,7 @@
 																	}`
 																: undefined}
 															loading={referencedScriptSettings.loading}
+															error={referencedScriptSettings.error}
 															canEdit={canEditWorkspaceScriptSettings}
 															onEdit={openWorkspaceScriptSettings}
 														/>
@@ -1394,8 +1401,9 @@
 												<div>
 													<FlowModuleCache
 														bind:flowModule
-														workspaceScriptCacheTtl={referencedScriptSettings.settings?.cache_ttl}
+														workspaceScriptCacheTtl={referencedCacheTtl}
 														loadingWorkspaceScript={referencedScriptSettings.loading}
+														workspaceScriptError={referencedScriptSettings.error}
 														canEditWorkspaceScript={canEditWorkspaceScriptSettings}
 														onEditWorkspaceScript={openWorkspaceScriptSettings}
 													/>

--- a/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
@@ -108,43 +108,52 @@
 	{/if}
 	{#if module.value.type === 'script'}
 		{#if !module.value.path.startsWith('hub/') && customUi?.scriptEdit != false}
-			<Button
-				unifiedSize="sm"
-				variant="subtle"
-				onClick={async () => {
-					if (module.value.type == 'script') {
-						const hash =
-							module.value.hash ??
-							(await getLatestHashForScript(module.value.path, opWorkspace?.()))
-						$scriptEditorDrawer?.openDrawer(hash, () => {
-							dispatch('reload')
-							sendUserToast('Script has been updated')
-						})
-					}
-				}}
-				startIcon={{ icon: Pen }}
-				iconOnly={false}
-				disabled={module.value.hash != undefined}
-			>
-				Edit
-			</Button>
-			<Button
-				unifiedSize="sm"
-				variant="subtle"
-				onClick={() => {
-					if (module.value.type == 'script') {
-						$workspaceScriptSettingsDrawer?.openDrawer(module.value.path, module.value.hash, () => {
-							dispatch('reload')
-						})
-					}
-				}}
-				startIcon={{ icon: Settings }}
-				iconOnly={false}
-				disabled={module.value.hash != undefined}
-				title="Edit the workspace script's runtime settings (concurrency, cache, timeout, ...)"
-			>
-				Settings
-			</Button>
+			<Popover notClickable placement="bottom">
+				<Button
+					unifiedSize="sm"
+					variant="subtle"
+					onClick={async () => {
+						if (module.value.type == 'script') {
+							const hash =
+								module.value.hash ??
+								(await getLatestHashForScript(module.value.path, opWorkspace?.()))
+							$scriptEditorDrawer?.openDrawer(hash, () => {
+								dispatch('reload')
+								sendUserToast('Script has been updated')
+							})
+						}
+					}}
+					startIcon={{ icon: Pen }}
+					iconOnly
+					disabled={module.value.hash != undefined}
+				/>
+				{#snippet text()}Edit the script's code{/snippet}
+			</Popover>
+			<!-- Only when the settings drawer is actually mounted (not in the local-dev
+				editors, which provide the context store but never render it). -->
+			{#if $workspaceScriptSettingsDrawer}
+				<Popover notClickable placement="bottom">
+					<Button
+						unifiedSize="sm"
+						variant="subtle"
+						onClick={() => {
+							if (module.value.type == 'script') {
+								$workspaceScriptSettingsDrawer?.openDrawer(
+									module.value.path,
+									module.value.hash,
+									() => {
+										dispatch('reload')
+									}
+								)
+							}
+						}}
+						startIcon={{ icon: Settings }}
+						iconOnly
+						disabled={module.value.hash != undefined}
+					/>
+					{#snippet text()}Edit the script's runtime settings (concurrency, cache, timeout, ...){/snippet}
+				</Popover>
+			{/if}
 		{/if}
 		{#if customUi?.tagEdit != false}
 			<FlowModuleWorkerTagSelect
@@ -157,15 +166,16 @@
 			/>
 		{/if}
 		{#if customUi?.scriptFork != false}
-			<Button
-				unifiedSize="sm"
-				variant="subtle"
-				on:click={() => dispatch('fork')}
-				startIcon={{ icon: GitFork }}
-				iconOnly={false}
-			>
-				Fork
-			</Button>
+			<Popover notClickable placement="bottom">
+				<Button
+					unifiedSize="sm"
+					variant="subtle"
+					on:click={() => dispatch('fork')}
+					startIcon={{ icon: GitFork }}
+					iconOnly
+				/>
+				{#snippet text()}Fork into an inline script{/snippet}
+			</Popover>
 		{/if}
 	{:else if module.value.type === 'flow'}
 		<Button

--- a/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
@@ -125,6 +125,7 @@
 					}}
 					startIcon={{ icon: Pen }}
 					iconOnly
+					aria-label="Edit the script's code"
 					disabled={module.value.hash != undefined}
 				/>
 				{#snippet text()}Edit the script's code{/snippet}
@@ -149,6 +150,7 @@
 						}}
 						startIcon={{ icon: Settings }}
 						iconOnly
+						aria-label="Edit the script's runtime settings"
 						disabled={module.value.hash != undefined}
 					/>
 					{#snippet text()}Edit the script's runtime settings (concurrency, cache, timeout, ...){/snippet}
@@ -173,6 +175,7 @@
 					on:click={() => dispatch('fork')}
 					startIcon={{ icon: GitFork }}
 					iconOnly
+					aria-label="Fork into an inline script"
 				/>
 				{#snippet text()}Fork into an inline script{/snippet}
 			</Popover>

--- a/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
@@ -13,7 +13,8 @@
 		Repeat,
 		Square,
 		Pin,
-		Save
+		Save,
+		Settings
 	} from 'lucide-svelte'
 	import Popover from '../../Popover.svelte'
 	import type { FlowEditorContext } from '../types'
@@ -28,7 +29,7 @@
 	}
 
 	let { module, tag }: Props = $props()
-	const { scriptEditorDrawer, flowEditorDrawer, opWorkspace } =
+	const { scriptEditorDrawer, workspaceScriptSettingsDrawer, flowEditorDrawer, opWorkspace } =
 		getContext<FlowEditorContext>('FlowEditorContext')
 
 	const dispatch = createEventDispatcher()
@@ -126,6 +127,23 @@
 				disabled={module.value.hash != undefined}
 			>
 				Edit
+			</Button>
+			<Button
+				unifiedSize="sm"
+				variant="subtle"
+				onClick={() => {
+					if (module.value.type == 'script') {
+						$workspaceScriptSettingsDrawer?.openDrawer(module.value.path, module.value.hash, () => {
+							dispatch('reload')
+						})
+					}
+				}}
+				startIcon={{ icon: Settings }}
+				iconOnly={false}
+				disabled={module.value.hash != undefined}
+				title="Edit the workspace script's runtime settings (concurrency, cache, timeout, ...)"
+			>
+				Settings
 			</Button>
 		{/if}
 		{#if customUi?.tagEdit != false}

--- a/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
@@ -9,6 +9,7 @@
 	import { Loader2, Save, DiffIcon, Settings } from 'lucide-svelte'
 	import ScriptAdvancedSettings from '$lib/components/ScriptAdvancedSettings.svelte'
 	import ScriptSettingsBadges from '$lib/components/ScriptSettingsBadges.svelte'
+	import Popover from '$lib/components/Popover.svelte'
 	import {
 		cleanValueProperties,
 		emptySchema,
@@ -279,14 +280,16 @@
 			{#if script}
 				<ScriptSettingsBadges settings={script} onclick={() => settingsDrawer?.openDrawer()} />
 			{/if}
-			<Button
-				disabled={!script}
-				variant="default"
-				startIcon={{ icon: Settings }}
-				on:click={() => settingsDrawer?.openDrawer()}
-			>
-				Settings
-			</Button>
+			<Popover notClickable placement="bottom">
+				<Button
+					disabled={!script}
+					variant="default"
+					iconOnly
+					startIcon={{ icon: Settings }}
+					on:click={() => settingsDrawer?.openDrawer()}
+				/>
+				{#snippet text()}Runtime settings (concurrency, cache, timeout, ...){/snippet}
+			</Popover>
 			<Button
 				disabled={!savedScript || !script}
 				variant="default"

--- a/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
@@ -6,7 +6,9 @@
 	import { ScriptService, type Preview, type Script } from '$lib/gen'
 	import { inferArgs } from '$lib/infer'
 	import { workspaceStore } from '$lib/stores'
-	import { Loader2, Save, DiffIcon } from 'lucide-svelte'
+	import { Loader2, Save, DiffIcon, Settings } from 'lucide-svelte'
+	import ScriptAdvancedSettings from '$lib/components/ScriptAdvancedSettings.svelte'
+	import ScriptSettingsBadges from '$lib/components/ScriptSettingsBadges.svelte'
 	import {
 		cleanValueProperties,
 		emptySchema,
@@ -56,6 +58,20 @@
 				on_behalf_of_email?: string
 				auto_kind?: string
 				has_preprocessor?: boolean
+				concurrent_limit?: number
+				concurrency_time_window_s?: number
+				concurrency_key?: string
+				cache_ttl?: number
+				cache_ignore_s3_path?: boolean
+				timeout?: number
+				debounce_delay_s?: number
+				debounce_key?: string
+				debounce_args_to_accumulate?: string[]
+				max_total_debouncing_time?: number
+				max_total_debounces_amount?: number
+				restart_unless_cancelled?: boolean
+				priority?: number
+				delete_after_secs?: number
 		  }
 		| undefined = $state(undefined)
 
@@ -77,6 +93,20 @@
 				on_behalf_of_email?: string
 				auto_kind?: string
 				has_preprocessor?: boolean
+				concurrent_limit?: number
+				concurrency_time_window_s?: number
+				concurrency_key?: string
+				cache_ttl?: number
+				cache_ignore_s3_path?: boolean
+				timeout?: number
+				debounce_delay_s?: number
+				debounce_key?: string
+				debounce_args_to_accumulate?: string[]
+				max_total_debouncing_time?: number
+				max_total_debounces_amount?: number
+				restart_unless_cancelled?: boolean
+				priority?: number
+				delete_after_secs?: number
 		  }
 		| undefined = $state(undefined)
 
@@ -135,6 +165,7 @@
 	let args = $state({})
 
 	let displayEditor = $state(true)
+	let settingsDrawer: Drawer | undefined = $state()
 </script>
 
 <ConfirmationModal
@@ -239,6 +270,17 @@
 			</div>
 		{/if}
 		{#snippet actions()}
+			{#if script}
+				<ScriptSettingsBadges settings={script} onclick={() => settingsDrawer?.openDrawer()} />
+			{/if}
+			<Button
+				disabled={!script}
+				variant="default"
+				startIcon={{ icon: Settings }}
+				on:click={() => settingsDrawer?.openDrawer()}
+			>
+				Settings
+			</Button>
 			<Button
 				disabled={!savedScript || !script}
 				variant="default"
@@ -290,3 +332,19 @@
 		displayEditor = true
 	}}
 />
+
+<Drawer bind:this={settingsDrawer} size="600px">
+	<DrawerContent title="Script settings" on:close={() => settingsDrawer?.closeDrawer()}>
+		{#if script}
+			<div class="flex flex-col gap-4">
+				<p class="text-xs text-secondary">
+					These runtime settings are saved together with the script when you press Save.
+				</p>
+				<ScriptAdvancedSettings {script} workspaceId={opWs} />
+			</div>
+		{/if}
+		{#snippet actions()}
+			<Button variant="border" on:click={() => settingsDrawer?.closeDrawer()}>Done</Button>
+		{/snippet}
+	</DrawerContent>
+</Drawer>

--- a/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
@@ -12,6 +12,7 @@
 	import {
 		cleanValueProperties,
 		emptySchema,
+		emptyString,
 		orderedJsonStringify,
 		sendUserToast
 	} from '$lib/utils'
@@ -132,6 +133,11 @@
 						is_template: false,
 						tag: script.tag,
 						kind: script.kind as Script['kind'] | undefined,
+						// Empty keys are shared global keys server-side; treat cleared inputs as unset.
+						concurrency_key: emptyString(script.concurrency_key)
+							? undefined
+							: script.concurrency_key,
+						debounce_key: emptyString(script.debounce_key) ? undefined : script.debounce_key,
 						lock: undefined
 					}
 				})

--- a/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/ScriptEditorDrawer.svelte
@@ -286,6 +286,7 @@
 					variant="default"
 					iconOnly
 					startIcon={{ icon: Settings }}
+					aria-label="Runtime settings"
 					on:click={() => settingsDrawer?.openDrawer()}
 				/>
 				{#snippet text()}Runtime settings (concurrency, cache, timeout, ...){/snippet}

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingInfo.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingInfo.svelte
@@ -10,18 +10,28 @@
 		// Rendered summary of the current value (only shown when active).
 		valueText?: string | undefined
 		loading?: boolean
+		// Set when loading the referenced script failed, to distinguish that from "not set".
+		error?: string | undefined
 		// Editing is possible only for non-hub, non-hash-pinned workspace scripts.
 		canEdit: boolean
 		onEdit?: () => void
 	}
 
-	let { label, active, valueText, loading = false, canEdit, onEdit }: Props = $props()
+	let {
+		label,
+		active,
+		valueText,
+		loading = false,
+		error = undefined,
+		canEdit,
+		onEdit
+	}: Props = $props()
 </script>
 
 <div class="flex flex-col gap-2 rounded-md border p-3 bg-surface-secondary">
 	<div class="flex flex-row items-center justify-between gap-2">
 		<span class="text-xs text-secondary">
-			{label} is configured on the referenced workspace script.
+			{label} is managed on the referenced workspace script.
 		</span>
 		{#if canEdit}
 			<Button size="xs" variant="border" startIcon={{ icon: Settings }} on:click={() => onEdit?.()}>
@@ -34,6 +44,8 @@
 			<span class="text-tertiary inline-flex items-center gap-1">
 				<Loader2 class="animate-spin" size={12} /> Loading current value…
 			</span>
+		{:else if error}
+			<span class="text-red-500">Could not load the current value: {error}</span>
 		{:else if active}
 			<span class="font-semibold text-emphasis">{valueText}</span>
 		{:else}

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingInfo.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingInfo.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import Button from '$lib/components/common/button/Button.svelte'
+	import { Loader2, Settings } from 'lucide-svelte'
+
+	interface Props {
+		// Human label of the setting, e.g. "Concurrency limit" or "Cache".
+		label: string
+		// Whether the setting is currently configured on the referenced script.
+		active: boolean
+		// Rendered summary of the current value (only shown when active).
+		valueText?: string | undefined
+		loading?: boolean
+		// Editing is possible only for non-hub, non-hash-pinned workspace scripts.
+		canEdit: boolean
+		onEdit?: () => void
+	}
+
+	let { label, active, valueText, loading = false, canEdit, onEdit }: Props = $props()
+</script>
+
+<div class="flex flex-col gap-2 rounded-md border p-3 bg-surface-secondary">
+	<div class="flex flex-row items-center justify-between gap-2">
+		<span class="text-xs text-secondary">
+			{label} is configured on the referenced workspace script.
+		</span>
+		{#if canEdit}
+			<Button size="xs" variant="border" startIcon={{ icon: Settings }} on:click={() => onEdit?.()}>
+				Edit script settings
+			</Button>
+		{/if}
+	</div>
+	<div class="text-xs">
+		{#if loading}
+			<span class="text-tertiary inline-flex items-center gap-1">
+				<Loader2 class="animate-spin" size={12} /> Loading current value…
+			</span>
+		{:else if active}
+			<span class="font-semibold text-emphasis">{valueText}</span>
+		{:else}
+			<span class="text-tertiary">Not set on the script.</span>
+		{/if}
+	</div>
+	{#if !canEdit}
+		<span class="text-2xs text-tertiary">
+			Hub scripts and steps pinned to a specific version cannot be edited from here.
+		</span>
+	{/if}
+</div>

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingInfo.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingInfo.svelte
@@ -14,6 +14,8 @@
 		error?: string | undefined
 		// Editing is possible only for non-hub, non-hash-pinned workspace scripts.
 		canEdit: boolean
+		// Explanation shown when editing isn't possible (varies: hub, pinned, dev editor).
+		noEditReason?: string | undefined
 		onEdit?: () => void
 	}
 
@@ -24,6 +26,7 @@
 		loading = false,
 		error = undefined,
 		canEdit,
+		noEditReason = undefined,
 		onEdit
 	}: Props = $props()
 </script>
@@ -52,9 +55,7 @@
 			<span class="text-tertiary">Not set on the script.</span>
 		{/if}
 	</div>
-	{#if !canEdit}
-		<span class="text-2xs text-tertiary">
-			Hub scripts and steps pinned to a specific version cannot be edited from here.
-		</span>
+	{#if !canEdit && noEditReason}
+		<span class="text-2xs text-tertiary">{noEditReason}</span>
 	{/if}
 </div>

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
@@ -19,27 +19,32 @@
 	let loading = $state(false)
 	let saving = $state(false)
 	let callback: (() => void) | undefined = undefined
+	// Guards against a slow load for a previously-opened script resolving after
+	// the drawer was reopened for a different one and overwriting its target.
+	let openSeq = 0
 
 	// Open the settings drawer for the workspace script referenced by `path`.
-	// A specific `hash` may be passed to load that version, but saving always
-	// creates a new version whose parent is resolved to the current deployed head.
+	// A specific `hash` may be passed to load that version.
 	export async function openDrawer(
 		path: string,
 		hash: string | undefined,
 		cb?: () => void
 	): Promise<void> {
+		const seq = ++openSeq
 		script = undefined
 		callback = cb
 		drawer?.openDrawer?.()
 		loading = true
 		try {
-			script = hash
+			const loaded = hash
 				? await ScriptService.getScriptByHash({ workspace: opWs!, hash })
 				: await ScriptService.getScriptByPath({ workspace: opWs!, path })
+			if (seq !== openSeq) return
+			script = loaded
 		} catch (e) {
-			sendUserToast(`Could not load script settings: ${e}`, true)
+			if (seq === openSeq) sendUserToast(`Could not load script settings: ${e}`, true)
 		} finally {
-			loading = false
+			if (seq === openSeq) loading = false
 		}
 	}
 
@@ -50,6 +55,9 @@
 			// Spread the full loaded script so fields we don't edit here (codebase,
 			// labels, envs, on_behalf_of_email, ...) survive the new version; only
 			// override lineage and normalize the edited settings.
+			// parent_hash without auto_parent is an optimistic-concurrency guard: if the
+			// script was deployed elsewhere while the drawer was open, the save fails
+			// loudly (non-linear lineage) instead of silently reverting that deploy.
 			// preserve_on_behalf_of/skip_draft_deletion keep a settings-only save from
 			// hijacking the execution identity or discarding the author's code draft.
 			await ScriptService.createScript({
@@ -59,7 +67,6 @@
 					summary: script.summary ?? '',
 					description: script.description ?? '',
 					parent_hash: script.hash,
-					auto_parent: true,
 					is_template: false,
 					lock: script.lock,
 					concurrency_key: emptyString(script.concurrency_key) ? undefined : script.concurrency_key,

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
@@ -44,6 +44,9 @@
 		loadError = undefined
 		current = { path, hash }
 		loading = true
+		// A save still in flight for the previous target no longer clears this flag
+		// (it is seq-guarded), so reset it here or the new target's Save stays disabled.
+		saving = false
 		try {
 			const loaded = hash
 				? await ScriptService.getScriptByHash({ workspace: opWs!, hash })
@@ -59,6 +62,11 @@
 
 	async function save(): Promise<void> {
 		if (!script) return
+		// The drawer is a singleton: bind this save to the target that started it, so a
+		// reopen for another script can't receive its callback or get closed under the
+		// user. The captured callback still fires — it refreshes the script it belongs to.
+		const seq = openSeq
+		const cb = callback
 		saving = true
 		try {
 			// Spread the full loaded script so fields we don't edit here (codebase,
@@ -84,12 +92,12 @@
 				}
 			})
 			sendUserToast('Script settings saved')
-			callback?.()
-			drawer?.closeDrawer()
+			cb?.()
+			if (seq === openSeq) drawer?.closeDrawer()
 		} catch (e) {
-			sendUserToast(`Could not save script settings: ${e.body ?? e}`, true)
+			if (seq === openSeq) sendUserToast(`Could not save script settings: ${e.body ?? e}`, true)
 		} finally {
-			saving = false
+			if (seq === openSeq) saving = false
 		}
 	}
 </script>

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
@@ -4,7 +4,7 @@
 	import ScriptSettingsBadges from '$lib/components/ScriptSettingsBadges.svelte'
 	import { ScriptService, type Script } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
-	import { sendUserToast } from '$lib/utils'
+	import { emptyString, sendUserToast } from '$lib/utils'
 	import { Loader2, Save } from 'lucide-svelte'
 	import { getContext } from 'svelte'
 	import type { FlowEditorContext } from '../types'
@@ -48,8 +48,10 @@
 		saving = true
 		try {
 			// Spread the full loaded script so fields we don't edit here (codebase,
-			// assets, labels, envs, on_behalf_of_email, ...) survive the new version;
-			// only override lineage and the edited settings live on `script`.
+			// labels, envs, on_behalf_of_email, ...) survive the new version; only
+			// override lineage and normalize the edited settings.
+			// preserve_on_behalf_of/skip_draft_deletion keep a settings-only save from
+			// hijacking the execution identity or discarding the author's code draft.
 			await ScriptService.createScript({
 				workspace: opWs!,
 				requestBody: {
@@ -59,7 +61,11 @@
 					parent_hash: script.hash,
 					auto_parent: true,
 					is_template: false,
-					lock: script.lock
+					lock: script.lock,
+					concurrency_key: emptyString(script.concurrency_key) ? undefined : script.concurrency_key,
+					debounce_key: emptyString(script.debounce_key) ? undefined : script.debounce_key,
+					preserve_on_behalf_of: true,
+					skip_draft_deletion: true
 				}
 			})
 			sendUserToast('Script settings saved')

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
@@ -47,42 +47,19 @@
 		if (!script) return
 		saving = true
 		try {
+			// Spread the full loaded script so fields we don't edit here (codebase,
+			// assets, labels, envs, on_behalf_of_email, ...) survive the new version;
+			// only override lineage and the edited settings live on `script`.
 			await ScriptService.createScript({
 				workspace: opWs!,
 				requestBody: {
-					path: script.path,
+					...script,
 					summary: script.summary ?? '',
 					description: script.description ?? '',
-					content: script.content,
-					schema: script.schema,
-					language: script.language,
-					kind: script.kind,
 					parent_hash: script.hash,
 					auto_parent: true,
 					is_template: false,
-					lock: script.lock,
-					tag: script.tag,
-					envs: script.envs,
-					concurrent_limit: script.concurrent_limit,
-					concurrency_time_window_s: script.concurrency_time_window_s,
-					concurrency_key: script.concurrency_key,
-					cache_ttl: script.cache_ttl,
-					cache_ignore_s3_path: script.cache_ignore_s3_path,
-					dedicated_worker: script.dedicated_worker,
-					priority: script.priority,
-					restart_unless_cancelled: script.restart_unless_cancelled,
-					timeout: script.timeout,
-					delete_after_secs: script.delete_after_secs,
-					debounce_key: script.debounce_key,
-					debounce_delay_s: script.debounce_delay_s,
-					debounce_args_to_accumulate: script.debounce_args_to_accumulate,
-					max_total_debouncing_time: script.max_total_debouncing_time,
-					max_total_debounces_amount: script.max_total_debounces_amount,
-					visible_to_runner_only: script.visible_to_runner_only,
-					ws_error_handler_muted: script.ws_error_handler_muted,
-					on_behalf_of_email: script.on_behalf_of_email,
-					has_preprocessor: script.has_preprocessor,
-					auto_kind: script.auto_kind
+					lock: script.lock
 				}
 			})
 			sendUserToast('Script settings saved')

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button, Drawer, DrawerContent } from '$lib/components/common'
+	import Alert from '$lib/components/common/alert/Alert.svelte'
 	import ScriptAdvancedSettings from '$lib/components/ScriptAdvancedSettings.svelte'
 	import ScriptSettingsBadges from '$lib/components/ScriptSettingsBadges.svelte'
 	import { ScriptService, type Script } from '$lib/gen'
@@ -17,8 +18,10 @@
 	// ScriptAdvancedSettings still edits it, so widen the local type to keep it.
 	let script: (Script & { cache_ignore_s3_path?: boolean }) | undefined = $state(undefined)
 	let loading = $state(false)
+	let loadError = $state<string | undefined>(undefined)
 	let saving = $state(false)
 	let callback: (() => void) | undefined = undefined
+	let current: { path: string; hash: string | undefined } | undefined = undefined
 	// Guards against a slow load for a previously-opened script resolving after
 	// the drawer was reopened for a different one and overwriting its target.
 	let openSeq = 0
@@ -30,10 +33,16 @@
 		hash: string | undefined,
 		cb?: () => void
 	): Promise<void> {
-		const seq = ++openSeq
-		script = undefined
 		callback = cb
 		drawer?.openDrawer?.()
+		await load(path, hash)
+	}
+
+	async function load(path: string, hash: string | undefined): Promise<void> {
+		const seq = ++openSeq
+		script = undefined
+		loadError = undefined
+		current = { path, hash }
 		loading = true
 		try {
 			const loaded = hash
@@ -42,7 +51,7 @@
 			if (seq !== openSeq) return
 			script = loaded
 		} catch (e) {
-			if (seq === openSeq) sendUserToast(`Could not load script settings: ${e}`, true)
+			if (seq === openSeq) loadError = `${e?.body ?? e}`
 		} finally {
 			if (seq === openSeq) loading = false
 		}
@@ -67,7 +76,6 @@
 					summary: script.summary ?? '',
 					description: script.description ?? '',
 					parent_hash: script.hash,
-					is_template: false,
 					lock: script.lock,
 					concurrency_key: emptyString(script.concurrency_key) ? undefined : script.concurrency_key,
 					debounce_key: emptyString(script.debounce_key) ? undefined : script.debounce_key,
@@ -88,10 +96,25 @@
 
 <Drawer bind:this={drawer} size="600px">
 	<DrawerContent title="Script settings" on:close={() => drawer?.closeDrawer()}>
-		{#if loading || !script}
+		{#if loading}
 			<div class="center-center flex-col h-full text-tertiary">
 				<Loader2 class="animate-spin" size={16} />
 				<span class="text-xs mt-1">Loading</span>
+			</div>
+		{:else if loadError || !script}
+			<div class="center-center flex-col h-full gap-3">
+				<Alert type="error" title="Could not load script settings" size="xs">
+					{loadError ?? 'Script not found.'}
+				</Alert>
+				{#if current}
+					<Button
+						size="xs"
+						variant="border"
+						on:click={() => current && load(current.path, current.hash)}
+					>
+						Retry
+					</Button>
+				{/if}
 			</div>
 		{:else}
 			<div class="flex flex-col gap-4">

--- a/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/WorkspaceScriptSettingsDrawer.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+	import { Button, Drawer, DrawerContent } from '$lib/components/common'
+	import ScriptAdvancedSettings from '$lib/components/ScriptAdvancedSettings.svelte'
+	import ScriptSettingsBadges from '$lib/components/ScriptSettingsBadges.svelte'
+	import { ScriptService, type Script } from '$lib/gen'
+	import { workspaceStore } from '$lib/stores'
+	import { sendUserToast } from '$lib/utils'
+	import { Loader2, Save } from 'lucide-svelte'
+	import { getContext } from 'svelte'
+	import type { FlowEditorContext } from '../types'
+
+	const flowEditorContext = getContext<FlowEditorContext>('FlowEditorContext')
+	let opWs = $derived(flowEditorContext?.opWorkspace?.() ?? $workspaceStore)
+
+	let drawer: Drawer | undefined = $state()
+	// cache_ignore_s3_path lives on NewScript but not the returned Script type;
+	// ScriptAdvancedSettings still edits it, so widen the local type to keep it.
+	let script: (Script & { cache_ignore_s3_path?: boolean }) | undefined = $state(undefined)
+	let loading = $state(false)
+	let saving = $state(false)
+	let callback: (() => void) | undefined = undefined
+
+	// Open the settings drawer for the workspace script referenced by `path`.
+	// A specific `hash` may be passed to load that version, but saving always
+	// creates a new version whose parent is resolved to the current deployed head.
+	export async function openDrawer(
+		path: string,
+		hash: string | undefined,
+		cb?: () => void
+	): Promise<void> {
+		script = undefined
+		callback = cb
+		drawer?.openDrawer?.()
+		loading = true
+		try {
+			script = hash
+				? await ScriptService.getScriptByHash({ workspace: opWs!, hash })
+				: await ScriptService.getScriptByPath({ workspace: opWs!, path })
+		} catch (e) {
+			sendUserToast(`Could not load script settings: ${e}`, true)
+		} finally {
+			loading = false
+		}
+	}
+
+	async function save(): Promise<void> {
+		if (!script) return
+		saving = true
+		try {
+			await ScriptService.createScript({
+				workspace: opWs!,
+				requestBody: {
+					path: script.path,
+					summary: script.summary ?? '',
+					description: script.description ?? '',
+					content: script.content,
+					schema: script.schema,
+					language: script.language,
+					kind: script.kind,
+					parent_hash: script.hash,
+					auto_parent: true,
+					is_template: false,
+					lock: script.lock,
+					tag: script.tag,
+					envs: script.envs,
+					concurrent_limit: script.concurrent_limit,
+					concurrency_time_window_s: script.concurrency_time_window_s,
+					concurrency_key: script.concurrency_key,
+					cache_ttl: script.cache_ttl,
+					cache_ignore_s3_path: script.cache_ignore_s3_path,
+					dedicated_worker: script.dedicated_worker,
+					priority: script.priority,
+					restart_unless_cancelled: script.restart_unless_cancelled,
+					timeout: script.timeout,
+					delete_after_secs: script.delete_after_secs,
+					debounce_key: script.debounce_key,
+					debounce_delay_s: script.debounce_delay_s,
+					debounce_args_to_accumulate: script.debounce_args_to_accumulate,
+					max_total_debouncing_time: script.max_total_debouncing_time,
+					max_total_debounces_amount: script.max_total_debounces_amount,
+					visible_to_runner_only: script.visible_to_runner_only,
+					ws_error_handler_muted: script.ws_error_handler_muted,
+					on_behalf_of_email: script.on_behalf_of_email,
+					has_preprocessor: script.has_preprocessor,
+					auto_kind: script.auto_kind
+				}
+			})
+			sendUserToast('Script settings saved')
+			callback?.()
+			drawer?.closeDrawer()
+		} catch (e) {
+			sendUserToast(`Could not save script settings: ${e.body ?? e}`, true)
+		} finally {
+			saving = false
+		}
+	}
+</script>
+
+<Drawer bind:this={drawer} size="600px">
+	<DrawerContent title="Script settings" on:close={() => drawer?.closeDrawer()}>
+		{#if loading || !script}
+			<div class="center-center flex-col h-full text-tertiary">
+				<Loader2 class="animate-spin" size={16} />
+				<span class="text-xs mt-1">Loading</span>
+			</div>
+		{:else}
+			<div class="flex flex-col gap-4">
+				<div class="flex flex-row items-center gap-2 flex-wrap">
+					<span class="text-xs text-tertiary">{script.path}</span>
+					<ScriptSettingsBadges settings={script} />
+				</div>
+				<p class="text-xs text-secondary">
+					Saving creates a new version of the workspace script with these runtime settings. The code
+					is left unchanged.
+				</p>
+				<ScriptAdvancedSettings {script} workspaceId={opWs} />
+			</div>
+		{/if}
+		{#snippet actions()}
+			<Button
+				on:click={save}
+				disabled={!script || loading || saving}
+				startIcon={{ icon: saving ? Loader2 : Save }}
+			>
+				Save
+			</Button>
+		{/snippet}
+	</DrawerContent>
+</Drawer>

--- a/frontend/src/lib/components/flows/types.ts
+++ b/frontend/src/lib/components/flows/types.ts
@@ -2,6 +2,7 @@ import type { Job, OpenFlow } from '$lib/gen'
 import type { History } from '$lib/history.svelte'
 import type { Writable } from 'svelte/store'
 import type ScriptEditorDrawer from './content/ScriptEditorDrawer.svelte'
+import type WorkspaceScriptSettingsDrawer from './content/WorkspaceScriptSettingsDrawer.svelte'
 import type FlowEditorDrawer from './content/FlowEditorDrawer.svelte'
 import type { FlowState } from './flowState'
 import type { FlowBuilderWhitelabelCustomUi } from '../custom_ui'
@@ -76,6 +77,7 @@ export type FlowEditorContext = {
 	currentEditor: Writable<CurrentEditor>
 	previewArgs: StateStore<Record<string, any>>
 	scriptEditorDrawer: Writable<ScriptEditorDrawer | undefined>
+	workspaceScriptSettingsDrawer: Writable<WorkspaceScriptSettingsDrawer | undefined>
 	flowEditorDrawer: Writable<FlowEditorDrawer | undefined>
 	history: History<OpenFlow>
 	pathStore: Writable<string>

--- a/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
+++ b/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
@@ -24,6 +24,9 @@ export function useWorkspaceScriptSettings(
 		const seq = ++loadSeq
 		if (!path || !workspace || path.startsWith('hub/')) {
 			settings = undefined
+			// Clear here too: this supersedes any in-flight load, whose guarded
+			// finally can no longer reset loading, else the card spins forever.
+			loading = false
 			return
 		}
 		loading = true

--- a/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
+++ b/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
@@ -12,6 +12,7 @@ export function useWorkspaceScriptSettings(
 ) {
 	let settings = $state<ScriptAdvancedSettingsFields | undefined>(undefined)
 	let loading = $state(false)
+	let error = $state<string | undefined>(undefined)
 	// Guards against an older in-flight load resolving after a newer one and
 	// clobbering the displayed settings when path/hash change quickly.
 	let loadSeq = 0
@@ -24,12 +25,14 @@ export function useWorkspaceScriptSettings(
 		const seq = ++loadSeq
 		if (!path || !workspace || path.startsWith('hub/')) {
 			settings = undefined
+			error = undefined
 			// Clear here too: this supersedes any in-flight load, whose guarded
 			// finally can no longer reset loading, else the card spins forever.
 			loading = false
 			return
 		}
 		loading = true
+		error = undefined
 		try {
 			const script = hash
 				? await ScriptService.getScriptByHash({ workspace, hash })
@@ -38,7 +41,11 @@ export function useWorkspaceScriptSettings(
 			settings = script as ScriptAdvancedSettingsFields
 		} catch (e) {
 			console.error('Could not load referenced script settings', e)
-			if (seq === loadSeq) settings = undefined
+			if (seq === loadSeq) {
+				settings = undefined
+				// Surface failure so cards distinguish "load failed" from "not set".
+				error = `${(e as { body?: string })?.body ?? e}`
+			}
 		} finally {
 			if (seq === loadSeq) loading = false
 		}
@@ -54,6 +61,9 @@ export function useWorkspaceScriptSettings(
 		},
 		get loading() {
 			return loading
+		},
+		get error() {
+			return error
 		},
 		reload() {
 			return load(pathGetter(), hashGetter(), workspaceGetter())

--- a/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
+++ b/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
@@ -1,0 +1,54 @@
+import { ScriptService } from '$lib/gen'
+import type { ScriptAdvancedSettingsFields } from '$lib/components/scriptSettings'
+
+// Loads the advanced runtime settings (concurrency, cache, timeout, ...) of the
+// workspace script referenced by a flow step, so the flow editor can surface the
+// current values instead of only a "set it on the script" warning. Reactive to
+// the path/hash/workspace getters; call reload() after saving new settings.
+export function useWorkspaceScriptSettings(
+	pathGetter: () => string | undefined,
+	hashGetter: () => string | undefined,
+	workspaceGetter: () => string | undefined
+) {
+	let settings = $state<ScriptAdvancedSettingsFields | undefined>(undefined)
+	let loading = $state(false)
+
+	async function load(
+		path: string | undefined,
+		hash: string | undefined,
+		workspace: string | undefined
+	) {
+		if (!path || !workspace || path.startsWith('hub/')) {
+			settings = undefined
+			return
+		}
+		loading = true
+		try {
+			const script = hash
+				? await ScriptService.getScriptByHash({ workspace, hash })
+				: await ScriptService.getScriptByPath({ workspace, path })
+			settings = script as ScriptAdvancedSettingsFields
+		} catch (e) {
+			console.error('Could not load referenced script settings', e)
+			settings = undefined
+		} finally {
+			loading = false
+		}
+	}
+
+	$effect(() => {
+		load(pathGetter(), hashGetter(), workspaceGetter())
+	})
+
+	return {
+		get settings() {
+			return settings
+		},
+		get loading() {
+			return loading
+		},
+		reload() {
+			return load(pathGetter(), hashGetter(), workspaceGetter())
+		}
+	}
+}

--- a/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
+++ b/frontend/src/lib/components/flows/useWorkspaceScriptSettings.svelte.ts
@@ -12,12 +12,16 @@ export function useWorkspaceScriptSettings(
 ) {
 	let settings = $state<ScriptAdvancedSettingsFields | undefined>(undefined)
 	let loading = $state(false)
+	// Guards against an older in-flight load resolving after a newer one and
+	// clobbering the displayed settings when path/hash change quickly.
+	let loadSeq = 0
 
 	async function load(
 		path: string | undefined,
 		hash: string | undefined,
 		workspace: string | undefined
 	) {
+		const seq = ++loadSeq
 		if (!path || !workspace || path.startsWith('hub/')) {
 			settings = undefined
 			return
@@ -27,12 +31,13 @@ export function useWorkspaceScriptSettings(
 			const script = hash
 				? await ScriptService.getScriptByHash({ workspace, hash })
 				: await ScriptService.getScriptByPath({ workspace, path })
+			if (seq !== loadSeq) return
 			settings = script as ScriptAdvancedSettingsFields
 		} catch (e) {
 			console.error('Could not load referenced script settings', e)
-			settings = undefined
+			if (seq === loadSeq) settings = undefined
 		} finally {
-			loading = false
+			if (seq === loadSeq) loading = false
 		}
 	}
 

--- a/frontend/src/lib/components/scriptSettings.test.ts
+++ b/frontend/src/lib/components/scriptSettings.test.ts
@@ -27,6 +27,14 @@ describe('getActiveScriptSettingsBadges', () => {
 		expect(keys).toEqual([])
 	})
 
+	it('treats non-positive concurrency limits and timeouts as inactive (legacy zero rows)', () => {
+		const keys = getActiveScriptSettingsBadges({
+			concurrent_limit: 0,
+			timeout: 0
+		}).map((b) => b.key)
+		expect(keys).toEqual([])
+	})
+
 	it('keeps delete_after_secs of 0 active (immediate deletion is a real setting)', () => {
 		const badge = getActiveScriptSettingsBadges({ delete_after_secs: 0 })
 		expect(badge.map((b) => b.key)).toEqual(['delete_after_use'])

--- a/frontend/src/lib/components/scriptSettings.test.ts
+++ b/frontend/src/lib/components/scriptSettings.test.ts
@@ -27,10 +27,11 @@ describe('getActiveScriptSettingsBadges', () => {
 		expect(keys).toEqual([])
 	})
 
-	it('treats non-positive concurrency limits and timeouts as inactive (legacy zero rows)', () => {
+	it('treats non-positive concurrency limits, timeouts and cache ttl as inactive (legacy zero rows)', () => {
 		const keys = getActiveScriptSettingsBadges({
 			concurrent_limit: 0,
-			timeout: 0
+			timeout: 0,
+			cache_ttl: 0
 		}).map((b) => b.key)
 		expect(keys).toEqual([])
 	})

--- a/frontend/src/lib/components/scriptSettings.test.ts
+++ b/frontend/src/lib/components/scriptSettings.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { getActiveScriptSettingsBadges } from './scriptSettings'
+
+describe('getActiveScriptSettingsBadges', () => {
+	it('returns no badges for undefined or empty settings', () => {
+		expect(getActiveScriptSettingsBadges(undefined)).toEqual([])
+		expect(getActiveScriptSettingsBadges({})).toEqual([])
+	})
+
+	it('only surfaces settings that are actually active', () => {
+		const keys = getActiveScriptSettingsBadges({
+			concurrent_limit: 3,
+			concurrency_time_window_s: 60,
+			cache_ttl: 600,
+			timeout: 120,
+			priority: 50,
+			tag: 'gpu'
+		}).map((b) => b.key)
+		expect(keys).toEqual(['concurrency', 'cache', 'timeout', 'priority', 'tag'])
+	})
+
+	it('treats a zero/absent priority and non-positive debounce as inactive', () => {
+		const keys = getActiveScriptSettingsBadges({
+			priority: 0,
+			debounce_delay_s: 0
+		}).map((b) => b.key)
+		expect(keys).toEqual([])
+	})
+
+	it('keeps delete_after_secs of 0 active (immediate deletion is a real setting)', () => {
+		const badge = getActiveScriptSettingsBadges({ delete_after_secs: 0 })
+		expect(badge.map((b) => b.key)).toEqual(['delete_after_use'])
+		expect(badge[0].detail).toContain('immediately')
+	})
+
+	it('pluralizes the concurrency detail correctly', () => {
+		expect(getActiveScriptSettingsBadges({ concurrent_limit: 1 })[0].detail).toContain(
+			'Max 1 execution'
+		)
+		expect(getActiveScriptSettingsBadges({ concurrent_limit: 2 })[0].detail).toContain(
+			'Max 2 executions'
+		)
+	})
+})

--- a/frontend/src/lib/components/scriptSettings.ts
+++ b/frontend/src/lib/components/scriptSettings.ts
@@ -1,0 +1,135 @@
+import {
+	Gauge,
+	Database,
+	Timer,
+	Hourglass,
+	Repeat,
+	Cpu,
+	Trash2,
+	ChevronsUp,
+	Tag
+} from 'lucide-svelte'
+import type { ScriptLang } from '$lib/gen'
+
+// Subset of Script/NewScript fields that make up the "advanced runtime settings"
+// surfaced both in the standalone script editor and, via the mini settings drawer,
+// from within the flow editor for workspace-script steps.
+export type ScriptAdvancedSettingsFields = {
+	path?: string
+	language?: ScriptLang
+	schema?: unknown
+	tag?: string
+	concurrent_limit?: number
+	concurrency_time_window_s?: number
+	concurrency_key?: string
+	cache_ttl?: number
+	cache_ignore_s3_path?: boolean
+	timeout?: number
+	debounce_delay_s?: number
+	debounce_key?: string
+	debounce_args_to_accumulate?: string[]
+	max_total_debouncing_time?: number
+	max_total_debounces_amount?: number
+	restart_unless_cancelled?: boolean
+	dedicated_worker?: boolean
+	delete_after_secs?: number
+	priority?: number
+}
+
+export type ScriptSettingsBadge = {
+	key: string
+	label: string
+	icon: any
+	detail: string
+}
+
+// Compute the list of active advanced settings for a script, used to render
+// at-a-glance badges in the editor top bar and in the flow drawers.
+export function getActiveScriptSettingsBadges(
+	settings: ScriptAdvancedSettingsFields | undefined
+): ScriptSettingsBadge[] {
+	if (!settings) return []
+	const badges: ScriptSettingsBadge[] = []
+	if (settings.concurrent_limit != undefined) {
+		badges.push({
+			key: 'concurrency',
+			label: 'Concurrency',
+			icon: Gauge,
+			detail: `Max ${settings.concurrent_limit} execution${
+				settings.concurrent_limit === 1 ? '' : 's'
+			}${
+				settings.concurrency_time_window_s != undefined
+					? ` / ${settings.concurrency_time_window_s}s`
+					: ''
+			}`
+		})
+	}
+	if (settings.cache_ttl != undefined) {
+		badges.push({
+			key: 'cache',
+			label: 'Cache',
+			icon: Database,
+			detail: `Cached for ${settings.cache_ttl}s`
+		})
+	}
+	if (settings.timeout != undefined) {
+		badges.push({
+			key: 'timeout',
+			label: 'Timeout',
+			icon: Timer,
+			detail: `${settings.timeout}s`
+		})
+	}
+	if (settings.debounce_delay_s != undefined && settings.debounce_delay_s > 0) {
+		badges.push({
+			key: 'debounce',
+			label: 'Debounce',
+			icon: Hourglass,
+			detail: `Debounced by ${settings.debounce_delay_s}s`
+		})
+	}
+	if (settings.restart_unless_cancelled) {
+		badges.push({
+			key: 'perpetual',
+			label: 'Perpetual',
+			icon: Repeat,
+			detail: 'Restarts unless cancelled'
+		})
+	}
+	if (settings.dedicated_worker) {
+		badges.push({
+			key: 'dedicated',
+			label: 'Dedicated',
+			icon: Cpu,
+			detail: 'Runs on dedicated workers'
+		})
+	}
+	if (settings.delete_after_secs != undefined) {
+		badges.push({
+			key: 'delete_after_use',
+			label: 'Delete after use',
+			icon: Trash2,
+			detail:
+				settings.delete_after_secs === 0
+					? 'Deleted immediately after completion'
+					: `Deleted ${settings.delete_after_secs}s after completion`
+		})
+	}
+	if (settings.priority != undefined && settings.priority > 0) {
+		badges.push({
+			key: 'priority',
+			label: 'High priority',
+			icon: ChevronsUp,
+			detail: `Priority ${settings.priority}`
+		})
+	}
+	if (settings.tag) {
+		badges.push({
+			key: 'tag',
+			label: settings.tag,
+			icon: Tag,
+			detail: `Worker tag: ${settings.tag}`
+		})
+	}
+	return badges
+}

--- a/frontend/src/lib/components/scriptSettings.ts
+++ b/frontend/src/lib/components/scriptSettings.ts
@@ -66,7 +66,7 @@ export function getActiveScriptSettingsBadges(
 			}`
 		})
 	}
-	if (settings.cache_ttl != undefined) {
+	if (settings.cache_ttl != undefined && settings.cache_ttl > 0) {
 		badges.push({
 			key: 'cache',
 			label: 'Cache',

--- a/frontend/src/lib/components/scriptSettings.ts
+++ b/frontend/src/lib/components/scriptSettings.ts
@@ -50,7 +50,9 @@ export function getActiveScriptSettingsBadges(
 ): ScriptSettingsBadge[] {
 	if (!settings) return []
 	const badges: ScriptSettingsBadge[] = []
-	if (settings.concurrent_limit != undefined) {
+	// Non-positive concurrent_limit / timeout are treated as unset by the runtime
+	// (legacy zero rows), so don't surface them as active settings.
+	if (settings.concurrent_limit != undefined && settings.concurrent_limit > 0) {
 		badges.push({
 			key: 'concurrency',
 			label: 'Concurrency',
@@ -72,7 +74,7 @@ export function getActiveScriptSettingsBadges(
 			detail: `Cached for ${settings.cache_ttl}s`
 		})
 	}
-	if (settings.timeout != undefined) {
+	if (settings.timeout != undefined && settings.timeout > 0) {
 		badges.push({
 			key: 'timeout',
 			label: 'Timeout',

--- a/frontend/src/routes/flows/dev/+page.svelte
+++ b/frontend/src/routes/flows/dev/+page.svelte
@@ -77,6 +77,7 @@
 
 	const previewArgsStore = $state({ val: {} })
 	const scriptEditorDrawer = writable(undefined)
+	const workspaceScriptSettingsDrawer = writable(undefined)
 	const history = initHistory(flowStore.val)
 
 	const stepsInputArgs = new StepsInputArgs()
@@ -94,6 +95,7 @@
 		selectionManager,
 		previewArgs: previewArgsStore,
 		scriptEditorDrawer,
+		workspaceScriptSettingsDrawer,
 		flowEditorDrawer: writable(undefined),
 		history,
 		pathStore: writable(''),
@@ -252,7 +254,7 @@
 	const selectedId = $derived(selectionManager.getSelectedId())
 	const selectedModule = $derived(
 		selectedId && flowStore.val?.value
-			? findModuleInFlow(flowStore.val.value, selectedId) ?? undefined
+			? (findModuleInFlow(flowStore.val.value, selectedId) ?? undefined)
 			: undefined
 	)
 
@@ -293,7 +295,11 @@
 				{/if}
 			</div>
 
-			<div class="flex justify-center pt-1 z-50 absolute gap-2 {compactPreview ? 'left-1/2 -translate-x-1/2 top-14' : 'right-2 top-2'}">
+			<div
+				class="flex justify-center pt-1 z-50 absolute gap-2 {compactPreview
+					? 'left-1/2 -translate-x-1/2 top-14'
+					: 'right-2 top-2'}"
+			>
 				<FlowPreviewButtons bind:this={flowPreviewButtons} {suspendStatus} />
 			</div>
 			<Splitpanes horizontal class="max-h-screen grow min-h-0">


### PR DESCRIPTION
## Summary

Fixes WIN-2233.

In the flow editor, steps that reference a **workspace script** could not view or edit the script-level runtime settings (concurrency, cache, timeout, debounce, dedicated worker, priority, delete-after-use). The Concurrency and Cache advanced tabs only showed a static "this can only be set on the script metadata" warning — no current value, no way to act on it — and there was no badge anywhere signalling that a script actually uses these settings.

This PR surfaces those settings directly from the flow editor (and improves the standalone script editor too).

## Changes

- **Mini settings drawer** (`ScriptAdvancedSettings` + `WorkspaceScriptSettingsDrawer`): a reusable subset of the script editor's Runtime settings (worker tag, concurrency, cache, timeout, debounce, perpetual, dedicated workers, delete-after-use, high priority). Reachable from:
  - a new **Settings** button in the workspace-script step header, and
  - the **Edit script settings** shortcut on the delegating tabs.

  Saving creates a new version of the workspace script with the code left unchanged (via `createScript` with `auto_parent`), then refreshes the step.
- **Inner Settings drawer inside the edit-code drawer** (`ScriptEditorDrawer`): the same settings, saved together with the code on the drawer's existing Save.
- **Delegation tabs now fetch current values** (`useWorkspaceScriptSettings`): the Concurrency and Cache tabs replace the bare warning with the referenced script's live value (e.g. "Max 5 executions within 60s", "Cached for 600s") plus an **Edit script settings** button. Hub scripts / hash-pinned steps stay read-only.
- **Badges** (`ScriptSettingsBadges`) showing which advanced settings are active, added to: the standalone script editor top bar, the edit-code drawer header, and above the workspace-script step preview. Clicking a badge jumps to the relevant settings.

No backend changes; no EE files touched.

## Screenshots

**Flow step → Advanced → Concurrency: icon-only header actions (Edit/Settings/Fork) and setting badges, the referenced script's live value, and an Edit script settings shortcut**

![shot-concurrency.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2233-surface-advanced-settings-for-workspace-scripts-in-flows/1784838929-shot-concurrency.png)

**Hovering an icon badge reveals the label and current value**

![badge-popover.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2233-surface-advanced-settings-for-workspace-scripts-in-flows/1784838932-badge-popover.png)

**Mini settings drawer (top): worker tag, concurrency, cache**

![shot-drawer-top.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2233-surface-advanced-settings-for-workspace-scripts-in-flows/1784838935-shot-drawer-top.png)

**Mini settings drawer (bottom): timeout, perpetual, dedicated workers, delete-after-use, priority**

![shot-drawer-bottom.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2233-surface-advanced-settings-for-workspace-scripts-in-flows/1784838937-shot-drawer-bottom.png)

**Edit-code drawer: icon-only Settings button + badges in the header**

![shot-edit-drawer.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2233-surface-advanced-settings-for-workspace-scripts-in-flows/1784838939-shot-edit-drawer.png)

**Standalone script editor top bar with the icon badges**

![shot-script-editor.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2233-surface-advanced-settings-for-workspace-scripts-in-flows/1784838941-shot-script-editor.png)

## Test plan

- [ ] Open a flow with a workspace-script step that has concurrency/cache/etc set → badges appear above the preview and in the step header.
- [ ] Advanced → Concurrency / Cache show the current value and an "Edit script settings" button.
- [ ] Click Settings (header) or Edit script settings → mini drawer loads the current values; change one and Save → a new script version is created, other settings preserved, and the info box/badges refresh.
- [ ] Edit (code) drawer shows badges + a Settings button opening the inner settings drawer, saved together with code.
- [ ] Standalone script editor top bar shows the badges; clicking one opens the Runtime settings.
- [ ] Hub-script / hash-pinned steps: settings shown read-only, no edit button.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Edit and view workspace script runtime settings directly from the flow editor. Replaces old warnings with live values, clear errors, and a quick path to update settings. Fixes WIN-2233.

- New Features
  - Mini “Script settings” drawer for workspace-script steps (from the step header or Concurrency/Cache). Edit worker tag, concurrency, cache, timeout, debounce, perpetual, dedicated workers, delete-after-use, and priority. Saving creates a new script version; code unchanged.
  - Concurrency and Cache tabs now show the referenced script’s current value and an “Edit script settings” shortcut. Hub scripts and hash-pinned steps stay read-only.
  - Setting badges in the standalone script editor top bar, the code editor drawer header, and above the workspace-script step preview. Icon chips with hover details; clickable when allowed and when the settings drawer is mounted.
  - Inner Settings drawer inside the script code editor; settings are saved with the existing Save. Step header actions (Edit, Settings, Fork) and the code drawer Settings button are icon-only with hover popovers.

- Bug Fixes
  - Subflow steps keep a plain limitation note; the delegation UI only applies to workspace-script steps.
  - Settings-only saves preserve all fields (codebase, labels, envs, execution identity, drafts), keep template status, normalize blank concurrency/debounce keys, and use a parent-hash guard for optimistic concurrency.
  - Surfaced values and badges stay in sync after header saves; editing and clickable badges respect custom UI gates and are disabled in local-dev editors unless the settings drawer is mounted. The settings loader is sequence-guarded and shows a recoverable load error with Retry; non-positive concurrency/timeout/cache_ttl are treated as unset. Added unit tests for badges, including zero-value cases.
  - Delegating cards surface load errors distinctly and use neutral wording; accessible names added to icon-only buttons and badges; read-only messages now explain the exact reason (hub, pinned version, or unavailable in this editor).
  - Bind settings save completion to the active drawer target to avoid closing/reloading a reopened one; saving state resets on reopen.

<sup>Written for commit ab6e239f8f26b5708ac1893529b9715bf4977171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

