### PR TITLE
fix: add missing is_operator guards to all workspace-object write handlers

### DIFF
--- a/backend/tests/fixtures/operator_write_guards.sql
+++ b/backend/tests/fixtures/operator_write_guards.sql
@@ -1,0 +1,14 @@
+-- Fixture for the operator write-guard regression test (WIN-2245).
+-- Layered on top of `base` (which provides test-workspace and the non-operator
+-- `test-user-2`/SECRET_TOKEN_2). Adds an Operator member so we can assert that
+-- Operators cannot reach the group / folder / variable / resource / schedule
+-- write handlers.
+
+INSERT INTO password(email, password_hash, login_type, super_admin, verified, name)
+    VALUES ('operator@windmill.dev', 'not-a-real-hash', 'password', false, true, 'Operator User');
+
+INSERT INTO usr(workspace_id, email, username, is_admin, operator, role) VALUES
+	('test-workspace', 'operator@windmill.dev', 'operator-user', false, true, 'Operator');
+
+INSERT INTO token(token_hash, token_prefix, token, email, label, super_admin) VALUES
+	(encode(sha256('OPERATOR_TOKEN'::bytea), 'hex'), 'OPERATOR_T', 'OPERATOR_TOKEN', 'operator@windmill.dev', 'operator token', false);

--- a/backend/tests/fixtures/operator_write_guards.sql
+++ b/backend/tests/fixtures/operator_write_guards.sql
@@ -1,8 +1,5 @@
--- Fixture for the operator write-guard regression test (WIN-2245).
--- Layered on top of `base` (which provides test-workspace and the non-operator
--- `test-user-2`/SECRET_TOKEN_2). Adds an Operator member so we can assert that
--- Operators cannot reach the group / folder / variable / resource / schedule
--- write handlers.
+-- Adds an Operator member on top of `base` (which provides test-workspace and
+-- the non-operator `test-user-2`/SECRET_TOKEN_2).
 
 INSERT INTO password(email, password_hash, login_type, super_admin, verified, name)
     VALUES ('operator@windmill.dev', 'not-a-real-hash', 'password', false, true, 'Operator User');

--- a/backend/tests/operator_write_guards.rs
+++ b/backend/tests/operator_write_guards.rs
@@ -1,16 +1,8 @@
-//! Operators are a read-only + execute-only role, but only the script / flow /
-//! app handlers used to enforce that on writes. RLS does not carry
-//! `is_operator` (only `is_admin` reaches `set_session_context`) and
-//! `check_scopes` is a no-op for a normal session, so an Operator could create
-//! and modify groups, folders, variables, resources, resource types and
-//! schedules through direct API calls — including overwriting shared `g/all/*`
-//! credentials.
-//!
-//! This pins the guard on every such write route: an Operator is rejected with
-//! 401 "Operators cannot ...", a regular member is not caught by it, and the
-//! token a job runs with is exempt. The trigger routes share the same guard in
-//! `windmill_trigger::handler` but are feature-gated per trigger kind, so they
-//! are not exercised here.
+//! Pins `OptJobAuthed::reject_operator_write` on every workspace-object write
+//! route it guards: an Operator is rejected with 401 "Operators cannot ...", a
+//! regular member is not caught by it, and the token a job runs with is exempt.
+//! The trigger routes share the same guard but are feature-gated per trigger
+//! kind, so they are not exercised here.
 
 use serde_json::json;
 use sqlx::{Pool, Postgres};
@@ -116,6 +108,16 @@ fn write_routes() -> Vec<(&'static str, String, serde_json::Value)> {
             "POST",
             "schedules/setenabled/u/test-user/s".into(),
             json!({"enabled": false}),
+        ),
+        (
+            "POST",
+            "acls/add/folder/f1".into(),
+            json!({"owner": "u/operator-user", "write": true}),
+        ),
+        (
+            "POST",
+            "acls/remove/folder/f1".into(),
+            json!({"owner": "u/test-user"}),
         ),
     ]
 }

