### PR TITLE
fix(ai): support OpenAI/Anthropic-compatible gateways in workspace AI settings

### DIFF
--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -30,6 +30,30 @@ pub const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 pub const DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/v1";
 pub const GOOGLE_AI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 
+/// Hosts that serve the OpenAI API with Azure conventions: Azure OpenAI
+/// (`*.openai.azure.com`), AI Foundry (`*.services.ai.azure.com`,
+/// `*.cognitiveservices.azure.com`), their sovereign-cloud counterparts, and API
+/// Management fronting either.
+const AZURE_HOST_SUFFIXES: [&str; 4] = [".azure.com", ".azure.us", ".azure.cn", ".azure-api.net"];
+
+fn is_azure_host(base_url: &str) -> bool {
+    let authority = base_url
+        .split_once("://")
+        .map_or(base_url, |(_, rest)| rest)
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let host = host_port
+        .rsplit_once(':')
+        .map_or(host_port, |(host, _)| host)
+        .to_ascii_lowercase();
+
+    AZURE_HOST_SUFFIXES
+        .iter()
+        .any(|suffix| host.ends_with(suffix))
+}
+
 /// Empty string signals BedrockClient::from_env() to use the region from AWS environment/config
 /// (e.g., AWS_REGION or AWS_DEFAULT_REGION env vars, or ~/.aws/config)
 pub const USE_ENV_REGION: &str = "";
@@ -107,7 +131,7 @@ impl AIProvider {
                     OPENAI_AZURE_BASE_PATH.clone()
                 };
 
-                Ok(azure_base_path.unwrap_or("https://api.openai.com/v1".to_string()))
+                Ok(azure_base_path.unwrap_or_else(|| OPENAI_BASE_URL.to_string()))
             }
             AIProvider::DeepSeek => Ok(DEEPSEEK_BASE_URL.to_string()),
             AIProvider::GoogleAI => Ok(GOOGLE_AI_BASE_URL.to_string()),
@@ -139,10 +163,18 @@ impl AIProvider {
     /// Check whether this provider/URL combination uses Azure conventions
     /// (the `api-key` auth header and Azure URL building). This covers Azure
     /// OpenAI, Azure AI Foundry, and the `OpenAI` provider pointed at an Azure
-    /// base path override.
+    /// endpoint through `openai_azure_base_path` or a resource base URL.
+    ///
+    /// The `OpenAI` provider is matched on the host and not on "base URL differs
+    /// from the default": every other custom base URL is an OpenAI-compatible
+    /// endpoint (gateway, proxy, self-hosted server) that expects bearer auth and
+    /// the plain `<base>/<path>` layout.
     pub fn is_azure(&self, base_url: &str) -> bool {
-        (matches!(self, AIProvider::OpenAI) && base_url != OPENAI_BASE_URL)
-            || matches!(self, AIProvider::AzureOpenAI | AIProvider::AzureFoundry)
+        match self {
+            AIProvider::AzureOpenAI | AIProvider::AzureFoundry => true,
+            AIProvider::OpenAI => is_azure_host(base_url),
+            _ => false,
+        }
     }
 
     /// Build an Azure-style OpenAI-compatible URL (Azure OpenAI / Azure AI Foundry)
@@ -298,6 +330,36 @@ mod tests {
             ),
             "https://example.openai.azure.com/openai/deployments/my-deployment/chat/completions"
         );
+    }
+
+    /// An OpenAI resource with a custom base URL is an OpenAI-compatible endpoint
+    /// unless it is an Azure host: treating every non-default base URL as Azure
+    /// swaps bearer auth for the `api-key` header and rewrites the path, which
+    /// gateways answer with 401/404.
+    #[test]
+    fn openai_is_azure_only_for_azure_hosts() {
+        for base_url in [
+            "https://gateway-eu.pydantic.dev/proxy/openai",
+            "https://openrouter.ai/api/v1",
+            "http://localhost:4000/v1",
+            OPENAI_BASE_URL,
+        ] {
+            assert!(
+                !AIProvider::OpenAI.is_azure(base_url),
+                "{base_url} must not be treated as Azure"
+            );
+        }
+
+        for base_url in [
+            "https://example.openai.azure.com/openai/deployments/my-deployment",
+            "https://wm-test-ai.services.ai.azure.com",
+            "https://contoso.azure-api.net/openai",
+        ] {
+            assert!(
+                AIProvider::OpenAI.is_azure(base_url),
+                "{base_url} must be treated as Azure"
+            );
+        }
     }
 
     #[test]

--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -34,9 +34,27 @@ pub const GOOGLE_AI_BASE_URL: &str = "https://generativelanguage.googleapis.com/
 /// (`*.openai.azure.com`), AI Foundry (`*.services.ai.azure.com`,
 /// `*.cognitiveservices.azure.com`), their sovereign-cloud counterparts, and API
 /// Management fronting either.
-const AZURE_HOST_SUFFIXES: [&str; 4] = [".azure.com", ".azure.us", ".azure.cn", ".azure-api.net"];
+const AZURE_HOST_SUFFIXES: &[&str] = &[
+    ".azure.com",
+    ".azure.us",
+    ".azure.cn",
+    ".azure-api.net",
+    ".azure-api.us",
+    ".azure-api.cn",
+];
 
