### PR TITLE
chore: pin ui_builder to 2471791 (svelte language server fix)

### DIFF
--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "013bf67",
-	"sha256": "4ad957f62a1cf2fe592144f7da702a899294a330acae40ef2d85ffd726326c91"
+	"version": "2471791",
+	"sha256": "04048791fb6b2ebca5cc30447e163826cdb143d65cce07a629252e131ac83618"
 }


### PR DESCRIPTION
Pins the in-editor builder to the build carrying windmill-labs/windmill-code-ui-builder#26.

```
frontend/scripts/ui_builder_artifact.json:  013bf67 -> 2471791
```

## What this picks up

`.svelte` files had no IntelliSense, no diagnostics and no go-to-definition, because the bundled extension's language server was dying on startup:

```
Client Svelte Web Extension: connection to server is erroring.
Reader received error. Reason: Uncaught TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')
Shutting down server.
```

TypeScript only defines `ts.sys` when it detects Node, and `svelte-language-server` reads it unguarded in ~26 places. Fixed in windmill-labs/svelte-vscode-web#1 along with a `vscode-languageclient` 7-vs-9 API break and a split filesystem that left the server running but permanently silent.

Builds and runtime were never affected by this — editor language support only. It is independent of the rune-module and delegated-event fixes already pinned here; the crashing bundle was byte-identical across those artifacts.

## Verification

Downloaded the published artifact, confirmed sha256 matches the pin, and checked all three fixes are actually in it:

| fix | evidence in `ui_builder-2471791.tar.gz` |
|---|---|
| rune modules (#24) | `.svelte.[jt]s` loader present in `worker-*.js` **and** `rolldownWorker-*.js` |
| delegated-event ABI (#25) | bundled compiler is **5.56.8** (was 5.46.1) |
| language server (#26) | `__tsSysShim` present in the extension's `server-*.js` |

The language-server fix itself was verified in a browser before merge: a `.svelte` file with a deliberate type error now reports `Type 'string' is not assignable to type 'number'. ts(2322)`, and `$state`/`$derived` raise nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the in-editor `ui_builder` artifact to `2471791` to pick up the Svelte language server fix, restoring `.svelte` IntelliSense, diagnostics, and go-to-definition. Builds and runtime are unaffected; this only changes editor language support.

- **Bug Fixes**
  - Fixes crash in bundled `svelte-language-server` (undefined `ts.sys`) that disabled `.svelte` editor features.
  - Updates `frontend/scripts/ui_builder_artifact.json` to version `2471791` with sha256 `04048791fb6b2ebca5cc30447e163826cdb143d65cce07a629252e131ac83618`.

<sup>Written for commit b38562be3ebcf5ffdfc2a0b3d7e1be2084d0e39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

