### PR TITLE
fix: do not apply workspace display name on git-sync pull

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -167,7 +167,7 @@ pub enum ObjectType {
     DatatableMigration,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28796/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28809/sync-script-to-git-repo-windmill";
 
 /// Hub script that applies a repository's state back into a workspace
 /// (the repo → Windmill / "pull" direction). Same script the UI runs from
@@ -175,7 +175,7 @@ pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28796/sync-script-to-git-repo
 /// ignores the slug, so the slug is kept free of characters that would be
 /// percent-encoded into the run URL (a `:` becomes `%3A`, which some hardened
 /// reverse proxies reject as double-encoding when the client re-encodes it).
-pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28795/git-sync-init-repository-windmill";
+pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28808/git-sync-init-repository-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.

--- a/cli/src/core/settings.ts
+++ b/cli/src/core/settings.ts
@@ -217,9 +217,8 @@ export async function pushWorkspaceSettings(
     throw new Error(`Failed to get workspace settings: ${err}`);
   }
 
-  // Exclude read-only fields from comparison (slack_team_id and slack_name are set via OAuth only).
-  // name is excluded too: the workspace display name is per-instance UX, not applied on pull (see below),
-  // so a name-only diff must not force the rest of the settings to re-apply.
+  // Exclude fields that are never applied here: slack_team_id/slack_name are OAuth-only,
+  // and name is not applied on pull (see below), so a name-only diff stays a no-op.
   const { slack_team_id: _lst, slack_name: _lsn, name: _ln, ...comparableLocal } = localSettings;
   const { slack_team_id: _rst, slack_name: _rsn, name: _rn, ...comparableRemote } = settings;
   if (isSuperset(comparableLocal, comparableRemote)) {
@@ -366,11 +365,10 @@ export async function pushWorkspaceSettings(
     });
   }
 
-  // The workspace display name is intentionally not applied on pull. It is a
-  // per-instance property, and settings.yaml is shared across the branches of a
-  // repo, so applying it would let one workspace's name overwrite another's when
-  // two workspaces sync the same repo. name stays in settings.yaml for reference
-  // (written on push), but only the workspace owner renames a live workspace.
+  // Workspace display name is intentionally not applied on pull: settings.yaml is shared
+  // across a repo's branches, so applying it would let one workspace's name overwrite
+  // another's when both sync the same repo. It stays in the file (written on push), but a
+  // live workspace is only renamed by its owner.
 
   if (localSettings.mute_critical_alerts != settings.mute_critical_alerts) {
     log.debug(`Updating mute critical alerts...`);

--- a/cli/src/core/settings.ts
+++ b/cli/src/core/settings.ts
@@ -217,9 +217,11 @@ export async function pushWorkspaceSettings(
     throw new Error(`Failed to get workspace settings: ${err}`);
   }
 
-  // Exclude read-only fields from comparison (slack_team_id and slack_name are set via OAuth only)
-  const { slack_team_id: _lst, slack_name: _lsn, ...comparableLocal } = localSettings;
-  const { slack_team_id: _rst, slack_name: _rsn, ...comparableRemote } = settings;
+  // Exclude read-only fields from comparison (slack_team_id and slack_name are set via OAuth only).
+  // name is excluded too: the workspace display name is per-instance UX, not applied on pull (see below),
+  // so a name-only diff must not force the rest of the settings to re-apply.
+  const { slack_team_id: _lst, slack_name: _lsn, name: _ln, ...comparableLocal } = localSettings;
+  const { slack_team_id: _rst, slack_name: _rsn, name: _rn, ...comparableRemote } = settings;
   if (isSuperset(comparableLocal, comparableRemote)) {
     log.debug(`Workspace settings are up to date`);
     return;
@@ -364,15 +366,11 @@ export async function pushWorkspaceSettings(
     });
   }
 
