### PR TITLE
fix: match WAC waitForApproval resume to its own step

### DIFF
--- a/backend/tests/wac_approval_resume.rs
+++ b/backend/tests/wac_approval_resume.rs
@@ -1,0 +1,104 @@
+//! Regression test for WAC `waitForApproval` reading the wrong approval result.
+//!
+//! Sequential `waitForApproval()` calls share the parent job_id, so the resume
+//! lookup must select the `resume_job` row whose `resume_id` matches the pending
+//! approval step's key — not the oldest row for the job. Before the fix, a job's
+//! second approval re-read the first approval's value (and cancels/timeouts
+//! inherited the first approval's `approved=true`).
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use uuid::Uuid;
+
+use windmill_common::wac::{save_checkpoint, WacCheckpoint, WacPendingSteps};
+use windmill_worker::wac_executor::{approval_resume_id, prepare_checkpoint_for_resume};
+
+async fn insert_resume(
+    db: &Pool<Postgres>,
+    job_id: Uuid,
+    key: &str,
+    value: serde_json::Value,
+    approved: bool,
+    age_seconds: i64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO resume_job (id, job, flow, created_at, value, approver, resume_id, approved)
+         VALUES ($1, $2, $2, now() - make_interval(secs => $3), $4, 'tester', $5, $6)",
+    )
+    .bind(Uuid::new_v4())
+    .bind(job_id)
+    .bind(age_seconds as f64)
+    .bind(value)
+    .bind(approval_resume_id(key) as i32)
+    .bind(approved)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn resume_matches_pending_approval_step(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let job_id = Uuid::new_v4();
+
+    // Minimal queue row so the resume_job.flow FK and the v2_job_status FK resolve.
+    sqlx::query(
+        "INSERT INTO v2_job_queue (id, workspace_id, scheduled_for, suspend)
+         VALUES ($1, 'test-workspace', now(), 1)",
+    )
+    .bind(job_id)
+    .execute(&db)
+    .await?;
+
+    // The workflow is parked on its *second* approval.
+    let pending_key = "approval_2";
+    let checkpoint = WacCheckpoint {
+        pending_steps: Some(WacPendingSteps {
+            mode: "approval".to_string(),
+            keys: vec![pending_key.to_string()],
+            job_ids: Default::default(),
+        }),
+        ..Default::default()
+    };
+    save_checkpoint(&db, &job_id, &checkpoint).await?;
+
+    // Two resume events for the same job: the first approval (older, approved) and
+    // the pending second approval (newer, cancelled). The pre-fix query
+    // `WHERE job = $1 ORDER BY created_at ASC LIMIT 1` would return the older row.
+    insert_resume(
+        &db,
+        job_id,
+        "approval",
+        json!({ "which": "first" }),
+        true,
+        10,
+    )
+    .await?;
+    insert_resume(
+        &db,
+        job_id,
+        pending_key,
+        json!({ "which": "second" }),
+        false,
+        0,
+    )
+    .await?;
+
+    let resumed = prepare_checkpoint_for_resume(&db, &job_id, checkpoint).await?;
+
+    let injected = resumed
+        .completed_steps
+        .get(pending_key)
+        .expect("pending approval step should be resolved");
+    assert_eq!(
+        injected["value"],
+        json!({ "which": "second" }),
+        "must read its own resume event, not the workflow's first approval"
+    );
+    assert_eq!(
+        injected["approved"],
+        json!(false),
+        "the cancelled second approval must keep approved=false"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -3127,13 +3127,9 @@ pub async fn handle_wac_v2_output(
 
             // Generate resume URLs for the inline approval buttons.
             // Use a hash of the step key as resume_id so each waitForApproval()
-            // in the same workflow gets a unique resume_job record.
-            let resume_id: u32 = {
-                use std::hash::{Hash, Hasher};
-                let mut hasher = std::collections::hash_map::DefaultHasher::new();
-                key.hash(&mut hasher);
-                (hasher.finish() & 0xFFFF_FFFF) as u32
-            };
+            // in the same workflow gets a unique resume_job record. The resume-side
+            // matching in prepare_checkpoint_for_resume derives the same id from the key.
+            let resume_id: u32 = crate::wac_executor::approval_resume_id(&key);
             // Generate stateless approval token using shared utility
             let approval_token =
                 windmill_common::variables::generate_approval_token(&job.workspace_id, job.id, db)

--- a/backend/windmill-worker/src/wac_executor.rs
+++ b/backend/windmill-worker/src/wac_executor.rs
@@ -49,6 +49,17 @@ pub enum WacOutput {
     Sleep { key: String, seconds: u32 },
 }
 
+/// Derive the per-approval `resume_id` from the step key. This MUST stay in sync with the
+/// resume/cancel URL generation in `handle_wac_v2_output` so that the resume endpoint and the
+/// checkpoint-resume matching agree on which `resume_job` row belongs to which
+/// `waitForApproval()` call within a workflow.
+pub fn approval_resume_id(key: &str) -> u32 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    (hasher.finish() & 0xFFFF_FFFF) as u32
+}
+
 /// A step dispatched by the WAC SDK.
 ///
 /// `dispatch_type` determines how the child job is created:
@@ -143,10 +154,18 @@ pub async fn prepare_checkpoint_for_resume(
                 .and_then(|p| p.keys.first().cloned())
                 .unwrap_or_default();
 
+            // Match the resume event to *this* approval step by its resume_id. Every
+            // waitForApproval() in the same workflow shares the parent job_id, so keying
+            // only on `job` (and taking the oldest row) made every step after the first
+            // re-inject the first approval's value. A canceled step then carries approved=false
+            // on its own row, and a timed-out step has no row at all -> the None branch below
+            // yields the approved=false default.
+            let resume_id = approval_resume_id(&approval_key) as i32;
             let resume_row = sqlx::query_as::<_, (sqlx::types::Json<Box<serde_json::value::RawValue>>, Option<String>, bool)>(
-                "SELECT value, approver, approved FROM resume_job WHERE job = $1 ORDER BY created_at ASC LIMIT 1",
+                "SELECT value, approver, approved FROM resume_job WHERE job = $1 AND resume_id = $2 ORDER BY created_at DESC LIMIT 1",
             )
             .bind(job_id)
+            .bind(resume_id)
             .fetch_optional(db)
             .await?;
 

--- a/backend/windmill-worker/src/wac_executor.rs
+++ b/backend/windmill-worker/src/wac_executor.rs
@@ -154,12 +154,10 @@ pub async fn prepare_checkpoint_for_resume(
                 .and_then(|p| p.keys.first().cloned())
                 .unwrap_or_default();
 
-            // Match the resume event to *this* approval step by its resume_id. Every
-            // waitForApproval() in the same workflow shares the parent job_id, so keying
-            // only on `job` (and taking the oldest row) made every step after the first
-            // re-inject the first approval's value. A canceled step then carries approved=false
-            // on its own row, and a timed-out step has no row at all -> the None branch below
-            // yields the approved=false default.
+            // Match the resume event to *this* approval step by its resume_id: every
+            // waitForApproval() in a workflow shares the parent job_id, so filtering only on
+            // `job` would let one step read another's approval. A timed-out step matches no
+            // row and falls through to the approved=false default in the None branch below.
             let resume_id = approval_resume_id(&approval_key) as i32;
             let resume_row = sqlx::query_as::<_, (sqlx::types::Json<Box<serde_json::value::RawValue>>, Option<String>, bool)>(
                 "SELECT value, approver, approved FROM resume_job WHERE job = $1 AND resume_id = $2 ORDER BY created_at DESC LIMIT 1",


### PR DESCRIPTION
## Summary
Sequential `waitForApproval()` calls in a workflow-as-code (WAC) job all share the same parent `job_id`. On resume, `prepare_checkpoint_for_resume` read the approval event with `WHERE job = $1 ORDER BY created_at ASC LIMIT 1` — always the **oldest** `resume_job` row for the job, and rows are never deleted. So every approval after the first re-injected the first approval's `{value, approver, approved}`, and canceled/timed-out steps inherited it too.

Repro (all three returned `{approved: true}` before the fix):

```python
from wmill import wait_for_approval, workflow

@workflow
async def main():
    a = await wait_for_approval(5)  # approved in UI
    b = await wait_for_approval(5)  # canceled in UI
    c = await wait_for_approval(5)  # not touched (timeout)
    return {"a": a, "b": b, "c": c}
```

Each approval already carries a unique `resume_id` derived from its step key (embedded in its resume/cancel URL and stored in `resume_job.resume_id`). The fix matches on that `resume_id` so each step consumes only its own resume event: a canceled step keeps `approved=false` on its own row, and a timed-out step matches no row and falls back to the existing `approved=false` default.

Fixes WIN-2240

## Changes
- `wac_executor.rs`: extract the step-key → `resume_id` hash into a shared `approval_resume_id()` helper, and use it in `prepare_checkpoint_for_resume` to fetch `resume_job WHERE job = $1 AND resume_id = $2` instead of the oldest row.
- `bun_executor.rs`: replace the inline key-hash in the approval-URL generation with the shared `approval_resume_id()`, so URL generation and resume matching can never drift.

## Test plan
- [x] Ran a 3-step WAC workflow (TS/bun) with sequential `waitForApproval()`: approved `a`, canceled `b`, let `c` time out.
- [x] Result: `a = {value:{step:a}, approved:true}`, `b = {value:{step:b}, approved:false}`, `c = {value:null, approved:false, approver:null}` — each step resolves to its own event.
- [x] Backend compiles cleanly under `cargo watch` (no new warnings/errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched resumes for sequential WAC `waitForApproval()` steps by matching each resume event to its own step via `resume_id`, preventing approvals from bleeding across steps. Adds a regression test to pin this behavior. Addresses WIN-2240.

- **Bug Fixes**
  - Match resume events by `resume_id` per step in `prepare_checkpoint_for_resume` (`resume_job WHERE job AND resume_id`, newest first).
  - Each step now uses its own approval; canceled/timed-out steps no longer inherit previous results.

- **Refactors**
  - Expose and reuse `approval_resume_id(key)` for both resume matching and approval URL generation in `bun_executor`; the integration test consumes it.

<sup>Written for commit 866039c0fc8d67c3c989dec158b5474ccc6d631f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

