### PR TITLE
fix: distinguish waiting-on-user from streaming in ai sessions

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -14,7 +14,6 @@
 		Folder,
 		Hand,
 		HistoryIcon,
-		Hourglass,
 		MousePointer2,
 		Plus,
 		TextSelect,
@@ -25,7 +24,7 @@
 	import { fade } from 'svelte/transition'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
-	import { isActiveUserQuestion, type DisplayMessage } from './shared'
+	import { isActiveUserQuestion, pendingUserAction, type DisplayMessage } from './shared'
 	import type { ContextElement } from './context'
 	import ChatQuickActions from './ChatQuickActions.svelte'
 	import ContextUsageIndicator from './ContextUsageIndicator.svelte'
@@ -486,19 +485,12 @@
 		}
 	})
 
-	// "Waiting for user" detection — when the latest tool message is staged
-	// for confirmation or has an unanswered askUserQuestion, the AI loop is
-	// paused on the user, not on its own work. The typing-dots indicator
-	// implies the AI is busy, which is misleading; surface a text pill
-	// instead so users know to act on the tool above.
-	const waitingForUserAction = $derived.by(() => {
-		if (!aiChatManager.loading) return false
-		const last = messages[messages.length - 1]
-		if (!last || last.role !== 'tool') return false
-		if (last.needsConfirmation && last.isLoading) return true
-		if (isActiveUserQuestion(last)) return true
-		return false
-	})
+	// The typing-dots indicator implies the AI is busy, which is misleading while
+	// the loop is parked on the user; surface a text pill instead so users know to
+	// act on the tool above.
+	const waitingForUserAction = $derived(
+		aiChatManager.loading && !!pendingUserAction(messages[messages.length - 1])
+	)
 
 	// While the AI is waiting on an answer to an askUserQuestion, the only valid
 	// input is one of the choices (or the custom answer) in the question card —
@@ -682,28 +674,19 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 								showFlowPendingActionControls ? 'bottom-14' : 'bottom-2'
 							)}
 						>
