### PR TITLE
feat: multiple homepage sort orders via an efficient merged runnables endpoint

### DIFF
--- a/backend/migrations/20260724094737_runnables_sort_indexes.down.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.down.sql
@@ -1,2 +1,5 @@
 DROP INDEX IF EXISTS index_script_on_workspace_created_at;
 DROP INDEX IF EXISTS index_flow_on_workspace_edited_at;
+DROP INDEX IF EXISTS index_script_on_workspace_name;
+DROP INDEX IF EXISTS index_flow_on_workspace_name;
+DROP INDEX IF EXISTS index_app_on_workspace_name;

--- a/backend/migrations/20260724094737_runnables_sort_indexes.down.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS index_script_on_workspace_created_at;
+DROP INDEX IF EXISTS index_flow_on_workspace_edited_at;

--- a/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
@@ -2,20 +2,21 @@
 -- keyset-paginated query stays an index scan (Merge Append + LIMIT) even on big
 -- workspaces, for both the time orders and the name orders.
 
--- Time orders. Scripts accumulate archived version rows, so scope that index to
--- the visible non-archived set the homepage browses.
+-- Time orders. Not scoped to archived = false: the endpoint also serves the
+-- "Only archived" view, and current (non-archived) versions carry the newest
+-- created_at so they cluster at the head of the index for the default browse
+-- anyway, while the archived view still gets an ordered index scan.
 CREATE INDEX IF NOT EXISTS index_script_on_workspace_created_at
-    ON script (workspace_id, created_at DESC)
-    WHERE archived = false;
+    ON script (workspace_id, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS index_flow_on_workspace_edited_at
     ON flow (workspace_id, edited_at DESC);
 
 -- Name orders sort on the lowered summary-or-path expression, so a matching
--- expression index makes that order presorted instead of a full sort per page.
+-- expression index makes that order presorted instead of a full sort per page
+-- (covers both the default and archived views).
 CREATE INDEX IF NOT EXISTS index_script_on_workspace_name
-    ON script (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)))
-    WHERE archived = false;
+    ON script (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));
 
 CREATE INDEX IF NOT EXISTS index_flow_on_workspace_name
     ON flow (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));

--- a/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
@@ -1,15 +1,24 @@
--- Indexes backing the unified homepage runnables listing when ordered by
--- last-updated time. The name orders already ride the existing
--- workspace_id+path indexes (script index_script_on_path_created_at, flow_pkey,
--- app unique_path_workspace_id), and apps are one row per path and few enough to
--- sort without a dedicated index. These two cover the large tables so the merged
--- keyset-paginated query stays an index scan even on big workspaces.
+-- Indexes backing the unified homepage runnables listing so the merged,
+-- keyset-paginated query stays an index scan (Merge Append + LIMIT) even on big
+-- workspaces, for both the time orders and the name orders.
 
--- Scripts accumulate archived version rows, so scope the index to the visible
--- non-archived set the homepage browses.
+-- Time orders. Scripts accumulate archived version rows, so scope that index to
+-- the visible non-archived set the homepage browses.
 CREATE INDEX IF NOT EXISTS index_script_on_workspace_created_at
     ON script (workspace_id, created_at DESC)
     WHERE archived = false;
 
 CREATE INDEX IF NOT EXISTS index_flow_on_workspace_edited_at
     ON flow (workspace_id, edited_at DESC);
+
+-- Name orders sort on the lowered summary-or-path expression, so a matching
+-- expression index makes that order presorted instead of a full sort per page.
+CREATE INDEX IF NOT EXISTS index_script_on_workspace_name
+    ON script (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)))
+    WHERE archived = false;
+
+CREATE INDEX IF NOT EXISTS index_flow_on_workspace_name
+    ON flow (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));
+
+CREATE INDEX IF NOT EXISTS index_app_on_workspace_name
+    ON app (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));

--- a/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
@@ -1,0 +1,15 @@
+-- Indexes backing the unified homepage runnables listing when ordered by
+-- last-updated time. The name orders already ride the existing
+-- (workspace_id, path) indexes (script index_script_on_path_created_at,
+-- flow_pkey, app unique_path_workspace_id); apps are one row per path and few
+-- enough to sort without a dedicated index. These two cover the large tables so
+-- the merged, keyset-paginated query stays an index scan even on big workspaces.
+
+-- Scripts accumulate archived version rows, so scope the index to the visible
+-- (non-archived) set the homepage browses.
+CREATE INDEX IF NOT EXISTS index_script_on_workspace_created_at
+    ON script (workspace_id, created_at DESC)
+    WHERE archived = false;
+
+CREATE INDEX IF NOT EXISTS index_flow_on_workspace_edited_at
+    ON flow (workspace_id, edited_at DESC);

--- a/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
@@ -1,12 +1,12 @@
 -- Indexes backing the unified homepage runnables listing when ordered by
 -- last-updated time. The name orders already ride the existing
--- (workspace_id, path) indexes (script index_script_on_path_created_at,
--- flow_pkey, app unique_path_workspace_id); apps are one row per path and few
--- enough to sort without a dedicated index. These two cover the large tables so
--- the merged, keyset-paginated query stays an index scan even on big workspaces.
+-- workspace_id+path indexes (script index_script_on_path_created_at, flow_pkey,
+-- app unique_path_workspace_id), and apps are one row per path and few enough to
+-- sort without a dedicated index. These two cover the large tables so the merged
+-- keyset-paginated query stays an index scan even on big workspaces.
 
 -- Scripts accumulate archived version rows, so scope the index to the visible
--- (non-archived) set the homepage browses.
+-- non-archived set the homepage browses.
 CREATE INDEX IF NOT EXISTS index_script_on_workspace_created_at
     ON script (workspace_id, created_at DESC)
     WHERE archived = false;

--- a/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
+++ b/backend/migrations/20260724094737_runnables_sort_indexes.up.sql
@@ -1,25 +1,26 @@
 -- Indexes backing the unified homepage runnables listing so the merged,
 -- keyset-paginated query stays an index scan (Merge Append + LIMIT) even on big
 -- workspaces, for both the time orders and the name orders.
+--
+-- `archived` is the second key so the default (archived = false) and the
+-- "Only archived" views each seek their own slice and still get the sort key
+-- ordered within it, instead of one view scanning past the other's rows. Apps
+-- have no archived column and are excluded from the archived view.
 
--- Time orders. Not scoped to archived = false: the endpoint also serves the
--- "Only archived" view, and current (non-archived) versions carry the newest
--- created_at so they cluster at the head of the index for the default browse
--- anyway, while the archived view still gets an ordered index scan.
+-- Time orders.
 CREATE INDEX IF NOT EXISTS index_script_on_workspace_created_at
-    ON script (workspace_id, created_at DESC);
+    ON script (workspace_id, archived, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS index_flow_on_workspace_edited_at
-    ON flow (workspace_id, edited_at DESC);
+    ON flow (workspace_id, archived, edited_at DESC);
 
 -- Name orders sort on the lowered summary-or-path expression, so a matching
--- expression index makes that order presorted instead of a full sort per page
--- (covers both the default and archived views).
+-- expression index makes that order presorted instead of a full sort per page.
 CREATE INDEX IF NOT EXISTS index_script_on_workspace_name
-    ON script (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));
+    ON script (workspace_id, archived, lower(COALESCE(NULLIF(summary, ''), path)));
 
 CREATE INDEX IF NOT EXISTS index_flow_on_workspace_name
-    ON flow (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));
+    ON flow (workspace_id, archived, lower(COALESCE(NULLIF(summary, ''), path)));
 
 CREATE INDEX IF NOT EXISTS index_app_on_workspace_name
     ON app (workspace_id, lower(COALESCE(NULLIF(summary, ''), path)));

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -176,6 +176,16 @@ async fn test_runnables_archived_versions_paginate_via_hash(
         .await?;
     }
 
+    // Favorite the path: a path-based favorite marks *every* archived version
+    // starred. The archived view must not pin/cap starred (that would drop
+    // versions past the cap from every page), so all three must still page once.
+    sqlx::query(
+        "INSERT INTO favorite (usr, workspace_id, path, favorite_kind) VALUES ('test-user', 'test-workspace', 'u/test-user/av', 'script')",
+    )
+    .execute(&db)
+    .await?;
+
+    // paginate_all pages one at a time, so every version crosses a page boundary.
     let items = paginate_all(port, "order_by=name&order_desc=false&show_archived=true").await;
     let av = items
         .iter()
