### PR TITLE
fix: loop "Test an iteration" progress bar, while-loop modules and schema

### DIFF
--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -34,16 +34,16 @@
 		properties: {
 			iter: {
 				type: 'object',
-				description: 'The iteration to simulate, exposed to the steps below as flow_input.iter',
+				description: 'The loop iterator, exposed to the steps below as flow_input.iter',
 				properties: {
 					index: {
 						type: 'integer',
 						min: 0,
-						description: 'Position in the iterated list. The first iteration is 0.'
+						description: "Position in the iterator's sequence. The first iteration is 0."
 					},
 					value: {
 						type: 'object',
-						description: 'The item of the iterated list this iteration receives.'
+						description: "The element of the iterator's sequence this iteration receives."
 					}
 				}
 			}
@@ -57,13 +57,13 @@
 		properties: {
 			iter: {
 				type: 'object',
-				description: 'The iteration to simulate, exposed to the steps below as flow_input.iter',
+				description: 'The loop iterator, exposed to the steps below as flow_input.iter',
 				properties: {
 					index: {
 						type: 'integer',
 						min: 0,
 						description:
-							'How many iterations have already run. The first iteration is 0. A while loop sets iter.value to this same number.'
+							'How many iterations have already run. The first iteration is 0. A while loop has no sequence, so it sets iter.value to this same number.'
 					}
 				}
 			}
@@ -72,7 +72,7 @@
 		type: 'object'
 	}
 
-	// A real while-loop iteration always sets iter.value to iter.index, and the first one runs
+	// A real while loop always sets iter.value to iter.index, and its first iteration runs
 	// at index 0. The preview flow holds only the loop body, so nothing else supplies that
 	// context: mirror the value and default the index so a preview matches an actual run.
 	function withWhileLoopIter(args: Record<string, any>): Record<string, any> {

--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -64,6 +64,13 @@
 		type: 'object'
 	}
 
+	// A real while-loop iteration sets iter.value to the iteration index, so the form only
+	// asks for the index and mirrors it here — an editable value could not occur in a run.
+	function withWhileLoopIterValue(args: Record<string, any>): Record<string, any> {
+		const iter = args.iter
+		return iter ? { ...args, iter: { ...iter, value: iter.index } } : args
+	}
+
 	let selectedJobStep: string | undefined = $state(undefined)
 
 	let isRunning: boolean = $state(false)
@@ -84,7 +91,7 @@
 		progressBar?.reset()
 		const newFlow = { value: { modules }, summary: '' }
 		jobId = await runFlowPreview(
-			args,
+			whileLoop ? withWhileLoopIterValue(args) : args,
 			newFlow,
 			$pathStore,
 			restartedFrom,

--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -64,11 +64,12 @@
 		type: 'object'
 	}
 
-	// A real while-loop iteration sets iter.value to the iteration index, so the form only
-	// asks for the index and mirrors it here — an editable value could not occur in a run.
-	function withWhileLoopIterValue(args: Record<string, any>): Record<string, any> {
-		const iter = args.iter
-		return iter ? { ...args, iter: { ...iter, value: iter.index } } : args
+	// A real while-loop iteration always sets iter.value to iter.index, and the first one runs
+	// at index 0. The preview flow holds only the loop body, so nothing else supplies that
+	// context: mirror the value and default the index so a preview matches an actual run.
+	function withWhileLoopIter(args: Record<string, any>): Record<string, any> {
+		const index = args.iter?.index ?? 0
+		return { ...args, iter: { ...args.iter, index, value: index } }
 	}
 
 	let selectedJobStep: string | undefined = $state(undefined)
@@ -91,7 +92,7 @@
 		progressBar?.reset()
 		const newFlow = { value: { modules }, summary: '' }
 		jobId = await runFlowPreview(
-			whileLoop ? withWhileLoopIterValue(args) : args,
+			whileLoop ? withWhileLoopIter(args) : args,
 			newFlow,
 			$pathStore,
 			restartedFrom,

--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -169,9 +169,11 @@
 		{/if}
 		<div></div>
 	</div>
-	<div class="w-full flex flex-col gap-y-1">
-		<FlowProgressBar {job} bind:this={progressBar} />
-	</div>
+	{#if jobId}
+		<div class="w-full flex flex-col gap-y-1">
+			<FlowProgressBar {job} bind:this={progressBar} />
+		</div>
+	{/if}
 	<div class="overflow-y-auto grow pr-4">
 		<div class="max-h-1/2 overflow-auto border-b">
 			<SchemaForm

--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -72,11 +72,11 @@
 		type: 'object'
 	}
 
-	// A real while loop always sets iter.value to iter.index, and its first iteration runs
-	// at index 0. The preview flow holds only the loop body, so nothing else supplies that
-	// context: mirror the value and default the index so a preview matches an actual run.
+	// A real while loop always sets iter.value to iter.index, and counts whole iterations from
+	// 0. The preview flow holds only the loop body, so nothing else supplies that context:
+	// mirror the value and clamp to a whole, non-negative index so a preview matches a run.
 	function withWhileLoopIter(args: Record<string, any>): Record<string, any> {
-		const index = args.iter?.index ?? 0
+		const index = Math.max(0, Math.floor(args.iter?.index ?? 0))
 		return { ...args, iter: { ...args.iter, index, value: index } }
 	}
 

--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -34,12 +34,16 @@
 		properties: {
 			iter: {
 				type: 'object',
+				description: 'The iteration to simulate, exposed to the steps below as flow_input.iter',
 				properties: {
 					index: {
-						type: 'number'
+						type: 'integer',
+						min: 0,
+						description: 'Position in the iterated list. The first iteration is 0.'
 					},
 					value: {
-						type: 'object'
+						type: 'object',
+						description: 'The item of the iterated list this iteration receives.'
 					}
 				}
 			}
@@ -53,9 +57,13 @@
 		properties: {
 			iter: {
 				type: 'object',
+				description: 'The iteration to simulate, exposed to the steps below as flow_input.iter',
 				properties: {
 					index: {
-						type: 'number'
+						type: 'integer',
+						min: 0,
+						description:
+							'How many iterations have already run. The first iteration is 0. A while loop sets iter.value to this same number.'
 					}
 				}
 			}

--- a/frontend/src/lib/components/flows/content/FlowWhileLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowWhileLoop.svelte
@@ -49,9 +49,10 @@
 
 <Drawer bind:open={previewOpen} alwaysOpen size="75%">
 	<FlowLoopIterationPreview
-		modules={mod.value.type == 'forloopflow' ? mod.value.modules : []}
+		modules={mod.value.type == 'whileloopflow' ? mod.value.modules : []}
 		open={previewOpen}
 		previewArgs={previewIterationArgs}
+		whileLoop
 		bind:job
 		bind:jobId
 		on:close={() => {


### PR DESCRIPTION
## Summary

Three fixes to the "Test an iteration" drawer on loop steps in the flow editor.

**1. Progress bar showed a loader before anything ran.** `FlowLoopIterationPreview` rendered `<FlowProgressBar>` unconditionally. With no job, `FlowProgressBar` falls back to `index=0, length=1`, and `ProgressBar` derives `finished = index == length` → `false` → status `running`, so it painted a spinner and `Step 1 — 0%` for a run that did not exist. Now gated on `jobId`, matching what `FlowPreviewContent.svelte` already does for the full-flow preview drawer.

**2. While-loop iterations ran no steps.** `FlowWhileLoop.svelte` passed `modules={mod.value.type == 'forloopflow' ? mod.value.modules : []}`. A while loop's value type is `whileloopflow`, so this branch was dead and the preview always ran an empty module list — "Test an iteration" silently did nothing.

**3. While loops showed the for-loop argument schema.** The `whileLoop` prop was never passed at that call site, so the drawer rendered `forloopSchema`, which has an `iter.value` field. `whileLoop` and `whileLoopSchema` already existed in the component but were unreachable.

Fixing (2) is what makes the while-loop preview actually execute steps, which in turn makes the `iter.value` divergence reachable: `worker_flow.rs:5278-5281` sets `value` to the iteration index for while loops, so a body step reading `flow_input.iter.value` would see `undefined` in the preview where a real run gives a number. `runPreview` now supplies that context for while loops: it mirrors `value` from `index` rather than exposing an editable field (in a real run the two are always equal, so a separate field could reach a state a run cannot), and defaults the index to `0` so a fresh drawer matches a real first iteration.

## Changes

- `FlowLoopIterationPreview.svelte`: wrap `<FlowProgressBar>` in `{#if jobId}`
- `FlowWhileLoop.svelte`: compare against `'whileloopflow'` so the loop's own modules reach the preview; pass `whileLoop` so the while-loop schema is used
- `FlowLoopIterationPreview.svelte`: mirror `iter.value` from `iter.index` when previewing a while-loop iteration
- `FlowLoopIterationPreview.svelte`: describe the `iter` fields and declare `index` as a non-negative integer (`type: 'integer'`, `min: 0`) on both loop schemas

`progressBar?.reset()` is unaffected by the gating: on the first run there is nothing to reset (a freshly mounted bar is already in the reset state), and on every later run `jobId` is already set, so the bar is mounted and `reset()` runs for real.

## Screenshots

**Progress bar** — before, drawer just opened with nothing run:

![before-drawer-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785158225-before-drawer-open.png)

After — no bar until a run exists:

![after-drawer-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785158225-after-drawer-open.png)

After — bar appears and tracks the run:

![after-drawer-run](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785158225-after-drawer-run.png)

**While loop** — before: for-loop schema (`iter.value` present) and the loop's step never runs, result is just `{"iter": {"value": null}}`:

![before-whileloop-run](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785158967-before-whileloop-run.png)

After — while-loop schema, `iter.index` only:

![after-whileloop-schema](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785158967-after-whileloop-schema.png)

After — the loop's inner step actually executes:

![after-whileloop-run](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785158967-after-whileloop-run.png)

Field descriptions in the drawer:

![iter-descriptions](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-test-loop/1785163298-after-iter-descriptions.png)

## Test plan

- [x] For-loop → "Test an iteration": drawer shows only the `iter` form and the status placeholder, no progress bar, no spinner
- [x] Click "Test iteration": bar appears and reaches `Done / 100%`
- [x] Click "Test iteration" a second time: bar drops from `Done 100%` back to `Step 1 — 0%` and tracks the new job, confirming `reset()` still fires
- [x] While-loop → "Test an iteration": drawer opens with no progress bar and the `iter.index`-only schema
- [x] While-loop iteration executes the loop's inner steps (verified a Bun step running in 0.198s; previously nothing ran)
- [x] Preview request body inspected — well-formed with the mirroring in place
- [x] `npm run check:fast` passes

- [x] Fresh while-loop drawer sends `args: {"iter":{"index":0,"value":0}}` — verified by capturing the preview request body, matching what a real first iteration supplies
- [x] Typing `5` into the index sends `args: {"iter":{"index":5,"value":5}}` — non-zero mirroring verified end-to-end
- [x] `iter` field descriptions render on both loop types, and `min: 0` reaches the input (`validity.rangeUnderflow` on a negative index)

Known limitation, pre-existing and not introduced here: the schema `min: 0` sets the native browser constraint (`validity.rangeUnderflow` is `true` on a negative index) but no visible error message appears, and nothing blocks the run.

Instrumenting `ArgInput.validateInput` shows it runs only at mount (`v: undefined`, `error: ''`) and not again when the value changes — reproduced on a fresh load and with a top-level probe property to rule out nesting and stale HMR. So `error` is never assigned, and schema `min`/`max` messages are inert for `SchemaForm` number fields generally, not just this one. `type: 'integer'` is declarative for the same reason: no `step="1"` is forwarded, so a fractional index is typable.

I have not diagnosed *why* that effect fails to re-run, so I am not asserting how broad the correct fix is. Either way it is an `ArgInput` change whose `valid` output feeds form-validity gating elsewhere, so it belongs in its own PR rather than this one.