-							{#if waitingForUserAction}
-								<span
-									class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface/80 backdrop-blur text-2xs text-accent"
-									aria-label="Waiting for your input"
-								>
-									<Hourglass class="w-3 h-3 hourglass-flip" />
-									Waiting for your input
-								</span>
-							{:else}
-								<ChatTypingIndicator
-									loading={aiChatManager.loading}
-									label={aiChatManager.loadingLabel
-										? aiChatManager.loadingLabel
-										: aiChatManager.compacting
-											? 'Compacting conversation'
-											: aiChatManager.currentReasoningActive &&
-												  !aiChatManager.currentReply &&
-												  !aiChatManager.currentReasoning
-												? (aiChatManager.reasoningHiddenIndicatorLabel ?? 'Thinking')
-												: undefined}
-								/>
-							{/if}
+							<ChatTypingIndicator
+								loading={aiChatManager.loading}
+								paused={waitingForUserAction}
+								label={aiChatManager.loadingLabel
+									? aiChatManager.loadingLabel
+									: aiChatManager.compacting
+										? 'Compacting conversation'
+										: aiChatManager.currentReasoningActive &&
+											  !aiChatManager.currentReply &&
+											  !aiChatManager.currentReasoning
+											? (aiChatManager.reasoningHiddenIndicatorLabel ?? 'Thinking')
+											: undefined}
+							/>
 						</div>
 					{/if}
 				</div>
@@ -1067,26 +1050,3 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 		{/if}
 	</div>
 </div>
-
-<style>
-	/* Hourglass flips every 4s with long rests at each upright position.
-	   `:global` because the class is applied to a child component's root
-	   (Lucide SVG) and Svelte scoped CSS otherwise wouldn't match it. */
-	:global(.hourglass-flip) {
-		animation: hourglass-flip 4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
-		transform-origin: center;
-	}
-	@keyframes hourglass-flip {
-		0%,
-		35% {
-			transform: rotate(0deg);
-		}
-		50%,
-		85% {
-			transform: rotate(180deg);
-		}
-		100% {
-			transform: rotate(360deg);
-		}
-	}
-</style>

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -24,7 +24,7 @@
 	import { fade } from 'svelte/transition'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
-	import { isActiveUserQuestion, pendingUserAction, type DisplayMessage } from './shared'
+	import { pendingUserAction, type DisplayMessage } from './shared'
 	import type { ContextElement } from './context'
 	import ChatQuickActions from './ChatQuickActions.svelte'
 	import ContextUsageIndicator from './ContextUsageIndicator.svelte'
@@ -488,14 +488,12 @@
 	// The typing-dots indicator implies the AI is busy, which is misleading while
 	// the loop is parked on the user; surface a text pill instead so users know to
 	// act on the tool above.
-	const waitingForUserAction = $derived(
-		aiChatManager.loading && !!pendingUserAction(messages[messages.length - 1])
-	)
+	const waitingForUserAction = $derived(aiChatManager.loading && !!pendingUserAction(messages))
 
 	// While the AI is waiting on an answer to an askUserQuestion, the only valid
 	// input is one of the choices (or the custom answer) in the question card —
 	// so disable the main chat input until the question is answered or canceled.
-	const hasActiveUserQuestion = $derived(isActiveUserQuestion(messages[messages.length - 1]))
+	const hasActiveUserQuestion = $derived(pendingUserAction(messages) === 'question')
 
 	// Get app context for display when in APP mode
 	const appContext = $derived.by((): SelectedContext | undefined => {

--- a/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
@@ -1,26 +1,39 @@
 <script lang="ts">
+	import { Hourglass } from 'lucide-svelte'
+
 	let {
 		loading,
 		compact = false,
+		paused = false,
 		label
-	}: { loading: boolean; compact?: boolean; label?: string } = $props()
+	}: { loading: boolean; compact?: boolean; paused?: boolean; label?: string } = $props()
 
 	// Wall-clock for the typing-dots indicator. Starts on the rising edge of
 	// `loading`, ticks once a second, frozen on the last value when loading
 	// ends so callers reading the dots briefly after still see a coherent number.
-	let loadingStartedAt = $state<number | undefined>(undefined)
-	let loadingElapsedMs = $state(0)
+	// While `paused` the clock is suspended and resumes from where it stopped:
+	// time the user spends answering a question is theirs, not the model's, and
+	// counting it makes a fast turn read as a slow one.
+	let elapsedMs = $state(0)
+	let accumulatedMs = 0
+	let wasLoading = false
 	$effect(() => {
 		if (!loading) {
-			loadingStartedAt = undefined
+			wasLoading = false
 			return
 		}
-		loadingStartedAt = Date.now()
-		loadingElapsedMs = 0
-		const interval = setInterval(() => {
-			if (loadingStartedAt) loadingElapsedMs = Date.now() - loadingStartedAt
-		}, 1000)
-		return () => clearInterval(interval)
+		if (!wasLoading) {
+			wasLoading = true
+			accumulatedMs = 0
+			elapsedMs = 0
+		}
+		if (paused) return
+		const startedAt = Date.now() - accumulatedMs
+		const interval = setInterval(() => (elapsedMs = Date.now() - startedAt), 1000)
+		return () => {
+			accumulatedMs = Date.now() - startedAt
+			clearInterval(interval)
+		}
 	})
 
 	function formatElapsed(ms: number): string {
@@ -35,30 +48,41 @@
 	}
 </script>
 
-<span
-	class={compact
-		? 'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-surface/80 backdrop-blur'
-		: 'inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface/80 backdrop-blur'}
-	aria-label="AI is generating a response"
->
-	<span class={compact ? 'inline-flex items-end gap-0.5' : 'inline-flex items-end gap-1'}>
-		<span
-			class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
-				' rounded-full bg-accent chat-typing-dot'}
-		></span>
-		<span
-			class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
-				' rounded-full bg-accent chat-typing-dot chat-typing-dot-2'}
-		></span>
-		<span
-			class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
-				' rounded-full bg-accent chat-typing-dot chat-typing-dot-3'}
-		></span>
-	</span>
-	<span class={(compact ? 'text-[10px]' : 'text-2xs') + ' text-tertiary tabular-nums leading-none'}
-		>{label ? label + ' · ' : ''}{formatElapsed(loadingElapsedMs)}</span
+{#if paused}
+	<span
+		class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface/80 backdrop-blur text-2xs text-accent"
+		aria-label="Waiting for your input"
 	>
-</span>
+		<Hourglass class="w-3 h-3 hourglass-flip" />
+		Waiting for your input
+	</span>
+{:else}
+	<span
+		class={compact
+			? 'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-surface/80 backdrop-blur'
+			: 'inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface/80 backdrop-blur'}
+		aria-label="AI is generating a response"
+	>
+		<span class={compact ? 'inline-flex items-end gap-0.5' : 'inline-flex items-end gap-1'}>
+			<span
+				class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
+					' rounded-full bg-accent chat-typing-dot'}
+			></span>
+			<span
+				class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
+					' rounded-full bg-accent chat-typing-dot chat-typing-dot-2'}
+			></span>
+			<span
+				class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
+					' rounded-full bg-accent chat-typing-dot chat-typing-dot-3'}
+			></span>
+		</span>
+		<span
+			class={(compact ? 'text-[10px]' : 'text-2xs') + ' text-tertiary tabular-nums leading-none'}
+			>{label ? label + ' · ' : ''}{formatElapsed(elapsedMs)}</span
+		>
+	</span>
+{/if}
 
 <style>
 	.chat-typing-dot {
@@ -78,6 +102,26 @@
 		}
 		30% {
 			opacity: 1;
+		}
+	}
+
+	/* Hourglass flips every 4s with long rests at each upright position. Global:
+	   the class lands on a lucide component's own element. */
+	:global(.hourglass-flip) {
+		animation: hourglass-flip 4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+		transform-origin: center;
+	}
+	@keyframes hourglass-flip {
+		0%,
+		35% {
+			transform: rotate(0deg);
+		}
+		50%,
+		85% {
+			transform: rotate(180deg);
+		}
+		100% {
+			transform: rotate(360deg);
 		}
 	}
 </style>

