### PR TITLE
chore: pin ruff to 0.16.0 and keep the python editor rule set stable

### DIFF
--- a/docker/DockerfileExtra
+++ b/docker/DockerfileExtra
@@ -68,7 +68,7 @@ ENV PIPENV_VENV_IN_PROJECT=1
 ENV XDG_CACHE_HOME=/pyls/.cache
 
 # Install Python packages for LSP using uv
-RUN uv pip install --system --break-system-packages pipenv tornado python-lsp-jsonrpc ruff Cython
+RUN uv pip install --system --break-system-packages pipenv tornado python-lsp-jsonrpc ruff==0.16.0 Cython
 
 # Install Node-based language servers
 RUN npm install -g diagnostic-languageserver pyright

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1272,7 +1272,15 @@
 					}
 				)
 
-				connectToLanguageServer(buildWsUrl('/ws/ruff'), 'ruff', {}, undefined)
+				// `ruff server` resolves settings per workspace folder, and the folder registered
+				// below is the document URI rather than a directory containing it, so a ruff.toml
+				// on disk never applies unless named here (written by lsp/pyls_launcher.py).
+				connectToLanguageServer(
+					buildWsUrl('/ws/ruff'),
+					'ruff',
+					{ settings: { configuration: '/tmp/monaco/ruff.toml' } },
+					undefined
+				)
 			} else if (lang === 'go') {
 				connectToLanguageServer(
 					buildWsUrl('/ws/go'),

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -970,7 +970,7 @@ export const settings: Record<string, Setting[]> = {
 		{
 			label: 'Ruff config (ruff.toml)',
 			description:
-				'Shared ruff.toml applied to the Python editor linter across the whole instance. The LSP container fetches this every minute and writes it next to edited files. See <a href="https://docs.astral.sh/ruff/configuration/">ruff docs</a>',
+				'Shared ruff.toml applied to the Python editor linter across the whole instance. The LSP container fetches this every minute and writes it next to edited files. Leave empty to use the Windmill default (<code>select = ["E4", "E7", "E9", "F"]</code>); anything set here replaces that default entirely. See <a href="https://docs.astral.sh/ruff/configuration/">ruff docs</a>',
 			key: 'ruff_config',
 			fieldType: 'codearea',
 			codeAreaLang: 'toml',

--- a/lsp/Dockerfile
+++ b/lsp/Dockerfile
@@ -37,7 +37,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GOBIN=/usr/local/go/bin
 RUN /usr/local/go/bin/go install -v golang.org/x/tools/gopls@latest
 
-RUN pip3 install tornado python-lsp-jsonrpc ruff
+RUN pip3 install tornado python-lsp-jsonrpc ruff==0.16.0
 
 COPY --from=denoland/deno:2.2.1 --chmod=755 /usr/bin/deno /usr/bin/deno
 

--- a/lsp/pyls_launcher.py
+++ b/lsp/pyls_launcher.py
@@ -18,9 +18,8 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
 
-# Named explicitly by the python editor in its LSP initializationOptions (see
-# Editor.svelte), which must stay in sync: ruff never discovers this file on its
-# own, since the editor registers the document URI as the workspace folder.
+# Named explicitly by the python editor's ruff initializationOptions, which must
+# stay in sync with this path (Editor.svelte explains why ruff needs it named).
 RUFF_CONFIG_PATH = "/tmp/monaco/ruff.toml"
 # How often to re-fetch the instance ruff config from the backend. Existing
 # ruff server processes won't pick up the change mid-session, but the next

--- a/lsp/pyls_launcher.py
+++ b/lsp/pyls_launcher.py
@@ -18,23 +18,48 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
 
-# Path where ruff (spawned with workspace rooted at /tmp/monaco) will discover
-# a ruff.toml. Ruff walks up from the file being linted looking for a
-# ruff.toml / .ruff.toml / pyproject.toml, so dropping it here covers every
-# python editor session.
+# Named explicitly by the python editor in its LSP initializationOptions (see
+# Editor.svelte), which must stay in sync: ruff never discovers this file on its
+# own, since the editor registers the document URI as the workspace folder.
 RUFF_CONFIG_PATH = "/tmp/monaco/ruff.toml"
 # How often to re-fetch the instance ruff config from the backend. Existing
 # ruff server processes won't pick up the change mid-session, but the next
 # editor reload / WebSocket reconnect will.
 RUFF_CONFIG_POLL_INTERVAL_SECS = int(os.environ.get("RUFF_CONFIG_POLL_INTERVAL_SECS", "60"))
 
+# Written whenever the instance sets no `ruff_config` of its own. Ruff's own
+# defaults grow between releases (0.16 went from 59 to 413 enabled rules), so
+# without this every ruff bump would change the diagnostics script authors see.
+DEFAULT_RUFF_CONFIG = '[lint]\nselect = ["E4", "E7", "E9", "F"]\n'
+
+
+def _write_ruff_config(content):
+    """Write content to RUFF_CONFIG_PATH, skipping the write when unchanged."""
+    try:
+        if os.path.exists(RUFF_CONFIG_PATH):
+            with open(RUFF_CONFIG_PATH, "r") as f:
+                if f.read() == content:
+                    return
+        os.makedirs(os.path.dirname(RUFF_CONFIG_PATH), exist_ok=True)
+        # Rename into place: a `ruff server` spawned mid-write must never read a
+        # truncated config, which would drop that session onto ruff's defaults.
+        tmp_path = RUFF_CONFIG_PATH + ".tmp"
+        with open(tmp_path, "w") as f:
+            f.write(content)
+        os.replace(tmp_path, RUFF_CONFIG_PATH)
+        log.info("Wrote ruff config to %s (%d bytes)", RUFF_CONFIG_PATH, len(content))
+    except OSError as e:
+        log.warning("Could not write ruff config to %s: %s", RUFF_CONFIG_PATH, e)
+
 
 def _sync_ruff_config_once():
-    """Fetch the instance ruff config from the windmill backend and write it
-    to disk. No-op when WINDMILL_BASE_URL is unset (e.g., running the LSP
-    standalone for local development)."""
+    """Fetch the instance ruff config from the windmill backend and write it to
+    disk, falling back to DEFAULT_RUFF_CONFIG when the instance has none.
+    Falls back without fetching when WINDMILL_BASE_URL is unset (e.g., running
+    the LSP standalone for local development)."""
     base_url = os.environ.get("WINDMILL_BASE_URL") or os.environ.get("BASE_INTERNAL_URL")
     if not base_url:
+        _write_ruff_config(DEFAULT_RUFF_CONFIG)
         return
     url = base_url.rstrip("/") + "/api/settings_u/ruff_config"
     try:
@@ -44,27 +69,17 @@ def _sync_ruff_config_once():
         log.warning("Could not fetch instance ruff config from %s: %s", url, e)
         return
 
-    try:
-        existing = ""
-        if os.path.exists(RUFF_CONFIG_PATH):
-            with open(RUFF_CONFIG_PATH, "r") as f:
-                existing = f.read()
-        if existing == body:
-            return
-        if body:
-            os.makedirs(os.path.dirname(RUFF_CONFIG_PATH), exist_ok=True)
-            with open(RUFF_CONFIG_PATH, "w") as f:
-                f.write(body)
-            log.info("Wrote instance ruff config to %s (%d bytes)", RUFF_CONFIG_PATH, len(body))
-        elif os.path.exists(RUFF_CONFIG_PATH):
-            os.remove(RUFF_CONFIG_PATH)
-            log.info("Removed %s (instance ruff config is empty)", RUFF_CONFIG_PATH)
-    except OSError as e:
-        log.warning("Could not write ruff config to %s: %s", RUFF_CONFIG_PATH, e)
+    # A blank-but-not-empty setting (a stray newline left in the codearea) would
+    # otherwise parse as a valid config selecting ruff's defaults.
+    _write_ruff_config(body if body.strip() else DEFAULT_RUFF_CONFIG)
 
 
 def start_ruff_config_poller():
-    """Fetch the ruff config once synchronously, then poll in the background."""
+    """Seed the default ruff config, fetch the instance override once
+    synchronously, then poll in the background."""
+    # Seeded first so a backend that is unreachable at startup still leaves the
+    # editor on the pinned rule selection rather than on ruff's own defaults.
+    _write_ruff_config(DEFAULT_RUFF_CONFIG)
     _sync_ruff_config_once()
 
     def loop():


### PR DESCRIPTION
## Summary

Fixes WIN-2246.

Updates ruff to 0.16.0 in the two images that install it, and pins it explicitly (alongside the existing `go1.26.0` / `deno 2.2.1` pins) so the python editor's linter no longer drifts with whatever PyPI serves at build time.

The bump is not a one-liner, because ruff 0.16 [enables 413 rules by default, up from 59](https://astral.sh/blog/ruff-v0.16.0). Two consequences had to be handled:

1. **The stock Windmill python template would light up with new diagnostics.** Verified against a real `ruff server` 0.16: the default template goes from 2 diagnostics (`E741`, `E722`) to 5 (`I001` on the import block, `B006` twice on the mutable defaults, `E722`, and `E741` silently *dropped* from the default set). The LSP container now always writes a Windmill default `ruff.toml` (`select = ["E4", "E7", "E9", "F"]` — exactly ruff's pre-0.16 default) when the instance-level `ruff_config` setting is empty, so an instance that never configured ruff sees the same diagnostics before and after the upgrade, and future ruff bumps don't move them either.

2. **The instance-level `ruff_config` setting was silently a no-op.** `ruff server` resolves settings per *registered workspace folder*, and the editor registers the document URI (`file:///tmp/monaco/<id>.py`) rather than a directory containing it — so ruff logs `No settings available for <file> - falling back to default settings` and never applies any `ruff.toml` it could otherwise discover on disk. Until 0.16 this was invisible, because ruff's own defaults happened to equal the config Windmill was writing. Now the editor passes the config path explicitly through the ruff client's `initializationOptions`, which makes both the Windmill default and any admin-set `ruff_config` actually take effect.

## Changes

- `lsp/Dockerfile`, `docker/DockerfileExtra`: pin `ruff==0.16.0`
- `lsp/pyls_launcher.py`: add `DEFAULT_RUFF_CONFIG`; write it at startup and whenever the instance `ruff_config` is empty/blank (previously the config file was deleted in that case); factor the write into `_write_ruff_config`, which renames into place so a `ruff server` spawning mid-write can't read a truncated config
- `frontend/src/lib/components/Editor.svelte`: pass `settings.configuration = '/tmp/monaco/ruff.toml'` in the ruff client's `initializationOptions`
- `frontend/src/lib/components/instanceSettings.ts`: document that an empty `ruff_config` falls back to the Windmill default, and that a non-empty value replaces it entirely

## Screenshots

Stock python template in the editor, against ruff 0.16 in every case (local LSP container running this branch's `pyls_launcher.py` with ruff 0.16.0, reached via the `ws_base_url` instance setting).

**Before this PR** — 5 diagnostics: `I001` on lines 1-2, `B006` on both mutable defaults, `E722`; `E741` on `l` is gone:

![before-ruff016](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2246-update-ruff-to-016/1785062760-before-ruff016.png)

**With this PR, no instance `ruff_config`** — back to the 2 diagnostics a 0.15 instance shows today (`E741` on `l`, `E722` on the bare `except`), hover confirms `Ruff E722`:

![after-ruff016-default](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2246-update-ruff-to-016/1785062760-after-ruff016-default.png)

**With `ruff_config = '[lint]\nselect = ["I"]'`** — the instance setting is now honored (it was ignored before this PR): only `I001` on the import block, hover confirms `Ruff I001`:

![editor4](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2246-update-ruff-to-016/1785062760-editor4.png)

## Test plan

Validated locally by running the real `pyls_launcher.py` against a real `ruff server` 0.16.0 over a websocket, with a stub backend standing in for `/api/settings_u/ruff_config` (8/8 checks pass):

- [x] empty instance config -> Windmill default written; ruff reports the legacy rule set only (`E722`, `E741`)
- [x] non-empty instance config written verbatim and honored by `ruff server` (`select = ["I"]` -> `I001` only)
- [x] instance config cleared -> default restored (previously the file was deleted, leaving ruff on its own defaults)
- [x] whitespace-only instance config treated as unset
- [x] backend unreachable -> existing config preserved; no `BASE_INTERNAL_URL` -> default seeded
- [x] for the record: ruff 0.16 with no config at all reports `B006`, `E722`, `I001`
- [x] browser-verified end to end in the python script editor (screenshots above), including a hover readout of the rule codes
- [x] `npm run check:fast` — one pre-existing unrelated failure (`modern-screenshot` is in `frontend/package.json` but not installed in this worktree's `node_modules`)

Not covered: building the two LSP images. `pip install ruff==0.16.0` was exercised via `uv` locally, but the full image builds (go toolchain + `pipenv install`) were not run here — CI covers them.

No automated test is shipped: `lsp/` has no test harness, and standing one up for a few lines of file I/O runs against AGENTS.md's "ship only the tests the PR needs". The harness described above stays out of the repo as dev scaffolding.

## Notes for reviewers

- `/tmp/monaco/ruff.toml` is now named in two places (frontend init options + launcher); both sides carry a comment pointing at the other. The path was already hardcoded on both sides (`computeUri` puts python documents under `/tmp/monaco/`).
- Pinning means ruff patch releases no longer arrive automatically — intentional, since a minor bump can change the default rule set under users. Bumping is now a one-line, reviewable change.
- Admins who previously set `ruff_config` and saw no effect will see it take effect after this PR. That is the fix, but it is a visible behavior change for them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2246 by pinning `ruff` to 0.16.0 and keeping the Python editor on the pre-0.16 rule set so lint results stay stable. The instance `ruff_config` now applies correctly.

- **Dependencies**
  - Pin `ruff==0.16.0` in both LSP images.

- **Bug Fixes**
  - Seed and maintain a default `ruff.toml` when `ruff_config` is empty or whitespace, using `select = ["E4", "E7", "E9", "F"]`; write atomically, poll for updates, and fall back to the default if the backend/env is missing or unreachable.
  - Pass the named config path to the `ruff` LSP via `initializationOptions` so it’s loaded; keep the path definition in the launcher and update the instance setting help text to clarify the default/override behavior.

<sup>Written for commit f2f151cbbfb06694a03aef538eee13c24d11e0e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

