### PR TITLE
fix: surface workspace ids on duplicate names and explain fork promotion

### DIFF
--- a/frontend/src/lib/components/git_sync/GitSyncSection.svelte
+++ b/frontend/src/lib/components/git_sync/GitSyncSection.svelte
@@ -6,6 +6,7 @@
 	import GitSyncRepositoryCard from './GitSyncRepositoryCard.svelte'
 	import GitSyncModalManager from './GitSyncModalManager.svelte'
 	import { enterpriseLicense, workspaceStore, userWorkspaces } from '$lib/stores'
+	import { base } from '$lib/base'
 	import { WorkspaceService } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
 	import { untrack } from 'svelte'
@@ -93,6 +94,15 @@
 	const promotionModeRepos = $derived(
 		showPromotion ? [] : [primaryPromotion, ...secondaryPromotion].filter((r) => r != null)
 	)
+	// Promotion is what a dev workspace does, so a fork that wants it can be
+	// re-designated as one. Pairing is prod-scoped and admin-gated there, so this
+	// only links to the parent's screen, and only when the parent is a workspace
+	// the user actually has.
+	const devPairingHref = $derived.by(() => {
+		const parent = currentWorkspace?.parent_workspace_id
+		if (!parent || !$userWorkspaces?.some((w) => w.id === parent)) return undefined
+		return `${base}/workspace_settings?workspace=${parent}&tab=dev_workspace`
+	})
 
 	// State for collapsible sections
 	let secondarySyncExpanded = $state(false)
@@ -320,6 +330,12 @@
 							Deploys in a fork always commit to the fork's own wm-fork/** branch, so a promotion
 							repository would never take effect here. Promote this fork's work by merging that
 							branch into the tracked branch instead.
