### PR TITLE
feat: bulk discard selected drafts on the compare & deploy page

### DIFF
--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -305,8 +305,8 @@
 		})
 	})
 	// Select all on the first non-empty load (acting on everything is the common
-	// intent);
-	// only once, so a refetch after a deploy doesn't re-select the leftovers.
+	// intent); only once, so a refetch after a deploy doesn't re-select the
+	// leftovers.
 	let hasAutoSelected = $state(false)
 
 	const deploymentStatus: Record<
@@ -499,6 +499,12 @@
 	let bulkDiscardItems = $state<Row[] | undefined>(undefined)
 	let discarding = $state(false)
 	const bulkPermanent = $derived((bulkDiscardItems ?? []).filter(isDestructiveDiscard))
+	// Third outcome the modal must cover: a draft-only item someone else also
+	// drafted isn't deleted — only this user's draft goes; the item survives via
+	// the other drafts.
+	const bulkSharedCount = $derived(
+		(bulkDiscardItems ?? []).filter((i) => i.draft_only && !isDestructiveDiscard(i)).length
+	)
 
 	function onDiscardSelectedClick() {
 		const toDiscard = visibleItems.filter((i) => selectedItems.includes(i.key) && isDiscardable(i))
@@ -875,6 +881,13 @@
 			? 's'
 			: ''}. Items with a deployed version revert to it.
 	</p>
