### PR TITLE
feat: hide empty owners from the homepage chips and cap them at 20

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -690,18 +690,38 @@
 		if (!includeWithoutMain) f.push('library scripts hidden')
 		return f
 	})
-	// Complete owner list: every folder (from the folder list, not just loaded
-	// pages) plus the user prefixes present in the loaded/filtered items. So a
-	// folder whose items are far down the stream is still a selectable chip.
-	let owners = $derived(
-		Array.from(
-			new Set([
-				...allFolderOwners,
-				...allUserOwners,
-				...(filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? [])
-			])
-		).sort()
+	// Pipeline folders qualify for a chip whenever a pipeline can show under the current
+	// kind. Unlike `visiblePipelineFolders` this ignores the selected owner — the chips are
+	// how you switch owners, so they must not narrow to the current one.
+	let chipPipelineFolders = $derived(
+		itemKind === 'all' || itemKind === 'script' ? pipelineFolders : new Set<string>()
 	)
+	// Owner chips: only the owners actually holding something the user can see, your own
+	// space first and the rest most-populated first. A chip for an empty owner filters to
+	// nothing, and a workspace's full folder and member lists are mostly those, so an owner
+	// counting 0 gets no chip at all — including your own space.
+	let owners = $derived.by(() => {
+		const self = $userStore?.username ? `u/${$userStore.username}` : undefined
+		const loaded = filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? []
+		if (ownerCounts == undefined) {
+			// No counts (archived view, or the request failed): every owner, alphabetically.
+			return Array.from(new Set([...allFolderOwners, ...allUserOwners, ...loaded])).sort()
+		}
+		const counted = new Map<string, number>(Object.entries(ownerCounts))
+		// The pipeline is a row of its own and its member scripts are folded out of the
+		// count, so it adds one where it renders — as in the tree node's own label.
+		for (const f of chipPipelineFolders) counted.set(`f/${f}`, (counted.get(`f/${f}`) ?? 0) + 1)
+		// No owner counts below what the loaded window already shows for it: the endpoint
+		// leaves out pipeline members and drafts, and a listed item must keep its chip.
+		const onScreen = new Map<string, number>()
+		for (const o of loaded) onScreen.set(o, (onScreen.get(o) ?? 0) + 1)
+		for (const [o, n] of onScreen) counted.set(o, Math.max(counted.get(o) ?? 0, n))
+		return [...counted.keys()].sort((a, b) => {
+			if (a === self) return -1
+			if (b === self) return 1
+			return (counted.get(b) ?? 0) - (counted.get(a) ?? 0) || cmp(a, b)
+		})
+	})
 	// Reload from the server whenever an input the endpoint resolves changes: order,
 	// archived/library scope, kind, the selected owner/folder, or entering/leaving
 	// search (see the reload effect below). Only the label filter and fuzzy ranking
@@ -717,22 +737,16 @@
 		treeView && !searching && ownerFilter == undefined && labelFilter == undefined
 	)
 	// How many runnables each owner (`f/<folder>` / `u/<user>`) holds for this user,
