### PR TITLE
fix: surface postgres publication errors as 400 instead of 500

### DIFF
--- a/backend/windmill-trigger-postgres/src/handler.rs
+++ b/backend/windmill-trigger-postgres/src/handler.rs
@@ -208,8 +208,7 @@ impl TriggerCrud for PostgresTrigger {
                 publication,
                 publication_data.map(|publication| publication.0),
             )
-            .await
-            .map_err(to_anyhow)?;
+            .await?;
         }
 
         remote_db_tx.commit().await.map_err(to_anyhow)?;
@@ -714,15 +713,13 @@ pub async fn update_pg_publication(
                     table_to_track.as_deref(),
                     &transaction_to_track,
                 )
-                .await
-                .map_err(to_anyhow)?;
+                .await?;
             } else {
                 let pg_14 = check_if_valid_publication_for_postgres_version(
                     pg_connection,
                     table_to_track.as_deref(),
                 )
-                .await
-                .map_err(to_anyhow)?;
+                .await?;
 
                 let mut query = format!("ALTER PUBLICATION {} SET ", quoted_publication_name);
                 let mut first = true;
@@ -832,8 +829,7 @@ pub async fn alter_publication(
         publication_data,
         publication.map(|publication| publication.0),
     )
-    .await
-    .map_err(to_anyhow)?;
+    .await?;
 
     tx.commit().await.map_err(to_anyhow)?;
 

--- a/backend/windmill-trigger-postgres/src/lib.rs
+++ b/backend/windmill-trigger-postgres/src/lib.rs
@@ -508,6 +508,10 @@ pub async fn create_pg_publication(
                             query.push_str(")");
                         }
 
+                        // A row filter has no bind parameter, so it goes in raw. Publication
+                        // DDL must therefore keep running through `Client::execute`, whose
+                        // `Parse` refuses more than one command: under `simple_query` or
+                        // `batch_execute` a filter could stack statements.
                         if let Some(where_clause) = &table.where_clause {
                             query.push_str(" WHERE (");
                             query.push_str(where_clause);


### PR DESCRIPTION
> **Scope:** this PR makes no claim about constraining the row filter. It is an error
> -handling fix. The `where_clause` is interpolated verbatim before and after it, exactly
> as on `main`. See "On the row filter" below.

## Summary

Four publication call sites wrap `.map_err(to_anyhow)?` around callees that already
return `windmill_common::error::Result`. Flattening through `anyhow` turns an
`Error::BadRequest` into an internal error, so the user gets a 500 with the explanatory
message lost.

The most visible case: `check_if_valid_publication_for_postgres_version` returns a
`BadRequest` explaining that PostgreSQL 14 supports neither `WHERE` clause filtering nor
selective column tracking, and telling the user those need 15+. On the `ALTER PUBLICATION`
path that guidance reached the user as an opaque 500.

## Changes

- Drop `.map_err(to_anyhow)` at the four sites calling `update_pg_publication`,
  `create_pg_publication` and `check_if_valid_publication_for_postgres_version`, so the
  error kind survives and the message is returned as a 400.
- Add a comment recording why the raw-interpolated row filter is safe today, at the point
  where someone would break it: publication DDL must keep going through `Client::execute`,
  whose `Parse` refuses more than one command.

## On the row filter

`where_clause` is interpolated verbatim into `CREATE`/`ALTER PUBLICATION ... WHERE (...)`.
That is unchanged by this PR and is not a reachable vulnerability:

- `Client::execute` prepares the statement, and the extended protocol's `Parse` refuses
  more than one command, so statements cannot be stacked.
- Escaping the wrapper within the single remaining statement can shape that publication:
  its table list and row filters. The trigger configuration UI already lets the caller
  choose both.
- Postgres forbids user-defined functions and subqueries in publication row filters, so
  there is no code execution and no exfiltration primitive.
- Both sinks require `postgres_triggers:write:<resource>` plus read on the resource. No
  privilege boundary is crossed, including for the operator role.

An earlier revision of this PR added a validator to keep the clause inside its wrapper. It
was dropped deliberately. It defended only against a hypothetical future refactor to
`simple_query`/`batch_execute`, and review found three separate ways its lexer disagreed
with Postgres about where a literal ends (`E'...'` escapes, a `$tag$` Postgres reads as
part of the preceding identifier, and a non-ASCII dollar tag), each of which let a clause
escape anyway. The surviving version still rejected legitimate filters containing a
backslash, including on read-back of existing publications via `pg_get_expr`. A validator
that is subtly wrong is worse than none, because it reads as a guarantee it does not give.
The comment carries the same information at none of that cost.

If we later want the wrapper genuinely enforced, the robust way is to have Postgres parse
the filter rather than to hand-roll its lexer.

## Test plan

- [x] `cargo check` clean; all 96 `windmill-trigger-postgres` tests pass.
- [ ] Manual: against a PostgreSQL 14 database, configure a trigger with a row filter or
      selective columns and confirm the API returns the version-guidance message as a 400
      rather than a 500, on both the create and the alter path.