### PR TITLE
fix: add the preprocessor node before the error handler run markers

### DIFF
--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -403,9 +403,12 @@ export function topologicalSort(
 		visited.add(id)
 
 		// A parent id with no node is a bug in whoever built the graph, but the whole editor
-		// unmounts if this throws, so skip it and let the rest of the graph render.
+		// unmounts if this throws, so warn and let the rest of the graph render.
 		const node = nodeMap.get(id)
-		if (!node) return
+		if (!node) {
+			console.warn('Edge to a node that does not exist: ', id)
+			return
+		}
 		node.parentIds?.forEach(visit)
 		result.push(node)
 	}
@@ -1234,6 +1237,14 @@ export function graphBuilder(
 			processModules(topLevelItems, undefined, inputNode, resultNode, false, undefined)
 		}
 
+		// Before the failure markers: the preprocessor can be the step that failed, and a marker is
+		// only anchored to a step already present in `nodes`.
+		if (preprocessorModule) {
+			addNode(preprocessorModule)
+			const id = JSON.parse(JSON.stringify(preprocessorModule.id))
+			addEdge(id, 'Input', undefined, undefined, { type: 'empty' })
+		}
+
 		if (failureModule) {
 			// Keyed by failing step, so a step that failed several times (loop iterations each run
 			// their own handler, with ids like `failure-0-1`) gets one marker, not a stack of them.
@@ -1257,12 +1268,6 @@ export function graphBuilder(
 				addFailureNode({ ...failureModule, id: x[1] })
 				addEdge(x[0], x[1], undefined, undefined, { type: 'empty' })
 			})
-		}
-
-		if (preprocessorModule) {
-			addNode(preprocessorModule)
-			const id = JSON.parse(JSON.stringify(preprocessorModule.id))
-			addEdge(id, 'Input', undefined, undefined, { type: 'empty' })
 		}
 
 		if (failureModule && !extra.flowModuleStates) {


### PR DESCRIPTION
## Summary

Follow-up to #10393, which merged before its last commit was pushed. Two review findings from that PR are therefore missing from main.

#10393 made the flow editor skip an error handler run marker whose failing step is no longer in the graph — that check reads `nodes`, so it only sees steps already added at that point. `addNode(preprocessorModule)` runs *after* the marker loop, so a marker anchored to `preprocessor` is now silently dropped where it used to render (`parents` is applied at the end of `graphBuilder`, once the preprocessor node exists). Moving the preprocessor block above the loop restores it.

Second, `topologicalSort` now skips a parent id with no node instead of throwing. That is deliberate — the alternative unmounts the whole editor — but it was silent, so the next dangling-edge source would render a subtly wrong graph with no signal. It now warns, matching the existing duplicate-node logging a few hundred lines below.

## Changes

- `graphBuilder.svelte.ts`: add the preprocessor node before the failure-marker loop, so a marker anchored to the preprocessor still finds its parent.
- `graphBuilder.svelte.ts`: `console.warn` when `topologicalSort` hits a parent id with no node, instead of skipping silently.

## Screenshots

Preprocessor node still renders above Input with its edge, with the reorder in place (the case this PR most directly touches):

![preprocessor-node-renders](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-preprocessor-node-order/1785263765-preprocessor-node-renders.png)

The #10393 behavior this must not regress — after deleting the failing step, the graph re-renders without the marker instead of unmounting:

![fixed-graph-after-delete](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-failure-marker-dangling-parent/1785257749-fixed-graph-after-delete.png)

## Test plan

- [ ] Flow with a preprocessor: the preprocessor node still renders above Input, with its edge, unchanged
- [ ] Flow with a failing step + error handler: test-run, then delete the failing step — still no crash, graph re-renders without the marker (the #10393 behavior is preserved)
- [ ] `npx vitest run src/lib/components/graph`

Note on verification: I could not exercise a preprocessor-anchored marker end to end, because a test run from the flow editor skips the preprocessor entirely (`flow_status.preprocessor_module` stays null and the error handler never fires). This change is the reviewer's code-reading finding plus the ordering fix, which is behavior-neutral for every case I could exercise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes node ordering in the flow editor so the preprocessor is added before failure-marker processing. Restores preprocessor-anchored error handler markers and warns when an edge targets a missing node.

- **Bug Fixes**
  - Add the preprocessor node before the failure-marker loop so its markers find their parent; keep its edge to Input.
  - In topological sort, log a console warning when a parent id has no node and continue rendering.

<sup>Written for commit 92aa894e79f7d666a6f18cebfb764f6fba0f64c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


