### PR TITLE
fix(frontend): sync eval drawer open state

### DIFF
--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/EvalV2InputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/EvalV2InputEditor.svelte
@@ -84,7 +84,7 @@
 		<Drawer
 			placement="bottom"
 			on:close={() => (fullscreen = false)}
-			open
+			bind:open={fullscreen}
 			offset={zIndexes.monacoEditor}
 		>
 			<Splitpanes horizontal class="h-full">


### PR DESCRIPTION
Fixes issue https://github.com/windmill-labs/windmill/issues/9278

## Summary
- Bind the eval input drawer `open` state to the local fullscreen state.
- Keeps the inline expression editor in sync when the fullscreen drawer is closed.
- Prevents eval configurations from rendering as a non-interactive code block after closing the drawer.

## Testing
- Reproduced the issue in the low-code app editor.
- Added a Text Input component with an eval-enabled Placeholder configuration.
- Entered code in the inline expression editor.
- Opened the fullscreen drawer editor.
- Closed the drawer.
- Verified the Placeholder configuration stayed interactive after closing the drawer.
- `npm run generate-backend-client`
- `npm run check`

## Screen recording
Before

https://github.com/user-attachments/assets/172eba9b-06ef-4f53-b9d8-45fa299c9e2c

After

https://github.com/user-attachments/assets/6e021144-cf9f-4feb-9c02-d92a24aa5994



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the eval input drawer’s open state to the local `fullscreen` flag to keep the inline expression editor interactive after closing the fullscreen editor. Fixes the bug where eval configs became a non-interactive code block after closing the drawer (fixes #9278).

<sup>Written for commit 878b3a66c3eccccfb20e140b86a4c6f5561479e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

