### PR TITLE
fix: home kind filter no longer resets a fork or reloads the page

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1361,7 +1361,7 @@
 					if (itemKind != 'all') {
 						subtab = v
 					}
-					setQuery(page.url, 'kind', v)
+					setQuery('kind', v)
 				}}
 			>
 				{#snippet children({ item })}

--- a/frontend/src/lib/navigation.test.ts
+++ b/frontend/src/lib/navigation.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { buildFilterUrl } from './navigation'
+import { describe, it, expect, vi } from 'vitest'
+
+const goto = vi.hoisted(() => vi.fn(async (_path: string) => {}))
+vi.mock('$app/navigation', () => ({ goto: (path: string) => goto(path) }))
+vi.mock('$app/paths', () => ({ base: '' }))
+
+import { buildFilterUrl, setQuery } from './navigation'
 
 // Parse the (un-based) app path the builder returns against a dummy origin so we can
 // assert on pathname / searchParams / hash without caring about ordering.
@@ -48,5 +53,29 @@ describe('buildFilterUrl', () => {
 		const u = parse(buildFilterUrl('/schedules', { path: 'f/x' }, { hash: 'f/a/b' }))
 		expect(u.searchParams.get('path')).toBe('f/x')
 		expect(u.hash).toBe('#f/a/b')
+	})
+})
+
+describe('setQuery', () => {
+	// setQuery reads nothing but `window.location.search`; the node test env has no
+	// real `location`, so a stub carrying the query is the whole browser it needs.
+	function addressBar(search: string) {
+		Object.defineProperty(globalThis, 'location', {
+			value: { search },
+			writable: true,
+			configurable: true
+		})
+	}
+
+	it('preserves params that only the address bar knows about', async () => {
+		goto.mockClear()
+		addressBar('?workspace=wm-fork-x&search=foo')
+
+		await setQuery('kind', 'script')
+
+		const u = parse(goto.mock.calls[0][0])
+		expect(u.searchParams.get('workspace')).toBe('wm-fork-x')
+		expect(u.searchParams.get('search')).toBe('foo')
+		expect(u.searchParams.get('kind')).toBe('script')
 	})
 })

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -36,19 +36,27 @@ export function buildFilterUrl(
 	return qs ? `${pathname}?${qs}${hash}` : `${pathname}${hash}`
 }
 
+/**
+ * Set (or, with an undefined value, drop) one query param on the current page and
+ * navigate, leaving every other param untouched.
+ *
+ * The starting query must come from `window.location`, never from a URL held
+ * elsewhere — above all `page.url`, which SvelteKit refreshes only on router-driven
+ * navigations. Params written with shallow routing (a workspace switch's
+ * `?workspace=`, anything `useSearchParams` writes) never reach `page.url`, so
+ * rebuilding the query from it navigates back to their pre-write values.
+ */
 export async function setQuery(
-	url: URL,
 	key: string,
 	value: string | undefined,
 	currentHash: string | undefined = undefined
 ): Promise<void> {
+	const searchParams = new URLSearchParams(window.location.search)
 	if (value !== undefined) {
-		url.searchParams.set(key, value)
+		searchParams.set(key, value)
 	} else {
-		url.searchParams.delete(key)
+		searchParams.delete(key)
 	}
-
-	let searchParams = url.searchParams.toString()
 
 	await goto(currentHash ? `?${searchParams}${currentHash}` : `?${searchParams}`)
 }

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -426,13 +426,18 @@
 				navigation.cancel()
 				window.location.href = navigation.to!.url.href
 			}
