### PR TITLE
test(cli): drain async dependency jobs after sync push to fix flake

### DIFF
--- a/cli/test/new_commands_helpers.ts
+++ b/cli/test/new_commands_helpers.ts
@@ -105,14 +105,9 @@ export async function waitForJob(
 }
 
 /**
- * A `sync push` of a script/flow/app returns as soon as the version is committed,
- * then enqueues an async dependency job (relock + raw-app bundle) that rewrites
- * that same version's value. Pulling or pushing again before it finishes races
- * the worker: an early pull reads pre-relock content, and a second push can be
- * clobbered by the earlier job's write-back, which reverts the deploy. Drain
- * those jobs after each push. The test workspace is isolated per test, so
- * waiting for the whole dependency queue to empty is both sufficient and
- * path-agnostic.
+ * `sync push` returns before its async dependency job (relock + raw-app bundle)
+ * rewrites the deployed version; pulling or re-pushing meanwhile races that
+ * write-back. Call after each push to let the isolated workspace's queue drain.
  */
 export async function waitForDeploymentJobs(
   backend: TestBackend,

--- a/cli/test/new_commands_helpers.ts
+++ b/cli/test/new_commands_helpers.ts
@@ -104,6 +104,36 @@ export async function waitForJob(
   throw new Error(`Job ${jobId} did not complete within ${timeoutMs}ms`);
 }
 
+/**
+ * A `sync push` of a script/flow/app returns as soon as the version is committed,
+ * then enqueues an async dependency job (relock + raw-app bundle) that rewrites
+ * that same version's value. Pulling or pushing again before it finishes races
+ * the worker: an early pull reads pre-relock content, and a second push can be
+ * clobbered by the earlier job's write-back, which reverts the deploy. Drain
+ * those jobs after each push. The test workspace is isolated per test, so
+ * waiting for the whole dependency queue to empty is both sufficient and
+ * path-agnostic.
+ */
+export async function waitForDeploymentJobs(
+  backend: TestBackend,
+  timeoutMs: number = 30000
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const resp = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/jobs/queue/list?job_kinds=dependencies,flowdependencies,appdependencies`
+    );
+    if (!resp.ok) {
+      await resp.text().catch(() => {});
+      throw new Error(`Failed to list queued dependency jobs: ${resp.status}`);
+    }
+    const jobs = await resp.json();
+    if (Array.isArray(jobs) && jobs.length === 0) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`Dependency jobs did not drain within ${timeoutMs}ms`);
+}
+
 export async function createRemoteFlow(
   backend: TestBackend,
   flowPath: string

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { withTestBackend } from "./test_backend.ts";
+import { waitForDeploymentJobs } from "./new_commands_helpers.ts";
 import { addWorkspace } from "../workspace.ts";
 import * as path from "node:path";
 import { writeFile, readFile, stat, rm, mkdir, readdir } from "node:fs/promises";
@@ -174,6 +175,7 @@ excludes: []`, "utf-8");
       ], tempDir, "raw_app_test");
 
       expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // =========================================================================
       // STEP 2: Clear disk and pull - verify raw app is pulled correctly
@@ -240,6 +242,7 @@ excludes: []`, "utf-8");
       ], tempDir, "raw_app_test");
 
       expect(pushResult2.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // =========================================================================
       // STEP 5: Clear disk (delete the app directory)
@@ -349,6 +352,7 @@ excludes: []`, "utf-8");
       ], tempDir, "raw_app_new_file_test");
 
       expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // Add a new file
       const newFilePath = path.join(appDir, "utils.ts");
@@ -364,6 +368,7 @@ excludes: []`, "utf-8");
       ], tempDir, "raw_app_new_file_test");
 
       expect(pushResult2.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // Clear and pull again
       await rm(appDir, { recursive: true });
@@ -420,6 +425,7 @@ excludes: []`, "utf-8");
         tempDir, "raw_app_ts_first_test"
       );
       expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // Edit App.tsx (and the .ts file that sorts first) and push again.
       const appTsxPath = path.join(appDir, "App.tsx");
@@ -436,6 +442,7 @@ excludes: []`, "utf-8");
         tempDir, "raw_app_ts_first_test"
       );
       expect(pushResult2.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // The App.tsx edit must have landed on the remote app's bundled files.
       const appResp = await backend.apiRequest!(
@@ -486,6 +493,7 @@ excludes: []`, "utf-8");
       ], tempDir, "raw_app_delete_file_test");
 
       expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       const indexCssPath = path.join(appDir, "index.css");
       const appTsxPath = path.join(appDir, "App.tsx");
@@ -507,6 +515,7 @@ excludes: []`, "utf-8");
       ], tempDir, "raw_app_delete_file_test");
 
       expect(pushResult2.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       // Clear and pull again
       await rm(appDir, { recursive: true });
@@ -620,6 +629,7 @@ excludes: []`, "utf-8");
         tempDir, "raw_app_camelcase_test"
       );
       expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
 
       await rm(appDir, { recursive: true });
 

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -47,6 +47,7 @@ import {
   newPathAssigner,
   newRawAppPathAssigner,
 } from "../windmill-utils-internal/src/path-utils/path-assigner.ts";
+import { waitForDeploymentJobs } from "./new_commands_helpers.ts";
 
 // =============================================================================
 // Test Fixtures - Every Type of Windmill Resource
@@ -495,58 +496,6 @@ async function cleanupTempDir(dir: string): Promise<void> {
   } catch {
     // Ignore cleanup errors
   }
