### PR TITLE
fix: operators cannot see flows and apps on the homepage

### DIFF
--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -277,11 +277,12 @@ fn new_app(path: &str, summary: &str) -> serde_json::Value {
 
 /// A single list request; returns the ordered `type:path` identifiers.
 async fn list_once(port: u16, query: &str) -> Vec<String> {
+    list_once_as(port, query, "SECRET_TOKEN").await
+}
+
+async fn list_once_as(port: u16, query: &str, token: &str) -> Vec<String> {
     let url = format!("http://localhost:{port}/api/w/test-workspace/runnables/list?{query}");
-    let resp = authed(client().get(&url), "SECRET_TOKEN")
-        .send()
-        .await
-        .unwrap();
+    let resp = authed(client().get(&url), token).send().await.unwrap();
     assert_eq!(resp.status(), 200, "list should succeed for {query}");
     let body: serde_json::Value = resp.json().await.unwrap();
     body["items"]
@@ -388,6 +389,71 @@ async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::R
         scripts.len(),
         4,
         "kinds=script -> 4 scripts, got {scripts:?}"
+    );
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnables_operator_sees_flows_and_apps(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+
+    // A folder the operator can read, holding one runnable of each kind.
+    let r = authed(
+        client().post(format!("{base}/folders/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&json!({
+        "name": "opview",
+        "owners": ["u/test-user"],
+        "extra_perms": { "u/test-user-3": false },
+    }))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 200, "create folder: {}", r.text().await?);
+
+    let r = authed(
+        client().post(format!("{base}/scripts/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&new_script("f/opview/s", "Op script"))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 201, "create script: {}", r.text().await?);
+    let r = authed(
+        client().post(format!("{base}/flows/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&new_flow("f/opview/f", "Op flow"))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 201, "create flow: {}", r.text().await?);
+    let r = authed(client().post(format!("{base}/apps/create")), "SECRET_TOKEN")
+        .json(&new_app("f/opview/a", "Op app"))
+        .send()
+        .await?;
+    assert_eq!(r.status(), 201, "create app: {}", r.text().await?);
+
+    sqlx::query(
+        "UPDATE usr SET operator = true, role = 'Operator' WHERE workspace_id = 'test-workspace' AND username = 'test-user-3'",
+    )
+    .execute(&db)
+    .await?;
+
+    // Operators run flows and apps, so the homepage listing must return them, not
+    // scripts alone.
+    let mut items = list_once_as(port, "", "SECRET_TOKEN_3").await;
+    items.sort();
+    assert_eq!(
+        items,
+        vec![
+            "app:f/opview/a".to_string(),
+            "flow:f/opview/f".to_string(),
+            "script:f/opview/s".to_string(),
+        ],
+        "an operator must see every kind they have read access to"
     );
     Ok(())
 }

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -276,10 +276,6 @@ async fn list_runnables(
     if show_archived {
         kinds.retain(|k| *k != "app");
     }
-    // Operators may only see scripts.
-    if authed.is_operator {
-        kinds.retain(|k| *k == "script");
-    }
 
     let branches = branch_sqls();
 


### PR DESCRIPTION
## Summary

Fixes GIT-935. Since v1.771.0 an operator's homepage lists only scripts — flows and apps they have read access to disappeared.

The merged runnables endpoint added in #10297 (`GET /w/{workspace}/runnables/list`), which now backs the homepage, dropped the flow and app UNION branches whenever `authed.is_operator`. That restriction has no basis elsewhere in the codebase: `list_flows` / `list_apps` never filtered on the operator role, and running flows and apps is the operator role's main purpose. Visibility is already enforced in-SQL by RLS (plus the token scope filters), so removing the kind filter returns exactly the items the operator has read access to — nothing more.

The operator-specific `auto_kind <> 'lib'` predicate on the script branch is unrelated and stays: it mirrors `list_scripts`, hiding library scripts with no runnable entrypoint.

## Changes

- `backend/windmill-api/src/runnables.rs`: drop the `is_operator -> scripts only` kind filter.
- `backend/tests/runnables_list_pagination.rs`: regression test — an operator with read access to a folder holding one script, one flow and one app gets all three back. Verified it fails (`["script:f/opview/s"]`) with the filter restored.

## Test plan

- [x] `cargo test --test runnables_list_pagination` — 7/7 pass; the new test fails on the pre-fix code.
- [x] `cargo check --features quickjs`, `rustfmt --check` on both touched files.
- [x] Manual e2e on a local instance with a real operator user (`operator@windmill.dev`, `operator = true`, read access to `f/shared`) against a workspace holding one script, one flow and one app:
  - before: `GET /runnables/list` returned `['script:f/shared/myscript']`
  - after: returns the script, the app and the flow; the homepage renders all three and the Flows tab lists the flow

## Screenshots

Operator homepage, "All" tab — script, app and flow all listed:

![operator-home-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-935-bugoperators-not-able-to-view-flows/1785114076-operator-home-after.png)

Operator homepage, "Flows" tab:

![operator-flows-tab-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-935-bugoperators-not-able-to-view-flows/1785114078-operator-flows-tab-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GIT-935: Operators can again see flows and apps on the homepage, not just scripts. Removes an incorrect role filter so the list endpoint returns all items operators can read.

- **Bug Fixes**
  - Removed the operator-only scripts filter in `GET /w/{workspace}/runnables/list`.
  - Kept library scripts hidden for operators (no runnable entrypoint).
  - Added a regression test verifying an operator sees one script, one flow, and one app when granted read access.

<sup>Written for commit fe40898a46bb9454a9b1ca9b8bfccffdfab4cbda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

