### PR TITLE
feat(hub): surface data pipelines in deploy-to-hub drawer

### DIFF
--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -179,6 +179,11 @@
 		 * When a node's nonce changes, it flashes a fading green background — its
 		 * producer just recomputed it. Driven by the replay player frame-by-frame. */
 		recomputedAssetIds?: ReadonlyMap<string, number>
+		/** Let the wheel zoom the canvas (and swallow the page scroll while doing
+		 * so). Default true for the full-height editor/player. Set false when the
+		 * canvas is embedded inline inside a scrollable container, so a wheel
+		 * gesture over it scrolls the container instead of being captured. */
+		scrollZoom?: boolean
 	}
 	let {
 		graph,
@@ -209,7 +214,8 @@
 		showMinimap = true,
 		viewportFitKey = '',
 		highlightActiveRun = false,
-		recomputedAssetIds
+		recomputedAssetIds,
+		scrollZoom = true
 	}: Props = $props()
 
 	// `${kind}:${path}` ids for the hovered / pinned runs (both script and flow
@@ -1188,6 +1194,8 @@
 		nodesDraggable={false}
 		nodesConnectable={false}
 		elementsSelectable
+		zoomOnScroll={scrollZoom}
+		preventScrolling={scrollZoom}
 		zoomOnDoubleClick={false}
 		connectionLineType={ConnectionLineType.SmoothStep}
 		defaultEdgeOptions={{ type: 'asset' }}

