### PR TITLE
fix(cli): sync push no longer reports success on a script it never deployed

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -887,6 +887,14 @@ export async function findContentFile(filePath: string) {
       : filePath.endsWith("script.lock")
       ? filePath.replace(".script.lock", ext)
       : filePath.replace(".script.yaml", ext);
+  // Every branch above is a no-op on a path that is neither flat nor
+  // module-entry metadata, which would make toCandidate the identity function
+  // and "resolve" the input to itself.
+  if (!isModuleFolderMeta && !/\.script\.(yaml|json|lock)$/.test(filePath)) {
+    throw new Error(
+      `${filePath} is not a script metadata file — no script file can be resolved from it.`
+    );
+  }
   const candidates = exts.map(toCandidate);
 
   const validCandidates = (

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -875,12 +875,12 @@ async function createScript(
 }
 
 /**
- * A script metadata file could not be paired with a script file on disk, so
- * nothing can be deployed for it. Distinct from a deploy that reached the
- * remote and was rejected: callers that can carry on with the rest of a
+ * A script metadata file could not be paired with exactly one script file on
+ * disk, so nothing can be deployed for it. Distinct from a deploy that reached
+ * the remote and was rejected: callers that can carry on with the rest of a
  * changeset catch this specifically.
  */
-export class MissingScriptContentFileError extends Error {}
+export class UnresolvableScriptContentFileError extends Error {}
 
 export async function findContentFile(filePath: string) {
   // Folder layout: __mod/script.yaml -> __mod/script.ts
@@ -899,7 +899,7 @@ export async function findContentFile(filePath: string) {
   // module-entry metadata, which would make toCandidate the identity function
   // and "resolve" the input to itself.
   if (!isModuleFolderMeta && !/\.script\.(yaml|json|lock)$/.test(filePath)) {
-    throw new MissingScriptContentFileError(
+    throw new UnresolvableScriptContentFileError(
       `${filePath} is not a script metadata file — no script file can be resolved from it.`
     );
   }
@@ -920,13 +920,13 @@ export async function findContentFile(filePath: string) {
     .filter((x) => x.file)
     .map((x) => x.path);
   if (validCandidates.length > 1) {
-    throw new Error(
-      "No content path given and more than one candidate found: " +
-        validCandidates.join(", ")
+    throw new UnresolvableScriptContentFileError(
+      `Multiple script files found next to ${filePath}: ${validCandidates.join(", ")} — ` +
+        `cannot tell which one the metadata belongs to. Keep exactly one.`
     );
   }
   if (validCandidates.length < 1) {
-    throw new MissingScriptContentFileError(
+    throw new UnresolvableScriptContentFileError(
       `No script file found next to ${filePath} — a script cannot be deployed from its metadata alone. ` +
         `Add the matching script file (e.g. ${toCandidate(".ts")} or ${toCandidate(
           ".py"

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -876,13 +876,15 @@ export async function findContentFile(filePath: string) {
   // Folder layout: __mod/script.yaml -> __mod/script.ts
   const isModuleFolderMeta =
     filePath.endsWith("/script.yaml") || filePath.endsWith("/script.json") || filePath.endsWith("/script.lock");
-  const candidates = isModuleFolderMeta
-    ? exts.map((x) => filePath.replace(/\/script\.(yaml|json|lock)$/, "/script" + x))
-    : filePath.endsWith("script.json")
-    ? exts.map((x) => filePath.replace(".script.json", x))
-    : filePath.endsWith("script.lock")
-    ? exts.map((x) => filePath.replace(".script.lock", x))
-    : exts.map((x) => filePath.replace(".script.yaml", x));
+  const toCandidate = (ext: string) =>
+    isModuleFolderMeta
+      ? filePath.replace(/\/script\.(yaml|json|lock)$/, "/script" + ext)
+      : filePath.endsWith("script.json")
+      ? filePath.replace(".script.json", ext)
+      : filePath.endsWith("script.lock")
+      ? filePath.replace(".script.lock", ext)
+      : filePath.replace(".script.yaml", ext);
+  const candidates = exts.map(toCandidate);
 
   const validCandidates = (
     await Promise.all(
@@ -906,7 +908,10 @@ export async function findContentFile(filePath: string) {
   }
   if (validCandidates.length < 1) {
     throw new Error(
-      `No content path given and no content file found for ${filePath}.`
+      `No script file found next to ${filePath} — a script cannot be deployed from its metadata alone. ` +
+        `Add the matching script file (e.g. ${toCandidate(".ts")} or ${toCandidate(
+          ".py"
+        )}) or remove ${filePath}.`
     );
   }
   return validCandidates[0];

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -874,6 +874,14 @@ async function createScript(
   return performance.now() - start;
 }
 
+/**
+ * A script metadata file could not be paired with a script file on disk, so
+ * nothing can be deployed for it. Distinct from a deploy that reached the
+ * remote and was rejected: callers that can carry on with the rest of a
+ * changeset catch this specifically.
+ */
+export class MissingScriptContentFileError extends Error {}
+
 export async function findContentFile(filePath: string) {
   // Folder layout: __mod/script.yaml -> __mod/script.ts
   const isModuleFolderMeta =
@@ -891,7 +899,7 @@ export async function findContentFile(filePath: string) {
   // module-entry metadata, which would make toCandidate the identity function
   // and "resolve" the input to itself.
   if (!isModuleFolderMeta && !/\.script\.(yaml|json|lock)$/.test(filePath)) {
-    throw new Error(
+    throw new MissingScriptContentFileError(
       `${filePath} is not a script metadata file — no script file can be resolved from it.`
     );
   }
@@ -918,7 +926,7 @@ export async function findContentFile(filePath: string) {
     );
   }
   if (validCandidates.length < 1) {
-    throw new Error(
+    throw new MissingScriptContentFileError(
       `No script file found next to ${filePath} — a script cannot be deployed from its metadata alone. ` +
         `Add the matching script file (e.g. ${toCandidate(".ts")} or ${toCandidate(
           ".py"

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -276,8 +276,10 @@ export async function handleScriptMetadata(
   const isFlatMeta = path.endsWith(".script.json") ||
     path.endsWith(".script.yaml") ||
     path.endsWith(".script.lock");
-  // Folder layout: my_script__mod/script.yaml
-  const isFolderMeta = !isFlatMeta && isScriptModulePath(path) && (
+  // Folder layout: my_script__mod/script.yaml. Only the entry point counts —
+  // a script.yaml nested deeper in the module tree is a module file, not the
+  // script's metadata.
+  const isFolderMeta = !isFlatMeta && isModuleEntryPoint(path) && (
     path.endsWith("/script.yaml") ||
     path.endsWith("/script.json") ||
     path.endsWith("/script.lock")
@@ -875,7 +877,8 @@ async function createScript(
 export async function findContentFile(filePath: string) {
   // Folder layout: __mod/script.yaml -> __mod/script.ts
   const isModuleFolderMeta =
-    filePath.endsWith("/script.yaml") || filePath.endsWith("/script.json") || filePath.endsWith("/script.lock");
+    isModuleEntryPoint(filePath) &&
+    (filePath.endsWith("/script.yaml") || filePath.endsWith("/script.json") || filePath.endsWith("/script.lock"));
   const toCandidate = (ext: string) =>
     isModuleFolderMeta
       ? filePath.replace(/\/script\.(yaml|json|lock)$/, "/script" + ext)

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -5260,7 +5260,9 @@ export async function push(
       );
     }
     if (failedChanges.length > 0) {
-      process.exit(1);
+      // Not process.exit: under Node a piped stdout write is async, so exiting
+      // here would truncate the JSON result mid-object for CI consumers.
+      process.exitCode = 1;
     }
   } else {
     // Dry-run with no changes reaches here (a ui/ diff would have made changes

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -40,7 +40,7 @@ import {
   findContentFile,
   findResourceFile,
   handleScriptMetadata,
-  MissingScriptContentFileError,
+  UnresolvableScriptContentFileError,
   removeExtensionToPath,
   filePathExtensionFromContentType,
 } from "../script/script.ts";
@@ -4674,7 +4674,7 @@ export async function push(
                     permissionedAsContext,
                   );
                 } catch (e) {
-                  if (!(e instanceof MissingScriptContentFileError)) {
+                  if (!(e instanceof UnresolvableScriptContentFileError)) {
                     throw e;
                   }
                   // Nothing deployable here, but the rest of the changeset is

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -40,6 +40,7 @@ import {
   findContentFile,
   findResourceFile,
   handleScriptMetadata,
+  MissingScriptContentFileError,
   removeExtensionToPath,
   filePathExtensionFromContentType,
 } from "../script/script.ts";
@@ -4407,6 +4408,10 @@ export async function push(
       log.info(`Parallelizing ${parallelizationFactor} changes at a time`);
     }
 
+    // Changes that could not be applied but do not invalidate the rest of the
+    // push. Reported at the end, and the push exits non-zero for them.
+    const failedChanges: { path: string; error: string }[] = [];
+
     // Create a pool of workers that processes items as they become available
     const pool = new Set();
     // Process folder.meta groups first (sequentially), then items in parallel.
@@ -4653,22 +4658,38 @@ export async function push(
               // A script deploys through its content file, which is normally in
               // the same group — but not always (excludes can filter it out).
               // Resolving it from disk keeps the deploy idempotent (via
-              // alreadySynced) and makes an unaccompanied metadata file raise
-              // instead of being counted as a change that reached the remote.
-              if (
-                !isRawAppFile(change.path) &&
-                (await handleScriptMetadata(
-                  change.path,
-                  workspace,
-                  alreadySynced,
-                  opts.message,
-                  rawWorkspaceDependencies,
-                  codebases,
-                  opts,
-                  permissionedAsContext,
-                ))
-              ) {
-                continue;
+              // alreadySynced) and stops an unaccompanied metadata file from
+              // being counted as a change that reached the remote.
+              if (!isRawAppFile(change.path)) {
+                let handled = false;
+                try {
+                  handled = await handleScriptMetadata(
+                    change.path,
+                    workspace,
+                    alreadySynced,
+                    opts.message,
+                    rawWorkspaceDependencies,
+                    codebases,
+                    opts,
+                    permissionedAsContext,
+                  );
+                } catch (e) {
+                  if (!(e instanceof MissingScriptContentFileError)) {
+                    throw e;
+                  }
+                  // Nothing deployable here, but the rest of the changeset is
+                  // unaffected — record it so the push reports a failure at the
+                  // end instead of aborting midway with a partial deploy.
+                  failedChanges.push({
+                    path: change.path,
+                    error: e.message,
+                  });
+                  log.error(e.message);
+                  continue;
+                }
+                if (handled) {
+                  continue;
+                }
               }
               if (
                 !isRawAppFile(change.path) &&
@@ -5185,11 +5206,16 @@ export async function push(
         );
       }
     }
+    const pushedCount = changes.length - failedChanges.length;
     if (opts.jsonOutput) {
       const result = {
-        success: true,
+        success: failedChanges.length === 0,
         lock_jobs: lockJobs,
-        message: `All ${changes.length} changes pushed to the remote workspace ${workspace.workspaceId} named ${workspace.name}`,
+        ...(failedChanges.length > 0 ? { failed: failedChanges } : {}),
+        message:
+          failedChanges.length > 0
+            ? `${pushedCount} of ${changes.length} changes pushed to the remote workspace ${workspace.workspaceId} named ${workspace.name}; ${failedChanges.length} failed`
+            : `All ${changes.length} changes pushed to the remote workspace ${workspace.workspaceId} named ${workspace.name}`,
         changes: changes.map((change) => ({
           type: change.name,
           path: change.path,
@@ -5211,6 +5237,15 @@ export async function push(
         duration_ms: Math.round(performance.now() - start),
       };
       console.log(JSON.stringify(result, null, 2));
+    } else if (failedChanges.length > 0) {
+      log.error(
+        colors.bold.red.underline(
+          `\n${pushedCount} of ${changes.length} changes pushed to the remote workspace ${
+            workspace.workspaceId
+          } named ${workspace.name}; ${failedChanges.length} failed:\n` +
+            failedChanges.map((f) => `  - ${f.path}`).join("\n"),
+        ),
+      );
     } else {
       log.info(
         colors.bold.green.underline(
@@ -5223,6 +5258,9 @@ export async function push(
           )}ms)`,
         ),
       );
+    }
+    if (failedChanges.length > 0) {
+      process.exit(1);
     }
   } else {
     // Dry-run with no changes reaches here (a ui/ diff would have made changes

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4650,6 +4650,26 @@ export async function push(
                 );
                 continue;
               }
+              // A script deploys through its content file, which is normally in
+              // the same group — but not always (excludes can filter it out).
+              // Resolving it from disk keeps the deploy idempotent (via
+              // alreadySynced) and makes an unaccompanied metadata file raise
+              // instead of being counted as a change that reached the remote.
+              if (
+                !isRawAppFile(change.path) &&
+                (await handleScriptMetadata(
+                  change.path,
+                  workspace,
+                  alreadySynced,
+                  opts.message,
+                  rawWorkspaceDependencies,
+                  codebases,
+                  opts,
+                  permissionedAsContext,
+                ))
+              ) {
+                continue;
+              }
               if (
                 !isRawAppFile(change.path) &&
                 (change.path.endsWith(".script.json") ||

--- a/cli/test/script_modules_unit.test.ts
+++ b/cli/test/script_modules_unit.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   writeModulesToDisk,
   readModulesFromDisk,
+  findContentFile,
 } from "../src/commands/script/script.ts";
 import { getTypeStrFromPath } from "../src/types.ts";
 
@@ -319,5 +320,46 @@ describe("module lock file handling", () => {
     expect(fs.existsSync(path.join(moduleFolderPath, "new.ts"))).toBe(true);
     // old.ts should still exist (writeModulesToDisk doesn't clean up)
     // This is intentional — cleanup happens at the sync level
+  });
+});
+
+// =============================================================================
+// findContentFile
+// =============================================================================
+
+describe("findContentFile", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-find-content-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("resolves the entry point of a module folder", async () => {
+    const modDir = path.join(tempDir, "my_script__mod");
+    fs.mkdirSync(modDir, { recursive: true });
+    fs.writeFileSync(path.join(modDir, "script.ts"), "export async function main() {}\n");
+    fs.writeFileSync(path.join(modDir, "script.yaml"), "summary: ''\n");
+
+    expect(await findContentFile(path.join(modDir, "script.yaml"))).toBe(
+      path.join(modDir, "script.ts")
+    );
+  });
+
+  // A script.yaml nested deeper in the module tree is a module file, not the
+  // script's metadata — resolving it to itself would make the caller deploy it
+  // as if it were a script.
+  test("rejects a script.yaml nested below the module entry point", async () => {
+    const nested = path.join(tempDir, "my_script__mod", "config");
+    fs.mkdirSync(nested, { recursive: true });
+    const nestedMeta = path.join(nested, "script.yaml");
+    fs.writeFileSync(nestedMeta, "nested: data\n");
+
+    await expect(findContentFile(nestedMeta)).rejects.toThrow(
+      "is not a script metadata file"
+    );
   });
 });

--- a/cli/test/script_modules_unit.test.ts
+++ b/cli/test/script_modules_unit.test.ts
@@ -18,6 +18,7 @@ import {
   writeModulesToDisk,
   readModulesFromDisk,
   findContentFile,
+  UnresolvableScriptContentFileError,
 } from "../src/commands/script/script.ts";
 import { getTypeStrFromPath } from "../src/types.ts";
 
@@ -346,6 +347,30 @@ describe("findContentFile", () => {
 
     expect(await findContentFile(path.join(modDir, "script.yaml"))).toBe(
       path.join(modDir, "script.ts")
+    );
+  });
+
+  // sync push catches UnresolvableScriptContentFileError to record the change as
+  // failed and carry on; any other error aborts the whole push, so every branch
+  // that simply cannot pair a metadata file with one script file must use it.
+  test("signals every unpairable case with UnresolvableScriptContentFileError", async () => {
+    const dir = path.join(tempDir, "f", "test");
+    fs.mkdirSync(dir, { recursive: true });
+
+    // no script file at all
+    const orphan = path.join(dir, "orphan.script.yaml");
+    fs.writeFileSync(orphan, "summary: ''\n");
+    await expect(findContentFile(orphan)).rejects.toBeInstanceOf(
+      UnresolvableScriptContentFileError
+    );
+
+    // two script files, so the metadata cannot name one
+    const ambiguous = path.join(dir, "both.script.yaml");
+    fs.writeFileSync(ambiguous, "summary: ''\n");
+    fs.writeFileSync(path.join(dir, "both.ts"), "export async function main() {}\n");
+    fs.writeFileSync(path.join(dir, "both.py"), "def main():\n    pass\n");
+    await expect(findContentFile(ambiguous)).rejects.toBeInstanceOf(
+      UnresolvableScriptContentFileError
     );
   });
 

--- a/cli/test/sync_push_script_metadata_only.test.ts
+++ b/cli/test/sync_push_script_metadata_only.test.ts
@@ -41,3 +41,49 @@ test(
     });
   },
 );
+
+// A metadata file with no script file anywhere is unpushable, but the rest of
+// the changeset is unaffected: the push must neither abort partway nor claim
+// success. `orphan` sorts between `alpha` and `zeta`, so an abort would leave
+// `zeta` undeployed.
+test(
+  "sync push reports failure for an unpushable script without dropping the rest",
+  { timeout: 120000 },
+  async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      await writeFile(
+        `${tempDir}/wmill.yaml`,
+        `defaultTs: bun\nincludes: ["f/**"]\nexcludes: []\n`,
+      );
+      for (const name of ["alpha", "zeta"]) {
+        await createLocalScript(
+          tempDir,
+          "f/test",
+          name,
+          "python3",
+          `def main():\n    return "${name}"\n`,
+        );
+      }
+      await writeFile(
+        `${tempDir}/f/test/orphan.script.yaml`,
+        `summary: orphan\ndescription: ''\nlock: ''\nkind: script\nschema: {}\n`,
+      );
+
+      const result = await backend.runCLICommand(
+        ["sync", "push", "--yes"],
+        tempDir,
+      );
+      expect(result.code).toBe(1);
+      expect(result.stdout + result.stderr).toContain(
+        "f/test/orphan.script.yaml",
+      );
+
+      for (const name of ["alpha", "zeta"]) {
+        const res = await backend.apiRequest!(
+          `/api/w/${backend.workspace}/scripts/get/p/f/test/${name}`,
+        );
+        expect(res.status).toBe(200);
+      }
+    });
+  },
+);

--- a/cli/test/sync_push_script_metadata_only.test.ts
+++ b/cli/test/sync_push_script_metadata_only.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression guard for `wmill sync push` reporting success on a script that was
+ * never deployed (WIN-2254).
+ *
+ * A `.script.yaml` change used to be skipped outright on the assumption that the
+ * sibling content file carried the deploy. When the content file is not part of
+ * the changeset — here because `excludes` keeps it out of the sync — nothing was
+ * sent to the remote, yet the push still printed "All N changes pushed" and
+ * exited 0.
+ */
+
+import { expect, test } from "bun:test";
+import { writeFile } from "node:fs/promises";
+import { withTestBackend } from "./test_backend.ts";
+import { createLocalScript } from "./test_fixtures.ts";
+
+test(
+  "sync push deploys a script whose metadata is the only changed file",
+  { timeout: 120000 },
+  async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      await writeFile(
+        `${tempDir}/wmill.yaml`,
+        `defaultTs: bun\nincludes: ["f/**"]\nexcludes: ["**/*.py"]\n`,
+      );
+      await createLocalScript(
+        tempDir,
+        "f/test",
+        "metadata_only",
+        "python3",
+        'def main():\n    return "deployed"\n',
+      );
+
+      const result = await backend.runCLICommand(
+        ["sync", "push", "--yes"],
+        tempDir,
+      );
+      expect(result.code).toBe(0);
+
+      const res = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/scripts/get/p/f/test/metadata_only`,
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).content).toContain("deployed");
+    });
+  },
+);

--- a/cli/test/sync_push_script_metadata_only.test.ts
+++ b/cli/test/sync_push_script_metadata_only.test.ts
@@ -1,12 +1,8 @@
 /**
- * Regression guard for `wmill sync push` reporting success on a script that was
- * never deployed (WIN-2254).
- *
- * A `.script.yaml` change used to be skipped outright on the assumption that the
- * sibling content file carried the deploy. When the content file is not part of
- * the changeset — here because `excludes` keeps it out of the sync — nothing was
- * sent to the remote, yet the push still printed "All N changes pushed" and
- * exited 0.
+ * A script change that `sync push` counts must reach the remote. Its content
+ * file is not guaranteed to be in the changeset — here `excludes` keeps it out
+ * of the sync, leaving the `.script.yaml` as the only change — so asserting the
+ * deployed content, not just the exit code, is what pins the guarantee.
  */
 
 import { expect, test } from "bun:test";


### PR DESCRIPTION
## Summary

`wmill sync push` could print `Done! All N changes pushed`, exit 0, and leave the script absent from the remote — silent data loss in the primary deploy path, and a CI gate on the exit code goes green on a deploy that never happened.

The apply loop skipped every *added* `.script.yaml` / `.script.json` / `.script.lock` outright, on the assumption that the sibling content file in the same group carried the deploy. When the content file is not in the changeset (for instance filtered out of the sync by `excludes`), nothing was sent to the remote, yet the metadata file was still counted in the "N changes pushed" total. The `edited` branch never had this hole — it already routes metadata changes through `handleScriptMetadata`, which resolves the content file from disk.

The `added` branch now does the same. The deploy stays idempotent (`handleFile` short-circuits on `alreadySynced`, so a group holding both the content file and its metadata still deploys exactly once, in either processing order).

A metadata file that cannot be paired with exactly one script file is unpushable — either none exists, or several do and nothing says which one the metadata describes. Rather than aborting mid-flight, which would leave the push partially applied and drop unrelated changes queued behind it, the push records the failure, logs it, applies everything else, and reports `N of M changes pushed; K failed` with a **non-zero exit**. Only this content-resolution failure is soft (`UnresolvableScriptContentFileError`); a deploy the remote rejected still aborts, since a server rejection says nothing about whether the remaining changes are safe to apply.

Before / after, with a `.script.yaml` whose `.py` sibling is kept out of the sync by `excludes`:

```
# before
remote (test2) <- local: 1 changes to apply
+ script f/test/excluded.script.yaml
Done! All 1 changes pushed ...          # exit 0, script absent on the remote

# after
+ script f/test/excluded.script.yaml
Creating new script f/test/excluded ...
Created new script f/test/excluded (4ms)
Done! All 1 changes pushed ...          # exit 0, script deployed
```

With an unpushable script alongside two healthy ones that sort either side of it:

```
Created new script f/test/alpha (5ms)
Multiple script files found next to f/test/both.script.yaml: f/test/both.ts, f/test/both.py —
cannot tell which one the metadata belongs to. Keep exactly one.
Created new script f/test/zeta (4ms)

10 of 11 changes pushed to the remote workspace test named test; 1 failed:
  - f/test/both.script.yaml
# exit 1 — alpha and zeta are deployed, both is not
```

`--json-output` mirrors this with `"success": false` and a `failed` array.

## Changes

- `cli/src/commands/sync/sync.ts`: the `added` branch routes script metadata/lock changes through `handleScriptMetadata` before the blanket skip, mirroring the `edited` branch.
- `cli/src/commands/sync/sync.ts`: unresolvable script changes are collected into `failedChanges` instead of throwing; the final report becomes `N of M changes pushed; K failed` and the command exits non-zero (`success: false` + `failed[]` under `--json-output`).
- `cli/src/commands/sync/sync.ts`: that exit uses `process.exitCode` rather than `process.exit`, so a large `--json-output` payload is not truncated at the pipe buffer.
- `cli/src/commands/script/script.ts`: both of `findContentFile`'s unpairable branches (no candidate, several candidates) raise `UnresolvableScriptContentFileError` with a message naming the expected or clashing files; inputs that are neither flat nor module-entry metadata are rejected up front rather than silently resolving to themselves.
- `cli/src/commands/script/script.ts`: `handleScriptMetadata` and `findContentFile` gate module-folder metadata on `isModuleEntryPoint` rather than `isScriptModulePath`, so a module file nested deeper (`f/foo__mod/config/script.yaml`) is not mistaken for the script's metadata.
- `cli/test/sync_push_script_metadata_only.test.ts`: the metadata-only change reaches the remote (asserting deployed *content*, not just exit 0); an unpushable script fails the exit code without dropping the rest of the changeset.
- `cli/test/script_modules_unit.test.ts`: `findContentFile` resolves a module entry point, rejects a `script.yaml` nested below it, and signals every unpairable case with the class `sync push` catches.

## Test plan

- [x] Both integration regression tests pass; the first fails on `main` (push exits 0, script 404s).
- [x] Each new unit test verified to fail with its fix reverted.
- [x] `bun test test/*_unit*.test.ts` — 979 pass, 0 fail.
- [x] `bun test` across `sync_pull_push`, `sync_push_auto_metadata_repro`, `script_envs_sync`, `raw_app_sync`, `folder_missing_meta`, `gitsync_promotion`, `variable_resource_push` (+ the new file) — 94–105 pass, 0 fail.
- [x] `bun test test/folder_default_permissioned_as.test.ts test/labels_export.test.ts test/override_settings_behavior.test.ts test/folder_schedule_push.test.ts test/app_inline_script_delete.test.ts` — 50 pass, 0 fail.
- [x] Manual push against a local backend: flat layout, `__mod/` folder layout, a `__mod/config/script.yaml` module file, and both unpushable cases (missing and ambiguous) in text and `--json-output` mode.
- [x] Truncation check: a 1904-change `--json-output` push through a pipe emitted 432 KiB of valid JSON and exit 1; with `process.exit` it was cut off at exactly 65536 bytes.
- [x] `bunx tsc --noEmit` — no new errors in the touched files (the repo has pre-existing errors elsewhere).
- [x] `relative_imports_skip.test.ts` fails 4 Python lockgen tests identically with and without this change (local backend binary built without the `python` feature).

## Known limitations

- On Windows the folder-layout half of the routing is inert: `handleScriptMetadata`'s module-entry check compares against `/script.yaml` while `change.path` is `\`-separated. The flat `.script.yaml` case (the reported bug) is separator-independent and works. Pre-existing, not addressed here.
- `sync.ts` has other pre-existing `process.exit(1)` call sites, one of which (`missing_folders`) prints JSON first. Their payloads are bounded well below the pipe buffer, so they are left alone rather than widening this diff.

Fixes WIN-2254

🤖 Generated with [Claude Code](https://claude.com/claude-code)