### PR TITLE
fix(ai): route Azure OpenAI agent steps through the Responses API

### DIFF
--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -857,6 +857,7 @@ mod tests {
             messages,
             tools: None,
             model: "claude-sonnet-4",
+            base_url: "https://api.anthropic.com/v1",
             temperature: None,
             reasoning_effort: None,
             max_tokens: None,

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -857,7 +857,6 @@ mod tests {
             messages,
             tools: None,
             model: "claude-sonnet-4",
-            base_url: "https://api.anthropic.com/v1",
             temperature: None,
             reasoning_effort: None,
             max_tokens: None,

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -75,30 +75,6 @@ lazy_static::lazy_static! {
 
 const CHAT_COMPLETIONS_ONLY_TTL: Duration = Duration::from_secs(3600);
 
-/// Whether a rejection means the route is absent for this deployment, rather than
-/// something about the request the step happened to build (a tool schema, a hosted tool
-/// the subscription blocks, the conversation itself), which a deployment that does serve
-/// the route rejects just as well. A 400 has to name the deployment to qualify, so a
-/// complaint about one part of the request is not read as a verdict on the endpoint.
-///
-/// Only a rejection that passes this may be remembered for later steps. Being wrong the
-/// other way is cheap: the route is still retried per step, it is just learned again.
-pub fn identifies_unserved_route(status: u16, body: &str, model: &str) -> bool {
-    if status == 404 {
-        return true;
-    }
-    let body = body.to_ascii_lowercase();
-    body.contains(&model.to_ascii_lowercase())
-        && [
-            "unsupported",
-            "not supported",
-            "does not exist",
-            "not found",
-        ]
-        .iter()
-        .any(|marker| body.contains(marker))
-}
-
 /// Whether this deployment is known not to serve the endpoint its provider prefers.
 pub fn is_chat_completions_only(base_url: &str, model: &str) -> bool {
     CHAT_COMPLETIONS_ONLY
@@ -128,39 +104,6 @@ mod chat_completions_only_tests {
         assert!(!is_chat_completions_only(
             "https://other.openai.azure.com/openai",
             "legacy-deployment"
-        ));
-    }
-
-    /// What a deployment is remembered for must be the route, not the request the step
-    /// happened to build: a schema or a hosted tool an endpoint rejects would otherwise
-    /// send every later step on that deployment to the endpoint this routing avoids.
-    #[test]
-    fn only_a_route_rejection_may_be_remembered() {
-        let model = "gpt-35-turbo";
-
-        assert!(identifies_unserved_route(404, "Resource not found", model));
-        assert!(identifies_unserved_route(
-            400,
-            r#"{"error":{"message":"The model gpt-35-turbo is unsupported for this operation"}}"#,
-            model
-        ));
-
-        assert!(!identifies_unserved_route(
-            400,
-            r#"{"error":{"message":"Invalid schema for function 'run_script': 'additionalProperties' is required"}}"#,
-            model
-        ));
-        assert!(!identifies_unserved_route(
-            400,
-            r#"{"error":{"code":"content_filter","message":"The response was filtered"}}"#,
-            model
-        ));
-        // Azure blocks the hosted web-search tool per subscription; the route it was
-        // asked for is served.
-        assert!(!identifies_unserved_route(
-            400,
-            r#"{"error":{"message":"The tool web_search is not supported for this subscription"}}"#,
-            model
         ));
     }
 }

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -48,6 +48,15 @@ pub fn create_query_builder(
     }
 }
 
+/// The builder for the same resource on the OpenAI-compatible `/chat/completions`
+/// surface, for a provider whose preferred surface it turned out not to serve
+/// (`QueryBuilder::supports_chat_completions_fallback`).
+pub fn create_chat_completions_query_builder(
+    credentials: &ProviderCredentials,
+) -> Box<dyn QueryBuilder> {
+    Box::new(OtherQueryBuilder::new(credentials.provider.clone()))
+}
+
 /// The proxy (workspace/instance AI settings) and the query builder (AI agent step)
 /// each derive the endpoint and the credential header for the same resource. They
 /// must agree, or a resource authenticates in one and 401s in the other.

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -31,7 +31,8 @@ pub fn create_query_builder(
         AIProvider::GoogleAI => Box::new(GoogleAIQueryBuilder::new(credentials.platform.clone())),
         // Azure OpenAI serves the same Responses API as OpenAI under `/openai/v1`, and
         // newer deployments reject a reasoning effort combined with function tools on
-        // `/chat/completions`.
+        // `/chat/completions`. This cannot be decided per model: on Azure the model name
+        // is a user-chosen deployment name, which says nothing about the model behind it.
         AIProvider::OpenAI | AIProvider::AzureOpenAI => {
             Box::new(OpenAIQueryBuilder::new(credentials.provider.clone()))
         }

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -75,26 +75,28 @@ lazy_static::lazy_static! {
 
 const CHAT_COMPLETIONS_ONLY_TTL: Duration = Duration::from_secs(3600);
 
-/// Whether a rejection names the route or the model as the thing that is unavailable,
-/// rather than something about the request the step happened to build (a tool schema,
-/// a structured-output schema, the conversation itself), which a deployment that does
-/// serve this route can reject just as well.
+/// Whether a rejection means the route is absent for this deployment, rather than
+/// something about the request the step happened to build (a tool schema, a hosted tool
+/// the subscription blocks, the conversation itself), which a deployment that does serve
+/// the route rejects just as well. A 400 has to name the deployment to qualify, so a
+/// complaint about one part of the request is not read as a verdict on the endpoint.
 ///
 /// Only a rejection that passes this may be remembered for later steps. Being wrong the
 /// other way is cheap: the route is still retried per step, it is just learned again.
-pub fn identifies_unserved_route(status: u16, body: &str) -> bool {
+pub fn identifies_unserved_route(status: u16, body: &str, model: &str) -> bool {
     if status == 404 {
         return true;
     }
     let body = body.to_ascii_lowercase();
-    [
-        "unsupported",
-        "not supported",
-        "does not exist",
-        "not found",
-    ]
-    .iter()
-    .any(|marker| body.contains(marker))
+    body.contains(&model.to_ascii_lowercase())
+        && [
+            "unsupported",
+            "not supported",
+            "does not exist",
+            "not found",
+        ]
+        .iter()
+        .any(|marker| body.contains(marker))
 }
 
 /// Whether this deployment is known not to serve the endpoint its provider prefers.
@@ -130,23 +132,35 @@ mod chat_completions_only_tests {
     }
 
     /// What a deployment is remembered for must be the route, not the request the step
-    /// happened to build: a schema an endpoint rejects would otherwise send every later
-    /// step on that deployment to the endpoint this routing exists to avoid.
+    /// happened to build: a schema or a hosted tool an endpoint rejects would otherwise
+    /// send every later step on that deployment to the endpoint this routing avoids.
     #[test]
     fn only_a_route_rejection_may_be_remembered() {
-        assert!(identifies_unserved_route(404, "Resource not found"));
+        let model = "gpt-35-turbo";
+
+        assert!(identifies_unserved_route(404, "Resource not found", model));
         assert!(identifies_unserved_route(
             400,
-            r#"{"error":{"message":"The model gpt-35-turbo is unsupported for this operation"}}"#
+            r#"{"error":{"message":"The model gpt-35-turbo is unsupported for this operation"}}"#,
+            model
         ));
 
         assert!(!identifies_unserved_route(
             400,
-            r#"{"error":{"message":"Invalid schema for function 'run_script': 'additionalProperties' is required"}}"#
+            r#"{"error":{"message":"Invalid schema for function 'run_script': 'additionalProperties' is required"}}"#,
+            model
         ));
         assert!(!identifies_unserved_route(
             400,
-            r#"{"error":{"code":"content_filter","message":"The response was filtered"}}"#
+            r#"{"error":{"code":"content_filter","message":"The response was filtered"}}"#,
+            model
+        ));
+        // Azure blocks the hosted web-search tool per subscription; the route it was
+        // asked for is served.
+        assert!(!identifies_unserved_route(
+            400,
+            r#"{"error":{"message":"The tool web_search is not supported for this subscription"}}"#,
+            model
         ));
     }
 }

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -29,7 +29,12 @@ pub fn create_query_builder(
 ) -> Box<dyn QueryBuilder> {
     match credentials.provider {
         AIProvider::GoogleAI => Box::new(GoogleAIQueryBuilder::new(credentials.platform.clone())),
-        AIProvider::OpenAI => Box::new(OpenAIQueryBuilder::new(credentials.provider.clone())),
+        // Azure OpenAI serves the same Responses API as OpenAI under `/openai/v1`, and
+        // newer deployments reject a reasoning effort combined with function tools on
+        // `/chat/completions`.
+        AIProvider::OpenAI | AIProvider::AzureOpenAI => {
+            Box::new(OpenAIQueryBuilder::new(credentials.provider.clone()))
+        }
         AIProvider::Anthropic => Box::new(AnthropicQueryBuilder::new(
             credentials.provider.clone(),
             credentials.platform.clone(),
@@ -139,7 +144,7 @@ mod parity_tests {
                 AIProvider::AzureOpenAI,
                 "https://example.openai.azure.com/openai",
                 "gpt-4o",
-                "chat/completions",
+                "responses",
             ),
             case(
                 AIProvider::OpenAI,

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -75,6 +75,28 @@ lazy_static::lazy_static! {
 
 const CHAT_COMPLETIONS_ONLY_TTL: Duration = Duration::from_secs(3600);
 
+/// Whether a rejection names the route or the model as the thing that is unavailable,
+/// rather than something about the request the step happened to build (a tool schema,
+/// a structured-output schema, the conversation itself), which a deployment that does
+/// serve this route can reject just as well.
+///
+/// Only a rejection that passes this may be remembered for later steps. Being wrong the
+/// other way is cheap: the route is still retried per step, it is just learned again.
+pub fn identifies_unserved_route(status: u16, body: &str) -> bool {
+    if status == 404 {
+        return true;
+    }
+    let body = body.to_ascii_lowercase();
+    [
+        "unsupported",
+        "not supported",
+        "does not exist",
+        "not found",
+    ]
+    .iter()
+    .any(|marker| body.contains(marker))
+}
+
 /// Whether this deployment is known not to serve the endpoint its provider prefers.
 pub fn is_chat_completions_only(base_url: &str, model: &str) -> bool {
     CHAT_COMPLETIONS_ONLY
@@ -104,6 +126,27 @@ mod chat_completions_only_tests {
         assert!(!is_chat_completions_only(
             "https://other.openai.azure.com/openai",
             "legacy-deployment"
+        ));
+    }
+
+    /// What a deployment is remembered for must be the route, not the request the step
+    /// happened to build: a schema an endpoint rejects would otherwise send every later
+    /// step on that deployment to the endpoint this routing exists to avoid.
+    #[test]
+    fn only_a_route_rejection_may_be_remembered() {
+        assert!(identifies_unserved_route(404, "Resource not found"));
+        assert!(identifies_unserved_route(
+            400,
+            r#"{"error":{"message":"The model gpt-35-turbo is unsupported for this operation"}}"#
+        ));
+
+        assert!(!identifies_unserved_route(
+            400,
+            r#"{"error":{"message":"Invalid schema for function 'run_script': 'additionalProperties' is required"}}"#
+        ));
+        assert!(!identifies_unserved_route(
+            400,
+            r#"{"error":{"code":"content_filter","message":"The response was filtered"}}"#
         ));
     }
 }

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -6,6 +6,10 @@ pub mod openai;
 pub mod openrouter;
 pub mod other;
 
+use std::time::{Duration, Instant};
+
+use windmill_common::cache::Cache;
+
 use crate::{
     ai_providers::{AIPlatform, AIProvider},
     credentials::ProviderCredentials,
@@ -55,6 +59,53 @@ pub fn create_chat_completions_query_builder(
     credentials: &ProviderCredentials,
 ) -> Box<dyn QueryBuilder> {
     Box::new(OtherQueryBuilder::new(credentials.provider.clone()))
+}
+
+lazy_static::lazy_static! {
+    /// Deployments that turned out not to serve the endpoint their provider prefers,
+    /// so the steps after the one that found out start on `/chat/completions` rather
+    /// than paying a rejected call each to learn the same thing. Keyed by endpoint and
+    /// deployment name, because Azure's Responses API support varies by both.
+    ///
+    /// Only rejections are remembered: a surface that answers costs nothing to keep
+    /// using. The entry expires because a deployment can gain Responses support
+    /// (Azure rolls it out per model and region) without anything here changing.
+    static ref CHAT_COMPLETIONS_ONLY: Cache<(String, String), Instant> = Cache::new(500);
+}
+
+const CHAT_COMPLETIONS_ONLY_TTL: Duration = Duration::from_secs(3600);
+
+/// Whether this deployment is known not to serve the endpoint its provider prefers.
+pub fn is_chat_completions_only(base_url: &str, model: &str) -> bool {
+    CHAT_COMPLETIONS_ONLY
+        .get(&(base_url.to_string(), model.to_string()))
+        .is_some_and(|learned_at| learned_at.elapsed() < CHAT_COMPLETIONS_ONLY_TTL)
+}
+
+/// Record that this deployment rejected the endpoint its provider prefers.
+pub fn remember_chat_completions_only(base_url: &str, model: &str) {
+    CHAT_COMPLETIONS_ONLY.insert((base_url.to_string(), model.to_string()), Instant::now());
+}
+
+#[cfg(test)]
+mod chat_completions_only_tests {
+    use super::*;
+
+    /// Azure's Responses API support varies by deployment, so what one deployment of a
+    /// resource rejected says nothing about the next one.
+    #[test]
+    fn a_rejection_is_remembered_per_deployment() {
+        let base_url = "https://rejection-per-deployment.openai.azure.com/openai";
+
+        remember_chat_completions_only(base_url, "legacy-deployment");
+
+        assert!(is_chat_completions_only(base_url, "legacy-deployment"));
+        assert!(!is_chat_completions_only(base_url, "gpt-5-deployment"));
+        assert!(!is_chat_completions_only(
+            "https://other.openai.azure.com/openai",
+            "legacy-deployment"
+        ));
+    }
 }
 
 /// The proxy (workspace/instance AI settings) and the query builder (AI agent step)

--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -387,12 +387,21 @@ impl OpenAIQueryBuilder {
         // Build tools array using typed structs
         let mut tools: Vec<ResponsesApiTool> = Vec::new();
 
-        // Add websearch tool if enabled
+        // Azure serves this API without the hosted tools OpenAI runs alongside it, and
+        // rejects the request rather than ignoring one it does not know. Dropping it
+        // keeps the step on this endpoint instead of trading its reasoning support for a
+        // search the resource was never going to run.
         if args.has_websearch {
-            tools.push(ResponsesApiTool::BuiltIn(ResponsesApiBuiltInTool {
-                r#type: "web_search".to_string(),
-                quality: None,
-            }));
+            if self.provider_kind.is_azure(args.base_url) {
+                tracing::warn!(
+                    "Web search is not available on Azure endpoints, running without it"
+                );
+            } else {
+                tools.push(ResponsesApiTool::BuiltIn(ResponsesApiBuiltInTool {
+                    r#type: "web_search".to_string(),
+                    quality: None,
+                }));
+            }
         }
 
         // Convert ToolDef to ResponsesApiFunctionTool (flat structure for Responses API)
@@ -632,6 +641,7 @@ mod tests {
             messages,
             tools: None,
             model: "gpt-5",
+            base_url: "https://api.openai.com/v1",
             temperature: None,
             reasoning_effort: None,
             max_tokens: None,
@@ -647,6 +657,48 @@ mod tests {
             .build_request(&args, &client(), "test-workspace")
             .await
             .unwrap()
+    }
+
+    /// Azure rejects the request over a hosted tool it does not serve, so asking for
+    /// web search there would cost the step this endpoint entirely.
+    #[tokio::test]
+    async fn asks_for_web_search_only_where_it_is_served() {
+        async fn tools_of(provider: AIProvider, base_url: &str) -> serde_json::Value {
+            let messages = vec![message("user", "what happened today?")];
+            let args = BuildRequestArgs {
+                messages: &messages,
+                tools: None,
+                model: "gpt-5",
+                base_url,
+                temperature: None,
+                reasoning_effort: None,
+                max_tokens: None,
+                output_schema: None,
+                output_type: &OutputType::Text,
+                system_prompt: None,
+                user_message: "hello",
+                attachments: None,
+                has_websearch: true,
+            };
+            let body = OpenAIQueryBuilder::new(provider)
+                .build_request(&args, &client(), "test-workspace")
+                .await
+                .unwrap();
+            serde_json::from_str::<serde_json::Value>(&body).unwrap()["tools"].clone()
+        }
+
+        assert_eq!(
+            tools_of(AIProvider::OpenAI, "https://api.openai.com/v1").await,
+            serde_json::json!([{ "type": "web_search" }])
+        );
+        assert_eq!(
+            tools_of(
+                AIProvider::AzureOpenAI,
+                "https://example.openai.azure.com/openai"
+            )
+            .await,
+            serde_json::json!([])
+        );
     }
 
     /// The worker prepends the system prompt as a system message *and* passes it as

--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -387,21 +387,12 @@ impl OpenAIQueryBuilder {
         // Build tools array using typed structs
         let mut tools: Vec<ResponsesApiTool> = Vec::new();
 
-        // Azure serves this API without the hosted tools OpenAI runs alongside it, and
-        // rejects the request rather than ignoring one it does not know. Dropping it
-        // keeps the step on this endpoint instead of trading its reasoning support for a
-        // search the resource was never going to run.
+        // Add websearch tool if enabled
         if args.has_websearch {
-            if self.provider_kind.is_azure(args.base_url) {
-                tracing::warn!(
-                    "Web search is not available on Azure endpoints, running without it"
-                );
-            } else {
-                tools.push(ResponsesApiTool::BuiltIn(ResponsesApiBuiltInTool {
-                    r#type: "web_search".to_string(),
-                    quality: None,
-                }));
-            }
+            tools.push(ResponsesApiTool::BuiltIn(ResponsesApiBuiltInTool {
+                r#type: "web_search".to_string(),
+                quality: None,
+            }));
         }
 
         // Convert ToolDef to ResponsesApiFunctionTool (flat structure for Responses API)
@@ -641,7 +632,6 @@ mod tests {
             messages,
             tools: None,
             model: "gpt-5",
-            base_url: "https://api.openai.com/v1",
             temperature: None,
             reasoning_effort: None,
             max_tokens: None,
@@ -657,48 +647,6 @@ mod tests {
             .build_request(&args, &client(), "test-workspace")
             .await
             .unwrap()
-    }
-
-    /// Azure rejects the request over a hosted tool it does not serve, so asking for
-    /// web search there would cost the step this endpoint entirely.
-    #[tokio::test]
-    async fn asks_for_web_search_only_where_it_is_served() {
-        async fn tools_of(provider: AIProvider, base_url: &str) -> serde_json::Value {
-            let messages = vec![message("user", "what happened today?")];
-            let args = BuildRequestArgs {
-                messages: &messages,
-                tools: None,
-                model: "gpt-5",
-                base_url,
-                temperature: None,
-                reasoning_effort: None,
-                max_tokens: None,
-                output_schema: None,
-                output_type: &OutputType::Text,
-                system_prompt: None,
-                user_message: "hello",
-                attachments: None,
-                has_websearch: true,
-            };
-            let body = OpenAIQueryBuilder::new(provider)
-                .build_request(&args, &client(), "test-workspace")
-                .await
-                .unwrap();
-            serde_json::from_str::<serde_json::Value>(&body).unwrap()["tools"].clone()
-        }
-
-        assert_eq!(
-            tools_of(AIProvider::OpenAI, "https://api.openai.com/v1").await,
-            serde_json::json!([{ "type": "web_search" }])
-        );
-        assert_eq!(
-            tools_of(
-                AIProvider::AzureOpenAI,
-                "https://example.openai.azure.com/openai"
-            )
-            .await,
-            serde_json::json!([])
-        );
     }
 
     /// The worker prepends the system prompt as a system message *and* passes it as

--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -508,6 +508,10 @@ impl QueryBuilder for OpenAIQueryBuilder {
         build_openai_compatible_proxy_request(args)
     }
 
+    fn supports_chat_completions_fallback(&self, base_url: &str) -> bool {
+        self.provider_kind.is_azure(base_url)
+    }
+
     async fn parse_streaming_response(
         &self,
         response: reqwest::Response,

--- a/backend/windmill-ai/src/query_builder.rs
+++ b/backend/windmill-ai/src/query_builder.rs
@@ -77,6 +77,15 @@ pub trait QueryBuilder: Send + Sync {
         false
     }
 
+    /// Whether a rejected request may be retried on the `/chat/completions`
+    /// surface of the same resource. Azure serves the Responses API for only a
+    /// subset of models and regions, and an Azure model name is a user-chosen
+    /// deployment name that says nothing about the model behind it, so such a
+    /// resource can only find out by being asked.
+    fn supports_chat_completions_fallback(&self, _base_url: &str) -> bool {
+        false
+    }
+
     /// Build a provider-specific request from an OpenAI-compatible proxy request.
     fn build_proxy_request(&self, args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest, Error> {
         Err(Error::BadRequest(format!(

--- a/backend/windmill-ai/src/query_builder.rs
+++ b/backend/windmill-ai/src/query_builder.rs
@@ -77,10 +77,9 @@ pub trait QueryBuilder: Send + Sync {
         false
     }
 
-    /// Whether a rejected request may be retried on the `/chat/completions`
-    /// surface of the same resource. Azure serves the Responses API for only a
-    /// subset of models and regions, and an Azure model name is a user-chosen
-    /// deployment name that says nothing about the model behind it, so such a
+    /// Whether a rejected request may be retried on the `/chat/completions` surface of
+    /// the same resource. Azure serves the Responses API for only a subset of models and
+    /// regions, and an Azure model name is a user-chosen deployment name, so such a
     /// resource can only find out by being asked.
     fn supports_chat_completions_fallback(&self, _base_url: &str) -> bool {
         false

--- a/backend/windmill-ai/src/query_builder.rs
+++ b/backend/windmill-ai/src/query_builder.rs
@@ -11,9 +11,6 @@ pub struct BuildRequestArgs<'a> {
     pub messages: &'a [OpenAIMessage],
     pub tools: Option<&'a [ToolDef]>,
     pub model: &'a str,
-    /// The resource's endpoint, for the request shapes a provider only accepts on
-    /// some of the endpoints it serves.
-    pub base_url: &'a str,
     pub temperature: Option<f32>,
     /// Provider-native reasoning effort token (e.g. `low`, `high`, `none`).
     /// Each `build_request` maps it onto the provider's thinking config.

--- a/backend/windmill-ai/src/query_builder.rs
+++ b/backend/windmill-ai/src/query_builder.rs
@@ -11,6 +11,9 @@ pub struct BuildRequestArgs<'a> {
     pub messages: &'a [OpenAIMessage],
     pub tools: Option<&'a [ToolDef]>,
     pub model: &'a str,
+    /// The resource's endpoint, for the request shapes a provider only accepts on
+    /// some of the endpoints it serves.
+    pub base_url: &'a str,
     pub temperature: Option<f32>,
     /// Provider-native reasoning effort token (e.g. `low`, `high`, `none`).
     /// Each `build_request` maps it onto the provider's thinking config.

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -835,6 +835,9 @@ pub async fn run_agent(
 
     // Create the query builder for the provider
     let mut query_builder = create_query_builder(&credentials, args.provider.get_model());
+    // Both outlive the iteration that discovers them: a request shape or a route the
+    // endpoint rejected once stays rejected for the whole step.
+    let mut include_usage = true;
 
     // Initialize messages
     let mut messages =
@@ -1195,12 +1198,10 @@ pub async fn run_agent(
                     req.body(body)
                 };
 
-            // Two request shapes can be rejected by the endpoint rather than by the
-            // model: `stream_options`, which not every OpenAI-compatible provider
-            // accepts, and the route itself, when an Azure resource is outside the
-            // Responses API's model/region matrix. Each is retried once, and whatever
-            // answers is kept for the rest of the step.
-            let mut include_usage = true;
+            // An endpoint can reject the request shape rather than the model:
+            // `stream_options`, which not every OpenAI-compatible provider accepts, and
+            // the route itself, when an Azure resource is outside the Responses API's
+            // model/region matrix. Each is retried once with that part dropped.
             let resp = loop {
                 let request_body = if include_usage {
                     query_builder

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -23,7 +23,7 @@ use crate::ai::tools::McpClientStub as McpClient;
 use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
-    providers::create_query_builder,
+    providers::{create_chat_completions_query_builder, create_query_builder},
     proxy::{
         common_outbound_headers, needs_unavailable_oauth_exchange, retain_effective_credentials,
     },
@@ -834,7 +834,7 @@ pub async fn run_agent(
     let api_key = credentials.api_key.as_deref().unwrap_or("");
 
     // Create the query builder for the provider
-    let query_builder = create_query_builder(&credentials, args.provider.get_model());
+    let mut query_builder = create_query_builder(&credentials, args.provider.get_model());
 
     // Initialize messages
     let mut messages =
@@ -1185,24 +1185,25 @@ pub async fn run_agent(
             let pinned_ai_client = pinned_ai_client_for(base_url).await?;
 
             // Helper to build HTTP request with headers
-            let build_http_request = |body: String| {
-                let mut req = pinned_ai_client
-                    .post(&endpoint)
-                    .timeout(timeout)
-                    .header("Content-Type", "application/json");
+            let build_http_request =
+                |endpoint: &str, auth_headers: &[(&'static str, String)], body: String| {
+                    let mut req = pinned_ai_client
+                        .post(endpoint)
+                        .timeout(timeout)
+                        .header("Content-Type", "application/json");
 
-                for (header_name, header_value) in &auth_headers {
-                    req = req.header(*header_name, header_value.clone());
-                }
+                    for (header_name, header_value) in auth_headers {
+                        req = req.header(*header_name, header_value.clone());
+                    }
 
-                for (header_name, header_value) in &trailing_headers {
-                    req = req.header(header_name.as_str(), header_value.as_str());
-                }
+                    for (header_name, header_value) in &trailing_headers {
+                        req = req.header(header_name.as_str(), header_value.as_str());
+                    }
 
-                req.body(body)
-            };
+                    req.body(body)
+                };
 
-            let resp = build_http_request(request_body.clone())
+            let resp = build_http_request(&endpoint, &auth_headers, request_body.clone())
                 .send()
                 .await
                 .map_err(|e| Error::internal_err(format!("Failed to call API: {}", e)))?;
@@ -1225,7 +1226,65 @@ pub async fn run_agent(
                             || text.contains("include_usage")
                             || text.contains("Additional properties are not allowed"));
 
-                    if should_retry {
+                    // A resource that does not serve the endpoint this provider prefers
+                    // (an Azure deployment outside the Responses API's model/region
+                    // matrix) rejects the route itself, so the same step runs on
+                    // `/chat/completions` instead, this iteration and the ones after it.
+                    let should_fall_back_to_chat_completions = query_builder
+                        .supports_chat_completions_fallback(base_url)
+                        && matches!(status.as_u16(), 400 | 404)
+                        && *output_type == OutputType::Text;
+
+                    if should_fall_back_to_chat_completions {
+                        tracing::info!(
+                            "Endpoint rejected the request ({}), falling back to chat/completions",
+                            status
+                        );
+
+                        query_builder = create_chat_completions_query_builder(&credentials);
+
+                        let fallback_body = query_builder
+                            .build_request(&build_args, client, &job.workspace_id)
+                            .await?;
+                        let fallback_endpoint = query_builder.get_endpoint(
+                            base_url,
+                            args.provider.get_model(),
+                            output_type,
+                        );
+                        let fallback_auth_headers = retain_effective_credentials(
+                            &credentials,
+                            query_builder.get_auth_headers(api_key, base_url, output_type),
+                        );
+
+                        let fallback_resp = build_http_request(
+                            &fallback_endpoint,
+                            &fallback_auth_headers,
+                            fallback_body,
+                        )
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            Error::internal_err(format!(
+                                "Failed to call API on chat/completions fallback: {}",
+                                e
+                            ))
+                        })?;
+
+                        match fallback_resp.error_for_status_ref() {
+                            Ok(_) => fallback_resp,
+                            Err(fallback_e) => {
+                                let fallback_text = fallback_resp
+                                    .text()
+                                    .await
+                                    .unwrap_or_else(|_| "<failed to read body>".to_string());
+                                return Err(Error::internal_err(format!(
+                                    "API error: {} - {} (the chat/completions fallback also \
+                                     failed: {} - {})",
+                                    e, text, fallback_e, fallback_text
+                                )));
+                            }
+                        }
+                    } else if should_retry {
                         tracing::info!(
                             "Retrying request without stream_options due to provider incompatibility"
                         );
@@ -1234,8 +1293,10 @@ pub async fn run_agent(
                             .build_request_without_usage(&build_args, client, &job.workspace_id)
                             .await?;
 
-                        let retry_resp =
-                            build_http_request(retry_body).send().await.map_err(|e| {
+                        let retry_resp = build_http_request(&endpoint, &auth_headers, retry_body)
+                            .send()
+                            .await
+                            .map_err(|e| {
                                 Error::internal_err(format!("Failed to call API on retry: {}", e))
                             })?;
 

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -23,7 +23,10 @@ use crate::ai::tools::McpClientStub as McpClient;
 use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
-    providers::{create_chat_completions_query_builder, create_query_builder},
+    providers::{
+        create_chat_completions_query_builder, create_query_builder, is_chat_completions_only,
+        remember_chat_completions_only,
+    },
     proxy::{
         common_outbound_headers, needs_unavailable_oauth_exchange, retain_effective_credentials,
     },
@@ -835,6 +838,11 @@ pub async fn run_agent(
 
     // Create the query builder for the provider
     let mut query_builder = create_query_builder(&credentials, args.provider.get_model());
+    if query_builder.supports_chat_completions_fallback(base_url)
+        && is_chat_completions_only(base_url, args.provider.get_model())
+    {
+        query_builder = create_chat_completions_query_builder(&credentials);
+    }
     // Both outlive the iteration that discovers them: a request shape or a route the
     // endpoint rejected once stays rejected for the whole step.
     let mut include_usage = true;
@@ -1260,6 +1268,7 @@ pub async fn run_agent(
                                 "Endpoint rejected the request ({}), falling back to chat/completions",
                                 status
                             );
+                            remember_chat_completions_only(base_url, args.provider.get_model());
                             query_builder = create_chat_completions_query_builder(&credentials);
                             include_usage = true;
                         } else {

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -1210,9 +1210,8 @@ pub async fn run_agent(
             // `stream_options`, which not every OpenAI-compatible provider accepts, and
             // the route itself, when an Azure resource is outside the Responses API's
             // model/region matrix. Each is retried once with that part dropped.
-            // Set when this send re-routed, so the endpoint that answered is the one
-            // remembered: a rejection the fallback did not resolve says nothing about
-            // which routes the deployment serves.
+            // Set where the route is found to be absent, and read once the fallback has
+            // answered: a rejection it did not resolve says nothing about the deployment.
             let mut rerouted_by_a_route_rejection = false;
             let resp = loop {
                 let request_body = if include_usage {

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -1149,7 +1149,6 @@ pub async fn run_agent(
                 messages: &messages,
                 tools: tool_defs.as_deref(),
                 model: args.provider.get_model(),
-                base_url,
                 temperature: args.temperature,
                 reasoning_effort: args.provider.get_reasoning_effort(),
                 max_tokens: args.max_completion_tokens,
@@ -1278,8 +1277,11 @@ pub async fn run_agent(
                                 "Endpoint rejected the request ({}), falling back to chat/completions",
                                 status
                             );
-                            rerouted_by_a_route_rejection =
-                                identifies_unserved_route(status.as_u16(), &text);
+                            rerouted_by_a_route_rejection = identifies_unserved_route(
+                                status.as_u16(),
+                                &text,
+                                args.provider.get_model(),
+                            );
                             query_builder = create_chat_completions_query_builder(&credentials);
                             include_usage = true;
                         } else {

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -1149,20 +1149,13 @@ pub async fn run_agent(
                 has_websearch,
             };
 
-            let request_body = query_builder
-                .build_request(&build_args, client, &job.workspace_id)
-                .await?;
-
-            let endpoint =
-                query_builder.get_endpoint(base_url, args.provider.get_model(), output_type);
-            let auth_headers = query_builder.get_auth_headers(api_key, base_url, output_type);
             // A worker cannot run the client credentials exchange, so an OAuth resource
             // has no token here: the request would carry an empty credential and come
             // back 401.
             if needs_unavailable_oauth_exchange(
                 &credentials,
                 args.provider.resource.token_url.as_deref(),
-                &auth_headers,
+                &query_builder.get_auth_headers(api_key, base_url, output_type),
             ) {
                 return Err(Error::ExecutionErr(format!(
                     "The {:?} resource authenticates with OAuth, which AI agent steps do not \
@@ -1171,7 +1164,6 @@ pub async fn run_agent(
                     credentials.provider
                 )));
             }
-            let auth_headers = retain_effective_credentials(&credentials, auth_headers);
 
             let timeout = resolve_job_timeout(conn, &job.workspace_id, job.id, job.timeout)
                 .await
@@ -1203,118 +1195,78 @@ pub async fn run_agent(
                     req.body(body)
                 };
 
-            let resp = build_http_request(&endpoint, &auth_headers, request_body.clone())
-                .send()
-                .await
-                .map_err(|e| Error::internal_err(format!("Failed to call API: {}", e)))?;
+            // Two request shapes can be rejected by the endpoint rather than by the
+            // model: `stream_options`, which not every OpenAI-compatible provider
+            // accepts, and the route itself, when an Azure resource is outside the
+            // Responses API's model/region matrix. Each is retried once, and whatever
+            // answers is kept for the rest of the step.
+            let mut include_usage = true;
+            let resp = loop {
+                let request_body = if include_usage {
+                    query_builder
+                        .build_request(&build_args, client, &job.workspace_id)
+                        .await?
+                } else {
+                    query_builder
+                        .build_request_without_usage(&build_args, client, &job.workspace_id)
+                        .await?
+                };
+                let endpoint =
+                    query_builder.get_endpoint(base_url, args.provider.get_model(), output_type);
+                let auth_headers = retain_effective_credentials(
+                    &credentials,
+                    query_builder.get_auth_headers(api_key, base_url, output_type),
+                );
 
-            // Check if request failed and we should retry without stream_options
-            let resp = match resp.error_for_status_ref() {
-                Ok(_) => resp,
-                Err(e) => {
-                    let status = resp.status();
-                    let text = resp
-                        .text()
-                        .await
-                        .unwrap_or_else(|_| "<failed to read body>".to_string());
+                let resp = build_http_request(&endpoint, &auth_headers, request_body)
+                    .send()
+                    .await
+                    .map_err(|e| Error::internal_err(format!("Failed to call API: {}", e)))?;
 
-                    // Retry without stream_options if provider supports it and error suggests incompatibility
-                    // Common error patterns: 400 Bad Request with mentions of stream_options or include_usage
-                    let should_retry = query_builder.supports_retry_without_usage()
-                        && status.as_u16() == 400
-                        && (text.contains("stream_options")
-                            || text.contains("include_usage")
-                            || text.contains("Additional properties are not allowed"));
-
-                    // A resource that does not serve the endpoint this provider prefers
-                    // (an Azure deployment outside the Responses API's model/region
-                    // matrix) rejects the route itself, so the same step runs on
-                    // `/chat/completions` instead, this iteration and the ones after it.
-                    let should_fall_back_to_chat_completions = query_builder
-                        .supports_chat_completions_fallback(base_url)
-                        && matches!(status.as_u16(), 400 | 404)
-                        && *output_type == OutputType::Text;
-
-                    if should_fall_back_to_chat_completions {
-                        tracing::info!(
-                            "Endpoint rejected the request ({}), falling back to chat/completions",
-                            status
-                        );
-
-                        query_builder = create_chat_completions_query_builder(&credentials);
-
-                        let fallback_body = query_builder
-                            .build_request(&build_args, client, &job.workspace_id)
-                            .await?;
-                        let fallback_endpoint = query_builder.get_endpoint(
-                            base_url,
-                            args.provider.get_model(),
-                            output_type,
-                        );
-                        let fallback_auth_headers = retain_effective_credentials(
-                            &credentials,
-                            query_builder.get_auth_headers(api_key, base_url, output_type),
-                        );
-
-                        let fallback_resp = build_http_request(
-                            &fallback_endpoint,
-                            &fallback_auth_headers,
-                            fallback_body,
-                        )
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            Error::internal_err(format!(
-                                "Failed to call API on chat/completions fallback: {}",
-                                e
-                            ))
-                        })?;
-
-                        match fallback_resp.error_for_status_ref() {
-                            Ok(_) => fallback_resp,
-                            Err(fallback_e) => {
-                                let fallback_text = fallback_resp
-                                    .text()
-                                    .await
-                                    .unwrap_or_else(|_| "<failed to read body>".to_string());
-                                return Err(Error::internal_err(format!(
-                                    "API error: {} - {} (the chat/completions fallback also \
-                                     failed: {} - {})",
-                                    e, text, fallback_e, fallback_text
-                                )));
-                            }
-                        }
-                    } else if should_retry {
-                        tracing::info!(
-                            "Retrying request without stream_options due to provider incompatibility"
-                        );
-
-                        let retry_body = query_builder
-                            .build_request_without_usage(&build_args, client, &job.workspace_id)
-                            .await?;
-
-                        let retry_resp = build_http_request(&endpoint, &auth_headers, retry_body)
-                            .send()
+                match resp.error_for_status_ref() {
+                    Ok(_) => break resp,
+                    Err(e) => {
+                        let status = resp.status();
+                        let text = resp
+                            .text()
                             .await
-                            .map_err(|e| {
-                                Error::internal_err(format!("Failed to call API on retry: {}", e))
-                            })?;
+                            .unwrap_or_else(|_| "<failed to read body>".to_string());
 
-                        match retry_resp.error_for_status_ref() {
-                            Ok(_) => retry_resp,
-                            Err(retry_e) => {
-                                let retry_text = retry_resp
-                                    .text()
-                                    .await
-                                    .unwrap_or_else(|_| "<failed to read body>".to_string());
-                                return Err(Error::internal_err(format!(
-                                    "API error on retry: {} - {}",
-                                    retry_e, retry_text
-                                )));
-                            }
+                        // Common error patterns: 400 Bad Request with mentions of stream_options or include_usage
+                        let rejects_usage_tracking = include_usage
+                            && query_builder.supports_retry_without_usage()
+                            && status.as_u16() == 400
+                            && (text.contains("stream_options")
+                                || text.contains("include_usage")
+                                || text.contains("Additional properties are not allowed"));
+
+                        // Only the first call of the step may re-route: an endpoint that
+                        // does not serve this API rejects that one already, whereas a
+                        // rejection once the conversation is under way is about the
+                        // conversation (context length, content filter, tool schema).
+                        let route_unserved = i == 0
+                            && query_builder.supports_chat_completions_fallback(base_url)
+                            && matches!(status.as_u16(), 400 | 404)
+                            && *output_type == OutputType::Text;
+
+                        if rejects_usage_tracking {
+                            tracing::info!(
+                                "Retrying request without stream_options due to provider incompatibility"
+                            );
+                            include_usage = false;
+                        } else if route_unserved {
+                            tracing::info!(
+                                "Endpoint rejected the request ({}), falling back to chat/completions",
+                                status
+                            );
+                            query_builder = create_chat_completions_query_builder(&credentials);
+                            include_usage = true;
+                        } else {
+                            return Err(Error::internal_err(format!(
+                                "API error calling {}: {} - {}",
+                                endpoint, e, text
+                            )));
                         }
-                    } else {
-                        return Err(Error::internal_err(format!("API error: {} - {}", e, text)));
                     }
                 }
             };

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -24,8 +24,8 @@ use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
     providers::{
-        create_chat_completions_query_builder, create_query_builder, identifies_unserved_route,
-        is_chat_completions_only, remember_chat_completions_only,
+        create_chat_completions_query_builder, create_query_builder, is_chat_completions_only,
+        remember_chat_completions_only,
     },
     proxy::{
         common_outbound_headers, needs_unavailable_oauth_exchange, retain_effective_credentials,
@@ -1277,11 +1277,11 @@ pub async fn run_agent(
                                 "Endpoint rejected the request ({}), falling back to chat/completions",
                                 status
                             );
-                            rerouted_by_a_route_rejection = identifies_unserved_route(
-                                status.as_u16(),
-                                &text,
-                                args.provider.get_model(),
-                            );
+                            // Only a 404 says the route is absent. A 400 is ambiguous —
+                            // a deployment that does serve the route rejects tool
+                            // schemas, blocked hosted tools and filtered content the
+                            // same way — so it re-routes this step and nothing more.
+                            rerouted_by_a_route_rejection = status.as_u16() == 404;
                             query_builder = create_chat_completions_query_builder(&credentials);
                             include_usage = true;
                         } else {

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -24,8 +24,8 @@ use windmill_ai::{
     ai_providers::AIProvider,
     image_handler::upload_image_to_s3,
     providers::{
-        create_chat_completions_query_builder, create_query_builder, is_chat_completions_only,
-        remember_chat_completions_only,
+        create_chat_completions_query_builder, create_query_builder, identifies_unserved_route,
+        is_chat_completions_only, remember_chat_completions_only,
     },
     proxy::{
         common_outbound_headers, needs_unavailable_oauth_exchange, retain_effective_credentials,
@@ -1149,6 +1149,7 @@ pub async fn run_agent(
                 messages: &messages,
                 tools: tool_defs.as_deref(),
                 model: args.provider.get_model(),
+                base_url,
                 temperature: args.temperature,
                 reasoning_effort: args.provider.get_reasoning_effort(),
                 max_tokens: args.max_completion_tokens,
@@ -1210,6 +1211,10 @@ pub async fn run_agent(
             // `stream_options`, which not every OpenAI-compatible provider accepts, and
             // the route itself, when an Azure resource is outside the Responses API's
             // model/region matrix. Each is retried once with that part dropped.
+            // Set when this send re-routed, so the endpoint that answered is the one
+            // remembered: a rejection the fallback did not resolve says nothing about
+            // which routes the deployment serves.
+            let mut rerouted_by_a_route_rejection = false;
             let resp = loop {
                 let request_body = if include_usage {
                     query_builder
@@ -1233,7 +1238,12 @@ pub async fn run_agent(
                     .map_err(|e| Error::internal_err(format!("Failed to call API: {}", e)))?;
 
                 match resp.error_for_status_ref() {
-                    Ok(_) => break resp,
+                    Ok(_) => {
+                        if rerouted_by_a_route_rejection {
+                            remember_chat_completions_only(base_url, args.provider.get_model());
+                        }
+                        break resp;
+                    }
                     Err(e) => {
                         let status = resp.status();
                         let text = resp
@@ -1268,7 +1278,8 @@ pub async fn run_agent(
                                 "Endpoint rejected the request ({}), falling back to chat/completions",
                                 status
                             );
-                            remember_chat_completions_only(base_url, args.provider.get_model());
+                            rerouted_by_a_route_rejection =
+                                identifies_unserved_route(status.as_u16(), &text);
                             query_builder = create_chat_completions_query_builder(&credentials);
                             include_usage = true;
                         } else {


### PR DESCRIPTION
## Summary

Fixes WIN-2260.

The `AzureOpenAI` provider fell through to `OtherQueryBuilder` in `create_query_builder`, which targets `/chat/completions`. Newer Azure OpenAI deployments reject a `reasoning_effort` combined with function tools on that endpoint, so AI agent steps on those models fail. `AzureOpenAI` now uses `OpenAIQueryBuilder` like `OpenAI` does, targeting `/responses`.

`OpenAIQueryBuilder` already handles Azure through `is_azure()`: `build_azure_openai_url` resolves every stored base-URL shape (bare resource root, `/openai`, `/openai/v1`, `/openai/deployments/<id>`) to `<root>/openai/v1/responses`, and auth stays on the `api-key` header. This also aligns the agent step with the copilot chat, which already routes `azure_openai` through the Responses API (`frontend/src/lib/components/copilot/lib.ts`).

Azure serves the Responses API for only a subset of models and regions, and the routing decision cannot be made per model — on Azure the model name is a deployment name chosen by the user, which says nothing about the model behind it. So a resource outside that matrix would have regressed from a working `/chat/completions` call to a failing `/responses` one. Two things keep those resources working without giving up the fix for everyone else:

- **Per step**, a first call rejected with 400/404 re-routes to `/chat/completions` and stays there for the rest of the step. A rejection once the conversation is under way is not re-routed: by then a 400 is about the conversation (context length, content filter, tool schema), and re-routing would hide the real cause and pin a working `/responses` step to the endpoint this PR moves off.
- **Across steps**, the worker remembers the deployment so later steps start on `/chat/completions` directly — but only when the fallback actually answered *and* the rejection was a **404**, the one status that says the route is absent. Every 400 is ambiguous, since a deployment that does serve the route rejects tool schemas, blocked hosted tools and filtered content the same way, so a 400 re-routes that step alone and is not remembered. The cost of that conservatism is one rejected call per step for a deployment that answers 400 rather than 404, which is what this PR would do anyway without the cache.

## Changes

- `create_query_builder`: `AIProvider::AzureOpenAI` joins the `AIProvider::OpenAI` arm, so it builds an `OpenAIQueryBuilder`.
- New `QueryBuilder::supports_chat_completions_fallback(base_url)` (default `false`), implemented by `OpenAIQueryBuilder` as `is_azure(base_url)` — the only resources whose preferred surface may not be served. `create_chat_completions_query_builder` builds the replacement.
- `ai_executor`: the two rejections that are about the request shape rather than the model — `stream_options` and the route itself — are handled by one retry loop around the send. Each is retried once with that part dropped, and both decisions persist across the step's iterations, so a later iteration does not re-send a shape the endpoint already rejected. Errors name the endpoint that failed.
- `is_chat_completions_only` / `remember_chat_completions_only`: a worker-local cache keyed by endpoint **and** deployment name (Azure's support varies by both), holding only rejections, expiring after an hour so a deployment that gains Responses support is picked up. The factory stays pure — the cache is consulted in the worker, so the API proxy is unaffected.
- Parity test: the `AzureOpenAI` case now pins `responses` instead of `chat/completions`. The test asserts the proxy and the agent step agree on the endpoint and the credential header, so it fails if the routing regresses.

## Notes

- Web search is unchanged: Azure serves the same `{"type": "web_search"}` hosted tool on `/openai/v1/responses` for GPT-4-and-later deployments ([docs](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/web-search)), so moving Azure onto this endpoint *gains* working web search for agent steps, where `OtherQueryBuilder` silently ignored it. A subscription that blocks the tool rejects the request with a 400 instead; that step re-routes and completes without search, and nothing is remembered.
- `azure_foundry` deliberately stays on `/chat/completions` for non-Claude deployments: that resource kind also fronts model families (Llama, DeepSeek, Mistral, Phi) with no Responses API. Now that a probe-and-remember mechanism exists, applying it to Foundry is a plausible follow-up, but it needs its own decision and is out of scope here.
- The cache is per worker process, so each worker pays at most one probe per deployment per TTL. A shared or DB-backed probe would cost more than the single rejected call it saves.

## Test plan

- [x] `cargo test -p windmill-ai` — 105 passed, including the parity case pinning the new route and a guard that the cache is keyed per deployment. `cargo check -p windmill-worker` clean.
- [x] End-to-end against a mock endpoint, running real AI agent steps with an inline provider resource (`reasoning_effort: medium`):
  - `azure_openai`, endpoint serves Responses → one call, **`POST /openai/v1/responses`**, `api-key` header, Responses-shaped body (`input` / `instructions` / `reasoning: {effort}`). Before the change the same step went to `/chat/completions`.
  - `azure_openai`, endpoint 404s Responses → `/responses`, then **re-routed to `/chat/completions`** with the same `api-key` header and a well-formed completions body; step completed on the fallback. Two consecutive steps → the endpoint saw `/responses` **once**: a 404 is remembered.
  - Endpoint 400s `/responses` with `Invalid schema for function ...`, and separately with `The tool web_search is not supported for this subscription` → the step re-routes and succeeds both times, and the **next step probes `/responses` again**: no 400 is remembered.
  - `customai`, endpoint 400s `stream_options` with "Additional properties are not allowed", model calls a tool → call 1 with `stream_options` rejected, call 2 without it returns the tool call, call 3 (with the tool result) sent without `stream_options`. The pre-existing retry still works for every OpenAI-compatible provider and is not re-litigated per iteration.
- [ ] Verify against a real Azure OpenAI resource on a Responses-capable deployment with a function tool attached.