--- a/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
@@ -8,12 +8,10 @@
 		label
 	}: { loading: boolean; compact?: boolean; paused?: boolean; label?: string } = $props()
 
-	// Wall-clock for the typing-dots indicator. Starts on the rising edge of
-	// `loading`, ticks once a second, frozen on the last value when loading
-	// ends so callers reading the dots briefly after still see a coherent number.
-	// While `paused` the clock is suspended and resumes from where it stopped:
-	// time the user spends answering a question is theirs, not the model's, and
-	// counting it makes a fast turn read as a slow one.
+	// Starts on the rising edge of `loading`, frozen on its last value once loading
+	// ends so a caller reading it just after still sees a coherent number. `paused`
+	// suspends it and resumes where it stopped: time the user spends answering is
+	// theirs, and counting it makes a fast turn read as a slow one.
 	let elapsedMs = $state(0)
 	let accumulatedMs = 0
 	let wasLoading = false

--- a/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
@@ -50,10 +50,11 @@
 
 {#if paused}
 	<span
-		class="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface/80 backdrop-blur text-2xs text-accent"
+		class={(compact ? 'gap-1 px-1.5 py-0.5 text-[10px]' : 'gap-1.5 px-2 py-1 text-2xs') +
+			' inline-flex items-center rounded-md bg-surface/80 backdrop-blur text-accent'}
 		aria-label="Waiting for your input"
 	>
-		<Hourglass class="w-3 h-3 hourglass-flip" />
+		<Hourglass class={(compact ? 'w-2.5 h-2.5' : 'w-3 h-3') + ' hourglass-flip'} />
 		Waiting for your input
 	</span>
 {:else}

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -888,6 +888,32 @@ describe('isActiveUserQuestion', () => {
 	})
 })
 
