### PR TITLE
test(wac): pin the failure record with one corpus both SDKs read

### DIFF
--- a/backend/windmill-common/src/wac_failure_corpus.json
+++ b/backend/windmill-common/src/wac_failure_corpus.json
@@ -1,0 +1,80 @@
+{
+  "_readme": [
+    "Cases the python and the typescript SDK must both satisfy when they serialize",
+    "a failed step() body into a `__wmill_error` marker.",
+    "",
+    "The two drifted apart twice while #10368 was in review: `name` was taken from",
+    "the constructor in one client and from `e.name` in the other, and `stack` was",
+    "written in two different formats. Each was caught by a reviewer reading the",
+    "diff, not by a test, because each suite only ever checked its own language.",
+    "A shared corpus turns the next divergence into a failure in both suites.",
+    "",
+    "It sits next to `wac_failure_record`, the function that decides the record's",
+    "final shape, because that is the contract these markers are the raw material",
+    "for. The SDK test suites read it by relative path.",
+    "",
+    "`thrown` describes a value each language constructs natively:",
+    "  name           the name the record must report",
+    "  message        the message the record must report",
+    "  props          own properties/attributes that must reach `extra`",
+    "  circular_prop  an own property holding a cycle, which must be dropped",
+    "                 without taking the rest of `extra` with it",
+    "`expect.stack` is only \"present\" or \"absent\": its text is language-specific",
+    "(each client matches its own executor's format) and is asserted there.",
+    "",
+    "Known divergence, deliberately not covered here: a non-finite float reaches",
+    "`extra` as the string \"NaN\" in python and as null in typescript, because",
+    "JSON.stringify has no hook for it. The executors differ the same way."
+  ],
+  "cases": [
+    {
+      "case": "a named error keeps its name and message",
+      "thrown": { "name": "HttpError", "message": "429 too many requests" },
+      "expect": {
+        "name": "HttpError",
+        "message": "429 too many requests",
+        "stack": "present",
+        "absent": ["extra", "extra_omitted"]
+      }
+    },
+    {
+      "case": "custom properties reach extra",
+      "thrown": {
+        "name": "HttpError",
+        "message": "429",
+        "props": { "code": 429, "retry_after": 5, "endpoint": "/v1/jobs" }
+      },
+      "expect": {
+        "name": "HttpError",
+        "message": "429",
+        "stack": "present",
+        "extra": { "code": 429, "retry_after": 5, "endpoint": "/v1/jobs" }
+      }
+    },
+    {
+      "case": "a property that cannot be serialized is dropped on its own",
+      "thrown": {
+        "name": "RequestError",
+        "message": "socket hang up",
+        "props": { "code": "ECONNRESET" },
+        "circular_prop": "request"
+      },
+      "expect": {
+        "name": "RequestError",
+        "message": "socket hang up",
+        "stack": "present",
+        "extra": { "code": "ECONNRESET" }
+      }
+    },
+    {
+      "case": "an error carrying nothing of its own has no extra",
+      "thrown": { "name": "ValueError", "message": "nope" },
+      "expect": {
+        "name": "ValueError",
+        "message": "nope",
+        "stack": "present",
+        "absent": ["extra"]
+      }
+    }
+  ]
+}

--- a/python-client/wmill/tests/test_workflow.py
+++ b/python-client/wmill/tests/test_workflow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import pathlib
 import pytest
 
 from datetime import datetime, timezone
@@ -966,6 +967,64 @@ class TestErrorPropagation:
         )
         assert r["type"] == "complete"
         assert "step failed" in r["result"]["caught"]
