### PR TITLE
fix: render the flow editor's error handler node as an inert run marker

### DIFF
--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -609,7 +609,15 @@
 			suspendStatus={suspendStatus.val}
 			{flowHasChanged}
 			chatInputEnabled={Boolean(flowStore.val.value?.chat_input_enabled)}
-			onDelete={(id) => requestDelete([id])}
+			onDelete={(id) => {
+				// The error handler's node is only a marker of the last run: dismissing it drops that
+				// run state and must leave `failure_module` in place.
+				if (id === 'failure') {
+					onDelete?.(id)
+					return
+				}
+				requestDelete([id])
+			}}
 			onInsert={async (detail) => {
 				if (!flowStore.val.value.modules || !Array.isArray(flowStore.val.value.modules)) return
 				await tick()

--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -609,15 +609,8 @@
 			suspendStatus={suspendStatus.val}
 			{flowHasChanged}
 			chatInputEnabled={Boolean(flowStore.val.value?.chat_input_enabled)}
-			onDelete={(id) => {
-				// The error handler's node is only a marker of the last run: dismissing it drops that
-				// run state and must leave `failure_module` in place.
-				if (id === 'failure') {
-					onDelete?.(id)
-					return
-				}
-				requestDelete([id])
-			}}
+			onDelete={(id) => requestDelete([id])}
+			onDismissRunNode={(id) => onDelete?.(id)}
 			onInsert={async (detail) => {
 				if (!flowStore.val.value.modules || !Array.isArray(flowStore.val.value.modules)) return
 				await tick()

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -27,6 +27,7 @@
 		type SimplifiableFlow
 	} from './graphBuilder.svelte'
 	import ModuleNode from './renderers/nodes/ModuleNode.svelte'
+	import FailureModuleNode from './renderers/nodes/FailureModuleNode.svelte'
 	import InputNode from './renderers/nodes/InputNode.svelte'
 	import BranchAllStart from './renderers/nodes/BranchAllStart.svelte'
 	import BranchAllEndNode from './renderers/nodes/BranchAllEndNode.svelte'
@@ -806,6 +807,7 @@
 	const nodeTypes = {
 		input2: InputNode,
 		module: ModuleNode,
+		failureModule: FailureModuleNode,
 		branchAllStart: BranchAllStart,
 		branchAllEnd: BranchAllEndNode,
 		forLoopEnd: ForLoopEndNode,

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -170,6 +170,9 @@
 		onMoveMultiple?: (ids: string[]) => void
 		movingIds?: string[]
 		onDelete?: (id: string) => void
+		/** Forget the run state of a node that only mirrors a run (the error handler marker), so it
+		 * stops being rendered. Must not touch the flow itself. */
+		onDismissRunNode?: (id: string) => void
 		onInsert?: (detail: {
 			sourceId?: string
 			targetId?: string
@@ -219,6 +222,7 @@
 	let {
 		onInsert = undefined,
 		onDelete = undefined,
+		onDismissRunNode = undefined,
 		onMove = undefined,
 		onDuplicate = undefined,
 		onDeleteBranch = undefined,
@@ -532,6 +536,9 @@
 		},
 		hideJobStatus: () => {
 			onHideJobStatus?.()
+		},
+		dismissRunNode: (id: string) => {
+			onDismissRunNode?.(id)
 		}
 	}
 

--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -62,6 +62,8 @@ export type GraphEventHandlers = {
 	deleteBranch: (detail: { id: string; index: number }, label: string) => void
 	select: (mod: string | FlowModule) => void
 	delete: (detail: { id: string }, label: string) => void
+	/** Drop a node that only mirrors run state (the error handler marker). Never edits the flow. */
+	dismissRunNode: (id: string) => void
 	newBranch: (id: string) => void
 	move: (detail: { id: string }) => void
 	duplicate: (detail: { id: string }) => void

--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -1232,6 +1232,8 @@ export function graphBuilder(
 		}
 
 		if (failureModule) {
+			// Keyed by failing step, so a step that failed several times (loop iterations each run
+			// their own handler, with ids like `failure-0-1`) gets one marker, not a stack of them.
 			let toAdd: Record<string, string> = {}
 			Object.keys(extra.flowModuleStates ?? {}).forEach((id) => {
 				if (id.startsWith('failure')) {

--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -123,6 +123,7 @@ export type FlowNode =
 	| CollapsedGroupN
 	| GroupHeadN
 	| GroupEndN
+	| FailureModuleN
 
 export type InputN = {
 	type: 'input2'
@@ -160,6 +161,18 @@ export type ModuleN = {
 		isOwner: boolean
 		assets: AssetWithAltAccessType[] | undefined
 		moduleAction: ModuleActionInfo | undefined
+	}
+}
+
+/** The error handler as it appears in the editor graph once a run triggered it: an inert
+ * marker of where the handler fired, not an editable step of the flow structure. */
+export type FailureModuleN = {
+	type: 'failureModule'
+	data: {
+		id: string
+		module: FlowModule
+		eventHandlers: GraphEventHandlers
+		flowModuleState: GraphModuleState | undefined
 	}
 }
 
@@ -479,6 +492,29 @@ export function graphBuilder(
 				},
 				type: 'module',
 				selectable: true
+			})
+
+			return module.id
+		}
+
+		// In the editor the error handler is configured from its own header button, so its graph node
+		// is only a marker of the last run: inert, dismissable, and never selectable. Everywhere else
+		// (run view, viewers) it stays a regular step card.
+		function addFailureNode(module: FlowModule) {
+			if (!extra.editMode) {
+				return addNode(module)
+			}
+
+			nodes.push({
+				id: module.id,
+				data: {
+					id: module.id,
+					module,
+					eventHandlers: eventHandlers,
+					flowModuleState: extra.flowModuleStates?.[module.id]
+				},
+				type: 'failureModule',
+				selectable: false
 			})
 
 			return module.id
@@ -1205,7 +1241,7 @@ export function graphBuilder(
 			})
 
 			Object.entries(toAdd).forEach((x) => {
-				addNode({ ...failureModule, id: x[1] })
+				addFailureNode({ ...failureModule, id: x[1] })
 				addEdge(x[0], x[1], undefined, undefined, { type: 'empty' })
 			})
 		}
@@ -1217,7 +1253,7 @@ export function graphBuilder(
 		}
 
 		if (failureModule && !extra.flowModuleStates) {
-			addNode(failureModule)
+			addFailureNode(failureModule)
 		}
 
 		Object.keys(parents).forEach((key) => {

--- a/frontend/src/lib/components/graph/renderers/nodes/FailureModuleNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/FailureModuleNode.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Bug, X } from 'lucide-svelte'
+	import { Bug, EyeOff } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import NodeWrapper from './NodeWrapper.svelte'
 	import Tooltip from '$lib/components/meltComponents/Tooltip.svelte'
@@ -29,11 +29,11 @@
 		class="flex flex-row justify-center items-center"
 		style="width: {NODE.width}px; height: {NODE.height}px;"
 	>
-		<div class="group relative h-full">
-			<Tooltip placement="bottom" class="h-full">
+		<div class="group relative">
+			<Tooltip placement="bottom">
 				<div
 					class={twMerge(
-						'flex flex-row items-center gap-2 rounded-md border border-dashed border-border-normal px-3 h-full max-w-full cursor-default',
+						'flex flex-row items-center gap-2 rounded-md border border-dashed border-border-normal px-3 py-1.5 max-w-full cursor-default',
 						colorClasses.bg
 					)}
 				>
@@ -47,17 +47,19 @@
 					it from the error handler button above the graph.
 				{/snippet}
 			</Tooltip>
+			<!-- Deliberately not an `X` on a bug badge: that is the header control which deletes
+			`failure_module` for good. This one only hides a run marker. -->
 			<Tooltip
 				placement="top"
-				class="absolute -top-1.5 -right-1.5 opacity-0 transition-opacity group-hover:opacity-100"
+				class="absolute -top-1.5 -right-1.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
 			>
 				<button
 					type="button"
 					aria-label="Hide error handler run marker"
 					class="rounded-full border border-border bg-surface p-0.5 text-secondary hover:bg-surface-hover"
-					onclick={() => data.eventHandlers.delete({ id: data.id }, '')}
+					onclick={() => data.eventHandlers.dismissRunNode(data.id)}
 				>
-					<X size={10} />
+					<EyeOff size={11} />
 				</button>
 				{#snippet text()}
 					Hide this marker until the next run. The error handler itself is kept.

--- a/frontend/src/lib/components/graph/renderers/nodes/FailureModuleNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/FailureModuleNode.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { Bug, X } from 'lucide-svelte'
+	import { twMerge } from 'tailwind-merge'
+	import NodeWrapper from './NodeWrapper.svelte'
+	import Tooltip from '$lib/components/meltComponents/Tooltip.svelte'
+	import type { FailureModuleN } from '../../graphBuilder.svelte'
+	import { getNodeColorClasses, NODE } from '$lib/components/graph'
+	import { msToSec } from '$lib/utils'
+
+	interface Props {
+		data: FailureModuleN['data']
+	}
+
+	let { data }: Props = $props()
+
+	let state = $derived(data.flowModuleState)
+	let colorClasses = $derived(getNodeColorClasses(state?.skipped ? '_Skipped' : state?.type, false))
+</script>
+
+<NodeWrapper>
+	{#if state?.duration_ms}
+		<div
+			class="absolute z-5 right-0 -top-4 mr-2 center-center text-2xs font-normal text-gray-400 dark:text-gray-500"
+		>
+			{msToSec(state.duration_ms)}s
+		</div>
+	{/if}
+	<div
+		class="flex flex-row justify-center items-center"
+		style="width: {NODE.width}px; height: {NODE.height}px;"
+	>
+		<div class="group relative h-full">
+			<Tooltip placement="bottom" class="h-full">
+				<div
+					class={twMerge(
+						'flex flex-row items-center gap-2 rounded-md border border-dashed border-border-normal px-3 h-full max-w-full cursor-default',
+						colorClasses.bg
+					)}
+				>
+					<Bug size={14} class={twMerge('shrink-0', colorClasses.text)} />
+					<div class={twMerge('truncate text-2xs', colorClasses.text)}>
+						{data.module.summary || 'Error handler'}
+					</div>
+				</div>
+				{#snippet text()}
+					Marks where the error handler ran during the last run. It is not a step of the flow: edit
+					it from the error handler button above the graph.
+				{/snippet}
+			</Tooltip>
+			<Tooltip
+				placement="top"
+				class="absolute -top-1.5 -right-1.5 opacity-0 transition-opacity group-hover:opacity-100"
+			>
+				<button
+					type="button"
+					aria-label="Hide error handler run marker"
+					class="rounded-full border border-border bg-surface p-0.5 text-secondary hover:bg-surface-hover"
+					onclick={() => data.eventHandlers.delete({ id: data.id }, '')}
+				>
+					<X size={10} />
+				</button>
+				{#snippet text()}
+					Hide this marker until the next run. The error handler itself is kept.
+				{/snippet}
+			</Tooltip>
+		</div>
+	</div>
+</NodeWrapper>


### PR DESCRIPTION
## Summary

Once a test run triggers a flow's error handler, the flow editor graph rendered the `failure_module` as a regular, full-width step card wired up like any other node: it could be selected, and its context menu offered Move / Duplicate / Add note plus a Delete that silently did nothing (`resolveDeleteTargets` has no target for `failure`, so `requestDelete` returned early). But that node is not part of the flow's module tree — it is an artifact of the last run, and the error handler is configured from its own button in the graph header.

It is now a distinct, inert marker in the editor: a small dashed pill that cannot be clicked or selected, whose only affordance is a hover badge that hides the marker. Hiding it drops the run state only — `failure_module` is untouched, so nothing becomes an unsaved flow change, and the marker comes back on the next run that triggers the handler. Both tooltips spell this out, and the badge deliberately uses an "eye off" icon rather than the `×` that the header control uses to delete the error handler for good.

The run view and the read-only viewers are unchanged: `addFailureNode()` only takes the special path when `editMode` is set, so `FlowStatusViewer` and `FlowGraphViewer` still render the normal step card with its result.

## Changes

- `graphBuilder.svelte.ts`: new `FailureModuleN` node type (`failureModule`) and an `addFailureNode()` helper that emits it when `extra.editMode` is set and falls back to the regular `addNode()` otherwise. The node is `selectable: false`.
- `renderers/nodes/FailureModuleNode.svelte` (new): dashed pill with a bug icon, the handler's summary and its run duration, colored by run state. No click handling, no context menu, no move handle. Hover (or keyboard focus) reveals a single "hide" badge.
- `graphBuilder.svelte.ts` / `FlowGraphV2.svelte`: `dismissRunNode` event handler and matching `onDismissRunNode` prop — a node whose id is a run-state key, not a module id, gets its own path instead of being squeezed through the delete pipeline.
- `FlowModuleSchemaMap.svelte`: routes `onDismissRunNode` to the callback `FlowBuilder` already uses to forget a node's run state (`delete localModuleStates[id]`).

Marker ids are not always the bare `failure`: sub-flow payloads run `failure_module.id_append(...)` (`windmill-types/src/flows.rs:631`), so a handler firing inside a loop or branch produces e.g. `failure-0-0`. Dismissal is keyed off the node's own id via the dedicated handler, so those work too.

## Screenshots

Before — the run artifact rendered as an editable-looking step, with a context menu whose Delete did nothing:

![before-builder-node-menu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/error-handler-graph-special/1785255008-before-builder-node-menu.png)

After — inert dashed marker, explaining itself on hover:

![after-run-marker](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/error-handler-graph-special/1785255010-after-run-marker.png)

The hide badge states that the error handler is kept:

![after-hide-tooltip](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/error-handler-graph-special/1785255012-after-hide-tooltip.png)

After hiding — the marker is gone, the error handler is still on the flow (bug button in the header):

![after-dismissed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/error-handler-graph-special/1785255015-after-dismissed.png)

A handler firing inside a loop (`failure-0-0`), same behavior:

![after-nested-marker-hover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/error-handler-graph-special/1785255811-after-nested-marker-hover.png)

Run view, unchanged — still the regular "Error Handler" step card:

![run-view-unchanged](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/error-handler-graph-special/1785255017-run-view-unchanged.png)

## Test plan

- [ ] In the flow editor, add an error handler and a step that fails, then run a test: the handler renders as a dashed pill, not a step card
- [ ] Clicking the pill does nothing — the right panel does not change and the header error-handler button does not become selected; it also cannot be rect-selected or removed with Del
- [ ] Hovering shows the hide badge; clicking it removes the marker while the error-handler button stays in the header, and the flow shows no unsaved change
- [ ] Running the flow again brings the marker back
- [ ] Same flow with the failing step inside a for-loop (marker id `failure-0-0`): the badge hides it too
- [ ] Open the same run at `/run/<id>`: the error handler still renders as the normal step card with its result
- [ ] Light and dark mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the flow error handler in the editor as a small, inert run marker instead of a selectable step. You can hide the marker without editing the flow; run view and read-only viewers are unchanged.

- Bug Fixes
  - Added `failureModule` node and `addFailureNode()` (edit mode only); falls back to normal node elsewhere.
  - New `FailureModuleNode.svelte`: dashed pill with bug icon and duration; not selectable; no context menu; hover badge to hide.
  - Introduced `dismissRunNode` event and `onDismissRunNode` prop; dismissal clears run state only, not `failure_module`.
  - Markers are keyed by failing step and support nested ids (e.g. `failure-0-0`); one marker per step; returns on the next run that triggers the handler.

<sup>Written for commit 43d2b99d4b441a195d50d05ce75f64d43410c958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

