### PR TITLE
fix: pin table actions column so it stays visible on narrow screens

### DIFF
--- a/frontend/src/lib/components/table/Cell.svelte
+++ b/frontend/src/lib/components/table/Cell.svelte
@@ -11,6 +11,7 @@
 		shouldStopPropagation?: boolean
 		selected?: boolean
 		sticky?: boolean
+		stickyEnd?: boolean
 		wrap?: boolean
 		children?: import('svelte').Snippet
 		[key: string]: any
@@ -24,6 +25,7 @@
 		shouldStopPropagation = false,
 		selected = false,
 		sticky = false,
+		stickyEnd = false,
 		wrap = false,
 		children,
 		...rest
@@ -53,6 +55,11 @@
 		last && size === 'xs' ? 'sm:pr-3' : '',
 
 		numeric ? 'text-right' : '',
+		// Pin an actions column to the right so it stays visible when a wide table
+		// scrolls horizontally. The background must be opaque so cells sliding under it
+		// are occluded — the row's hover tint is translucent and would bleed through.
+		stickyEnd ? 'sticky right-0 border-l' : '',
+		stickyEnd ? (head ? 'bg-surface-secondary' : 'bg-surface') : '',
 		sticky ? `!p-0 sticky ${first ? 'left-0' : 'right-0'}` : 'px-2 py-2',
 		size === 'sm' ? 'px-1.5 py-2.5' : '',
 		size === 'lg' ? 'px-3 py-4' : '',

--- a/frontend/src/routes/(root)/(logged)/folders/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/folders/+page.svelte
@@ -180,7 +180,7 @@
 						<Cell head class="w-20">Variables</Cell>
 						<Cell head class="w-20">Resources</Cell>
 						<Cell head class="w-20">Participants</Cell>
-						<Cell head last />
+						<Cell head last stickyEnd />
 					</tr>
 				</Head>
 				<tbody class="divide-y">
@@ -242,7 +242,7 @@
 								<FolderUsageInfo {name} tabular />
 
 								<Cell><FolderInfo members={computeMembers(owners, extra_perms)} /></Cell>
