### PR TITLE
fix: operators cannot archive or delete flows and apps

### DIFF
--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -1622,6 +1622,11 @@ async fn archive_flow_by_path(
     Path((w_id, path)): Path<(String, StripPath)>,
     Json(archived): Json<Archived>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot archive flows for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("flows:write:{}", path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
@@ -1762,6 +1767,11 @@ async fn delete_flow_by_path(
     Path((w_id, path)): Path<(String, StripPath)>,
     Query(query): Query<DeleteFlowQuery>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete flows for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("flows:write:{}", path))?;
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -2121,6 +2121,11 @@ async fn delete_app(
     Extension(webhook): Extension<WebhookShared>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> Result<String> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot delete apps for security reasons".to_string(),
+        ));
+    }
     let path = path.to_path();
     check_scopes(&authed, || format!("apps:write:{}", path))?;
 


### PR DESCRIPTION
## Summary

`create_flow` / `update_flow` and `create_app` / `update_app` reject operators, but `archive_flow_by_path`, `delete_flow_by_path` and `delete_app` never got the same guard. An operator with write access to a folder could therefore **delete a flow or app they were not allowed to edit** — and archive one. Scripts already get this right: `archive_script` is operator-guarded and `delete_script_by_path` is admin-only.

Found while verifying the Operator role boundary for windmill-labs/windmilldocs#1596 (the docs claimed "operators do not have the ability to create or modify entities"; the real boundary is authoring and running *code*, which archiving or deleting a flow or app plainly is).

Verified on a live instance with a real operator account, before → after:

| Route | before | after |
|---|---|---|
| `POST /flows/archive/{path}` | 200 `Flow ... archived` | 401 `Operators cannot archive flows` |
| `DELETE /flows/delete/{path}` | 200 `Flow ... deleted` | 401 `Operators cannot delete flows` |
| `DELETE /apps/delete/p/{path}` | 200 `app ... deleted` | 401 `Operators cannot delete apps` |

A non-operator member with the same folder write still gets 200 on all three.

`POST /flows/archive/{path}` is also the **unarchive** route (it takes `archived: true|false`), so operators can no longer unarchive either. That is intended and mirrors the existing `archive_script_by_hash` precedent, but it is a behavior change beyond what the title says.

## Changes

- `archive_flow_by_path`, `delete_flow_by_path` (`windmill-api-flows/src/flows.rs`), `delete_app` (`windmill-api/src/apps.rs`): added the existing operator guard, placed before `check_scopes` / `check_deploy_rules` like its siblings.

## Test plan

- [x] `cargo check -p windmill-api-flows -p windmill-api` clean.
- [x] Manual e2e on a dev instance: the before/after table above, plus the non-operator regression check.

No test added: this is a three-line reuse of a guard whose shape is already established across ~20 call sites.

**Correction to an earlier version of this description**, which claimed the guard was "already pinned by `backend/tests/inline_preview_auth.rs` and `app_preview_auth.rs`. That is wrong — those pin `"Operators cannot run preview jobs"` on the preview-job routes and never touch flow/app archive or delete, so these three guards have no test coverage. I still think no test is the right call, but for the honest reason rather than that one: the recurring failure here is *a different route missing the guard each time* (CVE-2026-22683 covered entity CRUD, GHSA-pp5h-96x3-3wqq was the inline-exec residual, this is the archive/delete residual), and a per-route test generalizes over none of that. Happy to add one if a reviewer disagrees.

## Adjacent, not fixed here

Three more mutating handlers remain reachable by an operator with folder write, all pre-existing and lower impact (metadata or a boolean, no data loss). Surfaced by the CI review; left out to keep this diff to the delete/archive hole:

- `update_flow_history` (`flows.rs`) and `update_app_history` (`apps.rs`) — write `deployment_metadata.deployment_msg`, gated only by `check_scopes` + RLS.
- `toggle_workspace_error_handler` (`flows.rs`, EE) — `UPDATE flow SET ws_error_handler_muted` with no operator check, i.e. an operator can silence a flow's error handler.