### PR TITLE
fix(ai): make the proxy and the AI agent step read a resource the same way

### DIFF
--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -224,6 +224,22 @@ impl AIProvider {
         }
     }
 
+    /// Build an Anthropic Messages API URL. The API lives under `<root>/v1/`, but a
+    /// resource may store the base URL with or without that `/v1` and a caller may
+    /// pass the path with or without it (the Anthropic SDK sends `v1/messages`,
+    /// `get_endpoint` asks for `messages`). Both forms resolve to the same endpoint
+    /// so a resource reads the same way from the proxy and from an agent step.
+    ///
+    /// This assumes the API is served under `/v1`, as api.anthropic.com and the
+    /// gateways in front of it are.
+    pub fn build_anthropic_api_url(base_url: &str, path: &str) -> String {
+        let base_url = base_url.trim_end_matches('/');
+        let root = base_url.strip_suffix("/v1").unwrap_or(base_url);
+        let path = path.trim_start_matches('/');
+        let path = path.strip_prefix("v1/").unwrap_or(path);
+        format!("{}/v1/{}", root.trim_end_matches('/'), path)
+    }
+
     /// Whether the URL is a bare scheme+host with no path component, e.g.
     /// `https://x.services.ai.azure.com` (vs `https://x.openai.azure.com/openai/deployments/y`).
     fn is_bare_host(url: &str) -> bool {

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -497,7 +497,6 @@ impl AnthropicQueryBuilder {
 
         let base_url = credentials.base_url.trim_end_matches('/');
         let is_vertex = self.is_vertex();
-        let is_anthropic_sdk = args.headers.get("X-Anthropic-SDK").is_some();
 
         let (url, body) = if is_vertex && *args.method != Method::GET {
             let (model, transformed_body) = Self::transform_proxy_body_for_vertex(&body)?;
@@ -514,11 +513,11 @@ impl AnthropicQueryBuilder {
                 AIProvider::build_azure_foundry_anthropic_url(base_url, path),
                 body,
             )
-        } else if is_anthropic_sdk {
-            let truncated_base_url = base_url.trim_end_matches("/v1");
-            (format!("{}/{}", truncated_base_url, args.path), body)
         } else {
-            (format!("{}/{}", base_url, args.path), body)
+            (
+                AIProvider::build_anthropic_api_url(base_url, args.path),
+                body,
+            )
         };
 
         let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
@@ -784,7 +783,7 @@ impl QueryBuilder for AnthropicQueryBuilder {
         } else if self.is_azure_foundry() {
             AIProvider::build_azure_foundry_anthropic_url(base_url, "messages")
         } else {
-            format!("{}/messages", base_url)
+            AIProvider::build_anthropic_api_url(base_url, "messages")
         }
     }
 
@@ -1184,7 +1183,6 @@ mod tests {
         let method = Method::POST;
         let mut headers = HeaderMap::new();
         headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
-        headers.insert("X-Anthropic-SDK", HeaderValue::from_static("true"));
 
         let request = builder
             .build_proxy_request(&ProxyBuildArgs {

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -41,3 +41,255 @@ pub fn create_query_builder(
         _ => Box::new(OtherQueryBuilder::new(credentials.provider.clone())),
     }
 }
+
+/// The proxy (workspace/instance AI settings) and the query builder (AI agent step)
+/// each derive the endpoint and the credential header for the same resource. They
+/// must agree, or a resource authenticates in one and 401s in the other.
+#[cfg(test)]
+mod parity_tests {
+    use super::*;
+    use crate::proxy::{
+        credential_header, proxy_execution_mode, retain_effective_credentials, ProxyBuildArgs,
+        ProxyExecutionMode, CREDENTIAL_HEADERS,
+    };
+    use crate::types::OutputType;
+    use http::{HeaderMap, Method};
+    use std::collections::HashMap;
+
+    struct ParityCase {
+        provider: AIProvider,
+        platform: AIPlatform,
+        base_url: &'static str,
+        model: &'static str,
+        /// The path the client SDK sends for the endpoint the query builder targets.
+        proxy_path: &'static str,
+    }
+
+    fn case(
+        provider: AIProvider,
+        base_url: &'static str,
+        model: &'static str,
+        proxy_path: &'static str,
+    ) -> ParityCase {
+        ParityCase { provider, platform: AIPlatform::Standard, base_url, model, proxy_path }
+    }
+
+    fn credentials(kase: &ParityCase) -> ProviderCredentials {
+        ProviderCredentials {
+            provider: kase.provider.clone(),
+            base_url: kase.base_url.to_string(),
+            api_key: Some("secret".to_string()),
+            access_token: None,
+            organization_id: None,
+            user: None,
+            region: None,
+            aws_access_key_id: None,
+            aws_secret_access_key: None,
+            aws_session_token: None,
+            platform: kase.platform.clone(),
+            custom_headers: HashMap::new(),
+        }
+    }
+
+    fn only_credentials<I: IntoIterator<Item = (String, String)>>(
+        headers: I,
+    ) -> Vec<(String, String)> {
+        let mut found = headers
+            .into_iter()
+            .filter(|(name, _)| {
+                CREDENTIAL_HEADERS
+                    .iter()
+                    .any(|credential| name.eq_ignore_ascii_case(credential))
+            })
+            .map(|(name, value)| (name.to_ascii_lowercase(), value))
+            .collect::<Vec<_>>();
+        found.sort();
+        found
+    }
+
+    fn cases() -> Vec<ParityCase> {
+        vec![
+            case(
+                AIProvider::Anthropic,
+                "https://api.anthropic.com/v1",
+                "claude-sonnet-5",
+                "v1/messages",
+            ),
+            // A gateway base URL without the `/v1` must resolve the same way in both.
+            case(
+                AIProvider::Anthropic,
+                "https://gateway.example/proxy/anthropic",
+                "claude-sonnet-5",
+                "v1/messages",
+            ),
+            ParityCase {
+                provider: AIProvider::Anthropic,
+                platform: AIPlatform::GoogleVertexAi,
+                base_url: "https://europe-west1-aiplatform.googleapis.com/v1/projects/p/locations/europe-west1/publishers/anthropic/models",
+                model: "claude-sonnet-5",
+                proxy_path: "v1/messages",
+            },
+            case(
+                AIProvider::AzureFoundry,
+                "https://example.services.ai.azure.com",
+                "claude-sonnet-5",
+                "v1/messages",
+            ),
+            case(
+                AIProvider::AzureOpenAI,
+                "https://example.openai.azure.com/openai",
+                "gpt-4o",
+                "chat/completions",
+            ),
+            case(
+                AIProvider::OpenAI,
+                "https://api.openai.com/v1",
+                "gpt-5.6-terra",
+                "responses",
+            ),
+            // An OpenAI-compatible gateway keeps bearer auth and the plain path.
+            case(
+                AIProvider::OpenAI,
+                "https://gateway.example/proxy/openai",
+                "gpt-5.6-terra",
+                "responses",
+            ),
+            // An OpenAI resource pointed at Azure through `openai_azure_base_path`.
+            case(
+                AIProvider::OpenAI,
+                "https://example.openai.azure.com/openai/deployments/gpt-4o",
+                "gpt-4o",
+                "responses",
+            ),
+            case(
+                AIProvider::CustomAI,
+                "https://litellm.example/v1",
+                "gpt-4o",
+                "chat/completions",
+            ),
+            // A base URL stored with a trailing slash must not double it.
+            case(
+                AIProvider::CustomAI,
+                "https://litellm.example/v1/",
+                "gpt-4o",
+                "chat/completions",
+            ),
+            case(
+                AIProvider::OpenRouter,
+                "https://openrouter.ai/api/v1",
+                "anthropic/claude-sonnet-5",
+                "chat/completions",
+            ),
+        ]
+    }
+
+    /// The agent step assembles credential headers itself (`ai_executor`), so the
+    /// rule it applies must match `credential_header`: the built-in credential is
+    /// dropped when the resource carries its own and when there is no key at all,
+    /// and an empty credential never goes out.
+    #[test]
+    fn both_paths_agree_on_when_the_built_in_credential_is_dropped() {
+        let mut kase = case(
+            AIProvider::CustomAI,
+            "https://gateway.example/v1",
+            "gpt-4o",
+            "chat/completions",
+        );
+        kase.platform = AIPlatform::Standard;
+
+        for (api_key, resource_header) in [
+            // Keyless endpoint: no credential from either path.
+            (None, None),
+            // Resource carries its own: only that one travels.
+            (None, Some(("x-api-key", "resource-key"))),
+            (Some("secret"), Some(("Authorization", "Bearer resource"))),
+            // Nothing to defer to: the built-in credential travels.
+            (Some("secret"), None),
+        ] {
+            let mut credentials = credentials(&kase);
+            credentials.api_key = api_key.map(str::to_string);
+            if let Some((name, value)) = resource_header {
+                credentials.custom_headers = HashMap::from([(name.to_string(), value.to_string())]);
+            }
+            let label = format!("api_key={api_key:?} resource_header={resource_header:?}");
+
+            let from_proxy = credential_header(&credentials, "authorization");
+            let from_agent_step = agent_step_credential(&credentials, &kase);
+
+            assert_eq!(
+                from_proxy, from_agent_step,
+                "{label}: proxy and agent step disagree on the built-in credential"
+            );
+            assert!(
+                from_agent_step
+                    .as_ref()
+                    .is_none_or(|(_, value)| value != "Bearer "),
+                "{label}: an empty credential must not be sent"
+            );
+        }
+    }
+
+    /// The credential the agent step is left with, through the same helper it uses.
+    fn agent_step_credential(
+        credentials: &ProviderCredentials,
+        kase: &ParityCase,
+    ) -> Option<(String, String)> {
+        let built = create_query_builder(credentials, kase.model).get_auth_headers(
+            credentials.api_key.as_deref().unwrap_or(""),
+            &credentials.base_url,
+            &OutputType::Text,
+        );
+        only_credentials(
+            retain_effective_credentials(credentials, built)
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), value)),
+        )
+        .pop()
+    }
+
+    #[test]
+    fn both_paths_agree_on_endpoint_and_credential() {
+        for kase in cases() {
+            let credentials = credentials(&kase);
+            let builder = create_query_builder(&credentials, kase.model);
+            let label = format!("{:?} {:?} {}", kase.provider, kase.platform, kase.base_url);
+
+            assert_eq!(
+                proxy_execution_mode(&kase.provider),
+                ProxyExecutionMode::HttpForward,
+                "{label}: only forwarded providers have both paths to compare"
+            );
+
+            let headers = HeaderMap::new();
+            // Vertex reads the model from the body to build its URL, so the body must
+            // name the same model the query builder is given.
+            let body = format!(r#"{{"model":"{}","messages":[]}}"#, kase.model);
+            let args = ProxyBuildArgs {
+                method: &Method::POST,
+                path: kase.proxy_path,
+                headers: &headers,
+                body: body.as_bytes(),
+                credentials: &credentials,
+            };
+            let proxied = builder
+                .build_proxy_request(&args)
+                .unwrap_or_else(|e| panic!("{label}: proxy request failed: {e}"));
+
+            assert_eq!(
+                builder.get_endpoint(&credentials.base_url, kase.model, &OutputType::Text),
+                proxied.url,
+                "{label}: agent step and proxy disagree on the endpoint"
+            );
+
+            let from_builder = builder
+                .get_auth_headers("secret", &credentials.base_url, &OutputType::Text)
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), value));
+            assert_eq!(
+                only_credentials(from_builder),
+                only_credentials(proxied.headers),
+                "{label}: agent step and proxy disagree on the credential header"
+            );
+        }
+    }
+}

