### PR TITLE
fix: mark Setup URL as required in self-managed GitHub App instructions

### DIFF
--- a/frontend/src/lib/components/instanceSettings/GhesAppSettings.svelte
+++ b/frontend/src/lib/components/instanceSettings/GhesAppSettings.svelte
@@ -187,8 +187,9 @@
 						<strong>Setup URL</strong> (under "Post installation"):
 						<code>&lt;your-windmill-url&gt;/gh_success</code> with "Redirect on update" checked.
 						Required for installing the app from workspace Git sync settings — GitHub redirects
-						here after installation to link it to the workspace. Without it, use the Workspace
-						assignments table below to link installations manually.
+						here after installation to link it to the workspace. Without it, installations can
+						still be linked manually from the Workspace assignments table that appears below
+						once the app details are saved.
 					</li>
 					<li>
 						<strong>Callback URL</strong>: <code>&lt;your-windmill-url&gt;/gh_success</code>

--- a/frontend/src/lib/components/instanceSettings/GhesAppSettings.svelte
+++ b/frontend/src/lib/components/instanceSettings/GhesAppSettings.svelte
@@ -184,11 +184,14 @@
 						<strong>Homepage URL</strong>: your Windmill instance URL
 					</li>
 					<li>
-						<strong>Callback URL</strong>: <code>&lt;your-windmill-url&gt;/gh_success</code>
+						<strong>Setup URL</strong> (under "Post installation"):
+						<code>&lt;your-windmill-url&gt;/gh_success</code> with "Redirect on update" checked.
+						Required for installing the app from workspace Git sync settings — GitHub redirects
+						here after installation to link it to the workspace. Without it, use the Workspace
+						assignments table below to link installations manually.
 					</li>
 					<li>
-						<strong>Setup URL</strong> (optional):
-						<code>&lt;your-windmill-url&gt;/gh_success</code> with "Redirect on update" checked
+						<strong>Callback URL</strong>: <code>&lt;your-windmill-url&gt;/gh_success</code>
 					</li>
 					<li>Uncheck <strong>Active</strong> under Webhook (not needed)</li>
 				</ul>


### PR DESCRIPTION
## Summary
The "How to create a GitHub App" help in the self-managed GitHub App instance settings labeled the Setup URL as "(optional)". It is actually the field that makes the install flow work: GitHub only redirects back to `<instance>/gh_success` (carrying `installation_id` + `state`) via the app's post-installation Setup URL, and that redirect is what links the installation to the workspace (`gh_success/+page.svelte` → `ghes_installation_callback`). Customers who skip it install the app on GitHub and see nothing happen in Windmill.

## Changes
- Reorder the Setup URL bullet above Callback URL in the "How to create a GitHub App" instructions in `GhesAppSettings.svelte`
- Replace "(optional)" with an explanation that the Setup URL is required for installing from workspace Git sync settings, and why
- Point to the Workspace assignments table as the manual fallback when the app was installed without a Setup URL

Companion docs PR in windmilldocs documents the same app-creation checklist (the docs previously said only "Register a new GitHub App" with no field guidance).

## Screenshots
Not captured: this change is static help text inside a collapsible in instance settings, and this machine has no runnable dev environment (no postgres, no build artifacts, no frontend node_modules). The text change was reviewed against the actual `gh_success` flow instead; svelte-autofixer passed with no issues.

## Test plan
- [ ] Open Instance settings → GitHub Enterprise App, enable self-managed mode, expand "How to create a GitHub App" and confirm the Setup URL bullet renders first with the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTZ5UBBLNh2rkgfNzUmCWs