### PR TITLE
fix(datatable): provision the replication user on managed postgres

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -1506,6 +1506,10 @@ struct CustomInstanceDbLogs {
     db_connect: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     grant_permissions: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    replication_user: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replication_user_error: Option<String>,
 }
 
 async fn list_custom_instance_pg_databases(
@@ -1705,29 +1709,23 @@ async fn setup_custom_instance_pg_database_inner(
             ))
         })?;
 
-    // The replication attribute lives on a dedicated role used by postgres trigger
-    // connections. The getter creates the role (with its stored password) when the
-    // migration couldn't.
-    if let Err(e) = windmill_common::utils::get_custom_pg_instance_replication_password(db).await {
-        tracing::error!("Failed to ensure custom_instance_replication_user exists: {e:#}");
-    }
-    if let Err(e) = client
-        .batch_execute(
-            "ALTER ROLE custom_instance_replication_user REPLICATION;
-             GRANT custom_instance_user TO custom_instance_replication_user;
-             ALTER ROLE custom_instance_user NOREPLICATION;",
-        )
-        .await
-    {
-        tracing::error!(
-            "Failed to grant replication permission to custom_instance_replication_user: {e:#}"
-        );
-    }
-
     logs.grant_permissions = "OK".to_string();
 
     drop(client); // /!\ Drop before joining to avoid deadlock
     windmill_common::shutdown_pg_connection(join_handle).await?;
+
+    // Roles are cluster-wide, so the dedicated role used by postgres trigger connections is
+    // provisioned on the main pool rather than on the new database. Reported as its own step
+    // rather than failing the setup: the database is usable for datatables without it, only
+    // postgres triggers are.
+    match windmill_common::utils::ensure_custom_instance_replication_user(db).await {
+        Ok(()) => logs.replication_user = "OK".to_string(),
+        Err(e) => {
+            tracing::error!("Failed to provision custom_instance_replication_user: {e:#}");
+            logs.replication_user = "FAIL".to_string();
+            logs.replication_user_error = Some(e.to_string());
+        }
+    }
 
     Ok(())
 }

