### PR TITLE
feat(pipeline): collapse secondary top-bar controls into an overflow menu

### DIFF
--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1422,6 +1422,11 @@
 	let recordingMode = $state(false)
 	let lastPipelineRecording = $state<PipelineRecording | undefined>(undefined)
 
+	// Shared by the overflow-menu Record item and the inline armed pill so their
+	// wording can't drift — both describe the same armed recorder.
+	const RECORDING_ARMED_HINT =
+		'Recording armed — the next pipeline run will be captured. Click to disarm.'
+
 	function downloadPipelineRecording() {
 		if (lastPipelineRecording) {
 			pipelineRecording.download(lastPipelineRecording)
@@ -1442,7 +1447,7 @@
 				iconColor: recordingMode ? 'rgb(220 38 38)' : undefined,
 				disabled: !!cascadeRunningRoot,
 				tooltip: recordingMode
-					? 'Recording armed — the next pipeline run will be captured. Click to disarm.'
+					? RECORDING_ARMED_HINT
 					: 'Arm the recorder so the next pipeline run is captured for offline replay',
 				action: () => (recordingMode = !recordingMode)
 			})
@@ -2415,7 +2420,7 @@
 						onclick={() => (recordingMode = false)}
 						disabled={!!cascadeRunningRoot}
 						class="flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium transition-colors disabled:opacity-50 bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-700 dark:text-red-400"
-						title="Recording armed — the next pipeline run will be captured. Click to disarm."
+						title={RECORDING_ARMED_HINT}
 					>
 						<Circle size={12} class="fill-red-600 text-red-600 animate-pulse" />
 						Recording

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1433,11 +1433,10 @@
 		}
 	}
 