--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -229,7 +229,6 @@ pub enum ToolChoice {
 }
 
 pub struct OpenAIQueryBuilder {
-    #[allow(dead_code)]
     provider_kind: AIProvider,
 }
 
@@ -578,16 +577,25 @@ impl QueryBuilder for OpenAIQueryBuilder {
     }
 
     fn get_endpoint(&self, base_url: &str, _model: &str, _output_type: &OutputType) -> String {
-        format!("{}/responses", base_url)
+        let base_url = base_url.trim_end_matches('/');
+        if self.provider_kind.is_azure(base_url) {
+            AIProvider::build_azure_openai_url(base_url, "responses")
+        } else {
+            format!("{}/responses", base_url)
+        }
     }
 
     fn get_auth_headers(
         &self,
         api_key: &str,
-        _base_url: &str,
+        base_url: &str,
         _output_type: &OutputType,
     ) -> Vec<(&'static str, String)> {
-        vec![("Authorization", format!("Bearer {}", api_key))]
+        if self.provider_kind.is_azure(base_url) {
+            vec![("api-key", api_key.to_string())]
+        } else {
+            vec![("Authorization", format!("Bearer {}", api_key))]
+        }
     }
 }
 

--- a/backend/windmill-ai/src/providers/openrouter.rs
+++ b/backend/windmill-ai/src/providers/openrouter.rs
@@ -143,6 +143,7 @@ impl QueryBuilder for OpenRouterQueryBuilder {
     }
 
     fn get_endpoint(&self, base_url: &str, _model: &str, _output_type: &OutputType) -> String {
+        let base_url = base_url.trim_end_matches('/');
         format!("{}/chat/completions", base_url)
     }
 