+	{#if bulkSharedCount > 0}
+		<p class="mt-2">
+			{bulkSharedCount} draft-only {bulkSharedCount === 1 ? 'item is' : 'items are'} also drafted by
+			other users: only your draft is removed and the {bulkSharedCount === 1 ? 'item' : 'items'} will
+			remain through theirs.
+		</p>
+	{/if}
 	{#if bulkPermanent.length > 0}
 		<p class="mt-2">
 			{bulkPermanent.length}

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -22,7 +22,11 @@
 		draftBaseIsStale
 	} from '$lib/utils_draft_deploy'
 	import { checkDeployPermission, type DeployPermission } from '$lib/utils_workspace_deploy'
-	import { type DraftItem, useWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
+	import {
+		type DraftItem,
+		invalidateWorkspaceDrafts,
+		useWorkspaceDrafts
+	} from '$lib/workspaceDrafts.svelte'
 	import type { Kind as LayoutKind } from '$lib/utils_deployable'
 	import { userStore } from '$lib/stores'
 
@@ -44,8 +48,8 @@
 		draftCount?: number
 		/** When set (reached via a session's Review button), preselect only the
 		 * rows this chat modified — `${UserDraftItemKind}:${path}` keys, matching
-		 * Row.key. Undefined → preselect all deployable rows (the default). All rows
-		 * are still shown either way. */
+		 * Row.key. Undefined → preselect all actionable rows (the default). All
+		 * rows are still shown either way. */
 		chatMask?: Set<string>
 		/** False while the (async) chatMask is still loading. The select-all default
 		 * waits for this so it doesn't race the mask and select everything. Defaults
@@ -184,13 +188,15 @@
 	// session AND it's the user's own draft (someone else's shows view-only in the
 	// "all drafts" view). A data-pipeline bundle is excluded — its scripts deploy
 	// individually inside the pipeline view. Every selectable row can at least be
-	// discarded: discarding your own draft never needs write permission on the
-	// path (the server enforces the same asymmetry as deploy).
+	// discarded: discarding your own email-scoped draft never needs write
+	// permission on the path — only legacy (ownerless) drafts stay write-gated,
+	// mirroring the server's discard check.
 	function isDiscardable(item: Row): boolean {
 		return (
 			deploymentStatus[item.key]?.status !== 'deployed' &&
 			item.mine &&
-			item.draftKind !== 'data_pipeline'
+			item.draftKind !== 'data_pipeline' &&
+			(!item.legacy_draft || item.can_write)
 		)
 	}
 
@@ -204,15 +210,19 @@
 	// `undefined` ⇒ selectable.
 	function blockedReason(item: Row): string | undefined {
 		if (!item.mine) return 'This draft belongs to another user'
+		if (item.legacy_draft && !item.can_write)
+			return 'Discarding a legacy draft requires write permission on the path'
 		return undefined
 	}
 
 	// Why a row can't be discarded (drives the Discard button's title).
-	// Discarding only removes the caller's own draft row, which they always own,
-	// so — unlike deploy — it never requires write permission on the path. The
-	// only block is someone else's draft (view-only in the "all drafts" view).
+	// Discarding only removes the caller's own draft row, so it doesn't require
+	// write permission on the path — except for legacy (ownerless) drafts, which
+	// the server write-gates like a deploy.
 	function discardBlockedReason(item: Row): string | undefined {
 		if (!item.mine) return 'This draft belongs to another user'
+		if (item.legacy_draft && !item.can_write)
+			return 'Discarding a legacy draft requires write permission on the path'
 		return undefined
 	}
 
@@ -294,7 +304,8 @@
 			if (ws === currentWorkspaceId) deployPerm = p
 		})
 	})
-	// Select all on the first non-empty load (deploy-all is the common intent);
+	// Select all on the first non-empty load (acting on everything is the common
+	// intent);
 	// only once, so a refetch after a deploy doesn't re-select the leftovers.
 	let hasAutoSelected = $state(false)
 
@@ -318,7 +329,7 @@
 
 	$effect(() => {
 		if (!hasAutoSelected && chatMaskReady && visibleItems.length > 0) {
-			// Default intent is deploy-all; when reached from a session's Review
+			// Default intent is act-on-all; when reached from a session's Review
 			// (chatMask set), preselect only that chat's items instead.
 			const selectable = visibleItems.filter(isDiscardable)
 			selectedItems = (
@@ -346,6 +357,10 @@
 	let discardableCount = $derived(
 		visibleItems.filter((i) => selectedItems.includes(i.key) && isDiscardable(i)).length
 	)
+	// Selected rows the user can discard but not deploy (own draft on a path
+	// without write permission) — surfaced under the footer so the diverging
+	// button counts are explained.
+	let undeployableSelectedCount = $derived(discardableCount - deployableCount)
 
 	let allSelected = $derived(
 		visibleItems.filter(isDiscardable).length > 0 &&
@@ -495,12 +510,15 @@
 		let changed = false
 		for (const item of toDiscard) {
 			deploymentStatus[item.key] = { status: 'loading' }
+			// invalidate: false — one refetch after the whole batch (below), not
+			// one per row.
 			const res = await discardDraft(
 				item.draftKind,
 				item.path,
 				currentWorkspaceId,
 				item.draft_only,
-				item.legacy_draft
+				item.legacy_draft,
+				false
 			)
 			if (res.success) {
 				changed = true
@@ -512,9 +530,12 @@
 		}
 		discarding = false
 		selectedItems = []
-		// The Draft list refetches itself (discardDraft invalidated it); refresh
-		// the fork comparison too.
-		if (changed) onChanged?.()
+		if (changed) {
+			// Refetch the Draft list once for the batch, then refresh the fork
+			// comparison.
+			invalidateWorkspaceDrafts(currentWorkspaceId)
+			onChanged?.()
+		}
 	}
 
 	function confirmBulkDiscard() {
@@ -828,6 +849,11 @@
 					</div>
 					{#if !deployPerm.ok}
 						<span class="text-xs text-yellow-600">{deployPerm.reason}</span>
+					{:else if undeployableSelectedCount > 0}
+						<span class="text-xs text-secondary">
+							{undeployableSelectedCount} selected draft{undeployableSelectedCount !== 1 ? 's' : ''}
+							can't be deployed (no write permission on the path) but can still be discarded
+						</span>
 					{/if}
 				</div>
 			{/snippet}

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -180,26 +180,30 @@
 		isFork && hideUnchanged ? items.filter((i) => i.unchanged_from_parent !== true) : items
 	)
 
-	// A row is actionable when it isn't already deployed this session, the user has
-	// write permission, AND it's their own draft (you can't deploy someone else's
-	// draft — those show view-only in the "all drafts" view). The server enforces
-	// the same; this keeps the UI honest. A data-pipeline bundle is never deployable
-	// from this page — its scripts deploy individually inside the pipeline view — so
-	// it's excluded from every selection path.
-	function isSelectable(item: Row): boolean {
+	// Selection gate: a row is actionable when it isn't already deployed this
+	// session AND it's the user's own draft (someone else's shows view-only in the
+	// "all drafts" view). A data-pipeline bundle is excluded — its scripts deploy
+	// individually inside the pipeline view. Every selectable row can at least be
+	// discarded: discarding your own draft never needs write permission on the
+	// path (the server enforces the same asymmetry as deploy).
+	function isDiscardable(item: Row): boolean {
 		return (
 			deploymentStatus[item.key]?.status !== 'deployed' &&
-			item.can_write &&
 			item.mine &&
 			item.draftKind !== 'data_pipeline'
 		)
 	}
 
-	// Why a row can't be deployed (drives the disabled-checkbox tooltip).
-	// `undefined` ⇒ actionable.
+	// Deploying additionally requires write permission on the path, so the Deploy
+	// count can be lower than the selection when a drafted path lost writability.
+	function isDeployable(item: Row): boolean {
+		return isDiscardable(item) && item.can_write
+	}
+
+	// Why a row can't be selected (drives the disabled-checkbox tooltip).
+	// `undefined` ⇒ selectable.
 	function blockedReason(item: Row): string | undefined {
 		if (!item.mine) return 'This draft belongs to another user'
-		if (!item.can_write) return "You don't have write permission on this path"
 		return undefined
 	}
 
@@ -316,7 +320,7 @@
 		if (!hasAutoSelected && chatMaskReady && visibleItems.length > 0) {
 			// Default intent is deploy-all; when reached from a session's Review
 			// (chatMask set), preselect only that chat's items instead.
-			const selectable = visibleItems.filter(isSelectable)
+			const selectable = visibleItems.filter(isDiscardable)
 			selectedItems = (
 				chatMask
 					? selectable.filter((i) =>
@@ -332,17 +336,20 @@
 		}
 	})
 
-	// Selected items still in the visible list and deployable. Derived (not a
-	// pruning effect) so the "Deploy N drafts" button stays reactive to the
-	// Workspace Drafts resource: deploy/discard drop items, and stale keys left in
-	// selectedItems are simply ignored here (and by deploySelected).
-	let selectedCount = $derived(
-		visibleItems.filter((i) => selectedItems.includes(i.key) && isSelectable(i)).length
+	// Selected items still in the visible list, per action. Derived (not a
+	// pruning effect) so the footer buttons stay reactive to the Workspace
+	// Drafts resource: deploy/discard drop items, and stale keys left in
+	// selectedItems are simply ignored here (and by the action handlers).
+	let deployableCount = $derived(
+		visibleItems.filter((i) => selectedItems.includes(i.key) && isDeployable(i)).length
+	)
+	let discardableCount = $derived(
+		visibleItems.filter((i) => selectedItems.includes(i.key) && isDiscardable(i)).length
 	)
 
 	let allSelected = $derived(
-		visibleItems.filter(isSelectable).length > 0 &&
-			visibleItems.filter(isSelectable).every((i) => selectedItems.includes(i.key))
+		visibleItems.filter(isDiscardable).length > 0 &&
+			visibleItems.filter(isDiscardable).every((i) => selectedItems.includes(i.key))
 	)
 
 	function toggleItem(item: { key: string }) {
@@ -354,7 +361,7 @@
 	}
 
 	function selectAll() {
-		selectedItems = visibleItems.filter(isSelectable).map((i) => i.key)
+		selectedItems = visibleItems.filter(isDiscardable).map((i) => i.key)
 	}
 
 	function deselectAll() {
@@ -394,8 +401,8 @@
 		deploying = true
 		// Snapshot the items to deploy: deployDraft invalidates the Workspace Drafts
 		// resource, so `items` can change mid-loop — iterate a stable copy. Guard on
-		// isSelectable so a non-writable row can never be deployed via a stale key.
-		const toDeploy = visibleItems.filter((i) => selectedItems.includes(i.key) && isSelectable(i))
+		// isDeployable so a non-writable row can never be deployed via a stale key.
+		const toDeploy = visibleItems.filter((i) => selectedItems.includes(i.key) && isDeployable(i))
 		let deployedAny = false
 		for (const item of toDeploy) {
 			deploymentStatus[item.key] = { status: 'loading' }
@@ -468,6 +475,52 @@
 		const item = discardTarget
 		discardTarget = undefined
 		if (item) void doDiscard(item)
+	}
+
+	// --- Bulk discard ---
+	// One click can drop many drafts at once, and some of them (draft_only with
+	// no other drafter) are permanent deletions — always confirm, listing the
+	// permanent ones explicitly.
+	let bulkDiscardItems = $state<Row[] | undefined>(undefined)
+	let discarding = $state(false)
+	const bulkPermanent = $derived((bulkDiscardItems ?? []).filter(isDestructiveDiscard))
+
+	function onDiscardSelectedClick() {
+		const toDiscard = visibleItems.filter((i) => selectedItems.includes(i.key) && isDiscardable(i))
+		if (toDiscard.length > 0) bulkDiscardItems = toDiscard
+	}
+
+	async function discardSelected(toDiscard: Row[]) {
+		discarding = true
+		let changed = false
+		for (const item of toDiscard) {
+			deploymentStatus[item.key] = { status: 'loading' }
+			const res = await discardDraft(
+				item.draftKind,
+				item.path,
+				currentWorkspaceId,
+				item.draft_only,
+				item.legacy_draft
+			)
+			if (res.success) {
+				changed = true
+				delete deploymentStatus[item.key]
+			} else {
+				deploymentStatus[item.key] = { status: 'failed', error: res.error }
+				sendUserToast(`Failed to discard ${item.path}: ${res.error}`, true)
+			}
+		}
+		discarding = false
+		selectedItems = []
+		// The Draft list refetches itself (discardDraft invalidated it); refresh
+		// the fork comparison too.
+		if (changed) onChanged?.()
+	}
+
+	function confirmBulkDiscard() {
+		const toDiscard = bulkDiscardItems
+		bulkDiscardItems = undefined
+		if (toDiscard) void discardSelected(toDiscard)
 	}
 
 	// Editor URL for a draft item, scoped to the current workspace. Raw apps live
@@ -559,7 +612,7 @@
 			{selectedItems}
 			{deploymentStatus}
 			{allSelected}
-			selectablePredicate={(item) => isSelectable(item as unknown as Row)}
+			selectablePredicate={(item) => isDiscardable(item as unknown as Row)}
 			selectBlockedReason={(item) => blockedReason(item as unknown as Row)}
 			onToggleItem={toggleItem}
 			onSelectAll={selectAll}
@@ -752,15 +805,27 @@
 
 			{#snippet footer()}
 				<div class="flex flex-col items-end gap-2">
-					<Button
-						variant="accent"
-						disabled={selectedCount === 0 || deploying || !deployPerm.ok}
-						title={!deployPerm.ok ? deployPerm.reason : undefined}
-						loading={deploying}
-						onClick={deploySelected}
-					>
-						Deploy {selectedCount} draft{selectedCount !== 1 ? 's' : ''}
-					</Button>
+					<div class="flex items-center gap-2">
+						<Button
+							variant="default"
+							destructive
+							disabled={discardableCount === 0 || deploying || discarding}
+							loading={discarding}
+							startIcon={{ icon: Undo2 }}
+							onClick={onDiscardSelectedClick}
+						>
+							Discard {discardableCount} draft{discardableCount !== 1 ? 's' : ''}
+						</Button>
+						<Button
+							variant="accent"
+							disabled={deployableCount === 0 || deploying || discarding || !deployPerm.ok}
+							title={!deployPerm.ok ? deployPerm.reason : undefined}
+							loading={deploying}
+							onClick={deploySelected}
+						>
+							Deploy {deployableCount} draft{deployableCount !== 1 ? 's' : ''}
+						</Button>
+					</div>
 					{#if !deployPerm.ok}
 						<span class="text-xs text-yellow-600">{deployPerm.reason}</span>
 					{/if}
@@ -771,6 +836,32 @@
 
 	<DiffDrawer bind:this={diffDrawer} {isFlow} />
 </div>
+
+<ConfirmationModal
+	open={bulkDiscardItems !== undefined}
+	title="Discard selected drafts"
+	confirmationText="Discard"
+	onConfirmed={confirmBulkDiscard}
+	onCanceled={() => (bulkDiscardItems = undefined)}
+>
+	<p>
+		This will discard {bulkDiscardItems?.length} draft{(bulkDiscardItems?.length ?? 0) !== 1
+			? 's'
+			: ''}. Items with a deployed version revert to it.
+	</p>
+	{#if bulkPermanent.length > 0}
+		<p class="mt-2">
+			{bulkPermanent.length}
+			{bulkPermanent.length === 1 ? 'item exists' : 'items exist'} only as a draft and will be
+			<span class="font-semibold">permanently deleted</span>:
+		</p>
+		<ul class="list-disc list-inside font-mono text-xs mt-1">
+			{#each bulkPermanent as item (item.key)}
+				<li>{item.draft_path ?? item.path}</li>
+			{/each}
+		</ul>
+	{/if}
+</ConfirmationModal>
 
 <!-- Only the destructive discard (deleting the last draft of a never-deployed
      item) opens this modal; non-destructive discards run without confirmation. -->

--- a/frontend/src/lib/utils_draft_deploy.ts
+++ b/frontend/src/lib/utils_draft_deploy.ts
@@ -712,7 +712,11 @@ export async function discardDraft(
 	path: string,
 	workspace: string,
 	_draftOnly = false,
-	legacy = false
+	legacy = false,
+	// Batch callers pass false and invalidate once after the last discard —
+	// per-item invalidation would refetch the whole draft list N times, with
+	// overlapping responses able to land out of order.
+	invalidate = true
 ): Promise<DeployResult> {
 	try {
 		if (legacy) {
@@ -723,7 +727,7 @@ export async function discardDraft(
 				requestBody: { value: null, legacy: true }
 			})
 			setLocalDraftHint(workspace, kind, path, false)
-			invalidateWorkspaceDrafts(workspace)
+			if (invalidate) invalidateWorkspaceDrafts(workspace)
 			return { success: true }
 		}
 		// postSave clears the syncer-owned `*` hint on the delete. `immediate`
@@ -731,7 +735,7 @@ export async function discardDraft(
 		// enqueue time and the invalidate below refetches before the delete,
 		// re-listing the just-discarded draft.
 		await UserDraftDbSyncer.save({ workspace, itemKind: kind, path, value: null, immediate: true })
-		invalidateWorkspaceDrafts(workspace)
+		if (invalidate) invalidateWorkspaceDrafts(workspace)
 		return { success: true }
 	} catch (e: any) {
 		return { success: false, error: e?.body ?? e?.message ?? String(e) }


### PR DESCRIPTION
## Summary

The Deploy-draft mode of the Compare & Deploy page (`/forks/compare?mode=draft`) only offered one bulk action: "Deploy N drafts". Cleaning up unwanted drafts meant discarding rows one at a time, with one confirmation each. This PR adds a bulk **"Discard N drafts"** button next to the deploy button, guarded by a single confirmation modal that explicitly lists — by path — every selected item that exists only as a draft, since discarding those is a permanent deletion rather than a revert.

It also fixes the selection gate to match the server's permission model: discarding your own (email-scoped) draft never requires write permission on the path, while deploying does. The former single `isSelectable` predicate is split into `isDiscardable` (own draft, not deployed this session, not a data-pipeline bundle, and — for legacy ownerless drafts only — writable) and `isDeployable` (`isDiscardable` + `can_write`). Each footer button counts its own eligible selection, so "Discard 5 / Deploy 4" can legitimately diverge when a drafted path lost writability; a footer hint explains the gap when it appears.

## Changes

- `CompareDrafts.svelte`: bulk "Discard N drafts" footer button (destructive styling) with a confirmation modal; permanent deletions (draft-only items) listed by path in the modal
- Sequential batch discard with per-row loading/failed status in the existing `deploymentStatus` map, a toast per failure, and a single workspace-drafts invalidation after the batch (`discardDraft` gains an `invalidate` opt-out so N discards don't trigger N overlapping list refetches)
- Selection gate split into `isDiscardable` / `isDeployable`; checkboxes, select-all, and the auto-select default now gate on discardability, with independent footer counts
- Legacy (ownerless) drafts stay write-gated in the UI, mirroring the server's discard check (`is_own_discard` excludes `legacy` in `drafts.rs`), with matching disabled-checkbox/row tooltips
- Footer hint when selected drafts are discardable but not deployable (no write permission on the path)

## Test plan

- [x] Bulk discard of draft-only items: modal lists them as permanently deleted; confirming removes the draft rows (verified in DB) and the items drop off the list
- [x] Bulk discard of a drafted-over deployed item reverts to the deployed version without touching it
- [x] Cancel leaves everything untouched
- [x] Network: N discards produce exactly N `drafts/update` POSTs and **one** final `drafts/list` refetch (not one per row)
- [x] Failure path: a failed row keeps a failed badge + toast while later rows still process
- [x] Buttons disable at 0 selected / while a deploy or discard is in flight
- [ ] `mine && !can_write` divergence (Discard count > Deploy count + footer hint) — not reproducible as a workspace admin (admins can write every path); verified by code inspection

## Screenshots

Deploy-draft mode with the new bulk Discard button next to Deploy:

![compare-drafts-page](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/delete-selected-drafts/1785229561-compare-drafts-page.png)

Confirmation modal listing draft-only items that will be permanently deleted:

![bulk-discard-confirm-modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/delete-selected-drafts/1785229564-bulk-discard-confirm-modal.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)