--- a/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
@@ -23,6 +23,7 @@
 	import AssetGraphCanvas from '$lib/components/assets/AssetGraph/AssetGraphCanvas.svelte'
 	import {
 		Check,
+		ChevronDown,
 		Cloud,
 		Code2,
 		Copy,
@@ -56,7 +57,9 @@
 
 	let recordDrawer = $state<Drawer | undefined>()
 	let pipelinePreviewDrawer = $state<Drawer | undefined>()
-	let pipelineGraphDrawer = $state<Drawer | undefined>()
+	// Inline pipeline graph above the item list, collapsed by default so the
+	// selection list stays the first thing in view.
+	let pipelineGraphOpen = $state(false)
 	let publishDrawer = $state<Drawer | undefined>()
 	let resourceDrawer = $state<Drawer | undefined>()
 	let triggerDrawer = $state<Drawer | undefined>()
@@ -308,32 +311,6 @@
 									{/each}
 								{/if}
 							</div>
-							{#if s.isPipelineProject}
-								<div class="flex flex-wrap items-center gap-2 text-xs">
-									<span class="font-semibold text-primary shrink-0">
-										Data pipeline
-										<span class="text-hint font-normal">
-											({s.pipelineScriptPaths.length} step{s.pipelineScriptPaths.length === 1
-												? ''
-												: 's'})
-										</span>
-										<Tooltip>
-											Scripts in this folder form a data-pipeline cascade (each reads or writes data
-											tables consumed by the next). Bundle the whole folder, then record the cascade
-											as one interactive replay in step 2.
-										</Tooltip>
-									</span>
-									<Button
-										variant="subtle"
-										unifiedSize="sm"
-										startIcon={{ icon: BarsStaggered }}
-										wrapperClasses="ml-auto"
-										onclick={() => pipelineGraphDrawer?.openDrawer()}
-									>
-										View pipeline graph
-									</Button>
-								</div>
-							{/if}
 						{/if}
 						{#if s.phase === 'draft'}
 							<div class="flex flex-col gap-1 pb-3">
@@ -490,6 +467,55 @@
 								<span class={s.allRecorded ? 'text-green-700 dark:text-green-400' : 'text-hint'}>
 									{s.allRecorded ? 'Full recordings' : 'Recordings recommended'}
 								</span>
+							</div>
+						{/if}
+						{#if s.phase === 'predeploy' && s.isPipelineProject}
+							<div
+								class="flex flex-col rounded-md border border-blue-300 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/40"
+							>
+								<button
+									type="button"
+									class="flex items-center gap-2 px-3 py-2 text-left"
+									aria-expanded={pipelineGraphOpen}
+									onclick={() => (pipelineGraphOpen = !pipelineGraphOpen)}
+								>
+									<BarsStaggered class="text-blue-600 dark:text-blue-400" />
+									<span class="text-sm font-semibold text-primary">Data pipeline</span>
+									<span class="text-xs text-hint">
+										({s.pipelineScriptPaths.length} step{s.pipelineScriptPaths.length === 1
+											? ''
+											: 's'})
+									</span>
+									<Tooltip>
+										Scripts in this folder form a data-pipeline cascade (each reads or writes data
+										tables consumed by the next). Bundle the whole folder, then record the cascade
+										as one interactive replay in step 2.
+									</Tooltip>
+									<ChevronDown
+										size={16}
+										class="ml-auto shrink-0 text-tertiary transition-transform {pipelineGraphOpen
+											? 'rotate-180'
+											: ''}"
+									/>
+								</button>
+								{#if pipelineGraphOpen}
+									<div
+										class="flex flex-col gap-2 border-t border-blue-200 p-3 dark:border-blue-900"
+									>
+										<span class="text-xs text-secondary">
+											The <span class="font-mono">{s.selectedFolder}/</span> scripts and the data tables
+											they read and write, as a single pipeline. This whole cascade can be captured as
+											an interactive replay once the project is bundled.
+										</span>
+										{#if s.pipelineGraph}
+											<div class="h-[420px] overflow-hidden rounded-md border bg-surface">
+												<AssetGraphCanvas graph={s.pipelineGraph} viewportFitKey={s.folder} />
+											</div>
+										{:else}
+											<span class="text-xs text-hint">Loading pipeline graph…</span>
+										{/if}
+									</div>
+								{/if}
 							</div>
 						{/if}
 					</div>
@@ -751,25 +777,6 @@
 						<PipelineRecordingReplay recording={s.pipelineRecordingResult} />
 					</div>
 				{/if}
-			</DrawerContent>
-		</Drawer>
-
-		<Drawer bind:this={pipelineGraphDrawer} size="1100px">
-			<DrawerContent title="Data pipeline" on:close={() => pipelineGraphDrawer?.closeDrawer()}>
-				<div class="flex h-full flex-col gap-3 min-h-0">
-					<p class="text-xs text-secondary shrink-0">
-						The <span class="font-mono">{s.selectedFolder}/</span> scripts and the data tables they read
-						and write, as a single pipeline. This whole cascade can be captured as an interactive replay
-						once the project is bundled.
-					</p>
-					{#if s.pipelineGraph}
-						<div class="flex-1 min-h-[600px] rounded-md border bg-surface overflow-hidden">
-							<AssetGraphCanvas graph={s.pipelineGraph} viewportFitKey={s.folder} />
-						</div>
-					{:else}
-						<span class="text-xs text-hint">Loading pipeline graph…</span>
-					{/if}
-				</div>
 			</DrawerContent>
 		</Drawer>
 

--- a/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
@@ -509,7 +509,11 @@
 										</span>
 										{#if s.pipelineGraph}
 											<div class="h-[420px] overflow-hidden rounded-md border bg-surface">
-												<AssetGraphCanvas graph={s.pipelineGraph} viewportFitKey={s.folder} />
+												<AssetGraphCanvas
+													graph={s.pipelineGraph}
+													viewportFitKey={s.folder}
+													scrollZoom={false}
+												/>
 											</div>
 										{:else}
 											<span class="text-xs text-hint">Loading pipeline graph…</span>

--- a/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
@@ -759,8 +759,8 @@
 				<div class="flex h-full flex-col gap-3 min-h-0">
 					<p class="text-xs text-secondary shrink-0">
 						The <span class="font-mono">{s.selectedFolder}/</span> scripts and the data tables they read
-						and write, as a single pipeline. Click a node to inspect it. This whole cascade can be captured
-						as an interactive replay once the project is bundled.
+						and write, as a single pipeline. This whole cascade can be captured as an interactive replay
+						once the project is bundled.
 					</p>
 					{#if s.pipelineGraph}
 						<div class="flex-1 min-h-[600px] rounded-md border bg-surface overflow-hidden">

--- a/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DeployToHub.svelte
@@ -20,6 +20,7 @@
 	import Toggle from '../Toggle.svelte'
 	import MigrationSqlEditor from './MigrationSqlEditor.svelte'
 	import PipelineRecordingReplay from '$lib/components/recording/PipelineRecordingReplay.svelte'
+	import AssetGraphCanvas from '$lib/components/assets/AssetGraph/AssetGraphCanvas.svelte'
 	import {
 		Check,
 		Cloud,
@@ -55,6 +56,7 @@
 
 	let recordDrawer = $state<Drawer | undefined>()
 	let pipelinePreviewDrawer = $state<Drawer | undefined>()
+	let pipelineGraphDrawer = $state<Drawer | undefined>()
 	let publishDrawer = $state<Drawer | undefined>()
 	let resourceDrawer = $state<Drawer | undefined>()
 	let triggerDrawer = $state<Drawer | undefined>()
@@ -306,6 +308,32 @@
 									{/each}
 								{/if}
 							</div>
+							{#if s.isPipelineProject}
+								<div class="flex flex-wrap items-center gap-2 text-xs">
+									<span class="font-semibold text-primary shrink-0">
+										Data pipeline
+										<span class="text-hint font-normal">
+											({s.pipelineScriptPaths.length} step{s.pipelineScriptPaths.length === 1
+												? ''
+												: 's'})
+										</span>
+										<Tooltip>
+											Scripts in this folder form a data-pipeline cascade (each reads or writes data
+											tables consumed by the next). Bundle the whole folder, then record the cascade
+											as one interactive replay in step 2.
+										</Tooltip>
+									</span>
+									<Button
+										variant="subtle"
+										unifiedSize="sm"
+										startIcon={{ icon: BarsStaggered }}
+										wrapperClasses="ml-auto"
+										onclick={() => pipelineGraphDrawer?.openDrawer()}
+									>
+										View pipeline graph
+									</Button>
+								</div>
+							{/if}
 						{/if}
 						{#if s.phase === 'draft'}
 							<div class="flex flex-col gap-1 pb-3">
@@ -469,8 +497,15 @@
 
 				{#snippet itemSummary(item)}
 					{@const it = item as DeployItem}
-					<span class="truncate">
-						{it.summary?.trim() || it.path}
+					<span class="flex min-w-0 items-center gap-1.5">
+						<span class="truncate">
+							{it.summary?.trim() || it.path}
+						</span>
+						{#if it.kind === 'script' && s.pipelineScriptPathSet.has(it.path)}
+							<Badge color="blue" size="xs" wrapperClass="shrink-0">
+								<BarsStaggered size={10} class="mr-0.5" />Pipeline
+							</Badge>
+						{/if}
 					</span>
 				{/snippet}
 
@@ -716,6 +751,25 @@
 						<PipelineRecordingReplay recording={s.pipelineRecordingResult} />
 					</div>
 				{/if}
+			</DrawerContent>
+		</Drawer>
+
+		<Drawer bind:this={pipelineGraphDrawer} size="1100px">
+			<DrawerContent title="Data pipeline" on:close={() => pipelineGraphDrawer?.closeDrawer()}>
+				<div class="flex h-full flex-col gap-3 min-h-0">
+					<p class="text-xs text-secondary shrink-0">
+						The <span class="font-mono">{s.selectedFolder}/</span> scripts and the data tables they read
+						and write, as a single pipeline. Click a node to inspect it. This whole cascade can be captured
+						as an interactive replay once the project is bundled.
+					</p>
+					{#if s.pipelineGraph}
+						<div class="flex-1 min-h-[600px] rounded-md border bg-surface overflow-hidden">
+							<AssetGraphCanvas graph={s.pipelineGraph} viewportFitKey={s.folder} />
+						</div>
+					{:else}
+						<span class="text-xs text-hint">Loading pipeline graph…</span>
+					{/if}
+				</div>
 			</DrawerContent>
 		</Drawer>
 

--- a/frontend/src/lib/components/workspaceSettings/deployToHubSession.svelte.ts
+++ b/frontend/src/lib/components/workspaceSettings/deployToHubSession.svelte.ts
@@ -325,6 +325,7 @@ export class DeployToHubSession {
 			this.items.some((i) => i.kind === 'script' && i.path === p)
 		)
 	)
+	pipelineScriptPathSet = $derived(new Set(this.pipelineScriptPaths))
 	isPipelineProject = $derived(this.pipelineScriptPaths.length > 0)
 	hubSlug = $derived(this.effectiveSlug || sanitizeSlug(this.hubName))
 


### PR DESCRIPTION
## Summary

In the deploy-to-hub drawer for a folder, the predeploy step listed the folder's scripts with no indication that some of them form a **data pipeline** — the pipeline-specific UI only appeared later, in the draft step. A user publishing a folder that contains a data pipeline saw "just a list of scripts" and couldn't tell the pipeline was there.

This surfaces the pipeline in the predeploy step:

- An **inline, collapsible "Data pipeline (N steps)" panel** directly above the item list (collapsed by default, so the selection list stays the first thing in view). Expanding it renders the folder's asset-graph cascade — scripts + the data tables they read/write — in place, via the existing read-only `AssetGraphCanvas`.
- Each pipeline-member script gets a small **Pipeline** badge in the item list, so pipeline scripts are distinguishable from plain scripts at a glance.

Detection is per-script (`in_pipeline`, i.e. `auto_kind='pipeline'`), the same definition the pipeline editor and recorder use — a folder can mix pipeline steps with plain utility scripts, and only the pipeline members are badged/counted. The pipeline graph was already fetched at load time (`#loadPipelineGraph`) for the draft-step recording panel; this reuses that data one step earlier. No backend changes.

Fixes WIN-2238

## Changes

- `deployToHubSession.svelte.ts`: add `pipelineScriptPathSet` derived (Set of pipeline-member script paths) for O(1) badge lookups.
- `DeployToHub.svelte`: inline collapsible "Data pipeline" panel above the list (rendering `AssetGraphCanvas`); Pipeline badge in `itemSummary`.

## Test plan

- [x] `svelte-check` passes (no new errors/warnings in the changed files)
- [x] Manually verified with a seeded 3-step pipeline folder (+ one plain utility script): badge shows on the 3 pipeline scripts and not on the plain one; the collapsible panel expands/collapses and renders the full `ingest_raw → raw_events → clean_events → aggregate_daily → daily_metrics` cascade inline above the list.

## Screenshots

### Collapsed by default, above the item list
![deploy-hub-inline-collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2238-show-data-pipelines-in-deploy-to-hub-drawer/1784890540-deploy-hub-inline-collapsed.png)

### Expanded — pipeline graph inline
![deploy-hub-inline-expanded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2238-show-data-pipelines-in-deploy-to-hub-drawer/1784890542-deploy-hub-inline-expanded.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)