### PR TITLE
perf: optimize get_datatable_full_schema to avoid timeout on large catalogs

### DIFF
--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -4835,6 +4835,10 @@ fn pg_action_to_string(action: &str) -> String {
 pub async fn pg_get_full_schema(
     client: &tokio_postgres::Client,
 ) -> Result<FullDatabaseSchema, String> {
+    // Primary-key and default-value info are joined in (a table has at most one
+    // primary-key constraint, so `pkc` stays 1:1) rather than fetched via
+    // per-column correlated subqueries — on large catalogs those subqueries run
+    // once per column and make the introspection time out.
     let column_rows = client
         .query(
             "SELECT
@@ -4842,19 +4846,17 @@ pub async fn pg_get_full_schema(
                 c.relname AS table_name,
                 a.attname AS column_name,
                 pg_catalog.format_type(a.atttypid, a.atttypmod) AS datatype,
-                (SELECT substring(pg_catalog.pg_get_expr(d.adbin, d.adrelid, true) for 128)
-                 FROM pg_catalog.pg_attrdef d
-                 WHERE d.adrelid = a.attrelid AND d.adnum = a.attnum AND a.atthasdef) AS default_value,
-                CASE a.attnotnull WHEN false THEN true ELSE false END AS nullable,
-                EXISTS (
-                    SELECT 1 FROM pg_catalog.pg_index i
-                    WHERE i.indrelid = c.oid AND i.indisprimary AND a.attnum = ANY(i.indkey)
-                ) AS is_primary_key,
-                (SELECT con.conname FROM pg_catalog.pg_constraint con
-                 WHERE con.conrelid = c.oid AND con.contype = 'p' LIMIT 1) AS pk_constraint_name
+                substring(pg_catalog.pg_get_expr(ad.adbin, ad.adrelid, true) for 128) AS default_value,
+                NOT a.attnotnull AS nullable,
+                COALESCE(pkc.conkey @> ARRAY[a.attnum], false) AS is_primary_key,
+                pkc.conname AS pk_constraint_name
             FROM pg_catalog.pg_attribute a
             JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
             JOIN pg_catalog.pg_namespace ns ON c.relnamespace = ns.oid
+            LEFT JOIN pg_catalog.pg_attrdef ad
+                ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum AND a.atthasdef
+            LEFT JOIN pg_catalog.pg_constraint pkc
+                ON pkc.conrelid = c.oid AND pkc.contype = 'p'
             WHERE c.relkind = 'r'
                 AND a.attnum > 0
                 AND NOT a.attisdropped


### PR DESCRIPTION
## Summary
`get_datatable_full_schema` times out (30s) on large catalogs (e.g. the `hub` workspace's `datatable://main`). The column-introspection query in `pg_get_full_schema` built every column row with three per-column correlated subqueries — default value (`pg_attrdef`), primary-key `EXISTS` (`pg_index`), and pk constraint name (`pg_constraint`). On a catalog with many tables/columns those subqueries run once per column, turning introspection into O(columns) index searches.

This replaces them with plain joins: a `LEFT JOIN` to `pg_attrdef` for defaults and a single `LEFT JOIN` to the table's primary-key constraint (a table has at most one, so the join stays 1:1) providing both `is_primary_key` (via `conkey @> ARRAY[a.attnum]`) and `pk_constraint_name`. The planner now does one hash/merge join instead of per-column correlated scans.

## Changes
- Rewrite the columns query in `pg_get_full_schema` (`backend/windmill-common/src/query_builders.rs`) to use joins instead of correlated subqueries. Output is byte-for-byte identical; the FK query is unchanged.

## Validation
- Verified byte-for-byte identical output between the old and new query against the local dev catalog (1262 column rows, `diff` clean).
- `EXPLAIN (ANALYZE, BUFFERS)`: the old plan shows `SubPlan 2`/`SubPlan 3` looping 1262× with ~11k shared-buffer hits; the new plan replaces them with hash joins and drops to a few hundred buffer hits.
- Backend compiles cleanly (`cargo watch`, health check passed).

## Test plan
- [ ] Call `POST /w/{workspace}/workspaces/get_datatable_full_schema` on a large catalog and confirm it returns within the timeout.
- [ ] Confirm the returned schema (columns, datatypes, defaults, nullability, primary keys, pk constraint names, foreign keys) matches expectations.

Fixes WIN-2239

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize `get_datatable_full_schema` to avoid 30s timeouts on large catalogs by switching from per-column subqueries to join-based introspection. Addresses WIN-2239 with identical returned schema.

- **Refactors**
  - Use LEFT JOINs to `pg_attrdef` (defaults) and the table’s primary-key `pg_constraint` to derive `is_primary_key` and `pk_constraint_name`.
  - Keep FK introspection unchanged.
  - Moves from O(columns) correlated subqueries to a single join plan for consistent performance on big catalogs.

<sup>Written for commit a6d596759333e7f73939ff24be19670fd4ca10ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

