### PR TITLE
fix(ai-agent): keep tool description through flow deployment

### DIFF
--- a/backend/windmill-types/src/flows.rs
+++ b/backend/windmill-types/src/flows.rs
@@ -875,19 +875,17 @@ pub struct AgentTool {
     pub value: ToolValue,
 }
 
-// Convert FlowModule -> AgentTool
-impl From<FlowModule> for AgentTool {
-    fn from(flow_module: FlowModule) -> Self {
+impl AgentTool {
+    /// Fold a `FlowModule` that went through dependency locking back into the tool it came from.
+    /// `description` has no `FlowModule` counterpart, so it must be carried over from the
+    /// existing tool: rebuilding an `AgentTool` from the module alone drops it on every deploy.
+    pub fn update_from_module(&mut self, flow_module: FlowModule) {
         let module_value = serde_json::from_str::<FlowModuleValue>(flow_module.value.get())
             .unwrap_or(FlowModuleValue::Identity);
 
-        AgentTool {
-            id: flow_module.id,
-            summary: flow_module.summary,
-            // FlowModule has no dedicated tool description; it is carried on AgentTool only.
-            description: None,
-            value: ToolValue::FlowModule(module_value),
-        }
+        self.id = flow_module.id;
+        self.summary = flow_module.summary;
+        self.value = ToolValue::FlowModule(module_value);
     }
 }
 
@@ -1340,6 +1338,41 @@ mod tests {
         });
         let val: FlowValue = serde_json::from_value(input).unwrap();
         assert_eq!(val.modules.len(), 1);
+    }
+
+    #[test]
+    fn agent_tool_keeps_description_through_locking() {
+        // #10244: the dependency job rebuilds each tool from its locked FlowModule; the
+        // tool description lives only on AgentTool and must survive that round-trip.
+        let mut tool: AgentTool = serde_json::from_value(json!({
+            "id": "b",
+            "summary": "my_tool",
+            "description": "when to call me",
+            "value": {
+                "tool_type": "flowmodule",
+                "type": "rawscript",
+                "content": "def main(): return 1",
+                "language": "python3",
+                "input_transforms": {}
+            }
+        }))
+        .unwrap();
+
+        let mut locked: FlowModule = Option::<FlowModule>::from(&tool).unwrap();
+        locked.value = to_raw_value(&json!({
+            "type": "rawscript",
+            "content": "def main(): return 1",
+            "language": "python3",
+            "lock": "# py: 3.11",
+            "input_transforms": {}
+        }));
+        tool.update_from_module(locked);
+
+        assert_eq!(tool.description.as_deref(), Some("when to call me"));
+        assert_eq!(tool.summary.as_deref(), Some("my_tool"));
+        assert!(serde_json::to_string(&tool.value)
+            .unwrap()
+            .contains("# py: 3.11"));
     }
 
     #[test]

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -1294,7 +1294,7 @@ async fn lock_modules(
                         let locked = locked_iter.next().ok_or_else(|| {
                             Error::internal_err("locked tool module should exist".to_string())
                         })?;
-                        tools[idx] = locked.into();
+                        tools[idx].update_from_module(locked);
                     }
 
                     e.value = FlowModuleValue::AIAgent {


### PR DESCRIPTION
## Summary

Fixes #10244. An AI agent tool's `description` (added in #10083) was silently wiped every time the flow was deployed: the field survived in the draft but came back empty after deploy, never reached `flow.yaml`, and the model kept receiving the tool *name* as its description.

Root cause is in the flow dependency job. To lock a tool's raw script, `lock_modules` projects each `AgentTool` down to a `FlowModule`, locks it, then rebuilt the tool with `tools[idx] = locked.into()`. `description` lives only on `AgentTool` — `FlowModule` has no counterpart — so that `From<FlowModule> for AgentTool` impl hardcoded `description: None`, and the round-trip dropped the user's text on every deployment.

## Changes

- Replace the lossy `From<FlowModule> for AgentTool` impl with `AgentTool::update_from_module`, which folds the locked module back into the existing tool in place and therefore keeps tool-level fields that have no module counterpart. Removing the `From` impl also stops the lossy conversion from being reintroduced by an innocent `.into()`.
- Update the single call site in `lock_modules`.
- Regression test pinning the `AgentTool -> FlowModule -> (locked) -> AgentTool` round-trip: the description survives and the locked value is adopted.

## Test plan

- [x] `cargo test -p windmill-types --lib agent_tool_keeps_description_through_locking`
- [x] End-to-end on a local dev instance: create a flow with an AI agent whose tool is a raw bun script and a non-empty tool description, let the dependency job deploy it, then re-read the deployed flow. Before the fix the tool comes back as `{"id","value","summary"}` with no `description`; after the fix `"description": "MY TOOL DESCRIPTION"` is still there.
- [x] Same flow reopened in the flow editor — the tool description field is populated instead of showing its placeholder.

## Screenshots

Deployed flow reopened in the editor, tool selected.

Before (description lost on deploy — field shows only its placeholder):

![before-tool-description-lost](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-43043d07/1785229764-before-tool-description-lost.png)

After (description persisted through deployment):

![fixed-tool-description](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-43043d07/1785229766-fixed-tool-description.png)

Note: descriptions already lost by a previous deployment are not recoverable — they have to be re-entered once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that cleared AI agent tool descriptions after flow deployment. Descriptions now persist through dependency locking and deployment.

- **Bug Fixes**
  - Replaced lossy `From<FlowModule> for AgentTool` with `AgentTool::update_from_module` to retain `description`.
  - Updated `lock_modules` in `windmill-worker` to use the new method and avoid `.into()`.
  - Added a regression test to ensure `description` survives and locked values are applied.

- **Migration**
  - Re-enter descriptions for tools deployed before this fix; previously lost text cannot be recovered.

<sup>Written for commit 7abe60914e132d64ae8d3ed504f5d463b6457a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

