### PR TITLE
fix(frontend): pin sveltekit version.name so builds are reproducible across architectures

### DIFF
--- a/.github/workflows/build-publish-rh-image.yml
+++ b/.github/workflows/build-publish-rh-image.yml
@@ -63,6 +63,7 @@ jobs:
           push: true
           build-args: |
             features=ee_rhel
+            WM_BUILD_VERSION=${{ github.sha }}
           secrets: |
             rh_username=${{ secrets.RH_USERNAME }}
             rh_password=${{ secrets.RH_PASSWORD }}

--- a/.github/workflows/build-publish-rh8-image.yml
+++ b/.github/workflows/build-publish-rh8-image.yml
@@ -65,6 +65,7 @@ jobs:
           push: true
           build-args: |
             features=ee_rhel
+            WM_BUILD_VERSION=${{ github.sha }}
           secrets: |
             rh_username=${{ secrets.RH_USERNAME }}
             rh_password=${{ secrets.RH_PASSWORD }}
@@ -82,6 +83,7 @@ jobs:
           push: true
           build-args: |
             features=ee_rhel
+            WM_BUILD_VERSION=${{ github.sha }}
           secrets: |
             rh_username=${{ secrets.RH_USERNAME }}
             rh_password=${{ secrets.RH_PASSWORD }}

--- a/.github/workflows/docker-image-rpi4.yml
+++ b/.github/workflows/docker-image-rpi4.yml
@@ -68,6 +68,7 @@ jobs:
           push: true
           build-args: |
             features=ce_rpi