+describe('pendingUserAction', () => {
+	const toolMessage = (overrides: Partial<ToolDisplayMessage> = {}): ToolDisplayMessage => ({
+		role: 'tool',
+		tool_call_id: 'call_p',
+		content: 'running',
+		isLoading: true,
+		...overrides
+	})
+
+	it('distinguishes an unanswered question from a staged confirmation', async () => {
+		const { pendingUserAction } = await import('./shared')
+		expect(
+			pendingUserAction(toolMessage({ userQuestion: { question: 'Pick one', choices: ['a'] } }))
+		).toBe('question')
+		expect(pendingUserAction(toolMessage({ needsConfirmation: true }))).toBe('confirmation')
+	})
+
+	it('is undefined for a tool the AI is running on its own', async () => {
+		const { pendingUserAction } = await import('./shared')
+		expect(pendingUserAction(toolMessage())).toBe(undefined)
+		expect(pendingUserAction(toolMessage({ needsConfirmation: true, isLoading: false }))).toBe(
+			undefined
+		)
+	})
+})
+
 describe('pollJobCompletion detach', () => {
 	function makeCallbacks() {
 		return {

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -923,6 +923,13 @@ describe('pendingUserAction', () => {
 		)
 	})
 
+	// Text emitted between two tool calls lands as an assistant card between them.
+	it('finds a blocked card behind an interleaved assistant card', async () => {
+		const { pendingUserAction } = await import('./shared')
+		const assistant: DisplayMessage = { role: 'assistant', content: 'and also…' }
+		expect(pendingUserAction([question, assistant, toolMessage()])).toBe('question')
+	})
+
 	it('stops at the previous turn rather than reviving its resolved cards', async () => {
 		const { pendingUserAction } = await import('./shared')
 		const userMessage: DisplayMessage = { role: 'user', index: 0, content: 'go on' }

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -897,20 +897,36 @@ describe('pendingUserAction', () => {
 		...overrides
 	})
 
+	const question = toolMessage({ userQuestion: { question: 'Pick one', choices: ['a'] } })
+
 	it('distinguishes an unanswered question from a staged confirmation', async () => {
 		const { pendingUserAction } = await import('./shared')
-		expect(
-			pendingUserAction(toolMessage({ userQuestion: { question: 'Pick one', choices: ['a'] } }))
-		).toBe('question')
-		expect(pendingUserAction(toolMessage({ needsConfirmation: true }))).toBe('confirmation')
+		expect(pendingUserAction([question])).toBe('question')
+		expect(pendingUserAction([toolMessage({ needsConfirmation: true })])).toBe('confirmation')
 	})
 
 	it('is undefined for a tool the AI is running on its own', async () => {
 		const { pendingUserAction } = await import('./shared')
-		expect(pendingUserAction(toolMessage())).toBe(undefined)
-		expect(pendingUserAction(toolMessage({ needsConfirmation: true, isLoading: false }))).toBe(
+		expect(pendingUserAction([toolMessage()])).toBe(undefined)
+		expect(pendingUserAction([toolMessage({ needsConfirmation: true, isLoading: false })])).toBe(
 			undefined
 		)
+	})
+
+	// A multi-tool turn creates every card before running the calls one at a time,
+	// so the blocked card is not the last message.
+	it('finds a blocked card sitting behind queued ones', async () => {
+		const { pendingUserAction } = await import('./shared')
+		expect(pendingUserAction([question, toolMessage(), toolMessage()])).toBe('question')
+		expect(pendingUserAction([toolMessage({ needsConfirmation: true }), toolMessage()])).toBe(
+			'confirmation'
+		)
+	})
+
+	it('stops at the previous turn rather than reviving its resolved cards', async () => {
+		const { pendingUserAction } = await import('./shared')
+		const userMessage: DisplayMessage = { role: 'user', index: 0, content: 'go on' }
+		expect(pendingUserAction([question, userMessage, toolMessage()])).toBe(undefined)
 	})
 })
 

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -648,11 +648,9 @@ export function isActiveUserQuestion(message: DisplayMessage | undefined): boole
 	)
 }
 
-// The loop is paused on the user rather than on its own work: either an
-// unanswered askUserQuestion or a tool call staged for confirmation (running a
-// script, deploying…). The manager stays `loading` throughout both, so anything
-// that renders progress must ask here first or it shows "the AI is working"
-// while the AI is in fact blocked on the user.
+// The loop is parked on the user: an unanswered askUserQuestion, or a tool call
+// staged for confirmation. The manager stays `loading` through both, so anything
+// rendering progress must ask here first or it reports "the AI is working".
 export type PendingUserAction = 'question' | 'confirmation'
 
 export function pendingUserAction(

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -648,6 +648,22 @@ export function isActiveUserQuestion(message: DisplayMessage | undefined): boole
 	)
 }
 
+// The loop is paused on the user rather than on its own work: either an
+// unanswered askUserQuestion or a tool call staged for confirmation (running a
+// script, deploying…). The manager stays `loading` throughout both, so anything
+// that renders progress must ask here first or it shows "the AI is working"
+// while the AI is in fact blocked on the user.
+export type PendingUserAction = 'question' | 'confirmation'
+
+export function pendingUserAction(
+	message: DisplayMessage | undefined
+): PendingUserAction | undefined {
+	if (!message || message.role !== 'tool') return undefined
+	if (isActiveUserQuestion(message)) return 'question'
+	if (message.needsConfirmation && message.isLoading) return 'confirmation'
+	return undefined
+}
+
 // Fires after every tool call resolves, with the tool name. Lets a host (e.g.
 // the sessions page) react to mutating tools — refreshing previews — without
 // the tool layer knowing about the UI. Single slot; the consumer filters by name

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -653,12 +653,16 @@ export function isActiveUserQuestion(message: DisplayMessage | undefined): boole
 // rendering progress must ask here first or it reports "the AI is working".
 export type PendingUserAction = 'question' | 'confirmation'
 
-export function pendingUserAction(
-	message: DisplayMessage | undefined
-): PendingUserAction | undefined {
-	if (!message || message.role !== 'tool') return undefined
-	if (isActiveUserQuestion(message)) return 'question'
-	if (message.needsConfirmation && message.isLoading) return 'confirmation'
+// Scans the turn's whole trailing run of tool cards, not just the last message:
+// providers create one card per tool call up front and then run the calls one at
+// a time, so the blocked call routinely sits behind cards still queued.
+export function pendingUserAction(messages: DisplayMessage[]): PendingUserAction | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i]
+		if (message.role !== 'tool') break
+		if (isActiveUserQuestion(message)) return 'question'
+		if (message.needsConfirmation && message.isLoading) return 'confirmation'
+	}
 	return undefined
 }
 

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -653,13 +653,15 @@ export function isActiveUserQuestion(message: DisplayMessage | undefined): boole
 // rendering progress must ask here first or it reports "the AI is working".
 export type PendingUserAction = 'question' | 'confirmation'
 