+
+
+class TestFailureRecordCorpus:
+    """The cases both SDKs must agree on, read from one shared file.
+
+    `name` and `stack` drifted between the two clients twice while the record
+    was being unified, and each time only a reviewer noticed: a suite that only
+    knows its own language cannot see a divergence. The corpus is the same file
+    the typescript suite reads.
+    """
+
+    CORPUS = json.loads(
+        (
+            pathlib.Path(__file__).resolve().parents[3]
+            / "backend/windmill-common/src/wac_failure_corpus.json"
+        ).read_text()
+    )
+
+    @staticmethod
+    def _construct(spec: dict) -> BaseException:
+        exc = type(spec["name"], (Exception,), {})(spec["message"])
+        for key, value in (spec.get("props") or {}).items():
+            setattr(exc, key, value)
+        if spec.get("circular_prop"):
+            cyclic: dict = {}
+            cyclic["self"] = cyclic
+            setattr(exc, spec["circular_prop"], cyclic)
+        return exc
+
+    @pytest.mark.parametrize("case", CORPUS["cases"], ids=lambda c: c["case"])
+    def test_marker_matches_the_shared_contract(self, case):
+        exc = self._construct(case["thrown"])
+
+        def raiser():
+            raise exc
+
+        # through the real step path, so the stack is the one a failure actually
+        # records rather than one this test happens to construct
+        async def run():
+            ctx = WorkflowCtx({})
+            try:
+                await ctx._run_inline_step("k", raiser)
+            except _StepSuspend as suspended:
+                return suspended.dispatch_info["result"]
+            raise AssertionError("a raising step did not suspend")
+
+        error = asyncio.run(run())["result"]["error"]
+
+        expect = case["expect"]
+        assert error["name"] == expect["name"]
+        assert error["message"] == expect["message"]
+        assert ("stack" in error) == (expect["stack"] == "present")
+        if "extra" in expect:
+            assert error["extra"] == expect["extra"]
+        for absent in expect.get("absent", []):
+            assert absent not in error
+        # whatever it kept has to survive the trip to the checkpoint
+        json.dumps(error, allow_nan=False)
 
 
 class TestRaisingInlineStepIsCheckpointed:

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -2784,21 +2784,27 @@ def _step_error_marker(key: str, exc: BaseException) -> dict:
         # connection raises in turn. This runs inside the ``except`` that is
         # reporting the user's failure, so an escape here would replace their
         # error with an unrelated one and skip the checkpoint entirely.