-	// in one request. It labels every node up front — a lazy owner's own count is
-	// unknown until it's expanded — and lets the tree drop the owners holding
-	// nothing instead of listing every workspace folder. Owners with none are
-	// omitted from the response, so an absent key means empty. Skipped outside lazy
-	// mode (the other modes group already-loaded rows) and in the archived view,
-	// which the endpoint doesn't count.
+	// in one request. It labels every tree node up front — a lazy owner's own count is
+	// unknown until it's expanded — and lets both the tree and the owner chips drop the
+	// owners holding nothing instead of listing every workspace folder. Owners with none
+	// are omitted from the response, so an absent key means empty. Fetched in every mode
+	// (the chips are shown in all of them) except the archived view, which the endpoint
+	// doesn't count.
 	let ownerCountsRes = resource(
-		[
-			() => $workspaceStore,
-			() => treeLazyMode,
-			() => archived,
-			() => itemKind,
-			() => includeWithoutMain
-		],
-		async ([ws, lazyMode, showArchived, kind, withoutMain]) => {
-			if (!ws || !lazyMode || showArchived) return undefined
+		[() => $workspaceStore, () => archived, () => itemKind, () => includeWithoutMain],
+		async ([ws, showArchived, kind, withoutMain]) => {
+			if (!ws || showArchived) return undefined
 			try {
 				const res = await ScriptService.countRunnablesByOwner({
 					workspace: ws,
@@ -741,7 +755,7 @@
 				})
 				return res.counts
 			} catch {
-				// Best-effort: without counts the tree shows every owner, as before.
+				// Best-effort: without counts the tree and the chips show every owner, as before.
 				return undefined
 			}
 		}
@@ -1390,6 +1404,7 @@
 			syncQuery
 			bind:selectedFilter={ownerFilter}
 			filters={owners}
+			maxDisplayed={20}
 			bottomMargin={false}
 		/>
 		{#if allLabels.length > 0}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -690,11 +690,14 @@
 		if (!includeWithoutMain) f.push('library scripts hidden')
 		return f
 	})
-	// Pipeline folders qualify for a chip whenever a pipeline can show under the current
-	// kind. Unlike `visiblePipelineFolders` this ignores the selected owner — the chips are
-	// how you switch owners, so they must not narrow to the current one.
+	// Pipeline folders qualify for a chip whenever a pipeline can render: the kind must admit
+	// one and no label filter may be active, since pipelines carry no labels. Unlike
+	// `visiblePipelineFolders` this ignores the selected owner — the chips are how you switch
+	// owners, so they must not narrow to the current one.
 	let chipPipelineFolders = $derived(
-		itemKind === 'all' || itemKind === 'script' ? pipelineFolders : new Set<string>()
+		(itemKind === 'all' || itemKind === 'script') && labelFilter == undefined
+			? pipelineFolders
+			: new Set<string>()
 	)
 	// Owner chips: only the owners actually holding something the user can see, your own
 	// space first and the rest most-populated first. A chip for an empty owner filters to
@@ -704,6 +707,9 @@
 		const self = $userStore?.username ? `u/${$userStore.username}` : undefined
 		const loaded = filteredItems?.map((x) => x.path.split('/').slice(0, 2).join('/')) ?? []
 		if (ownerCounts == undefined) {
+			// Counts still in flight: the folder/user lists resolve first, so painting the full
+			// list here would show the wall this drops and snap to the ranked set a tick later.
+			if (!archived && ownerCountsRes.loading) return []
 			// No counts (archived view, or the request failed): every owner, alphabetically.
 			return Array.from(new Set([...allFolderOwners, ...allUserOwners, ...loaded])).sort()
 		}
@@ -712,15 +718,27 @@
 		// count, so it adds one where it renders — as in the tree node's own label.
 		for (const f of chipPipelineFolders) counted.set(`f/${f}`, (counted.get(`f/${f}`) ?? 0) + 1)
 		// No owner counts below what the loaded window already shows for it: the endpoint
-		// leaves out pipeline members and drafts, and a listed item must keep its chip.
+		// leaves pipeline members out, and a listed item must keep its chip.
 		const onScreen = new Map<string, number>()
 		for (const o of loaded) onScreen.set(o, (onScreen.get(o) ?? 0) + 1)
 		for (const [o, n] of onScreen) counted.set(o, Math.max(counted.get(o) ?? 0, n))
-		return [...counted.keys()].sort((a, b) => {
-			if (a === self) return -1
-			if (b === self) return 1
-			return (counted.get(b) ?? 0) - (counted.get(a) ?? 0) || cmp(a, b)
-		})
+		return (
+			[...counted.keys()]
+				// The user-folder restriction drops other users' rows from the list, so their chips
+				// would filter to nothing — the same rule `filterItemsPathsBaseOnUserFilters` applies.
+				.filter(
+					(o) =>
+						!filterUserFolders ||
+						!filterUserFoldersType ||
+						o.startsWith('f/') ||
+						(filterUserFoldersType === 'u/username and f/*' && o === self)
+				)
+				.sort((a, b) => {
+					if (a === self) return -1
+					if (b === self) return 1
+					return (counted.get(b) ?? 0) - (counted.get(a) ?? 0) || cmp(a, b)
+				})
+		)
 	})
 	// Reload from the server whenever an input the endpoint resolves changes: order,
 	// archived/library scope, kind, the selected owner/folder, or entering/leaving