-	// Secondary top-bar controls collapsed into a single overflow (⋮) menu so the
-	// bar stays legible on small screens — only the primary actions (mode toggle,
-	// Run pipeline, Save, Activity) stay inline. Recording lives here rather than
-	// on the bar at all times; while armed it also surfaces a compact inline pill
-	// (below) so its state stays visible.
+	// Secondary top-bar controls (recorder, macros) collapse into a single
+	// overflow (⋮) menu so the bar stays legible on small screens; only primary
+	// actions stay inline. Recording lives here rather than on the bar at all
+	// times — while armed it surfaces a compact inline pill (below) instead.
 	let overflowMenuItems = $derived.by<Item[]>(() => {
 		const items: Item[] = []
 		if (!isOperator && allPipelineScripts.length > 0) {
@@ -2411,9 +2410,8 @@
 		{/if}
 		<div class="flex flex-row items-center gap-2 flex-1 justify-end">
 			{#if !isOperator && allPipelineScripts.length > 0}
-				<!-- Recorder arming lives in the overflow (⋮) menu; only its armed
-				     state surfaces on the bar, as a compact disarm pill, so "Record"
-				     no longer occupies the bar at all times. -->
+				<!-- Only the armed state surfaces on the bar (arming lives in the ⋮
+				     menu) — a compact disarm pill. -->
 				{#if recordingMode}
 					<button
 						type="button"
@@ -2529,8 +2527,6 @@
 				iconOnly
 				title="Refresh"
 			/>
-			<!-- Overflow menu for secondary controls (recorder, macros) — keeps the
-			     bar to primary actions and prevents crowding on small screens. -->
 			<DropdownV2 size="sm" items={overflowMenuItems} />
 		</div>
 	</div>

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -109,7 +109,7 @@
 		type ScriptLang
 	} from '$lib/gen'
 	import { resource } from 'runed'
-	import { emptySchema, sendUserToast } from '$lib/utils'
+	import { emptySchema, sendUserToast, type Item } from '$lib/utils'
 	import type { Schema } from '$lib/common'
 	import { beforeNavigate, goto } from '$app/navigation'
 	import { fade } from 'svelte/transition'
@@ -1428,6 +1428,41 @@
 		}
 	}
 
+	// Secondary top-bar controls collapsed into a single overflow (⋮) menu so the
+	// bar stays legible on small screens — only the primary actions (mode toggle,
+	// Run pipeline, Save, Activity) stay inline. Recording lives here rather than
+	// on the bar at all times; while armed it also surfaces a compact inline pill
+	// (below) so its state stays visible.
+	let overflowMenuItems = $derived.by<Item[]>(() => {
+		const items: Item[] = []
+		if (!isOperator && allPipelineScripts.length > 0) {
+			items.push({
+				displayName: recordingMode ? 'Disarm recorder' : 'Record next run',
+				icon: Circle,
+				iconColor: recordingMode ? 'rgb(220 38 38)' : undefined,
+				disabled: !!cascadeRunningRoot,
+				tooltip: recordingMode
+					? 'Recording armed — the next pipeline run will be captured. Click to disarm.'
+					: 'Arm the recorder so the next pipeline run is captured for offline replay',
+				action: () => (recordingMode = !recordingMode)
+			})
+			if (lastPipelineRecording && !cascadeRunningRoot) {
+				items.push({
+					displayName: 'Download last recording',
+					icon: Download,
+					action: () => downloadPipelineRecording()
+				})
+			}
+		}
+		items.push({
+			displayName: 'Macros',
+			icon: SquareFunction,
+			tooltip: "Browse the workspace's DuckDB macros (deployed // macros libraries)",
+			action: () => macroDrawer?.openDrawer()
+		})
+		return items
+	})
+
 	// Script path → its schedule's configured args, so a manual "Run pipeline"
 	// launches a schedule-triggered script with the same payload a real tick
 	// would (rather than empty args). Schedule is the only trigger that stores a
@@ -2371,40 +2406,21 @@
 		{/if}
 		<div class="flex flex-row items-center gap-2 flex-1 justify-end">
 			{#if !isOperator && allPipelineScripts.length > 0}
-				<!-- Recorder: arm to capture the next pipeline run into a
-				     downloadable recording the /pipeline_replay player can rerun offline
-				     (parity with the flow/script recorders). -->
-				{#if lastPipelineRecording && !cascadeRunningRoot}
-					<Button
-						variant="subtle"
-						unifiedSize="sm"
-						startIcon={{ icon: Download }}
-						onclick={downloadPipelineRecording}
-						title="Download the last recorded pipeline run"
+				<!-- Recorder arming lives in the overflow (⋮) menu; only its armed
+				     state surfaces on the bar, as a compact disarm pill, so "Record"
+				     no longer occupies the bar at all times. -->
+				{#if recordingMode}
+					<button
+						type="button"
+						onclick={() => (recordingMode = false)}
+						disabled={!!cascadeRunningRoot}
+						class="flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium transition-colors disabled:opacity-50 bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-700 dark:text-red-400"
+						title="Recording armed — the next pipeline run will be captured. Click to disarm."
 					>
-						Download recording
-					</Button>
+						<Circle size={12} class="fill-red-600 text-red-600 animate-pulse" />
+						Recording
+					</button>
 				{/if}
-				<button
-					type="button"
-					onclick={() => (recordingMode = !recordingMode)}
-					disabled={!!cascadeRunningRoot}
-					class={twMerge(
-						'flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium transition-colors disabled:opacity-50',
-						recordingMode
-							? 'bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-700 dark:text-red-400'
-							: 'bg-surface border-gray-300 dark:border-gray-600 text-secondary hover:bg-surface-hover'
-					)}
-					title={recordingMode
-						? 'Recording armed — the next pipeline run will be captured. Click to disarm.'
-						: 'Arm the recorder so the next pipeline run is captured for offline replay'}
-				>
-					<Circle
-						size={12}
-						class={recordingMode ? 'fill-red-600 text-red-600 animate-pulse' : ''}
-					/>
-					{recordingMode ? 'Recording' : 'Record'}
-				</button>
 				<!-- Pipeline-level run: always visible in both View and Edit so a
 				     run never requires hunting for a specific node's play button
 				     (dbt `build` / Dagster "Materialize all"). Runs every script in
@@ -2502,21 +2518,15 @@
 			<Button
 				variant="subtle"
 				unifiedSize="sm"
-				startIcon={{ icon: SquareFunction }}
-				onclick={() => macroDrawer?.openDrawer()}
-				title="Browse the workspace's DuckDB macros (deployed // macros libraries)"
-			>
-				Macros
-			</Button>
-			<Button
-				variant="subtle"
-				unifiedSize="sm"
 				startIcon={{ icon: RefreshCw }}
 				onclick={() => graphRes.refetch()}
 				disabled={graphRes.loading}
 				iconOnly
 				title="Refresh"
 			/>
+			<!-- Overflow menu for secondary controls (recorder, macros) — keeps the
+			     bar to primary actions and prevents crowding on small screens. -->
+			<DropdownV2 size="sm" items={overflowMenuItems} />
 		</div>
 	</div>
 


### PR DESCRIPTION
## Summary

The data-pipeline editor top bar mixed primary actions (mode toggle, Run pipeline, Save all) with secondary ones (Record, Download recording, Macros), so on small screens the bar overflowed and the always-present **Record** button added noise. This reorganizes the bar so only primary actions stay inline and the rest collapse into a single overflow (⋮) menu.

Fixes WIN-2237

## Changes

- Added an overflow `DropdownV2` (⋮) at the far right of the top bar holding the secondary controls: **Record next run** (arm/disarm the recorder), **Download last recording** (only when a recording exists), and **Macros**.
- Removed the always-visible **Record** button and standalone **Macros** button from the bar.
- Recording no longer occupies the bar at all times — when armed, a compact red **Recording** pill appears inline (click to disarm), matching the issue's ask ("record is too nit to be there at all time, maybe just when recording").
- Kept the primary actions inline: mode toggle, Run pipeline, Save all / autosave / save-errors (edit mode), Activity (view mode), and Refresh (icon).

The menu items are gated identically to the old buttons: recorder/download are hidden for operators and empty pipelines; Macros stays available to everyone.

## Design notes / alternatives considered

The issue asked for multiple suggestions. I went with the most conservative default — a single ⋮ overflow menu plus an armed-state pill — because it declutters without hiding any primary action or changing behavior. Alternatives not taken: moving Activity/Refresh into the menu too (they're primary enough in view mode to stay inline), or a labeled "More" button instead of the icon-only ⋮ (the ⋮ matches the rest of the app's overflow menus).

## Testing

- `npm run check:fast` — clean for the changed file (only a pre-existing, unrelated `modern-screenshot` error in `RawAppEditor.svelte`).
- Manual verification with Playwright against the running dev server (seeded a 2-script pipeline):
  - **View mode**: bar shows Run pipeline / Activity / Refresh / ⋮; menu opens with "Record next run" + "Macros".
  - Clicking **Record next run** arms the recorder and surfaces the inline **Recording** pill; clicking the pill disarms.
  - **Edit mode**: bar shows Run pipeline / Refresh / ⋮ (Activity is view-only, Save all appears with drafts).

## Screenshots

### View mode — overflow menu open
![pipeline-topbar-menu-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2237-reorganize-pipeline-top-bar-controls-into-menu/1784887187-pipeline-topbar-menu-open.png)

### Recording armed — inline pill
![pipeline-topbar-recording](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2237-reorganize-pipeline-top-bar-controls-into-menu/1784887189-pipeline-topbar-recording.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed secondary pipeline top-bar controls into a ⋮ overflow menu, keeping only primary actions inline. Addresses WIN-2237 by showing recording only when active and reducing crowding on small screens.

- **New Features**
  - Added a right-aligned overflow menu with “Record next run”, “Download last recording” (when available), and “Macros”.
  - Replaced the always-visible Record button with a compact inline “Recording” pill that appears only when armed (click to disarm).
  - Kept primary actions inline: mode toggle, Run pipeline, Save/Activity, Refresh.
  - Preserves existing visibility rules (recorder/download hidden for operators and empty pipelines); no behavior changes.

- **Refactors**
  - Hoisted the “Recording armed…” tooltip into a shared `RECORDING_ARMED_HINT` const and consolidated the overflow-menu rationale into a single code comment to avoid duplication.

<sup>Written for commit c70858cc665c71b0a49bea2acad5f3a87f683f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