--- a/backend/tests/operator_write_guards.rs
+++ b/backend/tests/operator_write_guards.rs
@@ -1,0 +1,167 @@
+//! Operators are a read-only + execute-only role, but only the script / flow /
+//! app handlers used to enforce that on writes. RLS does not carry
+//! `is_operator` (only `is_admin` reaches `set_session_context`) and
+//! `check_scopes` is a no-op for a normal session, so an Operator could create
+//! and modify groups, folders, variables, resources, resource types and
+//! schedules through direct API calls — including overwriting shared `g/all/*`
+//! credentials.
+//!
+//! This pins the guard on every such write route: an Operator is rejected with
+//! 401 "Operators cannot ...", and a regular member is not caught by it. The
+//! trigger routes share the same guard in `windmill_trigger::handler` but are
+//! feature-gated per trigger kind, so they are not exercised here.
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+const GUARD_PREFIX: &str = "Operators cannot";
+
+/// (method, path suffix under /api/w/test-workspace, body)
+fn write_routes() -> Vec<(&'static str, String, serde_json::Value)> {
+    vec![
+        ("POST", "groups/create".into(), json!({"name": "g1"})),
+        ("POST", "groups/update/all".into(), json!({"summary": "x"})),
+        (
+            "POST",
+            "groups/adduser/all".into(),
+            json!({"username": "test-user-2"}),
+        ),
+        (
+            "POST",
+            "groups/removeuser/all".into(),
+            json!({"username": "test-user-2"}),
+        ),
+        ("DELETE", "groups/delete/all".into(), json!(null)),
+        ("POST", "folders/create".into(), json!({"name": "f1"})),
+        ("POST", "folders/update/f1".into(), json!({"summary": "x"})),
+        (
+            "POST",
+            "folders/addowner/f1".into(),
+            json!({"owner": "u/operator-user", "write": true}),
+        ),
+        (
+            "POST",
+            "folders/removeowner/f1".into(),
+            json!({"owner": "u/test-user"}),
+        ),
+        ("DELETE", "folders/delete/f1".into(), json!(null)),
+        (
+            "POST",
+            "variables/create".into(),
+            json!({"path": "g/all/v", "value": "x", "is_secret": false, "description": ""}),
+        ),
+        (
+            "POST",
+            "variables/update/g/all/v".into(),
+            json!({"value": "x"}),
+        ),
+        ("DELETE", "variables/delete/g/all/v".into(), json!(null)),
+        (
+            "DELETE",
+            "variables/delete_bulk".into(),
+            json!({"paths": ["g/all/v"]}),
+        ),
+        (
+            "POST",
+            "resources/create".into(),
+            json!({"path": "g/all/r", "value": {}, "resource_type": "postgresql"}),
+        ),
+        (
+            "POST",
+            "resources/update/g/all/r".into(),
+            json!({"description": "x"}),
+        ),
+        (
+            "POST",
+            "resources/update_value/g/all/r".into(),
+            json!({"value": {}}),
+        ),
+        ("DELETE", "resources/delete/g/all/r".into(), json!(null)),
+        (
+            "DELETE",
+            "resources/delete_bulk".into(),
+            json!({"paths": ["g/all/r"]}),
+        ),
+        (
+            "POST",
+            "resources/type/create".into(),
+            json!({"name": "rt1", "schema": {}}),
+        ),
+        (
+            "POST",
+            "resources/type/update/rt1".into(),
+            json!({"description": "x"}),
+        ),
+        ("DELETE", "resources/type/delete/rt1".into(), json!(null)),
+        (
+            "POST",
+            "schedules/create".into(),
+            json!({"path": "u/operator-user/s", "schedule": "0 0 * * * *", "timezone": "UTC",
+                   "script_path": "u/test-user/noop", "is_flow": false, "args": {}}),
+        ),
+        (
+            "POST",
+            "schedules/update/u/test-user/s".into(),
+            json!({"schedule": "0 0 * * * *", "timezone": "UTC", "args": {}}),
+        ),
+        (
+            "DELETE",
+            "schedules/delete/u/test-user/s".into(),
+            json!(null),
+        ),
+    ]
+}
+
+async fn send(
+    port: u16,
+    token: &str,
+    method: &str,
+    path: &str,
+    body: &serde_json::Value,
+) -> anyhow::Result<(u16, String)> {
+    let client = reqwest::Client::new();
+    let url = format!("http://localhost:{port}/api/w/test-workspace/{path}");
+    let mut req = match method {
+        "POST" => client.post(&url),
+        _ => client.delete(&url),
+    }
+    .header("Authorization", format!("Bearer {token}"));
+    if !body.is_null() {
+        req = req.json(body);
+    }
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+    Ok((status, resp.text().await?))
+}
+
+#[sqlx::test(fixtures("base", "operator_write_guards"))]
+async fn operators_cannot_write_workspace_objects(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    for (method, path, body) in write_routes() {
+        let (status, resp) = send(port, "OPERATOR_TOKEN", method, &path, &body).await?;
+        assert_eq!(
+            status, 401,
+            "{method} {path}: operator must be rejected, got {status}: {resp}"
+        );
+        assert!(
+            resp.contains(GUARD_PREFIX),
+            "{method} {path}: rejection must be the operator guard, got: {resp}"
+        );
+
+        // The guard must not over-block a regular member: whatever else the
+        // request runs into (permissions, missing object), it must not be the
+        // operator guard.
+        let (_, resp) = send(port, "SECRET_TOKEN_2", method, &path, &body).await?;
+        assert!(
+            !resp.contains(GUARD_PREFIX),
+            "{method} {path}: non-operator must not hit the operator guard, got: {resp}"
+        );
+    }
+
+    Ok(())
+}

--- a/backend/tests/operator_write_guards.rs
+++ b/backend/tests/operator_write_guards.rs
@@ -7,12 +7,14 @@
 //! credentials.
 //!
 //! This pins the guard on every such write route: an Operator is rejected with
-//! 401 "Operators cannot ...", and a regular member is not caught by it. The
-//! trigger routes share the same guard in `windmill_trigger::handler` but are
-//! feature-gated per trigger kind, so they are not exercised here.
+//! 401 "Operators cannot ...", a regular member is not caught by it, and the
+//! token a job runs with is exempt. The trigger routes share the same guard in
+//! `windmill_trigger::handler` but are feature-gated per trigger kind, so they
+//! are not exercised here.
 
 use serde_json::json;
 use sqlx::{Pool, Postgres};
+use windmill_common::{auth::create_jwt_token, db::Authed};
 use windmill_test_utils::*;
 
 const GUARD_PREFIX: &str = "Operators cannot";
@@ -110,6 +112,11 @@ fn write_routes() -> Vec<(&'static str, String, serde_json::Value)> {
             "schedules/delete/u/test-user/s".into(),
             json!(null),
         ),
+        (
+            "POST",
+            "schedules/setenabled/u/test-user/s".into(),
+            json!({"enabled": false}),
+        ),
     ]
 }
 
@@ -162,6 +169,54 @@ async fn operators_cannot_write_workspace_objects(db: Pool<Postgres>) -> anyhow:
             "{method} {path}: non-operator must not hit the operator guard, got: {resp}"
         );
     }
+
+    Ok(())
+}
+
+/// The token a job runs with carries the operator's `is_operator`, so the guard
+/// must let it through — otherwise `wmill.setState` / `setVariable` /
+/// `setResource`, which hit these very routes, break for every operator-launched
+/// run.
+#[sqlx::test(fixtures("base", "operator_write_guards"))]
+async fn operator_job_token_can_still_write(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    set_jwt_secret().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let job_token = create_jwt_token(
+        Authed {
+            email: "operator@windmill.dev".to_string(),
+            username: "operator-user".to_string(),
+            is_admin: false,
+            is_operator: true,
+            groups: vec!["all".to_string()],
+            folders: vec![],
+            scopes: None,
+            token_prefix: None,
+        },
+        "test-workspace",
+        3600,
+        Some(uuid::Uuid::new_v4()),
+        Some("ephemeral-script".to_string()),
+        None,
+        None,
+    )
+    .await?;
+
+    let (status, resp) = send(
+        port,
+        &job_token,
+        "POST",
+        "resources/create",
+        &json!({"path": "u/operator-user/state", "value": {"n": 1}, "resource_type": "state"}),
+    )
+    .await?;
+    assert_eq!(
+        status, 201,
+        "operator job token must be able to write its own state, got {status}: {resp}"
+    );
 
     Ok(())
 }

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -43,6 +43,26 @@ pub struct OptJobAuthed {
     pub authed: ApiAuthed,
 }
 