-		} else if (toPath && (isEditorPath(currentPath) || window.crossOriginIsolated)) {
+		} else if (toPath && isEditorPath(currentPath)) {
 			// Reverse of the guard above: leaving the isolated editor document must
 			// also fully reload, or its COEP header sticks for the rest of the SPA
 			// session and blocks CORP-less cross-origin subresources (e.g. images in
 			// a viewed app — see needs_cross_origin_isolation in static_assets.rs).
-			// The path check covers plain-HTTP origins, where `crossOriginIsolated`
-			// stays false even with the headers applied.
+			// Key off the path, never `window.crossOriginIsolated`: a deployment may
+			// isolate the whole site (frontend/static/_headers does, for Cloudflare
+			// Pages), and there the flag is true on every page — turning every
+			// navigation into a full page load, while the reload it forces cannot
+			// clear an isolation the next document asserts too. Among the routes this
+			// layout governs, only the editor is served the headers, so entering it is
+			// the only way into an isolated document here.
 			navigation.cancel()
 			window.location.href = navigation.to!.url.href
 		}

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -327,7 +327,7 @@
 						<ToggleButtonGroup
 							bind:selected={subtab}
 							onSelected={(v) => {
-								setQuery(page.url, 'kind', v, window.location.hash)
+								setQuery('kind', v, window.location.hash)
 							}}
 							noWFull
 						>

--- a/frontend/src/routes/(root)/(logged)/amqp_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/amqp_triggers/+page.svelte
@@ -238,13 +238,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/azure_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/azure_triggers/+page.svelte
@@ -258,13 +258,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/email_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/email_triggers/+page.svelte
@@ -204,13 +204,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/gcp_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/gcp_triggers/+page.svelte
@@ -251,13 +251,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/kafka_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/kafka_triggers/+page.svelte
@@ -242,13 +242,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/mqtt_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/mqtt_triggers/+page.svelte
@@ -238,13 +238,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/nats_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/nats_triggers/+page.svelte
@@ -241,13 +241,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/postgres_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/postgres_triggers/+page.svelte
@@ -255,13 +255,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/routes/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/routes/+page.svelte
@@ -220,13 +220,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/sqs_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sqs_triggers/+page.svelte
@@ -235,13 +235,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined

