### PR TITLE
fix(wac): checkpoint step errors so a caught exception does not hang replay

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1799,13 +1799,10 @@ pub async fn handle_bun_job(
             format!("argsObjToArr(args)")
         };
 
-        // Kept free of comments — this whole string is written out per job.
-        //
-        // `_takePendingSuspend` hands back a StepSuspend the workflow body caught
-        // and swallowed (it is an `Error`, so a plain `try/catch` eats it); honour
-        // it rather than reporting a `complete` whose step never reached the
-        // checkpoint. Called optionally: the client resolves from npm and may
-        // predate the method.
+        // Kept comment-free — this string is written out per job.
+        // `_takePendingSuspend` returns a StepSuspend the body caught and swallowed
+        // (it is an `Error`), so honour it instead of reporting a `complete` whose
+        // step never reached the checkpoint. Optional: npm clients may predate it.
         let wrapper_content = if is_wac_v2 {
             format!(
                 r#"

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1799,6 +1799,13 @@ pub async fn handle_bun_job(
             format!("argsObjToArr(args)")
         };
 
+        // Kept free of comments — this whole string is written out per job.
+        //
+        // `_takePendingSuspend` hands back a StepSuspend the workflow body caught
+        // and swallowed (it is an `Error`, so a plain `try/catch` eats it); honour
+        // it rather than reporting a `complete` whose step never reached the
+        // checkpoint. Called optionally: the client resolves from npm and may
+        // predate the method.
         let wrapper_content = if is_wac_v2 {
             format!(
                 r#"
@@ -1843,10 +1850,6 @@ async function run() {{
     try {{
         const result = await workflowFn(...argsArr);
         setWorkflowCtx(null);
-        // A StepSuspend is an Error, so a `try/catch` in the workflow body can
-        // swallow it. Honour it here rather than reporting a `complete` whose
-        // step never reached the checkpoint. Optional call: the client is
-        // resolved from npm and may predate this method.
         const swallowed = ctx._takePendingSuspend?.();
         if (swallowed) {{
             throw swallowed;

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1843,6 +1843,14 @@ async function run() {{
     try {{
         const result = await workflowFn(...argsArr);
         setWorkflowCtx(null);
+        // A StepSuspend is an Error, so a `try/catch` in the workflow body can
+        // swallow it. Honour it here rather than reporting a `complete` whose
+        // step never reached the checkpoint. Optional call: the client is
+        // resolved from npm and may predate this method.
+        const swallowed = ctx._takePendingSuspend?.();
+        if (swallowed) {{
+            throw swallowed;
+        }}
         // Flush any unawaited tasks (e.g. forgotten await on last statement)
         const trailing = ctx._flushPending();
         if (trailing.length > 0) {{

--- a/python-client/wmill/tests/test_workflow.py
+++ b/python-client/wmill/tests/test_workflow.py
@@ -3,7 +3,7 @@
 import asyncio
 import pytest
 
-from wmill.client import WorkflowCtx, _StepSuspend, TaskError, workflow, task, step, sleep, parallel, wait_for_approval, _run_workflow
+from wmill.client import WorkflowCtx, _StepSuspend, TaskError, workflow, task, step, sleep, parallel, wait_for_approval, _run_workflow, _run_workflow_async
 
 
 @task
@@ -912,6 +912,105 @@ class TestErrorPropagation:
         )
         assert r["type"] == "complete"
         assert "step failed" in r["result"]["caught"]
+
+
+class TestRaisingInlineStepIsCheckpointed:
+    """A ``step()`` whose body raises must still land in ``completed_steps``.
+
+    Otherwise a workflow that catches the exception and later dispatches a task
+    replays with ``_executing_key`` set, reaches the unrecorded key, and parks
+    on the never-resolving future forever.
+    """
+
+    MARKER = {
+        "__wmill_error": True,
+        "message": "boom",
+        "step_key": "risky",
+        "result": {"error": "boom", "type": "ValueError"},
+    }
+
+    @staticmethod
+    def _boom():
+        raise ValueError("boom")
+
+    @classmethod
+    def _wf(cls):
+        @workflow
+        async def wf(x: int):
+            try:
+                await step("risky", cls._boom)
+            except Exception:
+                pass
+            return await double(x=x)
+
+        return wf
+
+    def test_first_run_emits_error_checkpoint(self):
+        r = _run_workflow(self._wf(), {}, {"x": 5})
+        assert r["type"] == "inline_checkpoint"
+        assert r["key"] == "risky"
+        assert r["result"] == self.MARKER
+
+    def test_fast_path_posts_error_and_raises_the_replay_exception(self, monkeypatch):
+        """The default path: the checkpoint is POSTed and the workflow body gets
+        the same ``TaskError`` a replay rebuilds from the marker — raising the
+        original ``ValueError`` here would make ``except ValueError:`` catch on
+        this run and miss on the next one."""
+        for var, val in (
+            ("WM_JOB_ID", "job-1"),
+            ("WM_WORKSPACE", "admins"),
+            ("BASE_INTERNAL_URL", "http://localhost:8000"),
+            ("WM_TOKEN", "tok"),
+        ):
+            monkeypatch.setenv(var, val)
+
+        posted = []
+
+        class _StubResponse:
+            def raise_for_status(self):
+                pass
+
+        class _StubClient:
+            async def post(self, url, json=None):
+                posted.append(json)
+                return _StubResponse()
+
+            async def aclose(self):
+                pass
+
+        async def run():
+            ctx = WorkflowCtx({})
+            ctx._inline_http_client = _StubClient()
+            with pytest.raises(TaskError, match="boom") as live:
+                await ctx._run_inline_step("risky", self._boom)
+            # ...and the replay of that very checkpoint raises the same thing.
+            replayed = WorkflowCtx({"completed_steps": {"risky": self.MARKER}})
+            with pytest.raises(TaskError, match="boom") as replay:
+                await replayed._run_inline_step("risky", self._boom)
+            assert type(live.value) is type(replay.value)
+            assert live.value.args == replay.value.args
+            assert live.value.result == replay.value.result == self.MARKER["result"]
+            assert isinstance(live.value.__cause__, ValueError)
+
+        asyncio.run(run())
+        assert len(posted) == 1
+        assert posted[0]["key"] == "risky"
+        assert posted[0]["result"] == self.MARKER
+
+    def test_replay_reraises_and_does_not_hang(self):
+        checkpoint = {
+            "completed_steps": {"risky": self.MARKER},
+            "_executing_key": "double",
+        }
+
+        async def run():
+            return await asyncio.wait_for(
+                _run_workflow_async(self._wf(), checkpoint, {"x": 5}), timeout=5
+            )
+
+        r = asyncio.run(run())
+        assert r["type"] == "complete"
+        assert r["result"] == 10
 
 
 # =====================================================================

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2689,6 +2689,29 @@ class TaskError(Exception):
         self.result = result
 
 
+def _step_error_marker(key: str, exc: BaseException) -> dict:
+    """Serialize a failed ``step()`` body into the ``__wmill_error`` marker that
+    task failures also use, so it can be stored in ``completed_steps``."""
+    return {
+        "__wmill_error": True,
+        "message": str(exc),
+        "step_key": key,
+        "result": {"error": str(exc), "type": type(exc).__name__},
+    }
+
+
+def _step_error_from_marker(marker: dict, name: str) -> TaskError:
+    """Rebuild the exception a failed step raises. Both the run that produced the
+    failure and every later replay go through here, so a workflow's ``except``
+    clauses see the same type either way."""
+    return TaskError(
+        marker.get("message", f"Step '{name}' failed"),
+        step_key=marker.get("step_key", ""),
+        child_job_id=marker.get("child_job_id", ""),
+        result=marker.get("result"),
+    )
+
+
 _workflow_ctx: _contextvars.ContextVar["WorkflowCtx"] = _contextvars.ContextVar(
     "_workflow_ctx"
 )
@@ -2858,12 +2881,7 @@ class WorkflowCtx:
         if key in self._completed:
             val = self._completed[key]
             if isinstance(val, dict) and val.get("__wmill_error"):
-                raise TaskError(
-                    val.get("message", f"Step '{name}' failed"),
-                    step_key=val.get("step_key", ""),
-                    child_job_id=val.get("child_job_id", ""),
-                    result=val.get("result"),
-                )
+                raise _step_error_from_marker(val, name)
             return val
 
         if self._executing_key is not None:
@@ -2873,9 +2891,21 @@ class WorkflowCtx:
         started_at = _dt.now(_tz.utc).isoformat()
         print(f"WM_WAC_STEP: {_json_mod.dumps({'key': key, 'started_at': started_at})}")
         t0 = _time_mod.monotonic()
-        result = fn()
-        if _asyncio.iscoroutine(result):
-            result = await result
+        # A raised step still has to reach ``completed_steps``: if the workflow
+        # catches the exception and later suspends on a task, the replay reaches
+        # this key with ``_executing_key`` set, finds nothing recorded, and parks
+        # forever on the ``_asyncio.Future()`` above. Record the failure with the
+        # same ``__wmill_error`` marker task failures use, so the replay re-raises
+        # it as ``TaskError`` right here. ``_StepSuspend`` and ``CancelledError``
+        # are ``BaseException`` and so pass through untouched.
+        step_error: Optional[Exception] = None
+        try:
+            result = fn()
+            if _asyncio.iscoroutine(result):
+                result = await result
+        except Exception as _exc:
+            step_error = _exc
+            result = _step_error_marker(key, _exc)
         duration_ms = int((_time_mod.monotonic() - t0) * 1000)
 
         # Fast path: POST the delta to the new per-job API endpoint and return
@@ -2892,6 +2922,7 @@ class WorkflowCtx:
         _base = os.environ.get("BASE_INTERNAL_URL")
         _token = os.environ.get("WM_TOKEN")
         if _fast_path_enabled and _job_id and _workspace and _base and _token:
+            _fast_path_ok = False
             try:
                 if self._inline_lock is None:
                     self._inline_lock = _asyncio.Lock()
@@ -2917,7 +2948,7 @@ class WorkflowCtx:
                         },
                     )
                     _resp.raise_for_status()
-                return result
+                _fast_path_ok = True
             except Exception as _e:
                 logger.info(
                     "WAC v2 inline fast path failed for key %s, falling back to suspend: %s",
@@ -2925,6 +2956,16 @@ class WorkflowCtx:
                     _e,
                 )
                 # fall through to the legacy suspend path
+            if _fast_path_ok:
+                # The failure is checkpointed, so raise it into the still-running
+                # workflow body — as the very ``TaskError`` a replay would rebuild
+                # from the marker, never as the original exception. A replay can
+                # only reconstruct what the marker holds, so raising the original
+                # type here would make ``except ValueError:`` catch on this run
+                # and miss on the next one.
+                if step_error is not None:
+                    raise _step_error_from_marker(result, name) from step_error
+                return result
 
         raise _StepSuspend({
             "mode": "inline_checkpoint",

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2962,7 +2962,9 @@ class WorkflowCtx:
                 # from the marker, never as the original exception. A replay can
                 # only reconstruct what the marker holds, so raising the original
                 # type here would make ``except ValueError:`` catch on this run
-                # and miss on the next one.
+                # and miss on the next one. ``__cause__`` carries the original for
+                # tracebacks only — it is absent on replay, so branching on it
+                # reintroduces that same split.
                 if step_error is not None:
                     raise _step_error_from_marker(result, name) from step_error
                 return result

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2891,13 +2891,10 @@ class WorkflowCtx:
         started_at = _dt.now(_tz.utc).isoformat()
         print(f"WM_WAC_STEP: {_json_mod.dumps({'key': key, 'started_at': started_at})}")
         t0 = _time_mod.monotonic()
-        # A raised step still has to reach ``completed_steps``: if the workflow
-        # catches the exception and later suspends on a task, the replay reaches
-        # this key with ``_executing_key`` set, finds nothing recorded, and parks
-        # forever on the ``_asyncio.Future()`` above. Record the failure with the
-        # same ``__wmill_error`` marker task failures use, so the replay re-raises
-        # it as ``TaskError`` right here. ``_StepSuspend`` and ``CancelledError``
-        # are ``BaseException`` and so pass through untouched.
+        # A raised step still has to reach ``completed_steps``, or a replay with
+        # ``_executing_key`` set finds nothing recorded and parks forever on the
+        # ``_asyncio.Future()`` above. ``_StepSuspend`` and ``CancelledError`` are
+        # ``BaseException``, so they pass through untouched.
         step_error: Optional[Exception] = None
         try:
             result = fn()
@@ -2957,14 +2954,10 @@ class WorkflowCtx:
                 )
                 # fall through to the legacy suspend path
             if _fast_path_ok:
-                # The failure is checkpointed, so raise it into the still-running
-                # workflow body — as the very ``TaskError`` a replay would rebuild
-                # from the marker, never as the original exception. A replay can
-                # only reconstruct what the marker holds, so raising the original
-                # type here would make ``except ValueError:`` catch on this run
-                # and miss on the next one. ``__cause__`` carries the original for
-                # tracebacks only — it is absent on replay, so branching on it
-                # reintroduces that same split.
+                # Raise what a replay would rebuild from the marker, never the
+                # original: a replay cannot reconstruct the original type, so
+                # raising it here would make ``except ValueError:`` catch on this
+                # run and miss on the next. ``__cause__`` is for tracebacks only.
                 if step_error is not None:
                     raise _step_error_from_marker(result, name) from step_error
                 return result

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -1524,12 +1524,11 @@ export class StepSuspend extends Error {
  *  failures also use, so it can be stored in `completed_steps`. */
 function stepErrorMarker(key: string, e: unknown): Record<string, any> {
   const message = e instanceof Error ? e.message : String(e);
-  return {
-    __wmill_error: true,
-    message,
-    step_key: key,
-    result: { error: message, type: e instanceof Error ? e.name : typeof e },
-  };
+  // Constructor name, not `e.name`: a `class MyError extends Error {}` that
+  // never assigns `this.name` reports "Error", which would make the same
+  // failure read as `MyError` in the python client and `Error` here.
+  const type = e instanceof Error ? (e.constructor?.name ?? e.name) : typeof e;
+  return { __wmill_error: true, message, step_key: key, result: { error: message, type } };
 }
 
 /** Rebuild the error a failed step throws. Both the run that produced the
@@ -1586,6 +1585,13 @@ export class WorkflowCtx {
     [k: string]: any;
   }> = [];
   private _suspended = false;
+  /** A suspend raised out of a step whose body threw. `StepSuspend` is an
+   *  `Error`, so the workflow's own `try { await step(...) } catch` — the very
+   *  shape a failing step is written for — swallows it, and the run would go on
+   *  to report `complete` with the step missing from `completed_steps`. Parked
+   *  here so the runner can re-throw it after the body returns. Python needs no
+   *  equivalent: `_StepSuspend` derives from `BaseException`. */
+  private _pendingSuspend: StepSuspend | null = null;
   /** When set, the task matching this key executes its inner function directly */
   _executingKey: string | null;
   /** Serializes fast-path POSTs across concurrent step() calls within one
@@ -1627,6 +1633,7 @@ export class WorkflowCtx {
     dispatch_type: string = "inline",
     options?: TaskOptions,
   ): PromiseLike<any> {
+    this._rethrowSwallowedSuspend();
     const key = this._allocKey(name || script || "step");
 
     if (key in this.completed) {
@@ -1697,6 +1704,7 @@ export class WorkflowCtx {
     selfApproval?: boolean;
     key?: string;
   }): PromiseLike<{ value: any; approver: string; approved: boolean }> {
+    this._rethrowSwallowedSuspend();
     if (options?.key !== undefined) assertUsableStepKey(options.key, "waitForApproval key");
     const key = this._allocKey(options?.key || "approval");
 
@@ -1734,6 +1742,7 @@ export class WorkflowCtx {
   }
 
   _sleep(seconds: number): PromiseLike<void> {
+    this._rethrowSwallowedSuspend();
     const key = this._allocKey("sleep");
 
     if (key in this.completed) {
@@ -1754,6 +1763,7 @@ export class WorkflowCtx {
   }
 
   async _runInlineStep<T>(name: string, fn: () => T | Promise<T>): Promise<T> {
+    this._rethrowSwallowedSuspend();
     const key = this._allocKey(name || "step");
 
     if (key in this.completed) {
@@ -1861,7 +1871,8 @@ export class WorkflowCtx {
         // marker, never as the original. A replay can only reconstruct what the
         // marker holds, so throwing the original here would let
         // `catch (e) { if (e instanceof TypeError) }` match on this run and miss
-        // on the next one. `cause` keeps the original reachable for logging.
+        // on the next one. `cause` carries the original for logging only — it is
+        // absent on replay, so branching on it reintroduces that same split.
         if (errored) {
           throw Object.assign(stepErrorFromMarker(result, name), { cause: stepError });
         }
@@ -1869,7 +1880,26 @@ export class WorkflowCtx {
       }
     }
 
-    throw new StepSuspend({ mode: "inline_checkpoint", steps: [], key, result, started_at: startedAt, duration_ms: durationMs });
+    const suspend = new StepSuspend({ mode: "inline_checkpoint", steps: [], key, result, started_at: startedAt, duration_ms: durationMs });
+    if (errored) this._pendingSuspend = suspend;
+    throw suspend;
+  }
+
+  /** Re-throw a swallowed suspend at the next SDK call. It happened before
+   *  whatever the body is doing now, so it wins: the run is unwinding either
+   *  way and everything after it re-runs on the replay. Left set, so a body
+   *  that catches in a loop can't swallow it a second time. */
+  private _rethrowSwallowedSuspend(): void {
+    if (this._pendingSuspend) throw this._pendingSuspend;
+  }
+
+  /** Hand the runner a suspend the workflow body caught and swallowed, so it is
+   *  honoured instead of silently turning into a `complete`. Returns null when
+   *  the suspend propagated normally. */
+  _takePendingSuspend(): StepSuspend | null {
+    const s = this._pendingSuspend;
+    this._pendingSuspend = null;
+    return s;
   }
 }
 

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -1520,6 +1520,29 @@ export class StepSuspend extends Error {
   }
 }
 
+/** Serialize a failed `step()` body into the `__wmill_error` marker that task
+ *  failures also use, so it can be stored in `completed_steps`. */
+function stepErrorMarker(key: string, e: unknown): Record<string, any> {
+  const message = e instanceof Error ? e.message : String(e);
+  return {
+    __wmill_error: true,
+    message,
+    step_key: key,
+    result: { error: message, type: e instanceof Error ? e.name : typeof e },
+  };
+}
+
+/** Rebuild the error a failed step throws. Both the run that produced the
+ *  failure and every later replay go through here, so a workflow's catch block
+ *  sees the same shape either way. */
+function stepErrorFromMarker(marker: any, name: string): Error {
+  const err = new Error(marker?.message || `Step '${name}' failed`);
+  (err as any).result = marker?.result;
+  (err as any).step_key = marker?.step_key;
+  (err as any).child_job_id = marker?.child_job_id;
+  return err;
+}
+
 export interface TaskOptions {
   timeout?: number;
   tag?: string;
@@ -1736,11 +1759,7 @@ export class WorkflowCtx {
     if (key in this.completed) {
       const value = this.completed[key];
       if (value && typeof value === "object" && (value as any).__wmill_error) {
-        const err = new Error((value as any).message || `Step '${name}' failed`);
-        (err as any).result = (value as any).result;
-        (err as any).step_key = (value as any).step_key;
-        (err as any).child_job_id = (value as any).child_job_id;
-        throw err;
+        throw stepErrorFromMarker(value, name);
       }
       return value as T;
     }
@@ -1753,7 +1772,23 @@ export class WorkflowCtx {
     const startedAt = new Date().toISOString();
     console.log(`WM_WAC_STEP: ${JSON.stringify({ key, started_at: startedAt })}`);
     const t0 = Date.now();
-    const result = await fn();
+    // A thrown step still has to reach `completed_steps`: if the workflow
+    // catches the error and later suspends on a task, the replay reaches this
+    // key with `_executingKey` set, finds nothing recorded, and parks forever
+    // on the never-resolving promise above. Record the failure with the same
+    // `__wmill_error` marker task failures use, so the replay re-throws it
+    // right here. A nested StepSuspend is control flow, not a step failure.
+    let result: T;
+    let stepError: unknown;
+    let errored = false;
+    try {
+      result = await fn();
+    } catch (e) {
+      if ((e as any)?.name === "StepSuspend" || e instanceof StepSuspend) throw e;
+      errored = true;
+      stepError = e;
+      result = stepErrorMarker(key, e) as any;
+    }
     const durationMs = Date.now() - t0;
 
     // Fast path: POST the delta to the new per-job API endpoint and return the
@@ -1810,14 +1845,27 @@ export class WorkflowCtx {
       });
       // Swallow chain errors so a past failure does not poison future awaits.
       this._inlineChain = chainTail.catch(() => {});
+      let fastPathOk = false;
       try {
         await chainTail;
-        return result as T;
+        fastPathOk = true;
       } catch (e) {
         console.log(
           `WAC v2 inline fast path failed for key ${key}, falling back to suspend: ${e}`,
         );
         // fall through to the legacy suspend path below
+      }
+      if (fastPathOk) {
+        // The failure is checkpointed, so throw it into the still-running
+        // workflow body — as the very error a replay would rebuild from the
+        // marker, never as the original. A replay can only reconstruct what the
+        // marker holds, so throwing the original here would let
+        // `catch (e) { if (e instanceof TypeError) }` match on this run and miss
+        // on the next one. `cause` keeps the original reachable for logging.
+        if (errored) {
+          throw Object.assign(stepErrorFromMarker(result, name), { cause: stepError });
+        }
+        return result as T;
       }
     }
 

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -1585,12 +1585,12 @@ export class WorkflowCtx {
     [k: string]: any;
   }> = [];
   private _suspended = false;
-  /** A suspend raised out of a step whose body threw. `StepSuspend` is an
-   *  `Error`, so the workflow's own `try { await step(...) } catch` — the very
-   *  shape a failing step is written for — swallows it, and the run would go on
-   *  to report `complete` with the step missing from `completed_steps`. Parked
-   *  here so the runner can re-throw it after the body returns. Python needs no
-   *  equivalent: `_StepSuspend` derives from `BaseException`. */
+  /** The last suspend this ctx raised. `StepSuspend` is an `Error`, so any
+   *  `try { await step(...) } catch` or `try { await someTask() } catch` in the
+   *  workflow body swallows it, and the run would go on to report a `complete`
+   *  whose step never reached `completed_steps`. Parked here so it can be
+   *  re-thrown at the next SDK call and by the runner after the body returns.
+   *  Python needs no equivalent: `_StepSuspend` derives from `BaseException`. */
   private _pendingSuspend: StepSuspend | null = null;
   /** When set, the task matching this key executes its inner function directly */
   _executingKey: string | null;
@@ -1684,7 +1684,7 @@ export class WorkflowCtx {
         this.pending = [];
         const names = steps.map(s => s.name).join(", ");
         console.log(`\n--- WAC: ${names} ---`);
-        throw new StepSuspend({
+        this._raiseSuspend({
           mode: steps.length > 1 ? "parallel" : "sequential",
           steps,
         });
@@ -1731,7 +1731,7 @@ export class WorkflowCtx {
 
     // Throw immediately — approval is always a blocking step
     console.log(`\n--- WAC: approval(${key}) ---`);
-    throw new StepSuspend({
+    this._raiseSuspend({
       mode: "approval",
       key,
       timeout: options?.timeout ?? 1800,
@@ -1754,7 +1754,7 @@ export class WorkflowCtx {
     }
 
     console.log(`\n--- WAC: sleep(${key}, ${seconds}s) ---`);
-    throw new StepSuspend({
+    this._raiseSuspend({
       mode: "sleep",
       key,
       seconds: Math.max(1, Math.round(seconds)),
@@ -1880,8 +1880,14 @@ export class WorkflowCtx {
       }
     }
 
-    const suspend = new StepSuspend({ mode: "inline_checkpoint", steps: [], key, result, started_at: startedAt, duration_ms: durationMs });
-    if (errored) this._pendingSuspend = suspend;
+    this._raiseSuspend({ mode: "inline_checkpoint", steps: [], key, result, started_at: startedAt, duration_ms: durationMs });
+  }
+
+  /** Raise a suspend, parking it so a body that catches it cannot make it
+   *  vanish. Every suspend this ctx raises goes through here. */
+  private _raiseSuspend(dispatchInfo: Record<string, any>): never {
+    const suspend = new StepSuspend(dispatchInfo);
+    this._pendingSuspend = suspend;
     throw suspend;
   }
 

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -1536,6 +1536,10 @@ function stepErrorMarker(key: string, e: unknown): Record<string, any> {
  *  sees the same shape either way. */
 function stepErrorFromMarker(marker: any, name: string): Error {
   const err = new Error(marker?.message || `Step '${name}' failed`);
+  // Matches the python client, which raises TaskError here; the failed body's
+  // own type stays in `result.type`. Keeps a failed job's serialized error
+  // identical across the two languages.
+  err.name = "TaskError";
   (err as any).result = marker?.result;
   (err as any).step_key = marker?.step_key;
   (err as any).child_job_id = marker?.child_job_id;
@@ -1586,11 +1590,9 @@ export class WorkflowCtx {
   }> = [];
   private _suspended = false;
   /** The last suspend this ctx raised. `StepSuspend` is an `Error`, so any
-   *  `try { await step(...) } catch` or `try { await someTask() } catch` in the
-   *  workflow body swallows it, and the run would go on to report a `complete`
-   *  whose step never reached `completed_steps`. Parked here so it can be
-   *  re-thrown at the next SDK call and by the runner after the body returns.
-   *  Python needs no equivalent: `_StepSuspend` derives from `BaseException`. */
+   *  `catch` in the workflow body swallows it and the run would report a
+   *  `complete` whose step never reached `completed_steps`. Python is immune:
+   *  `_StepSuspend` derives from `BaseException`. */
   private _pendingSuspend: StepSuspend | null = null;
   /** When set, the task matching this key executes its inner function directly */
   _executingKey: string | null;
@@ -1640,6 +1642,7 @@ export class WorkflowCtx {
       const value = this.completed[key];
       if (value && typeof value === "object" && (value as any).__wmill_error) {
         const err = new Error((value as any).message || `Task '${name}' failed`);
+        err.name = "TaskError";
         (err as any).result = (value as any).result;
         (err as any).step_key = (value as any).step_key;
         (err as any).child_job_id = (value as any).child_job_id;
@@ -1782,12 +1785,10 @@ export class WorkflowCtx {
     const startedAt = new Date().toISOString();
     console.log(`WM_WAC_STEP: ${JSON.stringify({ key, started_at: startedAt })}`);
     const t0 = Date.now();
-    // A thrown step still has to reach `completed_steps`: if the workflow
-    // catches the error and later suspends on a task, the replay reaches this
-    // key with `_executingKey` set, finds nothing recorded, and parks forever
-    // on the never-resolving promise above. Record the failure with the same
-    // `__wmill_error` marker task failures use, so the replay re-throws it
-    // right here. A nested StepSuspend is control flow, not a step failure.
+    // A thrown step still has to reach `completed_steps`, or a replay with
+    // `_executingKey` set finds nothing recorded and parks forever on the
+    // never-resolving promise above. A nested StepSuspend is control flow,
+    // not a step failure.
     let result: T;
     let stepError: unknown;
     let errored = false;
@@ -1866,13 +1867,10 @@ export class WorkflowCtx {
         // fall through to the legacy suspend path below
       }
       if (fastPathOk) {
-        // The failure is checkpointed, so throw it into the still-running
-        // workflow body — as the very error a replay would rebuild from the
-        // marker, never as the original. A replay can only reconstruct what the
-        // marker holds, so throwing the original here would let
-        // `catch (e) { if (e instanceof TypeError) }` match on this run and miss
-        // on the next one. `cause` carries the original for logging only — it is
-        // absent on replay, so branching on it reintroduces that same split.
+        // Throw what a replay would rebuild from the marker, never the
+        // original: a replay cannot reconstruct the original type, so throwing
+        // it here would match `e instanceof TypeError` on this run and miss on
+        // the next. `cause` is for logging only — absent on replay.
         if (errored) {
           throw Object.assign(stepErrorFromMarker(result, name), { cause: stepError });
         }
@@ -1884,8 +1882,8 @@ export class WorkflowCtx {
   }
 
   /** Raise a suspend, parking it so a body that catches it cannot make it
-   *  vanish. Every suspend this ctx raises goes through here. */
-  private _raiseSuspend(dispatchInfo: Record<string, any>): never {
+   *  vanish. Every suspend raised for this ctx must go through here. */
+  _raiseSuspend(dispatchInfo: Record<string, any>): never {
     const suspend = new StepSuspend(dispatchInfo);
     this._pendingSuspend = suspend;
     throw suspend;
@@ -1981,7 +1979,7 @@ export function task<T extends (...args: any[]) => Promise<any>>(
       if ((stepResult as any)?._execute_directly) {
         return (async () => {
           const result = await fn(...args);
-          throw new StepSuspend({ mode: "step_complete", steps: [], result });
+          ctx._raiseSuspend({ mode: "step_complete", steps: [], result });
         })();
       }
       return stepResult;

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -1273,6 +1273,7 @@ describe("error propagation via __wmill_error marker", () => {
       await runWorkflow(wf, checkpoint, [5]);
       expect(true).toBe(false); // should not reach here
     } catch (e: any) {
+      expect(e.name).toBe("TaskError");
       expect(e.message).toContain("double");
       expect(e.result).toEqual({ message: "division by zero" });
       expect(e.child_job_id).toBe("abc-123");
@@ -1449,6 +1450,19 @@ describe("throwing inline step is checkpointed", () => {
     const result = await runWorkflow(wf, {}, []);
     expect(result.type).toBe("inline_checkpoint");
     expect(result.result).toBe(42);
+  });
+
+  test("a replayed step failure is named TaskError, like the python client", async () => {
+    const ctx = new WorkflowCtx({ completed_steps: { step_0: marker } });
+    let caught: any;
+    try {
+      await ctx._runInlineStep("risky", () => 1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(`${caught.name}: ${caught.message}`).toBe("TaskError: boom");
+    // the failing body's own type stays addressable here
+    expect(caught.result).toEqual({ error: "boom", type: "TypeError" });
   });
 
   test("a child job cannot swallow its own completion signal", async () => {

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -29,6 +29,12 @@ class WorkflowCtx {
   private _pendingSuspend: StepSuspend | null = null;
   _executingKey: string | null;
 
+  private _raiseSuspend(dispatchInfo: Record<string, any>): never {
+    const suspend = new StepSuspend(dispatchInfo);
+    this._pendingSuspend = suspend;
+    throw suspend;
+  }
+
   private _rethrowSwallowedSuspend(): void {
     if (this._pendingSuspend) throw this._pendingSuspend;
   }
@@ -91,7 +97,7 @@ class WorkflowCtx {
         this._suspended = true;
         const steps = [...this.pending];
         this.pending = [];
-        throw new StepSuspend({
+        this._raiseSuspend({
           mode: steps.length > 1 ? "parallel" : "sequential",
           steps,
         });
@@ -119,7 +125,7 @@ class WorkflowCtx {
     if (this._executingKey !== null) {
       return { then: () => new Promise(() => {}) };
     }
-    throw new StepSuspend({
+    this._raiseSuspend({
       mode: "sleep",
       key,
       seconds: Math.max(1, Math.round(seconds)),
@@ -166,14 +172,12 @@ class WorkflowCtx {
         },
       };
     }
-    const suspend = new StepSuspend({
+    this._raiseSuspend({
       mode: "inline_checkpoint",
       steps: [],
       key,
       result,
     });
-    if (errored) this._pendingSuspend = suspend;
-    throw suspend;
   }
 }
 
@@ -1429,6 +1433,34 @@ describe("throwing inline step is checkpointed", () => {
     expect(result.type).toBe("inline_checkpoint");
     expect(result.key).toBe("step_0");
     expect(result.result).toEqual(marker);
+  });
+
+  test("a swallowed suspend from a succeeding step still reaches the runner", async () => {
+    const wf = workflow(async () => {
+      try {
+        await step("fine", () => 42);
+      } catch {
+        // a body that catches broadly must not be able to erase the suspend
+      }
+      return "never reached on the first run";
+    });
+    const result = await runWorkflow(wf, {}, []);
+    expect(result.type).toBe("inline_checkpoint");
+    expect(result.result).toBe(42);
+  });
+
+  test("a swallowed suspend from a task dispatch still reaches the runner", async () => {
+    const wf = workflow(async (x: number) => {
+      try {
+        await double(x);
+      } catch {
+        // ditto for task steps
+      }
+      return "never reached on the first run";
+    });
+    const result = await runWorkflow(wf, {}, [5]);
+    expect(result.type).toBe("dispatch");
+    expect(result.steps[0].key).toBe("step_0");
   });
 
   test("replay rethrows the error and does not hang", async () => {

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -134,7 +134,21 @@ class WorkflowCtx {
       return new Promise(() => {});
     }
 
-    const result = await fn();
+    let result: any;
+    try {
+      result = await fn();
+    } catch (e: any) {
+      if (e?.name === "StepSuspend" || e instanceof StepSuspend) throw e;
+      result = {
+        __wmill_error: true,
+        message: e instanceof Error ? e.message : String(e),
+        step_key: key,
+        result: {
+          error: e instanceof Error ? e.message : String(e),
+          type: e instanceof Error ? e.name : typeof e,
+        },
+      };
+    }
     throw new StepSuspend({
       mode: "inline_checkpoint",
       steps: [],
@@ -1340,6 +1354,55 @@ describe("error propagation via __wmill_error marker", () => {
     const result = await runWorkflow(wf, checkpoint, [5]);
     expect(result.type).toBe("complete");
     expect(result.result).toEqual({ __wmill_error: false, data: "not an error" });
+  });
+});
+
+// A step() whose body throws must still land in completed_steps. Otherwise a
+// workflow that catches the error and later dispatches a task replays with
+// _executingKey set, reaches the unrecorded key, and parks on the
+// never-resolving promise forever.
+describe("throwing inline step is checkpointed", () => {
+  const marker = {
+    __wmill_error: true,
+    message: "boom",
+    step_key: "step_0",
+    result: { error: "boom", type: "TypeError" },
+  };
+
+  test("a throwing step suspends with an error checkpoint", async () => {
+    const ctx = new WorkflowCtx({});
+    let caught: any;
+    try {
+      await ctx._runInlineStep("risky", () => {
+        throw new TypeError("boom");
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(StepSuspend);
+    expect(caught.dispatchInfo.mode).toBe("inline_checkpoint");
+    expect(caught.dispatchInfo.key).toBe("step_0");
+    expect(caught.dispatchInfo.result).toEqual(marker);
+  });
+
+  test("replay rethrows the error and does not hang", async () => {
+    const wf = workflow(async (x: number) => {
+      try {
+        await step("risky", () => {
+          throw new TypeError("boom");
+        });
+      } catch {
+        // swallowed on purpose — the workflow keeps going
+      }
+      return await double(x);
+    });
+    const result = await runWorkflow(
+      wf,
+      { completed_steps: { step_0: marker }, _executing_key: "step_1" },
+      [5],
+    );
+    expect(result.type).toBe("complete");
+    expect(result.result).toBe(10);
   });
 });
 

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -26,7 +26,18 @@ class WorkflowCtx {
     key: string;
   }> = [];
   private _suspended = false;
+  private _pendingSuspend: StepSuspend | null = null;
   _executingKey: string | null;
+
+  private _rethrowSwallowedSuspend(): void {
+    if (this._pendingSuspend) throw this._pendingSuspend;
+  }
+
+  _takePendingSuspend(): StepSuspend | null {
+    const s = this._pendingSuspend;
+    this._pendingSuspend = null;
+    return s;
+  }
 
   constructor(checkpoint: Record<string, any> = {}) {
     this.completed = checkpoint?.completed_steps ?? {};
@@ -43,6 +54,7 @@ class WorkflowCtx {
     args: Record<string, any> = {},
     options?: Record<string, any>,
   ): PromiseLike<any> {
+    this._rethrowSwallowedSuspend();
     const key = this._allocKey();
 
     if (key in this.completed) {
@@ -99,6 +111,7 @@ class WorkflowCtx {
   }
 
   _sleep(seconds: number): PromiseLike<void> {
+    this._rethrowSwallowedSuspend();
     const key = this._allocKey();
     if (key in this.completed) {
       return { then: (resolve: any) => resolve(undefined) };
@@ -118,6 +131,7 @@ class WorkflowCtx {
     name: string,
     fn: () => T | Promise<T>
   ): Promise<T> {
+    this._rethrowSwallowedSuspend();
     const key = this._allocKey();
 
     if (key in this.completed) {
@@ -135,26 +149,31 @@ class WorkflowCtx {
     }
 
     let result: any;
+    let errored = false;
     try {
       result = await fn();
     } catch (e: any) {
       if (e?.name === "StepSuspend" || e instanceof StepSuspend) throw e;
+      errored = true;
+      const message = e instanceof Error ? e.message : String(e);
       result = {
         __wmill_error: true,
-        message: e instanceof Error ? e.message : String(e),
+        message,
         step_key: key,
         result: {
-          error: e instanceof Error ? e.message : String(e),
-          type: e instanceof Error ? e.name : typeof e,
+          error: message,
+          type: e instanceof Error ? (e.constructor?.name ?? e.name) : typeof e,
         },
       };
     }
-    throw new StepSuspend({
+    const suspend = new StepSuspend({
       mode: "inline_checkpoint",
       steps: [],
       key,
       result,
     });
+    if (errored) this._pendingSuspend = suspend;
+    throw suspend;
   }
 }
 
@@ -277,6 +296,9 @@ async function runWorkflow(
   _workflowCtx = ctx;
   try {
     const result = await fn(...args);
+    // Mirrors bun_executor.rs: honour a suspend the body caught and swallowed.
+    const swallowed = ctx._takePendingSuspend?.();
+    if (swallowed) throw swallowed;
     // Flush unawaited tasks
     const pending = ctx._flushPending();
     if (pending.length > 0) {
@@ -1369,6 +1391,21 @@ describe("throwing inline step is checkpointed", () => {
     result: { error: "boom", type: "TypeError" },
   };
 
+  // The workflow body catches — the shape a failing step is written for, and
+  // the one that makes StepSuspend (an Error) swallowable in TS.
+  const catchingWf = () =>
+    workflow(async (x: number) => {
+      let caught = null;
+      try {
+        await step("risky", () => {
+          throw new TypeError("boom");
+        });
+      } catch (e: any) {
+        caught = `${e.name}: ${e.message}`;
+      }
+      return { caught, doubled: await double(x) };
+    });
+
   test("a throwing step suspends with an error checkpoint", async () => {
     const ctx = new WorkflowCtx({});
     let caught: any;
@@ -1385,22 +1422,23 @@ describe("throwing inline step is checkpointed", () => {
     expect(caught.dispatchInfo.result).toEqual(marker);
   });
 
+  test("a swallowed suspend still reaches the runner", async () => {
+    // Without _pendingSuspend the catch eats the suspend and the run reports a
+    // dispatch (or a complete) with `risky` missing from completed_steps.
+    const result = await runWorkflow(catchingWf(), {}, [5]);
+    expect(result.type).toBe("inline_checkpoint");
+    expect(result.key).toBe("step_0");
+    expect(result.result).toEqual(marker);
+  });
+
   test("replay rethrows the error and does not hang", async () => {
-    const wf = workflow(async (x: number) => {
-      try {
-        await step("risky", () => {
-          throw new TypeError("boom");
-        });
-      } catch {
-        // swallowed on purpose — the workflow keeps going
-      }
-      return await double(x);
-    });
     const result = await runWorkflow(
-      wf,
+      catchingWf(),
       { completed_steps: { step_0: marker }, _executing_key: "step_1" },
       [5],
     );
+    // The child runs only the dispatched task, so its result is that task's —
+    // what matters is that it got there instead of parking on `risky`.
     expect(result.type).toBe("complete");
     expect(result.result).toBe(10);
   });

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -29,7 +29,7 @@ class WorkflowCtx {
   private _pendingSuspend: StepSuspend | null = null;
   _executingKey: string | null;
 
-  private _raiseSuspend(dispatchInfo: Record<string, any>): never {
+  _raiseSuspend(dispatchInfo: Record<string, any>): never {
     const suspend = new StepSuspend(dispatchInfo);
     this._pendingSuspend = suspend;
     throw suspend;
@@ -67,6 +67,7 @@ class WorkflowCtx {
       const value = this.completed[key];
       if (value && typeof value === "object" && (value as any).__wmill_error) {
         const err = new Error((value as any).message || `Task '${name}' failed`);
+        err.name = "TaskError";
         (err as any).result = (value as any).result;
         (err as any).step_key = (value as any).step_key;
         (err as any).child_job_id = (value as any).child_job_id;
@@ -144,6 +145,7 @@ class WorkflowCtx {
       const value = this.completed[key];
       if (value && typeof value === "object" && (value as any).__wmill_error) {
         const err = new Error((value as any).message || `Step '${name}' failed`);
+        err.name = "TaskError";
         (err as any).result = (value as any).result;
         throw err;
       }
@@ -230,7 +232,7 @@ function task<T extends (...args: any[]) => Promise<any>>(
       if ((stepResult as any)?._execute_directly) {
         return (async () => {
           const result = await fn(...args);
-          throw new StepSuspend({
+          ctx._raiseSuspend({
             mode: "step_complete",
             steps: [],
             result,
@@ -1447,6 +1449,22 @@ describe("throwing inline step is checkpointed", () => {
     const result = await runWorkflow(wf, {}, []);
     expect(result.type).toBe("inline_checkpoint");
     expect(result.result).toBe(42);
+  });
+
+  test("a child job cannot swallow its own completion signal", async () => {
+    // The catch below is reached only if step_complete escapes the parking
+    // mechanism; the child would then report the catch branch as the result.
+    const wf = workflow(async (x: number) => {
+      try {
+        await double(x);
+      } catch {
+        return "swallowed";
+      }
+      return "unreachable";
+    });
+    const result = await runWorkflow(wf, { _executing_key: "step_0" }, [5]);
+    expect(result.type).toBe("complete");
+    expect(result.result).toBe(10);
   });
 
   test("a swallowed suspend from a task dispatch still reaches the runner", async () => {


### PR DESCRIPTION
Fixes WIN-2249

## Summary

In the WAC v2 SDKs, a `step()` whose body raised unwound past **both** the fast-path checkpoint POST and the suspend raise, so the step's key was never written to `completed_steps`. A workflow that caught the exception and later dispatched a `task()` replayed with `_executing_key` set, reached the unrecorded key, and parked forever — the child job hung indefinitely.

The failed step is now recorded with the same `__wmill_error` marker task failures already use, and the failure surfaces as **the same exception on the live run and on every replay**.

### Determinism, not the original exception

The obvious fix — re-raise the original exception after checkpointing — makes the workflow behave differently on replay, which breaks the invariant WAC depends on. A replay can only rebuild the exception from the JSON marker, so it can only ever produce a `TaskError` / plain `Error`:

| | live run | replay |
|---|---|---|
| before | `ValueError("boom")` | `TaskError("boom")` |
| `except ValueError:` | caught, workflow continues | **not caught, child job crashes** |

Both paths now go through one shared constructor, so type, message, `result`, `step_key` and `child_job_id` match. The original is attached as `__cause__` / `cause` for tracebacks only — it is absent on replay, so branching on it reintroduces the same split (noted in both comments).

### Swallowed suspends (TypeScript only)

`StepSuspend extends Error`, so any `try { await step(...) } catch` or `try { await someTask() } catch` in the workflow body swallows the suspend signal — and a failing step is exactly the shape people wrap in `try/catch`. Left alone, the run would report a `complete` with the step missing from the checkpoint: a silently wrong result, worse than the hang being fixed.

Every suspend the ctx raises is now parked on it, re-thrown at the next SDK call, and honoured by the runner on the normal-return path. This covers task dispatches, `sleep`, `waitForApproval` and successful steps on the suspend path, not just the failing step this PR made reachable — protecting only the failing case would have been an arbitrary split. Python needs no equivalent: `_StepSuspend` derives from `BaseException`.

## Changes

- `python-client/wmill/wmill/client.py` — `_step_error_marker()` / `_step_error_from_marker()`; `fn()` wrapped so a raise is checkpointed; the fast path raises the rebuilt `TaskError` `from` the original. The cached-replay branch now uses the same helper.
- `typescript-client/client.ts` — same split (`stepErrorMarker` / `stepErrorFromMarker`); `_raiseSuspend()` / `_rethrowSwallowedSuspend()` / `_takePendingSuspend()`; marker `type` uses the constructor name so a `class MyError extends Error {}` that never sets `this.name` doesn't report `Error` where Python reports `MyError`.
- `backend/windmill-worker/src/bun_executor.rs` — the WAC wrapper re-throws a swallowed suspend before reporting `complete`. Optional call, since the client is resolved from npm and may predate the method.
- Tests in both clients.

## Test plan

Verified end-to-end against a local backend built with `--features python`, driving a real preview job through a real child-job replay, with the local client installed as a wheel via PEP 723 metadata.

- [x] **before/after e2e** — pre-fix wheel: parent suspends, child `019fa2d0-b7fe-…` stuck `QueuedJob running=True`, **hung for 200s**. Fixed wheel: completes in 3s with `{"caught": "TaskError: boom", "doubled": 10}`.
- [x] **live checkpoint** — `completed_steps.risky` holds the marker, `job_ids.double` a real child job replayed to `10`.
- [x] **uncaught step failure** — job fails cleanly as `TaskError` carrying `{"type": "ValueError", "error": "boom"}` and `step_key: "risky"`; no replay loop.
- [x] **suspend path** (`WM_WAC_INLINE_FAST_PATH=0`) — worker replay loop against the real python client returns the identical result to the fast path.
- [x] **TS swallowed suspends** — failing step, succeeding step, task dispatch and `sleep` all verified against the real `client.ts` (via the generated `src/`) with a faithful reproduction of the `bun_executor.rs` wrapper; plus subclass naming (`MyError`, not `Error`).
- [x] `pytest tests/test_workflow.py` — 95 passed (`TestTaskDecorator::test_preserves_function_name` fails on `main` too).
- [x] `bun test tests/` — 139 passed. `cargo check --features python` clean.

### Coverage caveat

`typescript-client/tests/workflow.test.ts` exercises a hand-maintained copy of the SDK, not `client.ts`, because `client.ts` imports build-time-generated `./services.gen` and `./core/OpenAPI`. Those tests also aren't run by CI (only `cli/test/` is). The copy is kept in sync here, and the real `client.ts` was verified directly as noted above; wiring it into CI is test-infrastructure work beyond this PR.