### PR TITLE
fix: don't crash the flow editor when a step with an error handler marker is deleted

### DIFF
--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -402,7 +402,10 @@ export function topologicalSort(
 		if (visited.has(id)) return
 		visited.add(id)
 
-		const node = nodeMap.get(id)!
+		// A parent id with no node is a bug in whoever built the graph, but the whole editor
+		// unmounts if this throws, so skip it and let the rest of the graph render.
+		const node = nodeMap.get(id)
+		if (!node) return
 		node.parentIds?.forEach(visit)
 		result.push(node)
 	}
@@ -1245,6 +1248,12 @@ export function graphBuilder(
 			})
 
 			Object.entries(toAdd).forEach((x) => {
+				// Run state outlives the flow it ran on: a step deleted since the run keeps its marker
+				// in `flowModuleStates`. Anchoring the marker to a step that is no longer in the graph
+				// leaves a parent id no node answers to, which the layout cannot sort.
+				if (!nodes.some((n) => n.id === x[0])) {
+					return
+				}
 				addFailureNode({ ...failureModule, id: x[1] })
 				addEdge(x[0], x[1], undefined, undefined, { type: 'empty' })
 			})

--- a/frontend/src/lib/components/graph/graphBuilder.test.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock modules that transitively import CSS/Monaco
+vi.mock('monaco-editor', () => ({}))
+vi.mock('@xyflow/svelte', () => ({}))
+vi.mock('./renderers/nodes/AssetNode.svelte', () => ({
+	assetDisplaysAsOutputInFlowGraph: () => false
+}))
+vi.mock('../modulesTest.svelte', () => ({}))
+
+import { topologicalSort } from './graphBuilder.svelte'
+
+describe('topologicalSort', () => {
+	it('skips parent ids with no node instead of throwing', () => {
+		const sorted = topologicalSort([
+			{ id: 'a' },
+			{ id: 'b', parentIds: ['a'] },
+			{ id: 'orphan', parentIds: ['deleted'] }
+		])
+
+		expect(sorted.map((n) => n.id)).toEqual(['orphan', 'b', 'a'])
+	})
+})


### PR DESCRIPTION
## Summary

Deleting a step that a run's error handler fired on unmounted the whole flow editor graph:

```
TypeError: can't access property "parentIds", node is undefined
  at visit → topologicalSort → canFormValidGroup → canCreateGroup → $effect (FlowGraphV2)
```

The error handler's graph node is anchored to the step that failed (`addEdge(parent_module, marker)`), but run state outlives the flow it ran on: deleting that step leaves the marker in `flowModuleStates` with a `parent_module` no node answers to. `topologicalSort` resolves parents with `nodeMap.get(id)!`, so the dangling id came back `undefined` and threw — taking the entire graph pane down with it.

This predates #10391: at `bd246644c9` the same `addEdge(x[0], x[1], ...)` ran unguarded against the same `nodeMap.get(id)!`. That PR only changed which function creates the marker node (`addNode` → `addFailureNode`); it made the marker prominent enough that people actually hit the "run, then delete that step" sequence.

## Changes

- `graphBuilder.svelte.ts`: skip a marker whose failing step is no longer in the graph, so no edge to a missing node is emitted (the cause).
- `graphBuilder.svelte.ts`: `topologicalSort` skips a parent id with no node instead of throwing. A dangling id from any source currently unmounts the editor; now the rest of the graph still renders (the blast radius).
- `graphBuilder.test.ts` (new): pins that `topologicalSort` tolerates a dangling parent id — the guard is a one-character revert away otherwise.

## Screenshots

Before — after deleting the step, the graph pane is blank:

![crash-graph-unmounted](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-failure-marker-dangling-parent/1785257746-crash-graph-unmounted.png)

After — the graph re-renders without the marker, error handler still on the flow:

![fixed-graph-after-delete](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-failure-marker-dangling-parent/1785257749-fixed-graph-after-delete.png)

## Test plan

- [ ] Flow with a failing step + an error handler: test-run it, then delete the failing step — no console error, the graph re-renders (marker gone, error handler still in the header), the editor stays usable
- [ ] Same flow, delete a *different* step instead — the marker stays anchored to the step that failed
- [ ] `npx vitest run src/lib/components/graph/graphBuilder.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented the flow editor from crashing when a step with a failure marker is deleted by ignoring orphaned markers and tolerating missing parent nodes during layout. The graph now re-renders without the marker and the editor stays usable.

- **Bug Fixes**
  - In `graphBuilder.svelte.ts`, skip adding a failure marker edge if its parent step no longer exists.
  - Make `topologicalSort` ignore parent IDs with no node instead of throwing, so the rest of the graph renders.
  - Add `graphBuilder.test.ts` to pin the missing-parent behavior.

<sup>Written for commit 52d18e23fbc69fd01051ce7f9114e59c6ae20923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

