### PR TITLE
fix(frontend): reference the file-search worker by its packaged .js name

### DIFF
--- a/frontend/src/lib/components/copilot/chat/files/fileEngine.ts
+++ b/frontend/src/lib/components/copilot/chat/files/fileEngine.ts
@@ -294,7 +294,10 @@ export function searchFilesInWorker(
 ): Promise<SearchResult> {
 	let worker: Worker
 	try {
-		worker = new Worker(new URL('./searchWorker.ts', import.meta.url), { type: 'module' })
+		// Reference the worker by its .js name: svelte-package doesn't rewrite this
+		// string literal and ships only searchWorker.js, so a `.ts` URL is dangling
+		// when the package is consumed downstream (vite maps `.js`→`.ts` here in-repo).
+		worker = new Worker(new URL('./searchWorker.js', import.meta.url), { type: 'module' })
 	} catch {
 		return searchFiles(entries, pattern, opts)
 	}


### PR DESCRIPTION
## Summary

`copilot/chat/files/fileEngine.ts` instantiates its search worker with:

```ts
new Worker(new URL('./searchWorker.ts', import.meta.url), { type: 'module' })
```

`svelte-package` does **not** rewrite string literals inside `new URL()`, and it ships only the compiled `searchWorker.js` (plus `.d.ts`) — never the `.ts` source. So the published `@windmill-labs/components` contains a `fileEngine.js` pointing at a file that isn't in the tarball, and **any downstream consumer that bundles this module fails to build**:

```
[commonjs--resolver] Could not resolve entry module
  "node_modules/@windmill-labs/components/package/components/copilot/chat/files/searchWorker.ts"
```

This is currently blocking windmillhub from upgrading to `1.767.x` at all (it reaches this module through its existing `AppPreview` / `FlowViewer` imports — see windmill-labs/windmillhub#154). The code is new since `1.706.1`, which is why nothing hit it before.

## Fix

Reference the worker by its packaged `.js` name. This resolves in **both** contexts:

- **In-repo:** vite maps a `.js` specifier back to the `.ts` source, so the app build still bundles `searchWorker.ts`.
- **Packaged:** `searchWorker.js` physically exists next to `fileEngine.js`, so consumers resolve it.

Verified with an isolated vite build (a `new URL('./searchWorker.js')` next to only a `searchWorker.ts` emits the worker chunk correctly), and by building windmillhub against a package with this exact change — the `Could not resolve` error goes away and the build completes.

## Test plan

- [x] `npm run check:fast` clean.
- [x] Isolated vite build proves `.js` → `.ts` resolution in-repo (worker chunk emitted).
- [x] windmillhub production build (`build` and `build:cf`) passes with this change applied to the installed package; fails without it.
- [ ] Republish `@windmill-labs/components` so windmillhub can drop to a clean bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reference the file-search worker by its packaged .js name to fix downstream build failures. Keeps local builds working and resolves missing file errors in packaged `@windmill-labs/components`.

- **Bug Fixes**
  - Instantiate the worker using './searchWorker.js' instead of '.ts'.
  - Works in-repo via `vite` mapping and in packages since `svelte-package` ships `searchWorker.js`; fixes consumer build errors.

<sup>Written for commit 5ca3104bac065a6b1d548085586f1bb535ae6304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

