### PR TITLE
fix(flows): mint fresh orchestration token so long steps don't expire the result-fetch JWT

### DIFF
--- a/backend/windmill-worker/src/result_processor.rs
+++ b/backend/windmill-worker/src/result_processor.rs
@@ -689,20 +689,28 @@ pub async fn handle_receive_completed_job(
     killpill_rx: &tokio::sync::broadcast::Receiver<()>,
     #[cfg(feature = "benchmark")] bench: &mut BenchmarkIter,
 ) -> Option<Arc<MiniPulledJob>> {
-    // WIN-2263: a flow step's ephemeral JWT (`jc.token`) is minted at step pull time with a
-    // lifetime of `SCRIPT_TOKEN_EXPIRY` (900s on cloud). It is reused here to build the client
-    // that drives post-completion flow orchestration — including the next step's input-transform
-    // isolated-eval, which fetches prior steps' results (`[...results.x]`). When the finished step
-    // ran longer than the token's lifetime (minus the 60s JWT leeway), that reused token is already
-    // expired and the result fetch is rejected as anonymous. Mint a fresh token for flow-step
-    // completions so the orchestration client's lifetime is independent of how long the step ran.
     let workspace = jc.job.workspace_id.clone();
-    let token = if jc.job.is_flow_step() {
+    // The client built here drives post-completion orchestration (the next step's input
+    // transforms fetch prior step results), which outlives the finished step. The step's own
+    // token has a `SCRIPT_TOKEN_EXPIRY` lifetime, so reusing it would fail that orchestration
+    // once the step itself ran longer than the token lives; refresh it when the step is old enough.
+    let token_maybe_expired = jc
+        .duration
+        .is_some_and(|d| d as u64 >= *windmill_common::worker::SCRIPT_TOKEN_EXPIRY * 1000 / 2);
+    let token = if jc.job.is_flow_step() && token_maybe_expired {
+        // Mirror `create_token`'s label so run-on-behalf-of flows keep their end-user override.
+        let label = if jc.job.permissioned_as != format!("u/{}", jc.job.created_by)
+            && jc.job.permissioned_as != jc.job.created_by
+        {
+            format!("ephemeral-script-end-user-{}", jc.job.created_by)
+        } else {
+            "ephemeral-script".to_string()
+        };
         match windmill_common::auth::create_token_for_owner(
             db,
             &jc.job.workspace_id,
             &jc.job.permissioned_as,
-            "ephemeral-script",
+            &label,
             *windmill_common::worker::SCRIPT_TOKEN_EXPIRY,
             &jc.job.permissioned_as_email,
             &jc.job.id,
@@ -712,12 +720,13 @@ pub async fn handle_receive_completed_job(
                 jc.job.flow_innermost_root_job.unwrap_or(jc.job.id)
             )),
         )
+        .warn_after_seconds(5)
         .await
         {
             Ok(t) => t,
             Err(e) => {
                 tracing::warn!(
-                    "WIN-2263: could not mint fresh flow-orchestration token for job {}, reusing step token: {e:#}",
+                    "could not mint fresh flow-orchestration token for job {}, reusing step token: {e:#}",
                     jc.job.id
                 );
                 jc.token.clone()

--- a/backend/windmill-worker/src/result_processor.rs
+++ b/backend/windmill-worker/src/result_processor.rs
@@ -689,8 +689,43 @@ pub async fn handle_receive_completed_job(
     killpill_rx: &tokio::sync::broadcast::Receiver<()>,
     #[cfg(feature = "benchmark")] bench: &mut BenchmarkIter,
 ) -> Option<Arc<MiniPulledJob>> {
-    let token = jc.token.clone();
+    // WIN-2263: a flow step's ephemeral JWT (`jc.token`) is minted at step pull time with a
+    // lifetime of `SCRIPT_TOKEN_EXPIRY` (900s on cloud). It is reused here to build the client
+    // that drives post-completion flow orchestration — including the next step's input-transform
+    // isolated-eval, which fetches prior steps' results (`[...results.x]`). When the finished step
+    // ran longer than the token's lifetime (minus the 60s JWT leeway), that reused token is already
+    // expired and the result fetch is rejected as anonymous. Mint a fresh token for flow-step
+    // completions so the orchestration client's lifetime is independent of how long the step ran.
     let workspace = jc.job.workspace_id.clone();
+    let token = if jc.job.is_flow_step() {
+        match windmill_common::auth::create_token_for_owner(
+            db,
+            &jc.job.workspace_id,
+            &jc.job.permissioned_as,
+            "ephemeral-script",
+            *windmill_common::worker::SCRIPT_TOKEN_EXPIRY,
+            &jc.job.permissioned_as_email,
+            &jc.job.id,
+            None,
+            Some(format!(
+                "job-span-{}",
+                jc.job.flow_innermost_root_job.unwrap_or(jc.job.id)
+            )),
+        )
+        .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "WIN-2263: could not mint fresh flow-orchestration token for job {}, reusing step token: {e:#}",
+                    jc.job.id
+                );
+                jc.token.clone()
+            }
+        }
+    } else {
+        jc.token.clone()
+    };
     let client = AuthedClient::new(base_internal_url.to_string(), workspace, token, None);
     let job = jc.job.clone();
     let mem_peak = jc.mem_peak.clone();


### PR DESCRIPTION
## Problem

Long-running flows intermittently fail at a step that reads a prior step's results in its input transform (e.g. `[...results.search_reddit]`), with:

```
Error during isolated evaluation of expression `[...results.search_reddit, results.search_reddit_comments]`:
QuickJS evaluation error: Error: Failed to fetch results for step 'search_reddit':
Bad request: As a non logged in user, you can only see jobs ran by anonymous users
```

The failure is **intermittent and uncorrelated with total flow duration** — a 106-min run succeeds while some 60-min runs fail — which makes it look mysterious. (Internal ref: WIN-2263.)

## Root cause

When a flow step completes, `handle_receive_completed_job` builds the `AuthedClient` that drives the **next** step's transition from the just-completed step's own ephemeral JWT (`jc.token`):

```rust
let token = jc.token.clone();
let client = AuthedClient::new(base_internal_url, workspace, token, None);
```

That client is threaded through `update_flow_status_after_job_completion` → `push_next_flow_job`, which evaluates the next module's input transforms. A `[...results.<step>]` expression forces the isolated-eval sandbox to fetch prior step results via `get_completed_job_result`, authenticated with that reused token.

The step JWT's lifetime is `SCRIPT_TOKEN_EXPIRY` (defaults to `MAX_TIMEOUT` = **900s on cloud**), and JWT validation (`jsonwebtoken` `Validation::new`) allows a **60s leeway**. So if the step **whose completion triggers the fetch** ran longer than `SCRIPT_TOKEN_EXPIRY + 60s` (~16 min on cloud), its token is already expired-beyond-leeway when the downstream fetch fires → auth resolves to anonymous → the fetch is rejected.

It's **per-step** duration, not total flow duration — hence the intermittency: a 106-min flow of short steps passes, while a 60-min flow with one >16-min step fails.

There's also a latent lifetime mismatch: a step may run up to `MAX_TIMEOUT`, and its token TTL is *also* `MAX_TIMEOUT`, so any step approaching its own timeout leaves a near-expired token for post-completion orchestration.

## Fix

Decouple the orchestration client's token from the finished step's token: when the completed job is a flow step, mint a fresh token (`create_token_for_owner`, same owner/perms/scopes as a normal step-pull token) for the orchestration client instead of reusing `jc.token`. Falls back to the step token if minting fails.

## Verification

Built the `windmill` binary from source and ran a deterministic repro (forloop `gen` → 95s `slow` step → `consume` with `[...results.gen]`) at `SCRIPT_TOKEN_EXPIRY=20` (so the ~95s step exceeds TTL+leeway), holding version/features/DB/flow constant:

| binary | outcome |
| -- | -- |
| stock release | **FAIL** — "As a non logged in user…" |
| self-built, **unpatched** (same version) | **FAIL** — identical error |
| self-built, **patched** (this PR) | **PASS** — no error, fresh-token path minted without hitting the fallback |

The two self-built rows differ only by this patch. Separately, raising `SCRIPT_TOKEN_EXPIRY` above the step duration also makes the same flow pass, confirming token lifetime is the sole variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)