### PR TITLE
fix: resolve svelte/style export conditions in raw-app CLI bundler

### DIFF
--- a/cli/src/commands/app/bundle.ts
+++ b/cli/src/commands/app/bundle.ts
@@ -35,9 +35,23 @@ export const DEFAULT_BUILD_OPTIONS = {
   loader: {
     ".css": "css" as const,
   },
+  // esbuild export conditions safe for any app: "style" resolves tailwindcss v4's CSS
+  // entry (@import "tailwindcss"); "module" is re-added because esbuild drops its
+  // auto-included "module" default once any custom condition is set. The Svelte-only
+  // "svelte" condition is gated per-app in conditionsFor().
+  conditions: ["style", "module"],
   logLevel: "info" as const,
   write: true,
 };
+
+// "svelte" points at raw .svelte sources that only compile with the Svelte plugin, so
+// enable it only for Svelte apps — for a plain app a Svelte-dual-published import would
+// otherwise resolve to .svelte and hard-fail with no loader configured.
+function conditionsFor(svelte: boolean): string[] {
+  return svelte
+    ? [...DEFAULT_BUILD_OPTIONS.conditions, "svelte"]
+    : DEFAULT_BUILD_OPTIONS.conditions;
+}
 
 /**
  * Detects which frontend frameworks are present in package.json
@@ -284,6 +298,7 @@ export async function createBundle(
 
   const buildOptions = {
     ...DEFAULT_BUILD_OPTIONS,
+    conditions: conditionsFor(frameworks.svelte),
     entryPoints: [entryPoint],
     outfile,
     sourcemap,
@@ -337,11 +352,13 @@ export async function createBundle(
 /**
  * Gets the esbuild build options for use in watch mode (dev server)
  * @param entryPoint Entry point file
+ * @param svelte Whether the app is a Svelte app (enables the "svelte" condition)
  * @returns esbuild build options
  */
-export function getDevBuildOptions(entryPoint: string = "index.tsx") {
+export function getDevBuildOptions(entryPoint: string = "index.tsx", svelte = false) {
   return {
     ...DEFAULT_BUILD_OPTIONS,
+    conditions: conditionsFor(svelte),
     entryPoints: [entryPoint],
     outfile: "dist/bundle.js",
     sourcemap: true,

--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -538,7 +538,7 @@ async function dev(opts: DevOptions, appFolder?: string) {
     });
   }
 
-  const buildOptions = getDevBuildOptions(entryPoint);
+  const buildOptions = getDevBuildOptions(entryPoint, frameworks.svelte);
 
   // Load framework-specific plugins (svelte, vue) based on package.json
   const frameworkPlugins = await createFrameworkPlugins(appDir);


### PR DESCRIPTION
## Summary

`wmill app dev` / `wmill app bundle` compile raw apps with esbuild, but the build config never set custom export conditions, so esbuild only used its browser-platform defaults (`browser`, `module`, `import`/`require`, `default`). Packages that gate their entry points behind other conditions failed to resolve, producing hard build errors:

- **tailwindcss v4** exposes its CSS entry only under the `style` condition, so `@import "tailwindcss"` failed with `Could not resolve "tailwindcss"`.
- **flowbite-svelte** (and Svelte component libraries generally) expose their entry only under the `svelte` condition, so `import { Button } from "flowbite-svelte"` failed with `Could not resolve "flowbite-svelte"`.

## Changes

Enable the needed esbuild conditions in `cli/src/commands/app/bundle.ts`, split by scope so plain apps aren't affected:

- **`style` + `module` — global** (`DEFAULT_BUILD_OPTIONS`, shared by `app bundle` and `app dev`):
  - `style` resolves tailwindcss v4's CSS entry and benefits any app (React or Svelte) that uses Tailwind or CSS-exporting libs.
  - `module` is re-added explicitly because esbuild stops auto-including its `module` default as soon as any custom condition is configured; omitting it would regress packages that expose their ESM entry only under `module`.
- **`svelte` — gated per-app** via `conditionsFor(frameworks.svelte)`. The `svelte` condition points at raw `.svelte` sources that only compile with the Svelte plugin (itself loaded only for Svelte apps). Enabling it globally would make a Svelte-dual-published import in a plain React/tsx app resolve to `.svelte` and **hard-fail** with `No loader is configured for ".svelte"`. Gating it costs nothing since a non-Svelte app can't use Svelte components anyway.

## E2E verification

Drove the real `createBundle` against four fixtures:

| Fixture | Expectation | Result |
|---|---|---|
| Svelte + Tailwind v4 + flowbite-svelte | resolves & builds | ✓ JS 634 KB (flowbite compiled), CSS 22 KB (tailwind via `style`) |
| pkg exposing ESM only via `module` | `module` preserved | ✓ resolves to ESM entry |
| plain React/tsx app | unaffected | ✓ builds unchanged |
| non-Svelte app importing a Svelte-dual pkg | unaffected & safe | ✓ resolves to default JS, never touches `.svelte` |

Before/after on the last fixture confirms the gate is load-bearing: with `svelte` global it hard-fails `No loader configured for ".svelte"`; with the per-app gate it resolves cleanly. The exported API returns `["style","module"]` for plain apps and `["style","module","svelte"]` for Svelte apps.

### Caveat (unchanged by this PR)

The `style` condition makes `@import "tailwindcss"` *resolve*, but esbuild does not run the Tailwind compiler, so utility classes are still not generated from that import alone — full Tailwind v4 utility support still requires precompiling with `@tailwindcss/cli`. flowbite-svelte, which ships precompiled component sources, is fully fixed.

## Test plan

- [x] `app bundle` on a Svelte app with `@import "tailwindcss"` (v4) + flowbite-svelte resolves and emits CSS
- [x] A raw app importing a package whose ESM entry is exposed only via `module` still resolves
- [x] Plain React/tsx raw apps bundle unchanged
- [x] A non-Svelte app importing a Svelte-dual-published package resolves to its JS entry (no `.svelte` hard-fail)

Fixes WIN-2235