### PR TITLE
fix: app stepper no longer runs its validation on subgrid focus

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppStepper.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppStepper.svelte
@@ -72,11 +72,10 @@
 		lastAction: undefined as 'previous' | 'next' | undefined
 	})
 
-	async function handleTabSelection() {
-		if (runnableComponent && !debugMode) {
-			await runnableComponent?.runComponent()
-		}
-
+	// Bookkeeping only. The runnable is the step validation function and must run exclusively in
+	// runStep, where its error gates the navigation: running it here would also fire it on every
+	// pointerdown in a subgrid, and a second time right after runStep moved to the next step.
+	function handleTabSelection() {
 		selectedIndex = tabs?.indexOf(selected)
 		if (selectedIndex > maxReachedIndex) {
 			maxReachedIndex = selectedIndex


### PR DESCRIPTION
## Summary

The Stepper component's runnable is a **step validation function**: it runs when the user tries to change step, and its error blocks the navigation.

`handleTabSelection()` also ran it, and that function is wired to the subgrid's `onFocus` — which `SubGridEditor` fires on every `pointerdown`. So merely clicking the background of a step re-ran the validation script: side effects fired again and, when the step was invalid, an "Error running frontend script" toast popped up out of nowhere.

The same call also made every navigation run the validation **twice**: `runStep()` runs it, then assigns `selected`, and the `$effect.pre` on `selected` called `handleTabSelection()` which ran it once more.

`handleTabSelection()` is now bookkeeping only (selected index, `maxReachedIndex`, `currentStepIndex` output, focused grid). `runStep()` — reached from Next, Previous, and clicking a reachable step in the header — remains the only place the runnable runs, which is the behavior the [docs](https://www.windmill.dev/docs/apps/app_configuration_settings/stepper) describe.

## Changes

- `AppStepper.svelte`: drop the `runnableComponent.runComponent()` call from `handleTabSelection()`; the function no longer needs to be `async`.

## Screenshots

Repro app: a 2-step stepper whose validation throws unless a button on step 1 was pressed. The validation script increments a counter shown in step 1, so the counter is the number of times it ran.

**Before** — 3 clicks on the empty background of step 1: validation ran 3 times and raised error toasts.

![before-bgclicks](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/stepper-lowcode/1785112466-before-bgclicks.png)

**After** — the same 3 background clicks: validation never runs.

![after-bgclicks](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/stepper-lowcode/1785112469-after-bgclicks.png)

**After** — Next with a failing validation still runs it once and blocks, marking step 1 in error.

![after-1-blocked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/stepper-lowcode/1785112470-after-1-blocked.png)

## Test plan

Validation-run counts measured on the repro app (viewer mode, `/apps/get`):

| action | before | after |
| --- | --- | --- |
| 3 clicks on step background | 3 | 0 |
| Next (blocked by failing validation) | 2 | 1 |
| Next + Previous (passing validation) | 4 | 2 |

- [x] Clicking the background of a step no longer runs the validation, in the viewer and in the editor
- [x] Next with a failing validation runs it once, stays on the step, marks it red
- [x] Next with a passing validation moves to step 2; Previous moves back
- [x] Clicking a reachable step in the header still runs the validation (editor and viewer)
- [x] `npm run check:fast` — only the pre-existing `modern-screenshot` error in `RawAppEditor.svelte`, untouched here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Stepper validation from running on subgrid focus and from running twice during navigation. Validation now runs only in `runStep`, stopping unexpected error toasts and side effects.

- **Bug Fixes**
  - Removed `runnableComponent.runComponent()` from `handleTabSelection()` in `AppStepper.svelte`; it now handles only selection bookkeeping.
  - Stops validation triggering on subgrid `pointerdown` and eliminates duplicate runs on Next/Previous or header step clicks.

<sup>Written for commit 7d37778507a9e10607b875933ae578e6dc377642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