-fn is_azure_host(base_url: &str) -> bool {
+/// The deployment path Azure OpenAI serves under. It identifies an Azure endpoint
+/// reached through a custom domain, which `AZURE_HOST_SUFFIXES` cannot catch — it
+/// is the format `openai_azure_base_path` documents.
+const AZURE_DEPLOYMENTS_PATH: &str = "/openai/deployments";
+
+/// Whether an OpenAI-API base URL is served by Azure, which authenticates with the
+/// `api-key` header and lays its routes out under `/openai/...`.
+///
+/// An OpenAI-compatible endpoint on an Azure-owned domain (e.g. a self-hosted
+/// server behind API Management) is misread as Azure; such a resource has to use
+/// the `customai` provider.
+fn is_azure_endpoint(base_url: &str) -> bool {
     let authority = base_url
         .split_once("://")
         .map_or(base_url, |(_, rest)| rest)
@@ -47,11 +65,13 @@ fn is_azure_host(base_url: &str) -> bool {
     let host = host_port
         .rsplit_once(':')
         .map_or(host_port, |(host, _)| host)
+        .trim_end_matches('.')
         .to_ascii_lowercase();
 
     AZURE_HOST_SUFFIXES
         .iter()
         .any(|suffix| host.ends_with(suffix))
+        || base_url.contains(AZURE_DEPLOYMENTS_PATH)
 }
 
 /// Empty string signals BedrockClient::from_env() to use the region from AWS environment/config
@@ -165,14 +185,13 @@ impl AIProvider {
     /// OpenAI, Azure AI Foundry, and the `OpenAI` provider pointed at an Azure
     /// endpoint through `openai_azure_base_path` or a resource base URL.
     ///
-    /// The `OpenAI` provider is matched on the host and not on "base URL differs
-    /// from the default": every other custom base URL is an OpenAI-compatible
-    /// endpoint (gateway, proxy, self-hosted server) that expects bearer auth and
-    /// the plain `<base>/<path>` layout.
+    /// A custom `OpenAI` base URL that is not an Azure endpoint is an
+    /// OpenAI-compatible one (gateway, proxy, self-hosted server) and keeps bearer
+    /// auth and the plain `<base>/<path>` layout.
     pub fn is_azure(&self, base_url: &str) -> bool {
         match self {
             AIProvider::AzureOpenAI | AIProvider::AzureFoundry => true,
-            AIProvider::OpenAI => is_azure_host(base_url),
+            AIProvider::OpenAI => is_azure_endpoint(base_url),
             _ => false,
         }
     }
@@ -333,12 +352,12 @@ mod tests {
     }
 
     /// An OpenAI resource with a custom base URL is an OpenAI-compatible endpoint
-    /// unless it is an Azure host: treating every non-default base URL as Azure
-    /// swaps bearer auth for the `api-key` header and rewrites the path, which
-    /// gateways answer with 401/404.
+    /// unless it is an Azure one. Azure treatment swaps bearer auth for the
+    /// `api-key` header and rewrites the path, so both directions must hold.
     #[test]
-    fn openai_is_azure_only_for_azure_hosts() {
+    fn openai_is_azure_only_for_azure_endpoints() {
         for base_url in [
+            // A gateway path ending in /openai must not read as Azure.
             "https://gateway-eu.pydantic.dev/proxy/openai",
             "https://openrouter.ai/api/v1",
             "http://localhost:4000/v1",
@@ -353,7 +372,10 @@ mod tests {
         for base_url in [
             "https://example.openai.azure.com/openai/deployments/my-deployment",
             "https://wm-test-ai.services.ai.azure.com",
-            "https://contoso.azure-api.net/openai",
+            "https://contoso.azure-api.cn/openai",
+            // Azure OpenAI behind a custom domain, the format
+            // `openai_azure_base_path` documents.
+            "https://openai.contoso.com/openai/deployments/gpt-4o",
         ] {
             assert!(
                 AIProvider::OpenAI.is_azure(base_url),

--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -71,7 +71,9 @@ fn is_azure_endpoint(base_url: &str) -> bool {
     AZURE_HOST_SUFFIXES
         .iter()
         .any(|suffix| host.ends_with(suffix))
-        || base_url.contains(AZURE_DEPLOYMENTS_PATH)
+        || base_url
+            .to_ascii_lowercase()
+            .contains(AZURE_DEPLOYMENTS_PATH)
 }
 
 /// Empty string signals BedrockClient::from_env() to use the region from AWS environment/config

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -2,7 +2,7 @@ use crate::{
     ai_google::parse_data_url,
     ai_providers::{AIPlatform, AIProvider},
     image_handler::prepare_messages_for_api,
-    proxy::{add_user_to_body, credentials_overridden, ProxyBuildArgs, ProxyRequest},
+    proxy::{add_user_to_body, resource_owns_credentials, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{AnthropicSSEParser, SSEParser},
     types::*,
@@ -547,7 +547,7 @@ impl AnthropicQueryBuilder {
         // Exactly one auth header, matching `get_auth_headers`: Vertex takes an
         // OAuth bearer token, every other Messages endpoint takes x-api-key.
         // Endpoints in front of Anthropic reject requests carrying both.
-        let auth_overridden = credentials_overridden(credentials, &["authorization", "x-api-key"]);
+        let auth_overridden = resource_owns_credentials(credentials);
 
         if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
             if is_vertex {

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -2,14 +2,13 @@ use crate::{
     ai_google::parse_data_url,
     ai_providers::{AIPlatform, AIProvider},
     image_handler::prepare_messages_for_api,
-    proxy::{add_user_to_body, resource_replaces_credential, ProxyBuildArgs, ProxyRequest},
+    proxy::{
+        add_user_to_body, common_outbound_headers, credential_header, ProxyBuildArgs, ProxyRequest,
+    },
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{AnthropicSSEParser, SSEParser},
     types::*,
-    utils::{
-        collect_system_prompt, extract_text_content, should_use_structured_output_tool,
-        AI_HTTP_HEADERS,
-    },
+    utils::{collect_system_prompt, extract_text_content, should_use_structured_output_tool},
 };
 use async_trait::async_trait;
 use http::Method;
@@ -544,46 +543,23 @@ impl AnthropicQueryBuilder {
             }
         }
 
-        // Exactly one auth header, matching `get_auth_headers`: Vertex takes an
-        // OAuth bearer token, every other Messages endpoint takes x-api-key.
-        // Endpoints in front of Anthropic reject requests carrying both.
-        let built_in_credential = if is_vertex {
-            "authorization"
-        } else {
-            "x-api-key"
-        };
-        let auth_overridden = resource_replaces_credential(credentials, built_in_credential);
-
-        if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
+        // One credential header, matching `get_auth_headers`: Vertex takes an OAuth
+        // bearer token, every other Messages endpoint takes x-api-key. Endpoints in
+        // front of Anthropic reject requests carrying both.
+        headers.extend(credential_header(
+            credentials,
             if is_vertex {
-                headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
+                "authorization"
             } else {
-                headers.push(("x-api-key".to_string(), api_key.clone()));
-            }
-        }
-
-        if let Some(access_token) = credentials
-            .access_token
-            .as_ref()
-            .filter(|_| !auth_overridden)
-        {
-            headers.push((
-                "authorization".to_string(),
-                format!("Bearer {}", access_token),
-            ));
-        }
+                "x-api-key"
+            },
+        ));
 
         if let Some(org_id) = credentials.organization_id.as_ref() {
             headers.push(("OpenAI-Organization".to_string(), org_id.clone()));
         }
 
-        for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
-            headers.push((header_name.clone(), header_value.clone()));
-        }
-
-        for (header_name, header_value) in &credentials.custom_headers {
-            headers.push((header_name.clone(), header_value.clone()));
-        }
+        headers.extend(common_outbound_headers(credentials));
 
         Ok(ProxyRequest { method: args.method.clone(), url, headers, body })
     }

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -2,7 +2,7 @@ use crate::{
     ai_google::parse_data_url,
     ai_providers::{AIPlatform, AIProvider},
     image_handler::prepare_messages_for_api,
-    proxy::{add_user_to_body, resource_owns_credentials, ProxyBuildArgs, ProxyRequest},
+    proxy::{add_user_to_body, resource_replaces_credential, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{AnthropicSSEParser, SSEParser},
     types::*,
@@ -547,7 +547,12 @@ impl AnthropicQueryBuilder {
         // Exactly one auth header, matching `get_auth_headers`: Vertex takes an
         // OAuth bearer token, every other Messages endpoint takes x-api-key.
         // Endpoints in front of Anthropic reject requests carrying both.
-        let auth_overridden = resource_owns_credentials(credentials);
+        let built_in_credential = if is_vertex {
+            "authorization"
+        } else {
+            "x-api-key"
+        };
+        let auth_overridden = resource_replaces_credential(credentials, built_in_credential);
 
         if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
             if is_vertex {

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -2,7 +2,7 @@ use crate::{
     ai_google::parse_data_url,
     ai_providers::{AIPlatform, AIProvider},
     image_handler::prepare_messages_for_api,
-    proxy::{add_user_to_body, ProxyBuildArgs, ProxyRequest},
+    proxy::{add_user_to_body, credentials_overridden, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{AnthropicSSEParser, SSEParser},
     types::*,
@@ -546,8 +546,10 @@ impl AnthropicQueryBuilder {
 
         // Exactly one auth header, matching `get_auth_headers`: Vertex takes an
         // OAuth bearer token, every other Messages endpoint takes x-api-key.
-        // Gateways in front of Anthropic reject requests carrying both.
-        if let Some(api_key) = credentials.api_key.as_ref() {
+        // Endpoints in front of Anthropic reject requests carrying both.
+        let auth_overridden = credentials_overridden(credentials, &["authorization", "x-api-key"]);
+
+        if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
             if is_vertex {
                 headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
             } else {
@@ -555,7 +557,11 @@ impl AnthropicQueryBuilder {
             }
         }
 
-        if let Some(access_token) = credentials.access_token.as_ref() {
+        if let Some(access_token) = credentials
+            .access_token
+            .as_ref()
+            .filter(|_| !auth_overridden)
+        {
             headers.push((
                 "authorization".to_string(),
                 format!("Bearer {}", access_token),
@@ -958,7 +964,6 @@ mod tests {
         assert_eq!(request.url, "https://api.anthropic.com/v1/messages");
         assert_eq!(request.body, body.to_vec());
         assert!(has_header(&request.headers, "x-api-key", "api-key"));
-        // Anthropic gateways reject requests that carry both credentials.
         assert!(!request
             .headers
             .iter()
@@ -1150,6 +1155,40 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, Error::BadRequest(message) if message.contains("Missing 'model'")));
+    }
+
+    /// Endpoints that authenticate with a bearer token configure it as a resource
+    /// header; the built-in x-api-key must then step aside, since outgoing headers
+    /// are appended and both credentials would travel.
+    #[test]
+    fn resource_header_replaces_the_built_in_credential() {
+        let mut credentials = credentials(AIPlatform::Standard);
+        credentials.custom_headers = HashMap::from([(
+            "Authorization".to_string(),
+            "Bearer gateway-token".to_string(),
+        )]);
+        let builder = AnthropicQueryBuilder::new(AIProvider::Anthropic, AIPlatform::Standard);
+        let method = Method::POST;
+
+        let request = builder
+            .build_proxy_request(&ProxyBuildArgs {
+                method: &method,
+                path: "messages",
+                headers: &HeaderMap::new(),
+                body: br#"{"model":"claude-sonnet-4","messages":[]}"#,
+                credentials: &credentials,
+            })
+            .unwrap();
+
+        assert!(has_header(
+            &request.headers,
+            "Authorization",
+            "Bearer gateway-token"
+        ));
+        assert!(!request
+            .headers
+            .iter()
+            .any(|(header_name, _)| header_name.eq_ignore_ascii_case("x-api-key")));
     }
 
     #[test]

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -544,10 +544,14 @@ impl AnthropicQueryBuilder {
             }
         }
 
+        // Exactly one auth header, matching `get_auth_headers`: Vertex takes an
+        // OAuth bearer token, every other Messages endpoint takes x-api-key.
+        // Gateways in front of Anthropic reject requests carrying both.
         if let Some(api_key) = credentials.api_key.as_ref() {
-            headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
-            if !is_vertex {
-                headers.push(("X-API-Key".to_string(), api_key.clone()));
+            if is_vertex {
+                headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
+            } else {
+                headers.push(("x-api-key".to_string(), api_key.clone()));
             }
         }
 
@@ -953,12 +957,12 @@ mod tests {
         assert_eq!(request.method, Method::POST);
         assert_eq!(request.url, "https://api.anthropic.com/v1/messages");
         assert_eq!(request.body, body.to_vec());
-        assert!(has_header(
-            &request.headers,
-            "authorization",
-            "Bearer api-key"
-        ));
-        assert!(has_header(&request.headers, "X-API-Key", "api-key"));
+        assert!(has_header(&request.headers, "x-api-key", "api-key"));
+        // Anthropic gateways reject requests that carry both credentials.
+        assert!(!request
+            .headers
+            .iter()
+            .any(|(header_name, _)| header_name.eq_ignore_ascii_case("authorization")));
         assert!(has_header(
             &request.headers,
             "anthropic-version",
@@ -1176,6 +1180,6 @@ mod tests {
             request.url,
             "https://wm-test-ai.services.ai.azure.com/anthropic/v1/messages"
         );
-        assert!(has_header(&request.headers, "X-API-Key", "api-key"));
+        assert!(has_header(&request.headers, "x-api-key", "api-key"));
     }
 }

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -102,29 +102,34 @@ pub fn resource_replaces_credential(credentials: &ProviderCredentials, built_in:
     })
 }
 
-/// The credential header to send in `built_in`, or `None` when the resource
-/// supplies its own. `authorization` carries a bearer token; every other
-/// credential header carries the raw key, which holds for every provider.
+/// The credential header for an outbound request, or `None` when the resource
+/// supplies its own.
 ///
-/// A resource resolves to an api key or an OAuth token, never both, so the two
-/// are interchangeable here.
+/// An api key goes in `built_in`, the header the provider authenticates keys
+/// with. An OAuth token is always a bearer token instead, whatever header that
+/// provider's keys use — Azure OpenAI reads keys from `api-key` but Entra ID
+/// tokens only from `authorization`. `authorization` carries `Bearer <secret>`
+/// and every other credential header carries the raw secret, for every provider.
 pub fn credential_header(
     credentials: &ProviderCredentials,
     built_in: &str,
 ) -> Option<(String, String)> {
+    // `resource_replaces_credential` also matches a resource `authorization`
+    // header, so this covers the bearer case whatever `built_in` is.
     if resource_replaces_credential(credentials, built_in) {
         return None;
     }
-    let secret = credentials
-        .api_key
-        .as_ref()
-        .or(credentials.access_token.as_ref())?;
-    let value = if built_in.eq_ignore_ascii_case("authorization") {
+    let (name, secret) = match (&credentials.api_key, &credentials.access_token) {
+        (_, Some(access_token)) => ("authorization", access_token),
+        (Some(api_key), None) => (built_in, api_key),
+        (None, None) => return None,
+    };
+    let value = if name.eq_ignore_ascii_case("authorization") {
         format!("Bearer {}", secret)
     } else {
         secret.clone()
     };
-    Some((built_in.to_string(), value))
+    Some((name.to_string(), value))
 }
 
 /// The headers every outbound AI request ends with: Windmill's own, then the
@@ -275,6 +280,66 @@ mod tests {
                 "Bearer gateway-token".to_string()
             )]
         );
+    }
+
+    /// Only the header the provider authenticates keys with hands over. A
+    /// credential-shaped header a provider does not read is an ordinary header,
+    /// and suppressing the built-in credential on account of it strands the
+    /// request with no credential at all.
+    #[test]
+    fn unrelated_credential_header_keeps_the_built_in_one() {
+        let mut credentials = credentials(AIProvider::CustomAI, "https://gateway.example/openai");
+        credentials.custom_headers =
+            HashMap::from([("x-api-key".to_string(), "routing-key".to_string())]);
+        let method = Method::POST;
+
+        let request = build_openai_compatible_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: "chat/completions",
+            headers: &HeaderMap::new(),
+            body: br#"{"model":"model","messages":[]}"#,
+            credentials: &credentials,
+        })
+        .unwrap();
+
+        assert!(request
+            .headers
+            .contains(&("authorization".to_string(), "Bearer api-key".to_string())));
+        assert!(request
+            .headers
+            .contains(&("x-api-key".to_string(), "routing-key".to_string())));
+    }
+
+    /// Azure reads api keys from `api-key` but Entra ID tokens only from
+    /// `authorization`, so an OAuth resource must stay on the bearer header
+    /// whatever the provider's key header is.
+    #[test]
+    fn oauth_token_is_sent_as_a_bearer_on_azure() {
+        let mut credentials = credentials(
+            AIProvider::AzureOpenAI,
+            "https://example.openai.azure.com/openai",
+        );
+        credentials.api_key = None;
+        credentials.access_token = Some("oauth-token".to_string());
+        let method = Method::POST;
+
+        let request = build_openai_compatible_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: "chat/completions",
+            headers: &HeaderMap::new(),
+            body: br#"{"model":"deployment","messages":[]}"#,
+            credentials: &credentials,
+        })
+        .unwrap();
+
+        assert!(request.headers.contains(&(
+            "authorization".to_string(),
+            "Bearer oauth-token".to_string()
+        )));
+        assert!(!request
+            .headers
+            .iter()
+            .any(|(header_name, _)| header_name.eq_ignore_ascii_case("api-key")));
     }
 
     #[test]

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -102,6 +102,47 @@ pub fn resource_replaces_credential(credentials: &ProviderCredentials, built_in:
     })
 }
 
+/// The credential header to send in `built_in`, or `None` when the resource
+/// supplies its own. `authorization` carries a bearer token; every other
+/// credential header carries the raw key, which holds for every provider.
+///
+/// A resource resolves to an api key or an OAuth token, never both, so the two
+/// are interchangeable here.
+pub fn credential_header(
+    credentials: &ProviderCredentials,
+    built_in: &str,
+) -> Option<(String, String)> {
+    if resource_replaces_credential(credentials, built_in) {
+        return None;
+    }
+    let secret = credentials
+        .api_key
+        .as_ref()
+        .or(credentials.access_token.as_ref())?;
+    let value = if built_in.eq_ignore_ascii_case("authorization") {
+        format!("Bearer {}", secret)
+    } else {
+        secret.clone()
+    };
+    Some((built_in.to_string(), value))
+}
+
+/// The headers every outbound AI request ends with: Windmill's own, then the
+/// resource's, which come last so a resource can add to what the provider set.
+pub fn common_outbound_headers(
+    credentials: &ProviderCredentials,
+) -> impl Iterator<Item = (String, String)> + '_ {
+    AI_HTTP_HEADERS
+        .iter()
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .chain(
+            credentials
+                .custom_headers
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone())),
+        )
+}
+
 pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest> {
     let credentials = args.credentials;
     let body = if let Some(user) = credentials.user.as_ref() {
@@ -120,39 +161,16 @@ pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Resul
 
     let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
 
-    let built_in_credential = if is_azure { "api-key" } else { "authorization" };
-    let auth_overridden = resource_replaces_credential(credentials, built_in_credential);
-
-    if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
-        if is_azure {
-            headers.push(("api-key".to_string(), api_key.clone()));
-        } else {
-            headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
-        }
-    }
-
-    if let Some(access_token) = credentials
-        .access_token
-        .as_ref()
-        .filter(|_| !auth_overridden)
-    {
-        headers.push((
-            "authorization".to_string(),
-            format!("Bearer {}", access_token),
-        ));
-    }
+    headers.extend(credential_header(
+        credentials,
+        if is_azure { "api-key" } else { "authorization" },
+    ));
 
     if let Some(org_id) = credentials.organization_id.as_ref() {
         headers.push(("OpenAI-Organization".to_string(), org_id.clone()));
     }
 
-    for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
-        headers.push((header_name.clone(), header_value.clone()));
-    }
-
-    for (header_name, header_value) in &credentials.custom_headers {
-        headers.push((header_name.clone(), header_value.clone()));
-    }
+    headers.extend(common_outbound_headers(credentials));
 
     Ok(ProxyRequest { method: args.method.clone(), url, headers, body })
 }

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -82,17 +82,23 @@ pub fn supports_query_builder_proxy(provider: &AIProvider) -> bool {
     proxy_execution_mode(provider).uses_query_builder_proxy()
 }
 
-/// The headers that carry a credential on an outbound AI request.
-pub const CREDENTIAL_HEADERS: [&str; 3] = ["authorization", "x-api-key", "api-key"];
+/// The headers a provider can carry its credential in. Any other resource header
+/// is passed through untouched, so a header one provider authenticates with stays
+/// an ordinary header for the providers that do not.
+pub const CREDENTIAL_HEADERS: [&str; 4] =
+    ["authorization", "x-api-key", "api-key", "x-goog-api-key"];
 
-/// Whether the resource supplies its own credential header, in which case the
-/// built-in one must be dropped rather than added: outgoing headers are appended,
-/// not replaced, so both would travel and endpoints reject ambiguous credentials.
-pub fn resource_owns_credentials(credentials: &ProviderCredentials) -> bool {
+/// Whether a resource header takes over `built_in`, the credential header Windmill
+/// would otherwise send. Outgoing headers are appended rather than replaced, so
+/// keeping the built-in one alongside a resource-supplied credential would put two
+/// on the wire, which endpoints reject.
+///
+/// An `authorization` header always takes over, whatever `built_in` is: every
+/// endpoint reads it as the credential, so it can never coexist with another one.
+pub fn resource_replaces_credential(credentials: &ProviderCredentials, built_in: &str) -> bool {
     credentials.custom_headers.keys().any(|header_name| {
-        CREDENTIAL_HEADERS
-            .iter()
-            .any(|name| header_name.eq_ignore_ascii_case(name))
+        header_name.eq_ignore_ascii_case(built_in)
+            || header_name.eq_ignore_ascii_case("authorization")
     })
 }
 
@@ -114,7 +120,8 @@ pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Resul
 
     let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
 
-    let auth_overridden = resource_owns_credentials(credentials);
+    let built_in_credential = if is_azure { "api-key" } else { "authorization" };
+    let auth_overridden = resource_replaces_credential(credentials, built_in_credential);
 
     if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
         if is_azure {

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -82,6 +82,17 @@ pub fn supports_query_builder_proxy(provider: &AIProvider) -> bool {
     proxy_execution_mode(provider).uses_query_builder_proxy()
 }
 
+/// Whether the resource supplies its own credential header, in which case the
+/// built-in one must be dropped rather than added: outgoing headers are appended,
+/// not replaced, so both would travel and endpoints reject ambiguous credentials.
+pub(crate) fn credentials_overridden(credentials: &ProviderCredentials, names: &[&str]) -> bool {
+    credentials.custom_headers.keys().any(|header_name| {
+        names
+            .iter()
+            .any(|name| header_name.eq_ignore_ascii_case(name))
+    })
+}
+
 pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest> {
     let credentials = args.credentials;
     let body = if let Some(user) = credentials.user.as_ref() {
@@ -100,7 +111,9 @@ pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Resul
 
     let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
 
-    if let Some(api_key) = credentials.api_key.as_ref() {
+    let auth_overridden = credentials_overridden(credentials, &["authorization", "api-key"]);
+
+    if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
         if is_azure {
             headers.push(("api-key".to_string(), api_key.clone()));
         } else {
@@ -108,7 +121,11 @@ pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Resul
         }
     }
 
-    if let Some(access_token) = credentials.access_token.as_ref() {
+    if let Some(access_token) = credentials
+        .access_token
+        .as_ref()
+        .filter(|_| !auth_overridden)
+    {
         headers.push((
             "authorization".to_string(),
             format!("Bearer {}", access_token),

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -82,12 +82,15 @@ pub fn supports_query_builder_proxy(provider: &AIProvider) -> bool {
     proxy_execution_mode(provider).uses_query_builder_proxy()
 }
 
+/// The headers that carry a credential on an outbound AI request.
+pub const CREDENTIAL_HEADERS: [&str; 3] = ["authorization", "x-api-key", "api-key"];
+
 /// Whether the resource supplies its own credential header, in which case the
 /// built-in one must be dropped rather than added: outgoing headers are appended,
 /// not replaced, so both would travel and endpoints reject ambiguous credentials.
-pub(crate) fn credentials_overridden(credentials: &ProviderCredentials, names: &[&str]) -> bool {
+pub fn resource_owns_credentials(credentials: &ProviderCredentials) -> bool {
     credentials.custom_headers.keys().any(|header_name| {
-        names
+        CREDENTIAL_HEADERS
             .iter()
             .any(|name| header_name.eq_ignore_ascii_case(name))
     })
@@ -111,7 +114,7 @@ pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Resul
 
     let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
 
-    let auth_overridden = credentials_overridden(credentials, &["authorization", "api-key"]);
+    let auth_overridden = resource_owns_credentials(credentials);
 
     if let Some(api_key) = credentials.api_key.as_ref().filter(|_| !auth_overridden) {
         if is_azure {
@@ -213,6 +216,40 @@ mod tests {
         assert!(request
             .headers
             .contains(&("OpenAI-Organization".to_string(), "org-id".to_string())));
+    }
+
+    /// A resource that carries its own credential owns authentication; outgoing
+    /// headers are appended, not replaced, so the built-in one must be dropped or
+    /// two credentials reach the endpoint.
+    #[test]
+    fn resource_header_replaces_the_built_in_credential() {
+        let mut credentials = credentials(AIProvider::CustomAI, "https://gateway.example/openai");
+        credentials.custom_headers = HashMap::from([(
+            "Authorization".to_string(),
+            "Bearer gateway-token".to_string(),
+        )]);
+        let method = Method::POST;
+
+        let request = build_openai_compatible_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: "chat/completions",
+            headers: &HeaderMap::new(),
+            body: br#"{"model":"model","messages":[]}"#,
+            credentials: &credentials,
+        })
+        .unwrap();
+
+        assert_eq!(
+            request
+                .headers
+                .iter()
+                .filter(|(header_name, _)| header_name.eq_ignore_ascii_case("authorization"))
+                .collect::<Vec<_>>(),
+            vec![&(
+                "Authorization".to_string(),
+                "Bearer gateway-token".to_string()
+            )]
+        );
     }
 
     #[test]

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -24,7 +24,7 @@ use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
     providers::create_query_builder,
-    proxy::{resource_owns_credentials, CREDENTIAL_HEADERS},
+    proxy::{resource_replaces_credential, CREDENTIAL_HEADERS},
     query_builder::{BuildRequestArgs, ParsedResponse},
     types::*,
     utils::{pinned_ai_client_for, should_use_structured_output_tool, AI_HTTP_HEADERS},
@@ -978,21 +978,18 @@ pub async fn run_agent(
             let endpoint =
                 query_builder.get_endpoint(base_url, args.provider.get_model(), output_type);
             let auth_headers = query_builder.get_auth_headers(api_key, base_url, output_type);
-            // A resource that carries its own credential owns authentication; the
+            // A resource carrying its own credential owns authentication; the
             // built-in one is dropped so the two do not both reach the endpoint.
             // Non-credential headers (`anthropic-version`) stay either way.
-            let auth_headers: Vec<_> = if resource_owns_credentials(&credentials) {
-                auth_headers
-                    .into_iter()
-                    .filter(|(header_name, _)| {
-                        !CREDENTIAL_HEADERS
-                            .iter()
-                            .any(|name| header_name.eq_ignore_ascii_case(name))
-                    })
-                    .collect()
-            } else {
-                auth_headers
-            };
+            let auth_headers: Vec<_> = auth_headers
+                .into_iter()
+                .filter(|(header_name, _)| {
+                    let carries_credential = CREDENTIAL_HEADERS
+                        .iter()
+                        .any(|name| header_name.eq_ignore_ascii_case(name));
+                    !carries_credential || !resource_replaces_credential(&credentials, header_name)
+                })
+                .collect();
 
             let timeout = resolve_job_timeout(conn, &job.workspace_id, job.id, job.timeout)
                 .await

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -24,10 +24,10 @@ use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
     providers::create_query_builder,
-    proxy::{resource_replaces_credential, CREDENTIAL_HEADERS},
+    proxy::{common_outbound_headers, resource_replaces_credential, CREDENTIAL_HEADERS},
     query_builder::{BuildRequestArgs, ParsedResponse},
     types::*,
-    utils::{pinned_ai_client_for, should_use_structured_output_tool, AI_HTTP_HEADERS},
+    utils::{pinned_ai_client_for, should_use_structured_output_tool},
 };
 use windmill_common::{
     cache,
@@ -995,7 +995,7 @@ pub async fn run_agent(
                 .await
                 .0;
 
-            let resource_headers = &credentials.custom_headers;
+            let trailing_headers = common_outbound_headers(&credentials).collect::<Vec<_>>();
 
             // `endpoint` derives from the user-controlled provider base_url, so pin
             // DNS to the SSRF-validated address: the connect must not rebind to an
@@ -1013,11 +1013,7 @@ pub async fn run_agent(
                     req = req.header(*header_name, header_value.clone());
                 }
 
-                for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
-                    req = req.header(header_name.as_str(), header_value.as_str());
-                }
-
-                for (header_name, header_value) in resource_headers {
+                for (header_name, header_value) in &trailing_headers {
                     req = req.header(header_name.as_str(), header_value.as_str());
                 }
 

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -24,6 +24,7 @@ use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
     providers::create_query_builder,
+    proxy::{resource_owns_credentials, CREDENTIAL_HEADERS},
     query_builder::{BuildRequestArgs, ParsedResponse},
     types::*,
     utils::{pinned_ai_client_for, should_use_structured_output_tool, AI_HTTP_HEADERS},
@@ -977,6 +978,21 @@ pub async fn run_agent(
             let endpoint =
                 query_builder.get_endpoint(base_url, args.provider.get_model(), output_type);
             let auth_headers = query_builder.get_auth_headers(api_key, base_url, output_type);
+            // A resource that carries its own credential owns authentication; the
+            // built-in one is dropped so the two do not both reach the endpoint.
+            // Non-credential headers (`anthropic-version`) stay either way.
+            let auth_headers: Vec<_> = if resource_owns_credentials(&credentials) {
+                auth_headers
+                    .into_iter()
+                    .filter(|(header_name, _)| {
+                        !CREDENTIAL_HEADERS
+                            .iter()
+                            .any(|name| header_name.eq_ignore_ascii_case(name))
+                    })
+                    .collect()
+            } else {
+                auth_headers
+            };
 
             let timeout = resolve_job_timeout(conn, &job.workspace_id, job.id, job.timeout)
                 .await


### PR DESCRIPTION
## Summary

An AI resource pointing at an OpenAI-compatible or Anthropic-compatible gateway (rather than the vendor's own API) works in an AI agent flow step but is rejected with `Unauthorized` when the same resource is used for the workspace/instance AI settings. The two paths build their requests differently, and only the proxy path sends credentials in a shape gateways reject.

Reproduced against a live gateway with `base_url` `https://<gateway>/proxy/openai` and `https://<gateway>/proxy/anthropic/v1`:

| Provider | Before | After |
|---|---|---|
| OpenAI | `401 Unauthorized - Missing Authorization Header` | `200` |
| Anthropic | `401 Unauthorized - Both Authorization and X-API-Key headers are set, use only one` | `200` |

**OpenAI** — `is_azure` classified *any* base URL other than `https://api.openai.com/v1` as Azure, so a gateway received the Azure `api-key` header instead of `Authorization: Bearer`, plus an `/openai/v1/`-rewritten path (a 404 on its own once auth is fixed). The agent-step path never had this problem because `OpenAIQueryBuilder` always sends bearer auth.

**Anthropic** — the proxy sent `authorization: Bearer <key>` *and* `X-API-Key: <key>`. Gateways reject ambiguous credentials. `get_auth_headers` (the agent-step path) already sends exactly one; the proxy now matches it.

## Changes

- `is_azure` matches the endpoint instead of "base URL differs from the default": Azure-owned host suffixes (including sovereign clouds and API Management) or the `/openai/deployments` path that `openai_azure_base_path` documents, so Azure OpenAI behind a custom domain keeps its current treatment.
- `build_anthropic_proxy_request` sends one credential header: bearer for Vertex, `x-api-key` everywhere else.
- A resource that sets its own `authorization`/`x-api-key`/`api-key` header now suppresses the built-in one, on **both** the proxy and the agent-step path. Outgoing headers are appended, not replaced, so a user-supplied auth header previously produced two credentials on the wire; this is the escape hatch for an Anthropic-compatible endpoint that wants bearer auth. Non-credential headers such as `anthropic-version` are unaffected.

### Known limitations

Both are the deliberate cost of having no rule that separates an Azure endpoint from a gateway by URL alone. A resource in either situation should use the `customai` / `azure_openai` provider as appropriate.

- An OpenAI-compatible endpoint hosted *on* an Azure-owned domain (e.g. a self-hosted server behind API Management) is still read as Azure. Unchanged from before.
- **Behavior change on upgrade:** an `openai_azure_base_path` (or OpenAI-resource `base_url`) pointing at Azure OpenAI through a customer-owned domain *without* the `/openai/deployments` path — e.g. `https://ai.corp.example/openai/v1` — now gets bearer auth and the plain path instead of `api-key` + Azure URL building. The repro gateway's URL ends in `/openai`, so no path rule distinguishes the two.

## Test plan

- [x] `cargo test -p windmill-ai` (99 pass), `cargo check`, `cargo fmt --check` on the touched crates
- [x] End-to-end against a live gateway through `POST /api/w/<ws>/ai/proxy/...`: both providers 401 before the change and 200 after, with fresh (non-cached) completions
- [x] Workspace settings → Windmill AI → "Test key" for both providers in the browser: `POST /ai/proxy/responses`, `POST /ai/proxy/v1/messages` and `GET /ai/proxy/models` all 200
- [ ] Regression check by a reviewer with Azure access, since `is_azure` also feeds the agent-step chat-completions builder (`other.rs`) — exercise each in **both** workspace settings and an AI agent step:
  - [ ] Azure OpenAI, bare-host base and `…/openai/deployments/<id>` base: still resolves to the `/openai/v1` (or deployment) URL with the `api-key` header
  - [ ] Azure AI Foundry serving Claude: `POST /ai/proxy/v1/messages` still completes now that only `x-api-key` is sent (bearer is no longer sent alongside it)