### PR TITLE
feat(apps): support the frontend SDK in sandboxed raw apps

### DIFF
--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -639,6 +639,9 @@ async fn get_raw_app_data(
             .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
             .header("X-Content-Type-Options", "nosniff")
             .header("Cross-Origin-Resource-Policy", "cross-origin")
+            // This URL carries the frontend-SDK handshake nonce, so it must not
+            // travel to whatever the bundle navigates to or links out to.
+            .header("Referrer-Policy", "no-referrer")
             .header(
                 http::header::CONTENT_SECURITY_POLICY,
                 "sandbox allow-scripts allow-forms allow-popups \
@@ -843,7 +846,13 @@ fn raw_app_wrapper_html(secret: &str) -> String {
       loadBundle();
     }
   });
-  try { window.parent.postMessage({ type: 'windmill:ready' }, '*'); } catch (_) {}
+  // Echo the handshake nonce from our own URL. It proves to the embedder that
+  // this is the document it loaded rather than one navigated into the frame
+  // afterwards, which is what gates the frontend SDK credential.
+  try {
+    var hs = new URLSearchParams(window.location.search).get('wm_hs') || undefined;
+    window.parent.postMessage({ type: 'windmill:ready', nonce: hs }, '*');
+  } catch (_) {}
   // Fallback for contexts that never send ctx (e.g. ctx-less rendering).
   setTimeout(loadBundle, 1500);
 })();

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -827,30 +827,26 @@ fn raw_app_wrapper_html(secret: &str) -> String {
   }
   function applyCtx(d) {
     if (!d || d.type !== 'windmill:ctx') return;
-    {
-      window.ctx = d.ctx;
-      if (window.__wmStorageShim && d.storage) {
-        window.__wmStorageShim.local.__hydrate(d.storage.local);
-        window.__wmStorageShim.session.__hydrate(d.storage.session);
-      }
-      // Frontend SDK: a bundled `windmill-client` reads window.process.env at
-      // module load, so the env must exist before the bundle script below is
-      // injected. BASE_URL is supplied by the embedder rather than derived —
-      // location.origin is "null" on this opaque origin.
-      if (d.sdk && d.sdk.token) {
-        window.process = { env: { WM_TOKEN: d.sdk.token, BASE_URL: d.sdk.baseUrl, WM_WORKSPACE: d.sdk.workspace } };
-      }
-      if (d.initialHash && d.initialHash !== '#' && !window.location.hash) {
-        try { history.replaceState(null, '', d.initialHash); } catch (_) {}
-      }
-      loadBundle();
+    window.ctx = d.ctx;
+    if (window.__wmStorageShim && d.storage) {
+      window.__wmStorageShim.local.__hydrate(d.storage.local);
+      window.__wmStorageShim.session.__hydrate(d.storage.session);
     }
+    // A bundled `windmill-client` reads window.process.env at module load, so the
+    // env must exist before the bundle script is injected below. BASE_URL comes
+    // from the embedder — location.origin is "null" on this opaque origin.
+    if (d.sdk && d.sdk.token) {
+      window.process = { env: { WM_TOKEN: d.sdk.token, BASE_URL: d.sdk.baseUrl, WM_WORKSPACE: d.sdk.workspace } };
+    }
+    if (d.initialHash && d.initialHash !== '#' && !window.location.hash) {
+      try { history.replaceState(null, '', d.initialHash); } catch (_) {}
+    }
+    loadBundle();
   }
-  // Announce readiness over a MessageChannel we own, echoing the nonce from our
-  // own URL. The nonce proves to the embedder which document is asking (one
-  // navigated in later cannot read it); replying on our port guarantees the
-  // answer reaches only this document, since replacing it discards the port.
-  // Both are needed before the embedder parts with the viewer's SDK token.
+  // The embedder parts with the viewer's SDK token only if both hold: the nonce
+  // from our URL says which document is asking (one navigated in later cannot
+  // read it), and our own port says the answer reaches only this document
+  // (replacing the document discards the port).
   try {
     var hs = new URLSearchParams(window.location.search).get('wm_hs') || undefined;
     var ch = new MessageChannel();
@@ -1347,8 +1343,9 @@ async fn mint_raw_app_sdk_token(
 /// and can call this endpoint itself. The boundary is the scope set — the token
 /// can never exceed the policy-declared scopes, which are also capped by the
 /// viewer's own permissions. Sandbox isolation is what contains an app's code; a
-/// sandboxed app holds nothing but this token, so there the prompt is the only
-/// way it gains any reach at all.
+/// sandboxed app has no other way to call the API directly, so there the prompt
+/// decides its whole API surface (its policy-approved runnables still run either
+/// way, through the bridge).
 ///
 /// The CALLER MUST verify that `opt_authed` may view `app_path` before calling:
 /// this mints on their behalf unconditionally and does no visibility check of its

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -830,6 +830,13 @@ fn raw_app_wrapper_html(secret: &str) -> String {
         window.__wmStorageShim.local.__hydrate(d.storage.local);
         window.__wmStorageShim.session.__hydrate(d.storage.session);
       }
+      // Frontend SDK: a bundled `windmill-client` reads window.process.env at
+      // module load, so the env must exist before the bundle script below is
+      // injected. BASE_URL is supplied by the embedder rather than derived —
+      // location.origin is "null" on this opaque origin.
+      if (d.sdk && d.sdk.token) {
+        window.process = { env: { WM_TOKEN: d.sdk.token, BASE_URL: d.sdk.baseUrl, WM_WORKSPACE: d.sdk.workspace } };
+      }
       if (d.initialHash && d.initialHash !== '#' && !window.location.hash) {
         try { history.replaceState(null, '', d.initialHash); } catch (_) {}
       }
@@ -1322,11 +1329,13 @@ async fn mint_raw_app_sdk_token(
 /// apps whose policy declares `frontend_sdk_scopes` get the viewer-scoped SDK
 /// token once the viewer confirms the permission prompt (`sdk_consent`).
 ///
-/// `sdk_consent` is the viewer's answer to that prompt, not a security boundary:
-/// an unsandboxed raw app's bundle runs same-origin with the viewer's session and
-/// can call this endpoint itself. The boundary is the scope set — the token can
-/// never exceed the policy-declared scopes, which are also capped by the viewer's
-/// own permissions. Sandbox isolation is what actually contains an app's code.
+/// For an unsandboxed app `sdk_consent` is the viewer's answer to that prompt,
+/// not a security boundary: its bundle runs same-origin with the viewer's session
+/// and can call this endpoint itself. The boundary is the scope set — the token
+/// can never exceed the policy-declared scopes, which are also capped by the
+/// viewer's own permissions. Sandbox isolation is what contains an app's code; a
+/// sandboxed app holds nothing but this token, so there the prompt is the only
+/// way it gains any reach at all.
 ///
 /// The CALLER MUST verify that `opt_authed` may view `app_path` before calling:
 /// this mints on their behalf unconditionally and does no visibility check of its
@@ -1342,15 +1351,9 @@ pub async fn build_embed_token_response(
     sdk_consent: bool,
 ) -> Result<EmbedTokenResponse> {
     // Only advertise scopes where a token could actually be minted, so the viewer
-    // never shows a permission prompt that can grant nothing: a sandboxed bundle
-    // lives on an opaque origin and can't use the token, and an anonymous visitor
-    // has no identity to mint against. The backend, not the viewer, decides this
-    // (the editor shows the author the same sandbox rule).
-    let sdk_scopes = if raw_app
-        && !policy.sandbox
-        && opt_authed.is_some()
-        && !policy.frontend_sdk_scopes.is_empty()
-    {
+    // is never shown a permission prompt that can grant nothing: an anonymous
+    // visitor has no identity to mint against.
+    let sdk_scopes = if raw_app && opt_authed.is_some() && !policy.frontend_sdk_scopes.is_empty() {
         Some(policy.frontend_sdk_scopes.clone())
     } else {
         None

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -825,13 +825,9 @@ fn raw_app_wrapper_html(secret: &str) -> String {
     s.src = './__SECRET__.js';
     document.body.appendChild(s);
   }
-  window.addEventListener('message', function (e) {
-    // Only our embedder may supply the context. It now carries the SDK's token
-    // and API base, so accepting it from any window would let another frame
-    // point the bundle's API calls at a host it controls.
-    if (e.source !== window.parent) return;
-    var d = e.data || {};
-    if (d.type === 'windmill:ctx') {
+  function applyCtx(d) {
+    if (!d || d.type !== 'windmill:ctx') return;
+    {
       window.ctx = d.ctx;
       if (window.__wmStorageShim && d.storage) {
         window.__wmStorageShim.local.__hydrate(d.storage.local);
@@ -849,13 +845,17 @@ fn raw_app_wrapper_html(secret: &str) -> String {
       }
       loadBundle();
     }
-  });
-  // Echo the handshake nonce from our own URL. It proves to the embedder that
-  // this is the document it loaded rather than one navigated into the frame
-  // afterwards, which is what gates the frontend SDK credential.
+  }
+  // Announce readiness over a MessageChannel we own, echoing the nonce from our
+  // own URL. The nonce proves to the embedder which document is asking (one
+  // navigated in later cannot read it); replying on our port guarantees the
+  // answer reaches only this document, since replacing it discards the port.
+  // Both are needed before the embedder parts with the viewer's SDK token.
   try {
     var hs = new URLSearchParams(window.location.search).get('wm_hs') || undefined;
-    window.parent.postMessage({ type: 'windmill:ready', nonce: hs }, '*');
+    var ch = new MessageChannel();
+    ch.port1.onmessage = function (e) { applyCtx(e.data); };
+    window.parent.postMessage({ type: 'windmill:ready', nonce: hs }, '*', [ch.port2]);
   } catch (_) {}
   // Fallback for contexts that never send ctx (e.g. ctx-less rendering).
   setTimeout(loadBundle, 1500);

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -826,6 +826,10 @@ fn raw_app_wrapper_html(secret: &str) -> String {
     document.body.appendChild(s);
   }
   window.addEventListener('message', function (e) {
+    // Only our embedder may supply the context. It now carries the SDK's token
+    // and API base, so accepting it from any window would let another frame
+    // point the bundle's API calls at a host it controls.
+    if (e.source !== window.parent) return;
     var d = e.data || {};
     if (d.type === 'windmill:ctx') {
       window.ctx = d.ctx;

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -655,7 +655,14 @@ pub async fn run_server(
                                 .layer(Extension(argon2.clone()))
                                 .layer(cors.clone()),
                         )
-                        .nest("/variables", variables::workspaced_service())
+                        // CORS so a sandboxed raw app's opaque-origin bundle can
+                        // read variables with its frontend SDK token. Bearer-only:
+                        // the layer never allows credentials, so no cookie can ride
+                        // a cross-origin call. Consistent with resources/users.
+                        .nest(
+                            "/variables",
+                            variables::workspaced_service().layer(cors.clone()),
+                        )
                         .nest("/volumes", volumes_oss::workspaced_service())
                         .nest("/workers", windmill_api_workers::workspaced_service())
                         .nest("/workspaces", workspaces::workspaced_service())

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -21,7 +21,10 @@
 		type OnBehalfOfChoice
 	} from '$lib/components/OnBehalfOfSelector.svelte'
 	import { canUserBypassRuleKind, protectionRulesState } from '$lib/workspaceProtectionRules.svelte'
-	import { FRONTEND_SDK_SCOPES } from '$lib/components/raw_apps/sdkScopes'
+	import {
+		FRONTEND_SDK_SCOPES,
+		MIN_SANDBOXED_SDK_VERSION
+	} from '$lib/components/raw_apps/sdkScopes'
 
 	const WM_DEPLOYERS_GROUP = 'wm_deployers'
 
@@ -370,9 +373,10 @@
 		{/if}
 		{#if policy.sandbox == true && policy.frontend_sdk_scopes?.length}
 			<div class="mt-2">
-				<Alert type="warning" title="Not available with sandbox isolation" size="xs">
-					A sandboxed app's bundle runs on an opaque origin and cannot use the SDK token. Turn off
-					sandbox isolation for these scopes to take effect.
+				<Alert type="info" title="Requires windmill-client {MIN_SANDBOXED_SDK_VERSION}" size="xs">
+					A sandboxed app calls the API cross-origin, which earlier versions of the SDK cannot do.
+					Make sure your app depends on <code>windmill-client@^{MIN_SANDBOXED_SDK_VERSION}</code> and
+					redeploy — apps bundled against an older version fail with a CORS error.
 				</Alert>
 			</div>
 		{/if}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -21,10 +21,7 @@
 		type OnBehalfOfChoice
 	} from '$lib/components/OnBehalfOfSelector.svelte'
 	import { canUserBypassRuleKind, protectionRulesState } from '$lib/workspaceProtectionRules.svelte'
-	import {
-		FRONTEND_SDK_SCOPES,
-		MIN_SANDBOXED_SDK_VERSION
-	} from '$lib/components/raw_apps/sdkScopes'
+	import { FRONTEND_SDK_SCOPES } from '$lib/components/raw_apps/sdkScopes'
 
 	const WM_DEPLOYERS_GROUP = 'wm_deployers'
 
@@ -373,10 +370,10 @@
 		{/if}
 		{#if policy.sandbox == true && policy.frontend_sdk_scopes?.length}
 			<div class="mt-2">
-				<Alert type="info" title="Requires windmill-client {MIN_SANDBOXED_SDK_VERSION}" size="xs">
-					A sandboxed app calls the API cross-origin, which earlier versions of the SDK cannot do.
-					Make sure your app depends on <code>windmill-client@^{MIN_SANDBOXED_SDK_VERSION}</code> and
-					redeploy — apps bundled against an older version fail with a CORS error.
+				<Alert type="info" title="Redeploy to use the SDK from a sandboxed app" size="xs">
+					A sandboxed app calls the API cross-origin, which older <code>windmill-client</code> versions
+					cannot do. An app bundled before this Windmill version fails with a CORS error until you deploy
+					it again, which re-bundles it against a current client.
 				</Alert>
 			</div>
 		{/if}

--- a/frontend/src/lib/components/apps/editor/PublicAppFrame.svelte
+++ b/frontend/src/lib/components/apps/editor/PublicAppFrame.svelte
@@ -277,8 +277,8 @@
 				if (!hasStoredSdkConsent(viewerEmail, workspaceId ?? '', appPath ?? '', sdkScopes)) {
 					// Ask before the app's code runs. For an unsandboxed app this is a
 					// decision point rather than a boundary — it runs with the viewer's
-					// session either way. For a sandboxed one the token is the only
-					// reach it gets, so the answer decides everything it can do.
+					// session either way. For a sandboxed one the token is its only
+					// direct API access, so the answer decides that whole surface.
 					status = 'sdkPrompt'
 					return
 				}

--- a/frontend/src/lib/components/apps/editor/PublicAppFrame.svelte
+++ b/frontend/src/lib/components/apps/editor/PublicAppFrame.svelte
@@ -241,7 +241,7 @@
 	})
 
 	// Read by RawAppPreview: the consented viewer-scoped SDK token to expose to
-	// the bundle (unsandboxed raw apps only).
+	// the bundle, sandboxed or not.
 	setContext('RAW_APP_SDK_TOKEN', {
 		get value() {
 			return sdkToken
@@ -268,8 +268,8 @@
 			appPath = resp.app_path ?? undefined
 			workspaceId = resp.workspace_id ?? undefined
 			// The backend only advertises scopes where a token could actually be
-			// minted (raw, unsandboxed, viewer authenticated), and mints one only on
-			// the follow-up request carrying the viewer's consent.
+			// minted (a raw app, viewer authenticated), and mints one only on the
+			// follow-up request carrying the viewer's consent.
 			sdkScopes = resp.sdk_scopes?.length ? resp.sdk_scopes : undefined
 			viewerEmail = resp.viewer_email ?? ''
 			sdkToken = undefined

--- a/frontend/src/lib/components/apps/editor/PublicAppFrame.svelte
+++ b/frontend/src/lib/components/apps/editor/PublicAppFrame.svelte
@@ -275,9 +275,10 @@
 			sdkToken = undefined
 			if (sdkScopes) {
 				if (!hasStoredSdkConsent(viewerEmail, workspaceId ?? '', appPath ?? '', sdkScopes)) {
-					// Ask before the app's code runs. This is the viewer's decision
-					// point, not a containment boundary — an unsandboxed app runs with
-					// their session either way; sandbox isolation is what contains it.
+					// Ask before the app's code runs. For an unsandboxed app this is a
+					// decision point rather than a boundary — it runs with the viewer's
+					// session either way. For a sandboxed one the token is the only
+					// reach it gets, so the answer decides everything it can do.
 					status = 'sdkPrompt'
 					return
 				}

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -57,10 +57,11 @@
 	// - DEFAULT (isolated): a real API URL serving a sandboxed, opaque-origin
 	//   document (`CSP: sandbox` response header + the iframe sandbox attribute),
 	//   so a malicious bundle can never reach the authenticated Windmill origin
-	//   (no cookie, no window.parent, no token). Root-relative so it resolves
-	//   against the real host even when this component itself runs inside an opaque
-	//   viewer (where `location.origin` is "null"). Context is handed over via
-	//   postMessage — never baked into the document, never a credential.
+	//   (no cookie, no window.parent). Root-relative so it resolves against the
+	//   real host even when this component itself runs inside an opaque viewer
+	//   (where `location.origin` is "null"). Context — and, when the viewer
+	//   approved SDK scopes, the viewer-scoped token — is handed over via
+	//   postMessage, never baked into the document.
 	// - UNSANDBOXED (the default — publisher did not opt into isolation): a
 	//   client-built blob: wrapper (same-origin with the SPA) loaded with `allow-same-origin`,
 	//   so relative `fetch('/api/...')` and the session cookie work. The backend
@@ -150,8 +151,21 @@
 		} catch (_) {}
 	}
 
+	// The token may only be handed over once per document we loaded ourselves. The
+	// reply is addressed to a browsing context, not a document, and it must target
+	// `*` because the sandboxed frame has an opaque origin — so a page the bundle
+	// (or a link the viewer clicked) navigated to keeps the same `contentWindow`
+	// and could ask for the credential again by posting `windmill:ready`. Reset
+	// only when WE change the iframe's src, which a navigation away does not.
+	let sdkHandedOff = false
+	$effect(() => {
+		iframeSrc
+		sdkHandedOff = false
+	})
+
 	function respondCtx() {
-		const sdkToken = sdkTokenCtx?.value
+		const sdkToken = sdkHandedOff ? undefined : sdkTokenCtx?.value
+		if (sdkToken) sdkHandedOff = true
 		iframe?.contentWindow?.postMessage(
 			{
 				type: 'windmill:ctx',

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -168,8 +168,10 @@
 	 * the port that document sent proves the answer reaches only it — posting to
 	 * `contentWindow` would land in whatever document is active by then. */
 	function respondCtx(nonceEcho?: string, port?: MessagePort) {
-		const proven = nonceEcho === handshakeNonce && port !== undefined
-		const sdkToken = proven ? sdkTokenCtx?.value : undefined
+		// No port means the sender is not a wrapper we served — every one of ours
+		// transfers one. Answering anyway would hand the viewer's identity to it.
+		if (!port) return
+		const sdkToken = nonceEcho === handshakeNonce ? sdkTokenCtx?.value : undefined
 		const payload = {
 			type: 'windmill:ctx',
 			// Same shape as the unsandboxed wrapper: always the object, so
@@ -182,8 +184,7 @@
 			// `baseUrl` comes from here because the bundle's own origin is opaque.
 			...(sdkToken ? { sdk: { token: sdkToken, baseUrl: window.location.origin, workspace } } : {})
 		}
-		if (port) port.postMessage(payload)
-		else iframe?.contentWindow?.postMessage(payload, '*')
+		port.postMessage(payload)
 	}
 
 	onMount(() => {

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -4,10 +4,11 @@
 	import type { Runnable } from './rawAppPolicy'
 	import { getContext, onMount, untrack } from 'svelte'
 	import { unsandboxedRawAppHtml } from './utils'
-	import { randomUUID } from '$lib/utils/uuid'
+	import { randomSecret } from '$lib/utils/uuid'
 
 	// Per-mount secret proving a `windmill:ready` came from the document we loaded.
-	const handshakeNonce = randomUUID()
+	// Gates a credential, so it must be unguessable — not `randomUUID`.
+	const handshakeNonce = randomSecret()
 
 	interface Props {
 		workspace: string

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -151,6 +151,7 @@
 	}
 
 	function respondCtx() {
+		const sdkToken = sdkTokenCtx?.value
 		iframe?.contentWindow?.postMessage(
 			{
 				type: 'windmill:ctx',
@@ -158,7 +159,14 @@
 				// `window.ctx.workspace` works for anonymous viewers too.
 				ctx: { ctx: user, workspace },
 				initialHash,
-				storage: { local: bundleStorage ?? {}, session: {} }
+				storage: { local: bundleStorage ?? {}, session: {} },
+				// The wrapper turns this into `window.process.env` before it injects
+				// the bundle, which is what a bundled `windmill-client` reads at
+				// module load. `baseUrl` must come from here: this component runs on
+				// the real origin, the bundle's is opaque.
+				...(sdkToken
+					? { sdk: { token: sdkToken, baseUrl: window.location.origin, workspace } }
+					: {})
 			},
 			'*'
 		)

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -103,12 +103,8 @@
 			new URLSearchParams(window.location.search).has('wm_coep') || window.crossOriginIsolated
 				? 'wm_coep=1&'
 				: ''
-		// The handshake nonce binds the credential reply to the document WE loaded.
-		// `windmill:ready` only proves which browsing context spoke, and the reply
-		// has to target `*` (the frame's origin is opaque), so without this any
-		// document navigated into that frame — including one an ancestor swapped in
-		// before our wrapper announced itself — could ask for the viewer's token.
-		// It lives in the frame's own URL, which a cross-origin ancestor cannot read.
+		// wm_hs: the handshake nonce, readable only by the document we load here —
+		// see `respondCtx` for what it gates.
 		return `/api/w/${workspace}/apps_u/get_data/v/${secret}.html?${coep}wm_hs=${handshakeNonce}`
 	})
 
@@ -143,8 +139,11 @@
 	const framed = typeof window !== 'undefined' && window.parent !== window && !storageAccessible()
 	let bundleStorage: Record<string, string> | undefined = undefined
 	let pendingReady = false
-	// Nonce from a `windmill:ready` we could not answer yet (storage still loading).
+	// The `windmill:ready` we could not answer yet (storage still loading). Holding
+	// the port is what makes the deferred reply safe: it stays bound to the document
+	// that sent it even if the frame is navigated while we wait.
 	let pendingNonce: string | undefined = undefined
+	let pendingPort: MessagePort | undefined = undefined
 
 	function readDirect(): Record<string, string> {
 		try {
@@ -164,30 +163,27 @@
 		} catch (_) {}
 	}
 
-	/** The credential only goes to a document that proved it is the one we loaded,
-	 * by echoing the nonce from its own URL. A document navigated into the frame
-	 * keeps the same `contentWindow` and can post `windmill:ready` at any time —
-	 * including before our wrapper does — but cannot read that URL. */
-	function respondCtx(nonceEcho?: string) {
-		const sdkToken = nonceEcho === handshakeNonce ? sdkTokenCtx?.value : undefined
-		iframe?.contentWindow?.postMessage(
-			{
-				type: 'windmill:ctx',
-				// Same shape as the unsandboxed wrapper: always the object, so
-				// `window.ctx.workspace` works for anonymous viewers too.
-				ctx: { ctx: user, workspace },
-				initialHash,
-				storage: { local: bundleStorage ?? {}, session: {} },
-				// The wrapper turns this into `window.process.env` before it injects
-				// the bundle, which is what a bundled `windmill-client` reads at
-				// module load. `baseUrl` must come from here: this component runs on
-				// the real origin, the bundle's is opaque.
-				...(sdkToken
-					? { sdk: { token: sdkToken, baseUrl: window.location.origin, workspace } }
-					: {})
-			},
-			'*'
-		)
+	/** The credential is gated on two things: the nonce proves which document is
+	 * asking (one navigated in later cannot read it from our URL), and replying on
+	 * the port that document sent proves the answer reaches only it — posting to
+	 * `contentWindow` would land in whatever document is active by then. */
+	function respondCtx(nonceEcho?: string, port?: MessagePort) {
+		const proven = nonceEcho === handshakeNonce && port !== undefined
+		const sdkToken = proven ? sdkTokenCtx?.value : undefined
+		const payload = {
+			type: 'windmill:ctx',
+			// Same shape as the unsandboxed wrapper: always the object, so
+			// `window.ctx.workspace` works for anonymous viewers too.
+			ctx: { ctx: user, workspace },
+			initialHash,
+			storage: { local: bundleStorage ?? {}, session: {} },
+			// The wrapper turns this into `window.process.env` before it injects the
+			// bundle, which is what a bundled `windmill-client` reads at module load.
+			// `baseUrl` comes from here because the bundle's own origin is opaque.
+			...(sdkToken ? { sdk: { token: sdkToken, baseUrl: window.location.origin, workspace } } : {})
+		}
+		if (port) port.postMessage(payload)
+		else iframe?.contentWindow?.postMessage(payload, '*')
 	}
 
 	onMount(() => {
@@ -206,7 +202,7 @@
 					bundleStorage = {}
 					if (pendingReady) {
 						pendingReady = false
-						respondCtx(pendingNonce)
+						respondCtx(pendingNonce, pendingPort)
 					}
 				}
 			}, 750)
@@ -222,7 +218,7 @@
 				bundleStorage = data.data || {}
 				if (pendingReady) {
 					pendingReady = false
-					respondCtx(pendingNonce)
+					respondCtx(pendingNonce, pendingPort)
 				}
 				return
 			}
@@ -231,14 +227,16 @@
 			if (data?.type === 'windmill:ready') {
 				// Hand the bundle its context + shared storage before it evaluates.
 				const nonceEcho = typeof data.nonce === 'string' ? data.nonce : undefined
+				const port = event.ports?.[0]
 				if (!framed) {
 					bundleStorage = readDirect()
-					respondCtx(nonceEcho)
+					respondCtx(nonceEcho, port)
 				} else if (bundleStorage !== undefined) {
-					respondCtx(nonceEcho)
+					respondCtx(nonceEcho, port)
 				} else {
 					pendingReady = true
 					pendingNonce = nonceEcho
+					pendingPort = port
 				}
 			} else if (data?.type === 'wm_ls_op') {
 				// The bundle mutated localStorage — apply it to the shared store.

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -4,6 +4,10 @@
 	import type { Runnable } from './rawAppPolicy'
 	import { getContext, onMount, untrack } from 'svelte'
 	import { unsandboxedRawAppHtml } from './utils'
+	import { randomUUID } from '$lib/utils/uuid'
+
+	// Per-mount secret proving a `windmill:ready` came from the document we loaded.
+	const handshakeNonce = randomUUID()
 
 	interface Props {
 		workspace: string
@@ -96,9 +100,15 @@
 		// — the wrapper would otherwise be blocked outright, URL flag or not.
 		const coep =
 			new URLSearchParams(window.location.search).has('wm_coep') || window.crossOriginIsolated
-				? '?wm_coep=1'
+				? 'wm_coep=1&'
 				: ''
-		return `/api/w/${workspace}/apps_u/get_data/v/${secret}.html${coep}`
+		// The handshake nonce binds the credential reply to the document WE loaded.
+		// `windmill:ready` only proves which browsing context spoke, and the reply
+		// has to target `*` (the frame's origin is opaque), so without this any
+		// document navigated into that frame — including one an ancestor swapped in
+		// before our wrapper announced itself — could ask for the viewer's token.
+		// It lives in the frame's own URL, which a cross-origin ancestor cannot read.
+		return `/api/w/${workspace}/apps_u/get_data/v/${secret}.html?${coep}wm_hs=${handshakeNonce}`
 	})
 
 	// Revoke blob: URLs (unsandboxed path) when they change or on unmount.
@@ -132,6 +142,8 @@
 	const framed = typeof window !== 'undefined' && window.parent !== window && !storageAccessible()
 	let bundleStorage: Record<string, string> | undefined = undefined
 	let pendingReady = false
+	// Nonce from a `windmill:ready` we could not answer yet (storage still loading).
+	let pendingNonce: string | undefined = undefined
 
 	function readDirect(): Record<string, string> {
 		try {
@@ -151,21 +163,12 @@
 		} catch (_) {}
 	}
 
-	// The token may only be handed over once per document we loaded ourselves. The
-	// reply is addressed to a browsing context, not a document, and it must target
-	// `*` because the sandboxed frame has an opaque origin — so a page the bundle
-	// (or a link the viewer clicked) navigated to keeps the same `contentWindow`
-	// and could ask for the credential again by posting `windmill:ready`. Reset
-	// only when WE change the iframe's src, which a navigation away does not.
-	let sdkHandedOff = false
-	$effect(() => {
-		iframeSrc
-		sdkHandedOff = false
-	})
-
-	function respondCtx() {
-		const sdkToken = sdkHandedOff ? undefined : sdkTokenCtx?.value
-		if (sdkToken) sdkHandedOff = true
+	/** The credential only goes to a document that proved it is the one we loaded,
+	 * by echoing the nonce from its own URL. A document navigated into the frame
+	 * keeps the same `contentWindow` and can post `windmill:ready` at any time —
+	 * including before our wrapper does — but cannot read that URL. */
+	function respondCtx(nonceEcho?: string) {
+		const sdkToken = nonceEcho === handshakeNonce ? sdkTokenCtx?.value : undefined
 		iframe?.contentWindow?.postMessage(
 			{
 				type: 'windmill:ctx',
@@ -202,7 +205,7 @@
 					bundleStorage = {}
 					if (pendingReady) {
 						pendingReady = false
-						respondCtx()
+						respondCtx(pendingNonce)
 					}
 				}
 			}, 750)
@@ -218,7 +221,7 @@
 				bundleStorage = data.data || {}
 				if (pendingReady) {
 					pendingReady = false
-					respondCtx()
+					respondCtx(pendingNonce)
 				}
 				return
 			}
@@ -226,13 +229,15 @@
 			if (event.source !== iframe?.contentWindow) return
 			if (data?.type === 'windmill:ready') {
 				// Hand the bundle its context + shared storage before it evaluates.
+				const nonceEcho = typeof data.nonce === 'string' ? data.nonce : undefined
 				if (!framed) {
 					bundleStorage = readDirect()
-					respondCtx()
+					respondCtx(nonceEcho)
 				} else if (bundleStorage !== undefined) {
-					respondCtx()
+					respondCtx(nonceEcho)
 				} else {
 					pendingReady = true
+					pendingNonce = nonceEcho
 				}
 			} else if (data?.type === 'wm_ls_op') {
 				// The bundle mutated localStorage — apply it to the shared store.

--- a/frontend/src/lib/components/raw_apps/sdkScopes.ts
+++ b/frontend/src/lib/components/raw_apps/sdkScopes.ts
@@ -3,12 +3,6 @@
 // in the backend `apps.rs` — both lists must stay in sync), plus the viewer-side
 // consent persistence for the permission banner.
 
-/** A sandboxed app calls the API from an opaque origin, which needs the
- * credential-free client shipped alongside this release: earlier versions force
- * `credentials: 'include'`, which CORS rejects. Tracks the monorepo version
- * because `windmill-client` is published from it in lockstep. */
-export const MIN_SANDBOXED_SDK_VERSION = __pkg__.version
-
 export const FRONTEND_SDK_SCOPES: { value: string; label: string; description: string }[] = [
 	{
 		value: 'jobs:run',

--- a/frontend/src/lib/components/raw_apps/sdkScopes.ts
+++ b/frontend/src/lib/components/raw_apps/sdkScopes.ts
@@ -3,6 +3,12 @@
 // in the backend `apps.rs` — both lists must stay in sync), plus the viewer-side
 // consent persistence for the permission banner.
 
+/** A sandboxed app calls the API from an opaque origin, which needs the
+ * credential-free client shipped alongside this release: earlier versions force
+ * `credentials: 'include'`, which CORS rejects. Tracks the monorepo version
+ * because `windmill-client` is published from it in lockstep. */
+export const MIN_SANDBOXED_SDK_VERSION = __pkg__.version
+
 export const FRONTEND_SDK_SCOPES: { value: string; label: string; description: string }[] = [
 	{
 		value: 'jobs:run',

--- a/frontend/src/lib/utils/uuid.ts
+++ b/frontend/src/lib/utils/uuid.ts
@@ -5,3 +5,13 @@ export function randomUUID() {
 		return v.toString(16)
 	})
 }
+
+/** Unguessable random token, for values whose unpredictability is load-bearing —
+ * anything gating a credential. `randomUUID` above is `Math.random()`-based and
+ * must not be used for those. `getRandomValues` (unlike `crypto.randomUUID`) is
+ * also available in insecure contexts, so this needs no fallback. */
+export function randomSecret(bytes = 32): string {
+	const buf = new Uint8Array(bytes)
+	crypto.getRandomValues(buf)
+	return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('')
+}

--- a/typescript-client/build.sh
+++ b/typescript-client/build.sh
@@ -22,12 +22,16 @@ const baseUrl = getEnv("BASE_INTERNAL_URL") ?? getEnv("BASE_URL") ?? "http://loc
 const baseUrlApi = (baseUrl ?? '') + "/api";
 
 EOF
+# WITH_CREDENTIALS mirrors setClient: cookies only when there is no bearer token.
+# A browser bundle that never calls setClient (a raw app, which gets its token
+# from window.process.env) must not send credentials — the API answers
+# `Access-Control-Allow-Origin: *`, so a credentialed cross-origin request fails.
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' 's/WITH_CREDENTIALS: false/WITH_CREDENTIALS: true/g' src/core/OpenAPI.ts
+  sed -i '' 's/WITH_CREDENTIALS: false/WITH_CREDENTIALS: !getEnv("WM_TOKEN")/g' src/core/OpenAPI.ts
   sed -i '' 's/TOKEN: undefined/TOKEN: getEnv("WM_TOKEN")/g' src/core/OpenAPI.ts
   sed -i '' "s/BASE: '\/api'/BASE: baseUrlApi/g" src/core/OpenAPI.ts
 else
-  sed -i 's/WITH_CREDENTIALS: false/WITH_CREDENTIALS: true/g' src/core/OpenAPI.ts
+  sed -i 's/WITH_CREDENTIALS: false/WITH_CREDENTIALS: !getEnv("WM_TOKEN")/g' src/core/OpenAPI.ts
   sed -i 's/TOKEN: undefined/TOKEN: getEnv("WM_TOKEN")/g' src/core/OpenAPI.ts
   sed -i "s/BASE: '\/api'/BASE: baseUrlApi/g" src/core/OpenAPI.ts
 fi

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -68,10 +68,11 @@ export function setClient(token?: string, baseUrl?: string) {
   if (token === undefined) {
     token = getEnv("WM_TOKEN") ?? "no_token";
   }
-  // Cookies are the fallback for when there is no bearer token. Sending both is
-  // not just redundant, it breaks the browser case outright: the API answers
-  // `Access-Control-Allow-Origin: *` and so can never allow credentials, and a
+  // Credentials must be off whenever a bearer token is in play: the API answers
+  // `Access-Control-Allow-Origin: *` and so can never allow them, and a
   // credentialed cross-origin request is rejected before the token is looked at.
+  // (`"no_token"` is still sent as a bearer, so this branch is about credentials
+  // mode only — it does not make cookie auth work.)
   OpenAPI.WITH_CREDENTIALS = token === "no_token";
   OpenAPI.TOKEN = token;
   OpenAPI.BASE = baseUrl + "/api";

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -68,11 +68,10 @@ export function setClient(token?: string, baseUrl?: string) {
   if (token === undefined) {
     token = getEnv("WM_TOKEN") ?? "no_token";
   }
-  // Credentials must be off whenever a bearer token is in play: the API answers
-  // `Access-Control-Allow-Origin: *` and so can never allow them, and a
-  // credentialed cross-origin request is rejected before the token is looked at.
-  // (`"no_token"` is still sent as a bearer, so this branch is about credentials
-  // mode only — it does not make cookie auth work.)
+  // Credentials must be off whenever a bearer is sent: the API answers
+  // `Access-Control-Allow-Origin: *`, so a credentialed cross-origin request is
+  // rejected before the token is read. Credentials mode only — `"no_token"` is
+  // still sent as a bearer, so this does not enable cookie auth.
   OpenAPI.WITH_CREDENTIALS = token === "no_token";
   OpenAPI.TOKEN = token;
   OpenAPI.BASE = baseUrl + "/api";

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -68,7 +68,11 @@ export function setClient(token?: string, baseUrl?: string) {
   if (token === undefined) {
     token = getEnv("WM_TOKEN") ?? "no_token";
   }
-  OpenAPI.WITH_CREDENTIALS = true;
+  // Cookies are the fallback for when there is no bearer token. Sending both is
+  // not just redundant, it breaks the browser case outright: the API answers
+  // `Access-Control-Allow-Origin: *` and so can never allow credentials, and a
+  // credentialed cross-origin request is rejected before the token is looked at.
+  OpenAPI.WITH_CREDENTIALS = token === "no_token";
   OpenAPI.TOKEN = token;
   OpenAPI.BASE = baseUrl + "/api";
 }
@@ -79,8 +83,12 @@ function getPublicBaseUrl(): string {
 
 export const getEnv = (key: string) => {
   if (typeof window === "undefined") {
-    // node
-    return process?.env?.[key];
+    // `process` may be undeclared entirely (web worker, browser-like runtimes
+    // without a node shim), where `process?.env` still throws a ReferenceError.
+    if (typeof process !== "undefined") {
+      return process?.env?.[key];
+    }
+    return globalThis?.process?.env?.[key];
   }
   // browser
   return window?.process?.env?.[key];


### PR DESCRIPTION
Stacked on #10377 (base branch `raw-apps-wmill-client-frontend`).

## Summary

#10377 shipped the viewer-permissioned `windmill-client` SDK for **unsandboxed** raw apps only. This lifts that restriction, so an app can have both sandbox isolation and frontend API access.

The blocker was never token delivery — it was that the published SDK forces `credentials: 'include'` on every generated-service call. Windmill's CORS answers `Access-Control-Allow-Origin: *` and never sets `allow_credentials`, so from a sandboxed app's opaque origin the browser rejects the request *before the token is consulted*. An opaque origin has no cookies to send anyway, so credentials buy nothing there.

Two things turned out **not** to be blockers, contrary to the follow-up note in #10377: the job-run routes already carry their own CORS layer (`jobs.rs:127`), as do `jobs_u/*`, `/resources` and `/users`. Only `/variables` was missing one.

## Changes

**`typescript-client`** — `WITH_CREDENTIALS` now mirrors one rule in both places: cookies only when there is no bearer token. `setClient()` sets it from the resolved token instead of hardcoding `true`, and the `build.sh` sed emits `!getEnv("WM_TOKEN")` instead of `true`, which is the path raw apps hit (they never call `setClient`). Also fixes `getEnv`'s bare `process?.env`, which throws `ReferenceError` where `process` is undeclared (web workers) — `build.sh` already injected the guarded form into `OpenAPI.ts`, the two copies had drifted.

**Backend** — `build_embed_token_response` no longer suppresses `sdk_scopes` for sandboxed apps; the sandboxed wrapper sets `window.process.env` from the existing `windmill:ctx` handshake, before it injects the bundle script (which is what makes the SDK's module-load auto-configuration work); `/variables` gets the CORS layer its sibling routers already have.

**Frontend** — `RawAppPreview.respondCtx` includes the `sdk` payload; `BASE_URL` is passed explicitly because `location.origin` is `"null"` on an opaque origin. The editor's "not available with sandbox isolation" warning becomes a note about the required client version.

## Trust model

Unchanged. The scopes, the consent prompt, the `raw_app_sdk` sentinel and the mint path are all mode-independent. Note the prompt matters *more* here: an unsandboxed app already runs with the viewer's whole session, so the token is strictly less than it had; a sandboxed app has nothing else, so this is its only reach.

## Known limitation

Bundles pin their SDK copy at deploy time, so **an existing sandboxed app must be redeployed** after the release carrying the client fix. Until then it fails with a CORS error — hence the editor note naming the required version (sourced from `__pkg__.version`, which tracks the monorepo release the client publishes from).

## Screenshots

Permission prompt on a sandboxed app:

![prompt](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-apps-sdk-sandboxed/1785249999-vs-1-prompt.png)

After Continue — SDK calls from inside the opaque iframe:

![app](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-apps-sdk-sandboxed/1785250002-vs-2-app.png)

## Test plan

- [x] Built the client locally and confirmed the emitted config: `WITH_CREDENTIALS: !getEnv("WM_TOKEN")`; at runtime `false` with a token, `true` without, and `setClient` follows the same rule
- [x] Sandboxed app now advertises `sdk_scopes` and mints on `?sdk_consent=true`
- [x] **A/B proving the client fix is load-bearing**: same app, same token — bundled against the published client → `SDK FAILED: Failed to fetch`; against the fixed client → `whoami` returns the viewer and `getVariableValue` returns the value
- [x] Frame is genuinely opaque: the wrapper's storage shim engaged (it only installs when real storage throws) and `window.parent.location` raises `SecurityError`; requests carry the bearer and **no cookie**
- [x] `/variables` CORS is what enables the variable read — control: `/scripts` (no layer) returns no `Access-Control-Allow-Origin`, `/variables` and `/resources` do
- [x] Regression: unsandboxed app still works unchanged
- [x] `cargo check --features quickjs`, `npm run check:fast`, `tsc` on the generated client