+							{#if devPairingHref}
+								<div class="mt-2">
+									To promote per item from this workspace, pair it with its parent as a
+									<a href={devPairingHref} class="text-blue-500 hover:underline">dev workspace</a>.
+								</div>
+							{/if}
 							{#if promotionModeRepos.length > 0}
 								<div class="mt-2">
 									Still set to promotion mode here, and still syncing deploys to the fork's branch:

--- a/frontend/src/lib/components/git_sync/GitSyncSection.svelte
+++ b/frontend/src/lib/components/git_sync/GitSyncSection.svelte
@@ -86,6 +86,13 @@
 	const devSingleRepo = $derived(isDevWorkspace && (gitSyncContext?.repositories?.length ?? 0) <= 1)
 	const secondarySync = $derived(gitSyncContext?.getSecondarySyncRepositories() || [])
 	const secondaryPromotion = $derived(gitSyncContext?.getSecondaryPromotionRepositories() || [])
+	// Fork creation keeps only sync-mode repositories and a fork is refused a
+	// promotion one, so the single way a fork holds one is a dev workspace
+	// detached back into a plain fork. Deploys still sync through it (only the
+	// promotion branching is dropped), so name it instead of showing nothing.
+	const promotionModeRepos = $derived(
+		showPromotion ? [] : [primaryPromotion, ...secondaryPromotion].filter((r) => r != null)
+	)
 
 	// State for collapsible sections
 	let secondarySyncExpanded = $state(false)
@@ -302,6 +309,24 @@
 								{/if}
 							{/if}
 						{/if}
+					</div>
+				{:else if !showPromotion}
+					<div class="mt-6">
+						<Alert
+							type="info"
+							title="Promotion does not apply to a fork"
+							documentationLink="https://www.windmill.dev/docs/advanced/workspace_forks"
+						>
+							Deploys in a fork always commit to the fork's own wm-fork/** branch, so a promotion
+							repository would never take effect here. Promote this fork's work by merging that
+							branch into the tracked branch instead.
+							{#if promotionModeRepos.length > 0}
+								<div class="mt-2">
+									Still set to promotion mode here, and still syncing deploys to the fork's branch:
+									{promotionModeRepos.map((r) => r.repo.git_repo_resource_path).join(', ')}
+								</div>
+							{/if}
+						</Alert>
 					</div>
 				{/if}
 			{/if}

--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -165,6 +165,20 @@
 	// shown in the breadcrumb).
 	const currentFamily = $derived(findRoot($workspaceStore ?? undefined))
 
+	// Workspace names carry no uniqueness constraint, and this menu labels every
+	// row by name alone: a prod/staging pair sharing one name renders as two
+	// identical rows. Show the (unique) id alongside the name wherever a name is
+	// shared, so the rows stay tellable apart.
+	const ambiguousNames = $derived.by(() => {
+		const seen = new Set<string>()
+		const ambiguous = new Set<string>()
+		for (const w of $userWorkspaces ?? []) {
+			if (seen.has(w.name)) ambiguous.add(w.name)
+			seen.add(w.name)
+		}
+		return ambiguous
+	})
+
 	// The active workspace itself (fork included) — names the settings entry.
 	const activeWorkspace = $derived($userWorkspaces?.find((w) => w.id === $workspaceStore))
 	const canManageWorkspace = $derived(
@@ -205,6 +219,9 @@
 				icon={Building}
 				iconProps={iconColor ? { style: `color: ${iconColor}` } : undefined}
 				label={currentFamily?.name ?? $workspaceStore ?? ''}
+				sublabel={!isCollapsed && currentFamily && ambiguousNames.has(currentFamily.name)
+					? currentFamily.id
+					: undefined}
 				{isCollapsed}
 				color={familyColor}
 				showChevron
@@ -293,6 +310,11 @@
 												>
 											{/if}
 										</div>
+										{#if ambiguousNames.has(workspace.name)}
+											<div class="truncate text-left text-2xs text-tertiary" title={workspace.id}>
+												{workspace.id}
+											</div>
+										{/if}
 									</div>
 								</div>
 								{#if isSelected}
@@ -363,7 +385,9 @@
 						{item}
 					>
 						<Settings size={16} />
-						{activeWorkspace?.name ?? $workspaceStore} settings
+						{(activeWorkspace && ambiguousNames.has(activeWorkspace.name)
+							? activeWorkspace.id
+							: activeWorkspace?.name) ?? $workspaceStore} settings
 					</MenuItem>
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary

Two UX fixes for confusions reported after upgrading from v1.745.0 to v1.767.0.

**1. Same-named workspaces are indistinguishable.** The v2 sidebar labels workspaces by display name, which has no uniqueness constraint. A prod/staging pair sharing one name renders as two identical rows, and the settings entry names the active workspace by that same shared name, so it reads as the wrong workspace. The workspace id is now shown wherever a name is shared. Instances with unique names see no change.

**2. Git promotion silently disappears on a fork.** Promotion is hidden on forks (#9552, v1.761.0) because it is a no-op there: `computeGitSyncDeployBranch` routes a fork's deploys to its own `wm-fork/**` branch regardless of `use_individual_branch` (`cli/src/utils/git.ts:175`, pinned by `cli/test/git_unit.test.ts:237`). But hiding it with no explanation is indistinguishable from the settings having been wiped by the upgrade. The section now explains why promotion does not apply, and names any promotion-mode repository still stored on the workspace.

On that second point, a fork can only hold a promotion-mode repository via a dev workspace detached back into a plain fork: fork creation keeps only sync-mode repos (`workspaces.rs:5431`) and a fork is refused one on save, while `detach_dev_workspace` clears `is_dev_workspace` and leaves `git_sync` intact. Such a repository still syncs deploys (normal deploys pass `skip_promotion_mode_repos = false`, and `dev_promotion_target_matches_parent` returns true once the workspace is no longer a dev), so the copy says it still syncs rather than calling it inactive.

## Changes

- `WorkspaceMenu.svelte`: derive the set of workspace names that appear more than once, then show the id under the name on each colliding row, as the trigger's `sublabel` (expanded sidebar only, since `MenuButton` renders a sublabel even when collapsed and grows `h-8` to `h-10`), and in place of the name in the "… settings" entry.
- `GitSyncSection.svelte`: when the promotion section is hidden because the workspace is a fork, render an explanation instead of nothing, listing any promotion-mode repositories that remain configured.

## Screenshots

Workspace menu with two workspaces both named "phoenix" (unique-named "Admins" is untouched, the settings entry now reads "phoenix-staging settings" instead of "phoenix settings"):

![pr-workspace-menu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/ambiguous-workspace-names-and-fork-promotion-notice/1784843412-pr-workspace-menu.png)

Collapsed sidebar keeps the icon-only trigger at neighbor height, with no id text in the rail:

![pr-sidebar-collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/ambiguous-workspace-names-and-fork-promotion-notice/1784843414-pr-sidebar-collapsed.png)

Git Sync settings on a fork:

![pr-promotion-alert](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/ambiguous-workspace-names-and-fork-promotion-notice/1784843416-pr-promotion-alert.png)

## Test plan

- [ ] Create two workspaces with the same display name: both rows in the workspace menu show their id, a uniquely-named workspace shows none, and the "… settings" entry names the active workspace unambiguously.
- [ ] Collapse the sidebar: the workspace trigger stays icon-only and the same height as its neighbors.
- [ ] On EE, open Git Sync settings on a fork workspace: the promotion card is replaced by the explanation, with no console errors.
- [ ] With a promotion-mode repository still stored on that fork (dev workspace since detached), its resource path is named in the notice.
- [ ] A dev workspace still shows its promotion toggle on the inherited repository card, and a root workspace still shows the full promotion section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disambiguates same‑named workspaces by showing IDs in the sidebar. Clarifies fork behavior in Git Sync by explaining why promotion is hidden, listing any promotion‑mode repos, and linking to dev‑workspace pairing when possible.

- **Bug Fixes**
  - Workspace menu: when names collide, show the workspace ID under each row, add the ID as the trigger sublabel (expanded only), and use the ID in the “… settings” entry; collapsed sidebar stays icon‑only.
  - Git Sync (forks): replace the hidden promotion card with an info notice that links docs, lists any promotion‑mode repositories still configured, notes deploys continue syncing to the fork’s `wm-fork/**` branch, and links to parent dev‑workspace pairing when the user has access.

<sup>Written for commit dcedbac5594a9c1dd6f7beeba484ca27c7ddf268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Fixes WIN-2234