### PR TITLE
fix: make same worker mutually exclusive with retries and sleeps in the flow editor

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -1270,7 +1270,11 @@
 															maximum number of attempts as defined below.
 														</Tooltip>
 													{/snippet}
-													<FlowRetries bind:flowModuleRetry={flowModule.retry} bind:flowModule />
+													<FlowRetries
+														bind:flowModuleRetry={flowModule.retry}
+														bind:flowModule
+														{isAgentTool}
+													/>
 												</Section>
 											{:else if advancedSelected === 'runtime' && advancedRuntimeSelected === 'concurrency'}
 												<Section label="Concurrency limits" class="flex flex-col gap-4" eeOnly>
@@ -1435,7 +1439,11 @@
 												</div>
 											{:else if advancedSelected === 'sleep'}
 												<div>
-													<FlowModuleSleep previousModuleId={previousModule?.id} bind:flowModule />
+													<FlowModuleSleep
+														previousModuleId={previousModule?.id}
+														bind:flowModule
+														{isAgentTool}
+													/>
 												</div>
 											{:else if advancedSelected === 'debounce'}
 												<div>

--- a/frontend/src/lib/components/flows/content/FlowModuleSleep.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleSleep.svelte
@@ -12,6 +12,8 @@
 	import Section from '$lib/components/Section.svelte'
 	import Label from '$lib/components/Label.svelte'
 	import { getStepPropPicker } from '../previousResults'
