### PR TITLE
fix: raw apps with no stylesheet were permanently un-deployable

### DIFF
--- a/backend/tests/raw_app_missing_css.rs
+++ b/backend/tests/raw_app_missing_css.rs
@@ -1,0 +1,172 @@
+//! Regression test for raw apps whose bundle has no stylesheet.
+//!
+//! `create_app_raw` stores the `css` blob only when the multipart field is
+//! present, so an app built from sources with no styles has no `css` row at
+//! all. The read side used to 404 for that, and cross-workspace deploy
+//! re-fetches both bundle parts and treats the 404 as fatal — which made such
+//! an app permanently un-deployable, with nothing to self-heal it.
+//!
+//! This test pins down:
+//!   - a bundle stored without a `css` part serves an empty stylesheet, not 404
+//!     (the fix; pre-fix this 404'd and broke every deploy of the app),
+//!   - a bundle that does have styles still serves them byte-for-byte (the
+//!     tolerance must not start blanking real stylesheets), and
+//!   - a missing `js` blob still 404s — the tolerance must not leak to the
+//!     half of the bundle whose absence really is broken.
+
+use reqwest::multipart;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+fn app_part(path: &str) -> anyhow::Result<multipart::Part> {
+    let app = serde_json::json!({
+        "path": path,
+        "summary": "",
+        "value": {},
+        "policy": { "execution_mode": "publisher" },
+        "raw_app": true,
+    });
+    Ok(multipart::Part::text(app.to_string()).mime_str("application/json")?)
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_raw_app_without_stylesheet_stays_readable(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let js_body = "console.log('app')";
+
+    // 1. Create a raw app with NO css part at all — exactly what a client that
+    //    omits the field produces, and the state the 16 broken versions are in.
+    let form = multipart::Form::new()
+        .part("app", app_part("u/test-user/nocss")?)
+        .part("js", multipart::Part::text(js_body));
+    let resp = authed(
+        client().post(format!("{base}/apps/create_raw")),
+        "SECRET_TOKEN",
+    )
+    .multipart(form)
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "creating a raw app without a css part should succeed: {}",
+        resp.text().await?
+    );
+
+    let secret = authed(
+        client().get(format!(
+            "{base}/apps/secret_of_latest_version/u/test-user/nocss"
+        )),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?
+    .text()
+    .await?;
+
+    // 2. The stylesheet is absent, not broken: serve it empty so deploy — which
+    //    re-fetches both parts — can carry the app to another workspace.
+    let resp = authed(
+        client().get(format!("{base}/apps/get_data/v/{secret}.css")),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "a bundle with no stylesheet must serve an empty one, not 404"
+    );
+    assert_eq!(resp.text().await?, "", "the empty stylesheet must be empty");
+
+    // 3. The JavaScript half is untouched by the fallback.
+    let resp = authed(
+        client().get(format!("{base}/apps/get_data/v/{secret}.js")),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await?, js_body);
+
+    // 4. An app that does have styles must still serve them unchanged — the
+    //    fallback must never blank a real stylesheet.
+    let css_body = "body { color: red }";
+    let form = multipart::Form::new()
+        .part("app", app_part("u/test-user/withcss")?)
+        .part("js", multipart::Part::text(js_body))
+        .part("css", multipart::Part::text(css_body));
+    let resp = authed(
+        client().post(format!("{base}/apps/create_raw")),
+        "SECRET_TOKEN",
+    )
+    .multipart(form)
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 201, "{}", resp.text().await?);
+
+    let styled_secret = authed(
+        client().get(format!(
+            "{base}/apps/secret_of_latest_version/u/test-user/withcss"
+        )),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?
+    .text()
+    .await?;
+
+    let resp = authed(
+        client().get(format!("{base}/apps/get_data/v/{styled_secret}.css")),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.text().await?,
+        css_body,
+        "an app with styles must round-trip them intact"
+    );
+
+    // 5. A missing `js` blob is a genuinely broken bundle and must still 404.
+    //    The API cannot create this state (js is mandatory on write), so drop
+    //    the row directly.
+    let version_id: i64 = sqlx::query_scalar(
+        "SELECT versions[array_upper(versions, 1)] FROM app
+         WHERE path = 'u/test-user/nocss' AND workspace_id = 'test-workspace'",
+    )
+    .fetch_one(&db)
+    .await?;
+    sqlx::query("DELETE FROM app_bundles WHERE app_version_id = $1 AND file_type = 'js'")
+        .bind(version_id)
+        .execute(&db)
+        .await?;
+
+    let resp = authed(
+        client().get(format!("{base}/apps/get_data/v/{secret}.js")),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        404,
+        "a missing js bundle must still fail loudly — the css tolerance must not leak to it"
+    );
+
+    Ok(())
+}

--- a/backend/tests/raw_app_missing_css.rs
+++ b/backend/tests/raw_app_missing_css.rs
@@ -1,16 +1,15 @@
-//! Regression test for raw apps whose bundle has no stylesheet.
+//! Raw app bundles whose stylesheet is absent rather than empty.
 //!
 //! `create_app_raw` stores the `css` blob only when the multipart field is
 //! present, so an app built from sources with no styles has no `css` row at
-//! all. The read side used to 404 for that, and cross-workspace deploy
-//! re-fetches both bundle parts and treats the 404 as fatal — which made such
-//! an app permanently un-deployable, with nothing to self-heal it.
+//! all. Cross-workspace deploy re-fetches both bundle parts and treats a
+//! non-200 as fatal, so 404ing the stylesheet makes such an app un-deployable:
+//! absent means empty.
 //!
 //! This test pins down:
-//!   - a bundle stored without a `css` part serves an empty stylesheet, not 404
-//!     (the fix; pre-fix this 404'd and broke every deploy of the app),
-//!   - a bundle that does have styles still serves them byte-for-byte (the
-//!     tolerance must not start blanking real stylesheets), and
+//!   - a bundle stored without a `css` part serves an empty stylesheet,
+//!   - a bundle that has styles serves them byte-for-byte, so the tolerance
+//!     never blanks a real stylesheet, and
 //!   - a missing `js` blob still 404s — the tolerance must not leak to the
 //!     half of the bundle whose absence really is broken.
 
@@ -47,8 +46,8 @@ async fn test_raw_app_without_stylesheet_stays_readable(db: Pool<Postgres>) -> a
 
     let js_body = "console.log('app')";
 
-    // 1. Create a raw app with NO css part at all — exactly what a client that
-    //    omits the field produces, and the state the 16 broken versions are in.
+    // 1. Create a raw app with NO css part at all — what a client that omits
+    //    the field produces.
     let form = multipart::Form::new()
         .part("app", app_part("u/test-user/nocss")?)
         .part("js", multipart::Part::text(js_body));

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -705,6 +705,15 @@ async fn get_raw_app_data(
         }
     }
 