-  if (localSettings.name != settings.name) {
-    log.debug(`Updating workspace name...`);
-    await wmill.changeWorkspaceName({
-      workspace,
-      requestBody: {
-        new_name: localSettings.name,
-      },
-    });
-  }
+  // The workspace display name is intentionally not applied on pull. It is a
+  // per-instance property, and settings.yaml is shared across the branches of a
+  // repo, so applying it would let one workspace's name overwrite another's when
+  // two workspaces sync the same repo. name stays in settings.yaml for reference
+  // (written on push), but only the workspace owner renames a live workspace.
 
   if (localSettings.mute_critical_alerts != settings.mute_critical_alerts) {
     log.debug(`Updating mute critical alerts...`);

--- a/cli/test/push_workspace_settings_name_unit.test.ts
+++ b/cli/test/push_workspace_settings_name_unit.test.ts
@@ -1,11 +1,6 @@
 /**
- * Unit tests for workspace-name handling in pushWorkspaceSettings (settings.ts).
- *
- * A pull applies the tracked settings.yaml onto the workspace. The workspace
- * display name lives in settings.yaml but must NOT be applied on pull: it is a
- * per-instance property, and settings.yaml is shared across the branches of a
- * repo, so applying it lets one workspace's name overwrite another's when two
- * workspaces sync the same repo. These tests pin that name is never pushed.
+ * Regression guard: a pull (pushWorkspaceSettings) must not apply the workspace
+ * display name from settings.yaml. Rationale lives at the apply site in settings.ts.
  */
 
 import { expect, test, describe, beforeEach, mock } from "bun:test";

--- a/cli/test/push_workspace_settings_name_unit.test.ts
+++ b/cli/test/push_workspace_settings_name_unit.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for workspace-name handling in pushWorkspaceSettings (settings.ts).
+ *
+ * A pull applies the tracked settings.yaml onto the workspace. The workspace
+ * display name lives in settings.yaml but must NOT be applied on pull: it is a
+ * per-instance property, and settings.yaml is shared across the branches of a
+ * repo, so applying it lets one workspace's name overwrite another's when two
+ * workspaces sync the same repo. These tests pin that name is never pushed.
+ */
+
+import { expect, test, describe, beforeEach, mock } from "bun:test";
+
+let changeWorkspaceNameCalls: unknown[] = [];
+let editWebhookCalls: unknown[] = [];
+let remoteName = "";
+let remoteWebhook: string | undefined = undefined;
+
+// Every wmill.* call reachable from pushWorkspaceSettings is stubbed so the
+// function runs without a backend; only the two we assert on record calls.
+mock.module("../gen/services.gen.ts", () => ({
+  getSettings: async (_a: { workspace: string }) => ({ webhook: remoteWebhook }),
+  getWorkspaceName: async (_a: { workspace: string }) => remoteName,
+  changeWorkspaceName: async (a: unknown) => {
+    changeWorkspaceNameCalls.push(a);
+  },
+  editWebhook: async (a: unknown) => {
+    editWebhookCalls.push(a);
+  },
+  editAutoInvite: async () => {},
+  editErrorHandler: async () => {},
+  editSuccessHandler: async () => {},
+  editDeployTo: async () => {},
+  editCopilotConfig: async () => {},
+  editLargeFileStorageConfig: async () => {},
+  editWorkspaceGitSyncConfig: async () => {},
+  editWorkspaceDefaultApp: async () => {},
+  editDefaultScripts: async () => {},
+  workspaceMuteCriticalAlertsUi: async () => {},
+  changeWorkspaceColor: async () => {},
+  updateOperatorSettings: async () => {},
+  editDataTableConfig: async () => {},
+  editSlackCommand: async () => {},
+  setWorkspaceSlackOauthConfig: async () => {},
+  deleteWorkspaceSlackOauthConfig: async () => {},
+}));
+
+const { pushWorkspaceSettings } = await import("../src/core/settings.ts");
+
+describe("pushWorkspaceSettings workspace name", () => {
+  const ws = "phoenix";
+
+  beforeEach(() => {
+    changeWorkspaceNameCalls = [];
+    editWebhookCalls = [];
+    remoteName = "phoenix";
+    remoteWebhook = undefined;
+  });
+
+  test("a differing name in settings.yaml is not applied to the workspace", async () => {
+    // Another setting also differs so the function proceeds past its no-op early
+    // return; only that setting must be applied, never the name.
+    remoteWebhook = "https://old";
+    await pushWorkspaceSettings(ws, "settings", undefined, {
+      name: "phoenix-staging",
+      webhook: "https://new",
+    });
+    expect(editWebhookCalls.length).toBe(1);
+    expect(changeWorkspaceNameCalls.length).toBe(0);
+  });
+
+  test("a name-only difference is a complete no-op", async () => {
+    await pushWorkspaceSettings(ws, "settings", undefined, {
+      name: "phoenix-staging",
+    });
+    expect(editWebhookCalls.length).toBe(0);
+    expect(changeWorkspaceNameCalls.length).toBe(0);
+  });
+});

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,6 +1,6 @@
 {
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28795/git-sync-init-repository-windmill",
+	"gitInitRepo": "hub/28808/git-sync-init-repository-windmill",
 	"slackErrorHandler": "hub/28794/workspace-or-schedule-error-handler-slack",
 	"emailErrorHandler": "hub/19795/workspace-or-error-handler-email",
 	"slackRecoveryHandler": "hub/28791/slack/schedule-recovery-handler-slack",


### PR DESCRIPTION
## Summary

The workspace display name is one of the settings tracked in git sync (`settings.yaml`, the `name` field). On every pull, `pushWorkspaceSettings` (the git→windmill apply path) called `changeWorkspaceName` whenever the tracked name differed from the live workspace name.

Because `settings.yaml` lives at the repo root and is shared across the branches of a repo, this let one workspace's name overwrite another's when two workspaces sync the same repo. Concretely: with a prod workspace on `master` and a staging workspace on `staging` of the same repo, once a `settings.yaml` carrying the staging name reached the branch prod pulls from, an automatic git-to-windmill pull silently renamed the prod workspace, with no user action.

This PR stops applying the display name on pull. The name is still written to `settings.yaml` on push (kept for reference), but a live workspace is only ever renamed by its owner via the UI/API, never by a pull.

## Changes

- `cli/src/core/settings.ts`: remove the `changeWorkspaceName` apply from `pushWorkspaceSettings` (the pull-apply path); exclude `name` from the `isSuperset` early-return so a name-only diff stays a clean no-op.
- `cli/test/push_workspace_settings_name_unit.test.ts`: regression guard — a differing `name` in `settings.yaml` is never applied while other differing settings still apply; a name-only diff is a complete no-op.
- **Hub delivery for backend auto-pull**: the backend auto-pull (`enqueue_git_pull_job`) runs a pinned Hub script that bundles a *published* `windmill-cli`, so the source fix only reaches auto-pull via a republished bundle. Published `windmill-cli@1.769.1` with the fix, republished both git-sync hub scripts to pin it, and bumped the pins:
  - `backend/windmill-common/src/workspaces.rs`: `GIT_SYNC_PULL_SCRIPT_PATH` 28795→28808, `LATEST_GIT_SYNC_SCRIPT_PATH` 28796→28809.
  - `frontend/src/lib/hubPaths.json`: `gitInitRepo` 28795→28808.
  - Both new hub scripts (28808 pull, 28809 sync) verified to bundle `windmill-cli@1.769.1`, which is verified to no longer emit the `changeWorkspaceName` pull-apply.

## Test plan

- [x] `UNIT_ONLY=1 bun test test/push_workspace_settings_name_unit.test.ts` passes; fails when the apply is re-introduced (verified)
- [x] Full CLI unit suite green (976 pass)
- [x] `windmill-cli@1.769.1` bundle confirmed to drop the name-apply (`changeWorkspaceName` call site + "Updating workspace name" log gone vs 1.769.0)
- [ ] Git Sync Integration Tests green (triggered by the `workspaces.rs` pin change)
- [ ] Manual: an automatic git→windmill pull with a differing tracked `name` leaves the workspace display name unchanged while other settings still apply