### PR TITLE
fix: remove unused mut breaking backend CI

### DIFF
--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -146,7 +146,7 @@ async fn list_foldernames(
     let mut sql = String::from("SELECT name FROM folder WHERE workspace_id = $1");
     let restricted = match build_scope_path_filter(&authed, "folders", "read") {
         ScopePathFilter::AllowAll => None,
-        ScopePathFilter::Restricted { exact, mut prefix } => {
+        ScopePathFilter::Restricted { exact, prefix } => {
             // A prefix grant also authorizes the folder at the prefix itself.
             let mut eq = exact;
             eq.append(&mut prefix.clone());


### PR DESCRIPTION
## Summary

`ScopePathFilter::Restricted { exact, mut prefix }` in `windmill-api-groups/src/folders.rs` never mutates `prefix` — it is only `.clone()`d into `eq` and `.iter()`d to build the LIKE patterns. Under CI's deny-warnings the `unused_mut` lint is an error, so `windmill-api-groups` fails to compile.

That reds out **`Backend only integration tests` and `CLI Tests` on every open PR**, not just the one where I hit it. Introduced by #10297.

```
error: variable does not need to be mutable
   --> windmill-api-groups/src/folders.rs:149:46
    |
149 |         ScopePathFilter::Restricted { exact, mut prefix } => {
    |                                              ----^^^^^^
    |                                              help: remove this `mut`
```

## Changes

- Drop the unused `mut`. No behavior change.

## Test plan

- [x] `RUSTFLAGS="-D warnings" cargo check -p windmill-api-groups` — was the error above, now clean.

Found while driving #10317 through review rounds; kept separate so it can land on its own rather than riding along in an unrelated feature PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove an unused `mut` in the `ScopePathFilter::Restricted { exact, prefix }` match arm in `windmill-api-groups/src/folders.rs` to satisfy the `unused_mut` lint under `-D warnings`. No behavior change; fixes backend CI and unblocks Backend-only integration tests and CLI tests across PRs.

<sup>Written for commit d6904d049681eee20dc5d9e9cf14ce6334c6864f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

