### PR TITLE
fix: make /usr/bin/coursier self-contained so java jobs work air-gapped

### DIFF
--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -25,15 +25,18 @@ COPY --from=ghcr.io/nushell/nushell:0.101.0-bookworm /usr/bin/nu /usr/bin/nu
 # Java
 RUN apt-get -y update && apt-get install -y default-jdk
 ARG COURSIER_VERSION=2.1.24
-# The released coursier launcher downloads its own JARs from Maven Central the first time it runs,
-# so java jobs break on air-gapped networks. Pre-warming a cache at build time cannot fix that:
-# the cache the worker reads lives under WINDMILL_DIR, which deployments mount over. Repackage the
-# CLI as a self-contained assembly instead, so /usr/bin/coursier starts with no cache and no network.
+# The released coursier launcher downloads its own JARs from Maven Central on first run, so java
+# jobs break on air-gapped networks; a build-time cache pre-warm cannot fix that because the cache
+# the worker reads lives under WINDMILL_DIR, which deployments mount over. Hence a self-contained
+# assembly, smoke-tested below: `about` must succeed and leave the cache it is given empty.
 RUN curl -fLo /tmp/coursier-launcher https://github.com/coursier/coursier/releases/download/v${COURSIER_VERSION}/coursier \
 	&& COURSIER_CACHE=/tmp/coursier-build-cache /usr/bin/java -jar /tmp/coursier-launcher \
 		bootstrap io.get-coursier:coursier-cli_2.13:${COURSIER_VERSION} --assembly -o /usr/bin/coursier \
 	&& chmod +x /usr/bin/coursier \
-	&& rm -rf /tmp/coursier-launcher /tmp/coursier-build-cache
+	&& mkdir -p /tmp/coursier-verify \
+	&& COURSIER_CACHE=/tmp/coursier-verify /usr/bin/java -jar /usr/bin/coursier about \
+	&& [ -z "$(ls -A /tmp/coursier-verify)" ] \
+	&& rm -rf /tmp/coursier-launcher /tmp/coursier-build-cache /tmp/coursier-verify /root/.cache/coursier
 
 # Ruby
 RUN apt-get install -y ruby ruby-bundler

--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -24,14 +24,16 @@ COPY --from=ghcr.io/nushell/nushell:0.101.0-bookworm /usr/bin/nu /usr/bin/nu
 
 # Java
 RUN apt-get -y update && apt-get install -y default-jdk
-RUN curl -fLo coursier https://github.com/coursier/coursier/releases/download/v2.1.24/coursier \
-	&& mv ./coursier /usr/bin/coursier \
-	&& chmod +x /usr/bin/coursier
-# The worker runs coursier with COURSIER_CACHE=$WINDMILL_DIR/cache/java/coursier-cache, so the
-# bootstrap JARs must be pre-warmed there: at coursier's default (~/.cache/coursier) they are
-# re-downloaded from Maven Central on the first java job, which fails on air-gapped networks.
-RUN mkdir -p /tmp/windmill/cache/java/coursier-cache \
-	&& COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache /usr/bin/java -jar /usr/bin/coursier about
+ARG COURSIER_VERSION=2.1.24
+# The released coursier launcher downloads its own JARs from Maven Central the first time it runs,
+# so java jobs break on air-gapped networks. Pre-warming a cache at build time cannot fix that:
+# the cache the worker reads lives under WINDMILL_DIR, which deployments mount over. Repackage the
+# CLI as a self-contained assembly instead, so /usr/bin/coursier starts with no cache and no network.
+RUN curl -fLo /tmp/coursier-launcher https://github.com/coursier/coursier/releases/download/v${COURSIER_VERSION}/coursier \
+	&& COURSIER_CACHE=/tmp/coursier-build-cache /usr/bin/java -jar /tmp/coursier-launcher \
+		bootstrap io.get-coursier:coursier-cli_2.13:${COURSIER_VERSION} --assembly -o /usr/bin/coursier \
+	&& chmod +x /usr/bin/coursier \
+	&& rm -rf /tmp/coursier-launcher /tmp/coursier-build-cache
 
 # Ruby
 RUN apt-get install -y ruby ruby-bundler
@@ -40,9 +42,7 @@ RUN apt-get install -y ruby ruby-bundler
 RUN apt-get install -y r-base-dev \
     && Rscript -e 'install.packages("renv", lib="/usr/lib/R/library", repos="https://cloud.r-project.org")'
 