+    // A bundle with no styles has no `css` row at all: the write side stores that
+    // blob only when the client sends the field. Absent means empty, not broken —
+    // 404ing here makes such an app permanently un-deployable, because a
+    // cross-workspace deploy re-fetches both parts and treats the 404 as fatal.
+    // A missing `js` is a genuinely broken bundle and must still 404.
+    if body.is_none() && file_type == "css" {
+        body = Some(Body::empty());
+    }
+
     if let Some(body) = body {
         // let stream = tokio_util::io::ReaderStream::new(file);
         let res = Response::builder()

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -710,7 +710,12 @@ async fn get_raw_app_data(
     // 404ing here makes such an app permanently un-deployable, because a
     // cross-workspace deploy re-fetches both parts and treats the 404 as fatal.
     // A missing `js` is a genuinely broken bundle and must still 404.
+    //
+    // Logged at debug, not warn: for a style-less app this is the normal path and
+    // fires on every page load. It is the only trace distinguishing that case from
+    // a css blob lost by an object-store migration, which lands here identically.
     if body.is_none() && file_type == "css" {
+        tracing::debug!(w_id = %w_id, app_version_id = %id, "no css bundle stored, serving empty stylesheet");
         body = Some(Body::empty());
     }
 

--- a/cli/test/raw_app_missing_css_unit.test.ts
+++ b/cli/test/raw_app_missing_css_unit.test.ts
@@ -14,10 +14,13 @@ function httpError(status: number) {
 }
 
 describe("getRawAppBundlePart", () => {
-  test("returns the blob when the fetch succeeds", async () => {
+  test("requests each half under its own extension", async () => {
+    const asked: Array<{ secretWithExtension: string; workspace: string }> = [];
     const provider = {
-      getRawAppData: (p: { secretWithExtension: string }) =>
-        Promise.resolve(`body-of-${p.secretWithExtension}`),
+      getRawAppData: (p: { secretWithExtension: string; workspace: string }) => {
+        asked.push(p);
+        return Promise.resolve(`body-of-${p.secretWithExtension}`);
+      },
     } as any;
 
     expect(await getRawAppBundlePart(provider, "sec", "js", "ws")).toBe(
@@ -26,6 +29,11 @@ describe("getRawAppBundlePart", () => {
     expect(await getRawAppBundlePart(provider, "sec", "css", "ws")).toBe(
       "body-of-sec.css"
     );
+    // Swapping the two extensions would deploy the stylesheet as the bundle.
+    expect(asked).toEqual([
+      { secretWithExtension: "sec.js", workspace: "ws" },
+      { secretWithExtension: "sec.css", workspace: "ws" },
+    ]);
   });
 
   test("treats a missing .css as empty rather than fatal", async () => {

--- a/cli/test/raw_app_missing_css_unit.test.ts
+++ b/cli/test/raw_app_missing_css_unit.test.ts
@@ -1,0 +1,66 @@
+/**
+ * A raw-app bundle with no styles may have no `.css` blob stored at all, which
+ * older backends serve as a 404. Deploy re-fetches both parts, so letting that
+ * 404 reject makes the app permanently un-deployable.
+ *
+ * The tolerance is deliberately narrow, and that narrowness is the point: a
+ * blanket catch would swallow auth/network failures and silently deploy an app
+ * with its styles stripped, and a missing `.js` is a genuinely broken bundle.
+ *
+ * No backend required — the provider is a stub.
+ */
+
+import { expect, test, describe } from "bun:test";
+import { getRawAppBundlePart } from "../windmill-utils-internal/src/deploy.ts";
+
+function providerThatFailsWith(err: unknown) {
+  return {
+    getRawAppData: () => Promise.reject(err),
+  } as any;
+}
+
+function httpError(status: number) {
+  return Object.assign(new Error(`HTTP ${status}`), { status });
+}
+
+describe("getRawAppBundlePart", () => {
+  test("returns the blob when the fetch succeeds", async () => {
+    const provider = {
+      getRawAppData: (p: { secretWithExtension: string }) =>
+        Promise.resolve(`body-of-${p.secretWithExtension}`),
+    } as any;
+
+    expect(await getRawAppBundlePart(provider, "sec", "js", "ws")).toBe(
+      "body-of-sec.js"
+    );
+    expect(await getRawAppBundlePart(provider, "sec", "css", "ws")).toBe(
+      "body-of-sec.css"
+    );
+  });
+
+  test("treats a missing .css as empty rather than fatal", async () => {
+    const provider = providerThatFailsWith(httpError(404));
+    expect(await getRawAppBundlePart(provider, "sec", "css", "ws")).toBe("");
+  });
+
+  test("still fails loudly on a missing .js", async () => {
+    const provider = providerThatFailsWith(httpError(404));
+    expect(getRawAppBundlePart(provider, "sec", "js", "ws")).rejects.toThrow();
+  });
+
+  test("does not swallow non-404 failures on .css", async () => {
+    for (const status of [401, 403, 500]) {
+      const provider = providerThatFailsWith(httpError(status));
+      expect(
+        getRawAppBundlePart(provider, "sec", "css", "ws")
+      ).rejects.toThrow();
+    }
+  });
+
+  test("does not swallow a .css failure that carries no status", async () => {
+    const provider = providerThatFailsWith(new Error("network down"));
+    expect(getRawAppBundlePart(provider, "sec", "css", "ws")).rejects.toThrow(
+      "network down"
+    );
+  });
+});

--- a/cli/test/raw_app_missing_css_unit.test.ts
+++ b/cli/test/raw_app_missing_css_unit.test.ts
@@ -1,14 +1,4 @@
-/**
- * A raw-app bundle with no styles may have no `.css` blob stored at all, which
- * older backends serve as a 404. Deploy re-fetches both parts, so letting that
- * 404 reject makes the app permanently un-deployable.
- *
- * The tolerance is deliberately narrow, and that narrowness is the point: a
- * blanket catch would swallow auth/network failures and silently deploy an app
- * with its styles stripped, and a missing `.js` is a genuinely broken bundle.
- *
- * No backend required — the provider is a stub.
- */
+/** Only a `.css` 404 may be forgiven — see `getRawAppBundlePart`. */
 
 import { expect, test, describe } from "bun:test";
 import { getRawAppBundlePart } from "../windmill-utils-internal/src/deploy.ts";
@@ -45,13 +35,15 @@ describe("getRawAppBundlePart", () => {
 
   test("still fails loudly on a missing .js", async () => {
     const provider = providerThatFailsWith(httpError(404));
-    expect(getRawAppBundlePart(provider, "sec", "js", "ws")).rejects.toThrow();
+    await expect(
+      getRawAppBundlePart(provider, "sec", "js", "ws")
+    ).rejects.toThrow();
   });
 
   test("does not swallow non-404 failures on .css", async () => {
     for (const status of [401, 403, 500]) {
       const provider = providerThatFailsWith(httpError(status));
-      expect(
+      await expect(
         getRawAppBundlePart(provider, "sec", "css", "ws")
       ).rejects.toThrow();
     }
@@ -59,8 +51,8 @@ describe("getRawAppBundlePart", () => {
 
   test("does not swallow a .css failure that carries no status", async () => {
     const provider = providerThatFailsWith(new Error("network down"));
-    expect(getRawAppBundlePart(provider, "sec", "css", "ws")).rejects.toThrow(
-      "network down"
-    );
+    await expect(
+      getRawAppBundlePart(provider, "sec", "css", "ws")
+    ).rejects.toThrow("network down");
   });
 });

--- a/cli/windmill-utils-internal/src/deploy.ts
+++ b/cli/windmill-utils-internal/src/deploy.ts
@@ -390,6 +390,32 @@ export async function checkItemExists(
   throw new Error(`Unknown kind: ${kind}`);
 }
 
+/**
+ * Fetch one part of a raw app's compiled bundle.
+ *
+ * A bundle with no styles may have no `css` blob stored at all, which older
+ * backends serve as a 404. Absent means empty, not broken — letting that reject
+ * makes such an app permanently un-deployable. Only `.css` and only a 404 are
+ * forgiven: swallowing auth/network failures would silently deploy the app with
+ * its styles stripped, and a missing `.js` is a genuinely broken bundle.
+ */
+export async function getRawAppBundlePart(
+  provider: DeployProvider,
+  secret: string,
+  ext: "js" | "css",
+  workspace: string
+): Promise<any> {
+  try {
+    return await provider.getRawAppData({
+      secretWithExtension: `${secret}.${ext}`,
+      workspace,
+    });
+  } catch (e: any) {
+    if (ext === "css" && e?.status === 404) return "";
+    throw e;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // deployItem
 // ---------------------------------------------------------------------------
@@ -480,14 +506,18 @@ export async function deployItem(
             workspace: workspaceFrom,
             path: app.path,
           });
-          const js = await provider.getRawAppData({
-            secretWithExtension: `${secret}.js`,
-            workspace: workspaceFrom,
-          });
-          const css = await provider.getRawAppData({
-            secretWithExtension: `${secret}.css`,
-            workspace: workspaceFrom,
-          });
+          const js = await getRawAppBundlePart(
+            provider,
+            secret,
+            "js",
+            workspaceFrom
+          );
+          const css = await getRawAppBundlePart(
+            provider,
+            secret,
+            "css",
+            workspaceFrom
+          );
           await provider.updateAppRaw({
             workspace: workspaceTo,
             path,
@@ -513,14 +543,18 @@ export async function deployItem(
             workspace: workspaceFrom,
             path: app.path,
           });
-          const js = await provider.getRawAppData({
-            secretWithExtension: `${secret}.js`,
-            workspace: workspaceFrom,
-          });
-          const css = await provider.getRawAppData({
-            secretWithExtension: `${secret}.css`,
-            workspace: workspaceFrom,
-          });
+          const js = await getRawAppBundlePart(
+            provider,
+            secret,
+            "js",
+            workspaceFrom
+          );
+          const css = await getRawAppBundlePart(
+            provider,
+            secret,
+            "css",
+            workspaceFrom
+          );
           await provider.createAppRaw({
             workspace: workspaceTo,
             formData: {

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1208,12 +1208,20 @@
 		} else if (e.data.type === 'getBundle') {
 			// The UI Builder omits `css` entirely when the app has no styles. Saving
 			// `undefined` drops the multipart field, and the backend then stores no
-			// css blob at all for that version — see `rawAppBundlerBridge`, which
-			// guards the same message for the chat/draft path.
-			getBundleResolve?.({
-				js: String(e.data.bundle?.js ?? ''),
-				css: String(e.data.bundle?.css ?? '')
-			})
+			// css blob at all for that version. `js` gets no such default: the
+			// backend accepts any present `js` field regardless of length, so an
+			// empty one would publish a blank app instead of failing.
+			// `rawAppBundlerBridge` holds the same invariant over its own
+			// `bundleRawAppResult` message for the chat/draft path.
+			const bundle = e.data.bundle
+			if (!bundle?.js) {
+				getBundleReject?.(new Error('Raw app bundler returned an empty JavaScript bundle.'))
+			} else {
+				getBundleResolve?.({
+					js: String(bundle.js),
+					css: String(bundle.css ?? '')
+				})
+			}
 		} else if (e.data.type === 'updateModules') {
 			modules = e.data.modules
 		} else if (e.data.type === 'setActiveDocument') {
@@ -1336,10 +1344,12 @@
 	}
 
 	let getBundleResolve: (({ css, js }: { css: string; js: string }) => void) | undefined = undefined
+	let getBundleReject: ((reason: Error) => void) | undefined = undefined
 
 	async function getBundle(): Promise<{ css: string; js: string }> {
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			getBundleResolve = resolve
+			getBundleReject = reject
 			iframe?.contentWindow?.postMessage(
 				{
 					type: 'getBundle'

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1206,7 +1206,14 @@
 				historyManager.markPendingChanges()
 			}
 		} else if (e.data.type === 'getBundle') {
-			getBundleResolve?.(e.data.bundle)
+			// The UI Builder omits `css` entirely when the app has no styles. Saving
+			// `undefined` drops the multipart field, and the backend then stores no
+			// css blob at all for that version — see `rawAppBundlerBridge`, which
+			// guards the same message for the chat/draft path.
+			getBundleResolve?.({
+				js: String(e.data.bundle?.js ?? ''),
+				css: String(e.data.bundle?.css ?? '')
+			})
 		} else if (e.data.type === 'updateModules') {
 			modules = e.data.modules
 		} else if (e.data.type === 'setActiveDocument') {


### PR DESCRIPTION
## Summary

A raw app saved with **no `.css` bundle row at all** could never be deployed to another
workspace again. Deploy re-fetches both halves of the bundle from the source workspace, and
a missing stylesheet returned **404**, which was treated as fatal. Nothing self-healed, and
workspace cloning copies `app_bundles` row by row — so one hand-made demo app became **16
broken versions across 4 app paths and 10 workspaces** on the shared dev database.

The write side already treats `css` as optional; only the read side disagreed. Absent now
means empty.

**Why it surfaced only now:** the producer defect shipped with `ui code builder v0`
(`3c68fef2ab`, 2025-04-20) and sat harmless for 15 months — a style-less app renders fine in
its own workspace, and the only signal was a console 404 that read as dev noise. It became
*fatal* when cross-workspace deploy arrived (`4342c18541`, #8756, 2026-04-08), and became
*visible* when forks and AI sessions started moving these apps between workspaces: every
affected version dates from 2026-06-25 → 07-08.

Notably, both sibling write paths had independently grown the same defensive default —
the chat bridge (#9349, 2026-05-27) and the CLI (#9629, 2026-06-17). Two authors patched
their own call site against a bundle they didn't trust; neither traced it to the shared
source, and the one path that never got a default kept writing broken rows.

## Changes

- **Producer** — `RawAppEditor.svelte`: the `getBundle` reply now defaults `css` to `''`.
  `js` is deliberately *not* defaulted: the backend accepts any present `js` field
  regardless of length, so an empty one would publish a blank app over a working one. A
  missing/empty `js` now rejects with a clear error, matching `rawAppBundlerBridge`.
- **Backend** — `get_raw_app_data`: when no row exists and the request is for `css`, serve
  200 with an empty body instead of 404. This repairs every already-broken app for all
  clients with no data migration and no package release. A missing `.js` still 404s.
  Also silences a real side effect: the raw-app wrapper hardcodes a `<link rel="stylesheet">`,
  so until now every style-less app logged a 404 on *every page load*.
- **Reader** — `cli/windmill-utils-internal/src/deploy.ts`: new `getRawAppBundlePart` helper
  tolerating **only** a `.css` 404. A blanket `catch` would swallow auth/network failures and
  silently deploy an app with its styles stripped.
- **Tests** — a backend integration regression test and a CLI unit test for the helper. Both
  were mutation-tested: reverting the fix, or widening the tolerance to a blanket `catch`,
  fails them.

## Notes for reviewers

- **No screenshots**: the frontend change is inside a `postMessage` handler and has no visible
  UI effect. It was still verified in a real browser — see the A/B below.
- `windmill-utils-internal` is consumed by the frontend as a **published package**, so the
  deploy.ts fix is inert for the frontend until the package is bumped and republished. The
  backend fix is what covers the frontend today; layer 3 matters for older backends.
- Commit `2682414496` on `glm/nit-edit-button` patches this frontend-side only
  (`getRawAppDataAllowingMissingCss`). It becomes redundant once this lands and should be
  deleted when that branch merges.
- Pre-existing, not addressed here: `updateApp` in `RawAppEditorHeader.svelte` has no
  try/catch around `getBundle()`, so its failures fall through to the global
  unhandled-rejection toast rather than a scoped one.

## Test plan

- [x] Backend regression test passes; fails with the exact assertion when the fallback is removed
- [x] CLI unit tests pass (5/5); 3 fail against a blanket-`catch` mutant
- [x] Broken app on a patched backend: `.css` → 200 `text/css` 0 bytes (was 404)
- [x] Missing `.js` still 404s — tolerance does not leak
- [x] App with real CSS (1662 bytes) round-trips byte-identical
- [x] Cross-workspace deploy of a css-less app: aborts unpatched → **HTTP 201** patched
- [x] Controlled browser A/B: with the fix the editor sends `app|js|css` and a 0-byte css row
      appears; with it reverted the request carries only `app|js` and no row is written
- [x] `cargo check -p windmill-api`, `npm run check` (0 errors), `tsc --noEmit` all clean