--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -1716,8 +1716,8 @@ async fn setup_custom_instance_pg_database_inner(
 
     // Roles are cluster-wide, so the dedicated role used by postgres trigger connections is
     // provisioned on the main pool rather than on the new database. Reported as its own step
-    // rather than failing the setup: the database is usable for datatables without it, only
-    // postgres triggers are.
+    // rather than failing the setup: without the role the database still serves datatables, only
+    // postgres triggers on them break.
     match windmill_common::utils::ensure_custom_instance_replication_user(db).await {
         Ok(()) => logs.replication_user = "OK".to_string(),
         Err(e) => {

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -29180,6 +29180,10 @@ components:
           $ref: "#/components/schemas/LoggedWizardStatus"
         grant_permissions:
           $ref: "#/components/schemas/LoggedWizardStatus"
+        replication_user:
+          $ref: "#/components/schemas/LoggedWizardStatus"
+        replication_user_error:
+          type: string
 
     CustomInstanceDbTag:
       type: string

--- a/backend/windmill-api/src/live_migrations.rs
+++ b/backend/windmill-api/src/live_migrations.rs
@@ -27,8 +27,9 @@ pub async fn custom_migrations(migrator: &mut CustomMigrator) -> Result<(), Erro
         tracing::error!(
             "Could not provision custom_instance_replication_user: {err:#}. Postgres triggers on \
              custom-instance datatables will not work until the role can open replication \
-             connections: grant the role owning DATABASE_URL either SUPERUSER, or (PG 16+) the \
-             REPLICATION attribute, or the replication role of your managed provider"
+             connections: grant the role owning DATABASE_URL either SUPERUSER or (PG 16+) the \
+             REPLICATION attribute. On AWS RDS this is handled by granting rds_replication, which \
+             requires no change; other managed providers are not covered"
         );
     }
 

--- a/backend/windmill-api/src/live_migrations.rs
+++ b/backend/windmill-api/src/live_migrations.rs
@@ -23,7 +23,36 @@ pub async fn custom_migrations(migrator: &mut CustomMigrator) -> Result<(), Erro
         tracing::error!("Could not normalize custom_instance_user attributes: {err:#}");
     }
 
+    if let Err(err) = ensure_custom_instance_replication_user(migrator).await {
+        tracing::error!(
+            "Could not provision custom_instance_replication_user: {err:#}. Postgres triggers on \
+             custom-instance datatables will not work until the role can open replication \
+             connections: grant the role owning DATABASE_URL either SUPERUSER, or (PG 16+) the \
+             REPLICATION attribute, or the replication role of your managed provider"
+        );
+    }
+
     Ok(())
+}
+
+// Converged on every boot, not once: the one-shot migration creates the role with the
+// REPLICATION attribute, which managed postgres rejects outright, so instances set up before
+// the provider-role fallback existed have no role at all. Scoped to instances that actually
+// have a custom-instance database, so the rest never see the error.
+async fn ensure_custom_instance_replication_user(
+    migrator: &mut CustomMigrator,
+) -> Result<(), Error> {
+    let has_custom_instance_db = sqlx::query_scalar::<_, bool>(
+        "SELECT COALESCE(value->'databases', '{}'::jsonb) <> '{}'::jsonb
+         FROM global_settings WHERE name = 'custom_instance_pg_databases'",
+    )
+    .fetch_optional(migrator.connection())
+    .await?
+    .unwrap_or(false);
+    if !has_custom_instance_db {
+        return Ok(());
+    }
+    windmill_common::utils::ensure_custom_instance_replication_user(migrator.connection()).await
 }
 
 // Converged on every boot, not once: the one-shot migration swallows errors (it must not

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -819,6 +819,10 @@ pub struct CustomInstanceDbLogs {
     pub db_connect: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub grant_permissions: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub replication_user: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replication_user_error: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -1079,10 +1079,15 @@ const GRANT_REPLICATION_CAPABILITY_PLPGSQL: &str = r#"
 
             IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user') THEN
                 EXECUTE 'GRANT custom_instance_user TO custom_instance_replication_user';
-                -- Guarded: ALTER ROLE ... NOREPLICATION is itself superuser-only on PG <= 15,
-                -- even when the attribute is already unset.
+                -- Stripping REPLICATION off custom_instance_user is a cleanup, so it is both
+                -- guarded and best-effort: the clause is superuser-only on PG <= 15 even when the
+                -- attribute is already unset, and failing it must not roll back the role above.
                 IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user' AND rolreplication) THEN
-                    EXECUTE 'ALTER ROLE custom_instance_user NOREPLICATION';
+                    BEGIN
+                        EXECUTE 'ALTER ROLE custom_instance_user NOREPLICATION';
+                    EXCEPTION WHEN insufficient_privilege THEN
+                        NULL;
+                    END;
                 END IF;
             END IF;
 "#;
@@ -1128,9 +1133,13 @@ lazy_static::lazy_static! {
     static ref REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL: String =
         provision_replication_user_sql("TRUE");
 
+    // The password test mirrors REPLICATION_PWD_READ_SQL, whose readers flatten a NULL away: a row
+    // holding a JSON null reads back as no password, so it must rotate rather than count as
+    // provisioned and strand the getter.
     static ref ENSURE_CUSTOM_INSTANCE_REPLICATION_USER_SQL: String = provision_replication_user_sql(
         "NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_replication_user')
-                OR NOT EXISTS (SELECT 1 FROM global_settings WHERE name = 'custom_instance_replication_pwd')"
+                OR NOT EXISTS (SELECT 1 FROM global_settings
+                    WHERE name = 'custom_instance_replication_pwd' AND value #>> '{}' IS NOT NULL)"
     );
 }
 

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -1099,6 +1099,11 @@ fn provision_replication_user_sql(rotate_condition: &str) -> String {
         DECLARE
             pwd text;
         BEGIN
+            -- Same lock as get_custom_pg_instance_replication_password: without it, every API
+            -- replica booting onto a version that provisions the role races into CREATE USER,
+            -- and the losers abort on duplicate_object.
+            PERFORM pg_advisory_xact_lock(hashtext('custom_instance_replication_pwd'));
+
             IF {rotate_condition} THEN
                 SELECT gen_random_uuid()::text INTO pwd;
 

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -1058,30 +1058,76 @@ pub async fn get_custom_pg_instance_password(db: &DB) -> Result<String> {
     )
 }
 
-const REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL: &str = r#"
+/// PL/pgSQL granting `custom_instance_replication_user` the ability to open replication
+/// connections, inlined into the `DO` blocks below.
+///
+/// The REPLICATION attribute requires a real superuser on PG <= 15 (PG 16+ accepts
+/// CREATEROLE + REPLICATION), and managed postgres never hands one out: on RDS the
+/// capability is carried by the `rds_replication` role instead. Both privilege failures
+/// raise `insufficient_privilege`, so the attribute is attempted first and the provider
+/// role is the fallback.
+const GRANT_REPLICATION_CAPABILITY_PLPGSQL: &str = r#"
+            BEGIN
+                EXECUTE 'ALTER ROLE custom_instance_replication_user REPLICATION';
+            EXCEPTION WHEN insufficient_privilege THEN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'rds_replication') THEN
+                    EXECUTE 'GRANT rds_replication TO custom_instance_replication_user';
+                ELSE
+                    RAISE;
+                END IF;
+            END;
+
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user') THEN
+                EXECUTE 'GRANT custom_instance_user TO custom_instance_replication_user';
+                -- Guarded: ALTER ROLE ... NOREPLICATION is itself superuser-only on PG <= 15,
+                -- even when the attribute is already unset.
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user' AND rolreplication) THEN
+                    EXECUTE 'ALTER ROLE custom_instance_user NOREPLICATION';
+                END IF;
+            END IF;
+"#;
+
+/// `rotate_condition` decides when a new password is generated: always for the refresh
+/// endpoint, only when the role or its stored password is missing for the boot converge.
+/// Both variants are a single statement so they can run on any executor, and both are
+/// atomic: a role that cannot be granted replication is rolled back rather than left
+/// half-provisioned.
+fn provision_replication_user_sql(rotate_condition: &str) -> String {
+    format!(
+        r#"
     DO $$
         DECLARE
             pwd text;
         BEGIN
-            SELECT gen_random_uuid()::text INTO pwd;
+            IF {rotate_condition} THEN
+                SELECT gen_random_uuid()::text INTO pwd;
 
-            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_replication_user') THEN
-                EXECUTE format('ALTER USER custom_instance_replication_user WITH PASSWORD %L REPLICATION', pwd);
-            ELSE
-                EXECUTE format('CREATE USER custom_instance_replication_user WITH PASSWORD %L REPLICATION', pwd);
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_replication_user') THEN
+                    EXECUTE format('ALTER USER custom_instance_replication_user WITH PASSWORD %L', pwd);
+                ELSE
+                    EXECUTE format('CREATE USER custom_instance_replication_user WITH PASSWORD %L', pwd);
+                END IF;
+
+                INSERT INTO global_settings (name, value)
+                VALUES ('custom_instance_replication_pwd', to_jsonb(pwd::text))
+                ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;
             END IF;
-
-            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_user') THEN
-                GRANT custom_instance_user TO custom_instance_replication_user;
-                ALTER ROLE custom_instance_user NOREPLICATION;
-            END IF;
-
-            INSERT INTO global_settings (name, value)
-            VALUES ('custom_instance_replication_pwd', to_jsonb(pwd::text))
-            ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value;
+{GRANT_REPLICATION_CAPABILITY_PLPGSQL}
         END
         $$;
-"#;
+"#
+    )
+}
+
+lazy_static::lazy_static! {
+    static ref REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL: String =
+        provision_replication_user_sql("TRUE");
+
+    static ref ENSURE_CUSTOM_INSTANCE_REPLICATION_USER_SQL: String = provision_replication_user_sql(
+        "NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'custom_instance_replication_user')
+                OR NOT EXISTS (SELECT 1 FROM global_settings WHERE name = 'custom_instance_replication_pwd')"
+    );
+}
 
 const REPLICATION_PWD_READ_SQL: &str =
     "SELECT value #>> '{}' FROM global_settings WHERE name = 'custom_instance_replication_pwd'";
@@ -1093,8 +1139,22 @@ const REPLICATION_PWD_READ_SQL: &str =
 /// Authorization: rotates a stored database credential and performs no authorization
 /// itself — callers MUST restrict this to superadmin or internal server paths.
 pub async fn refresh_custom_instance_replication_user_pwd(db: &DB) -> Result<()> {
-    sqlx::query(REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL)
+    sqlx::query(REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL.as_str())
         .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Create `custom_instance_replication_user` if it is missing and (re)grant it replication,
+/// leaving an existing password in place. Idempotent, so it can be converged on every boot.
+///
+/// Authorization: same contract as [`refresh_custom_instance_replication_user_pwd`] —
+/// callers MUST restrict this to superadmin or internal server paths.
+pub async fn ensure_custom_instance_replication_user<'c>(
+    executor: impl sqlx::PgExecutor<'c>,
+) -> Result<()> {
+    sqlx::query(ENSURE_CUSTOM_INSTANCE_REPLICATION_USER_SQL.as_str())
+        .execute(executor)
         .await?;
     Ok(())
 }
@@ -1127,7 +1187,7 @@ pub async fn get_custom_pg_instance_replication_password(db: &DB) -> Result<Stri
         tx.commit().await?;
         return Ok(pwd);
     }