+            WM_BUILD_VERSION=${{ github.sha }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
             ${{ steps.meta-public.outputs.tags }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -93,6 +93,7 @@ jobs:
           push: true
           build-args: |
             features=ce
+            WM_BUILD_VERSION=${{ github.sha }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEV_SHA }}
             ${{ steps.meta-public.outputs.tags }}
@@ -155,6 +156,7 @@ jobs:
           push: true
           build-args: |
             features=ee
+            WM_BUILD_VERSION=${{ github.sha }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ee:${{ env.DEV_SHA }}
             ${{ steps.meta-ee-public.outputs.tags }}
@@ -254,6 +256,7 @@ jobs:
           target: debuginfo
           build-args: |
             features=ee
+            WM_BUILD_VERSION=${{ github.sha }}
           outputs: type=local,dest=./debuginfo
 
       - name: Rename debug file with corresponding architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,11 @@ COPY /python-client/docs/ /frontend/static/pydocs/
 RUN npm run generate-backend-client
 ENV NODE_OPTIONS "--max-old-space-size=8192"
 ARG VITE_BASE_URL ""
+# Pass the commit sha: it must be identical across the per-architecture builds of one
+# commit (else the images disagree on asset filenames) and differ between commits (else
+# a client that 404s on a chunk after a redeploy never full-page reloads). See
+# frontend/svelte.config.js.
+ARG WM_BUILD_VERSION ""
 # Read more about macro in docker/dev.nu
 # -- MACRO-SPREAD-WASM-PARSER-DEV-ONLY -- #
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,10 +79,7 @@ COPY /python-client/docs/ /frontend/static/pydocs/
 RUN npm run generate-backend-client
 ENV NODE_OPTIONS "--max-old-space-size=8192"
 ARG VITE_BASE_URL ""
-# Pass the commit sha: it must be identical across the per-architecture builds of one
-# commit (else the images disagree on asset filenames) and differ between commits (else
-# a client that 404s on a chunk after a redeploy never full-page reloads). See
-# frontend/svelte.config.js.
+# Must be declared for the build-arg to reach the bundle. See frontend/svelte.config.js.
 ARG WM_BUILD_VERSION=""
 # Read more about macro in docker/dev.nu
 # -- MACRO-SPREAD-WASM-PARSER-DEV-ONLY -- #

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release -p windmill_duckdb_ffi_internal
 
-# Pinned: the bundler's per-architecture native bindings (@rolldown/binding-linux-*) can
-# hash chunk filenames differently, and the build output is embedded in the binary via
-# rust_embed, so an unpinned stage makes each arch's image serve HTML referencing chunks
-# the other arch lacks (404s on mixed-arch clusters). Output is JS/CSS/HTML/WASM only.
-FROM --platform=linux/amd64 node:24-alpine as frontend
+FROM node:24-alpine as frontend
 
 # install dependencies
 WORKDIR /frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ARG VITE_BASE_URL ""
 # commit (else the images disagree on asset filenames) and differ between commits (else
 # a client that 404s on a chunk after a redeploy never full-page reloads). See
 # frontend/svelte.config.js.
-ARG WM_BUILD_VERSION ""
+ARG WM_BUILD_VERSION=""
 # Read more about macro in docker/dev.nu
 # -- MACRO-SPREAD-WASM-PARSER-DEV-ONLY -- #
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,11 +54,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release -p windmill_duckdb_ffi_internal
 
-# Pinned to a single platform: rollup picks platform-specific native binaries that
-# emit different content-hashed chunk filenames for identical sources. The assets are
-# embedded in the binary via rust_embed, so an unpinned stage makes the amd64 and arm64
-# images serve HTML referencing assets the other arch does not have (404s on mixed-arch
-# clusters). The output is JS/CSS/HTML/WASM only, so the build platform does not leak in.
+# Pinned: the bundler's per-architecture native bindings (@rolldown/binding-linux-*) can
+# hash chunk filenames differently, and the build output is embedded in the binary via
+# rust_embed, so an unpinned stage makes each arch's image serve HTML referencing chunks
+# the other arch lacks (404s on mixed-arch clusters). Output is JS/CSS/HTML/WASM only.
 FROM --platform=linux/amd64 node:24-alpine as frontend
 
 # install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release -p windmill_duckdb_ffi_internal
 
-FROM node:24-alpine as frontend
+# Pinned to a single platform: rollup picks platform-specific native binaries that
+# emit different content-hashed chunk filenames for identical sources. The assets are
+# embedded in the binary via rust_embed, so an unpinned stage makes the amd64 and arm64
+# images serve HTML referencing assets the other arch does not have (404s on mixed-arch
+# clusters). The output is JS/CSS/HTML/WASM only, so the build platform does not leak in.
+FROM --platform=linux/amd64 node:24-alpine as frontend
 
 # install dependencies
 WORKDIR /frontend

--- a/docker/RHEL8/Dockerfile
+++ b/docker/RHEL8/Dockerfile
@@ -41,6 +41,8 @@ COPY /python-client/docs/ /frontend/static/pydocs/
 
 RUN npm run generate-backend-client
 ENV NODE_OPTIONS "--max-old-space-size=8192"
+# Must be declared for the build-arg to reach the bundle. See frontend/svelte.config.js.
+ARG WM_BUILD_VERSION=""
 RUN npm run build
 
 

--- a/docker/RHEL9/Dockerfile
+++ b/docker/RHEL9/Dockerfile
@@ -41,6 +41,8 @@ COPY /python-client/docs/ /frontend/static/pydocs/
 
 RUN npm run generate-backend-client
 ENV NODE_OPTIONS "--max-old-space-size=8192"
+# Must be declared for the build-arg to reach the bundle. See frontend/svelte.config.js.
+ARG WM_BUILD_VERSION=""
 RUN npm run build
 
 

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -29,10 +29,10 @@ const config = {
 						assets: 'build',
 						fallback: '200.html'
 					}),
-		// Must stay deterministic: SvelteKit defaults this to Date.now(), which differs
-		// between the per-architecture builds of the same commit and cascades into
-		// different content-hashed chunk filenames. Those assets are embedded in the
-		// binary, so mixed-arch clusters would 404 on each other's chunks.
+		// Same for every build of one revision (SvelteKit's Date.now() default is not, so
+		// the per-architecture images disagreed on content-hashed asset filenames and
+		// mixed-arch clusters 404ed on each other's chunks), and different between
+		// revisions (SvelteKit only full-page reloads on a missing chunk if this changed).
 		version: { name: process.env.WM_BUILD_VERSION || pkg.version },
 		prerender: { entries: [] },
 		paths: {

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,6 +1,12 @@
 import preprocess from 'svelte-preprocess'
 import adapter from '@sveltejs/adapter-static'
 import { preprocessMeltUI, sequence } from '@melt-ui/pp'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const pkg = JSON.parse(
+	readFileSync(fileURLToPath(new URL('package.json', import.meta.url)), 'utf8')
+)
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -23,6 +29,11 @@ const config = {
 						assets: 'build',
 						fallback: '200.html'
 					}),
+		// Must stay deterministic: SvelteKit defaults this to Date.now(), which differs
+		// between the per-architecture builds of the same commit and cascades into
+		// different content-hashed chunk filenames. Those assets are embedded in the
+		// binary, so mixed-arch clusters would 404 on each other's chunks.
+		version: { name: process.env.WM_BUILD_VERSION || pkg.version },
 		prerender: { entries: [] },
 		paths: {
 			base: process.env.VITE_BASE_URL ?? ''


### PR DESCRIPTION
## Summary

In a mixed-architecture cluster, HTML served by an `amd64` pod references `_app/immutable/chunks/<hash>.js` files that do not exist on `arm64` pods (and vice versa), so bundle requests 404.

The cause is **not** architecture-specific code generation. SvelteKit defaults `kit.version.name` to `Date.now().toString()`. That string is embedded in a client chunk — and in the `__sveltekit_<hash>` global derived from it — so it changes that chunk's content hash, which cascades into new filenames for about a quarter of `_app/immutable`. Since the assets are baked into the binary via `rust_embed`, the two architecture images of the same release ship different asset names. The two depot builders simply start a few hundred milliseconds apart.

Fixes WIN-2242

## Evidence

Diffing `/static_frontend/_app/immutable` between both architecture variants of the published `windmill:1.770.0`:

| | |
|---|---|
| files per variant | 863 |
| filenames that differ | ~224 |
| chunks byte-identical | 637 / 860 |
| chunks byte-identical **after normalizing chunk-name references** | **854 / 855** |

Exactly one chunk genuinely differs, and this is its entire diff:

```
amd64: globalThis.__sveltekit_h4zbwy … pe=`1784913453235`
arm64: globalThis.__sveltekit_1jgnowm … pe=`1784913453653`
```

418 ms apart. The bundler (Vite 8 / rolldown) is deterministic across `arm64` and `amd64`; two builds on the *same* machine diverged identically (448-line diff, same magnitude as the cross-arch diff).

## Changes

- `frontend/svelte.config.js`: `version: { name: process.env.WM_BUILD_VERSION || pkg.version }`.
- `Dockerfile`: `ARG WM_BUILD_VERSION`, declared immediately before `RUN npm run build`.
- `docker-image.yml` (×3, including the debuginfo extraction), `docker-image-rpi4.yml`, `build-publish-rh-image.yml`, `build-publish-rh8-image.yml` (×2): pass `WM_BUILD_VERSION=${{ github.sha }}`.

The value has to satisfy two constraints at once: **identical across the per-architecture builds of one commit** (or the images disagree on asset filenames), and **different between commits** (SvelteKit only full-page reloads on a failed chunk import when the deployed `_app/version.json` differs from the baked-in version — `runtime/client/client.js:1186`; equal values would strand an open tab on an error page after a redeploy). The commit sha satisfies both. `pkg.version` remains the fallback so unwired and local builds are still architecture-consistent.

## Tradeoff

Because the arg feeds the bundle step, `RUN npm run build` now re-runs on backend-only commits (~1-3 min per build job on native builders); `npm ci` and every earlier layer stay cached. Scoping the value to the frontend input paths would preserve that cache, but any input missed from the list would silently reintroduce the stranding bug, so the commit sha is the safer default.

## Considered and rejected

Pinning the Docker frontend stage to `--platform=linux/amd64` (this PR's original approach, reverted). It fixes the symptom, but depot builds each platform on its own native machine, so the arm64 builder runs the stage under QEMU. Measured on this PR's own run [30115908242](https://github.com/windmill-labs/windmill/actions/runs/30115908242): `npm run build` took **1946s (32.4 min)** emulated, and the `build` job went from ~13 min to 50 min. It also leaves the build non-reproducible and does nothing for the redeploy-recovery case.

## Test plan

- [x] Two consecutive builds at the same `WM_BUILD_VERSION` produce byte-identical output (864 files, same names and hashes).
- [x] Different `WM_BUILD_VERSION` values produce different manifests, and `_app/version.json` carries the passed value.
- [x] Control: with the config change reverted, two builds differ by 448 lines — matching the cross-arch diff on the shipped image.
- [x] `ARG WM_BUILD_VERSION` reaches the build environment (same mechanism `VITE_BASE_URL` already relies on); all four workflow files parse as valid YAML.
- [x] `npm run check:fast` clean.
- [x] App boots and logs in normally with the pinned version (dev server, Playwright).
- [ ] End-to-end: once this PR's multi-platform image builds, diff `_app/immutable` between both architecture variants and confirm the filename lists match.

## Screenshots

No visible UI change — this is build configuration. Included only to show the app boots normally with the pinned version:

![app-boot](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2242-fixdocker-pin-frontend-build-stage-to-single-platform-for/1784928294-app-boot.png)