### PR TITLE
chore: remove the unreachable hub raw-app embed proxy

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -23284,40 +23284,6 @@ paths:
               schema:
                 type: string
 
-  /w/{workspace}/hub/raw_apps/{id}/embed:
-    post:
-      summary: set or clear the embed url of a hub raw app
-      description: |
-        Requires the caller to be a workspace admin. Forwards the request to the
-        configured Hub scoped to the `{workspace}:{folder}` source and returns
-        the Hub's status code and raw response body.
-      operationId: publishHubRawAppEmbed
-      tags:
-        - hubPublish
-      parameters:
-        - $ref: "#/components/parameters/WorkspaceId"
-        - name: id
-          in: path
-          required: true
-          description: hub id of the raw app
-          schema:
-            type: integer
-            format: int64
-        - $ref: "#/components/parameters/HubPublishFolder"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RawAppEmbedBody"
-      responses:
-        "200":
-          description: raw Hub response body (status code is passed through from the Hub)
-          content:
-            text/plain:
-              schema:
-                type: string
-
   /w/{workspace}/hub/raw_apps/{id}/recording:
     post:
       summary: attach a recorded session to a hub raw app
@@ -32885,18 +32851,6 @@ components:
         - raw
         - apps
         - summary
-        - project_slug
-
-    RawAppEmbedBody:
-      type: object
-      properties:
-        external_embed_url:
-          type: string
-          nullable: true
-          description: explicit `null` clears the embed (unpublish)
-        project_slug:
-          $ref: "#/components/schemas/HubProjectSlug"
-      required:
         - project_slug
 
     RecordingBody:

--- a/backend/windmill-api/src/hub_publish.rs
+++ b/backend/windmill-api/src/hub_publish.rs
@@ -22,7 +22,6 @@ pub fn workspaced_service() -> Router {
         .route("/flows", post(publish_flow))
         .route("/apps", post(publish_app))
         .route("/raw_apps", post(publish_raw_app))
-        .route("/raw_apps/{id}/embed", post(publish_raw_app_embed))
         .route("/raw_apps/{id}/recording", post(publish_raw_app_recording))
         .route(
             "/scripts/{ask_id}/recording",
@@ -304,21 +303,6 @@ async fn publish_raw_app(
     Json(body): Json<PublishRawAppBody>,
 ) -> Result<impl IntoResponse, Error> {
     ctx.post("/raw_apps", &body).await
-}
-
-#[derive(Deserialize, Serialize)]
-struct RawAppEmbedBody {
-    // No skip_serializing_if: `null` must reach the Hub to clear the embed (unpublish).
-    external_embed_url: Option<String>,
-    project_slug: ProjectSlug,
-}
-
-async fn publish_raw_app_embed(
-    ctx: HubPublishCtx,
-    Path((_workspace, id)): Path<(String, i64)>,
-    Json(body): Json<RawAppEmbedBody>,
-) -> Result<impl IntoResponse, Error> {
-    ctx.post(&format!("/raw_apps/{}/embed", id), &body).await
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

`POST /w/{workspace}/hub/raw_apps/{id}/embed` set or cleared a Hub raw app's `external_embed_url` — the live `app.windmill.dev` iframe that used to serve as a raw app's demo on the Hub.

#10318 replaced that demo with a recorded session and removed `Share as iframe`, which was the proxy's only caller (`#setAppShared` / `#pushRawAppEmbed` in `deployToHubSession.svelte.ts`). Nothing in the frontend, the CLI or the backend reaches it now, so it is an authenticated route kept alive for no consumer.

Found while auditing what `external_embed_url` still supports after #10318.

## Scope

This drops **only Windmill's write path**. It is deliberately not a removal of the feature:

- The Hub still stores `external_embed_url`, and 4 of the 9 raw apps currently published carry one.
- The Hub still renders it (`RawAppView` → live iframe for approved apps) and still exposes its own producers: the `raw_apps/add` form, the `raw_apps/[id]/[summary]/edit` form, and `POST /raw_apps/{id}/embed`.

Retiring the feature properly means backfilling recordings for those apps first — several of them store app YAML rather than a file tree, so `canRenderBundle` is false and dropping the iframe today would leave them with no App tab at all. That is a separate change on the Hub side.

## Changes

- `hub_publish.rs` — drop the `/raw_apps/{id}/embed` route, the `publish_raw_app_embed` handler and the `RawAppEmbedBody` struct
- `openapi.yaml` — drop the corresponding path entry (`publishHubRawAppEmbed`) and the `RawAppEmbedBody` schema

`frontend/src/lib/gen` is gitignored and regenerated at build time, so no client files appear in the diff; the regeneration was run locally to confirm the operation disappears cleanly and that the edited YAML still parses.

## Test plan

- [x] `cargo check -p windmill-api` — clean, no warnings
- [x] `npm run generate-backend-client` — succeeds (validates the edited `openapi.yaml`) and emits no `RawAppEmbedBody` / `publishHubRawAppEmbed`
- [x] No remaining references to `publish_raw_app_embed`, `RawAppEmbedBody`, `publishHubRawAppEmbed` or `raw_apps/{id}/embed` across `backend/`, `frontend/src` and `cli/`
- [ ] The sibling `POST /hub/raw_apps/{id}/recording` still routes (returns 401 unauthenticated rather than 404)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unreachable Hub raw-app embed proxy `POST /w/{workspace}/hub/raw_apps/{id}/embed`. This drops our write path only; the Hub still stores and renders `external_embed_url`, and the recording endpoint remains.

- **Refactors**
  - Deleted `publish_raw_app_embed` and `RawAppEmbedBody` from `backend/windmill-api/src/hub_publish.rs`.
  - Removed `publishHubRawAppEmbed` path and `RawAppEmbedBody` schema from `backend/windmill-api/openapi.yaml`.

<sup>Written for commit 2d8133397c231d159f810acfc0e0698a5a13e2f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

