### PR TITLE
fix: show scheduled singlestepflow runs in flow history sidebar

### DIFF
--- a/backend/windmill-api-inputs/src/lib.rs
+++ b/backend/windmill-api-inputs/src/lib.rs
@@ -190,8 +190,16 @@ async fn get_input_history(
         kind @ JobKind::Script if g.include_preview.unwrap_or(false) => {
             vec![kind, JobKind::Preview]
         }
-        kind @ JobKind::Flow if g.include_preview.unwrap_or(false) => {
-            vec![kind, JobKind::FlowPreview]
+        // A scheduled/triggered flow is wrapped in a synthetic SingleStepFlow when the
+        // schedule has a dynamic-skip handler (or a scheduled script has native retry),
+        // so its runs land under `singlestepflow`, not `flow` (see schedule.rs). Include
+        // it here or those runs never surface in the run-history sidebar.
+        JobKind::Flow => {
+            let mut kinds = vec![JobKind::Flow, JobKind::SingleStepFlow];
+            if g.include_preview.unwrap_or(false) {
+                kinds.push(JobKind::FlowPreview);
+            }
+            kinds
         }
         kind => vec![kind],
     };

--- a/backend/windmill-api-inputs/src/lib.rs
+++ b/backend/windmill-api-inputs/src/lib.rs
@@ -73,14 +73,6 @@ impl Display for RunnableType {
 }
 
 impl RunnableType {
-    fn job_kind(&self) -> JobKind {
-        match self {
-            RunnableType::ScriptHash => JobKind::Script,
-            RunnableType::ScriptPath => JobKind::Script,
-            RunnableType::FlowPath => JobKind::Flow,
-        }
-    }
-
     fn column_name(&self) -> &'static str {
         match self {
             RunnableType::ScriptHash => "runnable_id",
@@ -160,18 +152,25 @@ async fn get_input_history(
     };
 
     // A scheduled runnable with a dynamic-skip handler (or a scheduled script with
-    // native retry) is wrapped in a synthetic `singlestepflow`, so its runs land
-    // under that kind rather than `flow`/`script` (see windmill-queue schedule.rs).
-    // singlestepflow wraps either a script or a flow, and the two may share a
-    // runnable_path, so in a flow's history only match flow-wrapped rows. The wrapped
-    // runnable type lives in raw_flow.modules[id in ('a','main')].value.type (mirrors
-    // the projection in windmill-api jobs.rs).
-    let singlestepflow_filter = if matches!(r.runnable_type, RunnableType::FlowPath) {
-        "AND (kind <> 'singlestepflow' OR EXISTS (\
-            SELECT 1 FROM jsonb_array_elements(v2_job.raw_flow->'modules') m \
-            WHERE m->>'id' IN ('a', 'main') AND m->'value'->>'type' = 'flow'))"
-    } else {
-        ""
+    // native retry) is wrapped in a synthetic `singlestepflow`, so its runs land under
+    // that kind rather than `flow`/`script` (see windmill-queue schedule.rs). Such a
+    // wrapper holds either a script or a flow, and the two may share a runnable_path, so
+    // match only the wrapped kind that belongs to the queried runnable. The wrapped type
+    // lives in raw_flow.modules[id in ('a','main')].value.type (mirrors the projection in
+    // windmill-api jobs.rs). runnable_id is NULL on these rows, so ScriptHash never matches.
+    let singlestepflow_filter = match r.runnable_type {
+        RunnableType::FlowPath => {
+            "AND (kind <> 'singlestepflow' OR EXISTS (\
+                SELECT 1 FROM jsonb_array_elements(v2_job.raw_flow->'modules') m \
+                WHERE m->>'id' IN ('a', 'main') AND m->'value'->>'type' = 'flow'))"
+        }
+        RunnableType::ScriptPath => {
+            "AND (kind <> 'singlestepflow' OR EXISTS (\
+                SELECT 1 FROM jsonb_array_elements(v2_job.raw_flow->'modules') m \
+                WHERE m->>'id' IN ('a', 'main') \
+                  AND COALESCE(m->'value'->>'type', 'script') <> 'flow'))"
+        }
+        RunnableType::ScriptHash => "",
     };
 
     // Two-step approach: first fetch 2*(per_page+offset) rows using created_at ordering
@@ -201,20 +200,32 @@ async fn get_input_history(
         _ => query.bind(&r.runnable_id),
     };
 
-    let job_kinds = match r.runnable_type.job_kind() {
-        kind @ JobKind::Script if g.include_preview.unwrap_or(false) => {
-            vec![kind, JobKind::Preview]
+    // Include SingleStepFlow so scheduled runs surface (see `singlestepflow_filter`
+    // above, which restricts it to the wrapped kind matching the runnable). ScriptHash
+    // is omitted: those wrappers carry no runnable_id, so it can never match.
+    let include_preview = g.include_preview.unwrap_or(false);
+    let job_kinds = match r.runnable_type {
+        RunnableType::ScriptHash => {
+            let mut kinds = vec![JobKind::Script];
+            if include_preview {
+                kinds.push(JobKind::Preview);
+            }
+            kinds
         }
-        // Include SingleStepFlow so scheduled flow runs surface (see
-        // `singlestepflow_filter` above); flow-wrapped rows are matched there.
-        JobKind::Flow => {
+        RunnableType::ScriptPath => {
+            let mut kinds = vec![JobKind::Script, JobKind::SingleStepFlow];
+            if include_preview {
+                kinds.push(JobKind::Preview);
+            }
+            kinds
+        }
+        RunnableType::FlowPath => {
             let mut kinds = vec![JobKind::Flow, JobKind::SingleStepFlow];
-            if g.include_preview.unwrap_or(false) {
+            if include_preview {
                 kinds.push(JobKind::FlowPreview);
             }
             kinds
         }
-        kind => vec![kind],
     };
 
     let rows = query

--- a/backend/windmill-api-inputs/src/lib.rs
+++ b/backend/windmill-api-inputs/src/lib.rs
@@ -159,6 +159,21 @@ async fn get_input_history(
         "AND parent_job IS NULL"
     };
 
+    // A scheduled runnable with a dynamic-skip handler (or a scheduled script with
+    // native retry) is wrapped in a synthetic `singlestepflow`, so its runs land
+    // under that kind rather than `flow`/`script` (see windmill-queue schedule.rs).
+    // singlestepflow wraps either a script or a flow, and the two may share a
+    // runnable_path, so in a flow's history only match flow-wrapped rows. The wrapped
+    // runnable type lives in raw_flow.modules[id in ('a','main')].value.type (mirrors
+    // the projection in windmill-api jobs.rs).
+    let singlestepflow_filter = if matches!(r.runnable_type, RunnableType::FlowPath) {
+        "AND (kind <> 'singlestepflow' OR EXISTS (\
+            SELECT 1 FROM jsonb_array_elements(v2_job.raw_flow->'modules') m \
+            WHERE m->>'id' IN ('a', 'main') AND m->'value'->>'type' = 'flow'))"
+    } else {
+        ""
+    };
+
     // Two-step approach: first fetch 2*(per_page+offset) rows using created_at ordering
     // (which leverages the ix_job_root_job_index_by_path_2 index on v2_job), then sort
     // the small result set by completed_at. This works because created_at and completed_at
@@ -172,7 +187,7 @@ async fn get_input_history(
             kind IN ('preview', 'flowpreview') as is_preview \
             FROM v2_job JOIN v2_job_completed USING (id) \
             WHERE v2_job.workspace_id = $3 AND {} = $1 AND kind = any($2) \
-            AND v2_job.script_entrypoint_override IS NULL \
+            AND v2_job.script_entrypoint_override IS NULL {singlestepflow_filter} \
             {args_query} AND v2_job_completed.status != 'skipped' {include_non_root} \
             ORDER BY v2_job.created_at DESC LIMIT $4\
         ) t ORDER BY completed_at DESC LIMIT $5 OFFSET $6",
@@ -190,10 +205,8 @@ async fn get_input_history(
         kind @ JobKind::Script if g.include_preview.unwrap_or(false) => {
             vec![kind, JobKind::Preview]
         }
-        // A scheduled/triggered flow is wrapped in a synthetic SingleStepFlow when the
-        // schedule has a dynamic-skip handler (or a scheduled script has native retry),
-        // so its runs land under `singlestepflow`, not `flow` (see schedule.rs). Include
-        // it here or those runs never surface in the run-history sidebar.
+        // Include SingleStepFlow so scheduled flow runs surface (see
+        // `singlestepflow_filter` above); flow-wrapped rows are matched there.
         JobKind::Flow => {
             let mut kinds = vec![JobKind::Flow, JobKind::SingleStepFlow];
             if g.include_preview.unwrap_or(false) {

--- a/backend/windmill-api-integration-tests/tests/inputs.rs
+++ b/backend/windmill-api-integration-tests/tests/inputs.rs
@@ -75,38 +75,26 @@ async fn test_inputs_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     Ok(())
 }
 
-// A scheduled/triggered flow whose schedule has a dynamic-skip handler runs as a
-// `singlestepflow`, not `flow` (see windmill-queue schedule.rs). The run-history
-// sidebar must surface those runs, so `get_input_history` includes that kind for
-// flow runnables.
+// A scheduled runnable with a dynamic-skip handler runs as a `singlestepflow`, not
+// `flow`/`script` (see windmill-queue schedule.rs). A flow's history must surface its
+// flow-wrapped singlestepflow runs, but a script and flow may share a path, so a
+// script-wrapped singlestepflow at the same path must NOT leak into the flow's history.
 #[sqlx::test(migrations = "../migrations", fixtures("base"))]
-async fn test_input_history_includes_singlestepflow(db: Pool<Postgres>) -> anyhow::Result<()> {
+async fn test_input_history_singlestepflow_flow_vs_script(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
     initialize_tracing().await;
 
-    let job_id = uuid::Uuid::new_v4();
-    sqlx::query(
-        "INSERT INTO v2_job (id, workspace_id, tag, created_by, permissioned_as, \
-         permissioned_as_email, kind, runnable_path, same_worker, visible_to_owner) \
-         VALUES ($1, 'test-workspace', 'flow', 'test-user', 'u/test-user', \
-         'test@windmill.dev', 'singlestepflow', 'f/test/scheduled_flow', false, true)",
-    )
-    .bind(job_id)
-    .execute(&db)
-    .await?;
-    sqlx::query(
-        "INSERT INTO v2_job_completed (id, workspace_id, duration_ms, deleted, status) \
-         VALUES ($1, 'test-workspace', 1, false, 'success')",
-    )
-    .bind(job_id)
-    .execute(&db)
-    .await?;
+    // Both rows share runnable_path; only the flow-wrapped one belongs in flow history.
+    let flow_job = insert_singlestepflow(&db, "flow").await?;
+    let script_job = insert_singlestepflow(&db, "script").await?;
 
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
     let base = format!("http://localhost:{port}/api/w/test-workspace/inputs");
 
     let resp = authed(client().get(format!(
-        "{base}/history?runnable_id=f/test/scheduled_flow&runnable_type=FlowPath"
+        "{base}/history?runnable_id=f/test/scheduled&runnable_type=FlowPath"
     )))
     .send()
     .await?;
@@ -115,12 +103,47 @@ async fn test_input_history_includes_singlestepflow(db: Pool<Postgres>) -> anyho
     assert_2xx(status, &body, "GET /inputs/history");
 
     let inputs: Vec<serde_json::Value> = serde_json::from_str(&body)?;
-    assert!(
+    let has = |id: &uuid::Uuid| {
         inputs
             .iter()
-            .any(|i| i.get("id").and_then(|v| v.as_str()) == Some(&job_id.to_string())),
-        "singlestepflow run missing from flow input history: {body}",
+            .any(|i| i.get("id").and_then(|v| v.as_str()) == Some(&id.to_string()))
+    };
+    assert!(
+        has(&flow_job),
+        "flow-wrapped singlestepflow missing: {body}"
+    );
+    assert!(
+        !has(&script_job),
+        "script-wrapped singlestepflow leaked into flow history: {body}",
     );
 
     Ok(())
+}
+
+// Insert a completed root singlestepflow at path f/test/scheduled wrapping `wrapped_type`
+// ('flow' or 'script') as its single module — mirrors the schedule.rs wrapper shape.
+async fn insert_singlestepflow(
+    db: &Pool<Postgres>,
+    wrapped_type: &str,
+) -> anyhow::Result<uuid::Uuid> {
+    let id = uuid::Uuid::new_v4();
+    let raw_flow = json!({ "modules": [{ "id": "a", "value": { "type": wrapped_type } }] });
+    sqlx::query(
+        "INSERT INTO v2_job (id, workspace_id, tag, created_by, permissioned_as, \
+         permissioned_as_email, kind, runnable_path, raw_flow, same_worker, visible_to_owner) \
+         VALUES ($1, 'test-workspace', 'flow', 'test-user', 'u/test-user', \
+         'test@windmill.dev', 'singlestepflow', 'f/test/scheduled', $2, false, true)",
+    )
+    .bind(id)
+    .bind(sqlx::types::Json(&raw_flow))
+    .execute(db)
+    .await?;
+    sqlx::query(
+        "INSERT INTO v2_job_completed (id, workspace_id, duration_ms, deleted, status) \
+         VALUES ($1, 'test-workspace', 1, false, 'success')",
+    )
+    .bind(id)
+    .execute(db)
+    .await?;
+    Ok(id)
 }

--- a/backend/windmill-api-integration-tests/tests/inputs.rs
+++ b/backend/windmill-api-integration-tests/tests/inputs.rs
@@ -74,3 +74,53 @@ async fn test_inputs_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// A scheduled/triggered flow whose schedule has a dynamic-skip handler runs as a
+// `singlestepflow`, not `flow` (see windmill-queue schedule.rs). The run-history
+// sidebar must surface those runs, so `get_input_history` includes that kind for
+// flow runnables.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_input_history_includes_singlestepflow(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let job_id = uuid::Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO v2_job (id, workspace_id, tag, created_by, permissioned_as, \
+         permissioned_as_email, kind, runnable_path, same_worker, visible_to_owner) \
+         VALUES ($1, 'test-workspace', 'flow', 'test-user', 'u/test-user', \
+         'test@windmill.dev', 'singlestepflow', 'f/test/scheduled_flow', false, true)",
+    )
+    .bind(job_id)
+    .execute(&db)
+    .await?;
+    sqlx::query(
+        "INSERT INTO v2_job_completed (id, workspace_id, duration_ms, deleted, status) \
+         VALUES ($1, 'test-workspace', 1, false, 'success')",
+    )
+    .bind(job_id)
+    .execute(&db)
+    .await?;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace/inputs");
+
+    let resp = authed(client().get(format!(
+        "{base}/history?runnable_id=f/test/scheduled_flow&runnable_type=FlowPath"
+    )))
+    .send()
+    .await?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    assert_2xx(status, &body, "GET /inputs/history");
+
+    let inputs: Vec<serde_json::Value> = serde_json::from_str(&body)?;
+    assert!(
+        inputs
+            .iter()
+            .any(|i| i.get("id").and_then(|v| v.as_str()) == Some(&job_id.to_string())),
+        "singlestepflow run missing from flow input history: {body}",
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-integration-tests/tests/inputs.rs
+++ b/backend/windmill-api-integration-tests/tests/inputs.rs
@@ -75,17 +75,18 @@ async fn test_inputs_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     Ok(())
 }
 
-// A scheduled runnable with a dynamic-skip handler runs as a `singlestepflow`, not
-// `flow`/`script` (see windmill-queue schedule.rs). A flow's history must surface its
-// flow-wrapped singlestepflow runs, but a script and flow may share a path, so a
-// script-wrapped singlestepflow at the same path must NOT leak into the flow's history.
+// A scheduled runnable with a dynamic-skip handler (or a scheduled script with native
+// retry) runs as a `singlestepflow`, not `flow`/`script` (see windmill-queue schedule.rs).
+// Both a flow's and a script's history must surface their own singlestepflow runs, but a
+// script and flow may share a path, so each side must match only the wrapped kind that
+// belongs to it — the other must not leak in.
 #[sqlx::test(migrations = "../migrations", fixtures("base"))]
 async fn test_input_history_singlestepflow_flow_vs_script(
     db: Pool<Postgres>,
 ) -> anyhow::Result<()> {
     initialize_tracing().await;
 
-    // Both rows share runnable_path; only the flow-wrapped one belongs in flow history.
+    // Both rows share runnable_path 'f/test/scheduled'.
     let flow_job = insert_singlestepflow(&db, "flow").await?;
     let script_job = insert_singlestepflow(&db, "script").await?;
 
@@ -93,28 +94,45 @@ async fn test_input_history_singlestepflow_flow_vs_script(
     let port = server.addr.port();
     let base = format!("http://localhost:{port}/api/w/test-workspace/inputs");
 
-    let resp = authed(client().get(format!(
-        "{base}/history?runnable_id=f/test/scheduled&runnable_type=FlowPath"
-    )))
-    .send()
-    .await?;
-    let status = resp.status().as_u16();
-    let body = resp.text().await?;
-    assert_2xx(status, &body, "GET /inputs/history");
-
-    let inputs: Vec<serde_json::Value> = serde_json::from_str(&body)?;
-    let has = |id: &uuid::Uuid| {
-        inputs
-            .iter()
-            .any(|i| i.get("id").and_then(|v| v.as_str()) == Some(&id.to_string()))
+    let history_ids = |runnable_type: &'static str| {
+        let base = base.clone();
+        async move {
+            let resp = authed(client().get(format!(
+                "{base}/history?runnable_id=f/test/scheduled&runnable_type={runnable_type}"
+            )))
+            .send()
+            .await?;
+            let status = resp.status().as_u16();
+            let body = resp.text().await?;
+            assert_2xx(status, &body, "GET /inputs/history");
+            let inputs: Vec<serde_json::Value> = serde_json::from_str(&body)?;
+            anyhow::Ok(
+                inputs
+                    .iter()
+                    .filter_map(|i| i.get("id").and_then(|v| v.as_str()).map(String::from))
+                    .collect::<std::collections::HashSet<_>>(),
+            )
+        }
     };
+
+    let flow_hist = history_ids("FlowPath").await?;
     assert!(
-        has(&flow_job),
-        "flow-wrapped singlestepflow missing: {body}"
+        flow_hist.contains(&flow_job.to_string()),
+        "flow-wrapped singlestepflow missing from flow history: {flow_hist:?}",
     );
     assert!(
-        !has(&script_job),
-        "script-wrapped singlestepflow leaked into flow history: {body}",
+        !flow_hist.contains(&script_job.to_string()),
+        "script-wrapped singlestepflow leaked into flow history: {flow_hist:?}",
+    );
+
+    let script_hist = history_ids("ScriptPath").await?;
+    assert!(
+        script_hist.contains(&script_job.to_string()),
+        "script-wrapped singlestepflow missing from script history: {script_hist:?}",
+    );
+    assert!(
+        !script_hist.contains(&flow_job.to_string()),
+        "flow-wrapped singlestepflow leaked into script history: {script_hist:?}",
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

The flow-view "History" run sidebar was silently excluding scheduled runs of some flows, while the "All runs" page (`/runs`) showed them. A customer's daily-scheduled flow appeared to have no recent history in the sidebar.

**Root cause:** The sidebar is backed by `get_input_history` (`backend/windmill-api-inputs/src/lib.rs`), which filtered job kind to `('flow','flowpreview')`. But when a schedule has a **dynamic-skip handler** (`schedule.dynamic_skip`) — or a scheduled script has **native retry** — the run is wrapped in a synthetic `SingleStepFlow` (`backend/windmill-queue/src/schedule.rs:273`,`:408`), landing under `kind='singlestepflow'`, not `flow`/`script`. Those runs were filtered out. Manual UI runs bypass the schedule path and run as plain `flow`, so only those showed up.

Verified against production data: the affected flow's daily scheduled runs are all `kind='singlestepflow'` (success on market days, `skipped` on non-market days via the skip handler), and the exact sidebar query returned only the single manual `flow` run.

## Changes

- `get_input_history`: include `JobKind::SingleStepFlow` in the job-kind filter for **flow** (`FlowPath`) and **script** (`ScriptPath`) runnables, so their scheduled singlestepflow runs surface. Consistent with `JobKind::is_flow()`, which already treats `SingleStepFlow` as a flow.
- **Disambiguate script- vs flow-wrapped `singlestepflow`:** a singlestepflow wraps either a script or a flow, and a script and flow may legally share a `runnable_path`. Each history side now matches only its own wrapped kind via `raw_flow.modules[id in ('a','main')].value.type` (`= 'flow'` for flow history, `<> 'flow'` for script history) — mirroring the projection in `windmill-api/src/jobs.rs`. Confirmed on prod: every flow-path singlestepflow wraps `type='flow'`, every script-path one wraps `type='script'` (no cross-contamination), and these wrappers carry a NULL `runnable_id` so `ScriptHash` history is structurally unaffected (left untouched).
- Regression test `test_input_history_singlestepflow_flow_vs_script`: inserts a flow-wrapped and a script-wrapped singlestepflow at the **same path**, and asserts each history side returns its own and excludes the other (all four directions).

### Notes
- `FlowNode` (flow-as-step) is intentionally not added: those are child jobs excluded by the existing `parent_job IS NULL` filter and don't carry the parent flow's `runnable_path`.
- `is_preview` stays correct: `singlestepflow` is not in the preview set, so scheduled runs get no false "preview" badge.
- **No performance impact:** `kind` is a post-index filter (scan uses `ix_job_root_job_index_by_path_2` on `workspace_id, runnable_path, created_at DESC`); the added `EXISTS` subplan only touches the ~40 already-index-narrowed rows. Measured ~0.5ms on prod.

## Test plan
- [x] `cargo test -p windmill-api-integration-tests --test inputs` passes
- [x] Test fails without each part of the fix — verified by reverting the kind-list change (returns `[]`) and the wrapped-type filter (cross-kind run leaks in)
- [ ] Manually: open a flow (and a script) whose schedule uses a dynamic-skip handler, let it run, open the "History" sidebar, confirm the scheduled run appears and matches `/runs`

Fixes WIN-2244