-# Fix runtime cache permissions for non-root user support (uid 1000, etc.)
-# The build pre-populates these caches with root-owned files (uv tool install ansible, the
-# coursier bootstrap), while the worker may run as any uid and needs to write to them.
-RUN set -e; for d in /tmp/windmill/cache/uv /tmp/windmill/cache/java; do \
-        chmod -R a+rw "$d"; find "$d" -type d -exec chmod 777 {} + ; \
-    done
+# Fix UV cache permissions for non-root user support (uid 1000, etc.)
+# The uv tool install ansible command populates the UV cache with root-owned files
+RUN chmod -R a+rw /tmp/windmill/cache/uv && \
+    find /tmp/windmill/cache/uv -type d -exec chmod 777 {} +

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -51,14 +51,16 @@ COPY --from=ghcr.io/nushell/nushell:0.101.0-bookworm /usr/bin/nu /usr/bin/nu
 
 # Java
 RUN apt-get -y update && apt-get install -y default-jdk
-RUN curl -fLo coursier https://github.com/coursier/coursier/releases/download/v2.1.24/coursier \
-	&& mv ./coursier /usr/bin/coursier \
-	&& chmod +x /usr/bin/coursier
-# The worker runs coursier with COURSIER_CACHE=$WINDMILL_DIR/cache/java/coursier-cache, so the
-# bootstrap JARs must be pre-warmed there: at coursier's default (~/.cache/coursier) they are
-# re-downloaded from Maven Central on the first java job, which fails on air-gapped networks.
-RUN mkdir -p /tmp/windmill/cache/java/coursier-cache \
-	&& COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache /usr/bin/java -jar /usr/bin/coursier about
+ARG COURSIER_VERSION=2.1.24
+# The released coursier launcher downloads its own JARs from Maven Central the first time it runs,
+# so java jobs break on air-gapped networks. Pre-warming a cache at build time cannot fix that:
+# the cache the worker reads lives under WINDMILL_DIR, which deployments mount over. Repackage the
+# CLI as a self-contained assembly instead, so /usr/bin/coursier starts with no cache and no network.
+RUN curl -fLo /tmp/coursier-launcher https://github.com/coursier/coursier/releases/download/v${COURSIER_VERSION}/coursier \
+	&& COURSIER_CACHE=/tmp/coursier-build-cache /usr/bin/java -jar /tmp/coursier-launcher \
+		bootstrap io.get-coursier:coursier-cli_2.13:${COURSIER_VERSION} --assembly -o /usr/bin/coursier \
+	&& chmod +x /usr/bin/coursier \
+	&& rm -rf /tmp/coursier-launcher /tmp/coursier-build-cache
 
 # Ruby
 RUN apt-get install -y ruby ruby-bundler
@@ -73,9 +75,7 @@ RUN apt-get install -y iptables
 # Kerberos runtime
 RUN apt-get install -y libsasl2-modules-gssapi-mit krb5-user
 
-# Fix runtime cache permissions for non-root user support (uid 1000, etc.)
-# The build pre-populates these caches with root-owned files (uv tool install ansible, the
-# coursier bootstrap), while the worker may run as any uid and needs to write to them.
-RUN set -e; for d in /tmp/windmill/cache/uv /tmp/windmill/cache/java; do \
-        chmod -R a+rw "$d"; find "$d" -type d -exec chmod 777 {} + ; \
-    done
+# Fix UV cache permissions for non-root user support (uid 1000, etc.)
+# The uv tool install ansible command populates the UV cache with root-owned files
+RUN chmod -R a+rw /tmp/windmill/cache/uv && \
+    find /tmp/windmill/cache/uv -type d -exec chmod 777 {} +

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -52,15 +52,18 @@ COPY --from=ghcr.io/nushell/nushell:0.101.0-bookworm /usr/bin/nu /usr/bin/nu
 # Java
 RUN apt-get -y update && apt-get install -y default-jdk
 ARG COURSIER_VERSION=2.1.24
-# The released coursier launcher downloads its own JARs from Maven Central the first time it runs,
-# so java jobs break on air-gapped networks. Pre-warming a cache at build time cannot fix that:
-# the cache the worker reads lives under WINDMILL_DIR, which deployments mount over. Repackage the
-# CLI as a self-contained assembly instead, so /usr/bin/coursier starts with no cache and no network.
+# The released coursier launcher downloads its own JARs from Maven Central on first run, so java
+# jobs break on air-gapped networks; a build-time cache pre-warm cannot fix that because the cache
+# the worker reads lives under WINDMILL_DIR, which deployments mount over. Hence a self-contained
+# assembly, smoke-tested below: `about` must succeed and leave the cache it is given empty.
 RUN curl -fLo /tmp/coursier-launcher https://github.com/coursier/coursier/releases/download/v${COURSIER_VERSION}/coursier \
 	&& COURSIER_CACHE=/tmp/coursier-build-cache /usr/bin/java -jar /tmp/coursier-launcher \
 		bootstrap io.get-coursier:coursier-cli_2.13:${COURSIER_VERSION} --assembly -o /usr/bin/coursier \
 	&& chmod +x /usr/bin/coursier \
