### PR TITLE
ci: run the SDK suites on release

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -45,6 +45,10 @@ jobs:
       # runner's system python and stops with "not compatible with the locked
       # Python requirement" rather than fetching one. Keep in step with
       # `requires-python` in uv.lock.
+      #
+      # Note this is not the version a worker runs the SDK on — those are 3.12.
+      # `uv.lock` asks for >=3.14, so pinning lower means regenerating it, which
+      # is worth doing separately.
       - name: Install the interpreter the lockfile requires
         run: uv python install 3.14
 

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -1,0 +1,62 @@
+# The python and typescript SDK unit suites. Both existed for a long time
+# without any workflow running them, so a red test could sit on main unnoticed —
+# one did. They are fast and need no services, so they run on every PR touching
+# either client.
+name: SDK Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "python-client/**"
+      - "typescript-client/**"
+      - ".github/workflows/sdk-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "python-client/**"
+      - "typescript-client/**"
+      - ".github/workflows/sdk-tests.yml"
+
+jobs:
+  typescript-client:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # No build step: these suites are deliberately free of the generated API
+      # client, so they run against the sources as committed.
+      - name: Run tests
+        working-directory: ./typescript-client
+        run: bun test --timeout 120000 tests/
+
+  python-client:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      # The interpreter is named explicitly: on a clean checkout uv picks the
+      # runner's system python and stops with "not compatible with the locked
+      # Python requirement" rather than fetching one. Keep in step with
+      # `requires-python` in uv.lock.
+      - name: Install the interpreter the lockfile requires
+        run: uv python install 3.14
+
+      # `--frozen` so a drifted lockfile fails here rather than quietly
+      # resolving to something nobody has run.
+      - name: Run tests
+        working-directory: ./python-client/wmill
+        env:
+          PYTHONPATH: .
+        run: uv run --frozen --python 3.14 pytest tests/ -q

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -1,23 +1,19 @@
 # The python and typescript SDK unit suites. Both existed for a long time
 # without any workflow running them, so a red test could sit on main unnoticed —
-# one did. They are fast and need no services, so they run on every PR touching
-# either client.
+# one did.
+#
+# Release only: these guard what gets published to npm / PyPI / JSR, and a tag is
+# the moment that matters. Note this runs *alongside* the publish workflows
+# rather than ahead of them, so it reports a broken SDK rather than holding one
+# back — gating would mean putting the job inside each publish workflow, since
+# Actions cannot express `needs` across workflows.
 name: SDK Tests
 
 on:
   workflow_dispatch:
   push:
-    branches: [main]
-    paths:
-      - "python-client/**"
-      - "typescript-client/**"
-      - ".github/workflows/sdk-tests.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "python-client/**"
-      - "typescript-client/**"
-      - ".github/workflows/sdk-tests.yml"
+    tags:
+      - "v*"
 
 jobs:
   typescript-client:

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -1,12 +1,11 @@
-# The python and typescript SDK unit suites. Both existed for a long time
-# without any workflow running them, so a red test could sit on main unnoticed —
-# one did.
+# The python and typescript SDK unit suites, on release tags only: they guard
+# what gets published to npm / PyPI / JSR, and a tag is the moment that decides
+# it.
 #
-# Release only: these guard what gets published to npm / PyPI / JSR, and a tag is
-# the moment that matters. Note this runs *alongside* the publish workflows
-# rather than ahead of them, so it reports a broken SDK rather than holding one
-# back — gating would mean putting the job inside each publish workflow, since
-# Actions cannot express `needs` across workflows.
+# This runs alongside the publish workflows rather than ahead of them, so it
+# reports a broken SDK rather than holding one back. Gating would mean putting
+# the job inside each publish workflow, since Actions cannot express `needs`
+# across workflows.
 name: SDK Tests
 
 on:

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -3191,9 +3191,9 @@ def task(
             return merged
 
         # Keeps the decorated function's identity: `@task` is applied to a
-        # top-level `async def`, and a caller introspecting it (or a traceback
-        # naming it) should see that function, not `wrapper`. The step key is
-        # computed from `func` above, so this does not affect dispatch.
+        # top-level `async def`, and a caller introspecting it should see that
+        # function, not `wrapper`. The step key is computed from `func` above,
+        # so this does not affect dispatch.
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # WAC v2: inside a @workflow context

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -3190,6 +3190,11 @@ def task(
                     merged[f"arg{i}"] = arg
             return merged
 
+        # Keeps the decorated function's identity: `@task` is applied to a
+        # top-level `async def`, and a caller introspecting it (or a traceback
+        # naming it) should see that function, not `wrapper`. The step key is
+        # computed from `func` above, so this does not affect dispatch.
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # WAC v2: inside a @workflow context
             ctx = _workflow_ctx.get(None)


### PR DESCRIPTION
## Summary

Neither SDK unit suite runs anywhere. The only `bun test` in CI is `cli/test/`,
and the only pytest is `integration_tests/ai_agent_tests`; nothing runs
`typescript-client/tests` or `python-client/wmill/tests`. So those suites protect
whatever a person happens to run locally, and a red test can sit on main
indefinitely.

One had. `TestTaskDecorator::test_preserves_function_name` fails on `main` today.

This runs both suites on release tags (`v*`), the moment that decides what gets
published to npm / PyPI / JSR, plus `workflow_dispatch` for running them by hand.

## It reports rather than gates

Worth being explicit: this workflow runs *alongside* `npm_on_release`,
`pypi_on_release` and `jsr_on_release`, not ahead of them, so a failure tells you
the release is broken rather than stopping it. Actions cannot express `needs`
across workflows, so gating would mean putting the test job inside each of those
three publish workflows. Happy to do that instead if you want the stronger
version; it is more churn in files that currently do one thing.

## The red test was a real regression, not a bad test

`@task` built its `wrapper` and returned it without `functools.wraps`, so a
decorated task reported `__name__ == "wrapper"`. The test asserting otherwise had
been failing unnoticed for exactly as long as nobody ran it.

Fixed rather than quarantined: the step key is computed from `func` at decoration
time and `inspect.signature` is taken on `func`, so wrapping changes nothing about
dispatch or argument handling. It restores the decorated function's identity for
anyone introspecting it or reading a traceback, and makes `inspect.signature` on a
task follow through to the real signature instead of `(*args, **kwargs)`.

## One wrinkle worth knowing

On a clean checkout `uv run --frozen` picks the runner's system python and stops
with *"not compatible with the locked Python requirement"* rather than fetching a
suitable one — `uv.lock` says `requires-python = ">=3.14"`. It only appeared to
work locally because a `.venv` was already there. The workflow installs the
interpreter explicitly; the comment says why so the next person does not
"simplify" it away.

## Test plan

- [x] `bun test --timeout 120000 tests/` in `typescript-client` — 163 pass
- [x] `uv run --frozen --python 3.14 pytest tests/ -q` in `python-client/wmill`
      from a **clean** checkout (`.venv` moved aside) — 103 pass, the full suite
      green for the first time
- [x] Reproduced the clean-checkout uv failure before adding the explicit
      interpreter step, so the step is known to be load-bearing
- [x] Workflow parses as YAML; triggers are `push: tags: v*` and
      `workflow_dispatch` only