-    sqlx::query(REFRESH_CUSTOM_INSTANCE_REPLICATION_USER_SQL)
+    sqlx::query(ENSURE_CUSTOM_INSTANCE_REPLICATION_USER_SQL.as_str())
         .execute(&mut *tx)
         .await?;
     let pwd = sqlx::query_scalar::<_, Option<String>>(REPLICATION_PWD_READ_SQL)

--- a/frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte
@@ -165,17 +165,26 @@
 									title: 'Grant permissions to custom_instance_user',
 									status: status?.logs.grant_permissions,
 									description:
-										'Gives custom_instance_user the required permissions to use the database. custom_instance_user is already created during a migration and has an auto-generated password stored in global_settings.custom_instance_pg_databases.user_pwd. Postgres triggers use custom_instance_replication_user (password in global_settings.custom_instance_replication_pwd). These are the commands : \n\n' +
+										'Gives custom_instance_user the required permissions to use the database. custom_instance_user is already created during a migration and has an auto-generated password stored in global_settings.custom_instance_pg_databases.user_pwd. These are the commands : \n\n' +
 										`GRANT CONNECT ON DATABASE "${dbname}" TO custom_instance_user;\n` +
 										'GRANT USAGE ON SCHEMA public TO custom_instance_user;\n' +
 										'GRANT CREATE ON SCHEMA public TO custom_instance_user;\n' +
 										`GRANT CREATE ON DATABASE "${dbname}" TO custom_instance_user;\n` +
 										'ALTER DEFAULT PRIVILEGES IN SCHEMA public \n' +
 										'  	GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES\n    TO custom_instance_user;\n' +
