### PR TITLE
fix: pass Windows system env vars to R renv install subprocess

### DIFF
--- a/backend/windmill-worker/src/r_executor.rs
+++ b/backend/windmill-worker/src/r_executor.rs
@@ -30,7 +30,7 @@ use crate::{
         par_install_language_dependencies_seq, DependencyGraph, InstallDeps, RequiredDependency,
     },
     DISABLE_NUSER, NSJAIL_AVAILABLE, NSJAIL_PATH, PATH_ENV, PROXY_ENVS, R_CACHE_DIR,
-    TRACING_PROXY_CA_CERT_PATH,
+    TRACING_PROXY_CA_CERT_PATH, WIN_ENVS,
 };
 use windmill_common::scripts::ScriptLang;
 
@@ -518,6 +518,9 @@ async fn install<'a>(
             cmd.env_clear()
                 .current_dir(&job_dir)
                 .env("PATH", PATH_ENV.as_str())
+                // On Windows, renv needs SystemRoot (winsock init — without it DNS
+                // and sockets fail) and LOCALAPPDATA (its cache root) to install.
+                .envs(WIN_ENVS.to_vec())
                 .envs(R_PROXY_ENVS.clone());
             cmd
                 .args(&[
@@ -694,15 +697,7 @@ async fn run<'a>(
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        #[cfg(windows)]
-        {
-            cmd.env("SystemRoot", crate::SYSTEM_ROOT.as_str())
-                .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
-                .env(
-                    "TMP",
-                    std::env::var("TMP").unwrap_or_else(|_| String::from("/tmp")),
-                );
-        }
+        cmd.envs(WIN_ENVS.to_vec());
         start_child_process(cmd, rscript_executable, false).await?
     };
     handle_child::handle_child(


### PR DESCRIPTION
## Summary

R package installation is completely broken on Windows workers: the per-package `renv::install` subprocess is spawned with `env_clear()` restoring only `PATH` and proxy vars. On Windows, a child process without `SystemRoot` cannot initialize winsock — every CRAN request fails with curl error 6 (DNS resolution) and renv's parallel graph installer dies in `renv_socket_server()` ("error creating socket server: couldn't find open port", since every localhost bind fails). Without `LOCALAPPDATA`, renv's cache root is missing and package downloads fail even once networking works.

The fix passes the existing `WIN_ENVS` static (`SystemRoot`, `USERPROFILE`, `TMP`, `LOCALAPPDATA`; empty on non-Windows) to the install command — the same pattern `python_versions.rs` already uses — and replaces the run phase's hand-rolled `#[cfg(windows)]` env block, which was missing `LOCALAPPDATA`, with the same helper.

Root cause was isolated empirically on a Windows VM by bisecting the child env var-by-var against `Rscript -e 'renv::install(...)'`: base cleared env fails at winsock (both DNS and socket-server symptoms), `+SystemRoot` fixes networking but downloads still fail, `+LOCALAPPDATA` makes the install succeed.

## Changes

- `install()` in `backend/windmill-worker/src/r_executor.rs`: add `.envs(WIN_ENVS.to_vec())` after `env_clear()` so the renv install subprocess gets `SystemRoot`/`USERPROFILE`/`TMP`/`LOCALAPPDATA` on Windows (no-op on Linux, where `WIN_ENVS` is empty).
- `run()` in the same file: replace the manual `#[cfg(windows)]` block (SystemRoot/USERPROFILE/TMP) with `.envs(WIN_ENVS.to_vec())`, adding the previously missing `LOCALAPPDATA` for user R code.

## Test plan

- [x] Verified on a Windows VM (windmill built from v1.768.0 + this patch, `--features rlang`, R 4.6.1, renv 1.2.3): 5/5 consecutive cold-cache R preview jobs (`jsonlite` resolved, downloaded, installed, executed) succeed; unpatched binary fails 100% of cold installs with the DNS/socket errors above.
- [x] Non-Windows behavior unchanged: `WIN_ENVS` is the empty vec on unix, and the run-phase refactor preserves the exact env set previously applied (plus `LOCALAPPDATA` on Windows only).