-	&& rm -rf /tmp/coursier-launcher /tmp/coursier-build-cache
+	&& mkdir -p /tmp/coursier-verify \
+	&& COURSIER_CACHE=/tmp/coursier-verify /usr/bin/java -jar /usr/bin/coursier about \
+	&& [ -z "$(ls -A /tmp/coursier-verify)" ] \
+	&& rm -rf /tmp/coursier-launcher /tmp/coursier-build-cache /tmp/coursier-verify /root/.cache/coursier
 
 # Ruby
 RUN apt-get install -y ruby ruby-bundler


### PR DESCRIPTION
## Summary

Follow-up to #10413 (WIN-2264). That PR moved the Coursier bootstrap pre-warm to the path the
worker reads (`$WINDMILL_DIR/cache/java/coursier-cache`), which is where the bug was — but review
of it surfaced that a build-time pre-warm at that path cannot actually deliver the air-gapped fix:

- **Deployments mount over it.** `docker-compose.yml:78` mounts `worker_dependency_cache` at
  `/tmp/windmill/cache`. Docker seeds only a *fresh* named volume from image content, so an
  upgrade over an existing volume — and any k8s `emptyDir`/PVC — hides the baked JARs entirely.
- **`WINDMILL_DIR` moves the target.** Any deployment overriding it lands the pre-warm at the
  wrong path again.

This replaces the mechanism rather than the path: `/usr/bin/coursier` is repackaged at build time
as a self-contained **assembly** (fat JAR). The released launcher is a bootstrap that downloads
`coursier-cli` and its deps from Maven Central on first run; the assembly embeds them, so the CLI
starts with **no cache and no network** regardless of mounts, volume age, or `WINDMILL_DIR`. The
runtime cache is then only used for user dependencies, which is what it is for.

Also reverts the Java half of #10413's permission step, which is now unnecessary — that also
resolves the P2 from #10413's review (the trailing `chmod -R` forced an overlay2 copy-up,
duplicating the ~43 MB cache into a second layer).

## Changes

- `docker/DockerfileFull`, `docker/DockerfileFullEe`: build `/usr/bin/coursier` with
  `coursier bootstrap io.get-coursier:coursier-cli_2.13:$COURSIER_VERSION --assembly`, using a
  throwaway `COURSIER_CACHE` that is removed in the same layer. Version pinned once via
  `ARG COURSIER_VERSION=2.1.24` (was duplicated between the download URL and the CLI it fetched).
- Build-time smoke test: `about` must run from the produced JAR **and leave the cache it is given
  empty**. That asserts the exact property this PR is about, and restores the accidental smoke
  test the old `coursier about` line provided. It matters here because `build_full` /
  `build_ee_full` are gated on `refs/tags/v*` (`.github/workflows/docker-image.yml:598,641`), so
  PR CI never builds these images — the first real build is at release time.
- Same files: drop the now-pointless bootstrap pre-warm and restore the permission-fix step to
  `uv` only.

**Image size:** the ~43 MB assembly replaces the ~43 MB pre-warmed cache *and* its ~43 MB
copy-up duplicate, so this is roughly 43 MB smaller than current `main` and on par with the
state before #10413. Pure JVM bytecode, so unchanged for both `amd64` and `arm64`.

## Test plan

Validated in a real Docker build of the exact stanza (extracted from `DockerfileFull` so the test
cannot drift), and on the host JDK inside a network namespace (`unshare -rn`) for true no-egress:

- [x] **Docker build of the stanza** succeeds; smoke test runs inline; image contains only the
      43 MB assembly at `/usr/bin/coursier`, with `/tmp/coursier-*` and `/root/.cache/coursier` gone.
- [x] **Offline, empty cache, as uid 1000**, worker-shaped invocation
      (`--network=none`, `COURSIER_CACHE=/tmp/windmill/cache/java/coursier-cache`) → `EXIT=0`.
- [x] **The smoke test has teeth**: the same assertion against the plain released launcher fails
      the build (`EXIT=1`) — it writes 207 files into a fresh cache, the assembly writes 0.
- [x] **`java -jar` compatibility** (raised in review): manifest carries
      `Main-Class: coursier.cli.Coursier` and `java -jar` exits 0 — same shell-preamble-then-zip
      shape as the released launcher the worker already runs this way.
- [x] **Current launcher, no network, empty cache** → `EXIT=255`,
      `Error while downloading …coursier-cli_2.13-2.1.24.jar: Network is unreachable`.
- [x] **CLI parity** — `resolve com.google.guava:guava:33.0.0-jre` returns an identical resolved
      graph from both launchers (only difference is the cold-cache download logs).
- [x] **No startup regression** — assembly offline `0.254s` vs bootstrap launcher with a warm
      cache `0.268s`.
- [x] `docker build --check` clean on both Dockerfiles.
- [ ] Not done here: a build of the real `:full` images (the host disk was full locally, and PR CI
      does not build them). The in-build smoke test is what guards the release-time build.