### PR TITLE
feat: show per-owner runnable counts in the homepage tree (WIN-2253)

### DIFF
--- a/backend/migrations/20260727093955_runnable_owner_prefix_indexes.down.sql
+++ b/backend/migrations/20260727093955_runnable_owner_prefix_indexes.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_script_owner_prefix;
+DROP INDEX IF EXISTS idx_flow_owner_prefix;
+DROP INDEX IF EXISTS idx_app_owner_prefix;
+DROP INDEX IF EXISTS app_extra_perms;

--- a/backend/migrations/20260727093955_runnable_owner_prefix_indexes.up.sql
+++ b/backend/migrations/20260727093955_runnable_owner_prefix_indexes.up.sql
@@ -1,0 +1,24 @@
+-- Indexes backing the homepage tree's per-owner runnable counts
+-- (/runnables/counts), which counts each `f/<folder>` / `u/<user>` prefix with a
+-- byte-ordered range `path ~>=~ owner || '/' AND path ~<~ owner || '0'`.
+-- text_pattern_ops is required: the default opclass sorts by the database
+-- collation, so a byte-prefix range cannot use it. `auto_kind` is an INCLUDE
+-- column so the library-script filter is answered from the index tuple and the
+-- count stays an index-only scan.
+-- Created CONCURRENTLY via the OVERRIDDEN_MIGRATIONS rewrite in windmill-api/src/db.rs.
+CREATE INDEX IF NOT EXISTS idx_script_owner_prefix
+    ON script (workspace_id, path text_pattern_ops)
+    INCLUDE (auto_kind)
+    WHERE archived = false;
+
+CREATE INDEX IF NOT EXISTS idx_flow_owner_prefix
+    ON flow (workspace_id, path text_pattern_ops)
+    WHERE archived = false;
+
+CREATE INDEX IF NOT EXISTS idx_app_owner_prefix
+    ON app (workspace_id, path text_pattern_ops);
+
+-- Same purpose as the existing script_extra_perms / flow_extra_perms GIN
+-- indexes: the counts endpoint finds items shared explicitly with the caller
+-- (or one of their groups) with a single `extra_perms ?| ARRAY[...]` scan.
+CREATE INDEX IF NOT EXISTS app_extra_perms ON app USING gin (extra_perms);