-										'ALTER ROLE custom_instance_user CREATEROLE;\n' +
+										'ALTER ROLE custom_instance_user CREATEROLE;'
+								},
+								{
+									title: 'Grant replication to custom_instance_replication_user',
+									status: status?.logs.replication_user,
+									description:
+										'Postgres triggers on custom-instance datatables connect as custom_instance_replication_user, whose password is stored in global_settings.custom_instance_replication_pwd. The role is cluster-wide, so it is created on the Windmill PostgreSQL instance rather than on this database : \n\n' +
 										'ALTER ROLE custom_instance_replication_user REPLICATION;\n' +
-										'GRANT custom_instance_user TO custom_instance_replication_user;\n' +
-										'ALTER ROLE custom_instance_user NOREPLICATION;'
+										'GRANT custom_instance_user TO custom_instance_replication_user;\n\n' +
+										'Setting REPLICATION requires a superuser on PostgreSQL 15 and older. Managed instances never grant one, so on AWS RDS Windmill falls back to GRANT rds_replication TO custom_instance_replication_user. The database stays usable for datatables if this step fails, but postgres triggers on them do not.' +
+										(status?.logs.replication_user_error
+											? `\n\nError: ${status.logs.replication_user_error}`
+											: '')
 								}
 							],
 							status?.error ?? undefined


### PR DESCRIPTION
## Summary

On a custom-instance datatable, postgres triggers connect as `custom_instance_replication_user`. That role was created with `CREATE USER … WITH PASSWORD … REPLICATION`, which requires a real Postgres superuser on PG <= 15 (PG 16+ accepts `CREATEROLE` + the `REPLICATION` attribute). Managed Postgres never hands out a real superuser — on RDS the master user is a member of `rds_superuser` with `rolsuper = f` — so the role is never created there, and the failure only surfaced as a raw `SqlErr: must be superuser to create replication users` when a superadmin clicked "Refresh custom instance passwords".

The role is now created without the attribute, and replication capability is granted in a separate, catchable step: the `REPLICATION` attribute first, falling back to the provider role (`rds_replication`) when the attribute is rejected with `insufficient_privilege`. Two related gaps are closed at the same time: instances whose one-shot migration silently swallowed the failure now repair themselves at boot, and the setup wizard reports the outcome instead of only logging it.