+impl OptJobAuthed {
+    /// Operators are a read-only + execute-only role, so they must not author
+    /// workspace objects. RLS carries no operator flag and `check_scopes` is a
+    /// no-op for a normal session, so every write handler has to reject them
+    /// explicitly. `what` completes "Operators cannot {what}".
+    ///
+    /// A running job is exempt: `job_id` is only set on the token minted for job
+    /// execution, and what a job writes is decided by the script's author, not by
+    /// the operator who ran it — `wmill.setState`/`setVariable`/`setResource` go
+    /// through these same routes.
+    pub fn reject_operator_write(&self, what: &str) -> Result<()> {
+        if self.authed.is_operator && self.job_id.is_none() {
+            return Err(Error::NotAuthorized(format!(
+                "Operators cannot {what} for security reasons"
+            )));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq)]
 pub struct ApiAuthed {
     pub email: String,

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -243,6 +243,11 @@ async fn create_folder(
     Path(w_id): Path<String>,
     Json(mut ng): Json<NewFolder>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create folders for security reasons".to_string(),
+        ));
+    }
     crate::check_demo_workspace_restriction(&authed, &w_id, "Folder creation")?;
     if let Some(labels) = ng.labels.as_mut() {
         dedup_labels(labels);
@@ -406,6 +411,12 @@ async fn update_folder(
     Json(mut ng): Json<UpdateFolder>,
 ) -> Result<String> {
     use sql_builder::prelude::*;
+
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update folders for security reasons".to_string(),
+        ));
+    }
 
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -757,6 +768,11 @@ async fn delete_folder(
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, name)): Path<(String, String)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete folders for security reasons".to_string(),
+        ));
+    }
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),
@@ -827,6 +843,11 @@ async fn add_owner(
     Path((w_id, name)): Path<(String, String)>,
     Json(Owner { owner, .. }): Json<Owner>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot add owners to folders for security reasons".to_string(),
+        ));
+    }
     crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
     let mut tx = user_db.begin(&authed).await?;
 
@@ -892,6 +913,11 @@ async fn remove_owner(
     Path((w_id, name)): Path<(String, String)>,
     Json(Owner { owner, write }): Json<Owner>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot remove owners from folders for security reasons".to_string(),
+        ));
+    }
     // remove_owner with a `write` value is a grant path: it jsonb_set's the owner's
     // permission level into extra_perms (only write=None is a pure revoke), so the
     // demo-workspace sharing restriction must apply when a level is being set.

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -15,7 +15,9 @@ use axum::{
 };
 use lazy_static::lazy_static;
 use regex::Regex;
-use windmill_api_auth::{build_scope_path_predicate, check_scopes, ApiAuthed, AuthCache, Tokened};
+use windmill_api_auth::{
+    build_scope_path_predicate, check_scopes, ApiAuthed, AuthCache, OptJobAuthed, Tokened,
+};
 use windmill_audit::audit_oss::{audit_log, AuditAuthorable};
 use windmill_audit::ActionKind;
 use windmill_common::DB;