+	import { SAME_WORKER_INCOMPATIBLE_MSG } from '../utils.svelte'
+	import { Alert } from '$lib/components/common'
 
 	interface Props {
 		flowModule: FlowModule
@@ -44,6 +46,7 @@
 	const result = flowStateStore.val[selectionManager.getSelectedId()]?.previewResult ?? {}
 
 	let isSleepEnabled = $derived(Boolean(flowModule.sleep))
+	let sameWorker = $derived(Boolean(flowStore.val.value.same_worker))
 </script>
 
 <Section label="Sleep" class="w-full">
@@ -54,8 +57,15 @@
 		</Tooltip>
 	{/snippet}
 
+	{#if sameWorker}
+		<Alert type="warning" size="xs" title="Disabled by the shared directory" class="mb-4">
+			{SAME_WORKER_INCOMPATIBLE_MSG} Disable `Same Worker` in the flow settings to use a sleep.
+		</Alert>
+	{/if}
+
 	<Toggle
 		checked={isSleepEnabled}
+		disabled={sameWorker}
 		class="mb-6"
 		on:change={() => {
 			if (isSleepEnabled && flowModule.sleep != undefined) {

--- a/frontend/src/lib/components/flows/content/FlowModuleSleep.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleSleep.svelte
@@ -18,9 +18,10 @@
 	interface Props {
 		flowModule: FlowModule
 		previousModuleId: string | undefined
+		isAgentTool?: boolean
 	}
 
-	let { flowModule = $bindable(), previousModuleId }: Props = $props()
+	let { flowModule = $bindable(), previousModuleId, isAgentTool = false }: Props = $props()
 
 	const { selectionManager, flowStore, flowStateStore, previewArgs } =
 		getContext<FlowEditorContext>('FlowEditorContext')
@@ -46,7 +47,8 @@
 	const result = flowStateStore.val[selectionManager.getSelectedId()]?.previewResult ?? {}
 
 	let isSleepEnabled = $derived(Boolean(flowModule.sleep))
-	let sameWorker = $derived(Boolean(flowStore.val.value.same_worker))
+	// Agent tools never go through the flow scheduler, so `same_worker` doesn't apply to them.
+	let sameWorker = $derived(Boolean(!isAgentTool && flowStore.val.value.same_worker))
 </script>
 
 <Section label="Sleep" class="w-full">
@@ -82,7 +84,7 @@
 		}}
 	/>
 	<Label label="Sleep for duration">
-		{#if flowModule.sleep && schema.properties['sleep']}
+		{#if flowModule.sleep && schema.properties['sleep'] && !sameWorker}
 			<div class="border rounded-md overflow-auto">
 				<PropPickerWrapper
 					noFlowPlugConnect={true}

--- a/frontend/src/lib/components/flows/content/FlowRetries.svelte
+++ b/frontend/src/lib/components/flows/content/FlowRetries.svelte
@@ -22,12 +22,14 @@
 		flowModuleRetry: Retry | undefined
 		disabled?: boolean
 		flowModule?: FlowModule
+		isAgentTool?: boolean
 	}
 
 	let {
 		flowModule = $bindable(),
 		flowModuleRetry = $bindable(),
-		disabled = false
+		disabled = false,
+		isAgentTool = false
 	}: Props = $props()
 
 	const flowEditorContext = getContext<FlowEditorContext>('FlowEditorContext')
@@ -56,8 +58,11 @@
 	)
 
 	// `flowModule` is only set when editing a flow step: the trigger/schedule usages of this
-	// component share the flow editor context but are unaffected by `same_worker`.
-	let sameWorker = $derived(Boolean(flowModule && flowStore?.val?.value?.same_worker))
+	// component share the flow editor context but are unaffected by `same_worker`, and so are
+	// agent tools, which never go through the flow scheduler.
+	let sameWorker = $derived(
+		Boolean(flowModule && !isAgentTool && flowStore?.val?.value?.same_worker)
+	)
 	let isDisabled = $derived(disabled || sameWorker)
 
 	let isRetryConditionEnabled = $derived(Boolean(flowModuleRetry?.retry_if))
@@ -127,7 +132,6 @@
 	<ToggleButtonGroup
 		bind:selected={delayType}
 		disabled={isDisabled}
-		class={`${isDisabled ? 'disabled' : ''}`}
 		on:selected={(e) => {
 			flowModuleRetry = undefined
 			if (e.detail === 'constant') {
@@ -146,7 +150,7 @@
 		{/snippet}
 	</ToggleButtonGroup>
 
-	{#if delayType === 'constant' || delayType === 'exponential'}
+	{#if (delayType === 'constant' || delayType === 'exponential') && !sameWorker}
 		<Section label="Retry Condition" class="w-full">
 			{#snippet header()}
 				<Tooltip>
@@ -230,7 +234,7 @@
 		</Section>
 	{/if}
 
-	{#if delayType === 'constant' || delayType === 'exponential'}
+	{#if (delayType === 'constant' || delayType === 'exponential') && !sameWorker}
 	<div class="flex h-[calc(100%-22px)]">
 		<div class="w-1/2 h-full overflow-auto pr-2">
 			{#if delayType === 'constant'}

--- a/frontend/src/lib/components/flows/content/FlowRetries.svelte
+++ b/frontend/src/lib/components/flows/content/FlowRetries.svelte
@@ -15,6 +15,8 @@
 	import { NEVER_TESTED_THIS_FAR } from '../models'
 	import { validateRetryConfig } from '$lib/utils'
 	import EEOnly from '$lib/components/EEOnly.svelte'
+	import Alert from '$lib/components/common/alert/Alert.svelte'
+	import { SAME_WORKER_INCOMPATIBLE_MSG } from '../utils.svelte'
 
 	interface Props {
 		flowModuleRetry: Retry | undefined
@@ -52,6 +54,11 @@
 				)
 			: null
 	)
+
+	// `flowModule` is only set when editing a flow step: the trigger/schedule usages of this
+	// component share the flow editor context but are unaffected by `same_worker`.
+	let sameWorker = $derived(Boolean(flowModule && flowStore?.val?.value?.same_worker))
+	let isDisabled = $derived(disabled || sameWorker)
 
 	let isRetryConditionEnabled = $derived(Boolean(flowModuleRetry?.retry_if))
 	let result = $derived(
@@ -111,9 +118,16 @@
 </script>
 
 <div class="flex flex-col gap-4">
+	{#if sameWorker}
+		<Alert type="warning" size="xs" title="Disabled by the shared directory">
+			{SAME_WORKER_INCOMPATIBLE_MSG} Disable `Same Worker` in the flow settings to use retries.
+		</Alert>
+	{/if}
+
 	<ToggleButtonGroup
 		bind:selected={delayType}
-		class={`${disabled ? 'disabled' : ''}`}
+		disabled={isDisabled}
+		class={`${isDisabled ? 'disabled' : ''}`}
 		on:selected={(e) => {
 			flowModuleRetry = undefined
 			if (e.detail === 'constant') {

--- a/frontend/src/lib/components/flows/content/FlowSettings.svelte
+++ b/frontend/src/lib/components/flows/content/FlowSettings.svelte
@@ -30,6 +30,7 @@
 	import OnBehalfOfSelector, {
 		type OnBehalfOfChoice
 	} from '$lib/components/OnBehalfOfSelector.svelte'
+	import { modulesWithRetryOrSleep, SAME_WORKER_INCOMPATIBLE_MSG } from '../utils.svelte'
 
 	interface Props {
 		noEditor: boolean
@@ -62,6 +63,11 @@
 	let dirtyPath = $state(false)
 
 	let displayWorkerTagPicker = $state(false)
+
+	// Only block turning it on: a flow deployed with both (CLI, YAML editor) must stay fixable.
+	let conflictingModuleIds = $derived(
+		flowStore.val.value.same_worker ? [] : modulesWithRetryOrSleep(flowStore.val.value.modules)
+	)
 
 	run(() => {
 		if (flowStore.val.tag) {
@@ -394,20 +400,31 @@
 
 				<!-- Shared Directory Section -->
 				{#if customUi?.settingsTabs?.sharedDiretory != false}
-					<Toggle
-						textClass="font-medium"
-						size="xs"
-						bind:checked={flowStore.val.value.same_worker}
-						options={{
-							right: 'Same Worker + Shared directory on `./shared`',
-							rightTooltip:
-								'Steps will share a folder at `./shared` in which they can store heavier data and ' +
-								'pass them to the next step. Beware that the `./shared` folder is not ' +
-								'preserved across suspends and sleeps.',
-							rightDocumentationLink:
-								'https://www.windmill.dev/docs/core_concepts/persistent_storage/within_windmill#shared-directory'
-						}}
-					/>
+					<div class="flex flex-col gap-1">
+						<Toggle
+							textClass="font-medium"
+							size="xs"
+							disabled={conflictingModuleIds.length > 0}
+							bind:checked={flowStore.val.value.same_worker}
+							options={{
+								right: 'Same Worker + Shared directory on `./shared`',
+								rightTooltip:
+									'Steps will share a folder at `./shared` in which they can store heavier data and ' +
+									'pass them to the next step. Beware that the `./shared` folder is not ' +
+									'preserved across suspends and sleeps.',
+								rightDocumentationLink:
+									'https://www.windmill.dev/docs/core_concepts/persistent_storage/within_windmill#shared-directory'
+							}}
+						/>
+						{#if conflictingModuleIds.length > 0}
+							<span class="text-xs text-secondary">
+								{SAME_WORKER_INCOMPATIBLE_MSG} Remove them from step{conflictingModuleIds.length > 1
+									? 's'
+									: ''}
+								{conflictingModuleIds.join(', ')} first.
+							</span>
+						{/if}
+					</div>
 				{/if}
 
 				<!-- Visibility Section -->

--- a/frontend/src/lib/components/flows/content/FlowSettings.svelte
+++ b/frontend/src/lib/components/flows/content/FlowSettings.svelte
@@ -66,7 +66,7 @@
 
 	// Only block turning it on: a flow deployed with both (CLI, YAML editor) must stay fixable.
 	let conflictingModuleIds = $derived(
-		flowStore.val.value.same_worker ? [] : modulesWithRetryOrSleep(flowStore.val.value.modules)
+		flowStore.val.value.same_worker ? [] : modulesWithRetryOrSleep(flowStore.val.value)
 	)
 
 	run(() => {

--- a/frontend/src/lib/components/flows/utils.svelte.ts
+++ b/frontend/src/lib/components/flows/utils.svelte.ts
@@ -6,7 +6,9 @@ import {
 	type Job,
 	type RestartedFrom,
 	type OpenFlow,
-	type MemoryConfig
+	type MemoryConfig,
+	type FlowValue,
+	type Retry
 } from '$lib/gen'
 import { workspaceStore } from '$lib/stores'
 import { cleanExpr, emptySchema } from '$lib/utils'
@@ -234,13 +236,28 @@ export function emptyFlowModuleState(): FlowModuleState {
 export const SAME_WORKER_INCOMPATIBLE_MSG =
 	'Retries and sleeps are not compatible with the shared directory (`Same Worker`): retry delays would be ignored and a sleep would lose the `./shared` folder.'
 
-export function modulesWithRetryOrSleep(modules: FlowModule[]): string[] {
+// Mirrors the backend's `Retry::has_attempts`: a retry with no attempt never runs, and the
+// retries tab renders it as "Disabled", so it must not block anything.
+function hasRetryAttempts(retry: Retry | undefined): boolean {
+	return (retry?.constant?.attempts ?? 0) > 0 || (retry?.exponential?.attempts ?? 0) > 0
+}
+
+export function modulesWithRetryOrSleep(flow: FlowValue): string[] {
+	// The failure and preprocessor modules live outside `modules` but run as regular steps on
+	// the same-worker hand-off. Agent tools don't: they never go through the flow scheduler.
+	const roots = [flow.modules, flow.failure_module, flow.preprocessor_module]
+		.flat()
+		.filter((m) => m != undefined)
 	const ids: string[] = []
-	forEachFlowModule(modules, (m) => {
-		if (m.retry != undefined || m.sleep != undefined) {
-			ids.push(m.id)
-		}
-	})
+	forEachFlowModule(
+		roots,
+		(m) => {
+			if (hasRetryAttempts(m.retry) || m.sleep != undefined) {
+				ids.push(m.id)
+			}
+		},
+		{ skipToolNodes: true }
+	)
 	return ids
 }
 

--- a/frontend/src/lib/components/flows/utils.svelte.ts
+++ b/frontend/src/lib/components/flows/utils.svelte.ts
@@ -13,6 +13,7 @@ import { cleanExpr, emptySchema } from '$lib/utils'
 import { get } from 'svelte/store'
 import type { FlowModuleState } from './flowState'
 import { type PickableProperties, dfs } from './previousResults'
+import { forEachFlowModule } from './dfs'
 import { NEVER_TESTED_THIS_FAR } from './models'
 import { sendUserToast } from '$lib/toast'
 import type { ExtendedOpenFlow } from './types'
@@ -225,6 +226,22 @@ export function emptyFlowModuleState(): FlowModuleState {
 		schema: emptySchema(),
 		previewResult: NEVER_TESTED_THIS_FAR
 	}
+}
+
+// `same_worker` hands the next step directly to the worker holding `./shared`, bypassing
+// `scheduled_for`: a retry delay is silently ignored, and a sleep breaks the hand-off so the
+// next step can land on another worker without `./shared`. Keep the two mutually exclusive.
+export const SAME_WORKER_INCOMPATIBLE_MSG =
+	'Retries and sleeps are not compatible with the shared directory (`Same Worker`): retry delays would be ignored and a sleep would lose the `./shared` folder.'
+
+export function modulesWithRetryOrSleep(modules: FlowModule[]): string[] {
+	const ids: string[] = []
+	forEachFlowModule(modules, (m) => {
+		if (m.retry != undefined || m.sleep != undefined) {
+			ids.push(m.id)
+		}
+	})
+	return ids
 }
 
 export function checkIfParentLoop(

--- a/frontend/src/lib/components/flows/utils.test.ts
+++ b/frontend/src/lib/components/flows/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FlowValue } from '$lib/gen'
+import { modulesWithRetryOrSleep } from './utils.svelte'
+
+const constantRetry = { constant: { attempts: 1, seconds: 5 } }
+
+function step(id: string, extra: Record<string, unknown> = {}) {
+	return { id, value: { type: 'identity' }, ...extra } as any
+}
+
+describe('modulesWithRetryOrSleep', () => {
+	it('reports retries and sleeps everywhere same_worker applies', () => {
+		const flow: FlowValue = {
+			modules: [
+				step('a', { retry: constantRetry }),
+				step('b', { sleep: { type: 'static', value: 3 } }),
+				step('c'),
+				{
+					id: 'd',
+					value: {
+						type: 'forloopflow',
+						modules: [step('e', { retry: constantRetry })],
+						iterator: { type: 'static', value: [] },
+						skip_failures: false
+					}
+				} as any
+			],
+			failure_module: step('failure', { retry: constantRetry }),
+			preprocessor_module: step('preprocessor', { sleep: { type: 'static', value: 1 } })
+		}
+
+		expect(modulesWithRetryOrSleep(flow)).toEqual(['a', 'b', 'e', 'failure', 'preprocessor'])
+	})
+
+	it('ignores what same_worker does not govern: agent tools and attempt-less retries', () => {
+		const flow: FlowValue = {
+			modules: [
+				step('a', { retry: { constant: { attempts: 0, seconds: 5 } } }),
+				{
+					id: 'b',
+					value: { type: 'aiagent', tools: [step('tool', { retry: constantRetry })] }
+				} as any
+			]
+		}
+
+		expect(modulesWithRetryOrSleep(flow)).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

`same_worker` hands the next step straight to the worker holding `./shared` instead of putting it back on the queue, so `scheduled_for` is never consulted (`get_same_worker_job` selects by id only). A step retry delay is therefore silently ignored, and `continue_on_same_worker` is explicitly false when a module has a `sleep`, so the next step can land on another worker without `./shared`.

The two settings were freely combinable in the flow editor while producing that silent misbehavior. They are now mutually exclusive in the UI.

## Changes

- `utils.svelte.ts`: new `modulesWithRetryOrSleep(flow)` — walks `modules` plus `failure_module` / `preprocessor_module`, skips agent tools (tool jobs never go through the flow scheduler), and mirrors the backend's `Retry::has_attempts` so an attempt-less retry object doesn't count.
- `FlowSettings.svelte`: the `Same Worker + Shared directory` toggle is disabled while any step configures a retry or a sleep, with a line naming the offending step ids. Only *turning it on* is blocked — a flow deployed with both (CLI, YAML editor) can still be fixed by switching it off.
- `FlowRetries.svelte` / `FlowModuleSleep.svelte`: with `Same Worker` on, the retry and sleep controls are disabled behind an explanatory alert (the detail editors are hidden rather than left editable under a "disabled" banner). Trigger/schedule uses of `FlowRetries` and agent tools are unaffected.
- `FlowRetries.svelte` also forwards its `disabled` prop to `ToggleButtonGroup`; it previously only set a `disabled` CSS class, for which no rule exists.
- Unit test pinning what the traversal counts (nested modules, failure/preprocessor, agent tools, attempt-less retry).

## Screenshots

Same Worker blocked while a step (here the error handler) has a retry:

![settings-same-worker-blocked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-same-worker-retry-ui/1785233356-settings-same-worker-blocked.png)

Retries and Sleep tabs with Same Worker on:

![step-retries-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-same-worker-retry-ui/1785233357-step-retries-disabled.png)

![step-sleep-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-same-worker-retry-ui/1785233358-step-sleep-disabled.png)

## Test plan

- [x] `npm run check` — only the pre-existing `modern-screenshot` error remains
- [x] `npx vitest run src/lib/components/flows/utils.test.ts`
- [x] Step with a constant retry → Same Worker toggle disabled naming step `a`; retry removed → toggle usable again
- [x] Error handler with a constant retry → toggle disabled naming step `failure`
- [x] Same Worker on → step's Error handling and Sleep tabs show the alert with inert controls; switching Same Worker off restores them

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “Same Worker + Shared directory” mutually exclusive with retries and sleeps in the flow editor to prevent ignored retry delays and losing ./shared after sleeps. The UI now blocks incompatible combinations and explains how to resolve them.

- **Bug Fixes**
  - Disable the Same Worker toggle when any step has retry attempts or a sleep; show the step ids; only blocks enabling so existing flows can be fixed.
  - With Same Worker on, disable Retry and Sleep editors for steps and show a brief warning; triggers/schedules and agent tools stay unaffected.
  - Add modulesWithRetryOrSleep() to find conflicting steps, covering nested modules plus failure/preprocessor, skipping agent tools, and ignoring attempt-less retries to match backend behavior.
  - Forward the disabled prop in FlowRetries to ToggleButtonGroup (was only a CSS class); add unit tests for traversal and edge cases.

<sup>Written for commit 1a3168cfa7a05c60a0d12f93b68ca7953aec582f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