-}
-
-// Polls /flows/deployment_status/p/{path} + /jobs_u/completed/get until the
-// most recent flow dependency job has completed. After a flow create/update
-// the API queues a FlowDependencies job that asynchronously fills inline-
-// script lockfiles and rewrites flow.value; tests that round-trip through
-// sync push/pull must wait for it or they race the worker (CI-only flake).
-// `deployment_status` is the right read here — `/flows/get` does not return
-// `dependency_job`, but the `deployment_metadata.job_id` row is written in
-// the same tx as the dep-job push, so the returned `job_id` is the latest
-// dep-job UUID by the time the create/update API call has returned. Returns
-// silently if the flow doesn't exist on the server (treats it as a no-op
-// push, since the route returns 404 when the flow row is missing).
-async function waitForFlowDependencyJob(
-  backend: any,
-  flowPath: string,
-  timeoutMs: number = 30000,
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const statusResp = await backend.apiRequest!(
-      `/api/w/${backend.workspace}/flows/deployment_status/p/${flowPath}`,
-    );
-    if (statusResp.status === 404) {
-      await statusResp.text().catch(() => {});
-      return;
-    }
-    if (!statusResp.ok) {
-      await statusResp.text().catch(() => {});
-      throw new Error(
-        `Failed to fetch deployment status for ${flowPath}: ${statusResp.status}`,
-      );
-    }
-    const status = await statusResp.json();
-    const depJobId: string | undefined = status?.job_id;
-    if (!depJobId) {
-      await new Promise((r) => setTimeout(r, 100));
-      continue;
-    }
-    const completed = await backend.apiRequest!(
-      `/api/w/${backend.workspace}/jobs_u/completed/get/${depJobId}`,
-    );
-    if (completed.ok) {
-      await completed.text();
-      return;
-    }
-    await completed.text().catch(() => {});
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  throw new Error(
-    `Flow dependency job for ${flowPath} did not complete within ${timeoutMs}ms`,
-  );
 }
 
 // =============================================================================
@@ -1853,11 +1802,11 @@ excludes: []
 
       expect(pushResult.code).toEqual(0);
 
-      // sync push of the flow enqueues an async FlowDependencies job that
-      // generates the inline-script lockfile and rewrites flow.value. Wait for
-      // it before pulling back, otherwise pull races the worker and the
-      // dry-run push idempotency check sees phantom diffs (CI-only flake).
-      await waitForFlowDependencyJob(backend, flowName);
+      // Both the script (empty lock) and the flow enqueue async dependency jobs
+      // that generate lockfiles and rewrite the deployed value. Drain them before
+      // pulling back, otherwise pull races the worker and the dry-run push
+      // idempotency check sees phantom diffs (CI-only flake).
+      await waitForDeploymentJobs(backend);
 
       // Pull back
       const pullResult = await backend.runCLICommand(


### PR DESCRIPTION
## Summary

The `CLI Tests` / `test-linux` job intermittently fails in `raw_app_sync.test.ts` ("full sync workflow - push, pull, modify, push, clear, pull") and `sync_pull_push.test.ts` ("Mixed scripts and flows with nonDottedPaths are idempotent"). Both are CI-only flakes that pass on re-run (e.g. run 30049774889 failed on attempt 1, green on attempt 2 with no code change).

Root cause: a `sync push` of a script / flow / raw app returns as soon as the new version is committed, but the server then enqueues an **async dependency job** (`dependencies` / `flowdependencies` / `appdependencies`) that relocks and rewrites *that same version's* value (and, for raw apps, rebuilds the bundle). If the test pulls or pushes again before that job finishes it races the worker:

- an early **pull** reads pre-relock content, and
- a second **push** can be clobbered by the earlier job's write-back, reverting the just-deployed change — which is exactly the "App.tsx reverts to `hello world`" symptom in the raw-app test.

I confirmed the window is real: instrumenting the new helper shows an in-flight `appdependencies` job present after **every** raw-app push in the test.

The mixed test already waited for the *flow* dependency job, but not the *script* one (the fixture ships an empty `lock: []`, which also enqueues a dependency job) — so it could still flake.

## Changes
- Add a shared `waitForDeploymentJobs(backend)` helper (`cli/test/new_commands_helpers.ts`) that polls `jobs/queue/list?job_kinds=dependencies,flowdependencies,appdependencies` until the isolated test workspace's dependency queue drains.
- `raw_app_sync.test.ts`: drain after each `sync push` before the next pull/push.
- `sync_pull_push.test.ts`: replace the flow-only `waitForFlowDependencyJob` wait with the generic drain (covers the script dependency job too) and remove the now-unused local helper.

No product code changes — test-only.

## Test plan
- [x] `raw_app_sync.test.ts` passes locally (6/6) with the prebuilt backend binary
- [x] `sync_pull_push.test.ts` passes locally (67/67)
- [x] Both files together: 76/76
- [x] `bunx tsc --noEmit` reports no new errors in the changed files
- [ ] CI `test-linux` green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes CLI sync tests by waiting for async dependency jobs to finish after each `sync push`, removing CI-only race flakes. Adds a shared drain helper and updates tests to use it; product code is unchanged.

- **Bug Fixes**
  - Added `waitForDeploymentJobs(backend)` to poll `/jobs/queue/list?job_kinds=dependencies,flowdependencies,appdependencies` until the test workspace queue is empty, and condensed its inline comment.
  - Called after each push in `raw_app_sync.test.ts`.
  - Replaced `waitForFlowDependencyJob` with the generic drain in `sync_pull_push.test.ts` and removed the old helper.

<sup>Written for commit 15375b2cbda9800b9a51aacdb8c30ba4fe1da912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