--- a/backend/windmill-ai/src/providers/other.rs
+++ b/backend/windmill-ai/src/providers/other.rs
@@ -286,6 +286,7 @@ impl QueryBuilder for OtherQueryBuilder {
     }
 
     fn get_endpoint(&self, base_url: &str, _model: &str, _output_type: &OutputType) -> String {
+        let base_url = base_url.trim_end_matches('/');
         if self.provider_kind.is_azure(base_url) {
             AIProvider::build_azure_openai_url(base_url, "chat/completions")
         } else {

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -132,6 +132,53 @@ pub fn credential_header(
     Some((name.to_string(), value))
 }
 
+/// Whether a resource authenticates by an OAuth exchange that only the API runs, so
+/// a worker has no way to obtain its token.
+///
+/// `auth_headers` is what the provider's query builder produced: a resource can still
+/// authenticate the request by supplying the credential header that provider actually
+/// reads. A credential-shaped header it does not read (an `x-api-key` used for routing
+/// by an OpenAI-compatible gateway, say) leaves the request unauthenticated, so it does
+/// not count.
+pub fn needs_unavailable_oauth_exchange(
+    credentials: &ProviderCredentials,
+    token_url: Option<&str>,
+    auth_headers: &[(&'static str, String)],
+) -> bool {
+    token_url.is_some()
+        && credentials.api_key.is_none()
+        && !auth_headers.iter().any(|(header_name, _)| {
+            CREDENTIAL_HEADERS
+                .iter()
+                .any(|name| header_name.eq_ignore_ascii_case(name))
+                && resource_replaces_credential(credentials, header_name)
+        })
+}
+
+/// Drop the query builder's built-in credential header when the resource carries
+/// its own, or when there is no key at all — an endpoint may authenticate the
+/// request another way (its own header, mTLS, or no auth), and an empty credential
+/// must not go out in its place. This applies `credential_header`'s rule to headers a
+/// query builder already built from `credentials.api_key`, so the agent step and the
+/// proxy send the same credential. (An OAuth `access_token` never reaches a query
+/// builder: only the API resolves one.) Non-credential headers always stay.
+pub fn retain_effective_credentials(
+    credentials: &ProviderCredentials,
+    auth_headers: Vec<(&'static str, String)>,
+) -> Vec<(&'static str, String)> {
+    auth_headers
+        .into_iter()
+        .filter(|(header_name, _)| {
+            let carries_credential = CREDENTIAL_HEADERS
+                .iter()
+                .any(|name| header_name.eq_ignore_ascii_case(name));
+            !carries_credential
+                || (credentials.api_key.is_some()
+                    && !resource_replaces_credential(credentials, header_name))
+        })
+        .collect()
+}
+
 /// The headers every outbound AI request ends with: Windmill's own, then the
 /// resource's, which come last so a resource can add to what the provider set.
 pub fn common_outbound_headers(
@@ -308,6 +355,47 @@ mod tests {
         assert!(request
             .headers
             .contains(&("x-api-key".to_string(), "routing-key".to_string())));
+    }
+
+    /// The OAuth guard must not reject the workaround its error names, and must not be
+    /// satisfied by a credential header the provider does not read.
+    #[test]
+    fn oauth_guard_follows_the_provider_credential_header() {
+        let token_url = Some("https://login.example/token");
+        let mut credentials = credentials(AIProvider::OpenAI, "https://api.openai.com/v1");
+        credentials.api_key = None;
+        let bearer = [("Authorization", String::new())];
+
+        assert!(needs_unavailable_oauth_exchange(
+            &credentials,
+            token_url,
+            &bearer
+        ));
+
+        // A routing header this provider never authenticates with leaves the request
+        // unauthenticated, so it must not satisfy the guard.
+        credentials.custom_headers =
+            HashMap::from([("x-api-key".to_string(), "routing".to_string())]);
+        assert!(needs_unavailable_oauth_exchange(
+            &credentials,
+            token_url,
+            &bearer
+        ));
+
+        // The header the provider does read stands in for the token.
+        credentials.custom_headers =
+            HashMap::from([("Authorization".to_string(), "Bearer static".to_string())]);
+        assert!(!needs_unavailable_oauth_exchange(
+            &credentials,
+            token_url,
+            &bearer
+        ));
+        // An api-key resource never needed the exchange in the first place.
+        assert!(!needs_unavailable_oauth_exchange(
+            &credentials,
+            None,
+            &bearer
+        ));
     }
 
     /// Azure reads api keys from `api-key` but Entra ID tokens only from

--- a/backend/windmill-ai/src/types.rs
+++ b/backend/windmill-ai/src/types.rs
@@ -196,6 +196,10 @@ pub struct ProviderResource {
     /// Custom HTTP headers to include in AI requests
     #[serde(default)]
     pub headers: HashMap<String, String>,
+    /// Set only by OAuth resources, which resolve to a token through a client
+    /// credentials exchange this crate does not perform.
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub token_url: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -24,7 +24,9 @@ use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
     providers::create_query_builder,
-    proxy::{common_outbound_headers, resource_replaces_credential, CREDENTIAL_HEADERS},
+    proxy::{
+        common_outbound_headers, needs_unavailable_oauth_exchange, retain_effective_credentials,
+    },
     query_builder::{BuildRequestArgs, ParsedResponse},
     types::*,
     utils::{pinned_ai_client_for, should_use_structured_output_tool},
@@ -978,18 +980,22 @@ pub async fn run_agent(
             let endpoint =
                 query_builder.get_endpoint(base_url, args.provider.get_model(), output_type);
             let auth_headers = query_builder.get_auth_headers(api_key, base_url, output_type);
-            // A resource carrying its own credential owns authentication; the
-            // built-in one is dropped so the two do not both reach the endpoint.
-            // Non-credential headers (`anthropic-version`) stay either way.
-            let auth_headers: Vec<_> = auth_headers
-                .into_iter()
-                .filter(|(header_name, _)| {
-                    let carries_credential = CREDENTIAL_HEADERS
-                        .iter()
-                        .any(|name| header_name.eq_ignore_ascii_case(name));
-                    !carries_credential || !resource_replaces_credential(&credentials, header_name)
-                })
-                .collect();
+            // A worker cannot run the client credentials exchange, so an OAuth resource
+            // has no token here: the request would carry an empty credential and come
+            // back 401.
+            if needs_unavailable_oauth_exchange(
+                &credentials,
+                args.provider.resource.token_url.as_deref(),
+                &auth_headers,
+            ) {
+                return Err(Error::ExecutionErr(format!(
+                    "The {:?} resource authenticates with OAuth, which AI agent steps do not \
+                     support. Set an API key on the resource, or carry the provider's credential \
+                     header in its `headers`.",
+                    credentials.provider
+                )));
+            }
+            let auth_headers = retain_effective_credentials(&credentials, auth_headers);
 
             let timeout = resolve_job_timeout(conn, &job.workspace_id, job.id, job.timeout)
                 .await

--- a/frontend/src/lib/components/copilot/chat/anthropic.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.ts
@@ -174,8 +174,7 @@ export async function getAnthropicCompletion(
 		signal: abortController.signal,
 		headers: {
 			'X-Provider': provider,
-			'anthropic-version': '2023-06-01',
-			'X-Anthropic-SDK': 'true'
+			'anthropic-version': '2023-06-01'
 		}
 	})
 

--- a/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
+++ b/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
@@ -137,9 +137,8 @@ describe('Anthropic Messages API routing', () => {
 
 		const headers = anthropicCreate.mock.calls[0][1].headers
 		// X-Provider must carry the real provider so the backend resolves Foundry
-		// credentials/URL; the SDK header selects the Messages API path.
+		// credentials and URL.
 		expect(headers['X-Provider']).toBe('azure_foundry')
-		expect(headers['X-Anthropic-SDK']).toBe('true')
 	})
 
 	it('getNonStreamingCompletion routes native Anthropic through the Anthropic client', async () => {

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -534,12 +534,10 @@ function buildAnthropicProxyRequest({
 	const { system, messages: anthropicMessages } = convertOpenAIToAnthropicMessages(messages)
 
 	// X-Provider must be the real provider (e.g. azure_foundry) so the backend
-	// resolves the right credentials and Anthropic URL; the SDK headers tell it to
-	// route through the Anthropic Messages API.
+	// resolves the right credentials and Anthropic URL.
 	const headers: Record<string, string> = {
 		'X-Provider': modelProvider.provider,
-		'anthropic-version': '2023-06-01',
-		'X-Anthropic-SDK': 'true'
+		'anthropic-version': '2023-06-01'
 	}
 
 	if (resourcePath) {


### PR DESCRIPTION
## Summary

Follow-up to #10356. That fix landed in the AI **proxy** (workspace/instance AI settings) only, because the proxy and the **AI agent step** derive the endpoint and the credential header from the same resource independently. Nothing forced them to agree, so a resource could authenticate in one and 401 in the other — which is why the bug went unnoticed until it was reported.

A parity test now pins them together across the provider/platform matrix. Every divergence below was found by that test failing, not by inspection.

## Changes

**Parity test** (`providers/mod.rs`) — asserts both paths derive the same endpoint and the same credential header from identical `ProviderCredentials`, and apply the same rule for *dropping* the built-in credential. Verified as a real guard, not decoration: it fails on #10356's bug (`left: [("x-api-key", …)]` vs `right: [("authorization", …), ("x-api-key", …)]`) and on each fix below when reverted.

**Anthropic base URLs were read differently.** The proxy trimmed and re-appended `/v1`; the agent step appended `/messages` to the stored value. So `base_url = https://gw/anthropic` worked in workspace settings and 404'd in an agent step. `build_anthropic_api_url` accepts both forms on both paths. The proxy URL also no longer depends on the client-supplied `X-Anthropic-SDK` header — the same resource resolved differently per caller — so that header is removed from both ends.

**A trailing slash doubled it.** `base_url = https://gw/v1/` produced `https://gw/v1//chat/completions` in an agent step while the proxy trimmed it.

**An OpenAI resource pointed at Azure.** The proxy applied Azure's URL layout and `api-key` header; the agent step sent bearer auth and the plain path, because `OpenAIQueryBuilder` ignored `is_azure`. Now aligned with `OtherQueryBuilder`.

**An empty credential where the proxy sends none.** With no api key the agent step sent `Authorization: Bearer ` while the proxy omitted the header entirely. `retain_effective_credentials` gives both the same rule, so a keyless endpoint (self-hosted vLLM/ollama with auth off), a resource-supplied credential header, or mTLS all keep working.

**OAuth resources in agent steps.** A worker has no client credentials exchange, so the request went out with an empty credential and came back 401. It now fails with the reason — unless the resource carries the credential header *its provider actually reads*, in which case it runs. A credential-shaped header the provider ignores (an `x-api-key` used for routing by an OpenAI-compatible gateway) does not count.

## Behavior changes to note

- An Anthropic-compatible endpoint serving `/messages` at its configured root (rather than `/v1/messages`) becomes unreachable. No such endpoint is known; api.anthropic.com and the gateways in front of it all serve `/v1`.
- An `openai` resource pointed at a bare `*.azure-api.net` APIM that fronts a bearer-auth backend now gets Azure treatment in agent steps too. That rule was already decided for the proxy in #10356; such a resource should use `customai`.

## Test plan

- [x] `cargo test -p windmill-ai` (104 pass), `cargo check`, `cargo fmt --check` on touched files
- [x] `npx vitest run lib.anthropicRouting.test.ts` (8 pass) for the removed header
- [x] Each new guard verified by reverting its fix and watching the specific case fail
- [ ] Manual: an Anthropic resource whose `base_url` omits `/v1`, exercised in **both** workspace settings and an AI agent step — both should reach `/v1/messages`
- [ ] Manual: an `openai` resource on an Azure deployment URL (or `openai_azure_base_path`) in an agent step — should authenticate with `api-key` instead of 401ing on a bearer
- [ ] Manual: a keyless `customai` resource against a local no-auth OpenAI-compatible server in an agent step — must still run

`frontend/` changes are header-protocol only (no visible UI), so no screenshots. `npm run check:fast` reports 3 errors, all pre-existing on main in files this PR does not touch (stale generated client + a missing dep).