### PR TITLE
fix(frontend): avoid legacy Ask AI shortcut collision

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1686,7 +1686,7 @@
 				editor?.trigger('keyboard', 'editor.action.commentLine', {})
 			})
 
-			editor?.addCommand(KeyMod.CtrlCmd | KeyCode.KeyL, function () {
+			editor?.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL, function () {
 				const selectedLines = getSelectedLines()
 				const selection = editor?.getSelection()
 				const hasSelection =

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -2659,7 +2659,7 @@
 									hidden={true}
 									direction="right"
 									panelName="AI"
-									shortcut="L"
+									shortcut="⇧L"
 									unifiedSize="sm"
 									usePopoverOverride={!$copilotInfo.enabled}
 									customHiddenIcon={{

--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -112,22 +112,12 @@
 	})
 </script>
 
-<svelte:window
-	onkeydown={(e) => {
-		if ((e.ctrlKey || e.metaKey) && e.key === 'l') {
-			e.preventDefault()
-			aiChatManager.toggleOpen()
-			aiChatDisplay?.focusInput()
-		}
-	}}
-/>
-
 {#snippet headerLeft()}
 	<HideButton
 		hidden={false}
 		direction="right"
 		panelName="AI"
-		shortcut="L"
+		shortcut="⇧L"
 		size="md"
 		on:click={() => aiChatManager.toggleOpen()}
 	/>

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -647,7 +647,7 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 			{@render emptyHint()}
 		{:else}
 			<span class="text-2xs text-gray-500 dark:text-gray-400 text-center px-2 my-2"
-				>You can use {getModifierKey()}L to open or close this chat, and {getModifierKey()}K in the
+				>You can use {getModifierKey()}⇧L to open or close this chat, and {getModifierKey()}K in the
 				script editor to modify selected lines.</span
 			>
 		{/if}

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -8,7 +8,7 @@
 	import { chatState } from './sharedChatState.svelte'
 	import { loadCopilot } from '$lib/aiStore'
 	import { aiChatManager } from './AIChatManager.svelte'
-	import { onDestroy } from 'svelte'
+	import { onDestroy, tick } from 'svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { Menu } from 'lucide-svelte'
 	import CreatedResourceActionDrawers from './CreatedResourceActionDrawers.svelte'
@@ -57,11 +57,26 @@
 	const historyManager = aiChatManager.historyManager
 	historyManager.init()
 
+	let aiChat: AiChat | undefined = $state(undefined)
+
+	async function handleAiShortcut(e: KeyboardEvent) {
+		if (disableAi || !(e.ctrlKey || e.metaKey) || !e.shiftKey || e.key.toLowerCase() !== 'l') {
+			return
+		}
+
+		e.preventDefault()
+		aiChatManager.toggleOpen()
+		await tick()
+		aiChat?.focusInput()
+	}
+
 	onDestroy(() => {
 		aiChatManager.cancel('aiChatLayout destroyed')
 		historyManager.close()
 	})
 </script>
+
+<svelte:window onkeydown={handleAiShortcut} />
 
 {#snippet burgerRow()}
 	<div
@@ -106,7 +121,7 @@
 				class={`flex flex-col min-h-0 z-[${zIndexes.aiChat}]`}
 			>
 				<div class="flex-1 min-h-0">
-					<AiChat />
+					<AiChat bind:this={aiChat} />
 				</div>
 				{#if showSessionsBetaBanner}
 					<SessionsBetaBanner variant="legacy" />

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -60,7 +60,13 @@
 	let aiChat: AiChat | undefined = $state(undefined)
 
 	async function handleAiShortcut(e: KeyboardEvent) {
-		if (disableAi || !(e.ctrlKey || e.metaKey) || !e.shiftKey || e.key.toLowerCase() !== 'l') {
+		if (
+			e.repeat ||
+			disableAi ||
+			!(e.ctrlKey || e.metaKey) ||
+			!e.shiftKey ||
+			e.key.toLowerCase() !== 'l'
+		) {
 			return
 		}
 

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -995,7 +995,7 @@
 														label="Ask AI"
 														class="!text-xs"
 														iconClasses="!text-ai"
-														shortcut={`${getModifierKey()}L`}
+														shortcut={`${getModifierKey()}⇧L`}
 													/>
 												{/if}
 											</div>
@@ -1128,7 +1128,7 @@
 												label="Ask AI"
 												class="!text-xs"
 												iconClasses="!text-ai"
-												shortcut={`${getModifierKey()}L`}
+												shortcut={`${getModifierKey()}⇧L`}
 											/>
 										{/if}
 									</div>
@@ -1262,7 +1262,7 @@
 									label="Ask AI"
 									class="!text-xs"
 									iconClasses="!text-ai"
-									shortcut={`${getModifierKey()}L`}
+									shortcut={`${getModifierKey()}⇧L`}
 								/>
 							</div>
 


### PR DESCRIPTION
Fixes issue https://github.com/windmill-labs/windmill/issues/9928

## Summary
- Changes the legacy Ask AI shortcut from Cmd/Ctrl+L to Cmd/Ctrl+Shift+L.
- Updates the visible legacy Ask AI shortcut labels to match the new binding.
- Handles the shortcut from the chat layout so the docked Ask AI panel can open even when it is currently closed.

## Why
Cmd/Ctrl+L is a browser-level shortcut for focusing the address bar in Safari, Chrome, and other browsers. Keeping `L` preserves the existing mnemonic, while adding Shift avoids the browser shortcut collision.

This applies to the legacy Ask AI panel, which is still available through the AI Sessions beta opt-out path.

## Testing
- Switched back from AI Sessions beta to the legacy Ask AI panel.
- Verified Cmd+L keeps the browser address-bar behavior and does not open Ask AI.
- Verified Cmd+Shift+L opens the legacy Ask AI chat.
- Verified visible legacy Ask AI labels show Cmd+Shift+L.
- `npm run generate-backend-client`
- `npm run check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Change the legacy Ask AI shortcut to Cmd/Ctrl+Shift+L to avoid the browser address bar collision. The shortcut now opens the panel when closed, focuses the input, and ignores repeated key presses.

- **Bug Fixes**
  - Switched legacy Ask AI to Cmd/Ctrl+Shift+L; Cmd/Ctrl+L remains for the browser address bar.
  - Centralized handling in the chat layout to toggle the docked panel, focus the input, and ignore repeated events.
  - Updated shortcut hints in the editor, chat, and navigation UI.

<sup>Written for commit 62ca54990fbf933fdfef000b0dbee09fba8471fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