@@ -183,7 +193,7 @@ async fn test_runnables_archived_versions_paginate_via_hash(
         .count();
     assert_eq!(
         av, 3,
-        "all three archived versions must page exactly once, got {items:?}"
+        "all three favorited archived versions must page exactly once, got {items:?}"
     );
     Ok(())
 }

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -1,0 +1,189 @@
+//! Regression tests for the merged runnables listing endpoint
+//! (`GET /w/{workspace}/runnables/list`), which UNION-ALLs scripts, flows and
+//! apps into one keyset-paginated, globally-ordered stream.
+//!
+//! The delicate part is the keyset cursor `(sort_key, path, kind, tiebreak)`.
+//! These tests pin two properties a naive cursor would break:
+//!   1. Cross-kind ties — a script and a flow sharing the exact same
+//!      `(sort_key, path)` must each appear exactly once across pages, never
+//!      duplicated or skipped, in every order.
+//!   2. Archived versions — several archived script versions at one path share
+//!      `(name, path, kind)`; the `hash` tiebreak keeps them individually
+//!      reachable when a group crosses a page boundary.
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+fn new_script(path: &str, summary: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": summary,
+        "description": "",
+        "content": "export async function main() {}",
+        "language": "deno",
+        "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object", "properties": {}, "required": [] }
+    })
+}
+
+fn new_flow(path: &str, summary: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": summary,
+        "description": "",
+        "value": { "modules": [] },
+        "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "object", "properties": {}, "required": [] }
+    })
+}
+
+/// Page through the endpoint one item at a time and return the ordered list of
+/// `type:path` identifiers.
+async fn paginate_all(port: u16, query: &str) -> Vec<String> {
+    let base = format!("http://localhost:{port}/api/w/test-workspace/runnables/list");
+    let mut out = vec![];
+    let mut cursor: Option<String> = None;
+    for _ in 0..50 {
+        let mut url = format!("{base}?{query}&per_page=1");
+        if let Some(c) = &cursor {
+            url.push_str(&format!("&cursor={c}"));
+        }
+        let resp = authed(client().get(&url), "SECRET_TOKEN")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200, "list should succeed");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        for it in body["items"].as_array().unwrap() {
+            out.push(format!(
+                "{}:{}",
+                it["type"].as_str().unwrap(),
+                it["path"].as_str().unwrap()
+            ));
+        }
+        match body["next_cursor"].as_str() {
+            Some(c) => cursor = Some(c.to_string()),
+            None => break,
+        }
+    }
+    out
+}
+
+fn assert_no_dupes(items: &[String], label: &str) {
+    let mut sorted = items.to_vec();
+    sorted.sort();
+    let mut deduped = sorted.clone();
+    deduped.dedup();
+    assert_eq!(
+        sorted, deduped,
+        "{label}: keyset pagination must not duplicate or skip items, got {items:?}"
+    );
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_keyset_no_dupes_across_kind_ties(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+
+    // A script and a flow sharing a path, plus two more scripts.
+    for (p, s) in [
+        ("u/test-user/tie", "Tie item"),
+        ("u/test-user/aaa", "Aaa"),
+        ("u/test-user/zzz", "Zzz"),
+    ] {
+        let r = authed(
+            client().post(format!("{base}/scripts/create")),
+            "SECRET_TOKEN",
+        )
+        .json(&new_script(p, s))
+        .send()
+        .await?;
+        assert_eq!(r.status(), 201, "create script: {}", r.text().await?);
+    }
+    let r = authed(
+        client().post(format!("{base}/flows/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&new_flow("u/test-user/tie", "Tie item"))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 201, "create flow: {}", r.text().await?);
+
+    // Force an exact (sort_time, path, summary) tie between the script and flow
+    // at u/test-user/tie so the cross-kind boundary is actually exercised.
+    let ts = "2026-07-20 10:00:00+00";
+    sqlx::query(
+        "UPDATE script SET created_at = $1::timestamptz WHERE workspace_id = 'test-workspace'",
+    )
+    .bind(ts)
+    .execute(&db)
+    .await?;
+    sqlx::query(
+        "UPDATE flow SET edited_at = $1::timestamptz WHERE workspace_id = 'test-workspace'",
+    )
+    .bind(ts)
+    .execute(&db)
+    .await?;
+
+    // Expected: 3 scripts + 1 flow, each exactly once.
+    for q in [
+        "order_by=updated&order_desc=true",
+        "order_by=name&order_desc=false",
+        "order_by=name&order_desc=true",
+    ] {
+        let items = paginate_all(port, q).await;
+        assert_eq!(items.len(), 4, "{q}: expected 4 items, got {items:?}");
+        assert_no_dupes(&items, q);
+        assert!(
+            items.contains(&"flow:u/test-user/tie".to_string()),
+            "{q}: flow present"
+        );
+        assert!(
+            items.contains(&"script:u/test-user/tie".to_string()),
+            "{q}: script present"
+        );
+    }
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_archived_versions_paginate_via_hash(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    // Three archived script versions at one path with identical summary — they
+    // share (name, path, kind); only the `hash` tiebreak keeps them distinct.
+    for (h, sec) in [(811111111i64, 0), (822222222, 1), (833333333, 2)] {
+        sqlx::query(
+            "INSERT INTO script (workspace_id, hash, path, summary, description, content, created_by, created_at, language, archived)
+             VALUES ('test-workspace', $1, 'u/test-user/av', 'AV', '', 'x', 'test-user', ('2026-07-19 10:00:0' || $2)::timestamptz, 'deno', true)",
+        )
+        .bind(h)
+        .bind(sec.to_string())
+        .execute(&db)
+        .await?;
+    }
+
+    let items = paginate_all(port, "order_by=name&order_desc=false&show_archived=true").await;
+    let av = items
+        .iter()
+        .filter(|i| *i == "script:u/test-user/av")
+        .count();
+    assert_eq!(
+        av, 3,
+        "all three archived versions must page exactly once, got {items:?}"
+    );
+    Ok(())
+}

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -224,6 +224,48 @@ async fn test_runnables_archived_shows_only_paths_whose_latest_is_archived(
     Ok(())
 }
 
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_archived_favorite_is_pinned_first(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    // Three fully-archived paths whose names sort aaa < mmm < zzz. Favorite the
+    // last-sorting one; the archived view pins starred first (each path is one row
+    // now), so it must lead under name-ascending order despite its late sort key.
+    for (h, name) in [
+        (911111111i64, "aaa"),
+        (922222222, "mmm"),
+        (933333333, "zzz"),
+    ] {
+        sqlx::query(
+            "INSERT INTO script (workspace_id, hash, path, summary, description, content, created_by, created_at, language, archived)
+             VALUES ('test-workspace', $1, $2, $3, '', 'x', 'test-user', '2026-07-19 10:00:00'::timestamptz, 'deno', true)",
+        )
+        .bind(h).bind(format!("u/test-user/{name}")).bind(name)
+        .execute(&db)
+        .await?;
+    }
+    sqlx::query(
+        "INSERT INTO favorite (usr, workspace_id, path, favorite_kind) VALUES ('test-user', 'test-workspace', 'u/test-user/zzz', 'script')",
+    )
+    .execute(&db)
+    .await?;
+
+    let items = paginate_all(port, "order_by=name&order_desc=false&show_archived=true").await;
+    let pos = |p: &str| items.iter().position(|i| i == p);
+    let zzz = pos("script:u/test-user/zzz").expect("favorited archived path present");
+    let aaa = pos("script:u/test-user/aaa").expect("aaa present");
+    let mmm = pos("script:u/test-user/mmm").expect("mmm present");
+    assert!(
+        zzz < aaa && zzz < mmm,
+        "favorited archived path must be pinned ahead of earlier-named non-favorites, got {items:?}"
+    );
+    Ok(())
+}
+
 fn new_app(path: &str, summary: &str) -> serde_json::Value {
     json!({
         "path": path,

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -197,3 +197,153 @@ async fn test_runnables_archived_versions_paginate_via_hash(
     );
     Ok(())
 }
+
+fn new_app(path: &str, summary: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": summary,
+        "value": {},
+        "policy": { "execution_mode": "publisher", "triggerables": {} }
+    })
+}
+
+/// A single list request; returns the ordered `type:path` identifiers.
+async fn list_once(port: u16, query: &str) -> Vec<String> {
+    let url = format!("http://localhost:{port}/api/w/test-workspace/runnables/list?{query}");
+    let resp = authed(client().get(&url), "SECRET_TOKEN")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "list should succeed for {query}");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    body["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|it| {
+            format!(
+                "{}:{}",
+                it["type"].as_str().unwrap(),
+                it["path"].as_str().unwrap()
+            )
+        })
+        .collect()
+}
+
+async fn seed_mixed(base: &str, db: &Pool<Postgres>) -> anyhow::Result<()> {
+    for (p, s) in [
+        ("f/alpha/one", "Deploy tool"),
+        ("f/alpha/two", "Cleanup job"),
+        ("f/beta/one", "Beta thing"),
+        ("u/test-user/solo", "Solo script"),
+    ] {
+        let r = authed(
+            client().post(format!("{base}/scripts/create")),
+            "SECRET_TOKEN",
+        )
+        .json(&new_script(p, s))
+        .send()
+        .await?;
+        assert_eq!(r.status(), 201, "create script {p}: {}", r.text().await?);
+    }
+    let r = authed(
+        client().post(format!("{base}/flows/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&new_flow("f/alpha/flowy", "Alpha flow"))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 201, "create flow: {}", r.text().await?);
+    let r = authed(client().post(format!("{base}/apps/create")), "SECRET_TOKEN")
+        .json(&new_app("f/beta/appy", "Beta app"))
+        .send()
+        .await?;
+    assert_eq!(r.status(), 201, "create app: {}", r.text().await?);
+    // Silence unused warnings on db in case future assertions drop it.
+    let _ = db;
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_path_start_scopes_to_folder(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+    seed_mixed(&base, &db).await?;
+
+    // path_start scopes to exactly one folder subtree (the folder-navigation path).
+    let mut alpha = list_once(port, "path_start=f/alpha/").await;
+    alpha.sort();
+    assert_eq!(
+        alpha,
+        vec![
+            "flow:f/alpha/flowy".to_string(),
+            "script:f/alpha/one".to_string(),
+            "script:f/alpha/two".to_string(),
+        ],
+        "path_start=f/alpha/ must return only that folder's items"
+    );
+
+    // A prefix that matches nothing returns an empty list, not an error.
+    let empty = list_once(port, "path_start=f/nope/").await;
+    assert!(
+        empty.is_empty(),
+        "unknown folder must be empty, got {empty:?}"
+    );
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+    seed_mixed(&base, &db).await?;
+
+    // Case-insensitive substring search over summary/path.
+    let deploy = list_once(port, "search=deploy").await;
+    assert_eq!(
+        deploy,
+        vec!["script:f/alpha/one".to_string()],
+        "search must substring-match the summary only"
+    );
+
+    // kinds filter selects a single kind.
+    let flows = list_once(port, "kinds=flow").await;
+    assert_eq!(flows, vec!["flow:f/alpha/flowy".to_string()], "kinds=flow");
+    let apps = list_once(port, "kinds=app").await;
+    assert_eq!(apps, vec!["app:f/beta/appy".to_string()], "kinds=app");
+    let scripts = list_once(port, "kinds=script").await;
+    assert_eq!(
+        scripts.len(),
+        4,
+        "kinds=script -> 4 scripts, got {scripts:?}"
+    );
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_starred_pinned_first(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+    seed_mixed(&base, &db).await?;
+
+    // Favorite a path that would otherwise sort last (name Z-ish); it must lead.
+    sqlx::query(
+        "INSERT INTO favorite (usr, workspace_id, path, favorite_kind) VALUES ('test-user','test-workspace','u/test-user/solo','script')",
+    )
+    .execute(&db)
+    .await?;
+
+    let items = list_once(port, "order_by=name&order_desc=false").await;
+    assert_eq!(
+        items.first().map(String::as_str),
+        Some("script:u/test-user/solo"),
+        "starred item pins to the top of the browse view regardless of order, got {items:?}"
+    );
+    Ok(())
+}

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -2,14 +2,15 @@
 //! (`GET /w/{workspace}/runnables/list`), which UNION-ALLs scripts, flows and
 //! apps into one keyset-paginated, globally-ordered stream.
 //!
-//! The delicate part is the keyset cursor `(sort_key, path, kind, tiebreak)`.
-//! These tests pin two properties a naive cursor would break:
+//! The delicate parts:
 //!   1. Cross-kind ties — a script and a flow sharing the exact same
 //!      `(sort_key, path)` must each appear exactly once across pages, never
-//!      duplicated or skipped, in every order.
-//!   2. Archived versions — several archived script versions at one path share
-//!      `(name, path, kind)`; the `hash` tiebreak keeps them individually
-//!      reachable when a group crosses a page boundary.
+//!      duplicated or skipped, in every order (the keyset cursor
+//!      `(sort_key, path, kind, tiebreak)`).
+//!   2. Archived view semantics — scripts keep every version as a row (old ones
+//!      archived=true), so "Only archived" must key off the LATEST row per path:
+//!      an active path's superseded version must not leak in, and a fully-archived
+//!      path appears exactly once.
 
 use serde_json::json;
 use sqlx::{Pool, Postgres};
@@ -156,44 +157,69 @@ async fn test_runnables_keyset_no_dupes_across_kind_ties(db: Pool<Postgres>) -> 
 }
 
 #[sqlx::test(fixtures("base"))]
-async fn test_runnables_archived_versions_paginate_via_hash(
+async fn test_runnables_archived_shows_only_paths_whose_latest_is_archived(
     db: Pool<Postgres>,
 ) -> anyhow::Result<()> {
     initialize_tracing().await;
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
 
-    // Three archived script versions at one path with identical summary — they
-    // share (name, path, kind); only the `hash` tiebreak keeps them distinct.
-    for (h, sec) in [(811111111i64, 0), (822222222, 1), (833333333, 2)] {
+    // Scripts keep every version as its own row; superseded ones are archived=true.
+    // "Only archived" must key off the LATEST row per path, not every row.
+
+    // Path A: an archived predecessor, then an active latest version. The path is
+    // active, so it must NOT appear in the archived view (the old version leaking in
+    // was the bug).
+    for (h, sec, archived) in [(811111111i64, 0, true), (822222222, 1, false)] {
         sqlx::query(
             "INSERT INTO script (workspace_id, hash, path, summary, description, content, created_by, created_at, language, archived)
-             VALUES ('test-workspace', $1, 'u/test-user/av', 'AV', '', 'x', 'test-user', ('2026-07-19 10:00:0' || $2)::timestamptz, 'deno', true)",
+             VALUES ('test-workspace', $1, 'u/test-user/active_hist', 'AH', '', 'x', 'test-user', ('2026-07-19 10:00:0' || $2)::timestamptz, 'deno', $3)",
         )
-        .bind(h)
-        .bind(sec.to_string())
+        .bind(h).bind(sec.to_string()).bind(archived)
         .execute(&db)
         .await?;
     }
 
-    // Favorite the path: a path-based favorite marks *every* archived version
-    // starred. The archived view must not pin/cap starred (that would drop
-    // versions past the cap from every page), so all three must still page once.
-    sqlx::query(
-        "INSERT INTO favorite (usr, workspace_id, path, favorite_kind) VALUES ('test-user', 'test-workspace', 'u/test-user/av', 'script')",
-    )
-    .execute(&db)
-    .await?;
+    // Path B: fully archived — an older archived version plus a latest archived one.
+    // The archived view must surface it exactly once (its latest row), not per version.
+    for (h, sec) in [(833333333i64, 0), (844444444, 1)] {
+        sqlx::query(
+            "INSERT INTO script (workspace_id, hash, path, summary, description, content, created_by, created_at, language, archived)
+             VALUES ('test-workspace', $1, 'u/test-user/archived_path', 'AP', '', 'x', 'test-user', ('2026-07-19 10:00:0' || $2)::timestamptz, 'deno', true)",
+        )
+        .bind(h).bind(sec.to_string())
+        .execute(&db)
+        .await?;
+    }
 
-    // paginate_all pages one at a time, so every version crosses a page boundary.
+    // Path-based favorites mark every version starred. The archived view must not
+    // pin/cap starred (that would drop rows), and each archived path still pages once.
+    for p in ["u/test-user/active_hist", "u/test-user/archived_path"] {
+        sqlx::query(
+            "INSERT INTO favorite (usr, workspace_id, path, favorite_kind) VALUES ('test-user', 'test-workspace', $1, 'script')",
+        )
+        .bind(p)
+        .execute(&db)
+        .await?;
+    }
+
+    // paginate_all pages one at a time, so a path crossing a page boundary is caught.
     let items = paginate_all(port, "order_by=name&order_desc=false&show_archived=true").await;
-    let av = items
-        .iter()
-        .filter(|i| *i == "script:u/test-user/av")
-        .count();
     assert_eq!(
-        av, 3,
-        "all three favorited archived versions must page exactly once, got {items:?}"
+        items
+            .iter()
+            .filter(|i| *i == "script:u/test-user/active_hist")
+            .count(),
+        0,
+        "an active path's archived predecessor must not leak into the archived view, got {items:?}"
+    );
+    assert_eq!(
+        items
+            .iter()
+            .filter(|i| *i == "script:u/test-user/archived_path")
+            .count(),
+        1,
+        "a fully-archived path must appear exactly once (its latest row), got {items:?}"
     );
     Ok(())
 }

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -192,8 +192,8 @@ async fn test_runnables_archived_shows_only_paths_whose_latest_is_archived(
         .await?;
     }
 
-    // Path-based favorites mark every version starred. The archived view must not
-    // pin/cap starred (that would drop rows), and each archived path still pages once.
+    // Favorite both paths (pinned first now); this test only checks presence/dedup, so
+    // pinning doesn't affect the assertions — favorite-ordering is covered separately.
     for p in ["u/test-user/active_hist", "u/test-user/archived_path"] {
         sqlx::query(
             "INSERT INTO favorite (usr, workspace_id, path, favorite_kind) VALUES ('test-user', 'test-workspace', $1, 'script')",

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -15,7 +15,10 @@ use axum::{
 };
 use lazy_static::lazy_static;
 use regex::Regex;
-use windmill_api_auth::{build_scope_path_predicate, check_scopes, ApiAuthed, AuthCache, Tokened};
+use windmill_api_auth::{
+    build_scope_path_filter, build_scope_path_predicate, check_scopes, ApiAuthed, AuthCache,
+    ScopePathFilter, Tokened,
+};
 use windmill_audit::audit_oss::{audit_log, AuditAuthorable};
 use windmill_audit::ActionKind;
 use windmill_common::DB;
@@ -135,18 +138,42 @@ async fn list_foldernames(
     let (per_page, offset) = paginate(pagination);
     let mut tx = user_db.begin(&authed).await?;
 
-    let allowed = build_scope_path_predicate(&authed, "folders", "read");
-    let rows = sqlx::query_scalar!(
-        "SELECT name FROM folder WHERE workspace_id = $1 ORDER BY name asc LIMIT $2 OFFSET $3",
-        w_id,
-        per_page as i64,
-        offset as i64
-    )
-    .fetch_all(&mut *tx)
-    .await?
-    .into_iter()
-    .filter(|name| allowed(&format!("f/{}", name)))
-    .collect::<Vec<_>>();
+    // Push the token's scope grant into the query so LIMIT/OFFSET page over the
+    // AUTHORIZED folders. Post-filtering the page in Rust (the previous approach) made
+    // the returned count smaller than per_page even when more authorized folders remain
+    // on later DB pages, so a paginating caller would stop early and miss them.
+    let mut sql = String::from("SELECT name FROM folder WHERE workspace_id = $1");
+    let restricted = match build_scope_path_filter(&authed, "folders", "read") {
+        ScopePathFilter::AllowAll => None,
+        ScopePathFilter::Restricted { exact, mut prefix } => {
+            // A prefix grant also authorizes the folder at the prefix itself.
+            let mut eq = exact;
+            eq.append(&mut prefix.clone());
+            let like: Vec<String> = prefix
+                .iter()
+                .map(|p| {
+                    format!(
+                        "{}/%",
+                        p.replace('\\', "\\\\")
+                            .replace('%', "\\%")
+                            .replace('_', "\\_")
+                    )
+                })
+                .collect();
+            sql.push_str(" AND (('f/' || name) = ANY($4) OR ('f/' || name) LIKE ANY($5))");
+            Some((eq, like))
+        }
+    };
+    sql.push_str(" ORDER BY name asc LIMIT $2 OFFSET $3");
+
+    let mut query = sqlx::query_scalar::<_, String>(&sql)
+        .bind(&w_id)
+        .bind(per_page as i64)
+        .bind(offset as i64);
+    if let Some((eq, like)) = restricted {
+        query = query.bind(eq).bind(like);
+    }
+    let rows = query.fetch_all(&mut *tx).await?;
 
     tx.commit().await?;
 

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -139,9 +139,10 @@ async fn list_foldernames(
     let mut tx = user_db.begin(&authed).await?;
 
     // Push the token's scope grant into the query so LIMIT/OFFSET page over the
-    // AUTHORIZED folders. Post-filtering the page in Rust (the previous approach) made
-    // the returned count smaller than per_page even when more authorized folders remain
-    // on later DB pages, so a paginating caller would stop early and miss them.
+    // AUTHORIZED folders — the returned count then reflects the authorized set, so a
+    // paginating caller can rely on `< per_page` meaning exhaustion. (Filtering after the
+    // LIMIT would let a page return fewer than per_page while authorized folders remain
+    // on later DB pages, stopping such a caller early.)
     let mut sql = String::from("SELECT name FROM folder WHERE workspace_id = $1");
     let restricted = match build_scope_path_filter(&authed, "folders", "read") {
         ScopePathFilter::AllowAll => None,

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -24827,8 +24827,8 @@ components:
           type: string
           format: date-time
         hash:
-          type: integer
-          format: int64
+          type: string
+          description: script version hash as a 16-char hex string
         language:
           type: string
         kind:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -19431,6 +19431,8 @@ paths:
         - folder
       parameters:
         - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
         - name: only_member_of
           in: query
           description: only list the folders the user is member of (default false)

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10481,6 +10481,73 @@ paths:
                     - path
                     - value
 
+  /w/{workspace}/runnables/list:
+    get:
+      summary: list runnables (scripts, flows, apps) merged, ordered and keyset-paginated
+      operationId: listRunnables
+      tags:
+        - script
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: order_by
+          in: query
+          description: "sort key: 'updated' (default) or 'name'"
+          schema:
+            type: string
+            enum:
+              - updated
+              - name
+        - $ref: "#/components/parameters/OrderDesc"
+        - name: kinds
+          in: query
+          description: comma-separated subset of script,flow,app (default all)
+          schema:
+            type: string
+        - name: show_archived
+          in: query
+          schema:
+            type: boolean
+        - name: include_without_main
+          in: query
+          description: include library scripts (no runnable main)
+          schema:
+            type: boolean
+        - name: path_start
+          in: query
+          description: restrict to paths under this prefix
+          schema:
+            type: string
+        - name: label
+          in: query
+          schema:
+            type: string
+        - name: search
+          in: query
+          description: case-insensitive substring match on summary or path
+          schema:
+            type: string
+        - $ref: "#/components/parameters/PerPage"
+        - name: cursor
+          in: query
+          description: opaque keyset cursor from a previous page's next_cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          description: a page of merged, ordered runnables
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RunnableItem"
+                  next_cursor:
+                    type: string
   /w/{workspace}/flows/list:
     get:
       summary: list all flows
@@ -24705,6 +24772,86 @@ components:
         - workspace_id
         - language
         - content
+
+    RunnableItem:
+      type: object
+      description: |
+        A row in the merged runnables listing. `type` is the discriminator;
+        kind-specific fields (hash/language/kind for scripts, execution_mode/
+        version for apps) are present only for that kind. `edited_at` is the
+        unified last-updated time (a script's created_at, a flow/app's edit
+        time).
+      properties:
+        type:
+          type: string
+          enum:
+            - script
+            - flow
+            - app
+        path:
+          type: string
+        summary:
+          type: string
+        workspace_id:
+          type: string
+        extra_perms:
+          type: object
+          additionalProperties:
+            type: boolean
+        starred:
+          type: boolean
+        archived:
+          type: boolean
+        is_draft:
+          type: boolean
+        draft_only:
+          type: boolean
+          nullable: true
+        draft_path:
+          type: string
+        draft_users:
+          type: array
+          items:
+            type: object
+        labels:
+          type: array
+          items:
+            type: string
+        inherited_labels:
+          type: array
+          items:
+            type: string
+        ws_error_handler_muted:
+          type: boolean
+        edited_at:
+          type: string
+          format: date-time
+        hash:
+          type: integer
+          format: int64
+        language:
+          type: string
+        kind:
+          type: string
+        auto_kind:
+          type: string
+        use_codebase:
+          type: boolean
+        has_deploy_errors:
+          type: boolean
+        raw_app:
+          type: boolean
+        execution_mode:
+          type: string
+        id:
+          type: integer
+          format: int64
+        version:
+          type: integer
+          format: int64
+      required:
+        - type
+        - path
 
     Script:
       type: object

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -93,6 +93,9 @@ lazy_static::lazy_static! {
                     (20260710073406, include_str!(
                         "../../migrations/20260710073406_index_v2_job_parent_job.up.sql"
                     ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
+                    (20260724094737, include_str!(
+                        "../../migrations/20260724094737_runnables_sort_indexes.up.sql"
+                    ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
                     ].into_iter().collect();
 }
 

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -101,6 +101,7 @@ mod indexer_oss;
 mod integration;
 mod internal_db;
 mod live_migrations;
+mod runnables;
 #[cfg(all(feature = "private", feature = "parquet"))]
 pub mod s3_proxy_ee;
 mod s3_proxy_oss;
@@ -571,6 +572,7 @@ pub async fn run_server(
                         .nest("/embeddings", embeddings::workspaced_service())
                         .nest("/favorites", favorite::workspaced_service())
                         .nest("/flows", flows::workspaced_service())
+                        .nest("/runnables", runnables::workspaced_service())
                         .nest(
                             "/workspace_dependencies",
                             workspace_dependencies::workspaced_service(),

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -1,0 +1,424 @@
+/*
+ * Author: Windmill Labs, Inc
+ * Copyright: Windmill Labs, Inc 2024
+ * This file and its contents are licensed under the AGPLv3 License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-AGPL for a copy of the license.
+ */
+
+//! Unified, keyset-paginated listing of a workspace's runnables (scripts,
+//! flows, apps) merged into one globally-ordered stream. The homepage uses it
+//! so a chosen order (recently updated / oldest / name) is correct and complete
+//! across all three kinds at any workspace size, instead of client-sorting a
+//! per-kind capped window.
+//!
+//! Efficiency: each kind is a UNION ALL branch ordered by an index
+//! (`(workspace_id, created_at)` / `(workspace_id, edited_at)` / `(workspace_id,
+//! path)`); Postgres merges the ordered branches and stops at the page limit.
+//! Pagination is keyset (a `(sort_key, path, kind)` cursor), so deep pages don't
+//! re-scan. Visibility is enforced in-SQL by RLS via the `user_db` transaction.
+
+use crate::db::{ApiAuthed, DB};
+use axum::{
+    extract::{Extension, Path, Query},
+    routing::get,
+    Json, Router,
+};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::{Deserialize, Serialize};
+use windmill_common::{
+    db::UserDB,
+    error::{Error, JsonResult},
+};
+use windmill_types::user_drafts::DraftUserRef;
+
+pub fn workspaced_service() -> Router {
+    Router::new().route("/list", get(list_runnables))
+}
+
+#[derive(Deserialize)]
+struct ListRunnablesQuery {
+    /// `updated` (default) or `name`.
+    order_by: Option<String>,
+    /// Descending when true (default true).
+    order_desc: Option<bool>,
+    /// Comma-separated subset of `script,flow,app`; omitted means all.
+    kinds: Option<String>,
+    show_archived: Option<bool>,
+    /// Include library scripts (no runnable main). Ignored for flows/apps.
+    include_without_main: Option<bool>,
+    /// Restrict to paths under this prefix (owner/folder filter).
+    path_start: Option<String>,
+    /// Comma-separated labels; a row matches if it (or its folder) carries all.
+    label: Option<String>,
+    /// Case-insensitive substring match on summary or path.
+    search: Option<String>,
+    per_page: Option<usize>,
+    /// Opaque keyset cursor from a previous page's `next_cursor`.
+    cursor: Option<String>,
+}
+
+#[derive(Serialize, sqlx::FromRow)]
+struct RunnableItem {
+    #[serde(rename = "type")]
+    kind: String, // 'script' | 'flow' | 'app'
+    path: String,
+    summary: Option<String>,
+    workspace_id: String,
+    extra_perms: serde_json::Value,
+    starred: bool,
+    archived: bool,
+    is_draft: bool,
+    draft_only: Option<bool>,
+    draft_path: Option<String>,
+    draft_users: Option<sqlx::types::Json<Vec<DraftUserRef>>>,
+    labels: Option<Vec<String>>,
+    inherited_labels: Option<Vec<String>>,
+    ws_error_handler_muted: Option<bool>,
+    edited_at: Option<chrono::DateTime<chrono::Utc>>,
+    // script-only
+    hash: Option<i64>,
+    language: Option<String>,
+    #[serde(rename = "kind")]
+    script_kind: Option<String>,
+    auto_kind: Option<String>,
+    use_codebase: Option<bool>,
+    has_deploy_errors: Option<bool>,
+    // app-only
+    raw_app: Option<bool>,
+    execution_mode: Option<String>,
+    id: Option<i64>,
+    version: Option<i64>,
+    // sort keys, echoed into the cursor (not serialized to the client)
+    #[serde(skip)]
+    sort_time: chrono::DateTime<chrono::Utc>,
+    #[serde(skip)]
+    sort_name: String,
+}
+
+#[derive(Serialize)]
+struct ListRunnablesResponse {
+    items: Vec<RunnableItem>,
+    next_cursor: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Cursor {
+    /// sort key of the last row: rfc3339 timestamp (updated) or lowered name.
+    k: String,
+    p: String,
+    t: String,
+}
+
+fn encode_cursor(item: &RunnableItem, order_by_name: bool) -> String {
+    let k = if order_by_name {
+        item.sort_name.clone()
+    } else {
+        item.sort_time.to_rfc3339()
+    };
+    let c = Cursor { k, p: item.path.clone(), t: item.kind.clone() };
+    URL_SAFE_NO_PAD.encode(serde_json::to_vec(&c).unwrap_or_default())
+}
+
+fn decode_cursor(raw: &str) -> Result<Cursor, Error> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(raw)
+        .map_err(|_| Error::BadRequest("invalid cursor".to_string()))?;
+    serde_json::from_slice(&bytes).map_err(|_| Error::BadRequest("invalid cursor".to_string()))
+}
+
+/// The three UNION-ALL branch SELECTs, each projecting the shared `RunnableItem`
+/// column set (NULL for columns that don't apply to that kind). `$1`=workspace,
+/// `$2`=username (favorites), `$3`=email (drafts). Kind-specific and per-request
+/// WHERE fragments are appended by the caller.
+struct Branches {
+    script: String,
+    flow: String,
+    app: String,
+}
+
+fn branch_sqls() -> Branches {
+    // draft_users subquery (correlated) mirrors the per-kind list endpoints; run
+    // only for the returned page, so its cost is bounded by per_page.
+    let draft_users = |typ_pred: &str| -> String {
+        format!(
+            "(SELECT json_agg(json_build_object('username', COALESCE(u.username, p.username, CASE WHEN p.email IS NOT NULL THEN d.email END)) ORDER BY COALESCE(u.username, p.username, CASE WHEN p.email IS NOT NULL THEN d.email END) NULLS LAST) \
+              FROM draft d \
+              LEFT JOIN usr u ON u.workspace_id = d.workspace_id AND u.email = d.email \
+              LEFT JOIN password p ON p.email = d.email AND p.super_admin = true \
+              WHERE d.workspace_id = o.workspace_id AND d.path = o.path AND {typ_pred}) as draft_users"
+        )
+    };
+
+    let script = format!(
+        "SELECT 'script' as kind, o.path, o.summary, o.workspace_id, o.extra_perms, \
+                favorite.path IS NOT NULL as starred, o.archived, \
+                draft.email IS NOT NULL as is_draft, NULL::bool as draft_only, NULL::text as draft_path, \
+                {draft_users}, o.labels, folder_labels(o.workspace_id, o.path) as inherited_labels, \
+                o.ws_error_handler_muted, o.created_at as edited_at, \
+                o.hash, o.language::text as language, o.kind::text as script_kind, o.auto_kind, \
+                o.codebase IS NOT NULL as use_codebase, \
+                (o.lock_error_logs IS NOT NULL) as has_deploy_errors, \
+                NULL::bool as raw_app, NULL::text as execution_mode, NULL::bigint as id, NULL::bigint as version, \
+                o.created_at as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name \
+         FROM script o \
+         LEFT JOIN favorite ON favorite.favorite_kind = 'script' AND favorite.workspace_id = o.workspace_id AND favorite.path = o.path AND favorite.usr = $2 \
+         LEFT JOIN draft ON draft.path = o.path AND draft.workspace_id = o.workspace_id AND draft.typ = 'script' AND draft.email = $3",
+        draft_users = draft_users("d.typ = 'script'")
+    );
+
+    let flow = format!(
+        "SELECT 'flow' as kind, o.path, o.summary, o.workspace_id, o.extra_perms, \
+                favorite.path IS NOT NULL as starred, o.archived, \
+                draft.email IS NOT NULL as is_draft, NULL::bool as draft_only, NULL::text as draft_path, \
+                {draft_users}, o.labels, folder_labels(o.workspace_id, o.path) as inherited_labels, \
+                o.ws_error_handler_muted, o.edited_at, \
+                NULL::bigint as hash, NULL::text as language, NULL::text as script_kind, NULL::text as auto_kind, \
+                NULL::bool as use_codebase, NULL::bool as has_deploy_errors, \
+                NULL::bool as raw_app, NULL::text as execution_mode, NULL::bigint as id, NULL::bigint as version, \
+                o.edited_at as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name \
+         FROM flow o \
+         LEFT JOIN favorite ON favorite.favorite_kind = 'flow' AND favorite.workspace_id = o.workspace_id AND favorite.path = o.path AND favorite.usr = $2 \
+         LEFT JOIN draft ON draft.path = o.path AND draft.workspace_id = o.workspace_id AND draft.typ = 'flow' AND draft.email = $3",
+        draft_users = draft_users("d.typ = 'flow'")
+    );
+
+    let app = format!(
+        "SELECT 'app' as kind, o.path, o.summary, o.workspace_id, o.extra_perms, \
+                favorite.path IS NOT NULL as starred, false as archived, \
+                draft.path IS NOT NULL as is_draft, NULL::bool as draft_only, NULL::text as draft_path, \
+                {draft_users}, o.labels, folder_labels(o.workspace_id, o.path) as inherited_labels, \
+                NULL::bool as ws_error_handler_muted, av.created_at as edited_at, \
+                NULL::bigint as hash, NULL::text as language, NULL::text as script_kind, NULL::text as auto_kind, \
+                NULL::bool as use_codebase, NULL::bool as has_deploy_errors, \
+                av.raw_app, o.policy->>'execution_mode' as execution_mode, o.id, \
+                o.versions[array_upper(o.versions, 1)] as version, \
+                COALESCE(av.created_at, 'epoch'::timestamptz) as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name \
+         FROM app o \
+         LEFT JOIN favorite ON favorite.favorite_kind = 'app' AND favorite.workspace_id = o.workspace_id AND favorite.path = o.path AND favorite.usr = $2 \
+         LEFT JOIN (SELECT DISTINCT path, workspace_id FROM draft WHERE typ IN ('app', 'raw_app') AND email = $3) draft ON draft.path = o.path AND draft.workspace_id = o.workspace_id \
+         LEFT JOIN app_version av ON av.id = o.versions[array_upper(o.versions, 1)]",
+        draft_users = draft_users("d.typ IN ('app', 'raw_app')")
+    );
+
+    Branches { script, flow, app }
+}
+
+async fn list_runnables(
+    authed: ApiAuthed,
+    Extension(user_db): Extension<UserDB>,
+    Extension(_db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Query(q): Query<ListRunnablesQuery>,
+) -> JsonResult<ListRunnablesResponse> {
+    let order_by_name = q.order_by.as_deref() == Some("name");
+    let desc = q.order_desc.unwrap_or(true);
+    let per_page = q.per_page.unwrap_or(50).clamp(1, 1000);
+    let show_archived = q.show_archived.unwrap_or(false);
+    let order_dir = if desc { "DESC" } else { "ASC" };
+    let sort_col = if order_by_name {
+        "sort_name"
+    } else {
+        "sort_time"
+    };
+
+    let mut kinds: Vec<&str> = match q.kinds.as_deref() {
+        None | Some("") => vec!["script", "flow", "app"],
+        Some(csv) => csv
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| ["script", "flow", "app"].contains(s))
+            .collect(),
+    };
+    // Apps carry no `archived` column and are never listed as archived.
+    if show_archived {
+        kinds.retain(|k| *k != "app");
+    }
+    // Operators may only see scripts.
+    if authed.is_operator {
+        kinds.retain(|k| *k == "script");
+    }
+
+    let branches = branch_sqls();
+
+    // Params after the fixed $1=w_id, $2=username, $3=email. `add_bind` returns
+    // the next placeholder (`$N`) and records the value in order.
+    let mut binds: Vec<String> = vec![];
+    let add_bind = |binds: &mut Vec<String>, v: String| -> String {
+        binds.push(v);
+        format!("${}", 3 + binds.len())
+    };
+
+    let mut common: Vec<String> = vec!["o.workspace_id = $1".to_string()];
+    if let Some(ps) = q.path_start.as_ref().filter(|s| !s.is_empty()) {
+        let p = add_bind(&mut binds, format!("{}%", ps));
+        common.push(format!("o.path LIKE {}", p));
+    }
+    if let Some(search) = q.search.as_ref().filter(|s| !s.is_empty()) {
+        let p = add_bind(&mut binds, format!("%{}%", search));
+        common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));
+    }
+    if let Some(label) = q.label.as_ref().filter(|s| !s.is_empty()) {
+        for l in label.split(',') {
+            let p = add_bind(&mut binds, l.trim().to_string());
+            common.push(format!(
+                "(o.labels @> ARRAY[{p}] OR folder_labels(o.workspace_id, o.path) @> ARRAY[{p}])"
+            ));
+        }
+    }
+    let common_where = common.join(" AND ");
+
+    // Keyset predicate for pages after the first (non-starred rows only). A
+    // row-value comparison keeps the composite order; the key is cast to the
+    // branch column's type.
+    let keyset_sql: Option<String> = match &q.cursor {
+        Some(raw) => {
+            let cur = decode_cursor(raw)?;
+            let kp = add_bind(&mut binds, cur.k);
+            let pp = add_bind(&mut binds, cur.p);
+            let tp = add_bind(&mut binds, cur.t);
+            let cmp = if desc { "<" } else { ">" };
+            let key_cast = if order_by_name {
+                format!("{}::text", kp)
+            } else {
+                format!("{}::timestamptz", kp)
+            };
+            Some(format!(
+                "({sort_col}, path, kind) {cmp} ({key_cast}, {pp}::text, {tp}::text)"
+            ))
+        }
+        None => None,
+    };
+
+    // Per-kind archived predicate (scripts/flows have the column; apps don't and
+    // are excluded from the archived view).
+    let archived_pred = if show_archived {
+        "o.archived = true"
+    } else {
+        "o.archived = false"
+    };
+    let mut script_extras: Vec<String> = vec![];
+    if !q.include_without_main.unwrap_or(false) || authed.is_operator {
+        script_extras.push("(o.auto_kind IS NULL OR o.auto_kind <> 'lib')".to_string());
+    }
+    script_extras.push(archived_pred.to_string());
+    let flow_extras: Vec<String> = vec![archived_pred.to_string()];
+    let app_extras: Vec<String> = vec![];
+
+    let build_branch = |base: &str,
+                        kind: &str,
+                        extras: &[String],
+                        starred_only: bool,
+                        keyset: Option<&str>,
+                        limit: Option<usize>|
+     -> String {
+        // Base-table predicates go inside the projection subquery (they read
+        // o.*/favorite.*); the keyset reads the projected sort aliases, so it
+        // sits in the wrapper WHERE where those aliases are visible.
+        let mut w = vec![common_where.clone()];
+        w.extend(extras.iter().cloned());
+        w.push(if starred_only {
+            "favorite.path IS NOT NULL".to_string()
+        } else {
+            "favorite.path IS NULL".to_string()
+        });
+        let keyset_clause = keyset
+            .map(|ks| format!(" WHERE {}", ks))
+            .unwrap_or_default();
+        // Per-branch LIMIT so each branch's correlated projections (draft_users,
+        // folder_labels) are evaluated only for its own top rows, not the whole
+        // table; the outer union re-limits to the global page.
+        let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
+        format!(
+            "(SELECT * FROM ({base} WHERE {where_}) {kind}_b{keyset_clause} ORDER BY {sort_col} {dir}, path {dir}, kind {dir}{limit_clause})",
+            where_ = w.join(" AND "),
+            dir = order_dir,
+        )
+    };
+
+    let branch_for = |kind: &str,
+                      starred_only: bool,
+                      keyset: Option<&str>,
+                      limit: Option<usize>|
+     -> Option<String> {
+        if !kinds.contains(&kind) {
+            return None;
+        }
+        let (base, extras): (&str, &[String]) = match kind {
+            "script" => (&branches.script, &script_extras),
+            "flow" => (&branches.flow, &flow_extras),
+            "app" => (&branches.app, &app_extras),
+            _ => return None,
+        };
+        Some(build_branch(
+            base,
+            kind,
+            extras,
+            starred_only,
+            keyset,
+            limit,
+        ))
+    };
+
+    let run_union = |branches_sql: Vec<String>, limit: Option<usize>| -> String {
+        let unioned = branches_sql.join(" UNION ALL ");
+        let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
+        format!(
+            "SELECT * FROM ({unioned}) q ORDER BY {sort_col} {dir}, path {dir}, kind {dir}{limit_clause}",
+            dir = order_dir,
+        )
+    };
+
+    let mut tx = user_db.begin(&authed).await?;
+    let mut items: Vec<RunnableItem> = vec![];
+    let first_page = q.cursor.is_none();
+
+    // Starred items pinned on top of the first page (a user's favorites are few),
+    // ordered; later pages are non-starred only.
+    if first_page {
+        let starred_branches: Vec<String> = ["script", "flow", "app"]
+            .iter()
+            .filter_map(|k| branch_for(k, true, None, None))
+            .collect();
+        if !starred_branches.is_empty() {
+            let sql = run_union(starred_branches, None);
+            let mut query = sqlx::query_as::<_, RunnableItem>(&sql)
+                .bind(&w_id)
+                .bind(&authed.username)
+                .bind(&authed.email);
+            for b in &binds {
+                query = query.bind(b);
+            }
+            items.extend(query.fetch_all(&mut *tx).await?);
+        }
+    }
+
+    // Non-starred page.
+    let ns_branches: Vec<String> = ["script", "flow", "app"]
+        .iter()
+        .filter_map(|k| branch_for(k, false, keyset_sql.as_deref(), Some(per_page)))
+        .collect();
+
+    let mut next_cursor: Option<String> = None;
+    if !ns_branches.is_empty() {
+        let sql = run_union(ns_branches, Some(per_page));
+        let mut query = sqlx::query_as::<_, RunnableItem>(&sql)
+            .bind(&w_id)
+            .bind(&authed.username)
+            .bind(&authed.email);
+        for b in &binds {
+            query = query.bind(b);
+        }
+        let ns = query.fetch_all(&mut *tx).await?;
+        if ns.len() == per_page {
+            if let Some(last) = ns.last() {
+                next_cursor = Some(encode_cursor(last, order_by_name));
+            }
+        }
+        items.extend(ns);
+    }
+
+    tx.commit().await?;
+
+    Ok(Json(ListRunnablesResponse { items, next_cursor }))
+}

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -473,14 +473,11 @@ async fn list_runnables(
     let mut items: Vec<RunnableItem> = vec![];
     let first_page = q.cursor.is_none();
 
-    // Pin starred on the first page only in the browse (non-archived) view, where
-    // favorites are one row per path and few. The archived view lists every
-    // version, so a path-based favorite marks all of them starred: pinning there
-    // would either fan into an unbounded first page or (if capped) drop starred
-    // versions past the cap from every page. So in the archived view we don't pin
-    // at all — a single ordered stream includes starred and non-starred alike.
-    let pin_starred = !show_archived;
-    if first_page && pin_starred {
+    // Pin starred on the first page. Both views are now one row per path (the
+    // archived view filters to each path's latest row, see archived_pred), so a
+    // favorite is a single row in either — the starred-first contract holds in the
+    // archived view too, and the pinned first page stays bounded.
+    if first_page {
         let starred_branches: Vec<String> = ["script", "flow", "app"]
             .iter()
             .filter_map(|k| branch_for(k, Some(true), None, None))
@@ -498,9 +495,8 @@ async fn list_runnables(
         }
     }
 
-    // Main paged stream: non-starred when we pinned starred above, otherwise
-    // (archived view) every row.
-    let main_fav = if pin_starred { Some(false) } else { None };
+    // Main paged stream: non-starred rows (starred were pinned on the first page above).
+    let main_fav = Some(false);
     let ns_branches: Vec<String> = ["script", "flow", "app"]
         .iter()
         .filter_map(|k| branch_for(k, main_fav, keyset_sql.as_deref(), Some(per_page)))

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -12,11 +12,14 @@
 //! across all three kinds at any workspace size, instead of client-sorting a
 //! per-kind capped window.
 //!
-//! Efficiency: each kind is a UNION ALL branch ordered by an index
-//! (`(workspace_id, created_at)` / `(workspace_id, edited_at)` / `(workspace_id,
-//! path)`); Postgres merges the ordered branches and stops at the page limit.
-//! Pagination is keyset (a `(sort_key, path, kind)` cursor), so deep pages don't
-//! re-scan. Visibility is enforced in-SQL by RLS via the `user_db` transaction.
+//! Efficiency: each kind is a UNION ALL branch ordered by an index on
+//! `(workspace_id, archived, <sort key>)` (created_at / edited_at, or the lowered
+//! summary-or-path expression for name orders); Postgres merges the ordered
+//! branches and stops at the page limit. Pagination is keyset — a
+//! `(sort_key, path, kind, tiebreak)` cursor, where `tiebreak` is a script's hash
+//! (0 for the one-row-per-path flow/app) so archived versions sharing a name and
+//! path stay individually reachable — so deep pages don't re-scan. Visibility is
+//! enforced in-SQL by RLS via the `user_db` transaction.
 
 use crate::db::{ApiAuthed, DB};
 use crate::utils::{build_scope_path_filter, ScopePathFilter};
@@ -393,10 +396,13 @@ async fn list_runnables(
         app_extras.push(s.clone());
     }
 
+    // Favorite filter for a branch: Some(true) = starred only, Some(false) =
+    // non-starred only, None = no filter (the archived view doesn't pin starred,
+    // so its single stream includes both — see the query assembly below).
     let build_branch = |base: &str,
                         kind: &str,
                         extras: &[String],
-                        starred_only: bool,
+                        fav: Option<bool>,
                         keyset: Option<&str>,
                         limit: Option<usize>|
      -> String {
@@ -405,11 +411,11 @@ async fn list_runnables(
         // sits in the wrapper WHERE where those aliases are visible.
         let mut w = vec![common_where.clone()];
         w.extend(extras.iter().cloned());
-        w.push(if starred_only {
-            "favorite.path IS NOT NULL".to_string()
-        } else {
-            "favorite.path IS NULL".to_string()
-        });
+        match fav {
+            Some(true) => w.push("favorite.path IS NOT NULL".to_string()),
+            Some(false) => w.push("favorite.path IS NULL".to_string()),
+            None => {}
+        }
         let keyset_clause = keyset
             .map(|ks| format!(" WHERE {}", ks))
             .unwrap_or_default();
@@ -425,7 +431,7 @@ async fn list_runnables(
     };
 
     let branch_for = |kind: &str,
-                      starred_only: bool,
+                      fav: Option<bool>,
                       keyset: Option<&str>,
                       limit: Option<usize>|
      -> Option<String> {
@@ -438,14 +444,7 @@ async fn list_runnables(
             "app" => (&branches.app, &app_extras),
             _ => return None,
         };
-        Some(build_branch(
-            base,
-            kind,
-            extras,
-            starred_only,
-            keyset,
-            limit,
-        ))
+        Some(build_branch(base, kind, extras, fav, keyset, limit))
     };
 
     let run_union = |branches_sql: Vec<String>, limit: Option<usize>| -> String {
@@ -461,19 +460,20 @@ async fn list_runnables(
     let mut items: Vec<RunnableItem> = vec![];
     let first_page = q.cursor.is_none();
 
-    // Starred items pinned on top of the first page, ordered; later pages are
-    // non-starred only. Uncapped in the default view — a user's favorites are
-    // one row per path and few, and capping there would make favorites past the
-    // cap vanish entirely (they are excluded from the non-starred stream). Only
-    // the archived view fans a favorite into many versions, so bound it there.
-    let starred_limit = if show_archived { Some(per_page) } else { None };
-    if first_page {
+    // Pin starred on the first page only in the browse (non-archived) view, where
+    // favorites are one row per path and few. The archived view lists every
+    // version, so a path-based favorite marks all of them starred: pinning there
+    // would either fan into an unbounded first page or (if capped) drop starred
+    // versions past the cap from every page. So in the archived view we don't pin
+    // at all — a single ordered stream includes starred and non-starred alike.
+    let pin_starred = !show_archived;
+    if first_page && pin_starred {
         let starred_branches: Vec<String> = ["script", "flow", "app"]
             .iter()
-            .filter_map(|k| branch_for(k, true, None, starred_limit))
+            .filter_map(|k| branch_for(k, Some(true), None, None))
             .collect();
         if !starred_branches.is_empty() {
-            let sql = run_union(starred_branches, starred_limit);
+            let sql = run_union(starred_branches, None);
             let mut query = sqlx::query_as::<_, RunnableItem>(&sql)
                 .bind(&w_id)
                 .bind(&authed.username)
@@ -485,10 +485,12 @@ async fn list_runnables(
         }
     }
 
-    // Non-starred page.
+    // Main paged stream: non-starred when we pinned starred above, otherwise
+    // (archived view) every row.
+    let main_fav = if pin_starred { Some(false) } else { None };
     let ns_branches: Vec<String> = ["script", "flow", "app"]
         .iter()
-        .filter_map(|k| branch_for(k, false, keyset_sql.as_deref(), Some(per_page)))
+        .filter_map(|k| branch_for(k, main_fav, keyset_sql.as_deref(), Some(per_page)))
         .collect();
 
     let mut next_cursor: Option<String> = None;

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -19,6 +19,7 @@
 //! re-scan. Visibility is enforced in-SQL by RLS via the `user_db` transaction.
 
 use crate::db::{ApiAuthed, DB};
+use crate::utils::{build_scope_path_filter, ScopePathFilter};
 use axum::{
     extract::{Extension, Path, Query},
     routing::get,
@@ -58,36 +59,55 @@ struct ListRunnablesQuery {
     cursor: Option<String>,
 }
 
+// Absent optional fields are omitted (not serialized as null) to match the
+// per-kind list contract; the frontend row components expect `undefined`.
 #[derive(Serialize, sqlx::FromRow)]
 struct RunnableItem {
     #[serde(rename = "type")]
     kind: String, // 'script' | 'flow' | 'app'
     path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     summary: Option<String>,
     workspace_id: String,
     extra_perms: serde_json::Value,
     starred: bool,
     archived: bool,
     is_draft: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     draft_only: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     draft_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     draft_users: Option<sqlx::types::Json<Vec<DraftUserRef>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     labels: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     inherited_labels: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     ws_error_handler_muted: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     edited_at: Option<chrono::DateTime<chrono::Utc>>,
     // script-only
+    #[serde(skip_serializing_if = "Option::is_none")]
     hash: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     language: Option<String>,
-    #[serde(rename = "kind")]
+    #[serde(rename = "kind", skip_serializing_if = "Option::is_none")]
     script_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     auto_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     use_codebase: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     has_deploy_errors: Option<bool>,
     // app-only
+    #[serde(skip_serializing_if = "Option::is_none")]
     raw_app: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     execution_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<i64>,
     // sort keys, echoed into the cursor (not serialized to the client)
     #[serde(skip)]
@@ -99,6 +119,7 @@ struct RunnableItem {
 #[derive(Serialize)]
 struct ListRunnablesResponse {
     items: Vec<RunnableItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     next_cursor: Option<String>,
 }
 
@@ -290,6 +311,44 @@ async fn list_runnables(
         None => None,
     };
 
+    // Fine-grained scoped tokens (e.g. `scripts:read:f/foo/*`) must be confined to
+    // their granted paths. RLS alone doesn't honor token scopes, so push the
+    // per-domain path grant into SQL (empty grant -> the branch matches nothing).
+    // Unscoped sessions -> AllowAll -> no predicate.
+    let scope_where = |filter: ScopePathFilter, binds: &mut Vec<String>| -> Option<String> {
+        match filter {
+            ScopePathFilter::AllowAll => None,
+            ScopePathFilter::Restricted { exact, prefix } => {
+                let mut terms: Vec<String> = vec![];
+                for e in exact {
+                    binds.push(e);
+                    terms.push(format!("o.path = ${}", 3 + binds.len()));
+                }
+                for pre in prefix {
+                    binds.push(pre.clone());
+                    let pe = format!("${}", 3 + binds.len());
+                    binds.push(format!("{}/%", pre));
+                    let pl = format!("${}", 3 + binds.len());
+                    terms.push(format!("(o.path = {} OR o.path LIKE {})", pe, pl));
+                }
+                Some(if terms.is_empty() {
+                    "false".to_string()
+                } else {
+                    format!("({})", terms.join(" OR "))
+                })
+            }
+        }
+    };
+    let script_scope = scope_where(
+        build_scope_path_filter(&authed, "scripts", "read"),
+        &mut binds,
+    );
+    let flow_scope = scope_where(
+        build_scope_path_filter(&authed, "flows", "read"),
+        &mut binds,
+    );
+    let app_scope = scope_where(build_scope_path_filter(&authed, "apps", "read"), &mut binds);
+
     // Per-kind archived predicate (scripts/flows have the column; apps don't and
     // are excluded from the archived view).
     let archived_pred = if show_archived {
@@ -302,8 +361,17 @@ async fn list_runnables(
         script_extras.push("(o.auto_kind IS NULL OR o.auto_kind <> 'lib')".to_string());
     }
     script_extras.push(archived_pred.to_string());
-    let flow_extras: Vec<String> = vec![archived_pred.to_string()];
-    let app_extras: Vec<String> = vec![];
+    if let Some(s) = &script_scope {
+        script_extras.push(s.clone());
+    }
+    let mut flow_extras: Vec<String> = vec![archived_pred.to_string()];
+    if let Some(s) = &flow_scope {
+        flow_extras.push(s.clone());
+    }
+    let mut app_extras: Vec<String> = vec![];
+    if let Some(s) = &app_scope {
+        app_extras.push(s.clone());
+    }
 
     let build_branch = |base: &str,
                         kind: &str,

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -462,16 +462,18 @@ async fn list_runnables(
     let first_page = q.cursor.is_none();
 
     // Starred items pinned on top of the first page, ordered; later pages are
-    // non-starred only. Bound each branch (like the non-starred ones) so a
-    // heavily-versioned favorite in the archived view can't fan into an unbounded
-    // set of correlated-subquery evaluations.
+    // non-starred only. Uncapped in the default view — a user's favorites are
+    // one row per path and few, and capping there would make favorites past the
+    // cap vanish entirely (they are excluded from the non-starred stream). Only
+    // the archived view fans a favorite into many versions, so bound it there.
+    let starred_limit = if show_archived { Some(per_page) } else { None };
     if first_page {
         let starred_branches: Vec<String> = ["script", "flow", "app"]
             .iter()
-            .filter_map(|k| branch_for(k, true, None, Some(per_page)))
+            .filter_map(|k| branch_for(k, true, None, starred_limit))
             .collect();
         if !starred_branches.is_empty() {
-            let sql = run_union(starred_branches, Some(per_page));
+            let sql = run_union(starred_branches, starred_limit);
             let mut query = sqlx::query_as::<_, RunnableItem>(&sql)
                 .bind(&w_id)
                 .bind(&authed.username)

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -361,15 +361,30 @@ async fn list_runnables(
             }
         }
     };
-    let script_scope = scope_where(
-        build_scope_path_filter(&authed, "scripts", "read"),
-        &mut binds,
-    );
-    let flow_scope = scope_where(
-        build_scope_path_filter(&authed, "flows", "read"),
-        &mut binds,
-    );
-    let app_scope = scope_where(build_scope_path_filter(&authed, "apps", "read"), &mut binds);
+    // Only push scope binds for kinds whose branch is actually included: a scoped token
+    // with e.g. `kinds=script` omits the flow/app branches, so binding their scope values
+    // (which no SQL references) would make the parameter count mismatch and 500.
+    let script_scope = if kinds.contains(&"script") {
+        scope_where(
+            build_scope_path_filter(&authed, "scripts", "read"),
+            &mut binds,
+        )
+    } else {
+        None
+    };
+    let flow_scope = if kinds.contains(&"flow") {
+        scope_where(
+            build_scope_path_filter(&authed, "flows", "read"),
+            &mut binds,
+        )
+    } else {
+        None
+    };
+    let app_scope = if kinds.contains(&"app") {
+        scope_where(build_scope_path_filter(&authed, "apps", "read"), &mut binds)
+    } else {
+        None
+    };
 
     // Per-kind archived predicate (scripts/flows have the column; apps don't and
     // are excluded from the archived view).

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -409,8 +409,8 @@ async fn list_runnables(
     }
 
     // Favorite filter for a branch: Some(true) = starred only, Some(false) =
-    // non-starred only, None = no filter (the archived view doesn't pin starred,
-    // so its single stream includes both — see the query assembly below).
+    // non-starred only, None = no filter. Both views pin starred on the first page
+    // (each is one row per path), so the paged stream always passes Some(false).
     let build_branch = |base: &str,
                         kind: &str,
                         extras: &[String],

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -31,6 +31,7 @@ use windmill_common::{
     db::UserDB,
     error::{Error, JsonResult},
 };
+use windmill_types::scripts::ScriptHash;
 use windmill_types::user_drafts::DraftUserRef;
 
 pub fn workspaced_service() -> Router {
@@ -87,9 +88,10 @@ struct RunnableItem {
     ws_error_handler_muted: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     edited_at: Option<chrono::DateTime<chrono::Utc>>,
-    // script-only
+    // script-only. ScriptHash serializes as the 16-char hex string that
+    // /scripts/get/{hash} parses (a raw i64 would produce a broken link).
     #[serde(skip_serializing_if = "Option::is_none")]
-    hash: Option<i64>,
+    hash: Option<ScriptHash>,
     #[serde(skip_serializing_if = "Option::is_none")]
     language: Option<String>,
     #[serde(rename = "kind", skip_serializing_if = "Option::is_none")]
@@ -459,15 +461,17 @@ async fn list_runnables(
     let mut items: Vec<RunnableItem> = vec![];
     let first_page = q.cursor.is_none();
 
-    // Starred items pinned on top of the first page (a user's favorites are few),
-    // ordered; later pages are non-starred only.
+    // Starred items pinned on top of the first page, ordered; later pages are
+    // non-starred only. Bound each branch (like the non-starred ones) so a
+    // heavily-versioned favorite in the archived view can't fan into an unbounded
+    // set of correlated-subquery evaluations.
     if first_page {
         let starred_branches: Vec<String> = ["script", "flow", "app"]
             .iter()
-            .filter_map(|k| branch_for(k, true, None, None))
+            .filter_map(|k| branch_for(k, true, None, Some(per_page)))
             .collect();
         if !starred_branches.is_empty() {
-            let sql = run_union(starred_branches, None);
+            let sql = run_union(starred_branches, Some(per_page));
             let mut query = sqlx::query_as::<_, RunnableItem>(&sql)
                 .bind(&w_id)
                 .bind(&authed.username)

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -16,9 +16,9 @@
 //! `(workspace_id, archived, <sort key>)` (created_at / edited_at, or the lowered
 //! summary-or-path expression for name orders); Postgres merges the ordered
 //! branches and stops at the page limit. Pagination is keyset — a
-//! `(sort_key, path, kind, tiebreak)` cursor, where `tiebreak` is a script's hash
-//! (0 for the one-row-per-path flow/app) so archived versions sharing a name and
-//! path stay individually reachable — so deep pages don't re-scan. Visibility is
+//! `(sort_key, path, kind, tiebreak)` cursor, where `tiebreak` (a script's hash,
+//! 0 for flow/app) is a stable final key that keeps the order total even when rows
+//! tie on (sort_key, path, kind) — so deep pages don't re-scan. Visibility is
 //! enforced in-SQL by RLS via the `user_db` transaction.
 
 use crate::db::{ApiAuthed, DB};
@@ -119,10 +119,9 @@ struct RunnableItem {
     sort_time: chrono::DateTime<chrono::Utc>,
     #[serde(skip)]
     sort_name: String,
-    // Final tiebreaker making the sort total: a script's hash (the archived view
-    // lists several versions sharing path+summary), 0 for the one-row-per-path
-    // flow/app. Without it a group of same-(name,path) versions crossing a page
-    // boundary would be skipped by the strict keyset.
+    // Final tiebreaker making the sort total: a script's hash, 0 for flow/app. A stable
+    // last key so rows that tie on (sort_key, path, kind) still have a strict order and
+    // none is skipped when a tie crosses a page boundary.
     #[serde(skip)]
     tiebreak: i64,
 }

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -114,6 +114,12 @@ struct RunnableItem {
     sort_time: chrono::DateTime<chrono::Utc>,
     #[serde(skip)]
     sort_name: String,
+    // Final tiebreaker making the sort total: a script's hash (the archived view
+    // lists several versions sharing path+summary), 0 for the one-row-per-path
+    // flow/app. Without it a group of same-(name,path) versions crossing a page
+    // boundary would be skipped by the strict keyset.
+    #[serde(skip)]
+    tiebreak: i64,
 }
 
 #[derive(Serialize)]
@@ -129,6 +135,9 @@ struct Cursor {
     k: String,
     p: String,
     t: String,
+    /// tiebreak (script hash / 0) of the last row.
+    #[serde(default)]
+    tb: i64,
 }
 
 fn encode_cursor(item: &RunnableItem, order_by_name: bool) -> String {
@@ -137,7 +146,7 @@ fn encode_cursor(item: &RunnableItem, order_by_name: bool) -> String {
     } else {
         item.sort_time.to_rfc3339()
     };
-    let c = Cursor { k, p: item.path.clone(), t: item.kind.clone() };
+    let c = Cursor { k, p: item.path.clone(), t: item.kind.clone(), tb: item.tiebreak };
     URL_SAFE_NO_PAD.encode(serde_json::to_vec(&c).unwrap_or_default())
 }
 
@@ -146,6 +155,14 @@ fn decode_cursor(raw: &str) -> Result<Cursor, Error> {
         .decode(raw)
         .map_err(|_| Error::BadRequest("invalid cursor".to_string()))?;
     serde_json::from_slice(&bytes).map_err(|_| Error::BadRequest("invalid cursor".to_string()))
+}
+
+/// Escape LIKE/ILIKE wildcards so a caller value (search term, path/scope
+/// prefix) matches literally. Relies on the default `\` escape character.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 /// The three UNION-ALL branch SELECTs, each projecting the shared `RunnableItem`
@@ -181,7 +198,7 @@ fn branch_sqls() -> Branches {
                 o.codebase IS NOT NULL as use_codebase, \
                 (o.lock_error_logs IS NOT NULL) as has_deploy_errors, \
                 NULL::bool as raw_app, NULL::text as execution_mode, NULL::bigint as id, NULL::bigint as version, \
-                o.created_at as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name \
+                o.created_at as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name, o.hash as tiebreak \
          FROM script o \
          LEFT JOIN favorite ON favorite.favorite_kind = 'script' AND favorite.workspace_id = o.workspace_id AND favorite.path = o.path AND favorite.usr = $2 \
          LEFT JOIN draft ON draft.path = o.path AND draft.workspace_id = o.workspace_id AND draft.typ = 'script' AND draft.email = $3",
@@ -197,7 +214,7 @@ fn branch_sqls() -> Branches {
                 NULL::bigint as hash, NULL::text as language, NULL::text as script_kind, NULL::text as auto_kind, \
                 NULL::bool as use_codebase, NULL::bool as has_deploy_errors, \
                 NULL::bool as raw_app, NULL::text as execution_mode, NULL::bigint as id, NULL::bigint as version, \
-                o.edited_at as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name \
+                o.edited_at as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name, 0::bigint as tiebreak \
          FROM flow o \
          LEFT JOIN favorite ON favorite.favorite_kind = 'flow' AND favorite.workspace_id = o.workspace_id AND favorite.path = o.path AND favorite.usr = $2 \
          LEFT JOIN draft ON draft.path = o.path AND draft.workspace_id = o.workspace_id AND draft.typ = 'flow' AND draft.email = $3",
@@ -214,7 +231,7 @@ fn branch_sqls() -> Branches {
                 NULL::bool as use_codebase, NULL::bool as has_deploy_errors, \
                 av.raw_app, o.policy->>'execution_mode' as execution_mode, o.id, \
                 o.versions[array_upper(o.versions, 1)] as version, \
-                COALESCE(av.created_at, 'epoch'::timestamptz) as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name \
+                COALESCE(av.created_at, 'epoch'::timestamptz) as sort_time, lower(COALESCE(NULLIF(o.summary, ''), o.path)) as sort_name, 0::bigint as tiebreak \
          FROM app o \
          LEFT JOIN favorite ON favorite.favorite_kind = 'app' AND favorite.workspace_id = o.workspace_id AND favorite.path = o.path AND favorite.usr = $2 \
          LEFT JOIN (SELECT DISTINCT path, workspace_id FROM draft WHERE typ IN ('app', 'raw_app') AND email = $3) draft ON draft.path = o.path AND draft.workspace_id = o.workspace_id \
@@ -272,11 +289,11 @@ async fn list_runnables(
 
     let mut common: Vec<String> = vec!["o.workspace_id = $1".to_string()];
     if let Some(ps) = q.path_start.as_ref().filter(|s| !s.is_empty()) {
-        let p = add_bind(&mut binds, format!("{}%", ps));
+        let p = add_bind(&mut binds, format!("{}%", escape_like(ps)));
         common.push(format!("o.path LIKE {}", p));
     }
     if let Some(search) = q.search.as_ref().filter(|s| !s.is_empty()) {
-        let p = add_bind(&mut binds, format!("%{}%", search));
+        let p = add_bind(&mut binds, format!("%{}%", escape_like(search)));
         common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));
     }
     if let Some(label) = q.label.as_ref().filter(|s| !s.is_empty()) {
@@ -298,6 +315,7 @@ async fn list_runnables(
             let kp = add_bind(&mut binds, cur.k);
             let pp = add_bind(&mut binds, cur.p);
             let tp = add_bind(&mut binds, cur.t);
+            let tbp = add_bind(&mut binds, cur.tb.to_string());
             let cmp = if desc { "<" } else { ">" };
             let key_cast = if order_by_name {
                 format!("{}::text", kp)
@@ -305,7 +323,7 @@ async fn list_runnables(
                 format!("{}::timestamptz", kp)
             };
             Some(format!(
-                "({sort_col}, path, kind) {cmp} ({key_cast}, {pp}::text, {tp}::text)"
+                "({sort_col}, path, kind, tiebreak) {cmp} ({key_cast}, {pp}::text, {tp}::text, {tbp}::bigint)"
             ))
         }
         None => None,
@@ -327,7 +345,7 @@ async fn list_runnables(
                 for pre in prefix {
                     binds.push(pre.clone());
                     let pe = format!("${}", 3 + binds.len());
-                    binds.push(format!("{}/%", pre));
+                    binds.push(format!("{}/%", escape_like(&pre)));
                     let pl = format!("${}", 3 + binds.len());
                     terms.push(format!("(o.path = {} OR o.path LIKE {})", pe, pl));
                 }
@@ -398,7 +416,7 @@ async fn list_runnables(
         // table; the outer union re-limits to the global page.
         let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
         format!(
-            "(SELECT * FROM ({base} WHERE {where_}) {kind}_b{keyset_clause} ORDER BY {sort_col} {dir}, path {dir}, kind {dir}{limit_clause})",
+            "(SELECT * FROM ({base} WHERE {where_}) {kind}_b{keyset_clause} ORDER BY {sort_col} {dir}, path {dir}, kind {dir}, tiebreak {dir}{limit_clause})",
             where_ = w.join(" AND "),
             dir = order_dir,
         )
@@ -432,7 +450,7 @@ async fn list_runnables(
         let unioned = branches_sql.join(" UNION ALL ");
         let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
         format!(
-            "SELECT * FROM ({unioned}) q ORDER BY {sort_col} {dir}, path {dir}, kind {dir}{limit_clause}",
+            "SELECT * FROM ({unioned}) q ORDER BY {sort_col} {dir}, path {dir}, kind {dir}, tiebreak {dir}{limit_clause}",
             dir = order_dir,
         )
     };

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -384,6 +384,19 @@ async fn list_runnables(
         script_extras.push("(o.auto_kind IS NULL OR o.auto_kind <> 'lib')".to_string());
     }
     script_extras.push(archived_pred.to_string());
+    if show_archived {
+        // The script table keeps every version as its own row and marks superseded
+        // ones archived=true, so a bare `archived = true` would surface an active
+        // path's old versions and repeat a genuinely archived path once per version.
+        // Match the canonical script listing: only a path whose LATEST row is archived
+        // belongs in the archived view. (Flows/apps are one row per path, so this only
+        // applies to scripts.)
+        script_extras.push(
+            "o.ctid = (SELECT ctid FROM script s2 WHERE s2.path = o.path \
+             AND s2.workspace_id = o.workspace_id ORDER BY s2.created_at DESC LIMIT 1)"
+                .to_string(),
+        );
+    }
     if let Some(s) = &script_scope {
         script_extras.push(s.clone());
     }

--- a/backend/windmill-api/src/utils.rs
+++ b/backend/windmill-api/src/utils.rs
@@ -10,7 +10,8 @@ use axum::{body::Body, response::Response};
 use serde::{Deserialize, Deserializer};
 
 pub use windmill_api_auth::{
-    build_scope_path_predicate, check_scopes, require_devops_role, require_super_admin,
+    build_scope_path_filter, build_scope_path_predicate, check_scopes, require_devops_role,
+    require_super_admin, ScopePathFilter,
 };
 
 #[cfg(feature = "private")]

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -509,10 +509,16 @@
 			} catch {
 				return
 			}
-			// Drop a stale response: the workspace or term moved on while it was in
-			// flight (debounce already cancels superseded timers; this guards the
-			// in-flight request so it never merges into a different workspace's list).
-			if (untrack(() => $workspaceStore) !== ws || untrack(() => filter) !== term) return
+			// Drop a stale response: workspace, term, or view scope moved on while it
+			// was in flight (debounce cancels superseded timers; this guards the
+			// in-flight request so an old scope/workspace can't merge into the new one).
+			if (
+				untrack(() => $workspaceStore) !== ws ||
+				untrack(() => filter) !== term ||
+				untrack(() => archived) !== showArchived ||
+				untrack(() => includeWithoutMain) !== withoutMain
+			)
+				return
 			mergeRunnables(res.items ?? [])
 		}, 300)
 		return () => clearTimeout(handle)

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -474,16 +474,22 @@
 	function sortName(x: { summary?: string; path: string }): string {
 		return x.summary && x.summary !== '' ? x.summary : x.path
 	}
-	// A $derived closure so its identity changes with `sortOrder`, which both
-	// re-runs `combinedItems` (flat view) and re-groups the tree (TreeViewRoot
-	// depends on this prop). Starred items are pinned on top in every order.
+	// A $derived closure so its identity changes with `sortOrder`/`archived`, which
+	// both re-runs `combinedItems` (flat view) and re-groups the tree (TreeViewRoot
+	// depends on this prop). Starred items are pinned on top — but NOT in archived
+	// mode: there the endpoint deliberately leaves favorites in the single keyset
+	// stream (an archived path can span many versions), so re-pinning them client-side
+	// would make a favorited row on a later page jump above earlier rows when it loads,
+	// breaking both starred-first and the selected order. Mirror the backend's
+	// pin_starred = !show_archived.
 	let compareItems = $derived.by(() => {
 		const order = sortOrder
+		const pinStarred = !archived
 		return (
 			a: { starred?: boolean; time?: number; summary?: string; path: string },
 			b: { starred?: boolean; time?: number; summary?: string; path: string }
 		): number => {
-			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
+			if (pinStarred && !!a.starred !== !!b.starred) return a.starred ? -1 : 1
 			switch (order) {
 				case 'updated_asc':
 					return (a.time ?? 0) - (b.time ?? 0)

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -181,7 +181,6 @@
 			serverCursor = undefined
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
-		const searching = filter !== ''
 		const gen = ++loadGen
 		// Snapshot the cursor now: a later request must not consume a cursor minted
 		// by an order/filter that has since changed.
@@ -194,9 +193,7 @@
 				orderDesc,
 				showArchived: archived ? true : undefined,
 				includeWithoutMain: includeWithoutMain ? true : undefined,
-				// A large page while searching so client fuzzy-match and facets see
-				// enough; browse pages are small and extended via the cursor.
-				perPage: searching ? 1000 : 100,
+				perPage: 100,
 				cursor
 			})
 		} catch (e: any) {
@@ -236,6 +233,41 @@
 		raw_apps = []
 		pipelineMemberFolders = memberFolders
 		loading = false
+	}
+
+	function itemKey(x: { type?: string; path: string; hash?: unknown }): string {
+		return `${x.type}/${x.path}${x.hash ? '/' + x.hash : ''}`
+	}
+
+	// Merge server rows (from the search-augmentation pass) into the loaded arrays,
+	// skipping ones already present. Lets a search reach matches outside the loaded
+	// browse window without re-fetching the whole list.
+	function mergeRunnables(newItems: RunnableItem[]) {
+		const have = new Set([...(scripts ?? []), ...(flows ?? []), ...(apps ?? [])].map(itemKey))
+		const s = [...(scripts ?? [])]
+		const f = [...(flows ?? [])]
+		const a = [...(apps ?? [])]
+		const memberFolders = new Set(pipelineMemberFolders)
+		let changed = false
+		for (const it of newItems) {
+			if (it.type === 'script' && it.auto_kind === 'pipeline') {
+				const m = it.path.match(/^f\/([^/]+)\//)
+				if (m) memberFolders.add(m[1])
+				continue
+			}
+			if (have.has(itemKey(it))) continue
+			const mapped = mapRunnable(it)
+			if (it.type === 'script') s.push(mapped as TableScript)
+			else if (it.type === 'flow') f.push(mapped as TableFlow)
+			else if (it.type === 'app') a.push(mapped as TableApp)
+			changed = true
+		}
+		if (changed) {
+			scripts = s
+			flows = f
+			apps = a
+			pipelineMemberFolders = memberFolders
+		}
 	}
 
 	// Item edits/deletes trigger a full reload; the merged endpoint returns every
@@ -440,8 +472,8 @@
 	)
 	// Reload the first page from the server whenever an input that the endpoint
 	// resolves changes: order, archived/library scope, or entering/leaving search
-	// (which switches page size). Owner/label/kind filtering and fuzzy ranking stay
-	// client-side over the loaded pages, so they don't reload here.
+	// (leaving drops the augmented matches below). Owner/label/kind filtering and
+	// fuzzy ranking stay client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
@@ -450,6 +482,28 @@
 				loadRunnables(true)
 			})
 		}
+	})
+
+	// Debounced server-side search augmentation. Instant filtering stays fully
+	// client-side (SearchItems over the loaded pages) for reactivity; this only
+	// fills in matches that live beyond the loaded browse window on large
+	// workspaces, so search stays complete without a request per keystroke.
+	$effect(() => {
+		const term = filter
+		const ws = $workspaceStore
+		if (term === '' || !ws || !$userStore) return
+		const handle = setTimeout(async () => {
+			let res: { items: RunnableItem[] }
+			try {
+				res = await ScriptService.listRunnables({ workspace: ws, search: term, perPage: 1000 })
+			} catch {
+				return
+			}
+			// Discard if the search moved on while the request was in flight.
+			if (untrack(() => filter) !== term) return
+			mergeRunnables(res.items ?? [])
+		}, 300)
+		return () => clearTimeout(handle)
 	})
 
 	let combinedItems = $derived(
@@ -596,6 +650,16 @@
 			await loadRunnables(false)
 		}
 		nbDisplayed += 30
+	}
+
+	// Fetch the next server page directly (tree view and the empty-state control
+	// use this — their "all shown" threshold is on a different scale than the flat
+	// list's, so they must not route through loadMore's item-count check).
+	async function fetchMoreServer() {
+		if (hasMoreServer && !searching) {
+			await loadRunnables(false)
+			nbDisplayed += 30
+		}
 	}
 
 	async function loadMoreAndPreselectFirstNew() {
@@ -1021,6 +1085,15 @@
 			     them (list rows / injected tree folders) when not actively searching;
 			     a no-match search still reads as empty. -->
 			<NoItemFound hasFilters={filter !== '' || archived || filterUserFolders} />
+			{#if hasMoreServer && !searching}
+				<!-- The active filter matched nothing on the loaded pages, but the server
+				     has more: keep paging reachable so matches on later pages aren't lost. -->
+				<div class="text-center text-xs text-secondary mt-2">
+					<button class="text-primary hover:text-emphasis underline" onclick={fetchMoreServer}
+						>Load more to search further</button
+					>
+				</div>
+			{/if}
 		{:else if treeView}
 			<TreeViewRoot
 				{items}
@@ -1028,7 +1101,7 @@
 				{collapseAll}
 				sortCompare={compareItems}
 				hasMoreServer={hasMoreServer && !searching}
-				onLoadMore={loadMore}
+				onLoadMore={fetchMoreServer}
 				pipelineFolders={visiblePipelineFolders}
 				isSearching={filter !== ''}
 				on:scriptChanged={() => loadScripts(includeWithoutMain)}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -4,6 +4,7 @@
 	import Toggle from '$lib/components/Toggle.svelte'
 	import {
 		AssetService,
+		FolderService,
 		type ListableApp,
 		type Script,
 		ScriptService,
@@ -116,6 +117,22 @@
 		new Set<string>([...(pipelineFoldersRes.current ?? []), ...pipelineMemberFolders])
 	)
 
+	// The workspace's full folder list, independent of which items are paged in,
+	// so the owner facet and tree show every folder even when its items sit far
+	// down the sorted stream. Cheap and cached per workspace.
+	let folderNamesRes = resource(
+		() => $workspaceStore,
+		async (ws) => {
+			if (!ws) return [] as string[]
+			try {
+				return await FolderService.listFolderNames({ workspace: ws })
+			} catch {
+				return [] as string[]
+			}
+		}
+	)
+	let allFolderOwners = $derived((folderNamesRes.current ?? []).map((f) => `f/${f}`))
+
 	let scripts: TableScript[] | undefined = $state()
 	let flows: TableFlow[] | undefined = $state()
 	let apps: TableApp[] | undefined = $state()
@@ -199,6 +216,10 @@
 				orderDesc,
 				showArchived: archived ? true : undefined,
 				includeWithoutMain: includeWithoutMain ? true : undefined,
+				// Selecting an owner/folder scopes the paged stream to it server-side,
+				// so a folder's full contents load on demand rather than relying on the
+				// folder happening to be within the loaded browse window.
+				pathStart: ownerFilter ? ownerFilter + '/' : undefined,
 				perPage: 100,
 				cursor
 			})
@@ -471,19 +492,25 @@
 	}
 
 	let collapseAll = $state(true)
+	// Complete owner list: every folder (from the folder list, not just loaded
+	// pages) plus the user prefixes present in the loaded/filtered items. So a
+	// folder whose items are far down the stream is still a selectable chip.
 	let owners = $derived(
 		Array.from(
-			new Set(filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? [])
+			new Set([
+				...allFolderOwners,
+				...(filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? [])
+			])
 		).sort()
 	)
-	// Reload the first page from the server whenever an input that the endpoint
-	// resolves changes: order, archived/library scope, or entering/leaving search
-	// (leaving drops the augmented matches below). Owner/label/kind filtering and
-	// fuzzy ranking stay client-side over the loaded pages, so they don't reload here.
+	// Reload the first page from the server whenever an input the endpoint resolves
+	// changes: order, archived/library scope, the selected owner/folder, or
+	// entering/leaving search. Label/kind filtering and fuzzy ranking stay
+	// client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
-			;[archived, includeWithoutMain, sortOrder, searching]
+			;[archived, includeWithoutMain, sortOrder, searching, ownerFilter]
 			untrack(() => {
 				loadRunnables(true)
 			})
@@ -498,9 +525,10 @@
 		const term = filter
 		const ws = $workspaceStore
 		// Same view scope as the browse list, so a search can't surface archived /
-		// library items the current view excludes.
+		// library items the current view excludes, and stays within the selected folder.
 		const showArchived = archived
 		const withoutMain = includeWithoutMain
+		const owner = ownerFilter
 		if (term === '' || !ws || !$userStore) return
 		const handle = setTimeout(async () => {
 			let res: { items: RunnableItem[] }
@@ -510,6 +538,7 @@
 					search: term,
 					showArchived: showArchived ? true : undefined,
 					includeWithoutMain: withoutMain ? true : undefined,
+					pathStart: owner ? owner + '/' : undefined,
 					perPage: 1000
 				})
 			} catch {
@@ -522,7 +551,8 @@
 				untrack(() => $workspaceStore) !== ws ||
 				untrack(() => filter) !== term ||
 				untrack(() => archived) !== showArchived ||
-				untrack(() => includeWithoutMain) !== withoutMain
+				untrack(() => includeWithoutMain) !== withoutMain ||
+				untrack(() => ownerFilter) !== owner
 			)
 				return
 			mergeRunnables(res.items ?? [])
@@ -574,21 +604,15 @@
 		}
 		prevWorkspace = ws
 	})
+	// The owner/folder filter is resolved server-side (path_start), so only the
+	// kind, user-folder toggle and label filters run client-side here.
 	let preFilteredItems = $derived(
-		ownerFilter != undefined
-			? combinedItems?.filter(
-					(x) =>
-						x.path.startsWith(ownerFilter + '/') &&
-						(x.type == itemKind || itemKind == 'all') &&
-						filterItemsPathsBaseOnUserFilters(x, filterUserFolders, filterUserFoldersType) &&
-						(labelFilter == undefined || itemLabels(x).includes(labelFilter))
-				)
-			: combinedItems?.filter(
-					(x) =>
-						(x.type == itemKind || itemKind == 'all') &&
-						filterItemsPathsBaseOnUserFilters(x, filterUserFolders, filterUserFoldersType) &&
-						(labelFilter == undefined || itemLabels(x).includes(labelFilter))
-				)
+		combinedItems?.filter(
+			(x) =>
+				(x.type == itemKind || itemKind == 'all') &&
+				filterItemsPathsBaseOnUserFilters(x, filterUserFolders, filterUserFoldersType) &&
+				(labelFilter == undefined || itemLabels(x).includes(labelFilter))
+		)
 	)
 	let items = $derived(filter !== '' ? filteredItems : preFilteredItems)
 	let displayedItems = $derived((items ?? []).slice(0, nbDisplayed))

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -110,7 +110,7 @@
 		}
 	)
 	// Folders of pipeline-member scripts present in the current listing (captured
-	// in loadScripts before they're filtered out). Unioned in so a folder whose
+	// in loadRunnables before they're filtered out). Unioned in so a folder whose
 	// only pipeline node is a never-deployed `// pipeline` script draft — not in
 	// listPipelineFolders (deployed-only) nor a `data_pipeline` bundle — still gets
 	// a pipeline entry instead of vanishing.
@@ -414,19 +414,16 @@
 		}
 	}
 
-	// Item edits/deletes trigger a full reload; the merged endpoint returns every
-	// kind, so any change reloads the whole list.
-	async function loadScripts(_?: boolean): Promise<void> {
+	// A row was created/edited/archived/moved/shared. The merged endpoint returns
+	// every kind, so ONE reload refreshes the whole list — the per-kind change events
+	// all route here rather than each firing its own identical query. loadRunnables
+	// clears the lazy folder store, so re-fetch whatever folders were expanded (this
+	// is a same-scope reload: treeKey is unchanged, so those TreeView nodes stay open
+	// and would otherwise go blank).
+	async function reloadItems(): Promise<void> {
+		const openFolders = Object.keys(folderLoad)
 		await loadRunnables(true)
-	}
-	async function loadFlows(): Promise<void> {
-		await loadRunnables(true)
-	}
-	async function loadApps(): Promise<void> {
-		await loadRunnables(true)
-	}
-	async function loadRawApps(): Promise<void> {
-		raw_apps = []
+		for (const f of openFolders) loadFolderItems(f)
 	}
 
 	function filterItemsPathsBaseOnUserFilters(
@@ -1316,16 +1313,11 @@
 					folderLoad={treeLazyMode ? folderLoad : undefined}
 					onExpandFolder={treeLazyMode ? loadFolderItems : undefined}
 					isSearching={filter !== ''}
-					on:scriptChanged={() => loadScripts(includeWithoutMain)}
-					on:flowChanged={loadFlows}
-					on:appChanged={loadApps}
-					on:rawAppChanged={loadRawApps}
-					on:reload={() => {
-						loadScripts(includeWithoutMain)
-						loadFlows()
-						loadApps()
-						loadRawApps()
-					}}
+					on:scriptChanged={reloadItems}
+					on:flowChanged={reloadItems}
+					on:appChanged={reloadItems}
+					on:rawAppChanged={reloadItems}
+					on:reload={reloadItems}
 					{showCode}
 				/>
 			{/key}
@@ -1345,16 +1337,11 @@
 				{#each displayedItems as item, i (item.type + '/' + item.path + (item.hash ? '/' + item.hash : ''))}
 					<Item
 						{item}
-						on:scriptChanged={() => loadScripts(includeWithoutMain)}
-						on:flowChanged={loadFlows}
-						on:appChanged={loadApps}
-						on:rawAppChanged={loadRawApps}
-						on:reload={() => {
-							loadScripts(includeWithoutMain)
-							loadFlows()
-							loadApps()
-							loadRawApps()
-						}}
+						on:scriptChanged={reloadItems}
+						on:flowChanged={reloadItems}
+						on:appChanged={reloadItems}
+						on:rawAppChanged={reloadItems}
+						on:reload={reloadItems}
 						{showCode}
 						showEditButton={showEditButtons}
 						keyboardSelected={selectedIndex === i}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -486,10 +486,10 @@
 	// the first page.
 	type SortOrder = 'updated_desc' | 'updated_asc' | 'name_asc' | 'name_desc'
 	const SORT_SETTING_NAME = 'homeSort'
-	// `short` labels the trigger button for non-default sorts; the default (recently
-	// updated) shows the icon only, so its short label is empty.
+	// `short` labels the trigger button next to the sort icon (the button is icon-only
+	// only while searching, when sorting is disabled — see below).
 	const sortOptions: { value: SortOrder; label: string; short: string }[] = [
-		{ value: 'updated_desc', label: 'Recently updated', short: '' },
+		{ value: 'updated_desc', label: 'Recently updated', short: 'Recent' },
 		{ value: 'updated_asc', label: 'Oldest updated', short: 'Oldest' },
 		{ value: 'name_asc', label: 'Name (A-Z)', short: 'A-Z' },
 		{ value: 'name_desc', label: 'Name (Z-A)', short: 'Z-A' }

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -528,17 +528,34 @@
 			b: { starred?: boolean; time?: number; summary?: string; path: string }
 		): number => {
 			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
+			// Match the endpoint's ordering exactly so a row on a later server page can't
+			// jump above already-shown rows on "load more": names compare case-insensitively
+			// (the endpoint sorts on `lower(summary-or-path)`), and the secondary key is the
+			// path in the SAME direction as the primary (server: `<col> <dir>, path <dir>`).
+			let primary: number
+			let asc: boolean
 			switch (order) {
 				case 'updated_asc':
-					return (a.time ?? 0) - (b.time ?? 0)
+					primary = (a.time ?? 0) - (b.time ?? 0)
+					asc = true
+					break
 				case 'name_asc':
-					return cmp(sortName(a), sortName(b))
+					primary = cmp(sortName(a).toLowerCase(), sortName(b).toLowerCase())
+					asc = true
+					break
 				case 'name_desc':
-					return cmp(sortName(b), sortName(a))
+					primary = cmp(sortName(b).toLowerCase(), sortName(a).toLowerCase())
+					asc = false
+					break
 				case 'updated_desc':
 				default:
-					return (b.time ?? 0) - (a.time ?? 0)
+					primary = (b.time ?? 0) - (a.time ?? 0)
+					asc = false
+					break
 			}
+			if (primary !== 0) return primary
+			const p = a.path.localeCompare(b.path)
+			return asc ? p : -p
 		}
 	})
 
@@ -686,10 +703,10 @@
 			])
 		).sort()
 	)
-	// Reload the first page from the server whenever an input the endpoint resolves
-	// changes: order, archived/library scope, the selected owner/folder, or
-	// entering/leaving search. Label/kind filtering and fuzzy ranking stay
-	// client-side over the loaded pages, so they don't reload here.
+	// Reload from the server whenever an input the endpoint resolves changes: order,
+	// archived/library scope, kind, the selected owner/folder, or entering/leaving
+	// search (see the reload effect below). Only the label filter and fuzzy ranking
+	// stay client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
 	// Lazy owner tree is active only in the tree view when browsing all (no owner
 	// selected, no search, no label filter): every folder AND user shows as a top-level
@@ -737,9 +754,12 @@
 	})
 
 	// Debounced server-side search augmentation. Instant filtering stays fully
-	// client-side (SearchItems over the loaded pages) for reactivity; this only
-	// fills in matches that live beyond the loaded browse window on large
-	// workspaces, so search stays complete without a request per keystroke.
+	// client-side (SearchItems over the loaded pages) for reactivity; this fetches ONE
+	// page of matches beyond the loaded browse window and, if the server has more,
+	// exposes them through an explicit "load more results" control (searchCursor) rather
+	// than auto-downloading the whole workspace for a broad term.
+	let searchCursor = $state<string | undefined>(undefined)
+	let searchLoadingMore = $state(false)
 	$effect(() => {
 		const term = filter
 		const ws = $workspaceStore
@@ -749,45 +769,73 @@
 		const withoutMain = includeWithoutMain
 		const owner = ownerFilter
 		const kind = itemKind
+		// Any term/scope change restarts search paging.
+		searchCursor = undefined
 		if (term === '' || !ws || !$userStore) return
-		// Stale if workspace, term, or view scope moved on (the debounce cancels
-		// superseded timers; this also guards each in-flight page so an old scope can't
-		// merge into the new one and aborts the paging loop mid-way).
-		const stale = () =>
-			untrack(() => $workspaceStore) !== ws ||
-			untrack(() => filter) !== term ||
-			untrack(() => archived) !== showArchived ||
-			untrack(() => includeWithoutMain) !== withoutMain ||
-			untrack(() => ownerFilter) !== owner ||
-			untrack(() => itemKind) !== kind
 		const handle = setTimeout(async () => {
-			// Page the search cursor to exhaustion so it stays workspace-complete at any
-			// match count; the debounce + stale() guard abort as soon as the term/scope
-			// changes, so a broad term never keeps paging an abandoned query.
-			let cursor: string | undefined = undefined
-			do {
-				let res: { items: RunnableItem[]; next_cursor?: string }
-				try {
-					res = await ScriptService.listRunnables({
-						workspace: ws,
-						search: term,
-						showArchived: showArchived ? true : undefined,
-						includeWithoutMain: withoutMain ? true : undefined,
-						kinds: kind !== 'all' ? kind : undefined,
-						pathStart: owner ? owner + '/' : undefined,
-						perPage: 1000,
-						cursor
-					})
-				} catch {
-					return
-				}
-				if (stale()) return
-				mergeRunnables(res.items ?? [])
-				cursor = res.next_cursor
-			} while (cursor)
+			let res: { items: RunnableItem[]; next_cursor?: string }
+			try {
+				res = await ScriptService.listRunnables({
+					workspace: ws,
+					search: term,
+					showArchived: showArchived ? true : undefined,
+					includeWithoutMain: withoutMain ? true : undefined,
+					kinds: kind !== 'all' ? kind : undefined,
+					pathStart: owner ? owner + '/' : undefined,
+					perPage: 1000
+				})
+			} catch {
+				return
+			}
+			// Drop a stale response: workspace, term, or view scope moved on while it was
+			// in flight (the debounce cancels superseded timers; this guards the request).
+			if (
+				untrack(() => $workspaceStore) !== ws ||
+				untrack(() => filter) !== term ||
+				untrack(() => archived) !== showArchived ||
+				untrack(() => includeWithoutMain) !== withoutMain ||
+				untrack(() => ownerFilter) !== owner ||
+				untrack(() => itemKind) !== kind
+			)
+				return
+			mergeRunnables(res.items ?? [])
+			searchCursor = res.next_cursor
 		}, 300)
 		return () => clearTimeout(handle)
 	})
+
+	// Fetch the next page of search matches on demand — one page per click, so a broad
+	// search stays complete without auto-loading the entire workspace into memory.
+	async function loadMoreSearchResults(): Promise<void> {
+		const ws = $workspaceStore
+		const cursor = searchCursor
+		if (!cursor || !ws || filter === '' || searchLoadingMore) return
+		searchLoadingMore = true
+		let res: { items: RunnableItem[]; next_cursor?: string }
+		try {
+			res = await ScriptService.listRunnables({
+				workspace: ws,
+				search: filter,
+				showArchived: archived ? true : undefined,
+				includeWithoutMain: includeWithoutMain ? true : undefined,
+				kinds: itemKind !== 'all' ? itemKind : undefined,
+				pathStart: ownerFilter ? ownerFilter + '/' : undefined,
+				perPage: 1000,
+				cursor
+			})
+		} catch {
+			searchLoadingMore = false
+			return
+		}
+		searchLoadingMore = false
+		// The term/scope may have moved on (which reset searchCursor); only merge and
+		// advance if this page is still the current one.
+		if (untrack(() => $workspaceStore) !== ws || filter === '' || searchCursor !== cursor) return
+		mergeRunnables(res.items ?? [])
+		searchCursor = res.next_cursor
+		// Reveal the freshly fetched matches instead of leaving them behind the display cap.
+		nbDisplayed += 30
+	}
 
 	let combinedItems = $derived(
 		flows == undefined || scripts == undefined || apps == undefined || raw_apps == undefined
@@ -1478,6 +1526,20 @@
 					></span
 				>
 			{/if}
+		{/if}
+		{#if searching && searchCursor}
+			<!-- The server has further search matches beyond the page already merged in;
+			     fetch them one page at a time on demand rather than auto-downloading a
+			     broad query's entire result set. -->
+			<div class="text-center text-xs text-secondary mt-2">
+				{#if searchLoadingMore}
+					Loading more results…
+				{:else}
+					<button class="text-primary hover:text-emphasis underline" onclick={loadMoreSearchResults}
+						>Load more results</button
+					>
+				{/if}
+			</div>
 		{/if}
 	</div>
 </CenteredPage>

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -3,14 +3,13 @@
 	import { Badge, Button, Skeleton } from '$lib/components/common'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import {
-		AppService,
 		AssetService,
-		FlowService,
 		type ListableApp,
 		type Script,
 		ScriptService,
 		type Flow,
-		type ListableRawApp
+		type ListableRawApp,
+		type RunnableItem
 	} from '$lib/gen'
 	import { resource } from 'runed'
 	import { getDraftItems } from '$lib/workspaceDrafts.svelte'
@@ -18,7 +17,6 @@
 	import type uFuzzy from '@leeoniya/ufuzzy'
 	import {
 		ArrowDownUp,
-		ChevronDown,
 		ChevronsDownUp,
 		ChevronsUpDown,
 		Code2,
@@ -132,76 +130,119 @@
 
 	let nbDisplayed = $state(15)
 
-	async function loadScripts(includeWithoutMain: boolean): Promise<void> {
-		const loadedScripts = await ScriptService.listScripts({
-			workspace: $workspaceStore!,
-			showArchived: archived ? true : undefined,
-			includeWithoutMain: includeWithoutMain ? true : undefined,
-			includeDraftOnly: true,
-			withoutDescription: true
-		})
+	// Keyset cursor for the next browse page; null once the stream is exhausted.
+	let serverCursor: string | undefined = undefined
+	let hasMoreServer = $state(false)
 
-		// Pipeline-member scripts (`auto_kind='pipeline'`) are represented by their
-		// pipeline's entry, not listed individually — but capture their folders so
-		// the pipeline entry still surfaces (incl. a members-only / draft-only folder).
-		const memberFolders = new Set<string>()
-		scripts = loadedScripts
-			.filter((script: Script) => {
-				if (script.auto_kind === 'pipeline') {
-					const m = script.path.match(/^f\/([^/]+)\//)
+	// Sort selector value -> merged-endpoint order params.
+	function sortToParams(o: SortOrder): { orderBy: 'updated' | 'name'; orderDesc: boolean } {
+		switch (o) {
+			case 'updated_asc':
+				return { orderBy: 'updated', orderDesc: false }
+			case 'name_asc':
+				return { orderBy: 'name', orderDesc: false }
+			case 'name_desc':
+				return { orderBy: 'name', orderDesc: true }
+			case 'updated_desc':
+			default:
+				return { orderBy: 'updated', orderDesc: true }
+		}
+	}
+
+	function mapRunnable(it: RunnableItem): TableScript | TableFlow | TableApp {
+		// The endpoint serializes absent optional fields as null; the per-kind list
+		// contract omits them, so strip nulls to keep `undefined` (a null draft_users
+		// / labels would otherwise crash the row components on `.length`).
+		const clean: Record<string, unknown> = {}
+		for (const [k, v] of Object.entries(it)) {
+			if (v !== null) clean[k] = v
+		}
+		const base = {
+			...clean,
+			canWrite:
+				canWrite(it.path, (it.extra_perms ?? {}) as any, $userStore) &&
+				(it.type === 'script' || it.workspace_id == $workspaceStore) &&
+				!$userStore?.operator
+		}
+		// combinedItems reads a script's time from `created_at`; the endpoint's
+		// unified `edited_at` holds exactly that for scripts.
+		if (it.type === 'script') return { ...base, created_at: it.edited_at } as unknown as TableScript
+		return base as unknown as TableFlow | TableApp
+	}
+
+	// The merged, server-ordered, keyset-paginated source. `reset` reloads from
+	// the first page (order/filter change or workspace switch); otherwise it
+	// appends the next page. All three kinds arrive interleaved and are split into
+	// the existing per-kind arrays so the downstream pipeline is unchanged.
+	async function loadRunnables(reset: boolean): Promise<void> {
+		const ws = $workspaceStore
+		if (!ws || !$userStore) return
+		if (reset) {
+			loading = true
+			serverCursor = undefined
+		}
+		const { orderBy, orderDesc } = sortToParams(sortOrder)
+		const searching = filter !== ''
+		let res: { items: RunnableItem[]; next_cursor?: string }
+		try {
+			res = await ScriptService.listRunnables({
+				workspace: ws,
+				orderBy,
+				orderDesc,
+				showArchived: archived ? true : undefined,
+				includeWithoutMain: includeWithoutMain ? true : undefined,
+				// A large page while searching so client fuzzy-match and facets see
+				// enough; browse pages are small and extended via the cursor.
+				perPage: searching ? 1000 : 100,
+				cursor: reset ? undefined : serverCursor
+			})
+		} catch (e) {
+			loading = false
+			return
+		}
+		serverCursor = res.next_cursor ?? undefined
+		hasMoreServer = !!res.next_cursor
+
+		const s: TableScript[] = reset ? [] : [...(scripts ?? [])]
+		const f: TableFlow[] = reset ? [] : [...(flows ?? [])]
+		const a: TableApp[] = reset ? [] : [...(apps ?? [])]
+		const memberFolders = reset ? new Set<string>() : new Set(pipelineMemberFolders)
+		for (const it of res.items ?? []) {
+			if (it.type === 'script') {
+				// Pipeline-member scripts are folded into their pipeline entry.
+				if (it.auto_kind === 'pipeline') {
+					const m = it.path.match(/^f\/([^/]+)\//)
 					if (m) memberFolders.add(m[1])
-					return false
+					continue
 				}
-				return true
-			})
-			.map((script: Script) => {
-				return {
-					canWrite: canWrite(script.path, script.extra_perms, $userStore) && !$userStore?.operator,
-					...script
-				}
-			})
+				s.push(mapRunnable(it) as TableScript)
+			} else if (it.type === 'flow') {
+				f.push(mapRunnable(it) as TableFlow)
+			} else if (it.type === 'app') {
+				a.push(mapRunnable(it) as TableApp)
+			}
+		}
+		scripts = s
+		flows = f
+		apps = a
+		raw_apps = []
 		pipelineMemberFolders = memberFolders
 		loading = false
 	}
 
+	// Item edits/deletes trigger a full reload; the merged endpoint returns every
+	// kind, so any change reloads the whole list.
+	async function loadScripts(_?: boolean): Promise<void> {
+		await loadRunnables(true)
+	}
 	async function loadFlows(): Promise<void> {
-		flows = (
-			await FlowService.listFlows({
-				workspace: $workspaceStore!,
-				showArchived: archived ? true : undefined,
-				includeDraftOnly: true,
-				withoutDescription: true
-			})
-		).map((x: Flow) => {
-			return {
-				canWrite:
-					canWrite(x.path, x.extra_perms, $userStore) &&
-					x.workspace_id == $workspaceStore &&
-					!$userStore?.operator,
-				...x
-			}
-		})
-		loading = false
+		await loadRunnables(true)
 	}
-
 	async function loadApps(): Promise<void> {
-		apps = (await AppService.listApps({ workspace: $workspaceStore!, includeDraftOnly: true })).map(
-			(app: ListableApp) => {
-				return {
-					canWrite:
-						canWrite(app.path!, app.extra_perms!, $userStore) &&
-						app.workspace_id == $workspaceStore &&
-						!$userStore?.operator,
-					...app
-				}
-			}
-		)
-		loading = false
+		await loadRunnables(true)
 	}
-
 	async function loadRawApps(): Promise<void> {
 		raw_apps = []
-		loading = false
 	}
 
 	function filterItemsPathsBaseOnUserFilters(
@@ -389,19 +430,16 @@
 			new Set(filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? [])
 		).sort()
 	)
+	// Reload the first page from the server whenever an input that the endpoint
+	// resolves changes: order, archived/library scope, or entering/leaving search
+	// (which switches page size). Owner/label/kind filtering and fuzzy ranking stay
+	// client-side over the loaded pages, so they don't reload here.
+	let searching = $derived(filter !== '')
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
-			;[archived, includeWithoutMain]
+			;[archived, includeWithoutMain, sortOrder, searching]
 			untrack(() => {
-				loadScripts(includeWithoutMain)
-				loadFlows()
-				if (!archived) {
-					loadApps()
-					loadRawApps()
-				} else {
-					apps = []
-					raw_apps = []
-				}
+				loadRunnables(true)
 			})
 		}
 	})
@@ -473,7 +511,12 @@
 	})
 
 	let selectedIndex: number = $state(-1)
-	let hasMore = $derived(items != undefined && items.length > nbDisplayed)
+	// More to show: either loaded items not yet sliced in, or the server has
+	// further browse pages (not while searching — search loads one large page and
+	// filters client-side).
+	let hasMore = $derived(
+		items != undefined && (items.length > nbDisplayed || (hasMoreServer && !searching))
+	)
 	let loadMoreIndex = $derived(displayedItems.length)
 	let loadMoreEl: HTMLButtonElement | undefined = $state()
 	let pendingAutoSelect = $state(true)
@@ -539,9 +582,17 @@
 		return () => window.removeEventListener('keydown', handleGlobalKeydown, true)
 	})
 
-	function loadMoreAndPreselectFirstNew() {
-		const previousNbDisplayed = nbDisplayed
+	async function loadMore() {
+		// Fetch the next server page once all loaded items are already sliced in.
+		if (items && nbDisplayed >= items.length && hasMoreServer && !searching) {
+			await loadRunnables(false)
+		}
 		nbDisplayed += 30
+	}
+
+	async function loadMoreAndPreselectFirstNew() {
+		const previousNbDisplayed = nbDisplayed
+		await loadMore()
 		selectedIndex = previousNbDisplayed
 	}
 
@@ -919,18 +970,16 @@
 						<Button
 							nonCaptureEvent
 							disabled={filter !== ''}
-							unifiedSize="xs"
+							iconOnly
+							size="xs"
 							color="light"
 							variant="default"
+							spacingSize="xs2"
 							startIcon={{ icon: ArrowDownUp }}
-							endIcon={{ icon: ChevronDown }}
-							btnClasses="font-normal"
 							title={filter !== ''
 								? 'Sorting is disabled while searching (results are ranked by relevance)'
-								: 'Sort'}
-						>
-							{sortOptions.find((o) => o.value === sortOrder)?.label ?? 'Sort'}
-						</Button>
+								: `Sort: ${sortOptions.find((o) => o.value === sortOrder)?.label ?? ''}`}
+						/>
 					{/snippet}
 				</DropdownV2>
 				{#if treeView}
@@ -1016,16 +1065,18 @@
 					/>
 				{/each}
 			</div>
-			{#if items && items?.length > 15 && nbDisplayed < items.length}
+			{#if items && items?.length > 15 && hasMore}
 				<span class="text-xs font-normal text-secondary"
-					>{nbDisplayed} items out of {items.length}
+					>{Math.min(nbDisplayed, items.length)} items{hasMoreServer && !searching
+						? ''
+						: ` out of ${items.length}`}
 					<button
 						bind:this={loadMoreEl}
 						class="ml-4 text-xs font-normal text-primary hover:text-emphasis rounded px-1 {selectedIndex ===
 						loadMoreIndex
 							? 'bg-gray-200 dark:bg-gray-700 underline'
 							: ''}"
-						onclick={() => (nbDisplayed += 30)}>load 30 more</button
+						onclick={loadMore}>load 30 more</button
 					></span
 				>
 			{/if}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -73,6 +73,11 @@
 		time?: number
 		starred?: boolean
 		hash?: string
+		// Fetch ordinal: the position this row arrived in from the server (which already
+		// applied the chosen order + starred-first). Sorting by it reproduces the server's
+		// global order EXACTLY — no client re-derivation that could disagree on collation
+		// or sub-millisecond ties and make a later page jump above shown rows.
+		ord?: number
 	}
 
 	type TableScript = TableItem<Script, 'script'>
@@ -164,6 +169,8 @@
 	let flows: TableFlow[] | undefined = $state()
 	let apps: TableApp[] | undefined = $state()
 	let raw_apps: TableRawApp[] | undefined = $state()
+	// Monotonic fetch-order counter stamped onto each row as it arrives (see TableItem.ord).
+	let fetchOrd = 0
 
 	let filteredItems: (TableScript | TableFlow | TableApp | TableRawApp)[] = $state([])
 
@@ -272,6 +279,7 @@
 		const f: TableFlow[] = reset ? [] : [...(flows ?? [])]
 		const a: TableApp[] = reset ? [] : [...(apps ?? [])]
 		const memberFolders = reset ? new Set<string>() : new Set(pipelineMemberFolders)
+		if (reset) fetchOrd = 0
 		for (const it of res.items ?? []) {
 			if (it.type === 'script') {
 				// Pipeline-member scripts are folded into their pipeline entry.
@@ -280,11 +288,11 @@
 					if (m) memberFolders.add(m[1])
 					continue
 				}
-				s.push(mapRunnable(it) as TableScript)
+				s.push({ ...mapRunnable(it), ord: fetchOrd++ } as TableScript)
 			} else if (it.type === 'flow') {
-				f.push(mapRunnable(it) as TableFlow)
+				f.push({ ...mapRunnable(it), ord: fetchOrd++ } as TableFlow)
 			} else if (it.type === 'app') {
-				a.push(mapRunnable(it) as TableApp)
+				a.push({ ...mapRunnable(it), ord: fetchOrd++ } as TableApp)
 			}
 		}
 		scripts = s
@@ -316,7 +324,9 @@
 				continue
 			}
 			if (have.has(itemKey(it))) continue
-			const mapped = mapRunnable(it)
+			// Appended after the browse window; a higher ord keeps them after it (search
+			// itself ranks by relevance, so this ordinal only matters if sort resumes).
+			const mapped = { ...mapRunnable(it), ord: fetchOrd++ }
 			if (it.type === 'script') s.push(mapped as TableScript)
 			else if (it.type === 'flow') f.push(mapped as TableFlow)
 			else if (it.type === 'app') a.push(mapped as TableApp)
@@ -434,7 +444,7 @@
 			// they never render as their own tree leaf (visiblePipelineFolders drives it).
 			if (it.type === 'script' && it.auto_kind === 'pipeline') continue
 			if (have.has(itemKey(it))) continue
-			merged.push(toTreeItem(it))
+			merged.push({ ...toTreeItem(it), ord: fetchOrd++ })
 		}
 		treeOwnerItems = merged
 		ownerLoad[owner] = {
@@ -513,59 +523,17 @@
 			action: () => (sortOrder = o.value)
 		}))
 	)
-	function sortName(x: { summary?: string; path: string }): string {
-		return x.summary && x.summary !== '' ? x.summary : x.path
-	}
-	// A $derived closure so its identity changes with `sortOrder`, which both re-runs
-	// `combinedItems` (flat view) and re-groups the tree (TreeViewRoot depends on this
-	// prop). Starred items are pinned on top in every order and view — the endpoint
-	// pins starred on the first page for both browse and archived (each is one row per
-	// path), so the client mirrors that.
+	// Preserve the endpoint's exact order rather than re-deriving it on the client:
+	// each row carries its server fetch ordinal (`ord`), which already reflects the
+	// chosen order, the (path, kind) tiebreaks, full-precision timestamps, the database
+	// collation, and starred-first pinning. Sorting by it can never disagree with the
+	// server, so a later page never jumps above shown rows on "load more". Depends on
+	// `sortOrder` only so its identity changes when the order does (re-grouping the tree,
+	// whose leaves also sort by ord); the actual reordering comes from the reload that
+	// restamps ord.
 	let compareItems = $derived.by(() => {
-		const order = sortOrder
-		// Compare the endpoint's unified sort timestamp as a STRING, not a JS Date: the
-		// response carries microseconds (…​.375007Z) but Date.getTime() truncates to ms,
-		// so two rows in the same millisecond would tie client-side and be re-ordered,
-		// letting a later server page jump above shown rows. Lexicographic order on the
-		// fixed ISO format is chronological. (Every kind's sort time is `edited_at` — for
-		// scripts mapRunnable sets it from the endpoint's value.)
-		const tcmp = (x?: string, y?: string) =>
-			(x ?? '') < (y ?? '') ? -1 : (x ?? '') > (y ?? '') ? 1 : 0
-		return (
-			a: { starred?: boolean; edited_at?: string; summary?: string; path: string; type?: string },
-			b: { starred?: boolean; edited_at?: string; summary?: string; path: string; type?: string }
-		): number => {
-			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
-			// Match the endpoint's ordering exactly so a row on a later server page can't
-			// jump above already-shown rows on "load more". The server orders by
-			// `<col> <dir>, path <dir>, kind <dir>`: names compare case-insensitively (it
-			// sorts on `lower(summary-or-path)`), then path, then kind ('app' < 'flow' <
-			// 'script'), each in the same direction as the primary.
-			let primary: number
-			let asc: boolean
-			switch (order) {
-				case 'updated_asc':
-					primary = tcmp(a.edited_at, b.edited_at)
-					asc = true
-					break
-				case 'name_asc':
-					primary = cmp(sortName(a).toLowerCase(), sortName(b).toLowerCase())
-					asc = true
-					break
-				case 'name_desc':
-					primary = cmp(sortName(b).toLowerCase(), sortName(a).toLowerCase())
-					asc = false
-					break
-				case 'updated_desc':
-				default:
-					primary = tcmp(b.edited_at, a.edited_at)
-					asc = false
-					break
-			}
-			if (primary !== 0) return primary
-			const p = a.path.localeCompare(b.path) || (a.type ?? '').localeCompare(b.type ?? '')
-			return asc ? p : -p
-		}
+		sortOrder
+		return (a: { ord?: number }, b: { ord?: number }): number => (a.ord ?? 0) - (b.ord ?? 0)
 	})
 
 	const opts: uFuzzy.Options = {

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -221,10 +221,10 @@
 
 	const cmp = new Intl.Collator('en').compare
 
-	// Sort options are computed entirely client-side over the already-loaded item
-	// fields (`time`, `path`, `summary`), so the backend query is unchanged and
-	// adding options costs it nothing even on very large workspaces. Starred items
-	// stay pinned on top of every order.
+	// Sorting is done client-side over fields the list already holds (`time`,
+	// `path`, `summary`): the list fetches every item up front, so no per-order
+	// backend query or index is needed even on very large workspaces. Starred
+	// items are pinned on top in every order.
 	type SortOrder = 'updated_desc' | 'updated_asc' | 'name_asc' | 'name_desc'
 	const SORT_SETTING_NAME = 'homeSort'
 	const sortOptions: { value: SortOrder; label: string }[] = [
@@ -249,23 +249,29 @@
 	function sortName(x: { summary?: string; path: string }): string {
 		return x.summary && x.summary !== '' ? x.summary : x.path
 	}
-	function compareItems(
-		a: { starred?: boolean; time?: number; summary?: string; path: string },
-		b: { starred?: boolean; time?: number; summary?: string; path: string }
-	): number {
-		if (a.starred != b.starred) return a.starred ? -1 : 1
-		switch (sortOrder) {
-			case 'updated_asc':
-				return (a.time ?? 0) - (b.time ?? 0)
-			case 'name_asc':
-				return cmp(sortName(a), sortName(b))
-			case 'name_desc':
-				return cmp(sortName(b), sortName(a))
-			case 'updated_desc':
-			default:
-				return (b.time ?? 0) - (a.time ?? 0)
+	// A $derived closure so its identity changes with `sortOrder`, which both
+	// re-runs `combinedItems` (flat view) and re-groups the tree (TreeViewRoot
+	// depends on this prop). Starred items are pinned on top in every order.
+	let compareItems = $derived.by(() => {
+		const order = sortOrder
+		return (
+			a: { starred?: boolean; time?: number; summary?: string; path: string },
+			b: { starred?: boolean; time?: number; summary?: string; path: string }
+		): number => {
+			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
+			switch (order) {
+				case 'updated_asc':
+					return (a.time ?? 0) - (b.time ?? 0)
+				case 'name_asc':
+					return cmp(sortName(a), sortName(b))
+				case 'name_desc':
+					return cmp(sortName(b), sortName(a))
+				case 'updated_desc':
+				default:
+					return (b.time ?? 0) - (a.time ?? 0)
+			}
 		}
-	}
+	})
 
 	const opts: uFuzzy.Options = {
 		sort: (info, haystack, needle) => {
@@ -963,6 +969,7 @@
 				{items}
 				{nbDisplayed}
 				{collapseAll}
+				sortCompare={compareItems}
 				pipelineFolders={visiblePipelineFolders}
 				isSearching={filter !== ''}
 				on:scriptChanged={() => loadScripts(includeWithoutMain)}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -176,9 +176,15 @@
 		// Only the very first load shows the skeleton; reorder/filter reloads keep
 		// the toolbar and current items visible (they're replaced on arrival) so the
 		// sort control itself doesn't flicker out when you use it.
+		// An append (load-more) needs a live cursor. If there isn't one — the stream
+		// is exhausted, or a reset just cleared it and its page-1 response hasn't
+		// landed — bail so a load-more can't append a fresh page-1 onto the old
+		// arrays (mixing streams) or clobber the pending reset's generation.
+		if (!reset && serverCursor === undefined) return
 		if (scripts === undefined) loading = true
 		if (reset) {
 			serverCursor = undefined
+			hasMoreServer = false
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		const gen = ++loadGen

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -211,6 +211,9 @@
 		if (reset) {
 			serverCursor = undefined
 			hasMoreServer = false
+			// The shared arrays are about to be replaced, so per-folder loaded state
+			// is stale; the tree will re-lazy-load folders on expand.
+			folderLoad = {}
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		const gen = ++loadGen
@@ -303,6 +306,52 @@
 			flows = f
 			apps = a
 			pipelineMemberFolders = memberFolders
+		}
+	}
+
+	// Per-top-level-folder lazy loading for tree view: expanding a folder loads its
+	// items on demand (server-scoped to that folder), paginated within the folder,
+	// instead of relying on the global browse window. Keyed by folder name (the
+	// `f/<name>` node). Loaded items are merged into the shared arrays.
+	type FolderLoadState = { cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+	let folderLoad = $state<Record<string, FolderLoadState>>({})
+
+	async function loadFolderItems(folder: string, more = false): Promise<void> {
+		const ws = $workspaceStore
+		if (!ws || !$userStore) return
+		const st = folderLoad[folder]
+		if (st?.loading) return
+		if (more ? !st?.hasMore : st?.loaded) return
+		folderLoad[folder] = {
+			cursor: st?.cursor,
+			hasMore: st?.hasMore ?? false,
+			loading: true,
+			loaded: st?.loaded ?? false
+		}
+		const { orderBy, orderDesc } = sortToParams(sortOrder)
+		let res: { items: RunnableItem[]; next_cursor?: string }
+		try {
+			res = await ScriptService.listRunnables({
+				workspace: ws,
+				orderBy,
+				orderDesc,
+				showArchived: archived ? true : undefined,
+				includeWithoutMain: includeWithoutMain ? true : undefined,
+				pathStart: `f/${folder}/`,
+				perPage: 100,
+				cursor: more ? st?.cursor : undefined
+			})
+		} catch (e: any) {
+			folderLoad[folder] = { ...folderLoad[folder], loading: false }
+			sendUserToast(`Failed to load folder ${folder}: ${e?.body ?? e?.message ?? e}`, true)
+			return
+		}
+		mergeRunnables(res.items ?? [])
+		folderLoad[folder] = {
+			cursor: res.next_cursor,
+			hasMore: !!res.next_cursor,
+			loading: false,
+			loaded: true
 		}
 	}
 
@@ -517,6 +566,14 @@
 	// entering/leaving search. Label/kind filtering and fuzzy ranking stay
 	// client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
+	// Lazy folder tree is active when browsing all (no owner, no search): show every
+	// folder as a top-level node and paginate each on expand. When a folder is
+	// selected or searching, the tree groups the (already-scoped) loaded items and
+	// the global "load more" applies within that scope.
+	let treeInjectFolders = $derived(
+		!searching && ownerFilter == undefined ? (folderNamesRes.current ?? []) : []
+	)
+	let treeGlobalHasMore = $derived(ownerFilter != undefined && !searching ? hasMoreServer : false)
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
 			;[archived, includeWithoutMain, sortOrder, searching, ownerFilter]
@@ -1157,9 +1214,12 @@
 				{nbDisplayed}
 				{collapseAll}
 				sortCompare={compareItems}
-				hasMoreServer={hasMoreServer && !searching}
+				hasMoreServer={treeGlobalHasMore}
 				onLoadMore={fetchMoreServer}
 				pipelineFolders={visiblePipelineFolders}
+				allFolders={treeInjectFolders}
+				{folderLoad}
+				onExpandFolder={loadFolderItems}
 				isSearching={filter !== ''}
 				on:scriptChanged={() => loadScripts(includeWithoutMain)}
 				on:flowChanged={loadFlows}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -425,17 +425,18 @@
 		}
 	}
 
-	// A row was created/edited/archived/moved/shared. The merged endpoint returns
-	// every kind, so ONE reload refreshes the whole list — the per-kind change events
-	// all route here rather than each firing its own identical query. loadRunnables
-	// clears the lazy owner store, so re-fetch whatever owners were expanded (this is
-	// a same-scope reload: treeKey is unchanged, so those TreeView nodes stay open and
-	// would otherwise go blank).
 	function collapseOwner(owner: string): void {
 		openOwners.delete(owner)
 	}
+	// Reload the merged list once and re-fetch the owners that are currently expanded so
+	// they don't go blank. Used both for row mutations (create/edit/archive/move/share)
+	// and for in-place scope changes (sort/archive/library/kind): those keep the tree in
+	// lazy mode (treeKey unchanged, so folders stay open like a file explorer), and the
+	// re-fetch reloads each open owner's items in the new order/filter. When a mode
+	// change (owner/search) has switched the tree out of lazy mode, there's nothing to
+	// re-fetch — the tree remounts and groups the global stream instead.
 	async function reloadItems(): Promise<void> {
-		const toReload = [...openOwners]
+		const toReload = treeLazyMode ? [...openOwners] : []
 		await loadRunnables(true)
 		for (const o of toReload) loadOwnerItems(o)
 	}
@@ -666,8 +667,13 @@
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
 			;[archived, includeWithoutMain, sortOrder, searching, ownerFilter, itemKind]
+			// reloadItems (not a bare loadRunnables) so an in-place change — sort, archive,
+			// library, kind — reloads the global stream AND re-fetches the currently-open
+			// owners in the new order/filter, keeping folders expanded (file-explorer style)
+			// rather than collapsing them. Mode changes (owner/search) flip treeLazyMode, so
+			// reloadItems skips the re-fetch and the {#key} remount handles the reset.
 			untrack(() => {
-				loadRunnables(true)
+				reloadItems()
 			})
 		}
 	})
@@ -777,12 +783,12 @@
 	// so the tree never depends on which owners happen to be in the loaded window.
 	// Otherwise (scoped/search/label) the tree just groups the global `items`.
 	let treeSource = $derived(treeLazyMode ? treeOwnerItems : items)
-	// Scope identity for the tree: any change here means folders must re-load fresh,
-	// so it keys a {#key} remount that collapses expanded folders (searching is a
-	// boolean so per-keystroke query changes don't remount — search updates in place).
-	let treeKey = $derived(
-		`${$workspaceStore}|${sortOrder}|${archived}|${includeWithoutMain}|${itemKind}|${ownerFilter}|${searching}|${labelFilter}`
-	)
+	// Remount identity: only a *mode* change (workspace, selected owner, entering/leaving
+	// search, label filter) restructures the tree, so only those key the {#key} remount.
+	// A sort/archive/library/kind change keeps the same lazy tree and is applied in place
+	// by reloadItems re-fetching the open owners — so expanded folders don't collapse when
+	// you re-sort (searching is a boolean so per-keystroke query changes don't remount).
+	let treeKey = $derived(`${$workspaceStore}|${ownerFilter}|${searching}|${labelFilter}`)
 	let displayedItems = $derived((items ?? []).slice(0, nbDisplayed))
 	$effect(() => {
 		items && resetScroll()
@@ -1320,6 +1326,7 @@
 					{nbDisplayed}
 					{collapseAll}
 					sortCompare={compareItems}
+					groupDesc={sortOrder === 'name_desc'}
 					hasMoreServer={treeGlobalHasMore}
 					onLoadMore={fetchMoreServer}
 					pipelineFolders={visiblePipelineFolders}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -37,6 +37,7 @@
 	import ToggleButton from '../common/toggleButton-v2/ToggleButton.svelte'
 	import FlowIcon from './FlowIcon.svelte'
 	import { canWrite, getLocalSetting, storeLocalSetting } from '$lib/utils'
+	import { sendUserToast } from '$lib/toast'
 	import { page } from '$app/state'
 	import { setQuery } from '$lib/navigation'
 	import Drawer from '../common/drawer/Drawer.svelte'
@@ -199,8 +200,9 @@
 				perPage: searching ? 1000 : 100,
 				cursor: reset ? undefined : serverCursor
 			})
-		} catch (e) {
+		} catch (e: any) {
 			loading = false
+			sendUserToast(`Failed to load items: ${e?.body ?? e?.message ?? e}`, true)
 			return
 		}
 		serverCursor = res.next_cursor ?? undefined
@@ -265,10 +267,10 @@
 
 	const cmp = new Intl.Collator('en').compare
 
-	// Sorting is done client-side over fields the list already holds (`time`,
-	// `path`, `summary`): the list fetches every item up front, so no per-order
-	// backend query or index is needed even on very large workspaces. Starred
-	// items are pinned on top in every order.
+	// The selected order maps to the endpoint's order_by/order_desc (see
+	// sortToParams) so it is applied server-side and stays correct across the
+	// whole workspace, not just loaded pages. Starred items are pinned on top of
+	// the first page.
 	type SortOrder = 'updated_desc' | 'updated_asc' | 'name_asc' | 'name_desc'
 	const SORT_SETTING_NAME = 'homeSort'
 	const sortOptions: { value: SortOrder; label: string }[] = [

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1304,8 +1304,8 @@
 					onLoadMore={fetchMoreServer}
 					pipelineFolders={visiblePipelineFolders}
 					allFolders={treeInjectFolders}
-					{folderLoad}
-					onExpandFolder={loadFolderItems}
+					folderLoad={treeLazyMode ? folderLoad : undefined}
+					onExpandFolder={treeLazyMode ? loadFolderItems : undefined}
 					isSearching={filter !== ''}
 					on:scriptChanged={() => loadScripts(includeWithoutMain)}
 					on:flowChanged={loadFlows}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -351,6 +351,9 @@
 		loading: boolean
 		loaded: boolean
 		gen: number
+		// Total rows fetched for this owner so far (leaves + subfolder rows) — the tree
+		// node's own children count undercounts because rows nest into subfolders.
+		count: number
 	}
 	let ownerLoad = $state<Record<string, OwnerLoadState>>({})
 	let treeOwnerItems = $state<ItemType[]>([])
@@ -391,7 +394,9 @@
 			hasMore: st?.hasMore ?? false,
 			loading: true,
 			loaded: st?.loaded ?? false,
-			gen
+			gen,
+			// A fresh (non-more) load replaces this owner's rows, so its count restarts.
+			count: more ? (st?.count ?? 0) : 0
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		let res: { items: RunnableItem[]; next_cursor?: string }
@@ -437,7 +442,8 @@
 			hasMore: !!res.next_cursor,
 			loading: false,
 			loaded: true,
-			gen
+			gen,
+			count: merged.filter((x) => x.path.startsWith(prefix)).length
 		}
 	}
 
@@ -685,20 +691,27 @@
 	// entering/leaving search. Label/kind filtering and fuzzy ranking stay
 	// client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
-	// Lazy owner tree is active when browsing all (no owner selected, no search, no
-	// label filter): every folder AND user shows as a top-level node and paginates on
-	// expand, its items coming from the separate `treeOwnerItems` store. A selected
-	// owner, an active search, or a label filter instead groups the global loaded
-	// window (label filtering is client-side over loaded rows, so it must see it).
-	let treeLazyMode = $derived(!searching && ownerFilter == undefined && labelFilter == undefined)
+	// Lazy owner tree is active only in the tree view when browsing all (no owner
+	// selected, no search, no label filter): every folder AND user shows as a top-level
+	// node and paginates on expand, its items coming from the separate `treeOwnerItems`
+	// store. In the flat view, or a selected owner / active search / label filter, the
+	// lazy store is unused (the flat list and reloadItems must not touch it), so this is
+	// false and those views group the global loaded window instead.
+	let treeLazyMode = $derived(
+		treeView && !searching && ownerFilter == undefined && labelFilter == undefined
+	)
 	let treeInjectFolders = $derived(treeLazyMode ? (folderNamesRes.current ?? []) : [])
 	let treeInjectUsers = $derived.by(() => {
+		// "Only f/*" hides every user namespace; "u/<you> and f/*" keeps just your own.
 		if (!treeLazyMode) return []
-		const s = new Set(usernamesRes.current ?? [])
+		if (filterUserFolders && filterUserFoldersType === 'only f/*') return []
+		const s = new Set<string>()
 		// Always inject your own personal space (u/<you>): list_usernames can be empty
 		// (you may not be a listed workspace member) yet u/<you> still holds runnables,
 		// and it must not vanish under a name sort whose first page is all folders.
 		if ($userStore?.username) s.add($userStore.username)
+		// Other users only when no user-folder restriction is active.
+		if (!filterUserFolders) for (const u of usernamesRes.current ?? []) s.add(u)
 		return [...s]
 	})
 	// The bottom "load more" only pages the *global* stream, which in lazy mode holds
@@ -737,34 +750,41 @@
 		const owner = ownerFilter
 		const kind = itemKind
 		if (term === '' || !ws || !$userStore) return
+		// Stale if workspace, term, or view scope moved on (the debounce cancels
+		// superseded timers; this also guards each in-flight page so an old scope can't
+		// merge into the new one and aborts the paging loop mid-way).
+		const stale = () =>
+			untrack(() => $workspaceStore) !== ws ||
+			untrack(() => filter) !== term ||
+			untrack(() => archived) !== showArchived ||
+			untrack(() => includeWithoutMain) !== withoutMain ||
+			untrack(() => ownerFilter) !== owner ||
+			untrack(() => itemKind) !== kind
 		const handle = setTimeout(async () => {
-			let res: { items: RunnableItem[] }
-			try {
-				res = await ScriptService.listRunnables({
-					workspace: ws,
-					search: term,
-					showArchived: showArchived ? true : undefined,
-					includeWithoutMain: withoutMain ? true : undefined,
-					kinds: kind !== 'all' ? kind : undefined,
-					pathStart: owner ? owner + '/' : undefined,
-					perPage: 1000
-				})
-			} catch {
-				return
+			let cursor: string | undefined = undefined
+			// Page to exhaustion so search stays workspace-complete beyond the first
+			// 1000 matches; the page cap bounds a pathologically broad term.
+			for (let page = 0; page < 20; page++) {
+				let res: { items: RunnableItem[]; next_cursor?: string }
+				try {
+					res = await ScriptService.listRunnables({
+						workspace: ws,
+						search: term,
+						showArchived: showArchived ? true : undefined,
+						includeWithoutMain: withoutMain ? true : undefined,
+						kinds: kind !== 'all' ? kind : undefined,
+						pathStart: owner ? owner + '/' : undefined,
+						perPage: 1000,
+						cursor
+					})
+				} catch {
+					return
+				}
+				if (stale()) return
+				mergeRunnables(res.items ?? [])
+				cursor = res.next_cursor
+				if (!cursor) break
 			}
-			// Drop a stale response: workspace, term, or view scope moved on while it
-			// was in flight (debounce cancels superseded timers; this guards the
-			// in-flight request so an old scope/workspace can't merge into the new one).
-			if (
-				untrack(() => $workspaceStore) !== ws ||
-				untrack(() => filter) !== term ||
-				untrack(() => archived) !== showArchived ||
-				untrack(() => includeWithoutMain) !== withoutMain ||
-				untrack(() => ownerFilter) !== owner ||
-				untrack(() => itemKind) !== kind
-			)
-				return
-			mergeRunnables(res.items ?? [])
 		}, 300)
 		return () => clearTimeout(handle)
 	})
@@ -827,13 +847,21 @@
 	// injected as a node and its rows come from the on-demand `treeOwnerItems` store,
 	// so the tree never depends on which owners happen to be in the loaded window.
 	// Otherwise (scoped/search/label) the tree just groups the global `items`.
-	let treeSource = $derived(treeLazyMode ? treeOwnerItems : items)
+	let treeSource = $derived(
+		treeLazyMode
+			? treeOwnerItems.filter((x) =>
+					filterItemsPathsBaseOnUserFilters(x, filterUserFolders, filterUserFoldersType)
+				)
+			: items
+	)
 	// Remount identity: only a *mode* change (workspace, selected owner, entering/leaving
 	// search, label filter) restructures the tree, so only those key the {#key} remount.
 	// A sort/archive/library/kind change keeps the same lazy tree and is applied in place
 	// by reloadItems re-fetching the open owners — so expanded folders don't collapse when
 	// you re-sort (searching is a boolean so per-keystroke query changes don't remount).
-	let treeKey = $derived(`${$workspaceStore}|${ownerFilter}|${searching}|${labelFilter}`)
+	let treeKey = $derived(
+		`${treeView}|${$workspaceStore}|${ownerFilter}|${searching}|${labelFilter}`
+	)
 	// A mode change restructures the tree (it remounts on treeKey), so the lazy owner
 	// store is stale — clear it here (the global reset no longer does). An in-place
 	// sort/filter change leaves treeKey unchanged, so the store survives and its owners

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -17,6 +17,8 @@
 	import { userStore, workspaceStore } from '$lib/stores'
 	import type uFuzzy from '@leeoniya/ufuzzy'
 	import {
+		ArrowDownUp,
+		Check,
 		ChevronsDownUp,
 		ChevronsUpDown,
 		Code2,
@@ -217,6 +219,46 @@
 
 	const cmp = new Intl.Collator('en').compare
 
+	// Sort options are computed entirely client-side over the already-loaded item
+	// fields (`time`, `path`, `summary`), so adding options costs the backend
+	// nothing even on very large workspaces. Starred items stay pinned on top of
+	// every order, matching the previous behavior.
+	type SortOrder = 'updated_desc' | 'updated_asc' | 'name_asc' | 'name_desc'
+	const SORT_SETTING_NAME = 'homeSort'
+	const sortOptions: { value: SortOrder; label: string }[] = [
+		{ value: 'updated_desc', label: 'Recently updated' },
+		{ value: 'updated_asc', label: 'Oldest updated' },
+		{ value: 'name_asc', label: 'Name (A-Z)' },
+		{ value: 'name_desc', label: 'Name (Z-A)' }
+	]
+	let sortOrder = $state<SortOrder>(
+		(sortOptions.find((o) => o.value === getLocalSetting(SORT_SETTING_NAME))?.value as SortOrder) ??
+			'updated_desc'
+	)
+	$effect(() => {
+		storeLocalSetting(SORT_SETTING_NAME, sortOrder === 'updated_desc' ? undefined : sortOrder)
+	})
+	function sortName(x: { summary?: string; path: string }): string {
+		return x.summary && x.summary !== '' ? x.summary : x.path
+	}
+	function compareItems(
+		a: { starred?: boolean; time?: number; summary?: string; path: string },
+		b: { starred?: boolean; time?: number; summary?: string; path: string }
+	): number {
+		if (a.starred != b.starred) return a.starred ? -1 : 1
+		switch (sortOrder) {
+			case 'updated_asc':
+				return (a.time ?? 0) - (b.time ?? 0)
+			case 'name_asc':
+				return cmp(sortName(a), sortName(b))
+			case 'name_desc':
+				return cmp(sortName(b), sortName(a))
+			case 'updated_desc':
+			default:
+				return (b.time ?? 0) - (a.time ?? 0)
+		}
+	}
+
 	const opts: uFuzzy.Options = {
 		sort: (info, haystack, needle) => {
 			let {
@@ -374,9 +416,7 @@
 						type: 'raw_app' as 'raw_app',
 						time: new Date(x.edited_at).getTime()
 					}))
-				].sort((a, b) =>
-					a.starred != b.starred ? (a.starred ? -1 : 1) : a.time - b.time > 0 ? -1 : 1
-				)
+				].sort(compareItems)
 	)
 	function itemLabels(x: { labels?: string[]; inherited_labels?: string[] }): string[] {
 		return [...(x.labels ?? []), ...(x.inherited_labels ?? [])]
@@ -855,6 +895,44 @@
 					/>
 				{/if}
 				<Toggle size="xs" bind:checked={treeView} options={{ right: 'Tree view' }} />
+				<Popover floatingConfig={{ placement: 'bottom-end' }}>
+					{#snippet trigger()}
+						<Button
+							startIcon={{ icon: ArrowDownUp }}
+							nonCaptureEvent
+							size="xs"
+							color="light"
+							variant="default"
+							spacingSize="xs2"
+							title="Sort"
+							disabled={filter !== ''}
+						>
+							{sortOptions.find((o) => o.value === sortOrder)?.label ?? 'Sort'}
+						</Button>
+					{/snippet}
+					{#snippet content({ close })}
+						<div class="p-1 flex flex-col">
+							{#each sortOptions as option (option.value)}
+								<button
+									class="text-left text-xs px-2 py-1.5 rounded hover:bg-surface-hover flex items-center gap-2 {option.value ===
+									sortOrder
+										? 'font-semibold text-emphasis'
+										: 'text-secondary'}"
+									onclick={() => {
+										sortOrder = option.value
+										close()
+									}}
+								>
+									<Check
+										size={14}
+										class={option.value === sortOrder ? 'opacity-100' : 'opacity-0'}
+									/>
+									{option.label}
+								</button>
+							{/each}
+						</div>
+					{/snippet}
+				</Popover>
 				{#if treeView}
 					<Button
 						unifiedSize="sm"

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -345,7 +345,13 @@
 	// first page happens to be all folder rows. `treeGen` ties every request to the
 	// active scope (order/archived/library/kind/workspace); a reset bumps it so an
 	// in-flight response from a stale scope is discarded.
-	type OwnerLoadState = { cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+	type OwnerLoadState = {
+		cursor?: string
+		hasMore: boolean
+		loading: boolean
+		loaded: boolean
+		gen: number
+	}
 	let ownerLoad = $state<Record<string, OwnerLoadState>>({})
 	let treeOwnerItems = $state<ItemType[]>([])
 	let treeGen = 0
@@ -370,16 +376,22 @@
 	async function loadOwnerItems(owner: string, more = false, force = false): Promise<void> {
 		const ws = $workspaceStore
 		if (!ws || !$userStore) return
-		const st = ownerLoad[owner]
-		if (st?.loading) return
-		if (!force && (more ? !st?.hasMore : st?.loaded)) return
+		// Track the owner as open first — even a no-op call (re-expanding a cached owner)
+		// means it's expanded, so later reloads must refresh it.
 		openOwners.add(owner)
+		const st = ownerLoad[owner]
+		// Only a load for the CURRENT generation blocks a new one. A load left in flight
+		// by a superseded generation (treeGen bumped on a sort/filter reload) has already
+		// been invalidated, so it must not wedge the owner as permanently loading.
+		if (st?.loading && st.gen === treeGen) return
+		if (!force && (more ? !st?.hasMore : st?.loaded)) return
 		const gen = treeGen
 		ownerLoad[owner] = {
 			cursor: st?.cursor,
 			hasMore: st?.hasMore ?? false,
 			loading: true,
-			loaded: st?.loaded ?? false
+			loaded: st?.loaded ?? false,
+			gen
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		let res: { items: RunnableItem[]; next_cursor?: string }
@@ -424,7 +436,8 @@
 			cursor: res.next_cursor,
 			hasMore: !!res.next_cursor,
 			loading: false,
-			loaded: true
+			loaded: true,
+			gen
 		}
 	}
 
@@ -473,11 +486,13 @@
 	// the first page.
 	type SortOrder = 'updated_desc' | 'updated_asc' | 'name_asc' | 'name_desc'
 	const SORT_SETTING_NAME = 'homeSort'
-	const sortOptions: { value: SortOrder; label: string }[] = [
-		{ value: 'updated_desc', label: 'Recently updated' },
-		{ value: 'updated_asc', label: 'Oldest updated' },
-		{ value: 'name_asc', label: 'Name (A-Z)' },
-		{ value: 'name_desc', label: 'Name (Z-A)' }
+	// `short` labels the trigger button for non-default sorts; the default (recently
+	// updated) shows the icon only, so its short label is empty.
+	const sortOptions: { value: SortOrder; label: string; short: string }[] = [
+		{ value: 'updated_desc', label: 'Recently updated', short: '' },
+		{ value: 'updated_asc', label: 'Oldest updated', short: 'Oldest' },
+		{ value: 'name_asc', label: 'Name (A-Z)', short: 'A-Z' },
+		{ value: 'name_desc', label: 'Name (Z-A)', short: 'Z-A' }
 	]
 	let sortOrder = $state<SortOrder>(
 		sortOptions.find((o) => o.value === getLocalSetting(SORT_SETTING_NAME))?.value ?? 'updated_desc'
@@ -632,6 +647,27 @@
 	}
 
 	let collapseAll = $state(true)
+	// Human-readable list of the filters currently narrowing the list. Empty means no
+	// filter is active, so an empty result then means the workspace itself has no items
+	// (NoItemFound shows the welcome message); otherwise the filters are just too narrow
+	// and NoItemFound lists them.
+	let activeFilters = $derived.by(() => {
+		const f: string[] = []
+		if (filter !== '') f.push(`search “${filter}”`)
+		if (itemKind !== 'all')
+			f.push(itemKind === 'script' ? 'Scripts' : itemKind === 'flow' ? 'Flows' : 'Apps')
+		if (ownerFilter != undefined) f.push(ownerFilter)
+		if (labelFilter != undefined) f.push(`label “${labelFilter}”`)
+		if (archived) f.push('archived only')
+		if (filterUserFolders)
+			f.push(
+				filterUserFoldersType === 'only f/*'
+					? 'only f/* folders'
+					: `only f/* and u/${$userStore?.username}`
+			)
+		if (!includeWithoutMain) f.push('library scripts hidden')
+		return f
+	})
 	// Complete owner list: every folder (from the folder list, not just loaded
 	// pages) plus the user prefixes present in the loaded/filtered items. So a
 	// folder whose items are far down the stream is still a selectable chip.
@@ -1283,10 +1319,12 @@
 					fixedHeight={false}
 				>
 					{#snippet buttonReplacement()}
+						{@const active = sortOptions.find((o) => o.value === sortOrder)}
+						{@const short = filter !== '' ? '' : (active?.short ?? '')}
 						<Button
 							nonCaptureEvent
 							disabled={filter !== ''}
-							iconOnly
+							iconOnly={short === ''}
 							size="xs"
 							color="light"
 							variant="default"
@@ -1294,8 +1332,10 @@
 							startIcon={{ icon: ArrowDownUp }}
 							title={filter !== ''
 								? 'Sorting is disabled while searching (results are ranked by relevance)'
-								: `Sort: ${sortOptions.find((o) => o.value === sortOrder)?.label ?? ''}`}
-						/>
+								: `Sort: ${active?.label ?? ''}`}
+						>
+							{#if short !== ''}{short}{/if}
+						</Button>
 					{/snippet}
 				</DropdownV2>
 				{#if treeView}
@@ -1328,7 +1368,7 @@
 			<!-- Pipelines aren't part of the text filter, so only fall through to show
 			     them (list rows / injected tree folders) when not actively searching;
 			     a no-match search still reads as empty. -->
-			<NoItemFound hasFilters={filter !== '' || archived || filterUserFolders} />
+			<NoItemFound {activeFilters} />
 			{#if hasMoreServer && !searching}
 				<!-- The active filter matched nothing on the loaded pages, but the server
 				     has more: keep paging reachable so matches on later pages aren't lost. -->

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -5,6 +5,7 @@
 	import {
 		AssetService,
 		FolderService,
+		UserService,
 		type ListableApp,
 		type Script,
 		ScriptService,
@@ -46,6 +47,7 @@
 	import DrawerContent from '../common/drawer/DrawerContent.svelte'
 	import Item from './Item.svelte'
 	import TreeViewRoot from './TreeViewRoot.svelte'
+	import type { ItemType } from './treeViewUtils'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import { getContext, tick, untrack } from 'svelte'
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
@@ -141,6 +143,22 @@
 		}
 	)
 	let allFolderOwners = $derived((folderNamesRes.current ?? []).map((f) => `f/${f}`))
+	// Every workspace username, so a user whose items sit beyond the loaded browse
+	// window is still a selectable owner chip (scoping the stream to `u/<user>/`).
+	// Without this, user owners would derive only from loaded rows and a user past
+	// the first page would be unreachable in the tree without searching.
+	let usernamesRes = resource(
+		() => $workspaceStore,
+		async (ws) => {
+			if (!ws) return [] as string[]
+			try {
+				return await UserService.listUsernames({ workspace: ws })
+			} catch {
+				return [] as string[] // best-effort facet
+			}
+		}
+	)
+	let allUserOwners = $derived((usernamesRes.current ?? []).map((u) => `u/${u}`))
 
 	let scripts: TableScript[] | undefined = $state()
 	let flows: TableFlow[] | undefined = $state()
@@ -211,9 +229,14 @@
 		if (reset) {
 			serverCursor = undefined
 			hasMoreServer = false
-			// The shared arrays are about to be replaced, so per-folder loaded state
-			// is stale; the tree will re-lazy-load folders on expand.
+			// The scope changed, so the lazily-loaded folder store and its per-folder
+			// cursors are stale. Bump treeGen first so any in-flight folder request is
+			// discarded on return, then clear. The tree remounts on the same scope key
+			// (see the {#key} around TreeViewRoot), collapsing folders so they re-load
+			// fresh on the next expand rather than lingering with old-scope rows.
+			treeGen++
 			folderLoad = {}
+			treeFolderItems = []
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		const gen = ++loadGen
@@ -228,6 +251,7 @@
 				orderDesc,
 				showArchived: archived ? true : undefined,
 				includeWithoutMain: includeWithoutMain ? true : undefined,
+				kinds: itemKind !== 'all' ? itemKind : undefined,
 				// Selecting an owner/folder scopes the paged stream to it server-side,
 				// so a folder's full contents load on demand rather than relying on the
 				// folder happening to be within the loaded browse window.
@@ -312,9 +336,28 @@
 	// Per-top-level-folder lazy loading for tree view: expanding a folder loads its
 	// items on demand (server-scoped to that folder), paginated within the folder,
 	// instead of relying on the global browse window. Keyed by folder name (the
-	// `f/<name>` node). Loaded items are merged into the shared arrays.
+	// `f/<name>` node).
+	//
+	// Folder items live in their OWN store (`treeFolderItems`), never merged into the
+	// global browse arrays: those advance by a single `serverCursor`, so injecting
+	// out-of-window folder rows there would make the flat stream non-contiguous and,
+	// once pagination reached those rows, duplicate them. `treeGen` ties every folder
+	// request to the active query scope (order/archived/library/kind/workspace); a
+	// reset bumps it so an in-flight response from a stale scope is discarded.
 	type FolderLoadState = { cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
 	let folderLoad = $state<Record<string, FolderLoadState>>({})
+	let treeFolderItems = $state<ItemType[]>([])
+	let treeGen = 0
+
+	// The endpoint returns a unified `edited_at` per row; combinedItems derives every
+	// kind's sort time from it (scripts read it as `created_at`, see mapRunnable), so
+	// the folder store mirrors that to keep tree ordering consistent with the list.
+	function toTreeItem(it: RunnableItem): ItemType {
+		return {
+			...mapRunnable(it),
+			time: new Date(it.edited_at ?? 0).getTime()
+		} as unknown as ItemType
+	}
 
 	async function loadFolderItems(folder: string, more = false): Promise<void> {
 		const ws = $workspaceStore
@@ -322,6 +365,7 @@
 		const st = folderLoad[folder]
 		if (st?.loading) return
 		if (more ? !st?.hasMore : st?.loaded) return
+		const gen = treeGen
 		folderLoad[folder] = {
 			cursor: st?.cursor,
 			hasMore: st?.hasMore ?? false,
@@ -337,16 +381,31 @@
 				orderDesc,
 				showArchived: archived ? true : undefined,
 				includeWithoutMain: includeWithoutMain ? true : undefined,
+				kinds: itemKind !== 'all' ? itemKind : undefined,
 				pathStart: `f/${folder}/`,
 				perPage: 100,
 				cursor: more ? st?.cursor : undefined
 			})
 		} catch (e: any) {
+			if (gen !== treeGen) return
 			folderLoad[folder] = { ...folderLoad[folder], loading: false }
 			sendUserToast(`Failed to load folder ${folder}: ${e?.body ?? e?.message ?? e}`, true)
 			return
 		}
-		mergeRunnables(res.items ?? [])
+		// The scope moved on while this was in flight (order/archive/library/kind/
+		// workspace changed and reset the tree); drop the response so stale rows from
+		// another scope can't appear under the current one.
+		if (gen !== treeGen) return
+		const have = new Set(treeFolderItems.map(itemKey))
+		const merged = [...treeFolderItems]
+		for (const it of res.items ?? []) {
+			// Pipeline-member scripts are folded into their folder's Pipeline entry, so
+			// they never render as their own tree leaf (visiblePipelineFolders drives it).
+			if (it.type === 'script' && it.auto_kind === 'pipeline') continue
+			if (have.has(itemKey(it))) continue
+			merged.push(toTreeItem(it))
+		}
+		treeFolderItems = merged
 		folderLoad[folder] = {
 			cursor: res.next_cursor,
 			hasMore: !!res.next_cursor,
@@ -557,6 +616,7 @@
 		Array.from(
 			new Set([
 				...allFolderOwners,
+				...allUserOwners,
 				...(filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? [])
 			])
 		).sort()
@@ -566,17 +626,21 @@
 	// entering/leaving search. Label/kind filtering and fuzzy ranking stay
 	// client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
-	// Lazy folder tree is active when browsing all (no owner, no search): show every
-	// folder as a top-level node and paginate each on expand. When a folder is
-	// selected or searching, the tree groups the (already-scoped) loaded items and
-	// the global "load more" applies within that scope.
-	let treeInjectFolders = $derived(
-		!searching && ownerFilter == undefined ? (folderNamesRes.current ?? []) : []
-	)
-	let treeGlobalHasMore = $derived(ownerFilter != undefined && !searching ? hasMoreServer : false)
+	// Lazy folder tree is active when browsing all (no owner selected, no search, no
+	// label filter): every folder shows as a top-level node and paginates on expand,
+	// its items coming from the separate `treeFolderItems` store. A selected owner,
+	// an active search, or a label filter instead groups the global loaded window
+	// (label filtering is client-side over loaded rows, so it must see that window).
+	let treeLazyMode = $derived(!searching && ownerFilter == undefined && labelFilter == undefined)
+	let treeInjectFolders = $derived(treeLazyMode ? (folderNamesRes.current ?? []) : [])
+	// Keep the global "load more" outside search: in lazy mode it advances the browse
+	// stream to surface more user/loose top-level items (folder rows from it are
+	// ignored by treeSource — folders come from the store); in scoped mode it pages
+	// within the selected owner.
+	let treeGlobalHasMore = $derived(!searching ? hasMoreServer : false)
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
-			;[archived, includeWithoutMain, sortOrder, searching, ownerFilter]
+			;[archived, includeWithoutMain, sortOrder, searching, ownerFilter, itemKind]
 			untrack(() => {
 				loadRunnables(true)
 			})
@@ -595,6 +659,7 @@
 		const showArchived = archived
 		const withoutMain = includeWithoutMain
 		const owner = ownerFilter
+		const kind = itemKind
 		if (term === '' || !ws || !$userStore) return
 		const handle = setTimeout(async () => {
 			let res: { items: RunnableItem[] }
@@ -604,6 +669,7 @@
 					search: term,
 					showArchived: showArchived ? true : undefined,
 					includeWithoutMain: withoutMain ? true : undefined,
+					kinds: kind !== 'all' ? kind : undefined,
 					pathStart: owner ? owner + '/' : undefined,
 					perPage: 1000
 				})
@@ -618,7 +684,8 @@
 				untrack(() => filter) !== term ||
 				untrack(() => archived) !== showArchived ||
 				untrack(() => includeWithoutMain) !== withoutMain ||
-				untrack(() => ownerFilter) !== owner
+				untrack(() => ownerFilter) !== owner ||
+				untrack(() => itemKind) !== kind
 			)
 				return
 			mergeRunnables(res.items ?? [])
@@ -670,17 +737,32 @@
 		}
 		prevWorkspace = ws
 	})
-	// The owner/folder filter is resolved server-side (path_start), so only the
-	// kind, user-folder toggle and label filters run client-side here.
+	// The kind and owner/folder filters are resolved server-side (kinds, path_start),
+	// so only the user-folder toggle and label filters run client-side here.
 	let preFilteredItems = $derived(
 		combinedItems?.filter(
 			(x) =>
-				(x.type == itemKind || itemKind == 'all') &&
 				filterItemsPathsBaseOnUserFilters(x, filterUserFolders, filterUserFoldersType) &&
 				(labelFilter == undefined || itemLabels(x).includes(labelFilter))
 		)
 	)
 	let items = $derived(filter !== '' ? filteredItems : preFilteredItems)
+	// Source the tree groups. In lazy mode, folder rows come from the on-demand
+	// `treeFolderItems` store while user/loose top-level rows come from the global
+	// window (its folder rows are dropped here so they don't double the store); every
+	// folder is injected as a node (see treeInjectFolders) whether or not it's loaded.
+	// Otherwise (scoped/search/label) the tree just groups the global `items`.
+	let treeSource = $derived(
+		treeLazyMode
+			? [...treeFolderItems, ...(preFilteredItems ?? []).filter((x) => !x.path.startsWith('f/'))]
+			: items
+	)
+	// Scope identity for the tree: any change here means folders must re-load fresh,
+	// so it keys a {#key} remount that collapses expanded folders (searching is a
+	// boolean so per-keystroke query changes don't remount — search updates in place).
+	let treeKey = $derived(
+		`${$workspaceStore}|${sortOrder}|${archived}|${includeWithoutMain}|${itemKind}|${ownerFilter}|${searching}|${labelFilter}`
+	)
 	let displayedItems = $derived((items ?? []).slice(0, nbDisplayed))
 	$effect(() => {
 		items && resetScroll()
@@ -1209,30 +1291,35 @@
 				</div>
 			{/if}
 		{:else if treeView}
-			<TreeViewRoot
-				{items}
-				{nbDisplayed}
-				{collapseAll}
-				sortCompare={compareItems}
-				hasMoreServer={treeGlobalHasMore}
-				onLoadMore={fetchMoreServer}
-				pipelineFolders={visiblePipelineFolders}
-				allFolders={treeInjectFolders}
-				{folderLoad}
-				onExpandFolder={loadFolderItems}
-				isSearching={filter !== ''}
-				on:scriptChanged={() => loadScripts(includeWithoutMain)}
-				on:flowChanged={loadFlows}
-				on:appChanged={loadApps}
-				on:rawAppChanged={loadRawApps}
-				on:reload={() => {
-					loadScripts(includeWithoutMain)
-					loadFlows()
-					loadApps()
-					loadRawApps()
-				}}
-				{showCode}
-			/>
+			<!-- Remount the tree on any scope change so expanded folders (their `opened`
+			     state is local to each TreeView) collapse and re-load fresh under the new
+			     order/archive/library/kind/owner rather than lingering with stale rows. -->
+			{#key treeKey}
+				<TreeViewRoot
+					items={treeSource}
+					{nbDisplayed}
+					{collapseAll}
+					sortCompare={compareItems}
+					hasMoreServer={treeGlobalHasMore}
+					onLoadMore={fetchMoreServer}
+					pipelineFolders={visiblePipelineFolders}
+					allFolders={treeInjectFolders}
+					{folderLoad}
+					onExpandFolder={loadFolderItems}
+					isSearching={filter !== ''}
+					on:scriptChanged={() => loadScripts(includeWithoutMain)}
+					on:flowChanged={loadFlows}
+					on:appChanged={loadApps}
+					on:rawAppChanged={loadRawApps}
+					on:reload={() => {
+						loadScripts(includeWithoutMain)
+						loadFlows()
+						loadApps()
+						loadRawApps()
+					}}
+					{showCode}
+				/>
+			{/key}
 		{:else}
 			<div class="border rounded-md bg-surface-tertiary">
 				{#if filter === ''}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -491,16 +491,28 @@
 	$effect(() => {
 		const term = filter
 		const ws = $workspaceStore
+		// Same view scope as the browse list, so a search can't surface archived /
+		// library items the current view excludes.
+		const showArchived = archived
+		const withoutMain = includeWithoutMain
 		if (term === '' || !ws || !$userStore) return
 		const handle = setTimeout(async () => {
 			let res: { items: RunnableItem[] }
 			try {
-				res = await ScriptService.listRunnables({ workspace: ws, search: term, perPage: 1000 })
+				res = await ScriptService.listRunnables({
+					workspace: ws,
+					search: term,
+					showArchived: showArchived ? true : undefined,
+					includeWithoutMain: withoutMain ? true : undefined,
+					perPage: 1000
+				})
 			} catch {
 				return
 			}
-			// Discard if the search moved on while the request was in flight.
-			if (untrack(() => filter) !== term) return
+			// Drop a stale response: the workspace or term moved on while it was in
+			// flight (debounce already cancels superseded timers; this guards the
+			// in-flight request so it never merges into a different workspace's list).
+			if (untrack(() => $workspaceStore) !== ws || untrack(() => filter) !== term) return
 			mergeRunnables(res.items ?? [])
 		}, 300)
 		return () => clearTimeout(handle)

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -134,6 +134,8 @@
 	// Keyset cursor for the next browse page; null once the stream is exhausted.
 	let serverCursor: string | undefined = undefined
 	let hasMoreServer = $state(false)
+	// Guards against out-of-order responses: only the latest request applies.
+	let loadGen = 0
 
 	// Sort selector value -> merged-endpoint order params.
 	function sortToParams(o: SortOrder): { orderBy: 'updated' | 'name'; orderDesc: boolean } {
@@ -151,15 +153,8 @@
 	}
 
 	function mapRunnable(it: RunnableItem): TableScript | TableFlow | TableApp {
-		// The endpoint serializes absent optional fields as null; the per-kind list
-		// contract omits them, so strip nulls to keep `undefined` (a null draft_users
-		// / labels would otherwise crash the row components on `.length`).
-		const clean: Record<string, unknown> = {}
-		for (const [k, v] of Object.entries(it)) {
-			if (v !== null) clean[k] = v
-		}
 		const base = {
-			...clean,
+			...it,
 			canWrite:
 				canWrite(it.path, (it.extra_perms ?? {}) as any, $userStore) &&
 				(it.type === 'script' || it.workspace_id == $workspaceStore) &&
@@ -187,6 +182,10 @@
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		const searching = filter !== ''
+		const gen = ++loadGen
+		// Snapshot the cursor now: a later request must not consume a cursor minted
+		// by an order/filter that has since changed.
+		const cursor = reset ? undefined : serverCursor
 		let res: { items: RunnableItem[]; next_cursor?: string }
 		try {
 			res = await ScriptService.listRunnables({
@@ -198,13 +197,17 @@
 				// A large page while searching so client fuzzy-match and facets see
 				// enough; browse pages are small and extended via the cursor.
 				perPage: searching ? 1000 : 100,
-				cursor: reset ? undefined : serverCursor
+				cursor
 			})
 		} catch (e: any) {
+			if (gen !== loadGen) return
 			loading = false
 			sendUserToast(`Failed to load items: ${e?.body ?? e?.message ?? e}`, true)
 			return
 		}
+		// A newer request superseded this one (e.g. order changed mid-flight); drop
+		// this response so a stale page/cursor can't be mixed with the new order.
+		if (gen !== loadGen) return
 		serverCursor = res.next_cursor ?? undefined
 		hasMoreServer = !!res.next_cursor
 
@@ -1024,6 +1027,8 @@
 				{nbDisplayed}
 				{collapseAll}
 				sortCompare={compareItems}
+				hasMoreServer={hasMoreServer && !searching}
+				onLoadMore={loadMore}
 				pipelineFolders={visiblePipelineFolders}
 				isSearching={filter !== ''}
 				on:scriptChanged={() => loadScripts(includeWithoutMain)}
@@ -1070,7 +1075,7 @@
 					/>
 				{/each}
 			</div>
-			{#if items && items?.length > 15 && hasMore}
+			{#if items && hasMore}
 				<span class="text-xs font-normal text-secondary"
 					>{Math.min(nbDisplayed, items.length)} items{hasMoreServer && !searching
 						? ''

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -177,8 +177,11 @@
 	async function loadRunnables(reset: boolean): Promise<void> {
 		const ws = $workspaceStore
 		if (!ws || !$userStore) return
+		// Only the very first load shows the skeleton; reorder/filter reloads keep
+		// the toolbar and current items visible (they're replaced on arrival) so the
+		// sort control itself doesn't flicker out when you use it.
+		if (scripts === undefined) loading = true
 		if (reset) {
-			loading = true
 			serverCursor = undefined
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -18,7 +18,7 @@
 	import type uFuzzy from '@leeoniya/ufuzzy'
 	import {
 		ArrowDownUp,
-		Check,
+		ChevronDown,
 		ChevronsDownUp,
 		ChevronsUpDown,
 		Code2,
@@ -27,6 +27,8 @@
 		SearchCode,
 		Tag
 	} from 'lucide-svelte'
+	import DropdownV2 from '$lib/components/DropdownV2.svelte'
+	import type { Item as MenuItem } from '$lib/utils'
 
 	import { HOME_SEARCH_SHOW_FLOW, HOME_SEARCH_PLACEHOLDER } from '$lib/consts'
 
@@ -220,9 +222,9 @@
 	const cmp = new Intl.Collator('en').compare
 
 	// Sort options are computed entirely client-side over the already-loaded item
-	// fields (`time`, `path`, `summary`), so adding options costs the backend
-	// nothing even on very large workspaces. Starred items stay pinned on top of
-	// every order, matching the previous behavior.
+	// fields (`time`, `path`, `summary`), so the backend query is unchanged and
+	// adding options costs it nothing even on very large workspaces. Starred items
+	// stay pinned on top of every order.
 	type SortOrder = 'updated_desc' | 'updated_asc' | 'name_asc' | 'name_desc'
 	const SORT_SETTING_NAME = 'homeSort'
 	const sortOptions: { value: SortOrder; label: string }[] = [
@@ -232,12 +234,18 @@
 		{ value: 'name_desc', label: 'Name (Z-A)' }
 	]
 	let sortOrder = $state<SortOrder>(
-		(sortOptions.find((o) => o.value === getLocalSetting(SORT_SETTING_NAME))?.value as SortOrder) ??
-			'updated_desc'
+		sortOptions.find((o) => o.value === getLocalSetting(SORT_SETTING_NAME))?.value ?? 'updated_desc'
 	)
 	$effect(() => {
 		storeLocalSetting(SORT_SETTING_NAME, sortOrder === 'updated_desc' ? undefined : sortOrder)
 	})
+	let sortItems: MenuItem[] = $derived(
+		sortOptions.map((o) => ({
+			displayName: o.label,
+			selected: o.value === sortOrder,
+			action: () => (sortOrder = o.value)
+		}))
+	)
 	function sortName(x: { summary?: string; path: string }): string {
 		return x.summary && x.summary !== '' ? x.summary : x.path
 	}
@@ -895,44 +903,30 @@
 					/>
 				{/if}
 				<Toggle size="xs" bind:checked={treeView} options={{ right: 'Tree view' }} />
-				<Popover floatingConfig={{ placement: 'bottom-end' }}>
-					{#snippet trigger()}
+				<DropdownV2
+					items={sortItems}
+					disabled={filter !== ''}
+					placement="bottom-end"
+					fixedHeight={false}
+				>
+					{#snippet buttonReplacement()}
 						<Button
-							startIcon={{ icon: ArrowDownUp }}
 							nonCaptureEvent
-							size="xs"
+							disabled={filter !== ''}
+							unifiedSize="xs"
 							color="light"
 							variant="default"
-							spacingSize="xs2"
-							title="Sort"
-							disabled={filter !== ''}
+							startIcon={{ icon: ArrowDownUp }}
+							endIcon={{ icon: ChevronDown }}
+							btnClasses="font-normal"
+							title={filter !== ''
+								? 'Sorting is disabled while searching (results are ranked by relevance)'
+								: 'Sort'}
 						>
 							{sortOptions.find((o) => o.value === sortOrder)?.label ?? 'Sort'}
 						</Button>
 					{/snippet}
-					{#snippet content({ close })}
-						<div class="p-1 flex flex-col">
-							{#each sortOptions as option (option.value)}
-								<button
-									class="text-left text-xs px-2 py-1.5 rounded hover:bg-surface-hover flex items-center gap-2 {option.value ===
-									sortOrder
-										? 'font-semibold text-emphasis'
-										: 'text-secondary'}"
-									onclick={() => {
-										sortOrder = option.value
-										close()
-									}}
-								>
-									<Check
-										size={14}
-										class={option.value === sortOrder ? 'opacity-100' : 'opacity-0'}
-									/>
-									{option.label}
-								</button>
-							{/each}
-						</div>
-					{/snippet}
-				</Popover>
+				</DropdownV2>
 				{#if treeView}
 					<Button
 						unifiedSize="sm"

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -229,15 +229,11 @@
 		if (reset) {
 			serverCursor = undefined
 			hasMoreServer = false
-			// The scope changed, so the lazily-loaded owner store and its per-owner
-			// cursors are stale. Bump treeGen first so any in-flight owner request is
-			// discarded on return, then clear. The tree remounts on the same scope key
-			// (see the {#key} around TreeViewRoot), collapsing owners so they re-load
-			// fresh on the next expand rather than lingering with old-scope rows.
-			treeGen++
-			ownerLoad = {}
-			treeOwnerItems = []
-			openOwners = new Set()
+			// Note: this resets only the global/flat stream. The lazy tree's own store
+			// (treeOwnerItems/ownerLoad/openOwners) is managed separately — a mode change
+			// clears it (see the treeKey effect), while an in-place sort/filter change
+			// replaces each open owner's rows atomically as they re-load (see
+			// loadOwnerItems), so expanded folders don't blank out mid-reorder.
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		const gen = ++loadGen
@@ -369,12 +365,14 @@
 	}
 
 	// `owner` is the full prefix: `f/<folder>` or `u/<username>`.
-	async function loadOwnerItems(owner: string, more = false): Promise<void> {
+	// `force` re-fetches an owner's first page even if already loaded (a re-sort /
+	// re-filter reload uses it to refresh the loaded rows in place).
+	async function loadOwnerItems(owner: string, more = false, force = false): Promise<void> {
 		const ws = $workspaceStore
 		if (!ws || !$userStore) return
 		const st = ownerLoad[owner]
 		if (st?.loading) return
-		if (more ? !st?.hasMore : st?.loaded) return
+		if (!force && (more ? !st?.hasMore : st?.loaded)) return
 		openOwners.add(owner)
 		const gen = treeGen
 		ownerLoad[owner] = {
@@ -407,8 +405,13 @@
 		// workspace changed and reset the tree); drop the response so stale rows from
 		// another scope can't appear under the current one.
 		if (gen !== treeGen) return
-		const have = new Set(treeOwnerItems.map(itemKey))
-		const merged = [...treeOwnerItems]
+		// A fresh load REPLACES this owner's rows (drop its previous ones, keep every
+		// other owner's untouched) so a re-sort/re-filter swaps its items atomically
+		// without blanking the whole tree; load-more appends to what's already shown.
+		const prefix = `${owner}/`
+		const base = more ? treeOwnerItems : treeOwnerItems.filter((x) => !x.path.startsWith(prefix))
+		const have = new Set(base.map(itemKey))
+		const merged = [...base]
 		for (const it of res.items ?? []) {
 			// Pipeline-member scripts are folded into their folder's Pipeline entry, so
 			// they never render as their own tree leaf (visiblePipelineFolders drives it).
@@ -436,9 +439,15 @@
 	// change (owner/search) has switched the tree out of lazy mode, there's nothing to
 	// re-fetch — the tree remounts and groups the global stream instead.
 	async function reloadItems(): Promise<void> {
+		// Invalidate any in-flight owner loads from the previous sort/filter so their
+		// late responses can't overwrite the fresh ones.
+		treeGen++
 		const toReload = treeLazyMode ? [...openOwners] : []
 		await loadRunnables(true)
-		for (const o of toReload) loadOwnerItems(o)
+		// force: the owners are still marked loaded, so re-fetch their first page and
+		// swap it in place (loadOwnerItems replaces each owner's rows atomically — the
+		// old rows stay visible until the new ones arrive, so nothing blanks mid-reorder).
+		for (const o of toReload) loadOwnerItems(o, false, true)
 	}
 
 	function filterItemsPathsBaseOnUserFilters(
@@ -789,6 +798,19 @@
 	// by reloadItems re-fetching the open owners — so expanded folders don't collapse when
 	// you re-sort (searching is a boolean so per-keystroke query changes don't remount).
 	let treeKey = $derived(`${$workspaceStore}|${ownerFilter}|${searching}|${labelFilter}`)
+	// A mode change restructures the tree (it remounts on treeKey), so the lazy owner
+	// store is stale — clear it here (the global reset no longer does). An in-place
+	// sort/filter change leaves treeKey unchanged, so the store survives and its owners
+	// are refreshed in place instead of blanking.
+	$effect(() => {
+		treeKey
+		untrack(() => {
+			treeGen++
+			ownerLoad = {}
+			treeOwnerItems = []
+			openOwners = new Set()
+		})
+	})
 	let displayedItems = $derived((items ?? []).slice(0, nbDisplayed))
 	$effect(() => {
 		items && resetScroll()

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -523,9 +523,17 @@
 	// path), so the client mirrors that.
 	let compareItems = $derived.by(() => {
 		const order = sortOrder
+		// Compare the endpoint's unified sort timestamp as a STRING, not a JS Date: the
+		// response carries microseconds (…​.375007Z) but Date.getTime() truncates to ms,
+		// so two rows in the same millisecond would tie client-side and be re-ordered,
+		// letting a later server page jump above shown rows. Lexicographic order on the
+		// fixed ISO format is chronological. (Every kind's sort time is `edited_at` — for
+		// scripts mapRunnable sets it from the endpoint's value.)
+		const tcmp = (x?: string, y?: string) =>
+			(x ?? '') < (y ?? '') ? -1 : (x ?? '') > (y ?? '') ? 1 : 0
 		return (
-			a: { starred?: boolean; time?: number; summary?: string; path: string; type?: string },
-			b: { starred?: boolean; time?: number; summary?: string; path: string; type?: string }
+			a: { starred?: boolean; edited_at?: string; summary?: string; path: string; type?: string },
+			b: { starred?: boolean; edited_at?: string; summary?: string; path: string; type?: string }
 		): number => {
 			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
 			// Match the endpoint's ordering exactly so a row on a later server page can't
@@ -537,7 +545,7 @@
 			let asc: boolean
 			switch (order) {
 				case 'updated_asc':
-					primary = (a.time ?? 0) - (b.time ?? 0)
+					primary = tcmp(a.edited_at, b.edited_at)
 					asc = true
 					break
 				case 'name_asc':
@@ -550,7 +558,7 @@
 					break
 				case 'updated_desc':
 				default:
-					primary = (b.time ?? 0) - (a.time ?? 0)
+					primary = tcmp(b.edited_at, a.edited_at)
 					asc = false
 					break
 			}
@@ -808,19 +816,27 @@
 	// Fetch the next page of search matches on demand — one page per click, so a broad
 	// search stays complete without auto-loading the entire workspace into memory.
 	async function loadMoreSearchResults(): Promise<void> {
+		// Capture the full scope: a cursor only encodes the last row's sort keys, so two
+		// different scopes can mint the same cursor — the response must be rejected unless
+		// EVERY scope input still matches, not just workspace + cursor.
 		const ws = $workspaceStore
+		const term = filter
+		const showArchived = archived
+		const withoutMain = includeWithoutMain
+		const owner = ownerFilter
+		const kind = itemKind
 		const cursor = searchCursor
-		if (!cursor || !ws || filter === '' || searchLoadingMore) return
+		if (!cursor || !ws || term === '' || searchLoadingMore) return
 		searchLoadingMore = true
 		let res: { items: RunnableItem[]; next_cursor?: string }
 		try {
 			res = await ScriptService.listRunnables({
 				workspace: ws,
-				search: filter,
-				showArchived: archived ? true : undefined,
-				includeWithoutMain: includeWithoutMain ? true : undefined,
-				kinds: itemKind !== 'all' ? itemKind : undefined,
-				pathStart: ownerFilter ? ownerFilter + '/' : undefined,
+				search: term,
+				showArchived: showArchived ? true : undefined,
+				includeWithoutMain: withoutMain ? true : undefined,
+				kinds: kind !== 'all' ? kind : undefined,
+				pathStart: owner ? owner + '/' : undefined,
 				perPage: 1000,
 				cursor
 			})
@@ -829,9 +845,17 @@
 			return
 		}
 		searchLoadingMore = false
-		// The term/scope may have moved on (which reset searchCursor); only merge and
-		// advance if this page is still the current one.
-		if (untrack(() => $workspaceStore) !== ws || filter === '' || searchCursor !== cursor) return
+		// Discard unless the term AND every view scope are still the ones we fetched for.
+		if (
+			untrack(() => $workspaceStore) !== ws ||
+			untrack(() => filter) !== term ||
+			untrack(() => archived) !== showArchived ||
+			untrack(() => includeWithoutMain) !== withoutMain ||
+			untrack(() => ownerFilter) !== owner ||
+			untrack(() => itemKind) !== kind ||
+			untrack(() => searchCursor) !== cursor
+		)
+			return
 		mergeRunnables(res.items ?? [])
 		searchCursor = res.next_cursor
 		// Reveal the freshly fetched matches instead of leaving them behind the display cap.

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -761,10 +761,11 @@
 			untrack(() => ownerFilter) !== owner ||
 			untrack(() => itemKind) !== kind
 		const handle = setTimeout(async () => {
+			// Page the search cursor to exhaustion so it stays workspace-complete at any
+			// match count; the debounce + stale() guard abort as soon as the term/scope
+			// changes, so a broad term never keeps paging an abandoned query.
 			let cursor: string | undefined = undefined
-			// Page to exhaustion so search stays workspace-complete beyond the first
-			// 1000 matches; the page cap bounds a pathologically broad term.
-			for (let page = 0; page < 20; page++) {
+			do {
 				let res: { items: RunnableItem[]; next_cursor?: string }
 				try {
 					res = await ScriptService.listRunnables({
@@ -783,8 +784,7 @@
 				if (stale()) return
 				mergeRunnables(res.items ?? [])
 				cursor = res.next_cursor
-				if (!cursor) break
-			}
+			} while (cursor)
 		}, 300)
 		return () => clearTimeout(handle)
 	})
@@ -1407,9 +1407,11 @@
 				</div>
 			{/if}
 		{:else if treeView}
-			<!-- Remount the tree on any scope change so expanded folders (their `opened`
-			     state is local to each TreeView) collapse and re-load fresh under the new
-			     order/archive/library/kind/owner rather than lingering with stale rows. -->
+			<!-- Remount the tree on a MODE change only (treeKey = view/owner/search/label):
+			     expanded folders (their `opened` state is local to each TreeView) collapse
+			     and re-load fresh for the new mode. An in-place order/archive/library/kind
+			     change keeps treeKey stable, so folders stay open and refresh via
+			     reloadItems instead (see loadOwnerItems). -->
 			{#key treeKey}
 				<TreeViewRoot
 					items={treeSource}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -639,11 +639,14 @@
 	// (label filtering is client-side over loaded rows, so it must see that window).
 	let treeLazyMode = $derived(!searching && ownerFilter == undefined && labelFilter == undefined)
 	let treeInjectFolders = $derived(treeLazyMode ? (folderNamesRes.current ?? []) : [])
-	// Keep the global "load more" outside search: in lazy mode it advances the browse
-	// stream to surface more user/loose top-level items (folder rows from it are
-	// ignored by treeSource — folders come from the store); in scoped mode it pages
-	// within the selected owner.
-	let treeGlobalHasMore = $derived(!searching ? hasMoreServer : false)
+	// The bottom "load more" only pages the *global* stream, which in lazy mode holds
+	// folder rows the tree ignores (folders come from the store and are all injected
+	// already) — so surfacing it there is confusing. Restrict it to scoped mode, where
+	// it pages within the selected owner. In lazy mode the footer instead reveals more
+	// root nodes purely client-side (nbDisplayed) when there are more than are shown,
+	// and each folder paginates within itself; users past the window are reached via
+	// their owner chip.
+	let treeGlobalHasMore = $derived(ownerFilter != undefined && !searching ? hasMoreServer : false)
 	$effect(() => {
 		if ($userStore && $workspaceStore) {
 			;[archived, includeWithoutMain, sortOrder, searching, ownerFilter, itemKind]

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -124,11 +124,20 @@
 		() => $workspaceStore,
 		async (ws) => {
 			if (!ws) return [] as string[]
+			// Page to exhaustion: listFolderNames is capped per page, so a workspace
+			// with more folders than the cap would otherwise be truncated.
+			const perPage = 1000
+			const all: string[] = []
 			try {
-				return await FolderService.listFolderNames({ workspace: ws })
+				for (let page = 1; ; page++) {
+					const batch = await FolderService.listFolderNames({ workspace: ws, page, perPage })
+					all.push(...batch)
+					if (batch.length < perPage) break
+				}
 			} catch {
-				return [] as string[]
+				// Best-effort facet; return whatever we gathered.
 			}
+			return all
 		}
 	)
 	let allFolderOwners = $derived((folderNamesRes.current ?? []).map((f) => `f/${f}`))

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -229,14 +229,15 @@
 		if (reset) {
 			serverCursor = undefined
 			hasMoreServer = false
-			// The scope changed, so the lazily-loaded folder store and its per-folder
-			// cursors are stale. Bump treeGen first so any in-flight folder request is
+			// The scope changed, so the lazily-loaded owner store and its per-owner
+			// cursors are stale. Bump treeGen first so any in-flight owner request is
 			// discarded on return, then clear. The tree remounts on the same scope key
-			// (see the {#key} around TreeViewRoot), collapsing folders so they re-load
+			// (see the {#key} around TreeViewRoot), collapsing owners so they re-load
 			// fresh on the next expand rather than lingering with old-scope rows.
 			treeGen++
-			folderLoad = {}
-			treeFolderItems = []
+			ownerLoad = {}
+			treeOwnerItems = []
+			openOwners = new Set()
 		}
 		const { orderBy, orderDesc } = sortToParams(sortOrder)
 		const gen = ++loadGen
@@ -338,20 +339,28 @@
 	// instead of relying on the global browse window. Keyed by folder name (the
 	// `f/<name>` node).
 	//
-	// Folder items live in their OWN store (`treeFolderItems`), never merged into the
-	// global browse arrays: those advance by a single `serverCursor`, so injecting
-	// out-of-window folder rows there would make the flat stream non-contiguous and,
-	// once pagination reached those rows, duplicate them. `treeGen` ties every folder
-	// request to the active query scope (order/archived/library/kind/workspace); a
-	// reset bumps it so an in-flight response from a stale scope is discarded.
-	type FolderLoadState = { cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
-	let folderLoad = $state<Record<string, FolderLoadState>>({})
-	let treeFolderItems = $state<ItemType[]>([])
+	// Every top-level namespace — a folder (`f/<name>`) OR a user (`u/<name>`) — is a
+	// lazily-loaded owner, keyed here by its full path prefix. Its items live in their
+	// OWN store (`treeOwnerItems`), never merged into the global browse arrays: those
+	// advance by a single `serverCursor`, so injecting out-of-window rows there would
+	// make the flat stream non-contiguous and, once pagination reached those rows,
+	// duplicate them. Loading users lazily too (rather than sourcing them from the
+	// loaded window) is why a user node no longer vanishes under a name sort whose
+	// first page happens to be all folder rows. `treeGen` ties every request to the
+	// active scope (order/archived/library/kind/workspace); a reset bumps it so an
+	// in-flight response from a stale scope is discarded.
+	type OwnerLoadState = { cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+	let ownerLoad = $state<Record<string, OwnerLoadState>>({})
+	let treeOwnerItems = $state<ItemType[]>([])
 	let treeGen = 0
+	// Owners the user currently has expanded (full path prefixes). A reload re-fetches
+	// only these: ownerLoad also retains collapsed owners as a cache, so keying reloads
+	// off its entries would re-request every owner ever opened in this scope.
+	let openOwners = new Set<string>()
 
 	// The endpoint returns a unified `edited_at` per row; combinedItems derives every
 	// kind's sort time from it (scripts read it as `created_at`, see mapRunnable), so
-	// the folder store mirrors that to keep tree ordering consistent with the list.
+	// the owner store mirrors that to keep tree ordering consistent with the list.
 	function toTreeItem(it: RunnableItem): ItemType {
 		return {
 			...mapRunnable(it),
@@ -359,14 +368,16 @@
 		} as unknown as ItemType
 	}
 
-	async function loadFolderItems(folder: string, more = false): Promise<void> {
+	// `owner` is the full prefix: `f/<folder>` or `u/<username>`.
+	async function loadOwnerItems(owner: string, more = false): Promise<void> {
 		const ws = $workspaceStore
 		if (!ws || !$userStore) return
-		const st = folderLoad[folder]
+		const st = ownerLoad[owner]
 		if (st?.loading) return
 		if (more ? !st?.hasMore : st?.loaded) return
+		openOwners.add(owner)
 		const gen = treeGen
-		folderLoad[folder] = {
+		ownerLoad[owner] = {
 			cursor: st?.cursor,
 			hasMore: st?.hasMore ?? false,
 			loading: true,
@@ -382,22 +393,22 @@
 				showArchived: archived ? true : undefined,
 				includeWithoutMain: includeWithoutMain ? true : undefined,
 				kinds: itemKind !== 'all' ? itemKind : undefined,
-				pathStart: `f/${folder}/`,
+				pathStart: `${owner}/`,
 				perPage: 100,
 				cursor: more ? st?.cursor : undefined
 			})
 		} catch (e: any) {
 			if (gen !== treeGen) return
-			folderLoad[folder] = { ...folderLoad[folder], loading: false }
-			sendUserToast(`Failed to load folder ${folder}: ${e?.body ?? e?.message ?? e}`, true)
+			ownerLoad[owner] = { ...ownerLoad[owner], loading: false }
+			sendUserToast(`Failed to load ${owner}: ${e?.body ?? e?.message ?? e}`, true)
 			return
 		}
 		// The scope moved on while this was in flight (order/archive/library/kind/
 		// workspace changed and reset the tree); drop the response so stale rows from
 		// another scope can't appear under the current one.
 		if (gen !== treeGen) return
-		const have = new Set(treeFolderItems.map(itemKey))
-		const merged = [...treeFolderItems]
+		const have = new Set(treeOwnerItems.map(itemKey))
+		const merged = [...treeOwnerItems]
 		for (const it of res.items ?? []) {
 			// Pipeline-member scripts are folded into their folder's Pipeline entry, so
 			// they never render as their own tree leaf (visiblePipelineFolders drives it).
@@ -405,8 +416,8 @@
 			if (have.has(itemKey(it))) continue
 			merged.push(toTreeItem(it))
 		}
-		treeFolderItems = merged
-		folderLoad[folder] = {
+		treeOwnerItems = merged
+		ownerLoad[owner] = {
 			cursor: res.next_cursor,
 			hasMore: !!res.next_cursor,
 			loading: false,
@@ -417,13 +428,16 @@
 	// A row was created/edited/archived/moved/shared. The merged endpoint returns
 	// every kind, so ONE reload refreshes the whole list — the per-kind change events
 	// all route here rather than each firing its own identical query. loadRunnables
-	// clears the lazy folder store, so re-fetch whatever folders were expanded (this
-	// is a same-scope reload: treeKey is unchanged, so those TreeView nodes stay open
-	// and would otherwise go blank).
+	// clears the lazy owner store, so re-fetch whatever owners were expanded (this is
+	// a same-scope reload: treeKey is unchanged, so those TreeView nodes stay open and
+	// would otherwise go blank).
+	function collapseOwner(owner: string): void {
+		openOwners.delete(owner)
+	}
 	async function reloadItems(): Promise<void> {
-		const openFolders = Object.keys(folderLoad)
+		const toReload = [...openOwners]
 		await loadRunnables(true)
-		for (const f of openFolders) loadFolderItems(f)
+		for (const o of toReload) loadOwnerItems(o)
 	}
 
 	function filterItemsPathsBaseOnUserFilters(
@@ -471,22 +485,18 @@
 	function sortName(x: { summary?: string; path: string }): string {
 		return x.summary && x.summary !== '' ? x.summary : x.path
 	}
-	// A $derived closure so its identity changes with `sortOrder`/`archived`, which
-	// both re-runs `combinedItems` (flat view) and re-groups the tree (TreeViewRoot
-	// depends on this prop). Starred items are pinned on top — but NOT in archived
-	// mode: there the endpoint deliberately leaves favorites in the single keyset
-	// stream (an archived path can span many versions), so re-pinning them client-side
-	// would make a favorited row on a later page jump above earlier rows when it loads,
-	// breaking both starred-first and the selected order. Mirror the backend's
-	// pin_starred = !show_archived.
+	// A $derived closure so its identity changes with `sortOrder`, which both re-runs
+	// `combinedItems` (flat view) and re-groups the tree (TreeViewRoot depends on this
+	// prop). Starred items are pinned on top in every order and view — the endpoint
+	// pins starred on the first page for both browse and archived (each is one row per
+	// path), so the client mirrors that.
 	let compareItems = $derived.by(() => {
 		const order = sortOrder
-		const pinStarred = !archived
 		return (
 			a: { starred?: boolean; time?: number; summary?: string; path: string },
 			b: { starred?: boolean; time?: number; summary?: string; path: string }
 		): number => {
-			if (pinStarred && !!a.starred !== !!b.starred) return a.starred ? -1 : 1
+			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
 			switch (order) {
 				case 'updated_asc':
 					return (a.time ?? 0) - (b.time ?? 0)
@@ -629,13 +639,22 @@
 	// entering/leaving search. Label/kind filtering and fuzzy ranking stay
 	// client-side over the loaded pages, so they don't reload here.
 	let searching = $derived(filter !== '')
-	// Lazy folder tree is active when browsing all (no owner selected, no search, no
-	// label filter): every folder shows as a top-level node and paginates on expand,
-	// its items coming from the separate `treeFolderItems` store. A selected owner,
-	// an active search, or a label filter instead groups the global loaded window
-	// (label filtering is client-side over loaded rows, so it must see that window).
+	// Lazy owner tree is active when browsing all (no owner selected, no search, no
+	// label filter): every folder AND user shows as a top-level node and paginates on
+	// expand, its items coming from the separate `treeOwnerItems` store. A selected
+	// owner, an active search, or a label filter instead groups the global loaded
+	// window (label filtering is client-side over loaded rows, so it must see it).
 	let treeLazyMode = $derived(!searching && ownerFilter == undefined && labelFilter == undefined)
 	let treeInjectFolders = $derived(treeLazyMode ? (folderNamesRes.current ?? []) : [])
+	let treeInjectUsers = $derived.by(() => {
+		if (!treeLazyMode) return []
+		const s = new Set(usernamesRes.current ?? [])
+		// Always inject your own personal space (u/<you>): list_usernames can be empty
+		// (you may not be a listed workspace member) yet u/<you> still holds runnables,
+		// and it must not vanish under a name sort whose first page is all folders.
+		if ($userStore?.username) s.add($userStore.username)
+		return [...s]
+	})
 	// The bottom "load more" only pages the *global* stream, which in lazy mode holds
 	// folder rows the tree ignores (folders come from the store and are all injected
 	// already) — so surfacing it there is confusing. Restrict it to scoped mode, where
@@ -753,16 +772,11 @@
 		)
 	)
 	let items = $derived(filter !== '' ? filteredItems : preFilteredItems)
-	// Source the tree groups. In lazy mode, folder rows come from the on-demand
-	// `treeFolderItems` store while user/loose top-level rows come from the global
-	// window (its folder rows are dropped here so they don't double the store); every
-	// folder is injected as a node (see treeInjectFolders) whether or not it's loaded.
+	// Source the tree groups. In lazy mode every top-level owner (folder and user) is
+	// injected as a node and its rows come from the on-demand `treeOwnerItems` store,
+	// so the tree never depends on which owners happen to be in the loaded window.
 	// Otherwise (scoped/search/label) the tree just groups the global `items`.
-	let treeSource = $derived(
-		treeLazyMode
-			? [...treeFolderItems, ...(preFilteredItems ?? []).filter((x) => !x.path.startsWith('f/'))]
-			: items
-	)
+	let treeSource = $derived(treeLazyMode ? treeOwnerItems : items)
 	// Scope identity for the tree: any change here means folders must re-load fresh,
 	// so it keys a {#key} remount that collapses expanded folders (searching is a
 	// boolean so per-keystroke query changes don't remount — search updates in place).
@@ -1310,8 +1324,10 @@
 					onLoadMore={fetchMoreServer}
 					pipelineFolders={visiblePipelineFolders}
 					allFolders={treeInjectFolders}
-					folderLoad={treeLazyMode ? folderLoad : undefined}
-					onExpandFolder={treeLazyMode ? loadFolderItems : undefined}
+					allUsers={treeInjectUsers}
+					ownerLoad={treeLazyMode ? ownerLoad : undefined}
+					onExpandOwner={treeLazyMode ? loadOwnerItems : undefined}
+					onCollapseOwner={treeLazyMode ? collapseOwner : undefined}
 					isSearching={filter !== ''}
 					on:scriptChanged={reloadItems}
 					on:flowChanged={reloadItems}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -524,14 +524,15 @@
 	let compareItems = $derived.by(() => {
 		const order = sortOrder
 		return (
-			a: { starred?: boolean; time?: number; summary?: string; path: string },
-			b: { starred?: boolean; time?: number; summary?: string; path: string }
+			a: { starred?: boolean; time?: number; summary?: string; path: string; type?: string },
+			b: { starred?: boolean; time?: number; summary?: string; path: string; type?: string }
 		): number => {
 			if (!!a.starred !== !!b.starred) return a.starred ? -1 : 1
 			// Match the endpoint's ordering exactly so a row on a later server page can't
-			// jump above already-shown rows on "load more": names compare case-insensitively
-			// (the endpoint sorts on `lower(summary-or-path)`), and the secondary key is the
-			// path in the SAME direction as the primary (server: `<col> <dir>, path <dir>`).
+			// jump above already-shown rows on "load more". The server orders by
+			// `<col> <dir>, path <dir>, kind <dir>`: names compare case-insensitively (it
+			// sorts on `lower(summary-or-path)`), then path, then kind ('app' < 'flow' <
+			// 'script'), each in the same direction as the primary.
 			let primary: number
 			let asc: boolean
 			switch (order) {
@@ -554,7 +555,7 @@
 					break
 			}
 			if (primary !== 0) return primary
-			const p = a.path.localeCompare(b.path)
+			const p = a.path.localeCompare(b.path) || (a.type ?? '').localeCompare(b.type ?? '')
 			return asc ? p : -p
 		}
 	})
@@ -929,9 +930,9 @@
 	})
 
 	let selectedIndex: number = $state(-1)
-	// More to show: either loaded items not yet sliced in, or the server has
-	// further browse pages (not while searching — search loads one large page and
-	// filters client-side).
+	// More to show: either loaded items not yet sliced in, or the server has further
+	// browse pages (not while searching — the browse cursor is paused then; further
+	// search matches load on demand via searchCursor / "Load more results").
 	let hasMore = $derived(
 		items != undefined && (items.length > nbDisplayed || (hasMoreServer && !searching))
 	)

--- a/frontend/src/lib/components/home/NoItemFound.svelte
+++ b/frontend/src/lib/components/home/NoItemFound.svelte
@@ -1,24 +1,39 @@
 <script lang="ts">
 	interface Props {
 		hasFilters?: boolean
+		// When provided (home page), it's the authoritative list of active filters:
+		// non-empty means the current filters are too narrow (and are listed to the
+		// user); empty means the workspace itself has no items. Takes precedence over
+		// `hasFilters`, which other callers still use as a plain boolean.
+		activeFilters?: string[]
 	}
 
-	let { hasFilters = false }: Props = $props()
+	let { hasFilters = false, activeFilters }: Props = $props()
+
+	let narrowed = $derived(activeFilters != undefined ? activeFilters.length > 0 : hasFilters)
 </script>
 
-{#if hasFilters}
+{#if narrowed}
 	<div class="flex justify-center items-center h-48">
-		<div class="text-primary text-center">
-			<div class="text-lg font-semibold text-emphasis">No items found</div>
-			<div class="text-xs font-normal text-hint">Try changing your search or filters</div>
+		<div class="text-primary text-center max-w-md px-4">
+			<div class="text-lg font-semibold text-emphasis">No items match the current filters</div>
+			{#if activeFilters && activeFilters.length > 0}
+				<div class="text-xs font-normal text-hint mt-1">
+					Active: {activeFilters.join(' · ')}
+				</div>
+				<div class="text-xs font-normal text-hint mt-0.5">Clear or widen them to see more.</div>
+			{:else}
+				<div class="text-xs font-normal text-hint">Try changing your search or filters</div>
+			{/if}
 		</div>
 	</div>
 {:else}
 	<div class="flex justify-center items-center h-48">
 		<div class="text-primary text-center">
 			<div class="text-lg font-semibold text-emphasis">Welcome to Windmill</div>
-			<div class="text-xs font-normal text-hint">Get started by creating your first script, flow, or app</div>
+			<div class="text-xs font-normal text-hint">
+				Get started by creating your first script, flow, or app
+			</div>
 		</div>
 	</div>
 {/if}
-

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -53,6 +53,14 @@
 	let opened: boolean = $state(true)
 
 	let showMax = $state(15)
+	// A lazy top-level folder paginates server-side ("Load more in this folder"),
+	// so show all of its already-loaded items rather than the tight client slice
+	// (which would add a second, confusing "Show more" button).
+	let effectiveMax = $derived(
+		depth === 0 && isFolderItem(item) && folderLoad?.[item.folderName] != undefined
+			? item.items.length
+			: showMax
+	)
 	$effect(() => {
 		opened = !collapseAll
 		// Expand-all opens folders; lazy-load a top-level folder's items when it
@@ -120,7 +128,7 @@
 						<span class="text-xs font-medium text-emphasis">Pipeline</span>
 					</a>
 				{/if}
-				{#each item.items.slice(0, showMax) as subItem, index ((subItem['path'] ? subItem['type'] + '__' + subItem['path'] + '__' + index : undefined) ?? 'folder__' + subItem['folderName'] + '__' + index)}
+				{#each item.items.slice(0, effectiveMax) as subItem, index ((subItem['path'] ? subItem['type'] + '__' + subItem['path'] + '__' + index : undefined) ?? 'folder__' + subItem['folderName'] + '__' + index)}
 					<TreeView
 						{isSearching}
 						{collapseAll}
@@ -135,7 +143,7 @@
 						depth={depth + 1}
 					/>
 				{/each}
-				{#if showMax < item.items.length}
+				{#if effectiveMax < item.items.length}
 					<!-- svelte-ignore a11y_click_events_have_key_events -->
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div
@@ -202,7 +210,7 @@
 		</div>
 		{#if opened || isSearching}
 			<div>
-				{#each item.items.slice(0, showMax) as subItem, index ((subItem['path'] ? subItem['type'] + '__' + subItem['path'] + '__' + index : undefined) ?? 'folder__' + subItem['folderName'] + '__' + index)}
+				{#each item.items.slice(0, effectiveMax) as subItem, index ((subItem['path'] ? subItem['type'] + '__' + subItem['path'] + '__' + index : undefined) ?? 'folder__' + subItem['folderName'] + '__' + index)}
 					<TreeView
 						{collapseAll}
 						item={subItem}
@@ -215,7 +223,7 @@
 						depth={depth + 1}
 					/>
 				{/each}
-				{#if showMax < item.items.length}
+				{#if effectiveMax < item.items.length}
 					<!-- svelte-ignore a11y_click_events_have_key_events -->
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -95,20 +95,23 @@
 	)
 
 	$effect(() => {
-		const willOpen = !collapseAll
-		opened = willOpen
+		// "Expand all" opens every node — EXCEPT top-level owners past the request cap:
+		// opening those without loading would leave them empty and, worse, take two
+		// clicks to load (first click just collapses). Keep them closed so one click
+		// opens+loads them. The cap bounds the request burst at a large nbDisplayed.
+		const cappedOwner =
+			!collapseAll && depth === 0 && ownerKey != undefined && rootIndex >= EXPAND_ALL_LOAD_LIMIT
+		const shouldOpen = !collapseAll && !cappedOwner
+		opened = shouldOpen
 		untrack(() => {
 			if (ownerKey == undefined) return
-			if (willOpen) {
-				// "Expand all" opens this owner; load it too so it isn't opened empty — but
-				// only for the first EXPAND_ALL_LOAD_LIMIT rendered roots, so a large
-				// nbDisplayed can't launch a request per owner. Beyond the cap, opening is
-				// visual only; the owner loads when clicked.
-				if (depth === 0 && rootIndex < EXPAND_ALL_LOAD_LIMIT) onExpandOwner?.(ownerKey)
+			if (shouldOpen) {
+				// Expand all opened+loads this in-cap owner.
+				onExpandOwner?.(ownerKey)
 			} else {
-				// "Collapse all" closes without a manual click, so untrack the owner here
-				// too — otherwise it lingers in openOwners and a later reload re-fetches
-				// every hidden owner, recreating the fan-out openOwners exists to prevent.
+				// Closed here (collapse all, or a capped owner under expand all): untrack it
+				// so a later reload doesn't re-fetch a hidden owner, recreating the fan-out
+				// openOwners exists to prevent.
 				onCollapseOwner?.(ownerKey)
 			}
 		})

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -88,17 +88,22 @@
 	$effect(() => {
 		const willOpen = !collapseAll
 		opened = willOpen
-		// "Collapse all" closes this node without a manual click, so untrack the owner
-		// here too — otherwise it lingers in openOwners and a later reload re-fetches
-		// every hidden owner, recreating the fan-out openOwners exists to prevent.
 		untrack(() => {
-			if (!willOpen && ownerKey != undefined) onCollapseOwner?.(ownerKey)
+			if (ownerKey == undefined) return
+			if (willOpen) {
+				// "Expand all" opens this owner; load it too so it isn't opened empty.
+				// Bounded: only the nbDisplayed root owners are rendered (TreeViewRoot
+				// slices to it), so this is a handful of requests — not one per workspace
+				// folder — and each renders a capped slice (see effectiveMax).
+				onExpandOwner?.(ownerKey)
+			} else {
+				// "Collapse all" closes without a manual click, so untrack the owner here
+				// too — otherwise it lingers in openOwners and a later reload re-fetches
+				// every hidden owner, recreating the fan-out openOwners exists to prevent.
+				onCollapseOwner?.(ownerKey)
+			}
 		})
 	})
-	// Deliberately NOT auto-loading an owner's items when it opens via collapseAll:
-	// with every folder and user injected as a top-level node, "expand all" would
-	// otherwise fire one request per owner (thousands on a large workspace). An owner
-	// loads only on an explicit click (see toggleOwner).
 	let lastToggle = 0
 	function toggleOwner() {
 		// A double-click would otherwise toggle twice — expand then immediately collapse,

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -194,9 +194,12 @@
 					</div>
 				{/if}
 				{#if ownerKey != undefined}
-					{#if ownerState?.loading}
+					{#if ownerState?.loading && item.items.length === 0}
+						<!-- Show the spinner only on the first load, when there's nothing yet. A
+						     re-sort/re-filter re-fetch keeps the old rows visible and swaps them
+						     in place, so flashing "Loading…" under them would just be noise. -->
 						<div class="text-center text-xs py-2 text-secondary">Loading…</div>
-					{:else if ownerState?.hasMore}
+					{:else if !ownerState?.loading && ownerState?.hasMore}
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -44,8 +44,8 @@
 	}: Props = $props()
 
 	// Bounds the request burst from "expand all": however many root owners are rendered
-	// (nbDisplayed can grow via "load 30 more"), it fetches at most this many. Owners
-	// past the cap open empty and load on an explicit click.
+	// (nbDisplayed can grow via "load 30 more"), it fetches at most this many. Lazy
+	// owners past the cap stay collapsed and load on a single click (see the effect).
 	const EXPAND_ALL_LOAD_LIMIT = 20
 
 	const isFolderItem = (i: typeof item): i is FolderItem => i && 'folderName' in i
@@ -95,23 +95,29 @@
 	)
 
 	$effect(() => {
-		// "Expand all" opens every node — EXCEPT top-level owners past the request cap:
-		// opening those without loading would leave them empty and, worse, take two
-		// clicks to load (first click just collapses). Keep them closed so one click
-		// opens+loads them. The cap bounds the request burst at a large nbDisplayed.
-		const cappedOwner =
-			!collapseAll && depth === 0 && ownerKey != undefined && rootIndex >= EXPAND_ALL_LOAD_LIMIT
-		const shouldOpen = !collapseAll && !cappedOwner
-		opened = shouldOpen
+		const expandAll = !collapseAll
 		untrack(() => {
+			// "Expand all" opens every node — EXCEPT LAZY top-level owners past the request
+			// cap: opening those without loading would leave them empty and take two clicks
+			// to load (the first would just collapse). Keep them closed so one click
+			// opens+loads them. Only lazy owners (ownerLoad present) issue requests, so a
+			// non-lazy owner (e.g. label-filtered mode, already loaded) is never capped.
+			const cappedOwner =
+				expandAll &&
+				depth === 0 &&
+				ownerKey != undefined &&
+				ownerLoad != undefined &&
+				rootIndex >= EXPAND_ALL_LOAD_LIMIT
+			const shouldOpen = expandAll && !cappedOwner
+			opened = shouldOpen
 			if (ownerKey == undefined) return
 			if (shouldOpen) {
-				// Expand all opened+loads this in-cap owner.
+				// Open+load this owner (onExpandOwner is a no-op for non-lazy owners).
 				onExpandOwner?.(ownerKey)
 			} else {
-				// Closed here (collapse all, or a capped owner under expand all): untrack it
-				// so a later reload doesn't re-fetch a hidden owner, recreating the fan-out
-				// openOwners exists to prevent.
+				// Closed here (collapse all, or a capped lazy owner): untrack it so a later
+				// reload doesn't re-fetch a hidden owner, recreating the fan-out openOwners
+				// exists to prevent.
 				onCollapseOwner?.(ownerKey)
 			}
 		})

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import TreeView from './TreeView.svelte'
+	import { untrack } from 'svelte'
 
 	import { ChevronDown, ChevronUp, Folder, FolderTree, NetworkIcon, User } from 'lucide-svelte'
 	import Item from './Item.svelte'
@@ -15,6 +16,13 @@
 		showCode: (path: string, summary: string) => void
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
+		// Lazy per-folder loading (top-level folders only): expanding a folder loads
+		// its items on demand and paginates within it.
+		folderLoad?: Record<
+			string,
+			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+		>
+		onExpandFolder?: (folder: string, more?: boolean) => void
 	}
 
 	let {
@@ -23,7 +31,9 @@
 		depth = 0,
 		showCode,
 		isSearching = false,
-		pipelineFolders
+		pipelineFolders,
+		folderLoad,
+		onExpandFolder
 	}: Props = $props()
 
 	const isFolderItem = (i: typeof item): i is FolderItem => i && 'folderName' in i
@@ -45,6 +55,12 @@
 	let showMax = $state(15)
 	$effect(() => {
 		opened = !collapseAll
+		// Expand-all opens folders; lazy-load a top-level folder's items when it
+		// opens. untrack so this only re-runs on collapseAll (not on item reloads,
+		// which would otherwise re-open a manually collapsed folder).
+		untrack(() => {
+			if (opened && depth === 0 && isFolder(item)) onExpandFolder?.(item.folderName)
+		})
 	})
 </script>
 
@@ -53,7 +69,11 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			onclick={() => (opened = !opened)}
+			onclick={() => {
+				opened = !opened
+				// Top-level folder: load its items on demand the first time it opens.
+				if (opened && depth === 0 && isFolder(item)) onExpandFolder?.(item.folderName)
+			}}
 			class="px-4 py-2 border-b w-full flex flex-row items-center justify-between cursor-pointer"
 		>
 			<div
@@ -129,6 +149,20 @@
 					>
 						Show more ({showMax}/{item.items.length})
 					</div>
+				{/if}
+				{#if depth === 0 && isFolder(item)}
+					{#if folderLoad?.[item.folderName]?.loading}
+						<div class="text-center text-xs py-2 text-secondary">Loading…</div>
+					{:else if folderLoad?.[item.folderName]?.hasMore}
+						<!-- svelte-ignore a11y_click_events_have_key_events -->
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<div
+							class="text-center text-xs py-2 text-primary cursor-pointer hover:text-emphasis"
+							onclick={() => isFolder(item) && onExpandFolder?.(item.folderName, true)}
+						>
+							Load more in this folder
+						</div>
+					{/if}
 				{/if}
 			</div>
 		{/if}

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -72,12 +72,16 @@
 	let ownerState = $derived(ownerKey != undefined ? ownerLoad?.[ownerKey] : undefined)
 
 	let showMax = $state(15)
-	// A lazy owner paginates server-side ("Load more"), so show all its already-loaded
-	// items rather than the tight client slice (which would add a second, confusing
-	// "Show more" button).
+	// A lazy owner paginates server-side ("Load more"), so when opened on its own it
+	// shows all its already-loaded rows (no second, confusing client "Show more").
+	// EXCEPT under "expand all" (collapseAll=false), which opens every visible owner at
+	// once — rendering all of each would be thousands of rows and freeze the tab — so
+	// there we cap to the client slice and let "Show more" reveal the rest per owner.
 	let effectiveMax = $derived(
 		isLazyOwner && ownerState != undefined && (isFolder(item) || isUser(item))
-			? item.items.length
+			? collapseAll
+				? item.items.length
+				: Math.min(item.items.length, showMax)
 			: showMax
 	)
 
@@ -207,7 +211,9 @@
 						     re-sort/re-filter re-fetch keeps the old rows visible and swaps them
 						     in place, so flashing "Loading…" under them would just be noise. -->
 						<div class="text-center text-xs py-2 text-secondary">Loading…</div>
-					{:else if !ownerState?.loading && ownerState?.hasMore}
+					{:else if !ownerState?.loading && ownerState?.hasMore && effectiveMax >= item.items.length}
+						<!-- Fetch the next server page only once every already-loaded row is shown
+						     (in "expand all" the client "Show more" above reveals those first). -->
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import TreeView from './TreeView.svelte'
+	import { untrack } from 'svelte'
 
 	import { ChevronDown, ChevronUp, Folder, FolderTree, NetworkIcon, User } from 'lucide-svelte'
 	import Item from './Item.svelte'
@@ -81,7 +82,14 @@
 	)
 
 	$effect(() => {
-		opened = !collapseAll
+		const willOpen = !collapseAll
+		opened = willOpen
+		// "Collapse all" closes this node without a manual click, so untrack the owner
+		// here too — otherwise it lingers in openOwners and a later reload re-fetches
+		// every hidden owner, recreating the fan-out openOwners exists to prevent.
+		untrack(() => {
+			if (!willOpen && ownerKey != undefined) onCollapseOwner?.(ownerKey)
+		})
 	})
 	// Deliberately NOT auto-loading an owner's items when it opens via collapseAll:
 	// with every folder and user injected as a top-level node, "expand all" would

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -15,13 +15,15 @@
 		showCode: (path: string, summary: string) => void
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
-		// Lazy per-folder loading (top-level folders only): expanding a folder loads
-		// its items on demand and paginates within it.
-		folderLoad?: Record<
+		// Lazy per-owner loading (top-level folders and users only): expanding an owner
+		// loads its items on demand and paginates within it. `ownerLoad` keys are full
+		// path prefixes (`f/<name>` / `u/<name>`).
+		ownerLoad?: Record<
 			string,
 			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
 		>
-		onExpandFolder?: (folder: string, more?: boolean) => void
+		onExpandOwner?: (owner: string, more?: boolean) => void
+		onCollapseOwner?: (owner: string) => void
 	}
 
 	let {
@@ -31,11 +33,15 @@
 		showCode,
 		isSearching = false,
 		pipelineFolders,
-		folderLoad,
-		onExpandFolder
+		ownerLoad,
+		onExpandOwner,
+		onCollapseOwner
 	}: Props = $props()
 
 	const isFolderItem = (i: typeof item): i is FolderItem => i && 'folderName' in i
+	const isFolder = isFolderItem
+	const isUser = (i: typeof item): i is UserItem => i && 'username' in i
+
 	// Hidden while searching: pipelines aren't part of the text filter (the list
 	// view hides their rows on a query too), so a folder matching the search
 	// shouldn't surface an unrelated Pipeline row.
@@ -46,52 +52,64 @@
 			(pipelineFolders?.has(item.folderName) ?? false)
 	)
 
-	const isFolder = isFolderItem
-	const isUser = (i: typeof item): i is UserItem => i && 'username' in i
-
 	let opened: boolean = $state(true)
 
-	// A top-level folder in lazy mode: its items are loaded on demand into a separate
-	// store (folderLoad tracks per-folder load state), so counts/pagination differ
-	// from a folder whose items are already grouped from the loaded window.
-	let isLazyFolder = $derived(depth === 0 && isFolderItem(item) && folderLoad != undefined)
+	// Full path prefix of this node when it's a top-level owner (folder or user).
+	let ownerKey = $derived(
+		depth === 0
+			? isFolder(item)
+				? `f/${item.folderName}`
+				: isUser(item)
+					? `u/${item.username}`
+					: undefined
+			: undefined
+	)
+	// A top-level owner in lazy mode: its items load on demand into a separate store
+	// (ownerLoad tracks per-owner state), so its count/pagination differ from a node
+	// whose items are already grouped from the loaded window.
+	let isLazyOwner = $derived(ownerKey != undefined && ownerLoad != undefined)
+	let ownerState = $derived(ownerKey != undefined ? ownerLoad?.[ownerKey] : undefined)
 
 	let showMax = $state(15)
-	// A lazy top-level folder paginates server-side ("Load more in this folder"),
-	// so show all of its already-loaded items rather than the tight client slice
-	// (which would add a second, confusing "Show more" button).
+	// A lazy owner paginates server-side ("Load more"), so show all its already-loaded
+	// items rather than the tight client slice (which would add a second, confusing
+	// "Show more" button).
 	let effectiveMax = $derived(
-		depth === 0 && isFolderItem(item) && folderLoad?.[item.folderName] != undefined
+		isLazyOwner && ownerState != undefined && (isFolder(item) || isUser(item))
 			? item.items.length
 			: showMax
 	)
+
 	$effect(() => {
 		opened = !collapseAll
 	})
-	// Deliberately NOT auto-loading a folder's items when it opens via collapseAll:
-	// with every workspace folder injected as a top-level node, "expand all" would
-	// otherwise fire one request per folder (thousands on a large workspace). A
-	// folder loads only on an explicit click (see toggleFolder).
-	let lastFolderToggle = 0
-	function toggleFolder() {
-		// A double-click would otherwise toggle twice — expand then immediately
-		// collapse, and for a lazy folder waste the fetch the first click kicked off,
-		// which reads as the folder "expanding and collapsing at once". Swallow a
-		// second toggle landing within 300ms so a rapid double-click settles open.
+	// Deliberately NOT auto-loading an owner's items when it opens via collapseAll:
+	// with every folder and user injected as a top-level node, "expand all" would
+	// otherwise fire one request per owner (thousands on a large workspace). An owner
+	// loads only on an explicit click (see toggleOwner).
+	let lastToggle = 0
+	function toggleOwner() {
+		// A double-click would otherwise toggle twice — expand then immediately collapse,
+		// and for a lazy owner waste the fetch the first click kicked off, which reads as
+		// the node "expanding and collapsing at once". Swallow a second toggle landing
+		// within 300ms so a rapid double-click settles open.
 		const now = Date.now()
-		if (now - lastFolderToggle < 300) return
-		lastFolderToggle = now
+		if (now - lastToggle < 300) return
+		lastToggle = now
 		opened = !opened
-		if (opened && depth === 0 && isFolder(item)) onExpandFolder?.(item.folderName)
+		if (ownerKey != undefined) {
+			if (opened) onExpandOwner?.(ownerKey)
+			else onCollapseOwner?.(ownerKey)
+		}
 	}
 </script>
 
-{#if isFolder(item)}
+{#if isFolder(item) || isUser(item)}
 	<div>
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			onclick={toggleFolder}
+			onclick={toggleOwner}
 			class="px-4 py-2 border-b w-full flex flex-row items-center justify-between cursor-pointer"
 		>
 			<div
@@ -99,7 +117,9 @@
 				style={depth > 0 ? `padding-left: ${depth * 16}px;` : ''}
 			>
 				<div class="flex justify-center items-center">
-					{#if depth === 0}
+					{#if isUser(item)}
+						<User size={16} class="text-secondary" />
+					{:else if depth === 0}
 						<Folder size={16} class="text-secondary" />
 					{:else}
 						<FolderTree size={16} class="text-secondary" />
@@ -107,15 +127,15 @@
 				</div>
 
 				<div>
-					<span class="whitespace-nowrap text-xs text-emphasis font-semibold"
-						>{#if depth === 0}f/{/if}{item.folderName}</span
-					>
+					<span class="whitespace-nowrap text-xs text-emphasis font-semibold">
+						{#if isUser(item)}u/{item.username}{:else}{#if depth === 0}f/{/if}{item.folderName}{/if}
+					</span>
 					<div class="text-2xs font-normal text-secondary whitespace-nowrap">
-						{#if isLazyFolder && !folderLoad?.[item.folderName]?.loaded}
-							<!-- Lazy folder not expanded yet: its true item count is unknown until
+						{#if isLazyOwner && !ownerState?.loaded}
+							<!-- Lazy owner not expanded yet: its true item count is unknown until
 							     loaded, so showing "(0 items)" would be misleading. -->
 							&nbsp;
-						{:else if isLazyFolder && folderLoad?.[item.folderName]?.hasMore}
+						{:else if isLazyOwner && ownerState?.hasMore}
 							({item.items.length}+ items)
 						{:else}
 							({pluralize(item.items.length, ' item')})
@@ -167,93 +187,25 @@
 					<div
 						class="text-center text-xs py-2 text-secondary cursor-pointer hover:text-primary"
 						onclick={() => {
-							if (isFolder(item)) {
-								showMax += Math.min(30, item.items.length - showMax)
-								showMax = showMax
-							}
+							showMax += Math.min(30, item.items.length - showMax)
 						}}
 					>
 						Show more ({showMax}/{item.items.length})
 					</div>
 				{/if}
-				{#if depth === 0 && isFolder(item)}
-					{#if folderLoad?.[item.folderName]?.loading}
+				{#if ownerKey != undefined}
+					{#if ownerState?.loading}
 						<div class="text-center text-xs py-2 text-secondary">Loading…</div>
-					{:else if folderLoad?.[item.folderName]?.hasMore}
+					{:else if ownerState?.hasMore}
 						<!-- svelte-ignore a11y_click_events_have_key_events -->
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div
 							class="text-center text-xs py-2 text-primary cursor-pointer hover:text-emphasis"
-							onclick={() => isFolder(item) && onExpandFolder?.(item.folderName, true)}
+							onclick={() => ownerKey != undefined && onExpandOwner?.(ownerKey, true)}
 						>
-							Load more in this folder
+							Load more
 						</div>
 					{/if}
-				{/if}
-			</div>
-		{/if}
-	</div>
-{:else if isUser(item)}
-	<div>
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			onclick={() => (opened = !opened)}
-			class="px-4 py-2 border-b w-full flex flex-row items-center justify-between cursor-pointer"
-		>
-			<div
-				class={twMerge('flex flex-row items-center gap-4 text-sm font-semibold')}
-				style={depth > 0 ? `padding-left: ${depth * 16}px;` : ''}
-			>
-				<div class="flex justify-center items-center">
-					<User size={16} class="text-secondary" />
-				</div>
-
-				<div>
-					<span class="whitespace-nowrap text-xs text-emphasis font-semibold"
-						>u/{item.username}</span
-					>
-					<div class="text-2xs font-normal text-secondary whitespace-nowrap"
-						>({pluralize(item.items.length, ' item')})</div
-					>
-				</div>
-			</div>
-			<div class="w-full flex flex-row-reverse">
-				{#if opened}
-					<ChevronUp size={16} />
-				{:else}
-					<ChevronDown size={16} />
-				{/if}
-			</div>
-		</div>
-		{#if opened || isSearching}
-			<div>
-				{#each item.items.slice(0, effectiveMax) as subItem, index ((subItem['path'] ? subItem['type'] + '__' + subItem['path'] + '__' + index : undefined) ?? 'folder__' + subItem['folderName'] + '__' + index)}
-					<TreeView
-						{collapseAll}
-						item={subItem}
-						on:scriptChanged
-						on:flowChanged
-						on:appChanged
-						on:rawAppChanged
-						on:reload
-						{showCode}
-						depth={depth + 1}
-					/>
-				{/each}
-				{#if effectiveMax < item.items.length}
-					<!-- svelte-ignore a11y_click_events_have_key_events -->
-					<!-- svelte-ignore a11y_no_static_element_interactions -->
-					<div
-						class="text-center text-xs text-secondary cursor-pointer py-2 hover:text-primary"
-						onclick={() => {
-							if (isUser(item)) {
-								showMax += Math.min(30, item.items.length - showMax)
-							}
-						}}
-					>
-						Show more ({showMax}/{item.items.length})
-					</div>
 				{/if}
 			</div>
 		{/if}

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -21,10 +21,13 @@
 		// path prefixes (`f/<name>` / `u/<name>`).
 		ownerLoad?: Record<
 			string,
-			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean; count: number }
 		>
 		onExpandOwner?: (owner: string, more?: boolean) => void
 		onCollapseOwner?: (owner: string) => void
+		// Position of this node among the rendered root nodes; "expand all" only
+		// auto-loads the first EXPAND_ALL_LOAD_LIMIT of them (see the effect below).
+		rootIndex?: number
 	}
 
 	let {
@@ -36,8 +39,14 @@
 		pipelineFolders,
 		ownerLoad,
 		onExpandOwner,
-		onCollapseOwner
+		onCollapseOwner,
+		rootIndex = 0
 	}: Props = $props()
+
+	// Bounds the request burst from "expand all": however many root owners are rendered
+	// (nbDisplayed can grow via "load 30 more"), it fetches at most this many. Owners
+	// past the cap open empty and load on an explicit click.
+	const EXPAND_ALL_LOAD_LIMIT = 20
 
 	const isFolderItem = (i: typeof item): i is FolderItem => i && 'folderName' in i
 	const isFolder = isFolderItem
@@ -91,11 +100,11 @@
 		untrack(() => {
 			if (ownerKey == undefined) return
 			if (willOpen) {
-				// "Expand all" opens this owner; load it too so it isn't opened empty.
-				// Bounded: only the nbDisplayed root owners are rendered (TreeViewRoot
-				// slices to it), so this is a handful of requests — not one per workspace
-				// folder — and each renders a capped slice (see effectiveMax).
-				onExpandOwner?.(ownerKey)
+				// "Expand all" opens this owner; load it too so it isn't opened empty — but
+				// only for the first EXPAND_ALL_LOAD_LIMIT rendered roots, so a large
+				// nbDisplayed can't launch a request per owner. Beyond the cap, opening is
+				// visual only; the owner loads when clicked.
+				if (depth === 0 && rootIndex < EXPAND_ALL_LOAD_LIMIT) onExpandOwner?.(ownerKey)
 			} else {
 				// "Collapse all" closes without a manual click, so untrack the owner here
 				// too — otherwise it lingers in openOwners and a later reload re-fetches
@@ -225,7 +234,7 @@
 							class="text-center text-xs py-2 text-primary cursor-pointer hover:text-emphasis"
 							onclick={() => ownerKey != undefined && onExpandOwner?.(ownerKey, true)}
 						>
-							Load more
+							Load more in {ownerKey} ({ownerState?.count ?? item.items.length} loaded)
 						</div>
 					{/if}
 				{/if}

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import TreeView from './TreeView.svelte'
-	import { untrack } from 'svelte'
 
 	import { ChevronDown, ChevronUp, Folder, FolderTree, NetworkIcon, User } from 'lucide-svelte'
 	import Item from './Item.svelte'
@@ -63,13 +62,11 @@
 	)
 	$effect(() => {
 		opened = !collapseAll
-		// Expand-all opens folders; lazy-load a top-level folder's items when it
-		// opens. untrack so this only re-runs on collapseAll (not on item reloads,
-		// which would otherwise re-open a manually collapsed folder).
-		untrack(() => {
-			if (opened && depth === 0 && isFolder(item)) onExpandFolder?.(item.folderName)
-		})
 	})
+	// Deliberately NOT auto-loading a folder's items when it opens via collapseAll:
+	// with every workspace folder injected as a top-level node, "expand all" would
+	// otherwise fire one request per folder (thousands on a large workspace). A
+	// folder loads only on an explicit click (see the onclick handler below).
 </script>
 
 {#if isFolder(item)}

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -51,6 +51,11 @@
 
 	let opened: boolean = $state(true)
 
+	// A top-level folder in lazy mode: its items are loaded on demand into a separate
+	// store (folderLoad tracks per-folder load state), so counts/pagination differ
+	// from a folder whose items are already grouped from the loaded window.
+	let isLazyFolder = $derived(depth === 0 && isFolderItem(item) && folderLoad != undefined)
+
 	let showMax = $state(15)
 	// A lazy top-level folder paginates server-side ("Load more in this folder"),
 	// so show all of its already-loaded items rather than the tight client slice
@@ -66,7 +71,19 @@
 	// Deliberately NOT auto-loading a folder's items when it opens via collapseAll:
 	// with every workspace folder injected as a top-level node, "expand all" would
 	// otherwise fire one request per folder (thousands on a large workspace). A
-	// folder loads only on an explicit click (see the onclick handler below).
+	// folder loads only on an explicit click (see toggleFolder).
+	let lastFolderToggle = 0
+	function toggleFolder() {
+		// A double-click would otherwise toggle twice — expand then immediately
+		// collapse, and for a lazy folder waste the fetch the first click kicked off,
+		// which reads as the folder "expanding and collapsing at once". Swallow a
+		// second toggle landing within 300ms so a rapid double-click settles open.
+		const now = Date.now()
+		if (now - lastFolderToggle < 300) return
+		lastFolderToggle = now
+		opened = !opened
+		if (opened && depth === 0 && isFolder(item)) onExpandFolder?.(item.folderName)
+	}
 </script>
 
 {#if isFolder(item)}
@@ -74,11 +91,7 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			onclick={() => {
-				opened = !opened
-				// Top-level folder: load its items on demand the first time it opens.
-				if (opened && depth === 0 && isFolder(item)) onExpandFolder?.(item.folderName)
-			}}
+			onclick={toggleFolder}
 			class="px-4 py-2 border-b w-full flex flex-row items-center justify-between cursor-pointer"
 		>
 			<div
@@ -98,7 +111,15 @@
 						>{#if depth === 0}f/{/if}{item.folderName}</span
 					>
 					<div class="text-2xs font-normal text-secondary whitespace-nowrap">
-						({pluralize(item.items.length, ' item')})
+						{#if isLazyFolder && !folderLoad?.[item.folderName]?.loaded}
+							<!-- Lazy folder not expanded yet: its true item count is unknown until
+							     loaded, so showing "(0 items)" would be misleading. -->
+							&nbsp;
+						{:else if isLazyFolder && folderLoad?.[item.folderName]?.hasMore}
+							({item.items.length}+ items)
+						{:else}
+							({pluralize(item.items.length, ' item')})
+						{/if}
 					</div>
 				</div>
 			</div>

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -11,6 +11,9 @@
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
 		sortCompare?: (a: ItemType, b: ItemType) => number
+		// Order of the top-level folder/user nodes: Z-A when the active sort is
+		// name-descending (like a file explorer), alphabetical otherwise.
+		groupDesc?: boolean
 		// The server has further pages beyond the loaded items; `onLoadMore` fetches
 		// the next one (grouping only reorders what's already loaded).
 		hasMoreServer?: boolean
@@ -37,6 +40,7 @@
 		isSearching = false,
 		pipelineFolders,
 		sortCompare,
+		groupDesc = false,
 		hasMoreServer = false,
 		onLoadMore,
 		allFolders = [],
@@ -52,13 +56,14 @@
 		pipelineFolders
 		isSearching
 		sortCompare
+		groupDesc
 		allFolders
 		allUsers
 		untrack(() => {
 			// While searching, `items` is already relevance-ranked and the sort
 			// selector is disabled, so keep that order: a no-op leaf comparator
 			// preserves insertion order within each group (Array.sort is stable).
-			const grouped = groupItems(items, isSearching ? () => 0 : sortCompare)
+			const grouped = groupItems(items, isSearching ? () => 0 : sortCompare, groupDesc)
 			// Ensure every pipeline folder is present at the top level so its
 			// "Pipeline" entry shows even when it has no listed items — a bundle-phase
 			// pipeline (only a draft so far) or a folder whose only scripts are
@@ -98,12 +103,13 @@
 					// Append the missing nodes and sort each section once (O(n log n)) rather
 					// than splicing each in with findIndex (O(n²) — at 10k owners that was
 					// ~50M comparisons on every page merge).
+					const dir = groupDesc ? -1 : 1
 					const users = grouped.filter((g) => 'username' in g) as { username: string }[]
 					const folders = grouped.filter((g) => 'folderName' in g) as { folderName: string }[]
 					users.push(...missingUsers)
 					folders.push(...missingFolders)
-					users.sort((a, b) => a.username.localeCompare(b.username))
-					folders.sort((a, b) => a.folderName.localeCompare(b.folderName))
+					users.sort((a, b) => dir * a.username.localeCompare(b.username))
+					folders.sort((a, b) => dir * a.folderName.localeCompare(b.folderName))
 					grouped.length = 0
 					grouped.push(
 						...(users as unknown as typeof grouped),

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -10,6 +10,7 @@
 		items: ItemType[] | undefined
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
+		sortCompare?: (a: ItemType, b: ItemType) => number
 	}
 
 	let {
@@ -18,7 +19,8 @@
 		nbDisplayed = $bindable(),
 		items,
 		isSearching = false,
-		pipelineFolders
+		pipelineFolders,
+		sortCompare
 	}: Props = $props()
 
 	let groupedItems: ReturnType<typeof groupItems> | 'loading' = $state('loading')
@@ -26,8 +28,9 @@
 		items
 		pipelineFolders
 		isSearching
+		sortCompare
 		untrack(() => {
-			const grouped = groupItems(items)
+			const grouped = groupItems(items, sortCompare)
 			// Ensure every pipeline folder is present at the top level so its
 			// "Pipeline" entry shows even when it has no listed items — a bundle-phase
 			// pipeline (only a draft so far) or a folder whose only scripts are

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -26,7 +26,7 @@
 		allUsers?: string[]
 		ownerLoad?: Record<
 			string,
-			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean; count: number }
 		>
 		onExpandOwner?: (owner: string, more?: boolean) => void
 		onCollapseOwner?: (owner: string) => void
@@ -133,9 +133,10 @@
 	</div>
 {:else}
 	<div class="border rounded-md bg-surface-tertiary">
-		{#each groupedItems.slice(0, nbDisplayed) as item ('folderName' in item ? `f__${item.folderName}` : 'username' in item ? `u__${item.username}` : `i__${item.type}__${item.path}`)}
+		{#each groupedItems.slice(0, nbDisplayed) as item, rootIndex ('folderName' in item ? `f__${item.folderName}` : 'username' in item ? `u__${item.username}` : `i__${item.type}__${item.path}`)}
 			{#if item}
 				<TreeView
+					{rootIndex}
 					{isSearching}
 					{collapseAll}
 					{item}

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -15,15 +15,18 @@
 		// the next one (grouping only reorders what's already loaded).
 		hasMoreServer?: boolean
 		onLoadMore?: () => void
-		// Lazy per-folder loading: every folder shows as a top-level node regardless
-		// of the loaded window; expanding one loads its items on demand, paginated
-		// within the folder. `folderLoad` keys are folder names.
+		// Lazy per-owner loading: every folder and every user shows as a top-level node
+		// regardless of the loaded window; expanding one loads its items on demand,
+		// paginated within it. `ownerLoad` keys are full path prefixes (`f/<name>` /
+		// `u/<name>`).
 		allFolders?: string[]
-		folderLoad?: Record<
+		allUsers?: string[]
+		ownerLoad?: Record<
 			string,
 			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
 		>
-		onExpandFolder?: (folder: string, more?: boolean) => void
+		onExpandOwner?: (owner: string, more?: boolean) => void
+		onCollapseOwner?: (owner: string) => void
 	}
 
 	let {
@@ -37,8 +40,10 @@
 		hasMoreServer = false,
 		onLoadMore,
 		allFolders = [],
-		folderLoad,
-		onExpandFolder
+		allUsers = [],
+		ownerLoad,
+		onExpandOwner,
+		onCollapseOwner
 	}: Props = $props()
 
 	let groupedItems: ReturnType<typeof groupItems> | 'loading' = $state('loading')
@@ -48,6 +53,7 @@
 		isSearching
 		sortCompare
 		allFolders
+		allUsers
 		untrack(() => {
 			// While searching, `items` is already relevance-ranked and the sort
 			// selector is disabled, so keep that order: a no-op leaf comparator
@@ -62,33 +68,47 @@
 			// folders in the results.
 			if (!isSearching) {
 				// Inject a top-level node for every pipeline folder (so its Pipeline entry
-				// shows even with no listed items) and every workspace folder (so folders
-				// whose items sit outside the loaded window still appear; expanding one
-				// loads its items on demand — see onExpandFolder).
-				const present = new Set(
+				// shows even with no listed items), every workspace folder, and every user
+				// — so an owner whose items sit outside the loaded window still appears;
+				// expanding one loads its items on demand (see onExpandOwner). Injecting
+				// users too is what stops a user node from vanishing under a name sort whose
+				// first page is all folder rows.
+				const presentFolders = new Set(
 					grouped
 						.filter((g) => 'folderName' in g)
 						.map((g) => (g as { folderName: string }).folderName)
 				)
-				const missing: { folderName: string; items: [] }[] = []
+				const missingFolders: { folderName: string; items: [] }[] = []
 				for (const folderName of [...(pipelineFolders ?? []), ...allFolders]) {
-					if (present.has(folderName)) continue
-					present.add(folderName)
-					missing.push({ folderName, items: [] })
+					if (presentFolders.has(folderName)) continue
+					presentFolders.add(folderName)
+					missingFolders.push({ folderName, items: [] })
 				}
-				if (missing.length) {
+				const presentUsers = new Set(
+					grouped.filter((g) => 'username' in g).map((g) => (g as { username: string }).username)
+				)
+				const missingUsers: { username: string; items: [] }[] = []
+				for (const username of allUsers) {
+					if (presentUsers.has(username)) continue
+					presentUsers.add(username)
+					missingUsers.push({ username, items: [] })
+				}
+				if (missingFolders.length || missingUsers.length) {
 					// `groupItems` returns user groups first, then folders alphabetically.
-					// Append the missing folder nodes and sort the folder section once
-					// (O(n log n)) rather than splicing each in with findIndex (O(n²) — at
-					// 10k folders that was ~50M comparisons on every page merge).
-					const users = grouped.filter((g) => 'username' in g)
-					const folders = grouped.filter((g) => 'folderName' in g) as {
-						folderName: string
-					}[]
-					folders.push(...missing)
+					// Append the missing nodes and sort each section once (O(n log n)) rather
+					// than splicing each in with findIndex (O(n²) — at 10k owners that was
+					// ~50M comparisons on every page merge).
+					const users = grouped.filter((g) => 'username' in g) as { username: string }[]
+					const folders = grouped.filter((g) => 'folderName' in g) as { folderName: string }[]
+					users.push(...missingUsers)
+					folders.push(...missingFolders)
+					users.sort((a, b) => a.username.localeCompare(b.username))
 					folders.sort((a, b) => a.folderName.localeCompare(b.folderName))
 					grouped.length = 0
-					grouped.push(...(users as typeof grouped), ...(folders as unknown as typeof grouped))
+					grouped.push(
+						...(users as unknown as typeof grouped),
+						...(folders as unknown as typeof grouped)
+					)
 				}
 			}
 			groupedItems = grouped
@@ -114,8 +134,9 @@
 					{collapseAll}
 					{item}
 					{pipelineFolders}
-					{folderLoad}
-					{onExpandFolder}
+					{ownerLoad}
+					{onExpandOwner}
+					{onCollapseOwner}
 					on:scriptChanged
 					on:flowChanged
 					on:appChanged

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -30,7 +30,10 @@
 		isSearching
 		sortCompare
 		untrack(() => {
-			const grouped = groupItems(items, sortCompare)
+			// While searching, `items` is already relevance-ranked and the sort
+			// selector is disabled, so keep that order: a no-op leaf comparator
+			// preserves insertion order within each group (Array.sort is stable).
+			const grouped = groupItems(items, isSearching ? () => 0 : sortCompare)
 			// Ensure every pipeline folder is present at the top level so its
 			// "Pipeline" entry shows even when it has no listed items — a bundle-phase
 			// pipeline (only a draft so far) or a folder whose only scripts are

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -15,6 +15,15 @@
 		// the next one (grouping only reorders what's already loaded).
 		hasMoreServer?: boolean
 		onLoadMore?: () => void
+		// Lazy per-folder loading: every folder shows as a top-level node regardless
+		// of the loaded window; expanding one loads its items on demand, paginated
+		// within the folder. `folderLoad` keys are folder names.
+		allFolders?: string[]
+		folderLoad?: Record<
+			string,
+			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
+		>
+		onExpandFolder?: (folder: string, more?: boolean) => void
 	}
 
 	let {
@@ -26,7 +35,10 @@
 		pipelineFolders,
 		sortCompare,
 		hasMoreServer = false,
-		onLoadMore
+		onLoadMore,
+		allFolders = [],
+		folderLoad,
+		onExpandFolder
 	}: Props = $props()
 
 	let groupedItems: ReturnType<typeof groupItems> | 'loading' = $state('loading')
@@ -35,6 +47,7 @@
 		pipelineFolders
 		isSearching
 		sortCompare
+		allFolders
 		untrack(() => {
 			// While searching, `items` is already relevance-ranked and the sort
 			// selector is disabled, so keep that order: a no-op leaf comparator
@@ -69,6 +82,24 @@
 					if (idx < 0) grouped.push(item)
 					else grouped.splice(idx, 0, item)
 				}
+				// Inject every workspace folder as a top-level node so folders whose
+				// items sit outside the loaded window still appear; expanding one loads
+				// its items on demand (see onExpandFolder).
+				const present2 = new Set(
+					grouped
+						.filter((g) => 'folderName' in g)
+						.map((g) => (g as { folderName: string }).folderName)
+				)
+				for (const folderName of allFolders.filter((f) => !present2.has(f)).sort()) {
+					const item = { folderName, items: [] }
+					const idx = grouped.findIndex(
+						(g) =>
+							'folderName' in g &&
+							(g as { folderName: string }).folderName.localeCompare(folderName) > 0
+					)
+					if (idx < 0) grouped.push(item)
+					else grouped.splice(idx, 0, item)
+				}
 			}
 			groupedItems = grouped
 		})
@@ -93,6 +124,8 @@
 					{collapseAll}
 					{item}
 					{pipelineFolders}
+					{folderLoad}
+					{onExpandFolder}
 					on:scriptChanged
 					on:flowChanged
 					on:appChanged

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -11,6 +11,10 @@
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
 		sortCompare?: (a: ItemType, b: ItemType) => number
+		// The server has further pages beyond the loaded items; `onLoadMore` fetches
+		// the next one (grouping only reorders what's already loaded).
+		hasMoreServer?: boolean
+		onLoadMore?: () => void
 	}
 
 	let {
@@ -20,7 +24,9 @@
 		items,
 		isSearching = false,
 		pipelineFolders,
-		sortCompare
+		sortCompare,
+		hasMoreServer = false,
+		onLoadMore
 	}: Props = $props()
 
 	let groupedItems: ReturnType<typeof groupItems> | 'loading' = $state('loading')
@@ -97,12 +103,17 @@
 			{/if}
 		{/each}
 	</div>
-	{#if groupedItems.length > 15 && nbDisplayed < groupedItems.length}
+	{#if nbDisplayed < groupedItems.length || hasMoreServer}
 		<span class="text-xs font-normal text-secondary"
-			>{nbDisplayed} root nodes out of {groupedItems.length}
+			>{Math.min(nbDisplayed, groupedItems.length)} root nodes{hasMoreServer
+				? ''
+				: ` out of ${groupedItems.length}`}
 			<button
 				class="ml-4 text-xs font-normal text-primary hover:text-emphasis"
-				onclick={() => (nbDisplayed += 30)}>load 30 more</button
+				onclick={() => {
+					if (nbDisplayed < groupedItems.length) nbDisplayed += 30
+					else onLoadMore?.()
+				}}>load 30 more</button
 			></span
 		>
 	{/if}

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -61,44 +61,34 @@
 			// hides them on `filter !== ''`), so injecting them would surface unrelated
 			// folders in the results.
 			if (!isSearching) {
+				// Inject a top-level node for every pipeline folder (so its Pipeline entry
+				// shows even with no listed items) and every workspace folder (so folders
+				// whose items sit outside the loaded window still appear; expanding one
+				// loads its items on demand — see onExpandFolder).
 				const present = new Set(
 					grouped
 						.filter((g) => 'folderName' in g)
 						.map((g) => (g as { folderName: string }).folderName)
 				)
-				// Insert each missing pipeline folder among the existing folders in name
-				// order — `groupItems` already sorts user groups first then folders
-				// alphabetically, so inserting before the first greater-named folder
-				// keeps that ordering (rather than prepending out of order).
-				for (const folderName of [...(pipelineFolders ?? [])]
-					.filter((f) => !present.has(f))
-					.sort()) {
-					const item = { folderName, items: [] }
-					const idx = grouped.findIndex(
-						(g) =>
-							'folderName' in g &&
-							(g as { folderName: string }).folderName.localeCompare(folderName) > 0
-					)
-					if (idx < 0) grouped.push(item)
-					else grouped.splice(idx, 0, item)
+				const missing: { folderName: string; items: [] }[] = []
+				for (const folderName of [...(pipelineFolders ?? []), ...allFolders]) {
+					if (present.has(folderName)) continue
+					present.add(folderName)
+					missing.push({ folderName, items: [] })
 				}
-				// Inject every workspace folder as a top-level node so folders whose
-				// items sit outside the loaded window still appear; expanding one loads
-				// its items on demand (see onExpandFolder).
-				const present2 = new Set(
-					grouped
-						.filter((g) => 'folderName' in g)
-						.map((g) => (g as { folderName: string }).folderName)
-				)
-				for (const folderName of allFolders.filter((f) => !present2.has(f)).sort()) {
-					const item = { folderName, items: [] }
-					const idx = grouped.findIndex(
-						(g) =>
-							'folderName' in g &&
-							(g as { folderName: string }).folderName.localeCompare(folderName) > 0
-					)
-					if (idx < 0) grouped.push(item)
-					else grouped.splice(idx, 0, item)
+				if (missing.length) {
+					// `groupItems` returns user groups first, then folders alphabetically.
+					// Append the missing folder nodes and sort the folder section once
+					// (O(n log n)) rather than splicing each in with findIndex (O(n²) — at
+					// 10k folders that was ~50M comparisons on every page merge).
+					const users = grouped.filter((g) => 'username' in g)
+					const folders = grouped.filter((g) => 'folderName' in g) as {
+						folderName: string
+					}[]
+					folders.push(...missing)
+					folders.sort((a, b) => a.folderName.localeCompare(b.folderName))
+					grouped.length = 0
+					grouped.push(...(users as typeof grouped), ...(folders as unknown as typeof grouped))
 				}
 			}
 			groupedItems = grouped

--- a/frontend/src/lib/components/home/treeViewUtils.ts
+++ b/frontend/src/lib/components/home/treeViewUtils.ts
@@ -48,7 +48,18 @@ function insertItemInFolder(
 	})
 }
 
-export function groupItems(items: ItemType[] | undefined): (ItemType | FolderItem | UserItem)[] {
+// Default leaf ordering when the caller doesn't impose one: starred first, then
+// most recently modified. Folders/users always sort alphabetically regardless.
+const defaultLeafCompare = (a: ItemType, b: ItemType): number => {
+	if (a.starred && !b.starred) return -1
+	if (!a.starred && b.starred) return 1
+	return getModifiedAt(b) - getModifiedAt(a)
+}
+
+export function groupItems(
+	items: ItemType[] | undefined,
+	leafCompare: (a: ItemType, b: ItemType) => number = defaultLeafCompare
+): (ItemType | FolderItem | UserItem)[] {
 	if (!items) {
 		return []
 	}
@@ -88,12 +99,15 @@ export function groupItems(items: ItemType[] | undefined): (ItemType | FolderIte
 		return (a['username'] ?? a['folderName'] ?? '').localeCompare(b['username'] ?? b['folderName'])
 	})
 
-	sortGroup(root)
+	sortGroup(root, leafCompare)
 
 	return root
 }
 
-function sortGroup(group: (ItemType | FolderItem | UserItem)[]) {
+function sortGroup(
+	group: (ItemType | FolderItem | UserItem)[],
+	leafCompare: (a: ItemType, b: ItemType) => number
+) {
 	group.forEach((item) => {
 		if ('items' in item) {
 			item.items.sort((a, b) => {
@@ -107,14 +121,12 @@ function sortGroup(group: (ItemType | FolderItem | UserItem)[]) {
 					return 1
 				}
 				if (isItemType(a) && isItemType(b)) {
-					if (a.starred && !b.starred) return -1
-					if (!a.starred && b.starred) return 1
-					return getModifiedAt(b) - getModifiedAt(a)
+					return leafCompare(a, b)
 				}
 				return 0
 			})
 
-			sortGroup(item.items)
+			sortGroup(item.items, leafCompare)
 		}
 	})
 }

--- a/frontend/src/lib/components/home/treeViewUtils.ts
+++ b/frontend/src/lib/components/home/treeViewUtils.ts
@@ -58,7 +58,12 @@ const defaultLeafCompare = (a: ItemType, b: ItemType): number => {
 
 export function groupItems(
 	items: ItemType[] | undefined,
-	leafCompare: (a: ItemType, b: ItemType) => number = defaultLeafCompare
+	leafCompare: (a: ItemType, b: ItemType) => number = defaultLeafCompare,
+	// Folders/users have only a name, so the sort key is always name; `groupDesc`
+	// flips its direction (Z-A) to follow a name-descending sort, like a file explorer
+	// reordering folders when you reverse the name sort. Time sorts pass false (no
+	// folder timestamp to order by, so folders stay alphabetical).
+	groupDesc: boolean = false
 ): (ItemType | FolderItem | UserItem)[] {
 	if (!items) {
 		return []
@@ -89,30 +94,37 @@ export function groupItems(
 		}
 	})
 
+	const dir = groupDesc ? -1 : 1
 	root.sort((a, b) => {
+		// Users always group before folders regardless of direction; only the name
+		// comparison within each kind follows `groupDesc`.
 		if ('username' in a && 'folderName' in b) {
 			return -1
 		}
 		if ('folderName' in a && 'username' in b) {
 			return 1
 		}
-		return (a['username'] ?? a['folderName'] ?? '').localeCompare(b['username'] ?? b['folderName'])
+		return (
+			dir * (a['username'] ?? a['folderName'] ?? '').localeCompare(b['username'] ?? b['folderName'])
+		)
 	})
 
-	sortGroup(root, leafCompare)
+	sortGroup(root, leafCompare, dir)
 
 	return root
 }
 
 function sortGroup(
 	group: (ItemType | FolderItem | UserItem)[],
-	leafCompare: (a: ItemType, b: ItemType) => number
+	leafCompare: (a: ItemType, b: ItemType) => number,
+	dir: number = 1
 ) {
 	group.forEach((item) => {
 		if ('items' in item) {
 			item.items.sort((a, b) => {
+				// Nested subfolders sort before leaves and follow the group direction.
 				if ('folderName' in a && 'folderName' in b) {
-					return a.folderName.localeCompare(b.folderName)
+					return dir * a.folderName.localeCompare(b.folderName)
 				}
 				if ('folderName' in a) {
 					return -1
@@ -126,7 +138,7 @@ function sortGroup(
 				return 0
 			})
 
-			sortGroup(item.items, leafCompare)
+			sortGroup(item.items, leafCompare, dir)
 		}
 	})
 }

--- a/frontend/src/lib/components/home/treeViewUtils.ts
+++ b/frontend/src/lib/components/home/treeViewUtils.ts
@@ -5,6 +5,9 @@ type TableItem<T, U extends 'script' | 'flow' | 'app' | 'raw_app'> = T & {
 	type?: U
 	time?: number
 	starred?: boolean
+	// Server fetch ordinal (see ItemsList) — the tree sorts leaves by it to preserve
+	// the endpoint's order rather than re-deriving it.
+	ord?: number
 }
 
 type TableScript = TableItem<Script, 'script'>


### PR DESCRIPTION
## Summary

Add multiple sort orders (recently updated / oldest / name A-Z / name Z-A) to the homepage, keeping "recently updated" as the default. Fixes WIN-2236.

The orders are produced **server-side** by a new merged, index-backed, keyset-paginated endpoint, so a chosen order is globally correct across scripts + flows + apps and stays efficient **even on very large workspaces** — and it pages past the old per-kind load caps (10k scripts / 1k flows / 1k apps) that a client-only sort was bounded by.

## Why an endpoint (not just a client sort)

The homepage merges three tables (script/flow/app) into one list. A *correct* combined order can only be produced after merging, and the per-kind endpoints cap what they return, so a pure client sort can only reorder a capped window. Doing the merge + order + pagination in one place fixes that.

## Backend — `GET /w/{workspace}/runnables/list`

- **Merged**: `UNION ALL` of script/flow/app with a shared projection carrying the fields the row components need.
- **Index-backed order**: each branch is ordered by an index so Postgres does a *Merge Append* and stops at the page limit. The migration adds time indexes (`script(workspace_id, archived, created_at)`, `flow(workspace_id, archived, edited_at)`) and expression indexes on `lower(COALESCE(NULLIF(summary,''), path))` for script/flow/app so the name orders are index-presorted too (verified the planner uses them).
- **Keyset pagination**: an opaque `(sort_key, path, kind, tiebreak)` cursor, so deep pages don't re-scan.
- **Bounded projections**: a per-branch `LIMIT` keeps the correlated subqueries (`draft_users`, `folder_labels`) evaluated only for the page, not the whole table — verified with `EXPLAIN ANALYZE` (SubPlan `loops` = page size, not row count).
- **Starred-first** on the first page; **RLS** enforces visibility in-SQL via the `user_db` transaction. Filters: `kinds`, `show_archived`, `include_without_main`, `path_start` (owner), `label`, `search`.

## Frontend — hybrid integration

- The homepage loads from `listRunnables` as the ordered, keyset-paginated source; the sort selector maps to `order_by`/`order_desc` and reloads; **"load more"** fetches the next page via the cursor. The sort trigger is an icon-only button with the four orders in the popover.
- **Kind and owner/folder filters are resolved server-side** (`kinds`, `path_start`), so selecting *Apps* or a folder browses the whole workspace for it, not just the loaded window.
- **Search is hybrid**: instant client-side fuzzy filtering over loaded pages for reactivity, plus a **debounced (300 ms) server augmentation** that pulls in matches beyond the loaded window — so search stays complete on large workspaces without a request per keystroke.
- **Complete facets**: the owner facet lists **every** workspace folder (paged to exhaustion) and **every** username, so an owner whose items sit far down the stream is still selectable.

### Lazy folder tree

The tree view lists **every workspace folder as a top-level node** regardless of the loaded window; expanding one **lazy-loads its items on demand** (server-scoped, with subfolders nesting) and paginates **within that folder** ("Load more in this folder").

Folder items live in a **separate store**, never merged into the global browse arrays — so a folder expansion can't pollute or duplicate the flat list, and each folder request is tied to a scope generation so a stale-scope response is discarded. Changing the order/scope remounts the tree so expanded folders re-load fresh. "Expand all" does not fan out a request per folder (a folder loads only on explicit click), keeping it safe at 10k+ folders.

## Known follow-ups (v1 scope)

- **Draft-only items** (never-deployed drafts) are not yet surfaced by the endpoint; deferred to a follow-up (still reachable via the drafts UI).
- The **label** filter and instant fuzzy ranking still operate over loaded pages (kind/owner/folder/search are workspace-wide).

## Screenshots

Sort selector (four orders, icon-only trigger):

![sort-dropdown](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2236-add-multiple-sort-options-to-homepage/1784905196-v2-sort-dropdown.png)

Lazy folder tree — every folder shown as a collapsed top-level node (17k-item workspace):

![tree-lazy-collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2236-add-multiple-sort-options-to-homepage/1784905192-v2-tree-lazy-collapsed.png)

Expanded folder with nested subfolders + per-folder "Load more in this folder":

![tree-lazy-expanded-subfolders](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2236-add-multiple-sort-options-to-homepage/1784905194-v2-tree-lazy-expanded-subfolders.png)

## Test plan

- [x] Endpoint validated via curl + 5 backend integration tests: all four orders, keyset pagination + cross-kind ties, starred-first, favorited archived-version pagination, `kinds`/`search`/`path_start`/`show_archived` filters.
- [x] `EXPLAIN ANALYZE` confirms per-page-bounded correlated projections and index-eligible ordering (~12-16 ms at 17k items).
- [x] Homepage (Playwright, 17k-item seed): four sorts reorder correctly (flat); load-more pages the cursor; server-side kind/owner filters; hybrid search finds items far past the loaded window; lazy tree shows all folders, expands + paginates per-folder, nests subfolders; **flat list stays contiguous & dedup-free after folder expansion**; sort change collapses expanded folders; tree+search hides empty folders; 0 feature-related console errors.
- [x] Full `npm run check` clean (only the pre-existing unrelated `modern-screenshot` error remains).
- [ ] `cargo check` + tests in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
