### PR TITLE
fix(wac): report a task failure the child round's body catches

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1800,12 +1800,9 @@ pub async fn handle_bun_job(
         };
 
         // Kept comment-free — this string is written out per job.
-        // `_takePendingSuspend` returns a StepSuspend the body caught and swallowed
-        // (it is an `Error`), so honour it instead of reporting a `complete` whose
-        // step never reached the checkpoint. `_takePendingStepFailure` does the same
-        // for the exception raised by the step a child round executes directly: it is
-        // the round's result, not something the body may handle, so a broad catch must
-        // not turn it into a successful `complete`. Optional: npm clients may predate them.
+        // `_takePendingStepFailure` / `_takePendingSuspend` hand back what the body
+        // caught and swallowed; honour them instead of reporting a `complete` (see
+        // `_pendingStepFailure` in client.ts). Optional: npm clients may predate them.
         let wrapper_content = if is_wac_v2 {
             format!(
                 r#"

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1802,7 +1802,10 @@ pub async fn handle_bun_job(
         // Kept comment-free — this string is written out per job.
         // `_takePendingSuspend` returns a StepSuspend the body caught and swallowed
         // (it is an `Error`), so honour it instead of reporting a `complete` whose
-        // step never reached the checkpoint. Optional: npm clients may predate it.
+        // step never reached the checkpoint. `_takePendingStepFailure` does the same
+        // for the exception raised by the step a child round executes directly: it is
+        // the round's result, not something the body may handle, so a broad catch must
+        // not turn it into a successful `complete`. Optional: npm clients may predate them.
         let wrapper_content = if is_wac_v2 {
             format!(
                 r#"
@@ -1847,6 +1850,10 @@ async function run() {{
     try {{
         const result = await workflowFn(...argsArr);
         setWorkflowCtx(null);
+        const failed = ctx._takePendingStepFailure?.();
+        if (failed) {{
+            throw failed.error;
+        }}
         const swallowed = ctx._takePendingSuspend?.();
         if (swallowed) {{
             throw swallowed;
@@ -1874,6 +1881,10 @@ async function run() {{
                 return {{ type: "sleep", key: dispatch.key, seconds: dispatch.seconds }};
             }}
             return {{ type: "dispatch", mode: dispatch.mode ?? "sequential", steps: dispatch.steps ?? [] }};
+        }}
+        const failed = ctx._takePendingStepFailure?.();
+        if (failed) {{
+            throw failed.error;
         }}
         throw e;
     }}

--- a/python-client/wmill/tests/test_workflow.py
+++ b/python-client/wmill/tests/test_workflow.py
@@ -407,10 +407,8 @@ class TestChildMode:
         assert result["result"] == 14
 
     def test_child_cannot_swallow_the_failure_of_the_step_it_executes(self):
-        # The failure of the step a child round runs directly IS that round's
-        # result. If `except Exception` could catch it, the child would report
-        # a success returning "swallowed", the parent would record that as the
-        # step's value, and `await boom()` there would never raise.
+        # If `except Exception` could catch it, the child would report a success
+        # returning "swallowed" and the parent would record that as the step's value.
         @task
         async def boom():
             raise ValueError("nope")

--- a/python-client/wmill/tests/test_workflow.py
+++ b/python-client/wmill/tests/test_workflow.py
@@ -406,6 +406,26 @@ class TestChildMode:
         assert result["type"] == "complete"
         assert result["result"] == 14
 
+    def test_child_cannot_swallow_the_failure_of_the_step_it_executes(self):
+        # The failure of the step a child round runs directly IS that round's
+        # result. If `except Exception` could catch it, the child would report
+        # a success returning "swallowed", the parent would record that as the
+        # step's value, and `await boom()` there would never raise.
+        @task
+        async def boom():
+            raise ValueError("nope")
+
+        @workflow
+        async def wf():
+            try:
+                await boom()
+            except Exception:
+                return "swallowed"
+            return "unreachable"
+
+        with pytest.raises(ValueError, match="nope"):
+            _run_workflow(wf, {"_executing_key": "boom"}, {})
+
     def test_child_replays_cached_steps(self):
         checkpoint = {
             "completed_steps": {"extract_data": {"data": [1, 2, 3]}},

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2676,10 +2676,10 @@ class _StepSuspend(BaseException):
 class _StepFailure(BaseException):
     """Carries the exception raised by the step a child round executes directly.
 
-    That exception *is* the round's result, so a broad ``except Exception`` in
-    the workflow body must not be able to turn it into a successful complete —
-    the parent would then record the caught branch's value as the step result.
-    Inherits from BaseException for the same reason ``_StepSuspend`` does.
+    That exception *is* the round's result, so a broad ``except Exception`` in the
+    body must not be able to turn it into a successful complete — the parent would
+    then record the caught branch's value as the step result. BaseException for the
+    same reason ``_StepSuspend`` is.
     """
 
     def __init__(self, exc: BaseException):

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2673,6 +2673,19 @@ class _StepSuspend(BaseException):
         self.dispatch_info = dispatch_info
 
 
+class _StepFailure(BaseException):
+    """Carries the exception raised by the step a child round executes directly.
+
+    That exception *is* the round's result, so a broad ``except Exception`` in
+    the workflow body must not be able to turn it into a successful complete —
+    the parent would then record the caught branch's value as the step result.
+    Inherits from BaseException for the same reason ``_StepSuspend`` does.
+    """
+
+    def __init__(self, exc: BaseException):
+        self.exc = exc
+
+
 class TaskError(Exception):
     """Raised when a WAC task step failed.
 
@@ -2799,9 +2812,12 @@ class WorkflowCtx:
         return value
 
     async def _execute_directly(self, func, **kwargs):
-        result = func(**kwargs)
-        if _asyncio.iscoroutine(result):
-            result = await result
+        try:
+            result = func(**kwargs)
+            if _asyncio.iscoroutine(result):
+                result = await result
+        except Exception as exc:
+            raise _StepFailure(exc) from exc
         raise _StepSuspend({"mode": "step_complete", "steps": [], "result": result})
 
     async def _never_resolve(self):
@@ -3266,6 +3282,9 @@ async def _run_workflow_async(func, checkpoint: dict, input_args: dict):
                 "steps": steps,
             }
         return {"type": "complete", "result": result}
+    except _StepFailure as e:
+        # Re-raise the step's own exception so the child job fails with it.
+        raise e.exc
     except _StepSuspend as e:
         info = e.dispatch_info
         mode = info.get("mode")

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2679,7 +2679,7 @@ class _StepFailure(BaseException):
     That exception *is* the round's result, so a broad ``except Exception`` in the
     body must not be able to turn it into a successful complete — the parent would
     then record the caught branch's value as the step result. BaseException for the
-    same reason ``_StepSuspend`` is.
+    same reason ``_StepSuspend`` is; a bare ``except:`` still swallows both.
     """
 
     def __init__(self, exc: BaseException):

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -1594,11 +1594,10 @@ export class WorkflowCtx {
    *  `complete` whose step never reached `completed_steps`. Python is immune:
    *  `_StepSuspend` derives from `BaseException`. */
   private _pendingSuspend: StepSuspend | null = null;
-  /** The failure raised by the step this child round is executing. In child
-   *  mode that exception *is* the round's result, so a `catch` in the workflow
-   *  body must not be able to turn it into a `complete` — the parent would then
-   *  record the caught branch's value as a successful step. Boxed because the
-   *  thrown value may be any falsy value. */
+  /** The failure raised by the step this child round is executing. That exception
+   *  *is* the round's result, so a `catch` in the body must not be able to turn it
+   *  into a `complete` — the parent would then record the caught branch's value as
+   *  a successful step. Boxed: the thrown value may be any falsy value. */
   private _pendingStepFailure: { error: unknown } | null = null;
   /** When set, the task matching this key executes its inner function directly */
   _executingKey: string | null;
@@ -1895,9 +1894,8 @@ export class WorkflowCtx {
     throw suspend;
   }
 
-  /** Raise the executing step's failure, parking it so a body that catches it
-   *  cannot make it vanish. Child mode only — in a parent round a task failure
-   *  is an ordinary `TaskError` the body may handle. */
+  /** Park then raise the executing step's failure. Child mode only — in a parent
+   *  round a task failure is an ordinary `TaskError` the body may handle. */
   _raiseStepFailure(error: unknown): never {
     this._pendingStepFailure = { error };
     throw error;
@@ -1921,8 +1919,7 @@ export class WorkflowCtx {
     return s;
   }
 
-  /** Same for the executing step's failure: the runner re-throws it so the
-   *  child job fails instead of reporting the caught branch as the result. */
+  /** Same for the executing step's failure, so the runner can fail the child job. */
   _takePendingStepFailure(): { error: unknown } | null {
     const f = this._pendingStepFailure;
     this._pendingStepFailure = null;

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -1594,6 +1594,12 @@ export class WorkflowCtx {
    *  `complete` whose step never reached `completed_steps`. Python is immune:
    *  `_StepSuspend` derives from `BaseException`. */
   private _pendingSuspend: StepSuspend | null = null;
+  /** The failure raised by the step this child round is executing. In child
+   *  mode that exception *is* the round's result, so a `catch` in the workflow
+   *  body must not be able to turn it into a `complete` — the parent would then
+   *  record the caught branch's value as a successful step. Boxed because the
+   *  thrown value may be any falsy value. */
+  private _pendingStepFailure: { error: unknown } | null = null;
   /** When set, the task matching this key executes its inner function directly */
   _executingKey: string | null;
   /** Serializes fast-path POSTs across concurrent step() calls within one
@@ -1635,7 +1641,7 @@ export class WorkflowCtx {
     dispatch_type: string = "inline",
     options?: TaskOptions,
   ): PromiseLike<any> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     const key = this._allocKey(name || script || "step");
 
     if (key in this.completed) {
@@ -1707,7 +1713,7 @@ export class WorkflowCtx {
     selfApproval?: boolean;
     key?: string;
   }): PromiseLike<{ value: any; approver: string; approved: boolean }> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     if (options?.key !== undefined) assertUsableStepKey(options.key, "waitForApproval key");
     const key = this._allocKey(options?.key || "approval");
 
@@ -1745,7 +1751,7 @@ export class WorkflowCtx {
   }
 
   _sleep(seconds: number): PromiseLike<void> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     const key = this._allocKey("sleep");
 
     if (key in this.completed) {
@@ -1766,7 +1772,7 @@ export class WorkflowCtx {
   }
 
   async _runInlineStep<T>(name: string, fn: () => T | Promise<T>): Promise<T> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     const key = this._allocKey(name || "step");
 
     if (key in this.completed) {
@@ -1889,11 +1895,20 @@ export class WorkflowCtx {
     throw suspend;
   }
 
-  /** Re-throw a swallowed suspend at the next SDK call. It happened before
-   *  whatever the body is doing now, so it wins: the run is unwinding either
-   *  way and everything after it re-runs on the replay. Left set, so a body
-   *  that catches in a loop can't swallow it a second time. */
-  private _rethrowSwallowedSuspend(): void {
+  /** Raise the executing step's failure, parking it so a body that catches it
+   *  cannot make it vanish. Child mode only — in a parent round a task failure
+   *  is an ordinary `TaskError` the body may handle. */
+  _raiseStepFailure(error: unknown): never {
+    this._pendingStepFailure = { error };
+    throw error;
+  }
+
+  /** Re-throw a swallowed suspend or step failure at the next SDK call. It
+   *  happened before whatever the body is doing now, so it wins: the run is
+   *  unwinding either way and everything after it re-runs on the replay. Left
+   *  set, so a body that catches in a loop can't swallow it a second time. */
+  private _rethrowSwallowed(): void {
+    if (this._pendingStepFailure) throw this._pendingStepFailure.error;
     if (this._pendingSuspend) throw this._pendingSuspend;
   }
 
@@ -1904,6 +1919,14 @@ export class WorkflowCtx {
     const s = this._pendingSuspend;
     this._pendingSuspend = null;
     return s;
+  }
+
+  /** Same for the executing step's failure: the runner re-throws it so the
+   *  child job fails instead of reporting the caught branch as the result. */
+  _takePendingStepFailure(): { error: unknown } | null {
+    const f = this._pendingStepFailure;
+    this._pendingStepFailure = null;
+    return f;
   }
 }
 
@@ -1978,7 +2001,13 @@ export function task<T extends (...args: any[]) => Promise<any>>(
       // and throw StepSuspend with mode "step_complete" to signal that we're done
       if ((stepResult as any)?._execute_directly) {
         return (async () => {
-          const result = await fn(...args);
+          let result: any;
+          try {
+            result = await fn(...args);
+          } catch (e) {
+            if ((e as any)?.name === "StepSuspend" || e instanceof StepSuspend) throw e;
+            ctx._raiseStepFailure(e);
+          }
           ctx._raiseSuspend({ mode: "step_complete", steps: [], result });
         })();
       }

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -1522,6 +1522,32 @@ describe("throwing inline step is checkpointed", () => {
     await expect(runWorkflow(wf, { _executing_key: "step_0" }, [])).rejects.toThrow("nope");
   });
 
+  test("a parked failure is re-raised at the next SDK call, not left to hang", async () => {
+    // A body that catches and carries on reaches an SDK call that, in child mode,
+    // never resolves — so without the re-raise the child parks there and hangs
+    // until timeout instead of reporting the failure. Raced against a deadline so
+    // that regression fails the test rather than wedging the suite.
+    const boom = task(async function boom() {
+      throw new TypeError("nope");
+    });
+    for (const carryOn of [() => double(1), () => sleep(1)]) {
+      const wf = workflow(async () => {
+        try {
+          await boom();
+        } catch {
+          // swallowed on purpose
+        }
+        await carryOn();
+        return "unreachable";
+      });
+      const run = Promise.race([
+        runWorkflow(wf, { _executing_key: "step_0" }, []),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("parked")), 500)),
+      ]);
+      await expect(run).rejects.toThrow("nope");
+    }
+  });
+
   test("a swallowed suspend from a task dispatch still reaches the runner", async () => {
     const wf = workflow(async (x: number) => {
       try {

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -1506,10 +1506,8 @@ describe("throwing inline step is checkpointed", () => {
   });
 
   test("a child job cannot swallow the failure of the step it executes", async () => {
-    // The failure of the step a child round runs directly IS that round's
-    // result. Without parking, the catch below turns the child into a success
-    // returning "swallowed", the parent records that as the step's value, and
-    // `await boom()` there never throws.
+    // Without parking, the catch below turns the child into a success returning
+    // "swallowed" and the parent records that as the step's value.
     const boom = task(async function boom() {
       throw new TypeError("nope");
     });

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -27,6 +27,7 @@ class WorkflowCtx {
   }> = [];
   private _suspended = false;
   private _pendingSuspend: StepSuspend | null = null;
+  private _pendingStepFailure: { error: unknown } | null = null;
   _executingKey: string | null;
 
   _raiseSuspend(dispatchInfo: Record<string, any>): never {
@@ -35,7 +36,13 @@ class WorkflowCtx {
     throw suspend;
   }
 
-  private _rethrowSwallowedSuspend(): void {
+  _raiseStepFailure(error: unknown): never {
+    this._pendingStepFailure = { error };
+    throw error;
+  }
+
+  private _rethrowSwallowed(): void {
+    if (this._pendingStepFailure) throw this._pendingStepFailure.error;
     if (this._pendingSuspend) throw this._pendingSuspend;
   }
 
@@ -43,6 +50,12 @@ class WorkflowCtx {
     const s = this._pendingSuspend;
     this._pendingSuspend = null;
     return s;
+  }
+
+  _takePendingStepFailure(): { error: unknown } | null {
+    const f = this._pendingStepFailure;
+    this._pendingStepFailure = null;
+    return f;
   }
 
   constructor(checkpoint: Record<string, any> = {}) {
@@ -60,7 +73,7 @@ class WorkflowCtx {
     args: Record<string, any> = {},
     options?: Record<string, any>,
   ): PromiseLike<any> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     const key = this._allocKey();
 
     if (key in this.completed) {
@@ -118,7 +131,7 @@ class WorkflowCtx {
   }
 
   _sleep(seconds: number): PromiseLike<void> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     const key = this._allocKey();
     if (key in this.completed) {
       return { then: (resolve: any) => resolve(undefined) };
@@ -138,7 +151,7 @@ class WorkflowCtx {
     name: string,
     fn: () => T | Promise<T>
   ): Promise<T> {
-    this._rethrowSwallowedSuspend();
+    this._rethrowSwallowed();
     const key = this._allocKey();
 
     if (key in this.completed) {
@@ -231,7 +244,13 @@ function task<T extends (...args: any[]) => Promise<any>>(
       const stepResult = ctx._nextStep(taskName, script, kwargs, taskOptions);
       if ((stepResult as any)?._execute_directly) {
         return (async () => {
-          const result = await fn(...args);
+          let result: any;
+          try {
+            result = await fn(...args);
+          } catch (e: any) {
+            if (e?.name === "StepSuspend" || e instanceof StepSuspend) throw e;
+            ctx._raiseStepFailure(e);
+          }
           ctx._raiseSuspend({
             mode: "step_complete",
             steps: [],
@@ -302,7 +321,10 @@ async function runWorkflow(
   _workflowCtx = ctx;
   try {
     const result = await fn(...args);
-    // Mirrors bun_executor.rs: honour a suspend the body caught and swallowed.
+    // Mirrors bun_executor.rs: honour a step failure or suspend the body caught
+    // and swallowed.
+    const failed = ctx._takePendingStepFailure?.();
+    if (failed) throw failed.error;
     const swallowed = ctx._takePendingSuspend?.();
     if (swallowed) throw swallowed;
     // Flush unawaited tasks
@@ -336,6 +358,8 @@ async function runWorkflow(
       }
       return { type: "dispatch", ...info };
     }
+    const failed = ctx._takePendingStepFailure?.();
+    if (failed) throw failed.error;
     throw e;
   } finally {
     _workflowCtx = null;
@@ -1479,6 +1503,25 @@ describe("throwing inline step is checkpointed", () => {
     const result = await runWorkflow(wf, { _executing_key: "step_0" }, [5]);
     expect(result.type).toBe("complete");
     expect(result.result).toBe(10);
+  });
+
+  test("a child job cannot swallow the failure of the step it executes", async () => {
+    // The failure of the step a child round runs directly IS that round's
+    // result. Without parking, the catch below turns the child into a success
+    // returning "swallowed", the parent records that as the step's value, and
+    // `await boom()` there never throws.
+    const boom = task(async function boom() {
+      throw new TypeError("nope");
+    });
+    const wf = workflow(async () => {
+      try {
+        await boom();
+      } catch {
+        return "swallowed";
+      }
+      return "unreachable";
+    });
+    await expect(runWorkflow(wf, { _executing_key: "step_0" }, [])).rejects.toThrow("nope");
   });
 
   test("a swallowed suspend from a task dispatch still reaches the runner", async () => {


### PR DESCRIPTION
## Summary

A WAC v2 task failure was silently **not** reported when the workflow body wrapped the task call in a broad `try/catch`.

A `@workflow` dispatches a task by re-running the *entire* workflow body in a child job with `_executing_key` set, so only the target step runs its inner function. In that child round the raw exception thrown by the task body propagated into the workflow body's own `try/catch`. The body caught it, the child job **completed successfully** returning whatever the catch branch produced, and the parent recorded that as a normal successful step result. In the parent, `await failing_task()` then resolved with the child's value instead of raising, and the user's error handler never ran.

```ts
const boom = task(async function boom() { throw new TypeError("nope"); });
export default workflow(async function main() {
  try { await boom(); } catch (e) { return { caught: "yes" }; }
  return { caught: null };
});
```

Before: parent result `{"caught": null}`, child job **success** with result `{"caught":"yes"}` — the failure vanished.
After: child job **fails** with `TypeError: nope`, the parent records the `__wmill_error` marker, and the replayed parent's catch runs with a `TaskError`.

This is the structural twin of #10348, which stopped a broad catch from swallowing a `step()` **suspend**. Same reasoning: in the child round the executing step's exception *is* the round's result, not something the body may handle. Only the child round is affected — a parent round that legitimately catches a `TaskError` and retries is untouched, because the parking path is reachable only when `_executing_key` matches the step.

## Changes

- **`typescript-client/client.ts`** — `WorkflowCtx` parks the executing step's failure in `_pendingStepFailure` and re-throws it at the next SDK call (`_rethrowSwallowedSuspend` → `_rethrowSwallowed`, which now covers both parked kinds). `task()`'s `_execute_directly` branch routes a thrown task body through `_raiseStepFailure`, passing `StepSuspend` through untouched. New `_takePendingStepFailure()` hands the parked failure to the runner.
- **`backend/windmill-worker/src/bun_executor.rs`** — the generated WAC wrapper calls `ctx._takePendingStepFailure?.()` on both the return and the catch path and re-throws the parked error, so a catching body cannot report a `complete`. Optional-call, like the existing `_takePendingSuspend?.()`: an npm client that predates the hook keeps today's behavior instead of erroring.
- **`python-client/wmill/wmill/client.py`** — `_execute_directly` wraps a raised task body in `_StepFailure`, a `BaseException` subclass (so `except Exception:` cannot catch it, same device as `_StepSuspend`); `_run_workflow_async` unwraps it and re-raises the step's own exception, which the generated Python wrapper's `except BaseException` turns into a failed child job with the original name/message/traceback. No backend change is needed for Python.

The two clients are not equally airtight: TypeScript's parking + wrapper drain makes the failure unswallowable by *any* catch, while Python's relies solely on `BaseException`, so a bare `except:` (or `gather(..., return_exceptions=True)`) still erases it. That is the same exposure `_StepSuspend` has had since #10348, so it is not a regression, and the `_StepFailure` docstring now says so rather than implying parity.
- Regression test in each client's workflow suite.

### Options considered

1. **Park the failure so it escapes the body's catch** — chosen. Mirrors #10348; degrades gracefully in both directions of SDK/backend version skew.
2. *Have the child wrapper detect that the executing step raised, regardless of what the body returned* — the wrapper cannot know without SDK cooperation, so it reduces to option 1 anyway.
3. *Do nothing and document `except TaskError` / `e.name !== "TaskError"`* — leaves a silent data-loss default; the failure disappearing is not something a user can be expected to defend against.

## Test plan

Verified end to end on a dev backend (bun **and** python WAC jobs, parent + child rounds inspected), with the SDK changes actually installed — the published npm/PyPI packages are what jobs install, so the fixed clients were staged into an isolated `WINDMILL_DIR` cache and the TS one was checked against a real `tsdown` build of the modified `client.ts`.

- [x] Repro before the fix, both languages: parent `{"caught": null}`, child **success** returning `{"caught":"yes"}`
- [x] After: child **fails** with the task's own error (`TypeError: nope` / `ValueError: nope`, traceback pointing at the user's `raise`); parent result is the catch branch's value produced on the *replay* round, with `e.name === "TaskError"`
- [x] Retry-loop shape (body catches `TaskError` and re-dispatches with different args) still completes: `{"value":"ok on 3","errors":["TaskError: …","TaskError: …"]}` in both languages
- [x] Catch-then-continue (`catch {} ; await other()`) — the parked failure is re-thrown at the next SDK call, the child fails, and the parent still runs `other()` on replay
- [x] Uncaught failure still fails the parent with the nested child error; `Promise.all` / `asyncio.gather` fan-out with one failing task behaves the same
- [x] Backward compat: pristine (pre-fix) `windmill-client@1.773.0` against the new backend wrapper runs without error, falling back to the old behavior
- [x] `bun test typescript-client/tests/workflow.test.ts` → 90 pass; each new test verified to fail without its fix (the catch-then-continue guard races against a 500ms deadline, so a regression fails it instead of wedging the suite on the never-resolving thenable)
- [x] `pytest python-client/wmill/tests/` → 96 pass (1 pre-existing unrelated failure, `test_preserves_function_name`, fails identically on `main`)
- [x] `python system_prompts/generate.py` → no generated-file drift

### Review nits dismissed

- *The TS regression test exercises the test file's inline mirror of the SDK, not `client.ts` itself.* That is pre-existing structure — all 89 tests in `workflow.test.ts` run against the mirror because `client.ts` imports the codegen'd `src/services.gen` and cannot be imported by a standalone `bun test` without running `build.sh` first. Restructuring the suite is out of scope here; the shipped `client.ts` path is what the end-to-end runs above covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a WAC v2 bug where a child round could swallow the executing task’s failure when the workflow body used a broad try/catch. The child now fails with the task’s error, and the parent receives a `TaskError` so user error handlers run as expected.

- Bug Fixes
  - TypeScript client: park executing-step failures in `_pendingStepFailure` and rethrow on the next SDK call; `task()` routes non-`StepSuspend` errors via `_raiseStepFailure`.
  - Bun wrapper: after return/catch, call `ctx._takePendingStepFailure?.()` and rethrow so a catching body cannot report `complete`; still honors `_takePendingSuspend?.()`. Optional calls for version skew.
  - Python client: wrap direct execution errors in `_StepFailure` (`BaseException`) and unwrap/re-raise in `_run_workflow_async`; no backend change needed.
  - Tests: added regression coverage in TS and Python, including a catch-then-continue test that ensures the failure is re-raised at the next SDK call (no child hang); verified graceful compatibility with `windmill-client@1.773.0`.

<sup>Written for commit 65c71324396d0cdc8d3dec84d8f48b77546a2007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

