### PR TITLE
feat: sidebar workspace toggle navigates home when already in workspace mode

### DIFF
--- a/frontend/src/lib/components/common/toggleButton-v2/ToggleButton.svelte
+++ b/frontend/src/lib/components/common/toggleButton-v2/ToggleButton.svelte
@@ -21,10 +21,11 @@
 		item: ToggleGroupElements['item']
 		value: ToggleGroupItemProps
 		class?: string
-		// Fires on every click, including one on the already-selected button — which
-		// the group's onSelected never reports (melt treats it as a deselection and
-		// the group keeps the current value).
-		onclick?: (e: MouseEvent) => void
+		// Fires on activation, including on the already-selected button — which the
+		// group's onSelected never reports (melt treats it as a deselection and the
+		// group keeps the current value). Keyboard activation needs its own keydown
+		// branch below: melt preventDefaults Enter/Space, so no click is synthesized.
+		onActivate?: (e: Event) => void
 	}
 
 	let {
@@ -43,7 +44,7 @@
 		item,
 		value,
 		class: className = '',
-		onclick
+		onActivate
 	}: Props = $props()
 
 	// Handle backward compatibility: small prop maps to size="sm"
@@ -79,7 +80,10 @@
 		)}
 		use:melt={$item(value)}
 		style={selectedColor ? `--selected-color: ${selectedColor}` : ''}
-		{onclick}
+		onclick={onActivate}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') onActivate?.(e)
+		}}
 	>
 		{#if icon}
 			{@const SvelteComponent = icon}

--- a/frontend/src/lib/components/common/toggleButton-v2/ToggleButton.svelte
+++ b/frontend/src/lib/components/common/toggleButton-v2/ToggleButton.svelte
@@ -82,7 +82,9 @@
 		style={selectedColor ? `--selected-color: ${selectedColor}` : ''}
 		onclick={onActivate}
 		onkeydown={(e) => {
-			if (e.key === 'Enter' || e.key === ' ') onActivate?.(e)
+			// `repeat` filtered out: a held key keeps firing keydown, and one activation
+			// must mean one call however the consumer's side effect behaves.
+			if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) onActivate?.(e)
 		}}
 	>
 		{#if icon}

--- a/frontend/src/lib/components/common/toggleButton-v2/ToggleButton.svelte
+++ b/frontend/src/lib/components/common/toggleButton-v2/ToggleButton.svelte
@@ -21,6 +21,10 @@
 		item: ToggleGroupElements['item']
 		value: ToggleGroupItemProps
 		class?: string
+		// Fires on every click, including one on the already-selected button — which
+		// the group's onSelected never reports (melt treats it as a deselection and
+		// the group keeps the current value).
+		onclick?: (e: MouseEvent) => void
 	}
 
 	let {
@@ -38,7 +42,8 @@
 		id = undefined,
 		item,
 		value,
-		class: className = ''
+		class: className = '',
+		onclick
 	}: Props = $props()
 
 	// Handle backward compatibility: small prop maps to size="sm"
@@ -74,6 +79,7 @@
 		)}
 		use:melt={$item(value)}
 		style={selectedColor ? `--selected-color: ${selectedColor}` : ''}
+		{onclick}
 	>
 		{#if icon}
 			{@const SvelteComponent = icon}

--- a/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
+++ b/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
@@ -4,6 +4,8 @@
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import { enterSessionMode, exitSessionMode } from './sessionSwitch.svelte'
 	import { goto } from '$lib/navigation'
+	import { page } from '$app/state'
+	import { base } from '$lib/base'
 
 	// Which side of the switch is active. `nav` = workspace navigation (the classic
 	// app), `session` = the sessions sidebar + chat + preview.
@@ -28,6 +30,9 @@
 	// drawer should dismiss like it does for any other nav link.
 	function onNavActivate() {
 		if (mode !== 'nav') return
+		// `goto` has no same-URL short-circuit, so navigating from home would push a
+		// duplicate history entry and make the next Back press look broken.
+		if (page.url.pathname === `${base}/`) return
 		void goto('/')
 	}
 </script>

--- a/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
+++ b/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	import { House, MessagesSquare } from 'lucide-svelte'
+	import { Building, MessagesSquare } from 'lucide-svelte'
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import { enterSessionMode, exitSessionMode } from './sessionSwitch.svelte'
+	import { goto } from '$lib/navigation'
 
 	// Which side of the switch is active. `nav` = workspace navigation (the classic
 	// app), `session` = the sessions sidebar + chat + preview.
@@ -20,6 +21,16 @@
 		if (next === 'session') void enterSessionMode()
 		else void exitSessionMode()
 	}
+
+	// Pressing the already-active "Workspace" side goes home, so the toggle doubles
+	// as the home button when there is no mode to switch to. It needs its own click
+	// handler because the group reports only real changes through onSelected.
+	// `onToggle` is deliberately not fired: this is a plain in-mode navigation, so
+	// the mobile menu drawer should dismiss like it does for any other nav link.
+	function onNavClick() {
+		if (mode !== 'nav') return
+		void goto('/')
+	}
 </script>
 
 <!-- Each ToggleButton renders inside a Tooltip wrapper, which is the actual flex
