### PR TITLE
docs: fix stale detach_dev_workspace comment on parent_workspace_id

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -7178,7 +7178,8 @@ async fn attach_dev_workspace(
 }
 
 /// Reverse [`attach_dev_workspace`] / clear the dev designation: unset the dev flag and remove the
-/// prod lock. The workspace keeps its `parent_workspace_id` (it remains an ordinary fork).
+/// prod lock. Whether `parent_workspace_id` is kept depends on the workspace's origin (see the
+/// UPDATE below): a genuine fork stays a fork, a standalone workspace returns to standalone.
 async fn detach_dev_workspace(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,


### PR DESCRIPTION
## Summary
The doc comment on `detach_dev_workspace` claims the workspace always *"keeps its `parent_workspace_id` (it remains an ordinary fork)"*, but the actual `UPDATE` below it clears the parent for standalone workspaces:

```sql
parent_workspace_id = CASE WHEN id LIKE 'wm-fork-%' THEN parent_workspace_id ELSE NULL END
```

So a genuine fork (`wm-fork-*` id) keeps its parent, while a standalone workspace that had been attached as a dev workspace returns to standalone. The comment has been stale since #9552 (v1.761.0) changed the query. This surfaced while diagnosing a customer report where an independently-created workspace attached-then-detached on an older version stayed classified as a fork (hiding the Git Promotion section); the comment reinforced the wrong mental model during that investigation.

Comment-only change, no behavioral effect.

## Changes
- Correct the `detach_dev_workspace` doc comment to describe the origin-dependent handling of `parent_workspace_id`, deferring the detailed rationale to the existing inline note on the `UPDATE`.

## Test plan
- [ ] N/A — documentation comment only; no code path changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the stale doc comment on `detach_dev_workspace` to match behavior: forks keep `parent_workspace_id`, standalone workspaces clear it when detached. Docs-only change; no behavior impact.

<sup>Written for commit a0aa32c9e6dbc85bf8ae53b395764d1ffe668d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

