### PR TITLE
fix(apps): stop cross-origin isolating the raw app viewer

### DIFF
--- a/backend/windmill-api/src/static_assets.rs
+++ b/backend/windmill-api/src/static_assets.rs
@@ -51,7 +51,12 @@ const TWO_HUNDRED: &str = "200.html";
 /// Check if the original path requires cross-origin isolation headers.
 ///
 /// These headers are needed for SharedArrayBuffer and TypeScript workers
-/// (raw app editor at `/apps_raw/`, in-browser bundler at `/ui_builder/`).
+/// (raw app editor at `/apps_raw/edit|add`, in-browser bundler at
+/// `/ui_builder/`). The raw app *viewer* (`/apps_raw/get/`) must NOT get them:
+/// COEP `require-corp` blocks the viewed app's cross-origin subresources
+/// (external images, embeds) that lack CORP, and would make apps break on a
+/// page reload while working when client-side-navigated to (the document
+/// keeps the non-isolated headers of the URL it was originally loaded from).
 ///
 /// Public apps (`/public/` and custom paths `/a/`) opt in via the `wm_coep`
 /// query param: a public (raw) app must set COEP to be embeddable as an iframe
@@ -62,7 +67,8 @@ const TWO_HUNDRED: &str = "200.html";
 /// explicitly requests it.
 #[cfg(feature = "static_frontend")]
 fn needs_cross_origin_isolation(original_path: &str, query: Option<&str>) -> bool {
-    original_path.starts_with("/apps_raw/")
+    original_path.starts_with("/apps_raw/edit/")
+        || original_path.starts_with("/apps_raw/add")
         || original_path.starts_with("/ui_builder/")
         || ((original_path.starts_with("/public/") || original_path.starts_with("/a/"))
             && query_has_flag(query, "wm_coep"))
@@ -152,7 +158,15 @@ mod tests {
     fn test_needs_cross_origin_isolation() {
         // editor + bundler are always isolated, regardless of query
         assert!(needs_cross_origin_isolation("/apps_raw/edit/foo", None));
+        assert!(needs_cross_origin_isolation("/apps_raw/add", None));
         assert!(needs_cross_origin_isolation("/ui_builder/index.html", None));
+
+        // the raw app viewer is NOT isolated: COEP would block the viewed
+        // app's cross-origin subresources on a page reload
+        assert!(!needs_cross_origin_isolation(
+            "/apps_raw/get/u/foo/bar",
+            None
+        ));
 
         // public apps (and custom paths) are isolated only when they opt in via wm_coep
         assert!(needs_cross_origin_isolation(

--- a/backend/windmill-api/src/static_assets.rs
+++ b/backend/windmill-api/src/static_assets.rs
@@ -50,13 +50,15 @@ const TWO_HUNDRED: &str = "200.html";
 
 /// Check if the original path requires cross-origin isolation headers.
 ///
-/// These headers are needed for SharedArrayBuffer and TypeScript workers
-/// (raw app editor at `/apps_raw/edit|add`, in-browser bundler at
+/// CANONICAL COEP RATIONALE (the dev-server mirror in `frontend/vite.config.js`
+/// and the navigation guards in `frontend/src/routes/(root)/(logged)/+layout.svelte`
+/// point here): the headers are needed for SharedArrayBuffer and TypeScript
+/// workers (raw app editor at `/apps_raw/edit|add`, in-browser bundler at
 /// `/ui_builder/`). The raw app *viewer* (`/apps_raw/get/`) must NOT get them:
 /// COEP `require-corp` blocks the viewed app's cross-origin subresources
-/// (external images, embeds) that lack CORP, and would make apps break on a
-/// page reload while working when client-side-navigated to (the document
-/// keeps the non-isolated headers of the URL it was originally loaded from).
+/// (external images, embeds) that lack CORP — and since headers stick to the
+/// document, apps would break on a page reload while working when reached via
+/// client-side navigation.
 ///
 /// Public apps (`/public/` and custom paths `/a/`) opt in via the `wm_coep`
 /// query param: a public (raw) app must set COEP to be embeddable as an iframe
@@ -67,7 +69,8 @@ const TWO_HUNDRED: &str = "200.html";
 /// explicitly requests it.
 #[cfg(feature = "static_frontend")]
 fn needs_cross_origin_isolation(original_path: &str, query: Option<&str>) -> bool {
-    original_path.starts_with("/apps_raw/edit/")
+    // no trailing slash on edit/add: matches the +layout.svelte guards
+    original_path.starts_with("/apps_raw/edit")
         || original_path.starts_with("/apps_raw/add")
         || original_path.starts_with("/ui_builder/")
         || ((original_path.starts_with("/public/") || original_path.starts_with("/a/"))
@@ -161,8 +164,7 @@ mod tests {
         assert!(needs_cross_origin_isolation("/apps_raw/add", None));
         assert!(needs_cross_origin_isolation("/ui_builder/index.html", None));
 
-        // the raw app viewer is NOT isolated: COEP would block the viewed
-        // app's cross-origin subresources on a page reload
+        // the raw app viewer must NOT be isolated
         assert!(!needs_cross_origin_isolation(
             "/apps_raw/get/u/foo/bar",
             None

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -81,8 +81,13 @@
 		// `wm_coep` (embed-in-cross-origin-isolated-page opt-in) must be propagated
 		// to the wrapper document: under a COEP `require-corp` embedder, a nested
 		// document is only allowed to load if it asserts COEP itself, so the
-		// backend adds the header when the flag is present.
-		const coep = new URLSearchParams(window.location.search).has('wm_coep') ? '?wm_coep=1' : ''
+		// backend adds the header when the flag is present. Also request it when
+		// this document is itself cross-origin isolated (e.g. the raw app editor)
+		// — the wrapper would otherwise be blocked outright, URL flag or not.
+		const coep =
+			new URLSearchParams(window.location.search).has('wm_coep') || window.crossOriginIsolated
+				? '?wm_coep=1'
+				: ''
 		return `/api/w/${workspace}/apps_u/get_data/v/${secret}.html${coep}`
 	})
 

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -415,8 +415,10 @@
 		// This ensures the cross-origin isolation headers are fetched from the server
 		// which are required for SharedArrayBuffer and TypeScript workers to work correctly
 		const toPath = navigation.to?.url.pathname
-		if (toPath && (toPath.startsWith('/apps_raw/add') || toPath.startsWith('/apps_raw/edit'))) {
-			const currentPath = navigation.from?.url.pathname
+		const currentPath = navigation.from?.url.pathname
+		const isEditorPath = (p: string | undefined) =>
+			!!p && (p.startsWith('/apps_raw/add') || p.startsWith('/apps_raw/edit'))
+		if (isEditorPath(toPath)) {
 			// Reload if we're not on an apps_raw path, or if we're on the raw app viewer
 			// (/apps_raw/get/): the viewer doesn't have cross-origin isolation headers, so
 			// we need a full reload to fetch them for the editor.
@@ -424,11 +426,13 @@
 				navigation.cancel()
 				window.location.href = navigation.to!.url.href
 			}
-		} else if (toPath && window.crossOriginIsolated) {
-			// The reverse also needs a full reload: the editor document is
-			// cross-origin isolated, and COEP `require-corp` would otherwise stick
-			// for the rest of the SPA session, blocking CORP-less cross-origin
-			// subresources everywhere (e.g. external images in a viewed app).
+		} else if (toPath && (isEditorPath(currentPath) || window.crossOriginIsolated)) {
+			// Reverse of the guard above: leaving the isolated editor document must
+			// also fully reload, or its COEP header sticks for the rest of the SPA
+			// session and blocks CORP-less cross-origin subresources (e.g. images in
+			// a viewed app — see needs_cross_origin_isolation in static_assets.rs).
+			// The path check covers plain-HTTP origins, where `crossOriginIsolated`
+			// stays false even with the headers applied.
 			navigation.cancel()
 			window.location.href = navigation.to!.url.href
 		}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -424,6 +424,13 @@
 				navigation.cancel()
 				window.location.href = navigation.to!.url.href
 			}
+		} else if (toPath && window.crossOriginIsolated) {
+			// The reverse also needs a full reload: the editor document is
+			// cross-origin isolated, and COEP `require-corp` would otherwise stick
+			// for the rest of the SPA session, blocking CORP-less cross-origin
+			// subresources everywhere (e.g. external images in a viewed app).
+			navigation.cancel()
+			window.location.href = navigation.to!.url.href
 		}
 	})
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,15 +24,36 @@ const remoteUrl =
 
 const cookieDomain = process.env.ISOLATE_DEV_AUTH === '1' ? '' : 'localhost'
 
+// Cross-origin isolation headers, scoped to the same paths as the production
+// server (backend/windmill-api/src/static_assets.rs `needs_cross_origin_isolation`):
+// the raw app editor + in-browser bundler need them (SharedArrayBuffer, TS
+// workers); everything else — in particular the raw app *viewer* at
+// /apps_raw/get — must not get them, because COEP `require-corp` blocks the
+// viewed app's cross-origin subresources (external images, embeds).
 // `enforce: 'pre'` so these headers are set before SvelteKit's sirv static
 // handler serves `static/` files and ends the response without calling next().
+function needsCrossOriginIsolation(url) {
+	const [path, query = ''] = url.split('?')
+	return (
+		path.startsWith('/apps_raw/edit/') ||
+		path.startsWith('/apps_raw/add') ||
+		path.startsWith('/ui_builder/') ||
+		((path.startsWith('/public/') || path.startsWith('/a/')) &&
+			new URLSearchParams(query).has('wm_coep'))
+	)
+}
+
 let plugin = {
 	name: 'configure-response-headers',
 	enforce: 'pre',
 	configureServer: (server) => {
-		server.middlewares.use((_req, res, next) => {
-			res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
-			res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+		server.middlewares.use((req, res, next) => {
+			if (needsCrossOriginIsolation(req.url ?? '')) {
+				res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+				res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+			}
+			// CORP on everything so dev assets stay loadable as subresources of
+			// isolated documents on other dev origins (e.g. 127.0.0.1 vs localhost).
 			res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin')
 			next()
 		})

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,18 +24,15 @@ const remoteUrl =
 
 const cookieDomain = process.env.ISOLATE_DEV_AUTH === '1' ? '' : 'localhost'
 
-// Cross-origin isolation headers, scoped to the same paths as the production
-// server (backend/windmill-api/src/static_assets.rs `needs_cross_origin_isolation`):
-// the raw app editor + in-browser bundler need them (SharedArrayBuffer, TS
-// workers); everything else — in particular the raw app *viewer* at
-// /apps_raw/get — must not get them, because COEP `require-corp` blocks the
-// viewed app's cross-origin subresources (external images, embeds).
+// Cross-origin isolation headers, scoped to mirror the production predicate —
+// see `needs_cross_origin_isolation` in backend/windmill-api/src/static_assets.rs
+// for which paths need them and why the raw app viewer must be excluded.
 // `enforce: 'pre'` so these headers are set before SvelteKit's sirv static
 // handler serves `static/` files and ends the response without calling next().
 function needsCrossOriginIsolation(url) {
 	const [path, query = ''] = url.split('?')
 	return (
-		path.startsWith('/apps_raw/edit/') ||
+		path.startsWith('/apps_raw/edit') ||
 		path.startsWith('/apps_raw/add') ||
 		path.startsWith('/ui_builder/') ||
 		((path.startsWith('/public/') || path.startsWith('/a/')) &&


### PR DESCRIPTION
## Summary

Deployed raw apps showed COEP errors (`ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep` on CORP-less cross-origin subresources such as external images) depending on *how* the page was reached:

- client-side navigation from the workspace home → app worked
- a hard reload of `/apps_raw/get/...` → COEP errors
- navigating back to the home and into the app again → still broken, until the home page itself was hard-reloaded

Root cause: `needs_cross_origin_isolation` in `static_assets.rs` matched **all** of `/apps_raw/`, including the workspace *viewer* route `/apps_raw/get/`, not just the editor routes that need SharedArrayBuffer/TS workers. So a hard load of the viewer served the SPA document with COOP/COEP, cross-origin isolating the whole SPA session, while a client-side nav kept the non-isolated document of the URL originally loaded — hence the reload-dependent behavior. (The navigation guard in `+layout.svelte` even documents the intended behavior: "the viewer doesn't have cross-origin isolation headers".)

## Changes

- **`backend/windmill-api/src/static_assets.rs`**: narrow the isolation predicate from `/apps_raw/` to the editor routes `/apps_raw/edit/` + `/apps_raw/add` (the `wm_coep` opt-in for `/public/`+`/a/` and `/ui_builder/` are unchanged). Extended the unit test with the viewer negative case.
- **`frontend/vite.config.js`**: the dev server previously applied COOP/COEP to *every* response, so every page in dev was isolated and the prod bug wasn't even reproducible. Scope the headers with the same predicate as prod (CORP stays global so dev assets remain loadable from isolated documents on sibling dev origins).
- **`frontend/src/routes/(root)/(logged)/+layout.svelte`**: the existing guard forces a full reload when navigating *into* the editor (to pick up the headers) — but nothing shed them on the way *out*, so editor → home → app kept the isolated document and broke the viewed app. Added the reverse guard: leaving an isolated document for a non-editor route forces a full reload.
- **`frontend/src/lib/components/raw_apps/RawAppPreview.svelte`**: request the COEP-asserting wrapper (`?wm_coep=1`) also when `window.crossOriginIsolated` is true, not only when the URL carries `wm_coep` — under a COEP embedder a nested document is blocked outright unless it asserts COEP itself.

## Test plan

- [x] `cargo test -p windmill-api --features static_frontend static_assets` — both header-predicate tests pass (viewer negative case pinned)
- [x] `cargo check -p windmill-api`, `npm run check` (0 errors)
- [x] Browser repro (raw app whose bundle renders `https://placehold.co/150.png`, no CORP header): before the fix, hard load of `/apps_raw/get/...` → `crossOriginIsolated: true`, image blocked with `ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep`; after, all four user flows (client-nav, hard reload, home→app, home reload→app) render the image with zero COEP errors, both unsandboxed and sandbox-opted apps
- [x] Editor unaffected: hard load of `/apps_raw/add` still `crossOriginIsolated: true`, bundler builds ("Build successful"), preview renders
- [x] Reverse guard: hard-load editor (isolated) → client-nav to home does a full reload (`crossOriginIsolated: false`) → app renders, no blocked requests
- [ ] Verify a public raw app embedded with `?wm_coep=on` still gets the headers (predicate unchanged; covered by unit test)

## Screenshots

Deployed raw app viewer after a **hard reload** — external CORP-less image loads (previously blocked):

![app_page](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/coep-reload-errors/1785225857-app_page.png)

Raw app editor (`/apps_raw/add`) still cross-origin isolated and fully functional (bundler build succeeds):

![editor_add_page](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/coep-reload-errors/1785225860-editor_add_page.png)

---

Local review: Claude branch-diff-reviewer ran clean ("Good to merge"). `local-review-codex` skipped: devbox codex CLI is 0.132.0 (< pinned 0.144.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAprL4Yp4T8GxYgSuuJJyT