### PR TITLE
fix(ai): pass only the output of a nested agent tool to the parent

### DIFF
--- a/backend/windmill-worker/src/ai/tools.rs
+++ b/backend/windmill-worker/src/ai/tools.rs
@@ -369,6 +369,8 @@ async fn execute_windmill_tool(
         tool_call_args.insert(key.clone(), result);
     }
 
+    let is_ai_agent_tool = matches!(tool_value, FlowModuleValue::AIAgent { .. });
+
     let job_payload = match tool_value {
         FlowModuleValue::Script { path: script_path, hash: script_hash, tag_override, .. } => {
             script_to_payload(
@@ -611,6 +613,7 @@ async fn execute_windmill_tool(
                 tool_module,
                 job_id,
                 outcome.is_success(),
+                is_ai_agent_tool,
                 inner_job_completed_rx,
                 messages,
                 final_events_str,
@@ -682,6 +685,15 @@ async fn handle_tool_execution_error(
     Ok(())
 }
 
+/// Extract the `output` field of an `AIAgentResult` envelope, serialized back to JSON.
+/// Returns `None` if the result is not a JSON object carrying an `output` field.
+fn extract_ai_agent_output(result: &RawValue) -> Option<String> {
+    serde_json::from_str::<HashMap<String, &RawValue>>(result.get())
+        .ok()?
+        .get("output")
+        .map(|output| output.get().to_string())
+}
+
 /// Handle tool execution success
 async fn handle_tool_execution_success(
     ctx: &mut ToolExecutionContext<'_>,
@@ -689,14 +701,16 @@ async fn handle_tool_execution_success(
     tool_module: &windmill_common::flows::FlowModule,
     job_id: Uuid,
     success: bool,
+    is_ai_agent_tool: bool,
     inner_job_completed_rx: JobCompletedReceiver,
     messages: &mut Vec<OpenAIMessage>,
     final_events_str: &mut String,
 ) -> Result<(), Error> {
     let send_result = inner_job_completed_rx.bounded_rx.try_recv().ok();
 
-    let result = if let Some(SendResult {
-        result: SendResultPayload::JobCompleted(ref jc), ..
+    let (result, job_success) = if let Some(SendResult {
+        result: SendResultPayload::JobCompleted(ref jc),
+        ..
     }) = send_result
     {
         let result = jc.result.clone();
@@ -738,16 +752,26 @@ async fn handle_tool_execution_success(
             .await
             .map_err(|e| Error::internal_err(format!("Failed to add completed job error: {e}")))?;
         }
-        result
+        (result, jc.success)
     } else {
         return Err(Error::internal_err(
             "Tool job completed but no result".to_string(),
         ));
     };
 
+    // A nested agent returns the whole `AIAgentResult` envelope: on top of `output` it carries
+    // the child's entire message history, stream log and token usage. Feeding that back would
+    // grow the caller's context by the child's full transcript on every call, so the caller only
+    // sees `output`. The envelope stays intact in the tool job's completed row.
+    let tool_result = if is_ai_agent_tool && job_success {
+        extract_ai_agent_output(&result).unwrap_or_else(|| result.get().to_string())
+    } else {
+        result.get().to_string()
+    };
+
     messages.push(OpenAIMessage {
         role: "tool".to_string(),
-        content: Some(OpenAIContent::Text(result.get().to_string())),
+        content: Some(OpenAIContent::Text(tool_result.clone())),
         tool_call_id: Some(tool_call.id.clone()),
         agent_action: Some(AgentAction::ToolCall {
             job_id,
@@ -762,7 +786,7 @@ async fn handle_tool_execution_success(
         let tool_result_event = StreamingEvent::ToolResult {
             call_id: tool_call.id.clone(),
             function_name: tool_call.function.name.clone(),
-            result: result.get().to_string(),
+            result: tool_result,
             success: true,
         };
         stream_event_processor
@@ -838,5 +862,27 @@ async fn add_tool_message_to_chat(
                 }
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_ai_agent_output;
+    use serde_json::value::RawValue;
+
+    #[test]
+    fn extracts_only_the_output_of_an_agent_result() {
+        let envelope = RawValue::from_string(
+            r#"{"output":{"answer":"42"},"messages":[{"role":"user","content":"hi"}],"wm_stream":"...","usage":{"total_tokens":10}}"#
+                .to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            extract_ai_agent_output(&envelope).as_deref(),
+            Some(r#"{"answer":"42"}"#)
+        );
+
+        let not_an_envelope = RawValue::from_string(r#"["a"]"#.to_string()).unwrap();
+        assert_eq!(extract_ai_agent_output(&not_an_envelope), None);
     }
 }


### PR DESCRIPTION
## Summary

When a nested AI agent (agent-as-tool) completed, the whole `AIAgentResult` envelope was injected into the parent agent's LLM context as the tool result: `output` plus the child's entire message history, its full streaming event log (`wm_stream`) and token usage. Every subsequent round of the parent then re-sent that transcript, so a child whose answer is a few thousand characters could add hundreds of thousands of characters (hundreds of thousands of input tokens) to the parent's context.

The parent now receives only the child's `output`. The full envelope is untouched where it matters: it is still what `add_completed_job` persists for the nested tool job, so the run page, the agent log viewer and debugging are unaffected.

Fixes WIN-2265

## Changes

- `execute_windmill_tool` computes `is_ai_agent_tool` from the tool's `FlowModuleValue` (true only for the arm that pushes `JobPayload::AIAgent`) and threads it to `handle_tool_execution_success`.
- `handle_tool_execution_success` extracts `.output` from the result for both the `tool` message pushed into the parent's conversation and the `StreamingEvent::ToolResult` payload. Extraction is gated on the tool job having succeeded, so a failed nested agent still hands the parent its untrimmed error payload; a result that unexpectedly isn't an `{"output": ...}` object falls back to the full result.
- Added a unit test for the extraction helper.

`handle_tool_execution_error` was deliberately left alone: it only runs for hard `handle_queued_job` failures, where the payload is an error string rather than an `AIAgentResult`, so threading the flag there would add an unused parameter and nothing else.

## Test plan

- [x] `cargo check -p windmill-worker --features quickjs`
- [x] `cargo test -p windmill-worker --features quickjs extracts_only_the_output` — passes
- [x] End-to-end against a local backend with a stub OpenAI-compatible provider: ran a preview flow whose AI agent step has a nested AI agent tool, with the stub returning a tool call on the parent's first round and a long answer from the child.
  - The parent's second request to the LLM carries a `tool` message of 226 chars — exactly the child's `output` — instead of the 915-char envelope.
  - The nested tool job's own `v2_job_completed.result` still holds all three keys (`output`, `messages`, `wm_stream`), 915 chars.
  - Parent flow result: `{"output": "PARENT_DONE", "messages": [..., {"role": "tool", "content": "\"CHILD_FINAL_ANSWER: ...\"", ...}]}`.

No frontend changes: the only consumer of the streamed `tool_result` event (`frontend/src/lib/components/chat/utils.ts`) reads `function_name` and `success`, never `result`, and the agent log viewer resolves the nested job by id and reads its persisted result.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass only the `output` of a nested agent tool back to the parent to avoid context bloat and excessive token usage, while keeping the full result envelope persisted for debugging and logs. Fixes WIN-2265.

- **Bug Fixes**
  - Detect agent-as-tool via `FlowModuleValue::AIAgent` and pass a flag to the success handler.
  - On successful nested agent runs, extract and use only `output` for the parent’s tool message and streamed `tool_result`; fallback to the full result if shape is unexpected.
  - Leave error cases unchanged so the parent receives the full error payload.
  - Add a unit test for the extraction helper.

<sup>Written for commit 93ee3560d120fa2df1542b54735a9c34b0b7d506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