-        # Narrow: what json raises for something it cannot represent. A broader
-        # catch would hide a mistake in this function as a silently missing
-        # field, which is how it read before.
-        try:
-            # ``parse_constant`` catches the one thing ``default`` cannot: a
-            # float is serializable, so ``NaN``/``Infinity`` pass through as
-            # bare literals that are not JSON and that the backend's extractor
-            # rejects — taking the whole checkpoint down with them. Kept as
-            # their text rather than dropped, so the attribute still says
-            # something.
-            error["extra"] = json.loads(
-                json.dumps(extra, default=_safe_str), parse_constant=lambda c: c
-            )
-        except (TypeError, ValueError, RecursionError):
-            pass
+        #
+        # Per attribute, so one that cannot be represented does not take the
+        # rest with it — an ``AxiosError``-shaped exception carrying both a
+        # ``code`` and a cyclic ``request`` keeps the ``code``. The typescript
+        # client admits properties one at a time for the same reason.
+        safe_extra = {}
+        for _k, _v in extra.items():
+            # Narrow: what json raises for something it cannot represent. A
+            # broader catch would hide a mistake here as a silently missing
+            # field, which is how it read before. ``parse_constant`` catches the
+            # one thing ``default`` cannot: a float is serializable, so
+            # ``NaN``/``Infinity`` pass through as bare literals that are not
+            # JSON and that the backend's extractor rejects.
+            try:
+                safe_extra[_k] = json.loads(
+                    json.dumps(_v, default=_safe_str), parse_constant=lambda c: c
+                )
+            except (TypeError, ValueError, RecursionError):
+                pass
+        if safe_extra:
+            error["extra"] = safe_extra
     return {
         "__wmill_error": True,
         "message": _safe_str(exc),

--- a/typescript-client/tests/workflow.test.ts
+++ b/typescript-client/tests/workflow.test.ts
@@ -10,6 +10,38 @@ import { expect, test, describe } from "bun:test";
 // backend's shape before, so a copy of them here would guard nothing.
 import { isSuspendSignal, stepErrorMarker, taskErrorFromMarker } from "../wacError";
 
+// The cases both SDKs must agree on, read from the same file the python suite
+// reads. `name` and `stack` drifted between the two clients twice while the
+// record was being unified, and a suite that only knows its own language cannot
+// see that.
+import corpus from "../../backend/windmill-common/src/wac_failure_corpus.json";
+
+describe("shared failure-record corpus", () => {
+  const construct = (spec: any): any => {
+    const e: any = Object.assign(new Error(spec.message), { name: spec.name });
+    for (const [k, v] of Object.entries(spec.props ?? {})) e[k] = v;
+    if (spec.circular_prop) {
+      const cyclic: any = {};
+      cyclic.self = cyclic;
+      e[spec.circular_prop] = cyclic;
+    }
+    return e;
+  };
+
+  for (const c of (corpus as any).cases) {
+    test(c.case, () => {
+      const error = stepErrorMarker("k", construct(c.thrown)).result.error;
+      expect(error.name).toBe(c.expect.name);
+      expect(error.message).toBe(c.expect.message);
+      expect("stack" in error).toBe(c.expect.stack === "present");
+      if (c.expect.extra) expect(error.extra).toEqual(c.expect.extra);
+      for (const absent of c.expect.absent ?? []) expect(absent in error).toBe(false);
+      // whatever it kept has to survive the trip to the checkpoint
+      expect(() => JSON.stringify(error)).not.toThrow();
+    });
+  }
+});
+
 // --- Inline SDK (mirrors client.ts implementation) ---
 
 class StepSuspend extends Error {


### PR DESCRIPTION
## Summary

Follow-up to #10368. That PR unified the WAC failure record; this one adds the test
that would have caught the way it kept coming apart.

Across #10368's review rounds the python and typescript markers drifted from each other
and from the executors twice: `name` was read from the constructor in one client and from
`e.name` in the other, and `stack` was written in two different formats. Both were caught
by a reviewer reading the diff. Neither could have been caught by the suites, because each
suite only knows its own language, and both were green the whole time.

## What this adds

`backend/windmill-common/src/wac_failure_corpus.json` describes failures in a
language-neutral way and states what the record must contain. Both SDK suites read that one
file and construct the value natively, so a divergence fails in both at once. It sits next
to `wac_failure_record`, the function that decides the record's final shape, because that is
the contract the markers are raw material for.

Four cases, chosen as the ones both languages must agree on: a named error keeps its name
and message; custom fields reach `extra`; a field that cannot be serialized is dropped
without taking the rest of `extra` with it; an error carrying nothing of its own has no
`extra`.

The corpus records one deliberate non-goal too: a non-finite float reaches `extra` as the
string `"NaN"` in python and as `null` in typescript, because `JSON.stringify` has no hook
for it. The executors differ the same way, so pinning it here would pin the wrong thing.

## One behaviour change

Case three failed on the python side, correctly. Python dropped **all** of `extra` when any
single attribute could not be serialized, where typescript admits properties one at a time.
An `AxiosError`-shaped exception carrying both a `code` and a cyclic `request` lost the
`code` in python and kept it in typescript. Python now admits per attribute, matching.

## The other half of the plan, and why it is not here

The companion item was to delete the typescript mirror: `workflow.test.ts` re-implements
`WorkflowCtx` inline, so most of the shipped client is covered only by a copy that is free
to drift. I tried to make the suite import the real `client.ts` and could not do it cleanly:

- `client.ts` imports `./services.gen` and `./core/OpenAPI`, which exist only after
  `build.sh` runs the generator.
- A bun plugin can redirect `./services.gen`, and does. It is never offered
  `./core/OpenAPI` at all: bun resolves that specifier and fails before any plugin hook
  runs. Verified with a catch-all `onResolve` that logs every specifier.
- `mock.module` cannot help either, since it needs the module to resolve first.
- Stub files at the paths the imports demand would work, but that means committing a
  hand-written `services.gen.ts` to the package root, which is a trap.

The honest fix is to extract the WAC engine into a dependency-free module the way
`wacError.ts` already was, and have `client.ts` re-export it. That is a real refactor of
`client.ts` rather than a test change, so it wants its own PR and its own review.

## Test plan

- [x] `pytest python-client/wmill/tests/test_workflow.py` — 106 pass (the one failure,
      `test_preserves_function_name`, fails identically on `main` and is unrelated)
- [x] `bun test typescript-client/tests` — 167 pass
- [x] `cargo check -p windmill-common`
- [x] **Mutation-checked both guards**, because a guard that cannot fail is worth nothing:
      reintroducing the constructor-name drift in typescript fails all four corpus cases;
      reverting python to all-or-nothing `extra` fails the two cases that cover it. Both
      pass again once restored.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the WAC failure-record contract across Python and TypeScript by adding a shared JSON corpus both SDKs read in tests. Also aligns Python `extra` serialization with TypeScript to drop only un-serializable fields.

- **New Features**
  - Added `backend/windmill-common/src/wac_failure_corpus.json` with four canonical failure cases.
  - Both SDK suites load this file, construct native errors, and assert `name`, `message`, `stack` presence, and `extra`.

- **Bug Fixes**
  - Python `_step_error_marker` now builds `extra` per attribute and skips only values that can’t be serialized.
  - Preserves valid fields when one is cyclic or invalid, matching the TypeScript client and executor behavior.

<sup>Written for commit a558d876d8a939d08106147b96e3d1090dd12166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