-								<Cell shouldStopPropagation>
+								<Cell last stickyEnd shouldStopPropagation>
 									<Dropdown
 										items={[
 											{

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -1176,83 +1176,85 @@
 												{/if}
 											</div>
 										</Cell>
-										<Cell stickyEnd class="flex justify-end">
-											{#if path && assetCanBeExplored({ kind: 'resource', path }, { resource_type }) && !$userStore?.operator}
-												<ExploreAssetButton
-													asset={{ kind: 'resource', path }}
-													_resourceMetadata={{ resource_type }}
-													class="w-24"
-												/>
-											{/if}
-											<Dropdown
-												class="w-fit"
-												items={[
-													{
-														displayName: 'Permissions',
-														icon: Shield,
-														action: () => {
-															shareModal?.openDrawer?.(path, 'resource')
-														}
-													},
-													{
-														displayName: 'Edit',
-														icon: Pen,
-														disabled: !canWrite || !showCreateButtons,
-														action: () => {
-															resourceEditor?.initEdit?.(path)
-														}
-													},
-													...(!ws_specific && isDeployable('resource', path, deployUiSettings)
-														? [
-																{
-																	displayName: 'Deploy to prod/staging',
-																	icon: FileUp,
-																	action: () => {
-																		deploymentDrawer?.openDrawer(path, 'resource')
+										<Cell stickyEnd>
+											<div class="flex justify-end">
+												{#if path && assetCanBeExplored({ kind: 'resource', path }, { resource_type }) && !$userStore?.operator}
+													<ExploreAssetButton
+														asset={{ kind: 'resource', path }}
+														_resourceMetadata={{ resource_type }}
+														class="w-24"
+													/>
+												{/if}
+												<Dropdown
+													class="w-fit"
+													items={[
+														{
+															displayName: 'Permissions',
+															icon: Shield,
+															action: () => {
+																shareModal?.openDrawer?.(path, 'resource')
+															}
+														},
+														{
+															displayName: 'Edit',
+															icon: Pen,
+															disabled: !canWrite || !showCreateButtons,
+															action: () => {
+																resourceEditor?.initEdit?.(path)
+															}
+														},
+														...(!ws_specific && isDeployable('resource', path, deployUiSettings)
+															? [
+																	{
+																		displayName: 'Deploy to prod/staging',
+																		icon: FileUp,
+																		action: () => {
+																			deploymentDrawer?.openDrawer(path, 'resource')
+																		}
 																	}
-																}
-															]
-														: []),
-													{
-														displayName: 'Delete',
-														disabled: !canWrite || !showCreateButtons,
-														icon: Trash,
-														type: 'delete',
-														action: (event) => {
-															// TODO
-															// @ts-ignore
-															if (event?.shiftKey) {
-																deleteResource(path, account)
-															} else {
-																deleteIsLinked = is_linked ?? false
-																deleteConfirmedCallback = () => {
+																]
+															: []),
+														{
+															displayName: 'Delete',
+															disabled: !canWrite || !showCreateButtons,
+															icon: Trash,
+															type: 'delete',
+															action: (event) => {
+																// TODO
+																// @ts-ignore
+																if (event?.shiftKey) {
 																	deleteResource(path, account)
+																} else {
+																	deleteIsLinked = is_linked ?? false
+																	deleteConfirmedCallback = () => {
+																		deleteResource(path, account)
+																	}
 																}
 															}
-														}
-													},
-													...(account != undefined
-														? [
-																{
-																	displayName: 'Refresh token',
-																	icon: RotateCw,
-																	action: async () => {
-																		await OauthService.refreshToken({
-																			workspace: $workspaceStore ?? '',
-																			id: account ?? 0,
-																			requestBody: {
-																				path
-																			}
-																		})
-																		sendUserToast('Token refreshed')
-																		loadResources()
+														},
+														...(account != undefined
+															? [
+																	{
+																		displayName: 'Refresh token',
+																		icon: RotateCw,
+																		action: async () => {
+																			await OauthService.refreshToken({
+																				workspace: $workspaceStore ?? '',
+																				id: account ?? 0,
+																				requestBody: {
+																					path
+																				}
+																			})
+																			sendUserToast('Token refreshed')
+																			loadResources()
+																		}
 																	}
-																}
-															]
-														: [])
-												]}
-											/>
-										</Cell>
+																]
+															: [])
+													]}
+												/>
+											</div></Cell
+										>
 									</Row>
 								{/each}
 							{/if}

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -1176,7 +1176,7 @@
 												{/if}
 											</div>
 										</Cell>
-										<Cell stickyEnd>
+										<Cell last stickyEnd>
 											<div class="flex justify-end">
 												{#if path && assetCanBeExplored({ kind: 'resource', path }, { resource_type }) && !$userStore?.operator}
 													<ExploreAssetButton

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -1008,7 +1008,7 @@
 								<Cell head>Resource type</Cell>
 								<Cell head>Description</Cell>
 								<Cell head />
-								<Cell head last />
+								<Cell head last stickyEnd />
 							</Row>
 						</Head>
 						<tbody class="divide-y bg-surface">
@@ -1176,7 +1176,7 @@
 												{/if}
 											</div>
 										</Cell>
-										<Cell class="flex justify-end">
+										<Cell stickyEnd class="flex justify-end">
 											{#if path && assetCanBeExplored({ kind: 'resource', path }, { resource_type }) && !$userStore?.operator}
 												<ExploreAssetButton
 													asset={{ kind: 'resource', path }}
@@ -1280,7 +1280,7 @@
 							<Row>
 								<Cell head first>Name</Cell>
 								<Cell head>Description</Cell>
-								<Cell head last />
+								<Cell head last stickyEnd />
 							</Row>
 						</Head>
 						<tbody class="divide-y bg-surface">
@@ -1316,7 +1316,7 @@
 												{removeMarkdown(truncate(description ?? '', 200))}
 											</span>
 										</Cell>
-										<Cell last>
+										<Cell last stickyEnd>
 											{#if !canWrite}
 												<Badge>
 													Shared globally

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -465,7 +465,11 @@
 												<div class="">
 													{#if refresh_error}
 														<Popover notClickable>
-															<div class="relative inline-flex justify-center items-center w-4 h-4">
+															<!-- isolate: confine the ping indicator's z-50 to a local stacking context
+											     so it can't paint over a sticky-pinned actions column scrolling past it -->
+															<div
+																class="relative inline-flex justify-center items-center w-4 h-4 isolate"
+															>
 																<Circle
 																	class="text-red-600 animate-ping absolute z-50 w-4 h-4 fill-current"
 																	size={12}

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -362,7 +362,7 @@
 								<Cell head>Value</Cell>
 								<Cell head>Description</Cell>
 								<Cell head />
-								<Cell head last />
+								<Cell head last stickyEnd />
 							</tr>
 						</Head>
 						<tbody class="divide-y">
@@ -514,7 +514,7 @@
 											{/if}
 										</div>
 									</Cell>
-									<Cell last shouldStopPropagation>
+									<Cell last stickyEnd shouldStopPropagation>
 										<Dropdown
 											items={() => {
 												let owner = isOwner(path, $userStore, $workspaceStore)


### PR DESCRIPTION
## Summary

Wide `DataTable`s scroll horizontally on narrow screens, and the trailing per-row **actions column** (the `⋯` menu, Edit/Delete, and the folders page's **Publish to Hub** entry) was pushed off the right edge into the horizontal-scroll overflow, where it was effectively unreachable.

This pins that actions column to the right edge of the scroll container so it stays visible regardless of table width.

## Changes

- **`Cell.svelte`**: add an opt-in `stickyEnd` prop. When set, the cell is pinned with `sticky right-0` plus a `border-l` divider and an **opaque** background (`bg-surface` for body cells, `bg-surface-secondary` for header cells). The background is deliberately opaque rather than the row's hover tint (`bg-surface-hover` is translucent, `rgba(...,0.2)`), so cells sliding underneath are occluded instead of bleeding through.
- **folders / variables / resources pages**: mark the trailing actions column (header + body cells) with `stickyEnd`. Folders is the widest (10 columns) and the page where this was originally noticed; resources covers both its tables (resources + resource types).
- On the resources workspace table, the actions cell used `class="flex justify-end"` directly on the `Cell`, which forces the `<td>` to `display: flex` and breaks `position: sticky` (a flex box in a table row is wrapped in an anonymous table-cell). Moved the flex layout to an inner `<div>` so the `<td>` stays `display: table-cell` and pins correctly.

Groups (3 columns) and assets (4 columns) were checked too — their last cell holds data rather than actions and the tables don't meaningfully overflow, so they were left unchanged.

## Screenshots

Verified in-browser (Playwright) on the `admins` workspace at narrow viewports.

**Folders — actions column pinned while the table overflows (hover row, no bleed-through):**

![folders-fixed-hover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pin-actions-column-wide-tables/1784889491-folders-fixed-hover.png)

**Folders — scrolled fully right: the Participants column slides cleanly under the pinned actions column:**

![folders-scrolled-right](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pin-actions-column-wide-tables/1784889493-folders-scrolled-right.png)

**Resources (Workspace tab) — scrolled right at 400px: `⋯` menu + Manage buttons stay pinned while the Path column scrolls off (this is the case the flex→table-cell fix addresses):**

![resources-fixed-scrolled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pin-actions-column-wide-tables/1784889919-resources-fixed-scrolled.png)

**Variables:**

![variables-narrow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pin-actions-column-wide-tables/1784889495-variables-narrow.png)

**Resources (Resource Types tab):**

![resource-types](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pin-actions-column-wide-tables/1784889499-resource-types.png)

## Test plan

- [ ] On a narrow viewport, open `/folders` in a workspace that has folders and confirm the `⋯` actions menu (with **Publish to Hub**) is always visible at the right edge, even while the rest of the table scrolls horizontally.
- [ ] Hover a row and scroll the table right — the pinned column stays opaque with no content bleeding through it.
- [ ] Repeat on `/variables` and `/resources` (both tabs); on resources Workspace, narrow enough to force horizontal scroll and confirm the actions cell stays pinned (not just the header).
- [ ] Confirm no visual regression on wider screens (the column looks like a normal last column with a left divider).