--- a/backend/tests/runnables_owner_counts.rs
+++ b/backend/tests/runnables_owner_counts.rs
@@ -1,0 +1,195 @@
+//! Regression test for `GET /w/{workspace}/runnables/counts`, which the homepage
+//! tree uses to label every folder / user node and to drop the empty ones.
+//!
+//! The endpoint runs off the non-RLS pool and re-derives visibility from `path`
+//! (admin / folder read set / own user space) plus one `extra_perms` pass, so it
+//! duplicates by hand what RLS otherwise enforces. That duplication is what can
+//! drift: a change to the RLS policies, or to how `authed.folders`/`groups` are
+//! populated, would silently make the counts over- or under-report. So the test
+//! pins them to the ground truth rather than to their own implementation — the
+//! counts must equal the per-owner grouping of `/runnables/list`, which is
+//! RLS-enforced, across every way an item can become visible.
+
+use sqlx::{Pool, Postgres};
+use std::collections::HashMap;
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+fn owner_of(path: &str) -> String {
+    path.split('/').take(2).collect::<Vec<_>>().join("/")
+}
+
+/// Per-owner counts derived from the RLS-enforced listing. Pipeline members are
+/// dropped to match what the tree renders (and what /counts promises): they are
+/// folded into their folder's single pipeline entry, never listed as rows.
+async fn counts_from_list(port: u16, token: &str) -> HashMap<String, i64> {
+    let base = format!("http://localhost:{port}/api/w/test-workspace/runnables/list");
+    let mut out: HashMap<String, i64> = HashMap::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut url = format!("{base}?per_page=100");
+        if let Some(c) = &cursor {
+            url.push_str(&format!("&cursor={c}"));
+        }
+        let resp = authed(client().get(&url), token).send().await.unwrap();
+        assert_eq!(resp.status(), 200, "list should succeed");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        for it in body["items"].as_array().unwrap() {
+            if it["auto_kind"].as_str() == Some("pipeline") {
+                continue;
+            }
+            *out.entry(owner_of(it["path"].as_str().unwrap()))
+                .or_insert(0) += 1;
+        }
+        match body["next_cursor"].as_str() {
+            Some(c) => cursor = Some(c.to_string()),
+            None => break,
+        }
+    }
+    out
+}
+
+async fn counts_endpoint(port: u16, token: &str) -> HashMap<String, i64> {
+    let url = format!("http://localhost:{port}/api/w/test-workspace/runnables/counts");
+    let resp = authed(client().get(&url), token).send().await.unwrap();
+    assert_eq!(resp.status(), 200, "counts should succeed");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    body["counts"]
+        .as_object()
+        .unwrap()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.as_i64().unwrap()))
+        .collect()
+}
+
+async fn insert_script(
+    db: &Pool<Postgres>,
+    hash: i64,
+    path: &str,
+    extra_perms: &str,
+    auto_kind: Option<&str>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO script (workspace_id, hash, path, summary, description, content, created_by, language, archived, extra_perms, auto_kind)
+         VALUES ('test-workspace', $1, $2, '', '', 'x', 'test-user', 'deno', false, $3::jsonb, $4)",
+    )
+    .bind(hash)
+    .bind(path)
+    .bind(extra_perms)
+    .bind(auto_kind)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_runnable_counts_match_rls_listing(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    // `team` is readable by test-user-2; `secret` is not. Everything visible to
+    // test-user-2 out of `secret` can only get there through an explicit share.
+    for (name, extra_perms) in [("team", r#"{"u/test-user-2": false}"#), ("secret", "{}")] {
+        sqlx::query(
+            "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms)
+             VALUES ('test-workspace', $1, $1, ARRAY[]::text[], $2::jsonb)",
+        )
+        .bind(name)
+        .bind(extra_perms)
+        .execute(&db)
+        .await?;
+    }
+    // `empty` has no runnables at all: it must be absent from the counts so the
+    // tree can drop it.
+    sqlx::query(
+        "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms)
+         VALUES ('test-workspace', 'empty', 'empty', ARRAY[]::text[], '{\"u/test-user-2\": false}'::jsonb)",
+    )
+    .execute(&db)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO usr_to_group (workspace_id, group_, usr) VALUES ('test-workspace', 'all', 'test-user-2')",
+    )
+    .execute(&db)
+    .await?;
+
+    // Visible through the folder grant.
+    insert_script(&db, 9000001, "f/team/s1", "{}", None).await?;
+    insert_script(&db, 9000002, "f/team/s2", "{}", None).await?;
+    // Visible through the caller's own user space.
+    insert_script(&db, 9000003, "u/test-user-2/mine", "{}", None).await?;
+    // Not visible at all: another user's space, and an unreadable folder.
+    insert_script(&db, 9000004, "u/test-user/theirs", "{}", None).await?;
+    insert_script(&db, 9000005, "f/secret/hidden", "{}", None).await?;
+    // Visible only through an individual share out of an unreadable folder.
+    insert_script(
+        &db,
+        9000006,
+        "f/secret/shared_to_user",
+        r#"{"u/test-user-2": false}"#,
+        None,
+    )
+    .await?;
+    // Visible only through a group the caller belongs to.
+    insert_script(
+        &db,
+        9000007,
+        "f/secret/shared_to_group",
+        r#"{"g/all": false}"#,
+        None,
+    )
+    .await?;
+    // A pipeline member in a readable folder: listed as the folder's pipeline
+    // entry, not as a runnable, so it must not inflate f/team's count.
+    insert_script(&db, 9000008, "f/team/step", "{}", Some("pipeline")).await?;
+
+    sqlx::query(
+        "INSERT INTO flow (workspace_id, path, summary, description, value, edited_by, schema, archived)
+         VALUES ('test-workspace', 'f/team/fl1', '', '', '{}'::jsonb, 'test-user', '{}'::json, false)",
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query(
+        "INSERT INTO app (workspace_id, path, summary, policy, versions, extra_perms)
+         VALUES ('test-workspace', 'f/team/app1', '', '{}'::jsonb, ARRAY[]::bigint[], '{}'::jsonb)",
+    )
+    .execute(&db)
+    .await?;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    // test-user-2 is a plain member: the folder grant, their own space, the direct
+    // share and the group share must each land, and nothing else.
+    let counts = counts_endpoint(port, "SECRET_TOKEN_2").await;
+    assert_eq!(
+        counts,
+        counts_from_list(port, "SECRET_TOKEN_2").await,
+        "non-admin counts must match the RLS-enforced listing"
+    );
+    assert_eq!(
+        counts,
+        HashMap::from([
+            ("f/team".to_string(), 4),
+            ("u/test-user-2".to_string(), 1),
+            ("f/secret".to_string(), 2),
+        ]),
+        "expected the folder grant (2 scripts + flow + app, pipeline member excluded), \
+         the own user space, and the two shares out of f/secret"
+    );
+
+    // An admin bypasses RLS entirely, so the counts must widen to the whole workspace.
+    assert_eq!(
+        counts_endpoint(port, "SECRET_TOKEN").await,
+        counts_from_list(port, "SECRET_TOKEN").await,
+        "admin counts must match the RLS-enforced listing"
+    );
+    Ok(())
+}

--- a/backend/tests/runnables_owner_counts.rs
+++ b/backend/tests/runnables_owner_counts.rs
@@ -56,8 +56,8 @@ async fn counts_from_list(port: u16, token: &str) -> HashMap<String, i64> {
     out
 }
 
-async fn counts_endpoint(port: u16, token: &str) -> HashMap<String, i64> {
-    let url = format!("http://localhost:{port}/api/w/test-workspace/runnables/counts");
+async fn counts_endpoint_q(port: u16, token: &str, query: &str) -> HashMap<String, i64> {
+    let url = format!("http://localhost:{port}/api/w/test-workspace/runnables/counts?{query}");
     let resp = authed(client().get(&url), token).send().await.unwrap();
     assert_eq!(resp.status(), 200, "counts should succeed");
     let body: serde_json::Value = resp.json().await.unwrap();
@@ -67,6 +67,10 @@ async fn counts_endpoint(port: u16, token: &str) -> HashMap<String, i64> {
         .iter()
         .map(|(k, v)| (k.clone(), v.as_i64().unwrap()))
         .collect()
+}
+
+async fn counts_endpoint(port: u16, token: &str) -> HashMap<String, i64> {
+    counts_endpoint_q(port, token, "").await
 }
 
 async fn insert_script(
@@ -185,11 +189,39 @@ async fn test_runnable_counts_match_rls_listing(db: Pool<Postgres>) -> anyhow::R
          the own user space, and the two shares out of f/secret"
     );
 
-    // An admin bypasses RLS entirely, so the counts must widen to the whole workspace.
+    // An admin bypasses RLS entirely (and takes the grouped whole-workspace path
+    // rather than the per-owner prefix scans), so the counts must widen accordingly.
     assert_eq!(
         counts_endpoint(port, "SECRET_TOKEN").await,
         counts_from_list(port, "SECRET_TOKEN").await,
         "admin counts must match the RLS-enforced listing"
+    );
+
+    // Every kind is its own count subquery, so a repeated entry must not be counted
+    // twice (nor multiply the scans).
+    assert_eq!(
+        counts_endpoint_q(port, "SECRET_TOKEN_2", "kinds=script,script").await,
+        counts_endpoint_q(port, "SECRET_TOKEN_2", "kinds=script").await,
+        "duplicate kinds must not double the counts"
+    );
+
+    // Operators see flows and apps like anyone else; only library scripts are hidden
+    // from them. (test-user-3 has no grants, so their own space is the whole story.)
+    sqlx::query("UPDATE usr SET operator = true WHERE workspace_id = 'test-workspace' AND username = 'test-user-3'")
+        .execute(&db)
+        .await?;
+    sqlx::query(
+        "INSERT INTO flow (workspace_id, path, summary, description, value, edited_by, schema, archived)
+         VALUES ('test-workspace', 'u/test-user-3/fl', '', '', '{}'::jsonb, 'test-user-3', '{}'::json, false)",
+    )
+    .execute(&db)
+    .await?;
+    insert_script(&db, 9000009, "u/test-user-3/lib", "{}", Some("lib")).await?;
+    assert_eq!(
+        counts_endpoint_q(port, "SECRET_TOKEN_3", "include_without_main=true").await,
+        HashMap::from([("u/test-user-3".to_string(), 1)]),
+        "an operator's flow must be counted, and library scripts stay hidden from them \
+         even when asked for"
     );
     Ok(())
 }

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10568,7 +10568,10 @@ paths:
             type: boolean
       responses:
         "200":
-          description: number of runnables per owner prefix, empty owners omitted
+          description: >-
+            number of runnables per owner prefix, empty owners omitted. Excludes
+            data-pipeline member scripts, which are listed as their folder's
+            single pipeline entry rather than as runnables.
           content:
             application/json:
               schema:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10548,6 +10548,39 @@ paths:
                       $ref: "#/components/schemas/RunnableItem"
                   next_cursor:
                     type: string
+  /w/{workspace}/runnables/counts:
+    get:
+      summary: count runnables per owner (folder or user space)
+      operationId: countRunnablesByOwner
+      tags:
+        - script
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: kinds
+          in: query
+          description: comma-separated subset of script,flow,app (default all)
+          schema:
+            type: string
+        - name: include_without_main
+          in: query
+          description: include library scripts (no runnable main)
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: number of runnables per owner prefix, empty owners omitted
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - counts
+                properties:
+                  counts:
+                    type: object
+                    description: owner prefix (f/<folder> or u/<user>) to count
+                    additionalProperties:
+                      type: integer
   /w/{workspace}/flows/list:
     get:
       summary: list all flows

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -96,6 +96,9 @@ lazy_static::lazy_static! {
                     (20260724094737, include_str!(
                         "../../migrations/20260724094737_runnables_sort_indexes.up.sql"
                     ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
+                    (20260727093955, include_str!(
+                        "../../migrations/20260727093955_runnable_owner_prefix_indexes.up.sql"
+                    ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
                     ].into_iter().collect();
 }
 

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -587,24 +587,32 @@ fn owner_prefix_range(alias: &str) -> String {
 /// predicates per row, which no index serves. The one case `path` cannot express
 /// is an item shared individually out of an otherwise unreadable owner; those
 /// owners are recovered by a second `extra_perms` pass over the GIN indexes.
+///
+/// The share pass's GIN indexes are on `extra_perms` alone, so on a multi-tenant
+/// instance its bitmap matches grantee keys (`g/all` exists in every workspace)
+/// across workspaces and `workspace_id` is only a recheck. Scoping the index
+/// would need `btree_gin`, a contrib extension self-hosted installs can't be
+/// assumed to have; the RLS policies already scan these indexes the same way.
 async fn count_runnables_by_owner(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
     Query(q): Query<CountRunnablesQuery>,
 ) -> JsonResult<RunnableCountsResponse> {
-    let mut kinds: Vec<&str> = match q.kinds.as_deref() {
+    let kinds: Vec<&str> = match q.kinds.as_deref() {
         None | Some("") => vec!["script", "flow", "app"],
-        Some(csv) => csv
-            .split(',')
-            .map(|s| s.trim())
-            .filter(|s| ["script", "flow", "app"].contains(s))
-            .collect(),
+        // Deduplicated: every kind becomes its own count subquery, so a repeated
+        // entry would both double that kind's count and multiply the scans.
+        Some(csv) => {
+            let mut ks: Vec<&str> = vec![];
+            for k in csv.split(',').map(|s| s.trim()) {
+                if ["script", "flow", "app"].contains(&k) && !ks.contains(&k) {
+                    ks.push(k);
+                }
+            }
+            ks
+        }
     };
-    // Operators may only see scripts, matching list_runnables.
-    if authed.is_operator {
-        kinds.retain(|k| *k == "script");
-    }
     if kinds.is_empty() {
         return Ok(Json(RunnableCountsResponse { counts: HashMap::new() }));
     }
@@ -654,30 +662,71 @@ async fn count_runnables_by_owner(
         _ => "app",
     };
 
-    // Pass 1 — prefix counts for every owner the caller reads wholesale.
-    // $1 = workspace, $2 = is_admin, $3 = readable folder names, $4 = username.
+    // `SELECT owner, count(*) ... GROUP BY owner` over a set of per-kind path
+    // selects — the shape both the admin sweep and the share pass end in.
+    let grouped_by_owner = |branches: Vec<String>| -> String {
+        format!(
+            "SELECT split_part(p.path, '/', 1) || '/' || split_part(p.path, '/', 2) AS owner, \
+                    count(*)::bigint AS count \
+             FROM ({}) p GROUP BY 1",
+            branches.join(" UNION ALL ")
+        )
+    };
+
+    let mut counts: HashMap<String, i64> = HashMap::new();
+
+    if authed.is_admin {
+        // Admins read the whole workspace, so one grouped scan per kind is the
+        // cheapest shape. Enumerating owners and prefix-scanning each instead
+        // would cost one scan per folder AND per member, growing with headcount
+        // rather than with content.
+        // $1 = workspace.
+        let mut binds: Vec<String> = vec![];
+        let branches: Vec<String> = kinds
+            .iter()
+            .map(|kind| {
+                let alias = "t";
+                let w = kind_filters(kind, alias, 1, &mut binds);
+                format!(
+                    "SELECT {alias}.path FROM {} {alias} WHERE {}",
+                    table_of(kind),
+                    w.join(" AND ")
+                )
+            })
+            .collect();
+        let sql = grouped_by_owner(branches);
+        let mut query = sqlx::query_as::<_, OwnerCount>(&sql).bind(&w_id);
+        for b in &binds {
+            query = query.bind(b);
+        }
+        for r in query.fetch_all(&db).await? {
+            counts.insert(r.owner, r.count);
+        }
+        counts.retain(|_, c| *c > 0);
+        return Ok(Json(RunnableCountsResponse { counts }));
+    }
+
+    // Pass 1 — prefix counts for the owners the caller reads wholesale: their
+    // folders and their own user space, a set bounded by the grants they hold.
+    // $1 = workspace, $2 = readable folder names, $3 = username.
     let mut binds: Vec<String> = vec![];
     let terms: Vec<String> = kinds
         .iter()
         .map(|kind| {
             let alias = "t";
-            let mut w = kind_filters(kind, alias, 4, &mut binds);
+            let mut w = kind_filters(kind, alias, 3, &mut binds);
             w.push(owner_prefix_range(alias));
             format!(
-                "(SELECT count(*) FROM {} {} WHERE {})",
+                "(SELECT count(*) FROM {} {alias} WHERE {})",
                 table_of(kind),
-                alias,
                 w.join(" AND ")
             )
         })
         .collect();
-    // The own-user-space arm is unconditional: a superadmin outside the
-    // workspace has no `usr` row but still gets their node counted.
     let sql = format!(
         "WITH owners(owner) AS ( \
-           SELECT 'f/' || name FROM folder WHERE workspace_id = $1 AND ($2 OR name = ANY($3)) \
-           UNION SELECT 'u/' || username FROM usr WHERE workspace_id = $1 AND ($2 OR username = $4) \
-           UNION SELECT 'u/' || $4 \
+           SELECT 'f/' || name FROM folder WHERE workspace_id = $1 AND name = ANY($2) \
+           UNION SELECT 'u/' || $3 \
          ) \
          SELECT o.owner AS owner, ({})::bigint AS count FROM owners o",
         terms.join(" + ")
@@ -685,58 +734,44 @@ async fn count_runnables_by_owner(
     let readable_folders: Vec<String> = authed.folders.iter().map(|f| f.0.clone()).collect();
     let mut query = sqlx::query_as::<_, OwnerCount>(&sql)
         .bind(&w_id)
-        .bind(authed.is_admin)
         .bind(&readable_folders)
         .bind(&authed.username);
     for b in &binds {
         query = query.bind(b);
     }
-    let mut counts: HashMap<String, i64> = query
-        .fetch_all(&db)
-        .await?
-        .into_iter()
-        .map(|r| (r.owner, r.count))
-        .collect();
+    for r in query.fetch_all(&db).await? {
+        counts.insert(r.owner, r.count);
+    }
 
     // Pass 2 — owners the caller only reaches through an individual share.
-    // Admins already have every owner from pass 1.
-    if !authed.is_admin {
-        let mut grantees = vec![format!("u/{}", authed.username)];
-        grantees.extend(authed.groups.iter().map(|g| format!("g/{}", g)));
-        // $1 = workspace, $2 = the caller's grantee keys.
-        let mut binds: Vec<String> = vec![];
-        let branches: Vec<String> = kinds
-            .iter()
-            .map(|kind| {
-                let alias = "t";
-                let mut w = kind_filters(kind, alias, 2, &mut binds);
-                w.push(format!("{alias}.extra_perms ?| $2"));
-                format!(
-                    "SELECT {}.path FROM {} {} WHERE {}",
-                    alias,
-                    table_of(kind),
-                    alias,
-                    w.join(" AND ")
-                )
-            })
-            .collect();
-        let sql = format!(
-            "SELECT split_part(s.path, '/', 1) || '/' || split_part(s.path, '/', 2) AS owner, \
-                    count(*)::bigint AS count \
-             FROM ({}) s GROUP BY 1",
-            branches.join(" UNION ALL ")
-        );
-        let mut query = sqlx::query_as::<_, OwnerCount>(&sql)
-            .bind(&w_id)
-            .bind(&grantees);
-        for b in &binds {
-            query = query.bind(b);
-        }
-        for r in query.fetch_all(&db).await? {
-            // Owners already in `counts` were counted whole in pass 1, shares
-            // included — only the ones missing there are added here.
-            counts.entry(r.owner).or_insert(r.count);
-        }
+    // $1 = workspace, $2 = the caller's grantee keys.
+    let mut grantees = vec![format!("u/{}", authed.username)];
+    grantees.extend(authed.groups.iter().map(|g| format!("g/{}", g)));
+    let mut binds: Vec<String> = vec![];
+    let branches: Vec<String> = kinds
+        .iter()
+        .map(|kind| {
+            let alias = "t";
+            let mut w = kind_filters(kind, alias, 2, &mut binds);
+            w.push(format!("{alias}.extra_perms ?| $2"));
+            format!(
+                "SELECT {alias}.path FROM {} {alias} WHERE {}",
+                table_of(kind),
+                w.join(" AND ")
+            )
+        })
+        .collect();
+    let sql = grouped_by_owner(branches);
+    let mut query = sqlx::query_as::<_, OwnerCount>(&sql)
+        .bind(&w_id)
+        .bind(&grantees);
+    for b in &binds {
+        query = query.bind(b);
+    }
+    for r in query.fetch_all(&db).await? {
+        // Owners already in `counts` were counted whole in pass 1, shares
+        // included — only the ones missing there are added here.
+        counts.entry(r.owner).or_insert(r.count);
     }
 
     counts.retain(|_, c| *c > 0);

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -555,7 +555,8 @@ struct CountRunnablesQuery {
 
 #[derive(Serialize)]
 struct RunnableCountsResponse {
-    /// Owner prefix (`f/<folder>` or `u/<user>`) -> number of visible runnables.
+    /// Owner prefix (`f/<folder>` or `u/<user>`) -> number of visible runnables,
+    /// counting what the tree lists as a row (see the pipeline note below).
     /// Owners with none are omitted so the tree can hide them.
     counts: HashMap<String, i64>,
 }
@@ -617,11 +618,18 @@ async fn count_runnables_by_owner(
             match kind {
                 "script" => {
                     w.push(format!("{alias}.archived = false"));
+                    // `pipeline` members are always excluded: the tree folds them into
+                    // their folder's single "Pipeline" entry and never lists them as
+                    // rows, so counting them would promise items that never appear.
+                    // `lib` follows the caller's include_without_main, as in the listing.
+                    let mut hidden = vec!["'pipeline'"];
                     if !with_libs {
-                        w.push(format!(
-                            "({alias}.auto_kind IS NULL OR {alias}.auto_kind <> 'lib')"
-                        ));
+                        hidden.push("'lib'");
                     }
+                    w.push(format!(
+                        "({alias}.auto_kind IS NULL OR {alias}.auto_kind NOT IN ({}))",
+                        hidden.join(", ")
+                    ));
                     if let Some(s) = scope_path_predicate(&authed, "scripts", alias, base, binds) {
                         w.push(s);
                     }

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -30,6 +30,7 @@ use axum::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use windmill_common::{
     db::UserDB,
     error::{Error, JsonResult},
@@ -38,7 +39,9 @@ use windmill_types::scripts::ScriptHash;
 use windmill_types::user_drafts::DraftUserRef;
 
 pub fn workspaced_service() -> Router {
-    Router::new().route("/list", get(list_runnables))
+    Router::new()
+        .route("/list", get(list_runnables))
+        .route("/counts", get(count_runnables_by_owner))
 }
 
 #[derive(Deserialize)]
@@ -167,6 +170,46 @@ fn escape_like(s: &str) -> String {
     s.replace('\\', "\\\\")
         .replace('%', "\\%")
         .replace('_', "\\_")
+}
+
+/// The `domain:action` scope grant of a fine-grained token (e.g.
+/// `scripts:read:f/foo/*`) as a predicate on `{alias}.path`, with its values
+/// appended to `binds` (placeholders numbered from `base + 1`). `None` means the
+/// token is unscoped for that domain and needs no predicate; an empty grant
+/// yields `false` so the branch matches nothing. RLS doesn't honor token scopes,
+/// so this has to be pushed into SQL.
+fn scope_path_predicate(
+    authed: &ApiAuthed,
+    domain: &str,
+    alias: &str,
+    base: usize,
+    binds: &mut Vec<String>,
+) -> Option<String> {
+    match build_scope_path_filter(authed, domain, "read") {
+        ScopePathFilter::AllowAll => None,
+        ScopePathFilter::Restricted { exact, prefix } => {
+            let mut terms: Vec<String> = vec![];
+            for e in exact {
+                binds.push(e);
+                terms.push(format!("{}.path = ${}", alias, base + binds.len()));
+            }
+            for pre in prefix {
+                binds.push(pre.clone());
+                let pe = format!("${}", base + binds.len());
+                binds.push(format!("{}/%", escape_like(&pre)));
+                let pl = format!("${}", base + binds.len());
+                terms.push(format!(
+                    "({}.path = {} OR {}.path LIKE {})",
+                    alias, pe, alias, pl
+                ));
+            }
+            Some(if terms.is_empty() {
+                "false".to_string()
+            } else {
+                format!("({})", terms.join(" OR "))
+            })
+        }
+    }
 }
 
 /// The three UNION-ALL branch SELECTs, each projecting the shared `RunnableItem`
@@ -329,55 +372,21 @@ async fn list_runnables(
         None => None,
     };
 
-    // Fine-grained scoped tokens (e.g. `scripts:read:f/foo/*`) must be confined to
-    // their granted paths. RLS alone doesn't honor token scopes, so push the
-    // per-domain path grant into SQL (empty grant -> the branch matches nothing).
-    // Unscoped sessions -> AllowAll -> no predicate.
-    let scope_where = |filter: ScopePathFilter, binds: &mut Vec<String>| -> Option<String> {
-        match filter {
-            ScopePathFilter::AllowAll => None,
-            ScopePathFilter::Restricted { exact, prefix } => {
-                let mut terms: Vec<String> = vec![];
-                for e in exact {
-                    binds.push(e);
-                    terms.push(format!("o.path = ${}", 3 + binds.len()));
-                }
-                for pre in prefix {
-                    binds.push(pre.clone());
-                    let pe = format!("${}", 3 + binds.len());
-                    binds.push(format!("{}/%", escape_like(&pre)));
-                    let pl = format!("${}", 3 + binds.len());
-                    terms.push(format!("(o.path = {} OR o.path LIKE {})", pe, pl));
-                }
-                Some(if terms.is_empty() {
-                    "false".to_string()
-                } else {
-                    format!("({})", terms.join(" OR "))
-                })
-            }
-        }
-    };
     // Only push scope binds for kinds whose branch is actually included: a scoped token
     // with e.g. `kinds=script` omits the flow/app branches, so binding their scope values
     // (which no SQL references) would make the parameter count mismatch and 500.
     let script_scope = if kinds.contains(&"script") {
-        scope_where(
-            build_scope_path_filter(&authed, "scripts", "read"),
-            &mut binds,
-        )
+        scope_path_predicate(&authed, "scripts", "o", 3, &mut binds)
     } else {
         None
     };
     let flow_scope = if kinds.contains(&"flow") {
-        scope_where(
-            build_scope_path_filter(&authed, "flows", "read"),
-            &mut binds,
-        )
+        scope_path_predicate(&authed, "flows", "o", 3, &mut binds)
     } else {
         None
     };
     let app_scope = if kinds.contains(&"app") {
-        scope_where(build_scope_path_filter(&authed, "apps", "read"), &mut binds)
+        scope_path_predicate(&authed, "apps", "o", 3, &mut binds)
     } else {
         None
     };
@@ -534,4 +543,194 @@ async fn list_runnables(
     tx.commit().await?;
 
     Ok(Json(ListRunnablesResponse { items, next_cursor }))
+}
+
+#[derive(Deserialize)]
+struct CountRunnablesQuery {
+    /// Comma-separated subset of `script,flow,app`; omitted means all.
+    kinds: Option<String>,
+    /// Include library scripts (no runnable main). Ignored for flows/apps.
+    include_without_main: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct RunnableCountsResponse {
+    /// Owner prefix (`f/<folder>` or `u/<user>`) -> number of visible runnables.
+    /// Owners with none are omitted so the tree can hide them.
+    counts: HashMap<String, i64>,
+}
+
+#[derive(sqlx::FromRow)]
+struct OwnerCount {
+    owner: String,
+    count: i64,
+}
+
+/// A byte-ordered range covering exactly the paths under `o.owner`: any
+/// `owner/<rest>` is >= `owner || '/'` and, since '/' (0x2F) is immediately
+/// followed by '0' (0x30), < `owner || '0'`. `~>=~` / `~<~` are the
+/// text_pattern_ops operators, which is what lets `idx_<kind>_owner_prefix`
+/// answer the count with an index-only scan — the default opclass sorts by the
+/// database collation and cannot serve a byte-prefix range.
+fn owner_prefix_range(alias: &str) -> String {
+    format!("{alias}.path ~>=~ (o.owner || '/') AND {alias}.path ~<~ (o.owner || '0')")
+}
+
+/// Per-owner runnable counts for the homepage tree, so every folder / user node
+/// can show its size and the empty ones can be dropped without loading them.
+///
+/// Runs off the non-RLS pool and re-derives visibility from `path` alone: an
+/// owner is readable whole or not at all (admin, folder in the caller's read
+/// set, or the caller's own user space). That is what makes the count an
+/// index-only prefix scan — RLS instead applies `split_part`/`current_setting`
+/// predicates per row, which no index serves. The one case `path` cannot express
+/// is an item shared individually out of an otherwise unreadable owner; those
+/// owners are recovered by a second `extra_perms` pass over the GIN indexes.
+async fn count_runnables_by_owner(
+    authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Query(q): Query<CountRunnablesQuery>,
+) -> JsonResult<RunnableCountsResponse> {
+    let mut kinds: Vec<&str> = match q.kinds.as_deref() {
+        None | Some("") => vec!["script", "flow", "app"],
+        Some(csv) => csv
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| ["script", "flow", "app"].contains(s))
+            .collect(),
+    };
+    // Operators may only see scripts, matching list_runnables.
+    if authed.is_operator {
+        kinds.retain(|k| *k == "script");
+    }
+    if kinds.is_empty() {
+        return Ok(Json(RunnableCountsResponse { counts: HashMap::new() }));
+    }
+    let with_libs = q.include_without_main.unwrap_or(false) && !authed.is_operator;
+
+    // Per-kind predicates shared by both passes. `alias` is the branch's table
+    // alias; `binds` collects the scope values, numbered from `base + 1`.
+    let kind_filters =
+        |kind: &str, alias: &str, base: usize, binds: &mut Vec<String>| -> Vec<String> {
+            let mut w = vec![format!("{alias}.workspace_id = $1")];
+            match kind {
+                "script" => {
+                    w.push(format!("{alias}.archived = false"));
+                    if !with_libs {
+                        w.push(format!(
+                            "({alias}.auto_kind IS NULL OR {alias}.auto_kind <> 'lib')"
+                        ));
+                    }
+                    if let Some(s) = scope_path_predicate(&authed, "scripts", alias, base, binds) {
+                        w.push(s);
+                    }
+                }
+                "flow" => {
+                    w.push(format!("{alias}.archived = false"));
+                    if let Some(s) = scope_path_predicate(&authed, "flows", alias, base, binds) {
+                        w.push(s);
+                    }
+                }
+                _ => {
+                    if let Some(s) = scope_path_predicate(&authed, "apps", alias, base, binds) {
+                        w.push(s);
+                    }
+                }
+            }
+            w
+        };
+    let table_of = |kind: &str| match kind {
+        "script" => "script",
+        "flow" => "flow",
+        _ => "app",
+    };
+
+    // Pass 1 — prefix counts for every owner the caller reads wholesale.
+    // $1 = workspace, $2 = is_admin, $3 = readable folder names, $4 = username.
+    let mut binds: Vec<String> = vec![];
+    let terms: Vec<String> = kinds
+        .iter()
+        .map(|kind| {
+            let alias = "t";
+            let mut w = kind_filters(kind, alias, 4, &mut binds);
+            w.push(owner_prefix_range(alias));
+            format!(
+                "(SELECT count(*) FROM {} {} WHERE {})",
+                table_of(kind),
+                alias,
+                w.join(" AND ")
+            )
+        })
+        .collect();
+    // The own-user-space arm is unconditional: a superadmin outside the
+    // workspace has no `usr` row but still gets their node counted.
+    let sql = format!(
+        "WITH owners(owner) AS ( \
+           SELECT 'f/' || name FROM folder WHERE workspace_id = $1 AND ($2 OR name = ANY($3)) \
+           UNION SELECT 'u/' || username FROM usr WHERE workspace_id = $1 AND ($2 OR username = $4) \
+           UNION SELECT 'u/' || $4 \
+         ) \
+         SELECT o.owner AS owner, ({})::bigint AS count FROM owners o",
+        terms.join(" + ")
+    );
+    let readable_folders: Vec<String> = authed.folders.iter().map(|f| f.0.clone()).collect();
+    let mut query = sqlx::query_as::<_, OwnerCount>(&sql)
+        .bind(&w_id)
+        .bind(authed.is_admin)
+        .bind(&readable_folders)
+        .bind(&authed.username);
+    for b in &binds {
+        query = query.bind(b);
+    }
+    let mut counts: HashMap<String, i64> = query
+        .fetch_all(&db)
+        .await?
+        .into_iter()
+        .map(|r| (r.owner, r.count))
+        .collect();
+
+    // Pass 2 — owners the caller only reaches through an individual share.
+    // Admins already have every owner from pass 1.
+    if !authed.is_admin {
+        let mut grantees = vec![format!("u/{}", authed.username)];
+        grantees.extend(authed.groups.iter().map(|g| format!("g/{}", g)));
+        // $1 = workspace, $2 = the caller's grantee keys.
+        let mut binds: Vec<String> = vec![];
+        let branches: Vec<String> = kinds
+            .iter()
+            .map(|kind| {
+                let alias = "t";
+                let mut w = kind_filters(kind, alias, 2, &mut binds);
+                w.push(format!("{alias}.extra_perms ?| $2"));
+                format!(
+                    "SELECT {}.path FROM {} {} WHERE {}",
+                    alias,
+                    table_of(kind),
+                    alias,
+                    w.join(" AND ")
+                )
+            })
+            .collect();
+        let sql = format!(
+            "SELECT split_part(s.path, '/', 1) || '/' || split_part(s.path, '/', 2) AS owner, \
+                    count(*)::bigint AS count \
+             FROM ({}) s GROUP BY 1",
+            branches.join(" UNION ALL ")
+        );
+        let mut query = sqlx::query_as::<_, OwnerCount>(&sql)
+            .bind(&w_id)
+            .bind(&grantees);
+        for b in &binds {
+            query = query.bind(b);
+        }
+        for r in query.fetch_all(&db).await? {
+            // Owners already in `counts` were counted whole in pass 1, shares
+            // included — only the ones missing there are added here.
+            counts.entry(r.owner).or_insert(r.count);
+        }
+    }
+
+    counts.retain(|_, c| *c > 0);
+    Ok(Json(RunnableCountsResponse { counts }))
 }

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -733,6 +733,14 @@
 		}
 	)
 	let ownerCounts = $derived(ownerCountsRes.current)
+	// The counts decide which owners the tree renders, so drawing it before they land
+	// would show every workspace folder and then prune it away. Hold the skeleton
+	// until the first response instead — it is fetched in parallel with the listing,
+	// so it costs no extra wait in practice. Only the first load gates: `current`
+	// survives a refetch, so an in-place scope change refreshes without flashing.
+	let treeCountsPending = $derived(
+		treeLazyMode && ownerCountsRes.current == undefined && ownerCountsRes.loading
+	)
 
 	// Owners the counts found the user has something in, split by kind. They cover
 	// what the folder/username lists miss: an item shared individually out of a
@@ -1480,7 +1488,7 @@
 		{/if}
 	</div>
 	<div>
-		{#if filteredItems == undefined}
+		{#if filteredItems == undefined || treeCountsPending}
 			<div class="mt-4"></div>
 			<Skeleton layout={[[2], 1]} />
 			{#each new Array(6) as _}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -479,6 +479,14 @@
 		for (const o of toReload) loadOwnerItems(o, false, true)
 	}
 
+	// For row mutations (create/delete/move/archive), which also change how many
+	// runnables an owner holds. A scope change (sort/archive/kind/…) doesn't go
+	// through here: the counts resource keys on those itself.
+	async function reloadItemsAndCounts(): Promise<void> {
+		void ownerCountsRes.refetch()
+		await reloadItems()
+	}
+
 	function filterItemsPathsBaseOnUserFilters(
 		item: TableScript | TableFlow | TableApp | TableRawApp,
 		filterUserFolders: boolean,
@@ -694,7 +702,49 @@
 	let treeLazyMode = $derived(
 		treeView && !searching && ownerFilter == undefined && labelFilter == undefined
 	)
-	let treeInjectFolders = $derived(treeLazyMode ? (folderNamesRes.current ?? []) : [])
+	// How many runnables each owner (`f/<folder>` / `u/<user>`) holds for this user,
+	// in one request. It labels every node up front — a lazy owner's own count is
+	// unknown until it's expanded — and lets the tree drop the owners holding
+	// nothing instead of listing every workspace folder. Owners with none are
+	// omitted from the response, so an absent key means empty. Skipped outside lazy
+	// mode (the other modes group already-loaded rows) and in the archived view,
+	// which the endpoint doesn't count.
+	let ownerCountsRes = resource(
+		[
+			() => $workspaceStore,
+			() => treeLazyMode,
+			() => archived,
+			() => itemKind,
+			() => includeWithoutMain
+		],
+		async ([ws, lazyMode, showArchived, kind, withoutMain]) => {
+			if (!ws || !lazyMode || showArchived) return undefined
+			try {
+				const res = await ScriptService.countRunnablesByOwner({
+					workspace: ws,
+					kinds: kind !== 'all' ? kind : undefined,
+					includeWithoutMain: withoutMain ? true : undefined
+				})
+				return res.counts
+			} catch {
+				// Best-effort: without counts the tree shows every owner, as before.
+				return undefined
+			}
+		}
+	)
+	let ownerCounts = $derived(ownerCountsRes.current)
+
+	// Owners the counts found the user has something in, split by kind. They cover
+	// what the folder/username lists miss: an item shared individually out of a
+	// folder or user space the user is otherwise not a member of.
+	function countOwners(kind: 'f' | 'u'): string[] {
+		return Object.keys(ownerCounts ?? {})
+			.filter((k) => k.startsWith(`${kind}/`))
+			.map((k) => k.slice(2))
+	}
+	let treeInjectFolders = $derived(
+		treeLazyMode ? [...new Set([...(folderNamesRes.current ?? []), ...countOwners('f')])] : []
+	)
 	let treeInjectUsers = $derived.by(() => {
 		// "Only f/*" hides every user namespace; "u/<you> and f/*" keeps just your own.
 		if (!treeLazyMode) return []
@@ -705,7 +755,10 @@
 		// and it must not vanish under a name sort whose first page is all folders.
 		if ($userStore?.username) s.add($userStore.username)
 		// Other users only when no user-folder restriction is active.
-		if (!filterUserFolders) for (const u of usernamesRes.current ?? []) s.add(u)
+		if (!filterUserFolders) {
+			for (const u of usernamesRes.current ?? []) s.add(u)
+			for (const u of countOwners('u')) s.add(u)
+		}
 		return [...s]
 	})
 	// The bottom "load more" only pages the *global* stream, which in lazy mode holds
@@ -1465,15 +1518,16 @@
 					pipelineFolders={visiblePipelineFolders}
 					allFolders={treeInjectFolders}
 					allUsers={treeInjectUsers}
+					ownerCounts={treeLazyMode ? ownerCounts : undefined}
 					ownerLoad={treeLazyMode ? ownerLoad : undefined}
 					onExpandOwner={treeLazyMode ? loadOwnerItems : undefined}
 					onCollapseOwner={treeLazyMode ? collapseOwner : undefined}
 					isSearching={filter !== ''}
-					on:scriptChanged={reloadItems}
-					on:flowChanged={reloadItems}
-					on:appChanged={reloadItems}
-					on:rawAppChanged={reloadItems}
-					on:reload={reloadItems}
+					on:scriptChanged={reloadItemsAndCounts}
+					on:flowChanged={reloadItemsAndCounts}
+					on:appChanged={reloadItemsAndCounts}
+					on:rawAppChanged={reloadItemsAndCounts}
+					on:reload={reloadItemsAndCounts}
 					{showCode}
 				/>
 			{/key}
@@ -1493,11 +1547,11 @@
 				{#each displayedItems as item, i (item.type + '/' + item.path + (item.hash ? '/' + item.hash : ''))}
 					<Item
 						{item}
-						on:scriptChanged={reloadItems}
-						on:flowChanged={reloadItems}
-						on:appChanged={reloadItems}
-						on:rawAppChanged={reloadItems}
-						on:reload={reloadItems}
+						on:scriptChanged={reloadItemsAndCounts}
+						on:flowChanged={reloadItemsAndCounts}
+						on:appChanged={reloadItemsAndCounts}
+						on:rawAppChanged={reloadItemsAndCounts}
+						on:reload={reloadItemsAndCounts}
 						{showCode}
 						showEditButton={showEditButtons}
 						keyboardSelected={selectedIndex === i}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -460,6 +460,10 @@
 	function collapseOwner(owner: string): void {
 		openOwners.delete(owner)
 	}
+	// The `f/<folder>` / `u/<user>` prefix a path belongs to.
+	function ownerOf(path: string): string {
+		return path.split('/').slice(0, 2).join('/')
+	}
 	// Reload the merged list once and re-fetch the owners that are currently expanded so
 	// they don't go blank. Used both for row mutations (create/edit/archive/move/share)
 	// and for in-place scope changes (sort/archive/library/kind): those keep the tree in
@@ -472,6 +476,16 @@
 		// late responses can't overwrite the fresh ones.
 		treeGen++
 		const toReload = treeLazyMode ? [...openOwners] : []
+		// Only the open owners are re-fetched below; a collapsed one keeps its rows as a
+		// cache, which this reload invalidates. Left in place they would outlive the scope
+		// they were loaded for: the owner stays grouped (so it keeps a node the new counts
+		// say is empty) and, since it is still marked loaded, expanding it again shows the
+		// previous scope's items instead of re-fetching. Drop them and let expand reload.
+		if (treeLazyMode) {
+			const open = new Set(toReload)
+			treeOwnerItems = treeOwnerItems.filter((x) => open.has(ownerOf(x.path)))
+			ownerLoad = Object.fromEntries(Object.entries(ownerLoad).filter(([o]) => open.has(o)))
+		}
 		await loadRunnables(true)
 		// force: the owners are still marked loaded, so re-fetch their first page and
 		// swap it in place (loadOwnerItems replaces each owner's rows atomically — the

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1519,6 +1519,7 @@
 					allFolders={treeInjectFolders}
 					allUsers={treeInjectUsers}
 					ownerCounts={treeLazyMode ? ownerCounts : undefined}
+					selfUsername={$userStore?.username}
 					ownerLoad={treeLazyMode ? ownerLoad : undefined}
 					onExpandOwner={treeLazyMode ? loadOwnerItems : undefined}
 					onCollapseOwner={treeLazyMode ? collapseOwner : undefined}

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -16,6 +16,9 @@
 		showCode: (path: string, summary: string) => void
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
+		// How many runnables each `f/<folder>` / `u/<user>` holds for this user, keyed by
+		// full prefix. Known before an owner is expanded, unlike its loaded rows.
+		ownerCounts?: Record<string, number>
 		// Lazy per-owner loading (top-level folders and users only): expanding an owner
 		// loads its items on demand and paginates within it. `ownerLoad` keys are full
 		// path prefixes (`f/<name>` / `u/<name>`).
@@ -37,6 +40,7 @@
 		showCode,
 		isSearching = false,
 		pipelineFolders,
+		ownerCounts,
 		ownerLoad,
 		onExpandOwner,
 		onCollapseOwner,
@@ -79,6 +83,9 @@
 	// whose items are already grouped from the loaded window.
 	let isLazyOwner = $derived(ownerKey != undefined && ownerLoad != undefined)
 	let ownerState = $derived(ownerKey != undefined ? ownerLoad?.[ownerKey] : undefined)
+	// The owner's true total, known without expanding it. Preferred over the loaded
+	// rows, which are one page deep and count a subfolder as a single child.
+	let ownerCount = $derived(ownerKey != undefined ? ownerCounts?.[ownerKey] : undefined)
 
 	let showMax = $state(15)
 	// A lazy owner paginates server-side ("Load more"), so when opened on its own it
@@ -166,9 +173,11 @@
 						{#if isUser(item)}u/{item.username}{:else}{#if depth === 0}f/{/if}{item.folderName}{/if}
 					</span>
 					<div class="text-2xs font-normal text-secondary whitespace-nowrap">
-						{#if isLazyOwner && !ownerState?.loaded}
-							<!-- Lazy owner not expanded yet: its true item count is unknown until
-							     loaded, so showing "(0 items)" would be misleading. -->
+						{#if ownerCount != undefined}
+							({pluralize(ownerCount, ' item')})
+						{:else if isLazyOwner && !ownerState?.loaded}
+							<!-- Lazy owner not expanded yet and no count for it: its true item count
+							     is unknown until loaded, so showing "(0 items)" would be misleading. -->
 							&nbsp;
 						{:else if isLazyOwner && ownerState?.hasMore}
 							({item.items.length}+ items)

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -83,9 +83,15 @@
 	// whose items are already grouped from the loaded window.
 	let isLazyOwner = $derived(ownerKey != undefined && ownerLoad != undefined)
 	let ownerState = $derived(ownerKey != undefined ? ownerLoad?.[ownerKey] : undefined)
-	// The owner's true total, known without expanding it. Preferred over the loaded
-	// rows, which are one page deep and count a subfolder as a single child.
-	let ownerCount = $derived(ownerKey != undefined ? ownerCounts?.[ownerKey] : undefined)
+	// What this owner renders, known without expanding it. Preferred over the loaded
+	// rows, which are one page deep and count a subfolder as a single child. An owner
+	// missing from `ownerCounts` holds nothing (the response omits those), so it reads
+	// as 0 rather than unknown. The pipeline entry is a row of its own and its member
+	// scripts are excluded from the count, so it adds one where it renders.
+	let ownerCount = $derived.by(() => {
+		if (ownerKey == undefined || ownerCounts == undefined) return undefined
+		return (ownerCounts[ownerKey] ?? 0) + (hasPipeline ? 1 : 0)
+	})
 
 	let showMax = $state(15)
 	// A lazy owner paginates server-side ("Load more"), so when opened on its own it

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import TreeView from './TreeView.svelte'
-	import { untrack } from 'svelte'
+	import { onDestroy, untrack } from 'svelte'
 
 	import { ChevronDown, ChevronUp, Folder, FolderTree, NetworkIcon, User } from 'lucide-svelte'
 	import Item from './Item.svelte'
@@ -135,6 +135,16 @@
 			}
 		})
 	})
+	// A node can go away without a collapse click — its owner dropped once the counts
+	// show it empty, or sliced out of the rendered window. Untracking it keeps the
+	// reload fan-out tied to what is actually on screen; without this a dropped owner
+	// stays registered and every later reload re-fetches it forever. Remounting
+	// re-registers it (see the collapseAll effect above).
+	onDestroy(() => {
+		const key = untrack(() => ownerKey)
+		if (key != undefined) onCollapseOwner?.(key)
+	})
+
 	let lastToggle = 0
 	function toggleOwner() {
 		// A double-click would otherwise toggle twice — expand then immediately collapse,

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -28,6 +28,9 @@
 		// by full prefix; owners holding none are absent. Undefined while it loads or
 		// when it doesn't apply, in which case every owner is injected as before.
 		ownerCounts?: Record<string, number>
+		// The viewer's own username: their personal space is a fixture of the tree and
+		// stays even when empty, so they have somewhere to create into.
+		selfUsername?: string
 		ownerLoad?: Record<
 			string,
 			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean; count: number }
@@ -50,6 +53,7 @@
 		allFolders = [],
 		allUsers = [],
 		ownerCounts,
+		selfUsername,
 		ownerLoad,
 		onExpandOwner,
 		onCollapseOwner
@@ -65,6 +69,7 @@
 		allFolders
 		allUsers
 		ownerCounts
+		selfUsername
 		untrack(() => {
 			// While searching, `items` is already relevance-ranked and the sort
 			// selector is disabled, so keep that order: a no-op leaf comparator
@@ -107,7 +112,9 @@
 				const missingUsers: { username: string; items: [] }[] = []
 				for (const username of allUsers) {
 					if (presentUsers.has(username)) continue
-					if (isEmptyOwner(`u/${username}`)) continue
+					// Your own space is exempt from the drop: it's where you create, so it
+					// stays visible (as "0 items") when empty rather than disappearing.
+					if (username !== selfUsername && isEmptyOwner(`u/${username}`)) continue
 					presentUsers.add(username)
 					missingUsers.push({ username, items: [] })
 				}

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -24,6 +24,10 @@
 		// `u/<name>`).
 		allFolders?: string[]
 		allUsers?: string[]
+		// How many runnables each `f/<folder>` / `u/<user>` holds for this user, keyed
+		// by full prefix; owners holding none are absent. Undefined while it loads or
+		// when it doesn't apply, in which case every owner is injected as before.
+		ownerCounts?: Record<string, number>
 		ownerLoad?: Record<
 			string,
 			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean; count: number }
@@ -45,6 +49,7 @@
 		onLoadMore,
 		allFolders = [],
 		allUsers = [],
+		ownerCounts,
 		ownerLoad,
 		onExpandOwner,
 		onCollapseOwner
@@ -59,6 +64,7 @@
 		groupDesc
 		allFolders
 		allUsers
+		ownerCounts
 		untrack(() => {
 			// While searching, `items` is already relevance-ranked and the sort
 			// selector is disabled, so keep that order: a no-op leaf comparator
@@ -83,9 +89,15 @@
 						.filter((g) => 'folderName' in g)
 						.map((g) => (g as { folderName: string }).folderName)
 				)
+				// Once counts are in, an owner holding nothing the user can see is dropped
+				// rather than injected — a workspace's folder list is mostly noise in the
+				// tree otherwise. Pipeline folders are exempt: their entry is the pipeline
+				// itself, whose member scripts are folded out of the runnable count.
+				const isEmptyOwner = (prefix: string) => ownerCounts != undefined && !ownerCounts[prefix]
 				const missingFolders: { folderName: string; items: [] }[] = []
 				for (const folderName of [...(pipelineFolders ?? []), ...allFolders]) {
 					if (presentFolders.has(folderName)) continue
+					if (!pipelineFolders?.has(folderName) && isEmptyOwner(`f/${folderName}`)) continue
 					presentFolders.add(folderName)
 					missingFolders.push({ folderName, items: [] })
 				}
@@ -95,6 +107,7 @@
 				const missingUsers: { username: string; items: [] }[] = []
 				for (const username of allUsers) {
 					if (presentUsers.has(username)) continue
+					if (isEmptyOwner(`u/${username}`)) continue
 					presentUsers.add(username)
 					missingUsers.push({ username, items: [] })
 				}
@@ -141,6 +154,7 @@
 					{collapseAll}
 					{item}
 					{pipelineFolders}
+					{ownerCounts}
 					{ownerLoad}
 					{onExpandOwner}
 					{onCollapseOwner}


### PR DESCRIPTION
Fixes WIN-2253

## What

The homepage tree listed **every** folder and user in the workspace as a root node, with a **blank** subtitle until you expanded one (its true size was unknowable without loading it). In a workspace with hundreds of folders, that is mostly noise: you scroll past folders you can see nothing in to reach the two you use.

This adds a per-owner count, fetched in one request, so the tree can label every node up front and drop the owners holding nothing.

## How

New endpoint `GET /w/{workspace}/runnables/counts?kinds=&include_without_main=` returning `{ "counts": { "f/analytics": 5, "u/admin": 2 } }`. Owners with nothing visible are omitted.

**It does not go through RLS.** RLS evaluates `split_part(path,'/',2) = ANY(regexp_split_to_array(current_setting('session.folders_read'), ','))` per row, which no index can serve, so any count under it degrades to a full workspace scan. Instead the endpoint runs on the plain pool and re-derives visibility from `path`:

- an owner is readable **whole or not at all** — admin, `f/<folder>` in the caller's read set, or the caller's own `u/<user>` space;
- its count is a byte-ordered prefix range, `path ~>=~ owner || '/' AND path ~<~ owner || '0'`.

That range is exact: every path under `owner` is `>= owner || '/'`, and since `'/'` (0x2F) is immediately followed by `'0'` (0x30) in ASCII, all of them are `< owner || '0'`. `~>=~` / `~<~` are the `text_pattern_ops` operators, which is what makes it indexable — the default opclass sorts by the database collation and cannot answer a byte-prefix range.

Admins are the exception: they read everything, so their owner set would be every folder *and* every member, and one prefix scan each would scale with headcount rather than with content. For them it is a single grouped scan per kind over the same indexes instead.

Hence the new migration:

- `idx_script_owner_prefix` — `(workspace_id, path text_pattern_ops) INCLUDE (auto_kind) WHERE archived = false`; `auto_kind` is an `INCLUDE` column so the library-script filter is answered from the index tuple and the scan stays index-only
- `idx_flow_owner_prefix` — same, `WHERE archived = false`
- `idx_app_owner_prefix` — same, no `archived` column on `app`
- `app_extra_perms` — GIN, matching the existing `script_extra_perms` / `flow_extra_perms`

The one thing `path` cannot express is an item **shared individually** out of an owner the caller is otherwise not a member of. A second pass recovers exactly those: one `extra_perms ?| ARRAY['u/<me>', 'g/<group>', …]` GIN scan per kind, grouped by owner. Owners already counted in pass 1 are readable whole, shares included, so merging by owner cannot double-count.

Fine-grained token scopes (`scripts:read:f/foo/*`) are pushed into both passes; the predicate builder is the one `list_runnables` already used, lifted out of its closure so both handlers share it.

### Frontend

`ItemsList` fetches the counts once per (workspace, kind, library, archived) scope and passes them down. `TreeView` shows the count instead of the blank placeholder. `TreeViewRoot` stops injecting an owner whose count is 0 — except pipeline folders, whose entry is the pipeline itself and whose member scripts are folded out of the runnable count. Owners that appear only in the counts (an individually-shared item in someone else's space) are now injected too, so they are reachable in the tree at all; previously they only showed up via search.

Counts are skipped in the archived view (the endpoint counts the live set) and outside lazy tree mode, where the tree groups already-loaded rows and its own counts are accurate. If the request fails the tree falls back to the previous behaviour.

The counts and the folder list are separate requests, so the tree holds its existing skeleton until the first counts response rather than rendering from whichever lands first — otherwise a slow counts response would draw every workspace folder and then prune it away. Both are issued in parallel with the listing, so in practice this costs no extra wait (in a local trace the counts landed 25 ms *before* the listing the tree was already waiting on). Only the first load gates: a scope change refreshes the counts in place without flashing the skeleton over a drawn tree.

The label counts what the node renders, so a folder with a data pipeline adds one for its Pipeline row — a folder holding a 5-step pipeline and one script reads "(2 items)" and expands to exactly the Pipeline row plus that script.

## Validation

`cargo check` clean, `npm run check` clean (0 errors). No new compile-time-checked queries, so the sqlx offline cache is unaffected.

**Correctness** — a synthetic workspace (500 folders, 100 user spaces, 53k runnables) with a non-admin `alice` holding: read on 2 folders, her own space, 30 scripts shared to `u/alice` in another user's space, and 20 apps shared to a group she belongs to. The endpoint returned exactly the same owner→count map as the equivalent query run under a real RLS session:

```
 f/fold1  | 100      {"f/fold1":100,"f/fold2":100,"f/fold42":20,
 f/fold2  | 100       "u/alice":1,"u/user7":30}
 f/fold42 |  20
 u/alice  |   1      RLS ground truth (left) vs /runnables/counts (right)
 u/user7  |  30
```

**Performance** — same fixture, `EXPLAIN ANALYZE`, warm:

| | |
|---|---|
| non-admin path, per-owner prefix counts (502 owners) | **7.3 ms** — Index Only Scan on all three tables |
| admin path, one grouped scan per kind | **9.3 ms** — Index Only Scan on all three tables |
| equivalent grouped count under RLS | 68 ms — Seq Scan per table |
| `extra_perms` share pass | 0.12 ms — Bitmap Index Scan on the GIN indexes |

**Manual** — driven in the browser with Playwright as both an admin and a non-admin; expanded folders load the items the count promised.

**Regression test** — `backend/tests/runnables_owner_counts.rs` asserts the endpoint's owner map equals the per-owner grouping of `/runnables/list` (which is RLS-enforced) for both a non-admin and an admin, over a fixture covering a folder grant, an own user space, a direct share and a group share out of an unreadable folder, a pipeline member, an operator, and a duplicated `kinds` value. It fails on each of the round-1 findings below.

## Screenshots

Admin, small workspace — `f/archive_2024` and `f/scratch` hold nothing and are gone; the rest are labelled.

| Before | After |
|---|---|
| ![before-admin-demo](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2253-add-folder-counts-to-homepage-tree-view/1785146554-before-admin-demo.png) | ![after-admin-demo](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2253-add-folder-counts-to-homepage-tree-view/1785146555-after-admin-demo.png) |

Non-admin in the 500-folder workspace. Before: four unlabelled nodes, one (`u/admin`) she can see nothing in, and her shared items unreachable. After: exactly the five owners she has something in — including `u/user7` (shared to her directly) and `f/fold42` (shared to her group), neither of which is in her folder list.

| Before | After |
|---|---|
| ![before-alice-perf](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2253-add-folder-counts-to-homepage-tree-view/1785146556-before-alice-perf.png) | ![after-alice-perf](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2253-add-folder-counts-to-homepage-tree-view/1785146558-after-alice-perf.png) |

A folder whose only content is a data pipeline: the member scripts are folded into the single Pipeline entry, so they are not counted as items and the folder is exempt from the empty-owner drop.

![pipeline folder](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2253-add-folder-counts-to-homepage-tree-view/1785148814-after2-pipes.png)

## Review round 1

- **Pipeline members inflated the count** (Claude + Codex, P1) — the script predicate excluded only `auto_kind = 'lib'`. A folder holding a 6-step pipeline read `(6 items)` and expanded to a single Pipeline row. `'pipeline'` is now always excluded; the folder keeps its node (`TreeViewRoot` already exempts pipeline folders from the empty-owner drop).
- **Operator counts omitted flows and apps** (Codex, P1) — the handler copied a `kinds.retain(script)` that `main` has since removed from `list_runnables`. Rebased onto `main` and dropped it; only library scripts stay hidden from operators.
- **Duplicate `kinds` double-counted** (Codex, P1) — `kinds=script,script` built the subquery twice. The list is now deduplicated.
- **Pass 1 scaled with headcount for admins** (Claude, P2) — replaced with a single grouped scan per kind, see above.
- **The caller's own `u/<me>` node could vanish** (Claude, P2) — it was dropped when empty, breaking the invariant that your personal space is always in the tree. Now exempt from the drop.
- **The share pass's GIN bitmap is not workspace-scoped** (Claude, P2) — accepted and documented in the handler. Scoping it needs `btree_gin`, a contrib extension self-hosted installs can't be assumed to have, and the RLS policies already scan these same indexes the same way; `workspace_id` remains a recheck.

## Review round 2

Codex and Pi: "Good to merge". Claude: nit-only.

- **A mixed pipeline folder labelled one short** — the Pipeline row is rendered but its member scripts are excluded from the count. The label now adds one where that row renders, so it matches the expanded contents.
- **An empty own user space rendered blank rather than `(0 items)`** — an owner missing from the response holds nothing, so it now reads as 0 instead of unknown.

Also in this round, unprompted by the reviewers: the two-request reflow described above.

## Review round 3

Claude and Pi: "Good to merge". Codex: **cached closed owners bypass per-scope pruning** — confirmed by reproducing it.

Expand `f/billing`, collapse it, switch the kind filter to Apps: the folder has no apps, so the counts omit it and it should disappear — instead it stayed, labelled `(0 items)`, and expanding it showed a flow and a script from the previous scope. `reloadItems` re-fetches only the *open* owners and `treeKey` doesn't include `itemKind`, so a collapsed owner's rows survive into a scope they were never loaded for. It then appears in `grouped`, which short-circuits the empty-owner check, and stays marked `loaded`, so re-expanding never re-fetches.

Fixed by dropping the cached rows and load state of every owner that isn't currently open, since those are exactly the ones the reload skips. Applying the counts to already-grouped roots instead would only have fixed the zero case — an owner that *does* have items in the new scope would still expand to the old scope's rows under a correct count. The stale rows predate this PR (a collapsed owner's cache was never invalidated on a scope change); the count only turned a quiet inconsistency into a visible contradiction.

Verified after the fix: `f/billing` is dropped, re-expanding `f/analytics` under Apps lists only the dashboard app, and an owner left *open* across a scope change still stays open and refreshes in place.

## Review round 4

Claude and Pi: "Good to merge". Codex: **count-pruned owners stay registered as open** — a follow-on from the round-3 fix, and confirmed by reproducing it.

Dropping an owner destroys its `TreeView` without any collapse click, so its key stayed in `openOwners` and every later reload re-fetched something no longer on screen. Measured on the demo workspace — expand `f/billing` and `f/shared_infra`, switch to Apps so both are pruned, then keep changing kind:

| | before | after |
|---|---|---|
| switch to Apps (both still open when the reload starts) | 2 requests | 2 requests |
| then switch to Flows | 2 requests for hidden owners | **0** |
| then switch back to Apps | 2 requests for hidden owners | **0** |

Fixed with an `onDestroy` in `TreeView` that untracks the owner, so the reload fan-out follows what is actually rendered. This also covers an expanded owner sliced out of the rendered window by `nbDisplayed`. An owner left *open* across a scope change still refreshes in place and stays open — verified separately.

## Review round 5

Codex, Claude and Pi: all "Good to merge". No findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