-// Scans the turn's whole trailing run of tool cards, not just the last message:
-// providers create one card per tool call up front and then run the calls one at
-// a time, so the blocked call routinely sits behind cards still queued.
+// Scans back to the turn boundary, not just the last message: a turn's cards are
+// created up front and run one at a time, and text between two tool calls pushes
+// an assistant card between them, so the blocked card is rarely last. Only cards
+// of a live turn can match — every resolution path clears `isLoading`.
 export function pendingUserAction(messages: DisplayMessage[]): PendingUserAction | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i]
-		if (message.role !== 'tool') break
+		if (message.role === 'user') break
+		if (message.role !== 'tool') continue
 		if (isActiveUserQuestion(message)) return 'question'
 		if (message.needsConfirmation && message.isLoading) return 'confirmation'
 	}

--- a/frontend/src/lib/components/sessions/SessionStatusDot.svelte
+++ b/frontend/src/lib/components/sessions/SessionStatusDot.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		AlertCircle,
-		AlertTriangle,
-		Building,
-		GitFork,
-		GitPullRequestClosed
-	} from 'lucide-svelte'
+	import { AlertTriangle, Building, CircleHelp, GitFork, GitPullRequestClosed } from 'lucide-svelte'
 	import type { SessionChatStatus } from './sessionRuntime.svelte'
 
 	// The fork icon is deliberately sync-state-agnostic (no ahead/behind/
