### PR TITLE
fix: open a pipeline step on its code, not its output

### DIFF
--- a/frontend/src/lib/components/recording/PipelineRecordingReplay.svelte
+++ b/frontend/src/lib/components/recording/PipelineRecordingReplay.svelte
@@ -269,12 +269,15 @@
 	})
 	// Land on the code, since that is what the step *is* — but fall back to Output
 	// when the recording carries none, so a recording made before `codes` existed
-	// does not open on an empty pane. Re-runs per selected step, so a tab the
-	// viewer picked by hand survives until they move to another step.
+	// does not open on an empty pane. Depends on the selected path alone: the
+	// lookup is untracked so a tab the viewer picked by hand survives until they
+	// move to another step, rather than resetting if the recording object changes.
 	$effect(() => {
 		const path = selection?.kind === 'runnable' ? selection.path : undefined
 		if (path === undefined) return
-		runnableTab = recording.codes?.[path] ? 'code' : 'output'
+		untrack(() => {
+			runnableTab = recording.codes?.[path] ? 'code' : 'output'
+		})
 	})
 
 	// Recorded data-sample for a selected asset node (ducklake/datatable).

--- a/frontend/src/lib/components/recording/PipelineRecordingReplay.svelte
+++ b/frontend/src/lib/components/recording/PipelineRecordingReplay.svelte
@@ -261,11 +261,20 @@
 		return (shownStatuses[selection.path] ?? finalStatuses[selection.path])?.status
 	})
 
-	// Output (args/logs/result) vs the step's source code, for a runnable node.
-	let runnableTab = $state<'output' | 'code'>('output')
+	// The step's source code vs its output (args/logs/result), for a runnable node.
+	let runnableTab = $state<'output' | 'code'>('code')
 	let selectedCode = $derived.by(() => {
 		if (selection?.kind !== 'runnable') return undefined
 		return recording.codes?.[selection.path]
+	})
+	// Land on the code, since that is what the step *is* — but fall back to Output
+	// when the recording carries none, so a recording made before `codes` existed
+	// does not open on an empty pane. Re-runs per selected step, so a tab the
+	// viewer picked by hand survives until they move to another step.
+	$effect(() => {
+		const path = selection?.kind === 'runnable' ? selection.path : undefined
+		if (path === undefined) return
+		runnableTab = recording.codes?.[path] ? 'code' : 'output'
 	})
 
 	// Recorded data-sample for a selected asset node (ducklake/datatable).
@@ -382,8 +391,8 @@
 											on:selected={(e) => (runnableTab = e.detail)}
 										>
 											{#snippet children({ item })}
-												<ToggleButton size="sm" value="output" label="Output" {item} />
 												<ToggleButton size="sm" value="code" label="Code" {item} />
+												<ToggleButton size="sm" value="output" label="Output" {item} />
 											{/snippet}
 										</ToggleButtonGroup>
 									</div>


### PR DESCRIPTION
## Summary

Clicking a script node in a pipeline replay opened the **Output** tab. The step's code is what a viewer is usually there to read — especially on the Hub, where the replay is a showcase rather than a debugging session — so it now opens on **Code**, and the Code toggle comes first in the group.

Noticed while embedding a pipeline replay on the Hub (windmill-labs/windmillhub#165): every script node opened on output, and reaching the code took an extra click on each one.

## Why it falls back

`codes` is optional on `PipelineRecording` and only arrived with #10055 (2026-07-23). A recording made before that carries no source at all, so defaulting it to Code would open a pane whose entire content is "No code was captured for this step in the recording."

So the default is Code *when the step has recorded source*, and Output otherwise. The reset is keyed on the selected step, which means a tab the viewer picks by hand survives until they open a different step.

## Changes

- `PipelineRecordingReplay.svelte` — default `runnableTab` to `code`, add a per-selection effect that falls back to `output` when `recording.codes?.[path]` is absent, and swap the toggle order so Code is first

## Test plan

- [x] `svelte-check` — no errors in the modified file
- [ ] Step with recorded code opens on Code
- [ ] Step in a pre-`codes` recording opens on Output rather than an empty Code pane
- [ ] Choosing Output by hand sticks while that step stays selected
- [ ] Selecting a different step re-applies the default

The unchecked boxes need a pipeline recording loaded in the player; the one I had available (2026-07-11) predates `codes`, so it only exercises the fallback path. Worth a look from someone with a current recording to hand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open runnable steps on Code by default in pipeline replays, with a fallback to Output when no code is recorded. This shows source first on the Hub and avoids empty panes for older recordings.

- **Bug Fixes**
  - Default to Code when a step has recorded source; fall back to Output for pre-`codes` recordings.
  - Keep the user’s chosen tab while the same step is selected; reset when switching steps.
  - Show the Code toggle before Output.

- **Refactors**
  - Make the reset depend only on the selected step path by untracking the `codes` lookup, preventing resets when the recording object changes.

<sup>Written for commit 1db7b4737bda0bf340ce18de406392632b8fdf7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