@@ -234,7 +236,7 @@ lazy_static! {
 }
 
 async fn create_folder(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Tokened { token }: Tokened,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -243,11 +245,8 @@ async fn create_folder(
     Path(w_id): Path<String>,
     Json(mut ng): Json<NewFolder>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create folders for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create folders")?;
+    let authed = job_authed.authed;
     crate::check_demo_workspace_restriction(&authed, &w_id, "Folder creation")?;
     if let Some(labels) = ng.labels.as_mut() {
         dedup_labels(labels);
@@ -403,7 +402,7 @@ use windmill_api_auth::is_owner;
 pub use windmill_api_auth::require_is_owner;
 
 async fn update_folder(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
@@ -412,11 +411,8 @@ async fn update_folder(
 ) -> Result<String> {
     use sql_builder::prelude::*;
 
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update folders for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update folders")?;
+    let authed = job_authed.authed;
 
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -762,17 +758,14 @@ async fn get_folder_usage(
 }
 
 async fn delete_folder(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, name)): Path<(String, String)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete folders for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete folders")?;
+    let authed = job_authed.authed;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),
@@ -837,17 +830,14 @@ async fn delete_folder(
 }
 
 async fn add_owner(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, name)): Path<(String, String)>,
     Json(Owner { owner, .. }): Json<Owner>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot add owners to folders for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("add owners to folders")?;
+    let authed = job_authed.authed;
     crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
     let mut tx = user_db.begin(&authed).await?;
 
@@ -907,17 +897,14 @@ async fn add_owner(
 }
 
 async fn remove_owner(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, name)): Path<(String, String)>,
     Json(Owner { owner, write }): Json<Owner>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot remove owners from folders for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("remove owners from folders")?;
+    let authed = job_authed.authed;
     // remove_owner with a `write` value is a grant path: it jsonb_set's the owner's
     // permission level into extra_perms (only write=None is a pure revoke), so the
     // demo-workspace sharing restriction must apply when a level is being set.

--- a/backend/windmill-api-groups/src/granular_acls.rs
+++ b/backend/windmill-api-groups/src/granular_acls.rs
@@ -18,7 +18,7 @@ use windmill_common::scripts::ScriptHash;
 use windmill_common::DB;
 use windmill_git_sync::{handle_deployment_metadata, DeployedObject};
 
-use windmill_api_auth::ApiAuthed;
+use windmill_api_auth::{ApiAuthed, OptJobAuthed};
 
 use serde::{Deserialize, Serialize};
 use windmill_common::{
@@ -90,12 +90,14 @@ pub struct GranularAcl {
 }
 
 async fn add_granular_acl(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(GranularAcl { owner, write }): Json<GranularAcl>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("grant permissions")?;
+    let authed = job_authed.authed;
     crate::check_demo_workspace_restriction(&authed, &w_id, "Sharing")?;
     let path = path.to_path();
 
@@ -325,12 +327,14 @@ async fn add_granular_acl(
 }
 
 async fn remove_granular_acl(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(GranularAcl { owner, .. }): Json<GranularAcl>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("revoke permissions")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
 
     let (kind, path) = path

--- a/backend/windmill-api-groups/src/groups.rs
+++ b/backend/windmill-api-groups/src/groups.rs
@@ -234,6 +234,11 @@ async fn create_group(
     Path(w_id): Path<String>,
     Json(ng): Json<NewGroup>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create groups for security reasons".to_string(),
+        ));
+    }
     crate::check_demo_workspace_restriction(&authed, &w_id, "Group creation")?;
     let mut tx = user_db.begin(&authed).await?;
 
@@ -629,6 +634,11 @@ async fn delete_group(
     Extension(user_db): Extension<UserDB>,
     Path((w_id, name)): Path<(String, String)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete groups for security reasons".to_string(),
+        ));
+    }
     let mut tx = user_db.begin(&authed).await?;
 
     if name == "all" {
@@ -692,6 +702,11 @@ async fn update_group(
     Path((w_id, name)): Path<(String, String)>,
     Json(eg): Json<EditGroup>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update groups for security reasons".to_string(),
+        ));
+    }
     let mut tx = user_db.begin(&authed).await?;
     if !authed.is_admin {
         require_is_owner(&name, &authed.username, &authed.groups, &w_id, &db).await?;
@@ -752,6 +767,11 @@ async fn add_user(
     Path((w_id, name)): Path<(String, String)>,
     Json(Username { username: user_username }): Json<Username>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot add users to groups for security reasons".to_string(),
+        ));
+    }
     let mut tx = user_db.begin(&authed).await?;
     if !authed.is_admin {
         require_is_owner(&name, &authed.username, &authed.groups, &w_id, &db).await?;
@@ -1147,6 +1167,11 @@ async fn remove_user(
     Path((w_id, name)): Path<(String, String)>,
     Json(Username { username: user_username }): Json<Username>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot remove users from groups for security reasons".to_string(),
+        ));
+    }
     let mut tx = user_db.begin(&authed).await?;
     if !authed.is_admin {
         require_is_owner(&name, &authed.username, &authed.groups, &w_id, &db).await?;

--- a/backend/windmill-api-groups/src/groups.rs
+++ b/backend/windmill-api-groups/src/groups.rs
@@ -6,7 +6,7 @@
  * LICENSE-AGPL for a copy of the license.
  */
 
-use windmill_api_auth::{require_super_admin, ApiAuthed};
+use windmill_api_auth::{require_super_admin, ApiAuthed, OptJobAuthed};
 use windmill_common::DB;
 
 use axum::{
@@ -228,17 +228,14 @@ async fn _check_nb_of_groups(db: &DB) -> Result<()> {
 }
 
 async fn create_group(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(_db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
     Json(ng): Json<NewGroup>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create groups for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create groups")?;
+    let authed = job_authed.authed;
     crate::check_demo_workspace_restriction(&authed, &w_id, "Group creation")?;
     let mut tx = user_db.begin(&authed).await?;
 
@@ -629,16 +626,13 @@ async fn get_group(
 }
 
 async fn delete_group(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, name)): Path<(String, String)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete groups for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete groups")?;
+    let authed = job_authed.authed;
     let mut tx = user_db.begin(&authed).await?;
 
     if name == "all" {
@@ -696,17 +690,14 @@ async fn delete_group(
 }
 
 async fn update_group(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, name)): Path<(String, String)>,
     Json(eg): Json<EditGroup>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update groups for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update groups")?;
+    let authed = job_authed.authed;
     let mut tx = user_db.begin(&authed).await?;
     if !authed.is_admin {
         require_is_owner(&name, &authed.username, &authed.groups, &w_id, &db).await?;
@@ -761,17 +752,14 @@ async fn update_group(
 }
 
 async fn add_user(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, name)): Path<(String, String)>,
     Json(Username { username: user_username }): Json<Username>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot add users to groups for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("add users to groups")?;
+    let authed = job_authed.authed;
     let mut tx = user_db.begin(&authed).await?;
     if !authed.is_admin {
         require_is_owner(&name, &authed.username, &authed.groups, &w_id, &db).await?;
@@ -1161,17 +1149,14 @@ async fn remove_user_igroup(
 }
 
 async fn remove_user(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, name)): Path<(String, String)>,
     Json(Username { username: user_username }): Json<Username>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot remove users from groups for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("remove users from groups")?;
+    let authed = job_authed.authed;
     let mut tx = user_db.begin(&authed).await?;
     if !authed.is_admin {
         require_is_owner(&name, &authed.username, &authed.groups, &w_id, &db).await?;

--- a/backend/windmill-api-schedule/src/lib.rs
+++ b/backend/windmill-api-schedule/src/lib.rs
@@ -17,8 +17,10 @@ use sql_builder::{prelude::Bind, SqlBuilder};
 use sqlx::{Postgres, Transaction};
 use std::str::FromStr;
 use windmill_api_auth::{
-    build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_super_admin, ApiAuthed,
+    build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_super_admin,
+    ApiAuthed, OptJobAuthed,
 };
+
 use windmill_audit::audit_oss::audit_log;
 use windmill_audit::ActionKind;
 use windmill_common::DB;
@@ -227,17 +229,14 @@ async fn validate_dynamic_skip<'c>(
 }
 
 async fn create_schedule(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
     Json(ns): Json<NewSchedule>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create schedules for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create schedules")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || format!("schedules:write:{}", ns.path))?;
     reject_reserved_schedule_path(&ns.path)?;
 
@@ -481,17 +480,14 @@ async fn create_schedule(
 }
 
 async fn edit_schedule(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(es): Json<EditSchedule>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update schedules for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update schedules")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     check_scopes(&authed, || format!("schedules:write:{}", path))?;
     reject_reserved_schedule_path(path)?;
@@ -1048,12 +1044,15 @@ pub async fn preview_schedule(
 }
 
 pub async fn set_enabled(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(payload): Json<SetEnabled>,
 ) -> Result<String> {
+    // Toggling also rewrites the schedule's `email`, i.e. who it runs as.
+    job_authed.reject_operator_write("enable or disable schedules")?;
+    let authed = job_authed.authed;
     let mut tx = user_db.begin(&authed).await?;
     let path = path.to_path();
     check_scopes(&authed, || format!("schedules:write:{}", path))?;
@@ -1227,16 +1226,13 @@ pub async fn set_enabled(
 // }
 
 async fn delete_schedule(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete schedules for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete schedules")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     check_scopes(&authed, || format!("schedules:write:{}", path))?;
     reject_reserved_schedule_path(path)?;

--- a/backend/windmill-api-schedule/src/lib.rs
+++ b/backend/windmill-api-schedule/src/lib.rs
@@ -233,6 +233,11 @@ async fn create_schedule(
     Path(w_id): Path<String>,
     Json(ns): Json<NewSchedule>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create schedules for security reasons".to_string(),
+        ));
+    }
     check_scopes(&authed, || format!("schedules:write:{}", ns.path))?;
     reject_reserved_schedule_path(&ns.path)?;
 
@@ -482,6 +487,11 @@ async fn edit_schedule(
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(es): Json<EditSchedule>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update schedules for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("schedules:write:{}", path))?;
     reject_reserved_schedule_path(path)?;
@@ -1222,6 +1232,11 @@ async fn delete_schedule(
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete schedules for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("schedules:write:{}", path))?;
     reject_reserved_schedule_path(path)?;

--- a/backend/windmill-api/src/capture.rs
+++ b/backend/windmill-api/src/capture.rs
@@ -64,7 +64,7 @@ use crate::triggers::postgres::{
 
 use crate::{
     args::RawWebhookArgs,
-    db::{ApiAuthed, DB},
+    db::{ApiAuthed, OptJobAuthed, DB},
     users::fetch_api_authed,
 };
 
@@ -531,12 +531,14 @@ async fn set_azure_trigger_config(
 }
 
 async fn set_config(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
     Json(nc): Json<NewCaptureConfig>,
 ) -> JsonResult<Option<TriggerConfig>> {
+    job_authed.reject_operator_write("configure trigger captures")?;
+    let authed = job_authed.authed;
     let nc = match nc.trigger_kind {
         TriggerKind::Postgres => {
             set_postgres_trigger_config(&w_id, authed.clone(), &db, user_db.clone(), nc).await?

--- a/backend/windmill-native-triggers/src/handler.rs
+++ b/backend/windmill-native-triggers/src/handler.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::PgConnection;
 use std::sync::Arc;
 use windmill_api_auth::{
-    check_scopes, create_token_internal, require_is_writer, ApiAuthed, NewToken,
+    check_scopes, create_token_internal, require_is_writer, ApiAuthed, NewToken, OptJobAuthed,
 };
 use windmill_audit::{audit_oss::audit_log, ActionKind};
 use windmill_common::{
@@ -104,12 +104,14 @@ async fn new_webhook_token(
 async fn create_native_trigger<T: External>(
     Extension(handler): Extension<Arc<T>>,
     Extension(service_name): Extension<ServiceName>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path(workspace_id): Path<String>,
     Json(data): Json<NativeTriggerData<T::ServiceConfig>>,
 ) -> JsonResult<CreateTriggerResponse> {
+    job_authed.reject_operator_write("create triggers")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("native_triggers:write:{}", &data.script_path)
     })?;
@@ -208,12 +210,14 @@ async fn create_native_trigger<T: External>(
 async fn update_native_trigger_handler<T: External>(
     Extension(handler): Extension<Arc<T>>,
     Extension(service_name): Extension<ServiceName>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((workspace_id, external_id)): Path<(String, String)>,
     Json(data): Json<NativeTriggerData<T::ServiceConfig>>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("update triggers")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("native_triggers:write:{}", &data.script_path)
     })?;
@@ -423,11 +427,13 @@ async fn get_native_trigger_handler<T: External>(
 async fn delete_native_trigger_handler<T: External>(
     Extension(handler): Extension<Arc<T>>,
     Extension(service_name): Extension<ServiceName>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((workspace_id, external_id)): Path<(String, String)>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("delete triggers")?;
+    let authed = job_authed.authed;
     let mut tx = user_db.begin(&authed).await?;
 
     let existing = get_native_trigger(&mut *tx, &workspace_id, service_name, &external_id)

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -11,7 +11,7 @@ use std::net::IpAddr;
 
 use windmill_api_auth::{
     build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_owner_of_path,
-    require_super_admin, ApiAuthed, Tokened,
+    require_super_admin, ApiAuthed, OptJobAuthed, Tokened,
 };
 use windmill_common::db::DB;
 use windmill_common::workspaces::{check_deploy_rules, RuleCheckResult};
@@ -1014,7 +1014,7 @@ struct CreateResourceQuery {
     update_if_exists: Option<bool>,
 }
 async fn create_resource(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
@@ -1022,11 +1022,8 @@ async fn create_resource(
     Query(q): Query<CreateResourceQuery>,
     Json(resource): Json<CreateResource>,
 ) -> Result<(StatusCode, String)> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create resources for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create resources")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || format!("resources:write:{}", resource.path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -1196,17 +1193,14 @@ async fn create_resource(
 }
 
 async fn delete_resource(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete resources for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete resources")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
 
     check_scopes(&authed, || format!("resources:write:{}", path))?;
@@ -1505,18 +1499,15 @@ pub async fn mark_linked_variables_ws_specific(
 }
 
 async fn delete_resources_bulk(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path(w_id): Path<String>,
     Json(request): Json<BulkDeleteRequest>,
 ) -> JsonResult<Vec<String>> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete resources for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete resources")?;
+    let authed = job_authed.authed;
     for path in &request.paths {
         check_scopes(&authed, || format!("resources:write:{}", path))?;
     }
@@ -1690,7 +1681,7 @@ async fn delete_resources_bulk(
 }
 
 async fn update_resource(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
@@ -1699,11 +1690,8 @@ async fn update_resource(
 ) -> Result<String> {
     use sql_builder::prelude::*;
 
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update resources for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update resources")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     check_scopes(&authed, || format!("resources:write:{}", path))?;
     // A rename moves the resource (and its linked variable) to ns.path, so the
@@ -1972,18 +1960,15 @@ struct UpdateResource {
 }
 
 async fn update_resource_value(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(nv): Json<UpdateResource>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update resources for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update resources")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     check_scopes(&authed, || format!("resources:write:{}", path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
@@ -2167,18 +2152,15 @@ async fn exists_resource_type(
 }
 
 async fn create_resource_type(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path(w_id): Path<String>,
     Json(resource_type): Json<CreateResourceType>,
 ) -> Result<(StatusCode, String)> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create resource types for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create resource types")?;
+    let authed = job_authed.authed;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),
@@ -2279,17 +2261,14 @@ async fn check_rt_path_conflict<'c>(
 }
 
 async fn delete_resource_type(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, name)): Path<(String, String)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete resource types for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete resource types")?;
+    let authed = job_authed.authed;
     require_admin(authed.is_admin, &authed.username)?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -2348,7 +2327,7 @@ async fn delete_resource_type(
 }
 
 async fn update_resource_type(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
@@ -2357,11 +2336,8 @@ async fn update_resource_type(
 ) -> Result<String> {
     use sql_builder::prelude::*;
 
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update resource types for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update resource types")?;
+    let authed = job_authed.authed;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -1022,6 +1022,11 @@ async fn create_resource(
     Query(q): Query<CreateResourceQuery>,
     Json(resource): Json<CreateResource>,
 ) -> Result<(StatusCode, String)> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create resources for security reasons".to_string(),
+        ));
+    }
     check_scopes(&authed, || format!("resources:write:{}", resource.path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -1197,6 +1202,11 @@ async fn delete_resource(
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete resources for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
 
     check_scopes(&authed, || format!("resources:write:{}", path))?;
@@ -1502,6 +1512,11 @@ async fn delete_resources_bulk(
     Path(w_id): Path<String>,
     Json(request): Json<BulkDeleteRequest>,
 ) -> JsonResult<Vec<String>> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete resources for security reasons".to_string(),
+        ));
+    }
     for path in &request.paths {
         check_scopes(&authed, || format!("resources:write:{}", path))?;
     }
@@ -1684,6 +1699,11 @@ async fn update_resource(
 ) -> Result<String> {
     use sql_builder::prelude::*;
 
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update resources for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("resources:write:{}", path))?;
     // A rename moves the resource (and its linked variable) to ns.path, so the
@@ -1959,6 +1979,11 @@ async fn update_resource_value(
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(nv): Json<UpdateResource>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update resources for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("resources:write:{}", path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
@@ -2149,6 +2174,11 @@ async fn create_resource_type(
     Path(w_id): Path<String>,
     Json(resource_type): Json<CreateResourceType>,
 ) -> Result<(StatusCode, String)> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create resource types for security reasons".to_string(),
+        ));
+    }
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),
@@ -2255,6 +2285,11 @@ async fn delete_resource_type(
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, name)): Path<(String, String)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete resource types for security reasons".to_string(),
+        ));
+    }
     require_admin(authed.is_admin, &authed.username)?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -2321,6 +2356,12 @@ async fn update_resource_type(
     Json(ns): Json<EditResourceType>,
 ) -> Result<String> {
     use sql_builder::prelude::*;
+
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update resource types for security reasons".to_string(),
+        ));
+    }
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),

--- a/backend/windmill-store/src/variables.rs
+++ b/backend/windmill-store/src/variables.rs
@@ -574,6 +574,11 @@ async fn create_variable(
     Query(AlreadyEncrypted { already_encrypted }): Query<AlreadyEncrypted>,
     Json(variable): Json<CreateVariable>,
 ) -> Result<(StatusCode, String)> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create variables for security reasons".to_string(),
+        ));
+    }
     check_scopes(&authed, || format!("variables:write:{}", variable.path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -707,6 +712,11 @@ async fn delete_variable(
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete variables for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
 
     check_scopes(&authed, || format!("variables:write:{}", path))?;
@@ -880,6 +890,11 @@ async fn delete_variables_bulk(
     Path(w_id): Path<String>,
     Json(request): Json<BulkDeleteRequest>,
 ) -> JsonResult<Vec<String>> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete variables for security reasons".to_string(),
+        ));
+    }
     for path in &request.paths {
         check_scopes(&authed, || format!("variables:write:{}", path))?;
     }
@@ -1057,6 +1072,12 @@ async fn update_variable(
     Json(ns): Json<EditVariable>,
 ) -> Result<String> {
     use sql_builder::prelude::*;
+
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update variables for security reasons".to_string(),
+        ));
+    }
 
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,

