### PR TITLE
fix(ai): resolve deployment-pinned Azure base URLs to the v1 surface

### DIFF
--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -48,6 +48,13 @@ const AZURE_HOST_SUFFIXES: &[&str] = &[
 /// is the format `openai_azure_base_path` documents.
 const AZURE_DEPLOYMENTS_PATH: &str = "/openai/deployments";
 
+/// Where the deployment path starts in `base_url`, i.e. the end of the resource root.
+/// ASCII lowercasing preserves byte offsets, so the index is a char boundary in
+/// `base_url` and slicing on it cannot panic; `to_lowercase` would not be.
+fn azure_deployments_index(base_url: &str) -> Option<usize> {
+    base_url.to_ascii_lowercase().find(AZURE_DEPLOYMENTS_PATH)
+}
+
 /// Whether an OpenAI-API base URL is served by Azure, which authenticates with the
 /// `api-key` header and lays its routes out under `/openai/...`.
 ///
@@ -71,9 +78,7 @@ fn is_azure_endpoint(base_url: &str) -> bool {
     AZURE_HOST_SUFFIXES
         .iter()
         .any(|suffix| host.ends_with(suffix))
-        || base_url
-            .to_ascii_lowercase()
-            .contains(AZURE_DEPLOYMENTS_PATH)
+        || azure_deployments_index(base_url).is_some()
 }
 
 /// Empty string signals BedrockClient::from_env() to use the region from AWS environment/config
@@ -201,9 +206,9 @@ impl AIProvider {
     /// Build an Azure-style OpenAI-compatible URL (Azure OpenAI / Azure AI Foundry)
     /// for the given path. The resource base URL may be stored as the bare resource
     /// root (e.g. `https://<res>.services.ai.azure.com`) or with a legacy `/openai`
-    /// or `/openai/v1` suffix (older Foundry resources shipped that way); those forms
-    /// resolve to the canonical `<root>/openai/v1/<path>`. Any other explicit path
-    /// (e.g. an Azure OpenAI `.../openai/deployments/<id>` base) is preserved as-is
+    /// or `/openai/v1` suffix (older Foundry resources shipped that way), or as a
+    /// deployment path (`.../openai/deployments/<id>`). All of those resolve to the
+    /// canonical `<root>/openai/v1/<path>`. Any other explicit path is preserved as-is
     /// with only `/<path>` appended.
     pub fn build_azure_openai_url(base_url: &str, path: &str) -> String {
         let base_url = base_url.trim_end_matches('/');
@@ -211,15 +216,17 @@ impl AIProvider {
             format!("{}/{}", base_url, path)
         } else if base_url.ends_with("/openai") {
             format!("{}/v1/{}", base_url, path)
-        } else if base_url.ends_with("/deployments") {
-            format!("{}/v1/{}", base_url.trim_end_matches("/deployments"), path)
+        } else if let Some(index) = azure_deployments_index(base_url) {
+            // A base naming the deployment surface, pinned to a deployment or not,
+            // resolves to the resource root: that surface serves only with an
+            // `api-version` query and 404s without one, while the v1 surface takes
+            // the deployment from the request body.
+            format!("{}/openai/v1/{}", &base_url[..index], path)
         } else if Self::is_bare_host(base_url) {
             // A resource root with no path (Foundry convention, or an Azure OpenAI
             // resource root) targets the OpenAI-compatible v1 surface.
             format!("{}/openai/v1/{}", base_url, path)
         } else {
-            // Any other explicit base path (e.g. an Azure OpenAI deployment URL
-            // `.../openai/deployments/<id>`) is kept intact.
             format!("{}/{}", base_url, path)
         }
     }
@@ -252,6 +259,9 @@ impl AIProvider {
     /// both the current root-URL convention and legacy `/openai/v1`-style values.
     fn azure_foundry_root(base_url: &str) -> &str {
         let base_url = base_url.trim_end_matches('/');
+        if let Some(index) = azure_deployments_index(base_url) {
+            return &base_url[..index];
+        }
         for suffix in [
             "/openai/v1",
             "/anthropic/v1",
@@ -358,14 +368,13 @@ mod tests {
             ),
             "https://example.openai.azure.com/openai/v1/chat/completions"
         );
-        // An Azure OpenAI base that pins a specific deployment must be preserved
-        // as-is (not have /openai/v1 appended after the deployment id).
+        // A base pinned to a deployment resolves to the v1 surface too.
         assert_eq!(
             AIProvider::build_azure_openai_url(
                 "https://example.openai.azure.com/openai/deployments/my-deployment",
                 "chat/completions"
             ),
-            "https://example.openai.azure.com/openai/deployments/my-deployment/chat/completions"
+            "https://example.openai.azure.com/openai/v1/chat/completions"
         );
     }
 
@@ -417,6 +426,15 @@ mod tests {
         assert_eq!(
             AIProvider::build_azure_foundry_anthropic_url(
                 "https://wm-test-ai.services.ai.azure.com/openai/v1",
+                "messages"
+            ),
+            "https://wm-test-ai.services.ai.azure.com/anthropic/v1/messages"
+        );
+        // A deployment-pinned base recovers the same root, so a Claude model on such
+        // a resource is routed like every other model on it.
+        assert_eq!(
+            AIProvider::build_azure_foundry_anthropic_url(
+                "https://wm-test-ai.services.ai.azure.com/openai/deployments/claude-sonnet-5",
                 "messages"
             ),
             "https://wm-test-ai.services.ai.azure.com/anthropic/v1/messages"

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -533,7 +533,7 @@ export const settings: Record<string, Setting[]> = {
 		{
 			label: 'Azure OpenAI base path',
 			description:
-				'All workspaces using an OpenAI resource for Windmill AI will run on the specified deployed model. Format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id}. <a href="https://www.windmill.dev/docs/core_concepts/ai_generation#azure-openai-advanced-models">Learn more</a>',
+				'All workspaces using an OpenAI resource for Windmill AI will run against the specified Azure resource. Format: https://{your-resource-name}.openai.azure.com/openai/deployments/{deployment-id} — keep the URL as stored; the model comes from each workspace\'s configured model list, whose entries must be your Azure deployment names. <a href="https://www.windmill.dev/docs/core_concepts/ai_generation#azure-openai-advanced-models">Learn more</a>',
 			key: 'openai_azure_base_path',
 			fieldType: 'text',
 			storage: 'setting',


### PR DESCRIPTION
## Summary

An Azure OpenAI base URL that names a deployment — the `https://<res>.openai.azure.com/openai/deployments/<id>` format the `openai_azure_base_path` instance setting documents — was appended to as-is. That targets Azure's legacy surface, which serves **only** with an `api-version` query string. Windmill never appends one, and the proxy path arrives through an axum path extractor that carries no query string, so a client SDK cannot supply it either.

The result: that base URL 404s on **both** paths, and always has.

Probed against a live Azure OpenAI resource with an empty body, so an existing route answers 400 and a missing one answers 404:

| URL | Result | |
|---|---|---|
| `…/openai/deployments/<id>/chat/completions` | **404 Resource not found** | what the proxy built |
| `…/openai/deployments/<id>/responses` | **404 Resource not found** | what the agent step built |
| `…/openai/deployments/<id>/chat/completions?api-version=…` | 400 | route exists — the query is mandatory |
| `…/openai/v1/chat/completions` | 400 → **200** with a real completion | what the proxy builds now |
| `…/openai/v1/responses` | 400 → **200** | what the agent step builds now |

## Changes

- A base containing `/openai/deployments`, pinned to a deployment or not, resolves to the resource root plus `/openai/v1/<path>`, like every other Azure shape. This replaces the `ends_with("/deployments")` branch, which handled only the unpinned form.
- `azure_foundry_root` recovers the root through the same helper, so a Foundry resource on such a base builds its Claude URL from the root too — otherwise this fix would have been one-sided, correcting GPT models while leaving Claude on the broken shape.
- The instance-settings help text said the URL makes every workspace "run on the specified deployed model". That surface never delivered it, and on the v1 surface the deployment comes from the request body, so the text now says where the model actually comes from.

## Notes for reviewers

- **The deployment id in the URL is now ignored**, and the model comes from each workspace's model list, whose entries must be Azure *deployment* names. Nothing regresses — the pinned URL 404'd unconditionally — but the failure shape moves from "404 on every call" to Azure's `DeploymentNotFound` if the model list holds Azure model names instead. That is strictly more actionable. Rewriting the body's `model` to match the URL would silently override an explicit user choice, which is worse.
- **Don't "clean up" a stored base URL to `…/openai/v1`.** Azure detection for a custom domain keys on the `/openai/deployments` marker, so shortening the URL loses `api-key` auth and 401s. Keep it as stored.
- The rewrite fires on any host containing `/openai/deployments`, not only Azure-owned ones, because custom-domain Azure resources are a supported case. A non-Azure facade serving that layout *without* requiring `api-version` would change behavior; no such endpoint is known, and gating on Azure host suffixes would drop the custom-domain Azure case this is meant to fix.

## Screenshots

Instance settings → Private Hub. The field is `hiddenIfEmpty`, so it renders only once set; shown here with an example value. The apostrophe, em dash and `Learn more` link all render correctly.

![azure-base-path-help](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/azure-deployment-pinned-url/1785168374-azure-help.png)

## Test plan

- [x] `cargo test -p windmill-ai` (104 pass), `cargo check`, `cargo fmt --check`
- [x] Live probe against an Azure OpenAI resource: the old URLs 404, the new ones return 200 with generated content
- [x] `npm run check:fast` — 3 errors, all pre-existing on main in files this PR does not touch
- [x] Help text verified in the browser (screenshot above)
- [ ] Reviewer with Azure access: confirm an `azure_openai` resource stored as a bare host or `/openai` base is unchanged (those branches are untouched), and that a Foundry Claude deployment on a deployment-pinned base now resolves

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Azure OpenAI deployment-pinned base URLs to the v1 surface so requests stop 404ing and succeed. Also fixes Foundry root detection and updates the instance setting help text.

- **Bug Fixes**
  - Any base containing `/openai/deployments` now resolves to `<root>/openai/v1/<path>`; the deployment id in the URL is ignored. The model comes from each workspace’s model list (use your Azure deployment names).
  - `azure_foundry_root` now strips the deployments path, so Foundry Claude URLs build from the resource root.

- **Migration**
  - No action needed; keep stored URLs as-is. Do not shorten them to `/openai/v1` or custom-domain Azure auth may break.
  - If model lists use Azure model names instead of deployment names, you’ll now see `DeploymentNotFound` instead of 404. Update entries to deployment names.

<sup>Written for commit 459684a453b5ed2b9f17788ac940254d33f8497f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