@@ -755,7 +773,7 @@
 				})
 				return res.counts
 			} catch {
-				// Best-effort: without counts the tree and the chips show every owner, as before.
+				// Best-effort: without counts the tree and the chips fall back to every owner.
 				return undefined
 			}
 		}

--- a/frontend/src/lib/components/home/ListFilters.svelte
+++ b/frontend/src/lib/components/home/ListFilters.svelte
@@ -75,17 +75,19 @@
 	)
 
 	let expanded = $state(false)
-	let hiddenCount = $derived(
-		maxDisplayed == undefined ? 0 : Math.max(0, filtersAndSelected.length - maxDisplayed)
-	)
-	let displayedFilters = $derived.by(() => {
-		if (expanded || hiddenCount === 0) return filtersAndSelected
+	let truncated = $derived.by(() => {
+		if (maxDisplayed == undefined || filtersAndSelected.length <= maxDisplayed)
+			return filtersAndSelected
 		const shown = filtersAndSelected.slice(0, maxDisplayed)
 		// Clicking the selected chip is how the filter is cleared, so it is never truncated
 		// away, however far down the order it sits.
 		if (selectedFilter && !shown.includes(selectedFilter)) shown.push(selectedFilter)
 		return shown
 	})
+	// Derived from what is actually withheld, so the selected chip kept above never counts
+	// as hidden — otherwise the toggle offers to reveal a chip that is already on screen.
+	let hiddenCount = $derived(filtersAndSelected.length - truncated.length)
+	let displayedFilters = $derived(expanded ? filtersAndSelected : truncated)
 </script>
 
 {#if Array.isArray(filtersAndSelected) && filtersAndSelected.length > 0}

--- a/frontend/src/lib/components/home/ListFilters.svelte
+++ b/frontend/src/lib/components/home/ListFilters.svelte
@@ -11,6 +11,9 @@
 		queryName?: string
 		syncQuery?: boolean
 		bottomMargin?: boolean
+		// Keep only the first N filters visible, the rest behind a "…" toggle. Unset
+		// shows every one.
+		maxDisplayed?: number
 	}
 
 	let {
@@ -19,7 +22,8 @@
 		resourceType = false,
 		queryName = 'filter',
 		syncQuery = false,
-		bottomMargin = true
+		bottomMargin = true,
+		maxDisplayed
 	}: Props = $props()
 
 	const queryChange: (value: URL) => void = (url: URL) => {
@@ -69,11 +73,24 @@
 				: [selectedFilter, ...filters]
 			: filters
 	)
+
+	let expanded = $state(false)
+	let hiddenCount = $derived(
+		maxDisplayed == undefined ? 0 : Math.max(0, filtersAndSelected.length - maxDisplayed)
+	)
+	let displayedFilters = $derived.by(() => {
+		if (expanded || hiddenCount === 0) return filtersAndSelected
+		const shown = filtersAndSelected.slice(0, maxDisplayed)
+		// Clicking the selected chip is how the filter is cleared, so it is never truncated
+		// away, however far down the order it sits.
+		if (selectedFilter && !shown.includes(selectedFilter)) shown.push(selectedFilter)
+		return shown
+	})
 </script>
 
 {#if Array.isArray(filtersAndSelected) && filtersAndSelected.length > 0}
 	<div class={`gap-2 w-full flex flex-wrap ${bottomMargin ? 'my-4' : 'mt-4'}`}>
-		{#each filtersAndSelected as filter (filter)}
+		{#each displayedFilters as filter (filter)}
 			<div>
 				<Badge
 					class="inline-flex items-center gap-1 align-middle"
@@ -104,5 +121,18 @@
 				</Badge>
 			</div>
 		{/each}
+		{#if hiddenCount > 0}
+			<div>
+				<Badge
+					class="inline-flex items-center gap-1 align-middle"
+					color={'transparent'}
+					clickable
+					title={expanded ? 'Show fewer' : `Show ${hiddenCount} more`}
+					onclick={() => (expanded = !expanded)}
+				>
+					{expanded ? 'Show less' : '…'}
+				</Badge>
+			</div>
+		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
## Summary

#10351 gave the homepage **tree** per-owner runnable counts and used them to drop the owners holding nothing. The owner **chips** above the list — the ones that filter to `f/<folder>` / `u/<user>` — never got that treatment: they still list every folder in the workspace and every member, in alphabetical order, whether or not there is anything behind them. In a workspace with a few hundred folders that is a wall of chips that mostly filter to an empty list, and it is the same wall in flat view, in search, and under a label filter.

This reuses the counts for the chips:

- an owner counting **0 gets no chip at all** — including your own `u/<you>`, which the tree keeps as a create target but which is a dead filter here
- the rest are ordered **most-populated first**, with `u/<you>` pinned to the front and an alphabetical tie-break
- only the first **20** are drawn, the remainder behind a `…` toggle

The counts request now runs in every mode rather than only in lazy tree mode, since the chips are drawn in all of them. It stays skipped in the archived view, which the endpoint doesn't count — there (and if the request fails) the chips fall back to the previous full alphabetical list.

## Changes

- `ItemsList.svelte`: `ownerCountsRes` drops its `treeLazyMode` key and guard, so `GET /runnables/counts` is fetched in flat view, search and label-filtered views too.
- `ItemsList.svelte`: `owners` is derived from the counts instead of `allFolderOwners ∪ allUserOwners ∪ loaded rows`. Two rules keep a chip that the raw count would lose: a pipeline folder counts +1 (the pipeline is a row of its own and its member scripts are folded out of the count, matching the tree node's label), and no owner counts below the number of rows the loaded window already shows for it (the endpoint leaves out pipeline members and drafts).
- `ListFilters.svelte`: new optional `maxDisplayed` prop — chips past it collapse behind a `…` / `Show less` toggle. The selected chip is never truncated away, since clicking it is how the filter is cleared. Unset (every other call site) keeps the current behavior.

## Test plan

- [x] Workspace with 30 seeded folders (12 empty, 18 holding 1–18 scripts): chips render `u/admin` first, then 18 → 1 by count, with `f/benchmarks` (5) ahead of `f/zzfull05` (5) on the alphabetical tie-break; the 12 empty folders and the empty `f/app_*` folders get no chip.
- [x] `…` reveals the remainder, `Show less` collapses again.
- [x] `?filter=f/test2` on an owner that sits past the 20-chip window: the selected chip is appended and clears on click.
- [x] Selecting a chip narrows the list (`f/benchmarks` → its 5 rows) without reshuffling the chip row.
- [x] Workspace where the viewer's own space is empty (and the workspace holds nothing): no chips at all, `u/admin` included.
- [x] Pipeline-only folders (`f/create`, `f/test2`) keep their chip and rank at 1, matching the tree's "(1 item)".
- [x] Archived view falls back to the full alphabetical list.
- [x] Tree view unchanged.
- [x] `npm run check:fast` clean for the touched files.

## Screenshots

Chips, collapsed at 20 (`u/admin` first, then by count):

![chips-collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/home-owner-chips-nonzero/1785162953-chips-collapsed.png)

Expanded through `…`:

![chips-expanded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/home-owner-chips-nonzero/1785162956-chips-expanded.png)

Tree view, unchanged, with the chip counts agreeing with the node labels:

![tree-view](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/home-owner-chips-nonzero/1785162958-tree-view.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide empty owner chips on the homepage and cap visible chips to 20 with a “…” toggle, ordered by most items and pinning your user first. Counts are now fetched in all modes so chips match the tree and reduce noise.

- **New Features**
  - Show chips only for owners with items; include pipeline folders (+1) and keep chips for owners already visible in the list.
  - Respect user-folder restrictions so chips never filter to nothing; only show `u/*` chips allowed by the current scope.
  - Order by item count (desc), pin `u/<you>` first, alphabetical tie-break.
  - Display up to 20 chips; “…” expands, “Show less” collapses; the selected chip is never hidden (`maxDisplayed` in `ListFilters.svelte`).
  - Fetch owner counts in all views except archived; avoid flicker while counts load and fall back to the full alphabetical list when counts are unavailable.

<sup>Written for commit b64de1400a8f8a5280e69805c4980b266317ca03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