--- a/backend/windmill-store/src/variables.rs
+++ b/backend/windmill-store/src/variables.rs
@@ -8,7 +8,7 @@
 
 use windmill_api_auth::{
     build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_owner_of_path,
-    ApiAuthed,
+    ApiAuthed, OptJobAuthed,
 };
 use windmill_common::db::DB;
 use windmill_common::workspaces::{check_deploy_rules, RuleCheckResult};
@@ -566,7 +566,7 @@ fn validate_already_encrypted_secret(path: &str, value: &str) -> Result<()> {
 }
 
 async fn create_variable(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
@@ -574,11 +574,8 @@ async fn create_variable(
     Query(AlreadyEncrypted { already_encrypted }): Query<AlreadyEncrypted>,
     Json(variable): Json<CreateVariable>,
 ) -> Result<(StatusCode, String)> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create variables for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create variables")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || format!("variables:write:{}", variable.path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
@@ -706,17 +703,14 @@ async fn encrypt_value(
 }
 
 async fn delete_variable(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete variables for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete variables")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
 
     check_scopes(&authed, || format!("variables:write:{}", path))?;
@@ -883,18 +877,15 @@ async fn delete_variable(
 }
 
 async fn delete_variables_bulk(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
     Path(w_id): Path<String>,
     Json(request): Json<BulkDeleteRequest>,
 ) -> JsonResult<Vec<String>> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete variables for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete variables")?;
+    let authed = job_authed.authed;
     for path in &request.paths {
         check_scopes(&authed, || format!("variables:write:{}", path))?;
     }
@@ -1063,7 +1054,7 @@ struct AlreadyEncrypted {
 }
 
 async fn update_variable(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Extension(webhook): Extension<WebhookShared>,
@@ -1073,11 +1064,8 @@ async fn update_variable(
 ) -> Result<String> {
     use sql_builder::prelude::*;
 
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update variables for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update variables")?;
+    let authed = job_authed.authed;
 
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,

--- a/backend/windmill-trigger-http/src/handler.rs
+++ b/backend/windmill-trigger-http/src/handler.rs
@@ -7,7 +7,7 @@ use axum::{extract::Path, routing::post, Extension, Json, Router};
 use http::StatusCode;
 use sqlx::PgConnection;
 use std::collections::HashSet;
-use windmill_api_auth::{check_scopes, ApiAuthed};
+use windmill_api_auth::{check_scopes, ApiAuthed, OptJobAuthed};
 use windmill_audit::{audit_oss::audit_log, ActionKind};
 use windmill_common::global_settings::HTTP_ROUTE_WORKSPACED_ROUTE;
 use windmill_common::{
@@ -240,12 +240,14 @@ pub async fn insert_new_trigger_into_db(
 }
 
 pub async fn create_many_http_triggers(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
     Json(new_http_triggers): Json<Vec<TriggerData<HttpConfigRequest>>>,
 ) -> Result<(StatusCode, String)> {
+    job_authed.reject_operator_write("create triggers")?;
+    let authed = job_authed.authed;
     // Admin check for instance-wide routes is done per-trigger in insert_new_trigger_into_db
 
     let handler = HttpTrigger;

--- a/backend/windmill-trigger-postgres/src/handler.rs
+++ b/backend/windmill-trigger-postgres/src/handler.rs
@@ -20,7 +20,7 @@ use windmill_common::{
 };
 use windmill_git_sync::DeployedObject;
 
-use windmill_api_auth::{check_scopes, ApiAuthed};
+use windmill_api_auth::{check_scopes, ApiAuthed, OptJobAuthed};
 use windmill_trigger::{Trigger, TriggerCrud, TriggerData};
 
 use super::{
@@ -461,12 +461,14 @@ pub async fn list_slot_name(
 }
 
 pub async fn create_slot(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
     Json(Slot { name }): Json<Slot>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("manage replication slots or publications")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("postgres_triggers:write:{}", postgres_resource_path)
     })?;
@@ -520,12 +522,14 @@ pub async fn drop_logical_replication_slot(pg_connection: &Client, slot_name: &s
 }
 
 pub async fn drop_slot_name(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((w_id, postgres_resource_path)): Path<(String, String)>,
     Json(Slot { name }): Json<Slot>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("manage replication slots or publications")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("postgres_triggers:write:{}", postgres_resource_path)
     })?;
@@ -623,12 +627,14 @@ pub async fn get_publication_info(
 }
 
 pub async fn create_publication(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
     Json(publication_data): Json<PublicationData>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("manage replication slots or publications")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("postgres_triggers:write:{}", postgres_resource_path)
     })?;
@@ -664,11 +670,13 @@ pub async fn create_publication(
 }
 
 pub async fn delete_publication(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("manage replication slots or publications")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("postgres_triggers:write:{}", postgres_resource_path)
     })?;
@@ -800,12 +808,14 @@ pub async fn update_pg_publication(
 }
 
 pub async fn alter_publication(
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((w_id, publication_name, postgres_resource_path)): Path<(String, String, String)>,
     Json(publication_data): Json<PublicationData>,
 ) -> Result<String> {
+    job_authed.reject_operator_write("manage replication slots or publications")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!("postgres_triggers:write:{}", postgres_resource_path)
     })?;

--- a/backend/windmill-trigger/src/handler.rs
+++ b/backend/windmill-trigger/src/handler.rs
@@ -12,7 +12,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sql_builder::{bind::Bind, SqlBuilder};
 use sqlx::{FromRow, PgConnection};
 use std::fmt::Debug;
-use windmill_api_auth::{build_scope_path_predicate, check_scopes, ApiAuthed};
+use windmill_api_auth::{build_scope_path_predicate, check_scopes, ApiAuthed, OptJobAuthed};
 use windmill_common::{
     db::UserDB,
     error::{Error, JsonResult, Result},
@@ -467,17 +467,14 @@ pub fn trigger_routes<T: TriggerCrud + 'static>() -> Router {
 
 async fn create_trigger<T: TriggerCrud>(
     Extension(handler): Extension<Arc<T>>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path(workspace_id): Path<String>,
     Json(mut new_trigger): Json<TriggerData<T::TriggerConfigRequest>>,
 ) -> Result<(StatusCode, String)> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot create triggers for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("create triggers")?;
+    let authed = job_authed.authed;
     check_scopes(&authed, || {
         format!(
             "{}:write:{}",
@@ -718,17 +715,14 @@ async fn get_trigger<T: TriggerCrud>(
 
 async fn update_trigger<T: TriggerCrud>(
     Extension(handler): Extension<Arc<T>>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path((workspace_id, path)): Path<(String, StripPath)>,
     Json(mut edit_trigger): Json<TriggerData<T::TriggerConfigRequest>>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot update triggers for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("update triggers")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     // A scoped token must be allowed on both the existing path (URL) and the
     // new path (body); checking only the latter would let it move a trigger it
@@ -866,16 +860,13 @@ async fn update_trigger<T: TriggerCrud>(
 
 async fn delete_trigger<T: TriggerCrud>(
     Extension(handler): Extension<Arc<T>>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((workspace_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
-    if authed.is_operator {
-        return Err(Error::NotAuthorized(
-            "Operators cannot delete triggers for security reasons".to_string(),
-        ));
-    }
+    job_authed.reject_operator_write("delete triggers")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     check_scopes(&authed, || {
         format!("{}:write:{}", T::scope_domain_name(), &path)
@@ -1025,12 +1016,15 @@ async fn parent_has_trigger(
 
 async fn set_trigger_mode<T: TriggerCrud>(
     Extension(handler): Extension<Arc<T>>,
-    authed: ApiAuthed,
+    job_authed: OptJobAuthed,
     Extension(user_db): Extension<UserDB>,
     Extension(db): Extension<DB>,
     Path((workspace_id, path)): Path<(String, StripPath)>,
     Json(payload): Json<SetTriggerModePayload>,
 ) -> Result<String> {
+    // Setting the mode also rewrites `permissioned_as`, i.e. who the trigger runs as.
+    job_authed.reject_operator_write("change the mode of triggers")?;
+    let authed = job_authed.authed;
     let path = path.to_path();
     check_scopes(&authed, || format!("{}:write", T::scope_domain_name()))?;
 

--- a/backend/windmill-trigger/src/handler.rs
+++ b/backend/windmill-trigger/src/handler.rs
@@ -473,6 +473,11 @@ async fn create_trigger<T: TriggerCrud>(
     Path(workspace_id): Path<String>,
     Json(mut new_trigger): Json<TriggerData<T::TriggerConfigRequest>>,
 ) -> Result<(StatusCode, String)> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create triggers for security reasons".to_string(),
+        ));
+    }
     check_scopes(&authed, || {
         format!(
             "{}:write:{}",
@@ -719,6 +724,11 @@ async fn update_trigger<T: TriggerCrud>(
     Path((workspace_id, path)): Path<(String, StripPath)>,
     Json(mut edit_trigger): Json<TriggerData<T::TriggerConfigRequest>>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot update triggers for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     // A scoped token must be allowed on both the existing path (URL) and the
     // new path (body); checking only the latter would let it move a trigger it
@@ -861,6 +871,11 @@ async fn delete_trigger<T: TriggerCrud>(
     Extension(db): Extension<DB>,
     Path((workspace_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete triggers for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || {
         format!("{}:write:{}", T::scope_domain_name(), &path)


### PR DESCRIPTION
## Summary

The operator role is documented as read-only + execute-only (the `operator_settings` flags are all "whether operators can **view** X"), but only the script / flow / app / raw-app handlers enforced that on writes. RLS does not carry `is_operator` — only `is_admin` reaches `set_session_context` — and `check_scopes` is a no-op for a normal session token, so an operator could create and modify groups, folders, variables, resources, resource types, schedules and triggers through direct API calls.

Verified against a real operator on a dev instance before the fix: `groups/create`, `folders/create`, `resources/type/create`, `resources/type/update`, `schedules/create`, `schedules/update`, `http_triggers/create` (workspaced), `http_triggers/update`, `http_triggers/delete` all returned 2xx, and — the worst of them — `variables/delete g/all/*` and `resources/update_value g/all/*` succeeded, i.e. workspace-wide credential deletion and poisoning.

Fixes WIN-2245

## Changes

Added `OptJobAuthed::reject_operator_write(what)` in `windmill-api-auth` and applied it at the top of every affected write handler, before `check_scopes` / `check_deploy_rules` / `require_admin` / `user_db.begin`:

- **groups**: `create`, `update`, `delete`, `adduser`, `removeuser`
- **folders**: `create`, `update`, `delete`, `addowner`, `removeowner`
- **granular ACLs**: `acls/add`, `acls/remove` — the generic form of `folders/addowner`, writing `extra_perms` on every ACLable kind
- **variables**: `create`, `update`, `delete`, `delete_bulk`
- **resources**: `create`, `update`, `update_value`, `delete`, `delete_bulk`, and resource types `create` / `update` / `delete`
- **schedules**: `create`, `update`, `delete`, `setenabled`
- **triggers** (generic `TriggerCrud` router, all kinds): `create`, `update`, `delete`, `setmode`; plus `http_triggers/create_many` and native-trigger `create` / `update` / `delete`
- **trigger infrastructure**: `capture/set_config` (provisions external config and starts listeners), `postgres_triggers/publication/{create,update,delete}`, `postgres_triggers/slot/{create,delete}`

**Job tokens are exempt.** A job's token carries the operator's `is_operator`, and `wmill.setState` / `setVariable` / `setResource` go through `resources/create`, `resources/update_value`, `variables/create` and `variables/update` — a bare guard broke every operator-launched run that touched its own state (confirmed e2e: `401 Operators cannot create resources`). `reject_operator_write` lets a request through when `job_id` is set, which only happens on the token minted for job execution. What a job writes is decided by the script's author, not by the operator who ran it, and operators cannot author scripts or run previews.

## Scope boundaries

- Instance-group handlers and `schedules/setdefaulthandler` were left alone — they already call `require_super_admin`. `variables/encrypt` is not a persistence write.
- `setenabled` (schedules) and `setmode` (triggers) were not in the issue's list but are guarded: both rewrite who the object runs as (`email` / `permissioned_as`), a strictly larger capability than the update route next to them.
- **Not guarded, deliberately:** the capture session lifecycle (`capture/ping_config`, `capture/{id}` delete, `capture/move`) — all RLS-scoped to rows an operator can no longer create — and the EE `gcp_triggers/subscription/delete`, which today has *no* owner check at all. That is a pre-existing authz gap on an EE-only file and wants its own issue plus a companion PR rather than being bundled here.
- The operator-visible pages (`operator_settings.{schedules,variables,resources,folders,groups,triggers}`) still render create/edit/delete controls, which will now surface a 401 toast. Hiding them is a separate frontend follow-up; the settings are documented as view grants, so the backend behavior here is the intended one.

## Test plan

- [x] `backend/tests/operator_write_guards.rs` — table-driven over all 28 always-compiled guarded routes: operator gets 401 + `Operators cannot …`, a regular member never hits the guard, and an operator **job** token can still write its own state. Verified the test fails on the pre-fix code (`POST groups/create` returns 200).
- [x] `cargo check --features http_trigger,websocket,native_trigger,postgres_trigger` clean; `rustfmt --check` clean on all touched files.
- [x] Manual e2e on a dev instance with a real operator user, including a build with the trigger features: every route above 401s post-fix (`http_triggers/{create,update,delete,setmode,create_many}`, `acls/{add,remove}` on folder and group kinds, `capture/set_config`, `postgres_triggers/{slot,publication}/create`), an admin and a plain non-operator member are unaffected on all of them, and a deployed script calling `wmill.setState()` run by the operator succeeds again.