### PR TITLE
fix(cli): resolve module script metadata on windows path separators

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -262,6 +262,20 @@ export async function findResourceFile(path: string) {
   return validCandidates[0];
 }
 
+// The separator is whatever the local filesystem uses, so both are accepted:
+// on Windows these paths reach us as `my_script__mod\script.yaml`.
+const MODULE_ENTRY_META_RE = /([\\/])script\.(yaml|json|lock)$/;
+
+/**
+ * Whether a path is a module folder's own metadata file (`__mod/script.yaml`).
+ * `isModuleEntryPoint` already pins the file to `script.*` directly under
+ * `__mod/`, so this only narrows it to the metadata extensions: a `script.yaml`
+ * nested deeper in the module tree is a module file, not the script's metadata.
+ */
+function isModuleEntryMetadata(p: string): boolean {
+  return isModuleEntryPoint(p) && MODULE_ENTRY_META_RE.test(p);
+}
+
 export async function handleScriptMetadata(
   path: string,
   workspace: Workspace,
@@ -276,14 +290,7 @@ export async function handleScriptMetadata(
   const isFlatMeta = path.endsWith(".script.json") ||
     path.endsWith(".script.yaml") ||
     path.endsWith(".script.lock");
-  // Folder layout: my_script__mod/script.yaml. Only the entry point counts —
-  // a script.yaml nested deeper in the module tree is a module file, not the
-  // script's metadata.
-  const isFolderMeta = !isFlatMeta && isModuleEntryPoint(path) && (
-    path.endsWith("/script.yaml") ||
-    path.endsWith("/script.json") ||
-    path.endsWith("/script.lock")
-  );
+  const isFolderMeta = !isFlatMeta && isModuleEntryMetadata(path);
   if (isFlatMeta || isFolderMeta) {
     const contentPath = await findContentFile(path);
     return handleFile(
@@ -884,12 +891,10 @@ export class UnresolvableScriptContentFileError extends Error {}
 
 export async function findContentFile(filePath: string) {
   // Folder layout: __mod/script.yaml -> __mod/script.ts
-  const isModuleFolderMeta =
-    isModuleEntryPoint(filePath) &&
-    (filePath.endsWith("/script.yaml") || filePath.endsWith("/script.json") || filePath.endsWith("/script.lock"));
+  const isModuleFolderMeta = isModuleEntryMetadata(filePath);
   const toCandidate = (ext: string) =>
     isModuleFolderMeta
-      ? filePath.replace(/\/script\.(yaml|json|lock)$/, "/script" + ext)
+      ? filePath.replace(MODULE_ENTRY_META_RE, "$1script" + ext)
       : filePath.endsWith("script.json")
       ? filePath.replace(".script.json", ext)
       : filePath.endsWith("script.lock")

--- a/cli/test/script_modules_unit.test.ts
+++ b/cli/test/script_modules_unit.test.ts
@@ -350,6 +350,19 @@ describe("findContentFile", () => {
     );
   });
 
+  // `isModuleEntryPoint` treats `\` as a separator on every platform, so
+  // findContentFile must too or it rejects every Windows module path. Runnable
+  // on POSIX because there the backslash is merely part of the file name.
+  test("resolves a module entry point written with a backslash separator", async () => {
+    const meta = path.join(tempDir, "my_script__mod") + "\\script.yaml";
+    const content = path.join(tempDir, "my_script__mod") + "\\script.ts";
+    fs.mkdirSync(path.dirname(meta), { recursive: true });
+    fs.writeFileSync(content, "export async function main() {}\n");
+    fs.writeFileSync(meta, "summary: ''\n");
+
+    expect(await findContentFile(meta)).toBe(content);
+  });
+
   // sync push catches UnresolvableScriptContentFileError to record the change as
   // failed and carry on; any other error aborts the whole push, so every branch
   // that simply cannot pair a metadata file with one script file must use it.

--- a/cli/test/sync_push_script_metadata_only.test.ts
+++ b/cli/test/sync_push_script_metadata_only.test.ts
@@ -74,7 +74,8 @@ test(
         tempDir,
       );
       expect(result.code).toBe(1);
-      expect(result.stdout + result.stderr).toContain(
+      // The push echoes local paths with the platform separator (`\` on Windows).
+      expect((result.stdout + result.stderr).replaceAll("\\", "/")).toContain(
         "f/test/orphan.script.yaml",
       );
 


### PR DESCRIPTION
## Summary

The `test-windows` job of `.github/workflows/cli-tests.yml` has been red on `main` since cdd8718a93 (#10353), which merged with the job already failing. Two tests fail, and only on Windows.

`findContentFile` decided a path was module-folder metadata with `filePath.endsWith("/script.yaml")`, but local paths on Windows arrive as `my_script__mod\script.yaml`. `isModuleEntryPoint` normalizes `\` to `/` and so already returned `true` for those paths, so the two predicates disagreed — and the "not a script metadata file" guard added by #10353 turned that disagreement into a throw.

That is a real Windows regression, not just a red test: since #10353 routes added `.script.yaml` changes through `handleScriptMetadata`, an added or edited `__mod\script.yaml` is now reported as an unpushable failed change and `sync push` exits 1.

The second failure is an over-specific assertion: `sync push` echoes local paths with the platform separator (`f\test\orphan.script.yaml`), as it already does for every other change line.

## Changes

- Extract `isModuleEntryMetadata`, backed by `/([\\/])script\.(yaml|json|lock)$/`, and use it in both `findContentFile` and `handleScriptMetadata` — which carried the same hardcoded `/`. The candidate-path rewrite reuses the captured separator instead of forcing `/`.
- Add a `findContentFile` regression test that feeds a backslash-separated module entry point. It runs on both platforms: on POSIX the backslash is just part of the file name, and `isModuleEntryPoint` treats it as a separator regardless.
- Normalize separators in the `sync push` failure assertion.

## Test plan

- [x] New unit test reproduces the exact Windows error on Linux (verified failing with the source fix reverted) and passes with it
- [x] `bun test test/sync_push_script_metadata_only.test.ts` — 2/2 against a real backend
- [x] Full CLI unit suite — 980/980
- [x] `bunx tsc --noEmit` — no new errors (6 pre-existing, none in touched files)
- [ ] `test-windows` job green on this PR (the only check that exercises the actual failure)

No frontend changes, so no screenshots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows-only regression where module script metadata paths with backslashes were misidentified. `__mod\script.yaml` is now detected correctly, `findContentFile` resolves the content file, and `sync push` no longer fails.

- **Bug Fixes**
  - Added `isModuleEntryMetadata` using `/([\\/])script\.(yaml|json|lock)$/` and applied it in both `findContentFile` and `handleScriptMetadata`.
  - Rewrites keep the original path separator when mapping metadata to content files.
  - Added a regression test for backslash-separated module paths and normalized separators in a `sync push` assertion.

<sup>Written for commit ed575856faef8236088d11f58eaa652095119d7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

