### PR TITLE
fix: app progress bar stuck on running, and misreporting queued/canceled jobs as errors

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -9257,6 +9257,7 @@ pub fn start_job_update_sse_stream(
         // Send initial update immediately
         let mut running = running;
         let mut mem_peak = 0;
+        let mut get_progress_m: bool = false;
 
         match get_job_update_data(
             &opt_authed,
@@ -9266,7 +9267,7 @@ pub fn start_job_update_sse_stream(
             &job_id,
             log_offset,
             stream_offset,
-            false,
+            get_progress.unwrap_or(false),
             running,
             true,
             true,
@@ -9282,6 +9283,9 @@ pub fn start_job_update_sse_stream(
         .await
         {
             Ok(mut update) => {
+                if update.progress.is_some() {
+                    get_progress_m = true;
+                }
                 last_update_hash = Some(update.hash_str());
                 let completion_sent = update.completed.unwrap_or(false);
                 if running.is_some() && update.running.is_some_and(|x| x) {
@@ -9327,7 +9331,6 @@ pub fn start_job_update_sse_stream(
             }
         }
 
-        let mut get_progress_m: bool = false;
         // Poll for updates every 1 second
         let mut i = 0;
         let start = Instant::now();
@@ -9417,6 +9420,26 @@ pub fn start_job_update_sse_stream(
                             get_progress_m = true;
                         } else {
                             last_progress_check = Instant::now();
+                        }
+                    }
+
+                    // A job that finishes in between two throttled progress checks would
+                    // otherwise report no progress at all, leaving the caller unable to tell
+                    // at which progress it ended.
+                    if get_progress.unwrap_or(false)
+                        && update.progress.is_none()
+                        && update.completed.unwrap_or(false)
+                    {
+                        match sqlx::query_scalar!(
+                            "SELECT (scalar_int)::int FROM job_stats WHERE job_id = $1 AND workspace_id = $2 AND metric_id = 'progress_perc'",
+                            job_id, &w_id)
+                            .fetch_optional(&db)
+                            .await
+                        {
+                            Ok(progress) => update.progress = progress.flatten(),
+                            Err(e) => tracing::warn!(
+                                "Failed to get final progress for job {job_id}: {e:#}"
+                            ),
                         }
                     }
 

--- a/frontend/src/lib/components/jobs/JobProgressBar.svelte
+++ b/frontend/src/lib/components/jobs/JobProgressBar.svelte
@@ -36,9 +36,10 @@
 		} else {
 			error = undefined
 		}
-		// Anything that is success automatically gets 100% progress
-		if (job['success'] && scriptProgress)
-			((index = 1), (subLength = 0), (subIndex = 0), (scriptProgress = 100))
+		// Anything that is success automatically gets 100% progress. Not gated on
+		// `scriptProgress`: a job can complete without ever reporting progress, and the bar
+		// would then stay on `Running` forever.
+		if (job['success']) ((index = 1), (subLength = 0), (subIndex = 0), (scriptProgress = 100))
 	}
 
 	export function reset() {

--- a/frontend/src/lib/components/jobs/JobProgressBar.svelte
+++ b/frontend/src/lib/components/jobs/JobProgressBar.svelte
@@ -26,19 +26,22 @@
 	let subLength: number = $state(100)
 	let length = $state(1)
 	let nextInProgress = false
+	let isCanceled = $state(false)
+	let isScheduled = $state(false)
 
 	let progressBar: ProgressBar | undefined = $state(undefined)
 	let lastJobId = $state()
 
 	function updateJobProgress(job: Job) {
-		if (!job['running'] && !job['success']) {
-			error = 0
-		} else {
-			error = undefined
-		}
+		const completed = job.type === 'CompletedJob'
+		isCanceled = job['canceled'] ?? false
+		// A job still in the queue simply has not started: not running is only a failure
+		// signal once the job is completed.
+		isScheduled = !completed && !job['running']
+		error = completed && !job['success'] && !isCanceled ? 0 : undefined
 		// Anything that is success automatically gets 100% progress. Not gated on
 		// `scriptProgress`: a job can complete without ever reporting progress, and the bar
-		// would then stay on `Running` forever.
+		// would then stay on `Running` forever. A canceled job keeps the progress it reached.
 		if (job['success']) ((index = 1), (subLength = 0), (subIndex = 0), (scriptProgress = 100))
 	}
 
@@ -49,6 +52,8 @@
 		subLength = 100
 		length = 1
 		index = 0
+		isCanceled = false
+		isScheduled = false
 		scriptProgress = undefined
 	}
 
@@ -78,4 +83,6 @@
 	class={className}
 	{compact}
 	{hideStepTitle}
+	{isCanceled}
+	{isScheduled}
 />


### PR DESCRIPTION
## Summary

Fixes WIN-2262. Three defects in the same progress bar, all only visible in the app
`Progress Bar by Job Id` component because every other consumer renders the bar behind
`{#if scriptProgress}` and therefore never hits them.

1. **Stuck on `Running`.** `JobProgressBar` only transitioned to `Done` when
   `job.success && scriptProgress` were both truthy. `scriptProgress` comes from the job update
   stream, which is throttled to look for progress at most every 5s, so a job that finished
   before the first check reported no progress at all and the bar never left `Running`.
2. **No final progress for a job that ended inside the throttle window**, so a failed job
   displayed 0% instead of the percentage it failed at. The Run page papers over this by
   calling `MetricsService.getJobProgress()` on completion, but that endpoint sits under the
   authed workspaced router: an anonymous viewer of a public app cannot call it, which is why
   the app viewer only ever used the SSE stream (`jobs_u/getupdate_sse`). Fixed in the stream
   instead of with a frontend fetch, so it works for anonymous viewers too.
3. **Queued and canceled jobs rendered as `Error occurred`.** The failure test was
   `!job.running && !job.success`, which a `QueuedJob` waiting for a worker satisfies before it
   has started. Cancellation was indistinguishable from failure. `ProgressBar` already knows how
   to render `(not started)` and `Canceled`; `JobProgressBar` never passed those props.

## Changes

- `JobProgressBar.svelte`: complete the bar on `job.success` alone, no longer gated on a
  progress value having arrived; only treat a job as failed once it is a `CompletedJob` that is
  neither successful nor canceled; forward `isCanceled` / `isScheduled` to `ProgressBar`.
- `jobs.rs` (`start_job_update_sse_stream`): when an update reports the job completed and the
  throttle skipped that iteration's progress check, read `progress_perc` once so the final
  update carries it. Also request progress on the stream's initial update (previously hardcoded
  `false`) and latch `get_progress_m` from it, so a job that already has progress when the
  stream opens reports it immediately instead of after the first 5s window.

The extra read runs at most once per stream, only when the caller passed `get_progress=true`,
and reuses the query text already in `job_metrics.rs` so the sqlx offline cache is unchanged.

Known gap: a job that was **already finished** when the app loads (a pinned static job id, or a
page reload) still shows its terminal state without a final percentage. The frontend
deliberately opens no stream for a completed job, and progress is not part of the
anonymous-readable job payload; exposing it would need a new `jobs_u` route, out of scope here.

No test added: these are rendering paths over a stream/throttle race, and the frontend has no
harness for `JobProgressBar` that would pin them without elaborate fixtures.

## Test plan

- [x] `npm run check` — 0 errors; backend compiles clean under `cargo watch`
- [x] App progress bar on an already-completed successful job → `Done 100%` (was `Running 0%`)
- [x] App button running an 8s job (no progress reported) → `Running` then `Done 100%`
- [x] App button running a job that sets progress 65% and fails 1.5s later (inside the old 5s
      blind window) → `Error occurred 65%` (was `Error occurred 0%`)
- [x] Bars pointed at a queued / canceled / failed / successful job → `(not started)`,
      `Canceled`, `Error occurred`, `Done 100%` (the first three were all `Error occurred`)
- [x] SSE probe on a completed job with `get_progress=true` returns `progress` in the
      completion update (before: absent)

## Screenshots

Four job states, one bar each — before / after:

![before-job-states](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785392352-before-job-states.png)
![after-job-states](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785392354-after-job-states.png)

Job already finished when the app loads — before / after:

![before-stuck-running](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785390328-before-stuck-running.png)
![final-success-done](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785391401-final-success-done.png)

Live run that reports 65% then fails 1.5s later — before / after:

![before-sse-failed-0](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785391398-before-sse-failed-0.png)
![after-sse-failed-65b](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785391400-after-sse-failed-65b.png)

Live 8s run with no progress reported reaching `Done`:

![after-live-done](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2262-fix-app-progress-bar-stuck-in-running-after-job-completes/1785390332-after-live-done.png)