@@ -34,12 +45,13 @@
 		<ToggleButton
 			{item}
 			value="nav"
-			icon={isCollapsed ? House : undefined}
+			icon={isCollapsed ? Building : undefined}
 			label="Workspace"
 			iconOnly={isCollapsed}
 			tooltip={isCollapsed ? 'Workspace' : undefined}
 			size="sm"
 			class="w-full justify-center"
+			onclick={onNavClick}
 		/>
 		<ToggleButton
 			{item}

--- a/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
+++ b/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
@@ -23,11 +23,10 @@
 	}
 
 	// Pressing the already-active "Workspace" side goes home, so the toggle doubles
-	// as the home button when there is no mode to switch to. It needs its own click
-	// handler because the group reports only real changes through onSelected.
-	// `onToggle` is deliberately not fired: this is a plain in-mode navigation, so
-	// the mobile menu drawer should dismiss like it does for any other nav link.
-	function onNavClick() {
+	// as the home button when there is no mode to switch to. `onToggle` is
+	// deliberately not fired: this is a plain in-mode navigation, so the mobile menu
+	// drawer should dismiss like it does for any other nav link.
+	function onNavActivate() {
 		if (mode !== 'nav') return
 		void goto('/')
 	}
@@ -51,7 +50,7 @@
 			tooltip={isCollapsed ? 'Workspace' : undefined}
 			size="sm"
 			class="w-full justify-center"
-			onclick={onNavClick}
+			onActivate={onNavActivate}
 		/>
 		<ToggleButton
 			{item}


### PR DESCRIPTION
## Summary

In the sidebar, the `Workspace` / `AI Sessions` switch did nothing when you pressed the side you were already on. Pressing `Workspace` while in workspace mode now navigates to Home, so the toggle doubles as a home button when there is no mode to switch to.

The switch is a melt single-type toggle group, which treats an activation of the already-selected side as a deselection — `ToggleButtonGroup` swallows it (`onValueChange` returns `curr` without dispatching), so `onSelected` never fires for that case. `SessionModeSwitch`'s existing `if (next === mode) return` guard was already unreachable. Hence the new `onActivate` escape hatch on `ToggleButton`.

The collapsed rail's `Workspace` icon also changes from `House` to `Building` — the icon `WorkspaceMenu`'s trigger and `WorkspaceIcon` already use for a workspace.

Exiting session mode is unchanged: pressing `Workspace` from `/sessions` still returns to the last remembered nav route, not Home.

## Changes

- `ToggleButton.svelte`: optional `onActivate` prop, so a caller can react to an activation of the already-selected item. Wired to both `onclick` and an Enter/Space `onkeydown` branch — melt `preventDefault`s Enter/Space on the item, which suppresses the browser-synthesized click, so a click-only hook would be pointer-only. Melt's own listeners neither stop propagation nor fire twice, so the group's state is untouched and each activation calls `onActivate` exactly once.
- `SessionModeSwitch.svelte`: `onNavActivate` on the `Workspace` button — `goto('/')` when `mode === 'nav'`, no-op otherwise so the existing `onSelected` → `exitSessionMode()` path still wins from session mode. It deliberately does not fire `onToggle` (that callback keeps the mobile drawer open across a *mode switch*; going home is an ordinary nav link and should dismiss it).
- `SessionModeSwitch.svelte`: collapsed-rail icon `House` → `Building`.

No test added: this is a Svelte-only interaction change with no new pure-logic utility to pin.

## Screenshots

Collapsed rail — the `Workspace` toggle now carries the `Building` workspace icon (selected, below the workspace avatar):

![rail-collapsed-context](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-home-navigation/1785331288-rail-collapsed-context.png)

Expanded rail — unchanged, label-only:

![rail-expanded-toggle](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-home-navigation/1785331290-rail-expanded-toggle.png)

Landing on Home after pressing the already-active `Workspace` toggle from `/runs`:

![home-collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-home-navigation/1785331292-home-collapsed.png)

## Test plan

Browser-verified against a local EE backend:

- [x] From `/runs` with the rail collapsed, click the already-selected `Workspace` toggle → lands on `/`
- [x] From `/schedules` with the rail expanded, same → lands on `/`, and the toggle stays `nav:on` (no deselect flicker)
- [x] Keyboard: focus the `Workspace` toggle and press Enter → lands on `/`, exactly one navigation (no double-fire from a synthesized click)
- [x] Keyboard: *holding* Enter adds exactly one history entry (the `e.repeat` guard)
- [x] Pressing `Workspace` twice while already on `/` adds no history entry, and Back returns straight to the previous page
- [x] Keyboard: same with Space → lands on `/`
- [x] From `/schedules` → `AI Sessions` → `Workspace` returns to `/schedules` (remembered nav route), not Home — by mouse
- [x] From `/folders` → `AI Sessions` → `Workspace` by keyboard Enter returns to `/folders`, not Home
- [x] Collapsed rail renders the `Building` icon
- [ ] Mobile drawer: pressing the already-selected `Workspace` toggle navigates home and dismisses the drawer; switching modes still preserves it