@@ -21,16 +15,20 @@
 		idle: 'No chat activity',
 		streaming: 'Generating response…',
 		'awaiting-user': 'Waiting for your reply',
+		'awaiting-answer': 'Waiting for your answer',
 		'needs-confirmation': 'Needs your confirmation',
 		draft: 'Unsent draft',
 		error: 'Last message had an error'
 	}
 
 	// Live chat signals take precedence over the persistent kind/fork
-	// indicator: streaming, needs-confirmation, and error are time-critical
-	// and warrant briefly hijacking the icon slot.
+	// indicator: they are time-critical and warrant briefly hijacking the icon
+	// slot.
 	const liveOverride = $derived(
-		status === 'streaming' || status === 'needs-confirmation' || status === 'error'
+		status === 'streaming' ||
+			status === 'awaiting-answer' ||
+			status === 'needs-confirmation' ||
+			status === 'error'
 	)
 
 	const persistentTitle = $derived(
@@ -51,8 +49,10 @@
 			<span class="w-[3px] h-[3px] rounded-full bg-blue-500 typing-dot dot-2"></span>
 			<span class="w-[3px] h-[3px] rounded-full bg-blue-500 typing-dot dot-3"></span>
 		</span>
-	{:else if status === 'needs-confirmation'}
-		<AlertCircle class="w-3 h-3 text-amber-500" />
+	{:else if status === 'awaiting-answer' || status === 'needs-confirmation'}
+		<!-- Both mean "the run is blocked on you"; at 12px a second amber circle
+		     glyph would be indistinguishable, so the tooltip carries which one. -->
+		<CircleHelp class="w-3 h-3 text-amber-500" />
 	{:else if status === 'error'}
 		<AlertTriangle class="w-3 h-3 text-red-500" />
 	{:else if isFork}

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -86,7 +86,7 @@ import type {
 	RawAppDomResult
 } from '$lib/components/raw_apps/rawAppDom'
 import { getNonStreamingMetadataCompletion } from '$lib/components/copilot/lib'
-import type { DisplayMessage } from '$lib/components/copilot/chat/shared'
+import { pendingUserAction, type DisplayMessage } from '$lib/components/copilot/chat/shared'
 import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs'
 
 // Per-kind load state for a session's editor target. Pure state container the
@@ -967,7 +967,10 @@ export function resetSessionPreviewTabs(sessionId: string, url: string): void {
 export type SessionChatStatus =
 	| 'idle'
 	| 'streaming'
+	// The assistant's turn ended and the user has yet to reply — passive, unlike
+	// 'awaiting-answer'/'needs-confirmation', where a running loop is blocked.
 	| 'awaiting-user'
+	| 'awaiting-answer'
 	| 'needs-confirmation'
 	| 'draft'
 	| 'error'
@@ -1243,10 +1246,15 @@ setScreenshotHandler(async ({ sessionId: callerSessionId }) => {
 
 export function getSessionChatStatus(runtime: SessionRuntime): SessionChatStatus {
 	const m = runtime.manager
+	const last = m.displayMessages[m.displayMessages.length - 1]
+	// A loop parked on the user still reports `loading`, so these must be tested
+	// before `streaming` — otherwise "answer me" renders as "the AI is typing"
+	// and a session that needs the user looks like one that doesn't.
+	const pending = pendingUserAction(last)
+	if (pending === 'question') return 'awaiting-answer'
+	if (pending === 'confirmation') return 'needs-confirmation'
 	if (m.loading) return 'streaming'
 	if (m.instructions.trim().length > 0) return 'draft'
-	const last = m.displayMessages[m.displayMessages.length - 1]
-	if (last?.role === 'tool' && last.needsConfirmation) return 'needs-confirmation'
 	if (last?.role === 'user' && last.error) return 'error'
 	if (last && (last.role === 'assistant' || last.role === 'tool')) return 'awaiting-user'
 	return 'idle'

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -1250,7 +1250,7 @@ export function getSessionChatStatus(runtime: SessionRuntime): SessionChatStatus
 	// A loop parked on the user still reports `loading`, so these must be tested
 	// before `streaming` — otherwise "answer me" renders as "the AI is typing"
 	// and a session that needs the user looks like one that doesn't.
-	const pending = pendingUserAction(last)
+	const pending = pendingUserAction(m.displayMessages)
 	if (pending === 'question') return 'awaiting-answer'
 	if (pending === 'confirmation') return 'needs-confirmation'
 	if (m.loading) return 'streaming'

--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -179,6 +179,15 @@
 		return ambiguous
 	})
 
+	// Opening while a fork is active expands that fork's family, so the tick sits
+	// on the active fork's own row instead of on its collapsed root.
+	function seedExpandedFamilies() {
+		expandedFamilies.clear()
+		if (currentFamily && currentFamily.id !== $workspaceStore) {
+			expandedFamilies.add(currentFamily.id)
+		}
+	}
+
 	// The active workspace itself (fork included) — names the settings entry.
 	const activeWorkspace = $derived($userWorkspaces?.find((w) => w.id === $workspaceStore))
 	const canManageWorkspace = $derived(
@@ -193,13 +202,14 @@
 
 <svelte:window onkeydowncapture={onExpandKeydown} />
 
-<!-- Expansion is per-open: every open starts with all families collapsed,
-     including the active fork's. -->
+<!-- Expansion is per-open: every open starts from the active workspace's family
+     alone, discarding whatever the previous open expanded. -->
 <Menu
 	{createMenu}
 	usePointerDownOutside
 	placement="bottom-start"
 	bind:open={menuOpen}
+	on:open={seedExpandedFamilies}
 	on:close={() => expandedFamilies.clear()}
 >
 	{#snippet triggr({ trigger })}


### PR DESCRIPTION
## Summary

Two small UX fixes, both about making state legible rather than changing behaviour.

**1. Workspace menu opens on the active fork's family.** Opening the top-left workspace picker while inside a fork showed every family collapsed, so the checkmark sat on the collapsed *root* row and you could not tell which fork you were in without expanding it yourself. The menu now seeds the active workspace's family as expanded on each open.

**2. "Waiting on you" is no longer indistinguishable from "generating".** When the AI loop parks on the user — an unanswered `askUserQuestion`, or a tool call staged for confirmation such as running a script — the manager is still `loading`. Two things read that as work in progress:

- `getSessionChatStatus` returned `streaming` before it ever reached its `needs-confirmation` branch (which was therefore dead), so the session list showed the blue typing dots for a session that was blocked on the user.
- `ChatTypingIndicator`'s clock ran off a fixed start timestamp. The chat already swapped the dots for a "Waiting for your input" pill, but the clock kept accumulating underneath, so answering a question after two minutes brought the indicator back reading `2m 15s` of model time that was actually your own deliberation.

Both paused-on-user cases now render an amber `?` in the session list (distinct from the blue dots), and the clock suspends while parked and resumes where it stopped. A single `pendingUserAction` predicate in `shared.ts` backs both call sites so they cannot drift apart.

I tried a separate `!` icon for confirmation vs `?` for a question, but at 12px two amber circle glyphs were indistinguishable, so both share the `?` and the tooltip carries which one ("Waiting for your answer" / "Needs your confirmation").

## Changes

- `WorkspaceMenu.svelte`: seed `expandedFamilies` with the active workspace's family root on `on:open`; still cleared on close, and roots/non-forked workspaces still open fully collapsed.
- `shared.ts`: add `pendingUserAction(message)` returning `'question' | 'confirmation' | undefined`, next to the existing `isActiveUserQuestion`.
- `sessionRuntime.svelte.ts`: test the paused-on-user cases *before* `m.loading` in `getSessionChatStatus`; add an `awaiting-answer` status.
- `SessionStatusDot.svelte`: amber `CircleHelp` for `awaiting-answer` / `needs-confirmation`, both added to the live-override set.
- `ChatTypingIndicator.svelte`: new `paused` prop that suspends and resumes the elapsed clock; the "Waiting for your input" pill moves in here (with its hourglass CSS) so one component owns "what the chat is doing" and the clock is not unmounted mid-turn. Honors `compact` on both branches.
- `AIChatDisplay.svelte`: `waitingForUserAction` now goes through `pendingUserAction`; renders a single always-mounted `ChatTypingIndicator`.

## Screenshots

Workspace menu opened from inside `Alpha fork` — the `Team` family is already expanded and the tick is on the fork's own row:

![workspace-menu-fork](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-workspace-family-expand/1785268565-workspace-menu-fork.png)

Session-list icons — blue dots for generating, amber `?` for both waiting states:

![session-status-icons](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-workspace-family-expand/1785268567-session-status-icons.png)

The chat indicator while parked on the user:

![waiting-pill](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-workspace-family-expand/1785268570-waiting-pill.png)

The last two are rendered from the real components in a throwaway harness route (not committed): this dev instance has no AI provider configured, so a live session could not be driven to a waiting state.

## Test plan

- [ ] With a fork active, open the workspace menu: its family is expanded and the tick is on the fork row. Expand another family, close, reopen — only the active family is expanded again.
- [ ] From a root workspace, the menu still opens with all families collapsed.
- [ ] Leave a session on an unanswered `askUserQuestion`: the session list shows the amber `?` ("Waiting for your answer"), not the typing dots.
- [ ] Leave a session on a staged run/deploy confirmation: same icon, tooltip reads "Needs your confirmation".
- [ ] In the chat, wait ~30s before answering a question: the elapsed clock resumes from where it froze instead of jumping by the wait. A new turn still resets it to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies "waiting on user" vs "generating" in AI sessions and auto-expands the active fork’s family when opening the workspace menu. Improves session list and chat clarity, and makes the active fork visible at a glance.

- **Bug Fixes**
  - Workspace menu: expands the active fork’s family on open; resets on close; root workspaces still start collapsed.
  - Session status: checks `pendingUserAction` (scans back to the turn boundary and handles interleaved assistant text, not just the last card) before `streaming`; adds `awaiting-answer` for unanswered questions.
  - Session list/indicator: blue dots for generating; amber `?` for waiting states with clear tooltips; a single `ChatTypingIndicator` now supports `paused`, shows a "Waiting for your input" pill, honors `compact`, and pauses/resumes the elapsed clock accurately.
  - Shared logic/tests: adds `pendingUserAction(messages)`; wires `AIChatDisplay`, `SessionStatusDot`, and runtime status to it; adds tests for question vs confirmation, queued/behind-interleaved cards, and stopping at the previous-turn boundary.

<sup>Written for commit d0e94039b495cb5084488e728c0e81ea8d89ed5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