--- a/frontend/src/routes/(root)/(logged)/websocket_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/websocket_triggers/+page.svelte
@@ -238,13 +238,11 @@
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders) {
 		setQuery(
-			new URL(window.location.href),
 			TRIGGER_PATH_KIND_FILTER_SETTING,
 			selectedFilterKind,
 			window.location.hash || undefined
 		).then(() => {
 			setQuery(
-				new URL(window.location.href),
 				FILTER_USER_FOLDER_SETTING_NAME,
 				String(filterUserFolders),
 				window.location.hash || undefined


### PR DESCRIPTION
## Summary

Two independent bugs on the home page's Script / Flow / App filter, found from one report ("selecting a fork then clicking a filter resets to root").

**1. The filter reverted the workspace to the root (and dropped the search text).**

`setQuery` (`frontend/src/lib/navigation.ts`) rebuilt the whole query string from a URL its caller passed in — and the home page passed `page.url`. SvelteKit refreshes `page.url` only on router-driven navigations: `replaceState`/`pushState` write the address bar and `page.state`, never `page.url`. Two params on that page are written exactly that way:

- `?workspace=<fork>` — `fixupUrlAfterWorkspaceSwitch` rewrites it with SvelteKit's shallow `replaceState` after a workspace switch.
- `?search=<text>` — `useSearchParams` writes it with raw `history.replaceState`.

So `page.url` still held the pre-switch `?workspace=<root>` and no `search` at all. Clicking a kind tab called `goto('?' + <stale params> + '&kind=script')`, landing on `?workspace=<root>&kind=script`; the logged layout's `onQueryChange` then read that param back and set the workspace store to the root.

`setQuery` now always sources the query from `window.location.search` — the address bar is the one URL that every writer, router-driven or shallow, keeps current. The `url` parameter is removed outright so a stale snapshot can't be handed in again.

**2. Every navigation was a full page reload on Cloudflare Pages deployments.**

Pre-existing, and reproducible on the `main` preview too, but it made the filter look broken. `frontend/static/_headers` applies COOP/COEP to `/*`, so `window.crossOriginIsolated` is true on *every* page of a Pages deployment. That tripped this branch in `(logged)/+layout.svelte`:

```js
} else if (toPath && (isEditorPath(currentPath) || window.crossOriginIsolated)) {
    navigation.cancel()
    window.location.href = navigation.to!.url.href
}
```

The branch exists to force one reload when *leaving* the cross-origin-isolated raw app editor, so its COEP header doesn't stick for the rest of the SPA session. With site-wide isolation that condition is true forever, and the reload it forces can't clear an isolation the next document asserts too — so every navigation became a page load for no benefit.

The path check alone is sufficient here. Of the four paths `needs_cross_origin_isolation` (`static_assets.rs:71`) matches, only `/apps_raw/edit` and `/apps_raw/add` are routes this layout governs: `/ui_builder/` has no SvelteKit route (iframe-only static bundle), and `/public/` and `/a/` sit outside `(logged)`. Entering the editor always forces a full load, so while the document is isolated its path *is* the editor path.

## Changes

- `setQuery(url, key, value, hash)` → `setQuery(key, value, hash)`; the query comes from `window.location.search`. It also no longer mutates the caller's URL object (it was mutating SvelteKit's `page.url` in place).
- Updated all 24 call sites: 11 trigger list pages, the home page's hub-tab kind toggle, and `ItemsList`. The trigger pages already passed `new URL(window.location.href)`, so they are unchanged in behavior; only the two `page.url` callers change.
- `ListFilters.svelte` untouched: it declares its own `setQuery` that shadows this one, writes via `pushState` rather than `goto`, and already reads the live URL.
- `(logged)/+layout.svelte`: the leaving-the-editor reload guard keys off the editor path only, not `window.crossOriginIsolated`.
- Regression test in `navigation.test.ts` pinning that params present only in the address bar survive into the `goto` target.

## Test plan

- [x] `npm run check` — 1 error, pre-existing and unrelated (`modern-screenshot` missing in this worktree)
- [x] `npx vitest run src/lib/navigation.test.ts --project server` — 5 passed
- [x] Full `--project server` suite: 4 failing files (copilot chat `ContextManager` / `app/core`, `raw_apps/utils`, dbtable `alterTable`) all pre-existing and unrelated — none reference `navigation`/`setQuery`
- [x] Local dev: with a fork selected and `foo` in the search box, clicking Scripts keeps `?workspace=wm-fork-…&search=foo&kind=script` and the sidebar stays on the fork. Reproduced the original failure first (it navigated to `?workspace=test&kind=script`, dropping both).
- [x] Local dev: `/routes` trigger page — the two chained `setQuery` calls still land both params
- [x] Cloudflare preview, filter click: no document reload, only the 2 expected `runnables/*` refetches
- [x] Cloudflare preview, plain sidebar nav (Runs → Home): no document reload
- [x] Cloudflare preview, **into** the raw app editor: still a hard document load, `crossOriginIsolated === true`, `new SharedArrayBuffer(8)` succeeds, tsserver workers running
- [x] Cloudflare preview, **out of** the editor: still a hard document load
- [x] Confirmed the reload is pre-existing: the same filter click on the `main` preview (windmill.pages.dev) also hard-reloads

## Screenshots

Home page in the fork, with the search text and the Scripts filter both applied — sidebar and banner still on `MyFork`:

![home: fork + search + kind filter all preserved](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-7704ae6a/1785239079-after-fork-kept.png)

## Follow-up (not in this PR)

- `frontend/static/_headers` isolates `/*` where the Rust server isolates only the routes that need it. Scoping it would also unbreak CORP-less cross-origin subresources on Pages deployments — but Cloudflare `_headers` cannot match on query string, so it can't express the `?wm_coep` opt-in for `/public/` and `/a/`. Left alone deliberately.
- Three other sites build a navigation target from `page.url` and share the staleness class: `runs/TimeframeSelect.svelte:16` (service logs; writes without navigating, so it corrupts the address bar rather than the store), `workspaceSettings/WorkspaceIntegrations.svelte:269`, `pipeline/[folder]/+page.svelte:172`.