## Changes

- `windmill-common/src/utils.rs`: split provisioning into "create the role + store its password" and "grant replication capability". The capability step tries `ALTER ROLE … REPLICATION` and, on `insufficient_privilege`, grants `rds_replication` when that role exists, otherwise re-raises. `ALTER ROLE custom_instance_user NOREPLICATION` is now guarded on the attribute actually being set, since the clause itself is superuser-only on PG <= 15. Both variants (rotate-always for the refresh endpoint, rotate-only-if-missing for the converge) are one statement and take `pg_advisory_xact_lock`, so concurrent replicas can't race into `CREATE USER`.
- `windmill-common/src/utils.rs`: new `ensure_custom_instance_replication_user`, idempotent and executor-generic.
- `windmill-api/src/live_migrations.rs`: converge the role on every boot for instances that have at least one custom-instance database, logging an actionable error when it cannot be provisioned. Instances without one are untouched and stay quiet.
- `windmill-api-settings/src/lib.rs`: the setup wizard provisions the role on the main pool (roles are cluster-wide) and reports `replication_user` / `replication_user_error` as its own step, replacing two silent `tracing::error!`s. The database stays usable for datatables when only this step fails, so the overall setup still reports success.
- `windmill-common/src/instance_config.rs`, `windmill-api/openapi.yaml`: mirror the two new log fields.
- `CustomInstanceDbWizardModal.svelte`: new step 7 with the commands it runs, the managed-Postgres note, and the underlying error inline.

## Screenshots

Step 7 on a superuser Postgres:

![wizard-step7-ok](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/datatable-replication-superuser-fix/1785229932-wizard-step7-ok.png)

Step 7 when the role cannot be granted replication (forced locally by raising `insufficient_privilege` with no provider role present) — the step goes red and auto-expands with the Postgres error, the preceding steps stay green:

![wizard-step7-fail](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/datatable-replication-superuser-fix/1785229933-wizard-step7-fail.png)

## Test plan

Verified locally against PG 18 (dev cluster) and by simulating a managed instance — a `CREATEROLE`-but-not-superuser role, a stub `rds_replication` granted to it with admin option, and a scratch database:

- [x] Old SQL as the simulated managed master: fails, no role created.
- [x] New SQL as the simulated managed master: role created without the attribute, granted `rds_replication` + `custom_instance_user`, password stored. Second run is a no-op and does not rotate.
- [x] Non-superuser with no provider replication role: raises, nothing left half-provisioned.
- [x] Superuser: `REPLICATION` attribute set, `custom_instance_user` left `NOREPLICATION`.
- [x] Through the API: wizard setup of a new custom-instance database reports step 7 green; with the attribute path forced to fail and a stub `rds_replication` present, the same button takes the fallback and grants it.
- [x] Boot converge: dropped the role and its stored password on an instance that has a custom-instance database, restarted the server, both reappear with no error logged.
- [ ] On RDS itself: setup a custom-instance database, confirm step 7 is green and `custom_instance_replication_user` is a member of `rds_replication`, then run a postgres trigger on a datatable in that database and confirm it streams (requires `rds.logical_replication = 1` on the parameter group).

No automated test: the provisioning path is cluster-global SQL, so an integration test would create and rotate the password of the real `custom_instance_replication_user` role for every other database on the same server — including a developer's dev instance. CI also always runs as a superuser, so it would only exercise the path that already worked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes replication user provisioning for custom-instance datatables on managed Postgres (e.g., RDS) so triggers can open replication connections. Adds a setup wizard step and makes boot converge self-heal edge cases.

- **Bug Fixes**
  - Create `custom_instance_replication_user` without `REPLICATION`, then grant it; fall back to `rds_replication` on `insufficient_privilege`. `custom_instance_user` cleanup is now guarded and best-effort (errors don’t roll back provisioning).
  - New idempotent `ensure_custom_instance_replication_user`: atomic, advisory-locked provisioning; converged on boot when any custom-instance DB exists; self-heals a missing or JSON-null stored password.
  - Setup wizard provisions on the main pool and reports a new step with outcome and error details (`replication_user`, `replication_user_error`). UI explains managed-Postgres fallback and that datatables still work if this step fails.

<sup>Written for commit d523161a07f01ad6a756319446a1f1a772b781a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

