### PR TITLE
fix: pre-warm coursier bootstrap cache at the worker's cache path

### DIFF
--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -27,7 +27,11 @@ RUN apt-get -y update && apt-get install -y default-jdk
 RUN curl -fLo coursier https://github.com/coursier/coursier/releases/download/v2.1.24/coursier \
 	&& mv ./coursier /usr/bin/coursier \
 	&& chmod +x /usr/bin/coursier
-RUN /usr/bin/java -jar /usr/bin/coursier about
+# The worker runs coursier with COURSIER_CACHE=$WINDMILL_DIR/cache/java/coursier-cache, so the
+# bootstrap JARs must be pre-warmed there: at coursier's default (~/.cache/coursier) they are
+# re-downloaded from Maven Central on the first java job, which fails on air-gapped networks.
+RUN mkdir -p /tmp/windmill/cache/java/coursier-cache \
+	&& COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache /usr/bin/java -jar /usr/bin/coursier about
 
 # Ruby
 RUN apt-get install -y ruby ruby-bundler
@@ -36,7 +40,9 @@ RUN apt-get install -y ruby ruby-bundler
 RUN apt-get install -y r-base-dev \
     && Rscript -e 'install.packages("renv", lib="/usr/lib/R/library", repos="https://cloud.r-project.org")'
 
-# Fix UV cache permissions for non-root user support (uid 1000, etc.)
-# The uv tool install ansible command populates the UV cache with root-owned files
-RUN chmod -R a+rw /tmp/windmill/cache/uv && \
-    find /tmp/windmill/cache/uv -type d -exec chmod 777 {} +
+# Fix runtime cache permissions for non-root user support (uid 1000, etc.)
+# The build pre-populates these caches with root-owned files (uv tool install ansible, the
+# coursier bootstrap), while the worker may run as any uid and needs to write to them.
+RUN set -e; for d in /tmp/windmill/cache/uv /tmp/windmill/cache/java; do \
+        chmod -R a+rw "$d"; find "$d" -type d -exec chmod 777 {} + ; \
+    done

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -54,7 +54,11 @@ RUN apt-get -y update && apt-get install -y default-jdk
 RUN curl -fLo coursier https://github.com/coursier/coursier/releases/download/v2.1.24/coursier \
 	&& mv ./coursier /usr/bin/coursier \
 	&& chmod +x /usr/bin/coursier
-RUN /usr/bin/java -jar /usr/bin/coursier about
+# The worker runs coursier with COURSIER_CACHE=$WINDMILL_DIR/cache/java/coursier-cache, so the
+# bootstrap JARs must be pre-warmed there: at coursier's default (~/.cache/coursier) they are
+# re-downloaded from Maven Central on the first java job, which fails on air-gapped networks.
+RUN mkdir -p /tmp/windmill/cache/java/coursier-cache \
+	&& COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache /usr/bin/java -jar /usr/bin/coursier about
 
 # Ruby
 RUN apt-get install -y ruby ruby-bundler
@@ -69,7 +73,9 @@ RUN apt-get install -y iptables
 # Kerberos runtime
 RUN apt-get install -y libsasl2-modules-gssapi-mit krb5-user
 
-# Fix UV cache permissions for non-root user support (uid 1000, etc.)
-# The uv tool install ansible command populates the UV cache with root-owned files
-RUN chmod -R a+rw /tmp/windmill/cache/uv && \
-    find /tmp/windmill/cache/uv -type d -exec chmod 777 {} +
+# Fix runtime cache permissions for non-root user support (uid 1000, etc.)
+# The build pre-populates these caches with root-owned files (uv tool install ansible, the
+# coursier bootstrap), while the worker may run as any uid and needs to write to them.
+RUN set -e; for d in /tmp/windmill/cache/uv /tmp/windmill/cache/java; do \
+        chmod -R a+rw "$d"; find "$d" -type d -exec chmod 777 {} + ; \
+    done


### PR DESCRIPTION
## Summary

Fixes WIN-2264.

`DockerfileFull` / `DockerfileFullEe` pre-warm the Coursier bootstrap during build with
`java -jar /usr/bin/coursier about`, but with no `COURSIER_CACHE` set that writes to
`/root/.cache/coursier/v1`. At runtime the worker always runs Coursier with
`COURSIER_CACHE=$WINDMILL_DIR/cache/java/coursier-cache` (`COURSIER_CACHE_DIR`,
`windmill-worker/src/worker.rs:234`), so the pre-warmed bootstrap JARs are never found and
Coursier re-downloads its own runtime JARs from Maven Central on the first Java job. Invisible
when Maven Central is reachable, fatal on restricted/air-gapped networks.

The pre-warm now targets the runtime cache path. Because that also creates
`/tmp/windmill/cache/java` as a root-owned `0755` dir inside the image (today the worker creates
it itself), the existing "fix UV cache permissions" step is extended to cover the Java cache —
without it a non-root worker (uid 1000) dies with `AccessDeniedException` on
`/tmp/windmill/cache/java/home`.

## Changes

- `docker/DockerfileFull`, `docker/DockerfileFullEe`: run the Coursier bootstrap pre-warm with
  `COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache` (the default `WINDMILL_DIR`-derived
  path the worker uses).
- Same files: the final permission-fix step now loops over both `/tmp/windmill/cache/uv` and
  `/tmp/windmill/cache/java` (with `set -e` so a failure on any dir still fails the build).

No net image growth: the same ~43 MB of bootstrap JARs simply move from `/root/.cache/coursier`
to the runtime cache path.

## Test plan

Validated on a minimal repro image (`debian:trixie-slim` + `default-jdk-headless` + the exact
Coursier stanza), running the worker's invocation shape offline (`--network=none`,
`COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache`) to simulate an air-gapped network:

- [x] **Cache location** — before: 43M in `/root/.cache/coursier`, runtime path absent. After:
      43M at `/tmp/windmill/cache/java/coursier-cache`.
- [x] **Air-gapped bootstrap, before the fix** — `EXIT=255`, six
      `Error while downloading https://repo1.maven.org/...coursier-cli_2.13-2.1.24.jar` failures.
- [x] **Air-gapped bootstrap, after the fix** — `EXIT=0`,
      `Cache location: /tmp/windmill/cache/java/coursier-cache`.
- [x] **Non-root (uid 1000), after the fix without the chmod** — `EXIT=1`,
      `java.nio.file.AccessDeniedException: /tmp/windmill/cache/java/home`.
- [x] **Non-root (uid 1000), with the chmod step** — `EXIT=0`.
- [x] `docker build --check` clean on both Dockerfiles.
- [ ] CI builds the full images (the real base image could not be built locally — host disk was
      full), then a Java script runs on a `:full` image.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-warms the `coursier` bootstrap at the worker’s runtime cache path and fixes cache permissions for non-root users. Prevents first-run downloads and failures on air-gapped networks (WIN-2264).

- **Bug Fixes**
  - Pre-warm `coursier` at `/tmp/windmill/cache/java/coursier-cache` in `DockerfileFull` and `DockerfileFullEe` to match the worker `COURSIER_CACHE`
  - Grant write access for non-root users by fixing perms on `/tmp/windmill/cache/uv` and `/tmp/windmill/cache/java`

<sup>Written for commit 5b645356e6b6a2f7d326096e60bdcef36227a810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

