### PR TITLE
fix: apply default workspace dependencies to raw app runnables

### DIFF
--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -12,7 +12,7 @@ import * as wmill from "../../../gen/services.gen.ts";
 import { ListableApp, Policy } from "../../../gen/types.gen.ts";
 
 import { GlobalOptions, isSuperset } from "../../types.ts";
-import { getWmillYamlPath } from "../../core/conf.ts";
+import { getWmillYamlPath, mergeConfigWithConfigFile } from "../../core/conf.ts";
 import { readInlinePathSync } from "../../utils/utils.ts";
 import devCommand from "./dev.ts";
 import lintCommand from "./lint.ts";
@@ -402,7 +402,14 @@ async function push(
 
   if (isRawAppByName || hasRawAppYaml) {
     const { pushRawApp } = await import("./raw_apps.ts");
-    await pushRawApp(workspace.workspaceId, remotePath, absoluteFilePath);
+    const merged = await mergeConfigWithConfigFile(opts);
+    await pushRawApp(
+      workspace.workspaceId,
+      remotePath,
+      absoluteFilePath,
+      undefined,
+      merged.defaultTs,
+    );
     log.info(colors.bold.underline.green("Raw app pushed"));
   } else {
     await pushApp(workspace.workspaceId, remotePath, absoluteFilePath);

--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -41,7 +41,7 @@ import {
   newRawAppPathAssigner,
   SupportedLanguage,
 } from "../../../windmill-utils-internal/src/path-utils/path-assigner.ts";
-import { mergeConfigWithConfigFile, SyncOptions } from "../../core/conf.ts";
+import { getDefaultTs, mergeConfigWithConfigFile, SyncOptions } from "../../core/conf.ts";
 import { resolveWorkspace } from "../../core/context.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { getNonDottedPaths } from "../../utils/resource_folders.ts";
@@ -471,10 +471,11 @@ async function updateRawAppRunnables(
   remotePath: string,
   appFolder: string,
   rawDeps?: Record<string, string>,
-  defaultTs: "bun" | "deno" = "bun",
+  defaultTs?: "bun" | "deno",
   noStaleMessage?: boolean,
   tempScriptRefs?: Record<string, string>
 ): Promise<string[]> {
+  const ts = defaultTs ?? (await getDefaultTs());
   const updatedRunnables: string[] = [];
   const runnablesFolder = path.join(appFolder, APP_BACKEND_FOLDER);
 
@@ -485,7 +486,7 @@ async function updateRawAppRunnables(
     // Folder may already exist
   }
 
-  const pathAssigner = newRawAppPathAssigner(defaultTs);
+  const pathAssigner = newRawAppPathAssigner(ts);
 
   for (const [runnableId, runnable] of Object.entries(runnables)) {
     // Only process inline scripts (runnableByName/inline with inlineScript)
@@ -845,7 +846,7 @@ export interface InferredSchemaResult {
 export async function inferRunnableSchemaFromFile(
   appFolder: string,
   runnableFilePath: string,
-  defaultTs: "bun" | "deno" = "bun",
+  defaultTs?: "bun" | "deno",
 ): Promise<InferredSchemaResult | undefined> {
   // Extract runnable ID from file path (e.g., "myRunnable.ts" -> "myRunnable",
   // "fetch_data.bun.ts" -> "fetch_data")
@@ -916,7 +917,7 @@ export async function inferRunnableSchemaFromFile(
     runnable?.type === "inline" ||
     runnable?.type === "runnableByName"
   ) {
-    language = getLanguageFromExtension(ext, defaultTs);
+    language = getLanguageFromExtension(ext, defaultTs ?? (await getDefaultTs()));
   } else {
     // Path-based runnable or unknown type - schema lives at the script/flow path
     return undefined;
@@ -981,8 +982,9 @@ export async function inferRunnableSchemaFromFile(
  */
 export async function inferAllInlineSchemas(
   appFolder: string,
-  defaultTs: "bun" | "deno" = "bun",
+  defaultTs?: "bun" | "deno",
 ): Promise<Record<string, any>> {
+  const ts = defaultTs ?? (await getDefaultTs());
   const schemas: Record<string, any> = {};
   const backendPath = path.join(appFolder, APP_BACKEND_FOLDER);
 
@@ -1002,7 +1004,7 @@ export async function inferAllInlineSchemas(
     const result = await inferRunnableSchemaFromFile(
       appFolder,
       fileName,
-      defaultTs,
+      ts,
     );
     if (result) {
       schemas[result.runnableId] = result.schema;

--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -194,7 +194,7 @@ export async function generateAppLocksInternal(
   const runnablesFolder = path.join(appFolder, APP_BACKEND_FOLDER);
   let rawAppRunnables: Record<string, any> = {};
   if (rawApp) {
-    rawAppRunnables = await loadRunnablesFromBackend(runnablesFolder);
+    rawAppRunnables = await loadRunnablesFromBackend(runnablesFolder, opts.defaultTs);
     if (Object.keys(rawAppRunnables).length === 0) {
       rawAppRunnables = (appFile as RawAppFile).runnables ?? {};
     }

--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -41,7 +41,7 @@ import {
   newRawAppPathAssigner,
   SupportedLanguage,
 } from "../../../windmill-utils-internal/src/path-utils/path-assigner.ts";
-import { getDefaultTs, mergeConfigWithConfigFile, SyncOptions } from "../../core/conf.ts";
+import { mergeConfigWithConfigFile, SyncOptions } from "../../core/conf.ts";
 import { resolveWorkspace } from "../../core/context.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { getNonDottedPaths } from "../../utils/resource_folders.ts";
@@ -471,11 +471,10 @@ async function updateRawAppRunnables(
   remotePath: string,
   appFolder: string,
   rawDeps?: Record<string, string>,
-  defaultTs?: "bun" | "deno",
+  defaultTs: "bun" | "deno" = "bun",
   noStaleMessage?: boolean,
   tempScriptRefs?: Record<string, string>
 ): Promise<string[]> {
-  const ts = defaultTs ?? (await getDefaultTs());
   const updatedRunnables: string[] = [];
   const runnablesFolder = path.join(appFolder, APP_BACKEND_FOLDER);
 
@@ -486,7 +485,7 @@ async function updateRawAppRunnables(
     // Folder may already exist
   }
 
-  const pathAssigner = newRawAppPathAssigner(ts);
+  const pathAssigner = newRawAppPathAssigner(defaultTs);
 
   for (const [runnableId, runnable] of Object.entries(runnables)) {
     // Only process inline scripts (runnableByName/inline with inlineScript)
@@ -846,7 +845,7 @@ export interface InferredSchemaResult {
 export async function inferRunnableSchemaFromFile(
   appFolder: string,
   runnableFilePath: string,
-  defaultTs?: "bun" | "deno",
+  defaultTs: "bun" | "deno" = "bun",
 ): Promise<InferredSchemaResult | undefined> {
   // Extract runnable ID from file path (e.g., "myRunnable.ts" -> "myRunnable",
   // "fetch_data.bun.ts" -> "fetch_data")
@@ -917,7 +916,7 @@ export async function inferRunnableSchemaFromFile(
     runnable?.type === "inline" ||
     runnable?.type === "runnableByName"
   ) {
-    language = getLanguageFromExtension(ext, defaultTs ?? (await getDefaultTs()));
+    language = getLanguageFromExtension(ext, defaultTs);
   } else {
     // Path-based runnable or unknown type - schema lives at the script/flow path
     return undefined;
@@ -982,9 +981,8 @@ export async function inferRunnableSchemaFromFile(
  */
 export async function inferAllInlineSchemas(
   appFolder: string,
-  defaultTs?: "bun" | "deno",
+  defaultTs: "bun" | "deno" = "bun",
 ): Promise<Record<string, any>> {
-  const ts = defaultTs ?? (await getDefaultTs());
   const schemas: Record<string, any> = {};
   const backendPath = path.join(appFolder, APP_BACKEND_FOLDER);
 
@@ -1004,7 +1002,7 @@ export async function inferAllInlineSchemas(
     const result = await inferRunnableSchemaFromFile(
       appFolder,
       fileName,
-      ts,
+      defaultTs,
     );
     if (result) {
       schemas[result.runnableId] = result.schema;

--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -187,7 +187,20 @@ export async function generateAppLocksInternal(
   );
   const appFile = (await yamlParseFile(appFilePath)) as AppFile;
 
-  const appValue = rawApp ? (appFile as RawAppFile).runnables : (appFile as NormalAppFile).value;
+  // Raw-app runnables live in their own files under backend/; raw_app.yaml only
+  // carries them in the legacy layout. Resolve them here, before any workspace
+  // dependency filtering, otherwise the deps of a file-based raw app are
+  // filtered against an empty runnables map and silently dropped.
+  const runnablesFolder = path.join(appFolder, APP_BACKEND_FOLDER);
+  let rawAppRunnables: Record<string, any> = {};
+  if (rawApp) {
+    rawAppRunnables = await loadRunnablesFromBackend(runnablesFolder);
+    if (Object.keys(rawAppRunnables).length === 0) {
+      rawAppRunnables = (appFile as RawAppFile).runnables ?? {};
+    }
+  }
+
+  const appValue = rawApp ? rawAppRunnables : (appFile as NormalAppFile).value;
   const folderNormalized = appFolder.replaceAll(SEP, "/");
 
   let filteredDeps: Record<string, string> = {};
@@ -199,15 +212,7 @@ export async function generateAppLocksInternal(
       const hashes = await generateAppHash({}, appFolder, rawApp, opts.defaultTs);
       const isDirectlyStale = await isAppDirectlyStale(appFolder, hashes, conf);
 
-      // For raw apps in new format, runnables are in separate files under backend/
-      let treeAppValue = structuredClone(appValue);
-      if (rawApp) {
-        const runnablesPath = path.join(appFolder, APP_BACKEND_FOLDER);
-        const runnablesFromFiles = await loadRunnablesFromBackend(runnablesPath);
-        if (Object.keys(runnablesFromFiles).length > 0) {
-          treeAppValue = runnablesFromFiles;
-        }
-      }
+      const treeAppValue = structuredClone(appValue);
 
       // First pass: add inline scripts as separate nodes, then add app node importing them
       const inlineScriptPaths: string[] = [];
@@ -303,23 +308,13 @@ export async function generateAppLocksInternal(
       }
 
       if (rawApp) {
-        const runnablesPath = path.join(appFolder, APP_BACKEND_FOLDER);
-
-        // Load runnables from separate files (new format) or fall back to raw_app.yaml (old format)
-        const rawAppFile = appFile as RawAppFile;
-        let runnables = await loadRunnablesFromBackend(runnablesPath);
-        if (Object.keys(runnables).length === 0 && rawAppFile.runnables) {
-          // Fall back to old format
-          runnables = rawAppFile.runnables;
-        }
-
         // Replace inline scripts for changed runnables
-        replaceInlineScripts(runnables, runnablesPath + SEP, false);
+        replaceInlineScripts(rawAppRunnables, runnablesFolder + SEP, false);
 
         // Update the app runnables with new locks (writes to separate files)
         updatedScripts = await updateRawAppRunnables(
           workspace,
-          runnables,
+          rawAppRunnables,
           remote_path,
           appFolder,
           filteredDeps,

--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -49,6 +49,9 @@ import {
   loadNonDottedPathsSetting,
 } from "../../utils/resource_folders.ts";
 
+// Resolved once per `wmill app dev` run from wmill.yaml; a bare `.ts` under
+// backend/ denotes this runtime, so readers must agree with the path assigner.
+let defaultTs: "bun" | "deno" = "bun";
 const DEFAULT_PORT = 4000;
 const DEFAULT_HOST = "localhost";
 
@@ -406,6 +409,7 @@ async function dev(opts: DevOptions, appFolder?: string) {
       : originalCwd;
     const relAppFolder = path.relative(workspaceRoot, targetDir) || ".";
     const mergedOpts = await mergeConfigWithConfigFile(opts);
+    defaultTs = mergedOpts.defaultTs ?? "bun";
     const codebases = await listSyncCodebases(mergedOpts);
     const { buildPreviewTempScriptRefs } = await import(
       "../generate-metadata/generate-metadata.ts"
@@ -491,7 +495,10 @@ async function dev(opts: DevOptions, appFolder?: string) {
   // change to trigger the watcher).
   const inferredSchemas: Record<string, any> = {};
   try {
-    Object.assign(inferredSchemas, await inferAllInlineSchemas(process.cwd()));
+    Object.assign(
+      inferredSchemas,
+      await inferAllInlineSchemas(process.cwd(), defaultTs),
+    );
   } catch (err: any) {
     log.warn(
       colors.yellow(
@@ -508,6 +515,7 @@ async function dev(opts: DevOptions, appFolder?: string) {
   try {
     const initialRunnables = await loadRunnablesFromBackend(
       path.join(process.cwd(), APP_BACKEND_FOLDER),
+      defaultTs,
     );
     Object.assign(
       pathRunnableSchemas,
@@ -675,6 +683,7 @@ async function dev(opts: DevOptions, appFolder?: string) {
           const result = await inferRunnableSchemaFromFile(
             process.cwd(),
             relativeToRunnables,
+            defaultTs,
           );
           if (result) {
             // Store inferred schema in memory
@@ -1437,7 +1446,7 @@ async function genRunnablesTs(
   const backendPath = path.join(localPath, APP_BACKEND_FOLDER);
 
   // Load runnables from separate files (new format) or fall back to raw_app.yaml (old format)
-  let runnables = await loadRunnablesFromBackend(backendPath);
+  let runnables = await loadRunnablesFromBackend(backendPath, defaultTs);
 
   if (Object.keys(runnables).length === 0) {
     // Fall back to old format
@@ -1581,7 +1590,7 @@ async function loadRunnables(): Promise<Record<string, Runnable>> {
     const backendPath = path.join(localPath, APP_BACKEND_FOLDER);
 
     // Load runnables from separate files (new format) or fall back to raw_app.yaml (old format)
-    let runnables = await loadRunnablesFromBackend(backendPath);
+    let runnables = await loadRunnablesFromBackend(backendPath, defaultTs);
 
     if (Object.keys(runnables).length === 0) {
       // Fall back to old format

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -1,6 +1,6 @@
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
-import { getDefaultTs } from "../../core/conf.ts";
+import { mergeConfigWithConfigFile } from "../../core/conf.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
 import { sep as SEP } from "node:path";
@@ -144,14 +144,13 @@ function getRunnableIdFromCodeFile(fileName: string): string | undefined {
  * Returns an empty object if the backend folder doesn't exist.
  *
  * @param backendPath - Path to the backend folder
- * @param defaultTs - TypeScript runtime a bare `.ts` denotes; resolved from
- *   wmill.yaml when omitted, so readers agree with what the assigner wrote
+ * @param defaultTs - TypeScript runtime a bare `.ts` denotes. Must match what
+ *   newRawAppPathAssigner used to write the file, or the round-trip relabels it.
  */
 export async function loadRunnablesFromBackend(
   backendPath: string,
-  defaultTs?: "bun" | "deno",
+  defaultTs: "bun" | "deno" = "bun",
 ): Promise<Record<string, any>> {
-  const ts = defaultTs ?? (await getDefaultTs());
   const runnables: Record<string, any> = {};
 
   try {
@@ -191,7 +190,7 @@ export async function loadRunnablesFromBackend(
         );
 
         if (contentFile) {
-          const language = getLanguageFromExtension(contentFile.ext, ts);
+          const language = getLanguageFromExtension(contentFile.ext, defaultTs);
           const lock = await readSiblingLock(backendPath, runnableId, allFiles);
 
           // Reconstruct inlineScript object
@@ -243,7 +242,7 @@ export async function loadRunnablesFromBackend(
       );
 
       if (contentFile) {
-        const language = getLanguageFromExtension(contentFile.ext, ts);
+        const language = getLanguageFromExtension(contentFile.ext, defaultTs);
         const lock = await readSiblingLock(backendPath, runnableId, allFiles);
 
         // Create inline runnable with default empty fields
@@ -347,6 +346,7 @@ export async function pushRawApp(
   remotePath: string,
   localPath: string,
   message?: string,
+  defaultTs: "bun" | "deno" = "bun",
 ): Promise<void> {
   if (alreadySynced.includes(localPath)) {
     return;
@@ -380,7 +380,10 @@ export async function pushRawApp(
   // Load runnables from separate YAML files in the backend folder
   // Falls back to reading from raw_app.yaml if no separate files exist (backward compat)
   const backendPath = path.join(localPath, APP_BACKEND_FOLDER);
-  const runnablesFromBackend = await loadRunnablesFromBackend(backendPath);
+  const runnablesFromBackend = await loadRunnablesFromBackend(
+    backendPath,
+    defaultTs,
+  );
 
   let runnables: Record<string, any>;
   if (Object.keys(runnablesFromBackend).length > 0) {
@@ -542,7 +545,14 @@ async function pushRawAppCommand(
   }
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
+  const merged = await mergeConfigWithConfigFile(opts);
 
-  await pushRawApp(workspace.workspaceId, remotePath, filePath);
+  await pushRawApp(
+    workspace.workspaceId,
+    remotePath,
+    filePath,
+    undefined,
+    merged.defaultTs,
+  );
   log.info(colors.bold.underline.green("Raw app pushed"));
 }

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -1,5 +1,6 @@
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
+import { getDefaultTs } from "../../core/conf.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
 import { sep as SEP } from "node:path";
@@ -143,12 +144,14 @@ function getRunnableIdFromCodeFile(fileName: string): string | undefined {
  * Returns an empty object if the backend folder doesn't exist.
  *
  * @param backendPath - Path to the backend folder
- * @param defaultTs - Default TypeScript runtime ("bun" or "deno")
+ * @param defaultTs - TypeScript runtime a bare `.ts` denotes; resolved from
+ *   wmill.yaml when omitted, so readers agree with what the assigner wrote
  */
 export async function loadRunnablesFromBackend(
   backendPath: string,
-  defaultTs: "bun" | "deno" = "bun",
+  defaultTs?: "bun" | "deno",
 ): Promise<Record<string, any>> {
+  const ts = defaultTs ?? (await getDefaultTs());
   const runnables: Record<string, any> = {};
 
   try {
@@ -188,7 +191,7 @@ export async function loadRunnablesFromBackend(
         );
 
         if (contentFile) {
-          const language = getLanguageFromExtension(contentFile.ext, defaultTs);
+          const language = getLanguageFromExtension(contentFile.ext, ts);
           const lock = await readSiblingLock(backendPath, runnableId, allFiles);
 
           // Reconstruct inlineScript object
@@ -240,7 +243,7 @@ export async function loadRunnablesFromBackend(
       );
 
       if (contentFile) {
-        const language = getLanguageFromExtension(contentFile.ext, defaultTs);
+        const language = getLanguageFromExtension(contentFile.ext, ts);
         const lock = await readSiblingLock(backendPath, runnableId, allFiles);
 
         // Create inline runnable with default empty fields

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4628,15 +4628,18 @@ export async function push(
                 newObj,
                 opts.plainSecrets ?? false,
                 alreadySynced,
-                opts.message,
-                originalWorkspaceSpecificPath,
-                permissionedAsContext,
-                isWsSpecific ? true : undefined,
                 {
-                  noninteractive: (opts.yes ?? false) || !process.stdin.isTTY,
-                  skipReencrypt: opts.skipReencryptOnKeyChange,
+                  message: opts.message,
+                  originalLocalPath: originalWorkspaceSpecificPath,
+                  permissionedAsContext,
+                  wsSpecific: isWsSpecific ? true : undefined,
+                  keyPushOpts: {
+                    noninteractive:
+                      (opts.yes ?? false) || !process.stdin.isTTY,
+                    skipReencrypt: opts.skipReencryptOnKeyChange,
+                  },
+                  defaultTs: opts.defaultTs,
                 },
-                opts.defaultTs,
               );
 
               if (stateTarget) {
@@ -4755,15 +4758,18 @@ export async function push(
                 obj,
                 opts.plainSecrets ?? false,
                 [],
-                opts.message,
-                localFilePath, // Pass the actual local file path
-                permissionedAsContext,
-                isAddedWsSpecific ? true : undefined,
                 {
-                  noninteractive: (opts.yes ?? false) || !process.stdin.isTTY,
-                  skipReencrypt: opts.skipReencryptOnKeyChange,
+                  message: opts.message,
+                  originalLocalPath: localFilePath,
+                  permissionedAsContext,
+                  wsSpecific: isAddedWsSpecific ? true : undefined,
+                  keyPushOpts: {
+                    noninteractive:
+                      (opts.yes ?? false) || !process.stdin.isTTY,
+                    skipReencrypt: opts.skipReencryptOnKeyChange,
+                  },
+                  defaultTs: opts.defaultTs,
                 },
-                opts.defaultTs,
               );
 
               if (stateTarget) {
@@ -4873,7 +4879,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        opts.message,
+                        { message: opts.message },
                       );
                     } else {
                       // Flow folder doesn't exist locally — delete on server
@@ -4915,7 +4921,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        opts.message,
+                        { message: opts.message },
                       );
                     } else {
                       // App folder doesn't exist locally — delete on server
@@ -4958,12 +4964,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        opts.message,
-                        undefined,
-                        undefined,
-                        undefined,
-                        undefined,
-                        opts.defaultTs,
+                        { message: opts.message, defaultTs: opts.defaultTs },
                       );
                     } else {
                       // The entire raw app folder was deleted locally,

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4636,6 +4636,7 @@ export async function push(
                   noninteractive: (opts.yes ?? false) || !process.stdin.isTTY,
                   skipReencrypt: opts.skipReencryptOnKeyChange,
                 },
+                opts.defaultTs,
               );
 
               if (stateTarget) {
@@ -4762,6 +4763,7 @@ export async function push(
                   noninteractive: (opts.yes ?? false) || !process.stdin.isTTY,
                   skipReencrypt: opts.skipReencryptOnKeyChange,
                 },
+                opts.defaultTs,
               );
 
               if (stateTarget) {
@@ -4957,6 +4959,11 @@ export async function push(
                         opts.plainSecrets ?? false,
                         alreadySynced,
                         opts.message,
+                        undefined,
+                        undefined,
+                        undefined,
+                        undefined,
+                        opts.defaultTs,
                       );
                     } else {
                       // The entire raw app folder was deleted locally,

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -196,40 +196,6 @@ export function getWmillYamlPath(): string | null {
   return findWmillYaml();
 }
 
-/**
- * The workspace's TypeScript runtime for extensionless `.ts`, per wmill.yaml.
- *
- * `getLanguageExtension` writes a bare `.ts` only when the script's language
- * equals `defaultTs` (a bun script in a deno workspace becomes `.bun.ts`), so
- * anything reading a bare `.ts` back must resolve it the same way or the
- * round-trip silently relabels the script.
- *
- * Memoized per cwd: resolving the config walks up to wmill.yaml through
- * `isGitRepository`/`getGitRepoRoot`, which shell out to git, and callers here
- * are per-runnable-folder. Keying on cwd rather than a single slot keeps this
- * correct across the chdir that `findWmillYaml` itself can perform.
- */
-const defaultTsByCwd = new Map<string, "bun" | "deno">();
-
-export async function getDefaultTs(): Promise<"bun" | "deno"> {
-  const cwd = process.cwd();
-  const cached = defaultTsByCwd.get(cwd);
-  if (cached) {
-    return cached;
-  }
-  let resolved: "bun" | "deno" = "bun";
-  try {
-    const conf = await readConfigFile({ warnIfMissing: false });
-    if (conf?.defaultTs === "deno") {
-      resolved = "deno";
-    }
-  } catch {
-    // no readable wmill.yaml — bun is the documented default
-  }
-  defaultTsByCwd.set(cwd, resolved);
-  return resolved;
-}
-
 let legacyConfigWarned = false;
 
 export async function readConfigFile(opts?: { warnIfMissing?: boolean }): Promise<SyncOptions> {

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -196,6 +196,40 @@ export function getWmillYamlPath(): string | null {
   return findWmillYaml();
 }
 
+/**
+ * The workspace's TypeScript runtime for extensionless `.ts`, per wmill.yaml.
+ *
+ * `getLanguageExtension` writes a bare `.ts` only when the script's language
+ * equals `defaultTs` (a bun script in a deno workspace becomes `.bun.ts`), so
+ * anything reading a bare `.ts` back must resolve it the same way or the
+ * round-trip silently relabels the script.
+ *
+ * Memoized per cwd: resolving the config walks up to wmill.yaml through
+ * `isGitRepository`/`getGitRepoRoot`, which shell out to git, and callers here
+ * are per-runnable-folder. Keying on cwd rather than a single slot keeps this
+ * correct across the chdir that `findWmillYaml` itself can perform.
+ */
+const defaultTsByCwd = new Map<string, "bun" | "deno">();
+
+export async function getDefaultTs(): Promise<"bun" | "deno"> {
+  const cwd = process.cwd();
+  const cached = defaultTsByCwd.get(cwd);
+  if (cached) {
+    return cached;
+  }
+  let resolved: "bun" | "deno" = "bun";
+  try {
+    const conf = await readConfigFile({ warnIfMissing: false });
+    if (conf?.defaultTs === "deno") {
+      resolved = "deno";
+    }
+  } catch {
+    // no readable wmill.yaml — bun is the documented default
+  }
+  defaultTsByCwd.set(cwd, resolved);
+  return resolved;
+}
+
 let legacyConfigWarned = false;
 
 export async function readConfigFile(opts?: { warnIfMissing?: boolean }): Promise<SyncOptions> {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -174,6 +174,21 @@ function redactString(s: string): string {
   return s.slice(0, 5) + "*".repeat(s.length - 5);
 }
 
+export interface PushObjOptions {
+  /** Optional commit/update message */
+  message?: string;
+  /** The original local file path (used for branch-specific resource file resolution) */
+  originalLocalPath?: string;
+  /** Identity to attribute the push to, for the types that carry one */
+  permissionedAsContext?: PermissionedAsContext;
+  /** Whether the item is workspace-specific */
+  wsSpecific?: boolean;
+  /** encryption_key push: non-interactive flag and explicit re-encryption choice */
+  keyPushOpts?: PushWorkspaceKeyOptions;
+  /** TypeScript runtime a bare `.ts` denotes, for raw-app runnables */
+  defaultTs?: "bun" | "deno";
+}
+
 /**
  * Pushes an object to the workspace server based on its type
  * @param workspace - The workspace ID to push to
@@ -182,19 +197,8 @@ function redactString(s: string): string {
  * @param newObj - The new object state to push
  * @param plainSecrets - Whether to store secrets in plain text
  * @param alreadySynced - Array to track already synced items
- * @param message - Optional commit/update message
- * @param originalLocalPath - The original local file path (used for branch-specific resource file resolution)
- * @param keyPushOpts - Options for the encryption_key push: non-interactive flag and explicit re-encryption choice
+ * @param opts - Per-type extras; see PushObjOptions
  */
-export interface PushObjOptions {
-  message?: string;
-  originalLocalPath?: string;
-  permissionedAsContext?: PermissionedAsContext;
-  wsSpecific?: boolean;
-  keyPushOpts?: PushWorkspaceKeyOptions;
-  defaultTs?: "bun" | "deno";
-}
-
 export async function pushObj(
   workspace: string,
   p: string,

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -198,6 +198,7 @@ export async function pushObj(
   permissionedAsContext?: PermissionedAsContext,
   wsSpecific?: boolean,
   keyPushOpts?: PushWorkspaceKeyOptions,
+  defaultTs?: "bun" | "deno",
 ) {
   const typeEnding = getTypeStrFromPath(p);
 
@@ -212,7 +213,7 @@ export async function pushObj(
     if (!rawAppName) {
       throw new Error(`Could not extract raw app name from path: ${p}`);
     }
-    await pushRawApp(workspace, rawAppName, buildFolderPath(rawAppName, "raw_app"), message);
+    await pushRawApp(workspace, rawAppName, buildFolderPath(rawAppName, "raw_app"), message, defaultTs);
   } else if (typeEnding === "folder") {
     await pushFolder(workspace, p, befObj, newObj);
   } else if (typeEnding === "variable") {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -186,6 +186,15 @@ function redactString(s: string): string {
  * @param originalLocalPath - The original local file path (used for branch-specific resource file resolution)
  * @param keyPushOpts - Options for the encryption_key push: non-interactive flag and explicit re-encryption choice
  */
+export interface PushObjOptions {
+  message?: string;
+  originalLocalPath?: string;
+  permissionedAsContext?: PermissionedAsContext;
+  wsSpecific?: boolean;
+  keyPushOpts?: PushWorkspaceKeyOptions;
+  defaultTs?: "bun" | "deno";
+}
+
 export async function pushObj(
   workspace: string,
   p: string,
@@ -193,13 +202,16 @@ export async function pushObj(
   newObj: any,
   plainSecrets: boolean,
   alreadySynced: string[],
-  message?: string,
-  originalLocalPath?: string,
-  permissionedAsContext?: PermissionedAsContext,
-  wsSpecific?: boolean,
-  keyPushOpts?: PushWorkspaceKeyOptions,
-  defaultTs?: "bun" | "deno",
+  opts: PushObjOptions = {},
 ) {
+  const {
+    message,
+    originalLocalPath,
+    permissionedAsContext,
+    wsSpecific,
+    keyPushOpts,
+    defaultTs,
+  } = opts;
   const typeEnding = getTypeStrFromPath(p);
 
   if (typeEnding === "app") {

--- a/cli/test/raw_app_workspace_deps_unit.test.ts
+++ b/cli/test/raw_app_workspace_deps_unit.test.ts
@@ -5,6 +5,11 @@
  * workspace dependency filtering must resolve those files, otherwise the
  * default `dependencies/package.json` is dropped and locks are regenerated
  * against unpinned versions.
+ *
+ * Exercised through the legacy (tree-less) path: tree mode sources its deps
+ * from `getMismatchedWorkspaceDeps()`, which is only populated by an
+ * `uploadScripts` round-trip, so it cannot run offline. Both paths filter the
+ * same `appValue`, so resolving it correctly is what this pins.
  */
 
 import { expect, test } from "bun:test";
@@ -49,7 +54,6 @@ test("raw app: default workspace deps are picked up from backend runnables", asy
       "utf-8",
     );
 
-    // Record the app's hashes while no workspace dependencies exist.
     await generateAppLocksInternal(
       APP_FOLDER,
       true,

--- a/cli/test/raw_app_workspace_deps_unit.test.ts
+++ b/cli/test/raw_app_workspace_deps_unit.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Raw app workspace dependencies
+ *
+ * A raw app keeps its runnables in `backend/`, not in `raw_app.yaml`. The
+ * workspace dependency filtering must resolve those files, otherwise the
+ * default `dependencies/package.json` is dropped and locks are regenerated
+ * against unpinned versions.
+ */
+
+import { expect, test } from "bun:test";
+import * as path from "node:path";
+import os from "node:os";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { generateAppLocksInternal } from "../src/commands/app/app_metadata.ts";
+import { Workspace } from "../src/commands/workspace/workspace.ts";
+
+const stubWorkspace: Workspace = {
+  remote: "http://localhost:0/",
+  workspaceId: "test",
+  name: "test",
+  token: "test",
+};
+
+const APP_FOLDER = path.join("f", "example.raw_app");
+
+async function withTempDir(fn: (tempDir: string) => Promise<void>): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "wmill_raw_app_deps_"));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    await fn(tempDir);
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("raw app: default workspace deps are picked up from backend runnables", async () => {
+  await withTempDir(async () => {
+    await mkdir(path.join(APP_FOLDER, "backend"), { recursive: true });
+    await writeFile(
+      path.join(APP_FOLDER, "raw_app.yaml"),
+      `summary: "example raw app"\npolicy:\n  execution_mode: publisher\n  triggerables: {}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      path.join(APP_FOLDER, "backend", "test.ts"),
+      `import * as wmill from "windmill-client"\n\nexport async function main() {\n  return wmill.getVariable("example")\n}\n`,
+      "utf-8",
+    );
+
+    // Record the app's hashes while no workspace dependencies exist.
+    await generateAppLocksInternal(
+      APP_FOLDER,
+      true,
+      false,
+      stubWorkspace,
+      { defaultTs: "bun" },
+      true, // justUpdateMetadataLock — no backend round-trip
+      true,
+    );
+
+    expect(
+      await generateAppLocksInternal(APP_FOLDER, true, true, stubWorkspace, { defaultTs: "bun" }, false, true),
+    ).toBeUndefined();
+
+    // The runnable has no `package_json` annotation, so it uses the default
+    // manifest — adding it must invalidate the app.
+    await mkdir("dependencies", { recursive: true });
+    await writeFile(
+      path.join("dependencies", "package.json"),
+      `{"dependencies": {"windmill-client": "1.742.0"}}`,
+      "utf-8",
+    );
+
+    expect(
+      await generateAppLocksInternal(APP_FOLDER, true, true, stubWorkspace, { defaultTs: "bun" }, false, true),
+    ).toEqual("f/example.raw_app");
+  });
+});


### PR DESCRIPTION
## Summary

`wmill generate-metadata` regenerated raw-app runnable locks without the default
Bun workspace manifest, so a pinned `windmill-client` drifted back to `latest`
on every run. Standalone Bun scripts and flow inline scripts with the same
import were unaffected.

Raw apps keep their runnables as files under `backend/`; `raw_app.yaml` only
carries a `runnables` map in the legacy layout. `generateAppLocksInternal` read
`appValue` straight from `raw_app.yaml` and fed that to
`filterWorkspaceDependenciesForApp`, so a file-based raw app filtered its
dependencies against an empty runnables map — the result was `{}` and the
dependency job ran with `raw_workspace_dependencies: null`.

### Regression window

Not a longstanding gap — this worked until v1.639.0:

- v1.590.0 (#7310) moved raw-app runnables into `backend/` files.
- v1.639.0 (#7993) introduced `filterWorkspaceDependenciesForApp` as a gate in
  front of lock generation. Before it, the raw workspace-dependency map was
  passed straight through to `updateRawAppRunnables`, so the on-disk layout was
  irrelevant and the pin was honored.

Raw apps in the legacy layout (runnables inline in `raw_app.yaml`) and normal
apps were never affected, which is why the feature still looks healthy in those
cases.

### Scope note

This grew past the original two-file fix during review. Chasing the root cause
surfaced a second, related defect — `loadRunnablesFromBackend` hardcoded `bun`
for a bare `.ts`, disagreeing with the assigner that wrote the file — and the
remaining call sites are fixed here rather than deferred.

## Changes

**The lock fix**

- `app_metadata.ts`: resolve raw-app runnables from `backend/` (falling back to
  `raw_app.yaml`) before workspace-dependency filtering. The two later, correct
  resolutions — the tree dry-run pass and the lock-generation branch — reuse
  that single load; having three independent answers to "where are the
  runnables", one of them wrong, is what produced this bug.

**The `defaultTs` round-trip**

`getLanguageExtension` writes a bare `.ts` only when the script's language
equals `defaultTs`, so in a `defaultTs: deno` workspace a bun runnable is
`test.bun.ts` and a plain `test.ts` means deno. Every reader hardcoded `bun`,
which relabeled the script and made the writer emit a duplicate `test.bun.ts`
beside `test.ts`. `defaultTs` is now threaded from each command entry, matching
how the pull side already feeds `newRawAppPathAssigner`:

- `sync.ts` → `pushObj` → `pushRawApp` (carries the effective, override-resolved
  `opts.defaultTs`)
- `app.ts` push and `pushRawAppCommand` → `pushRawApp`
- `dev.ts`: resolved once at startup, passed to `loadRunnablesFromBackend` (×3),
  `inferAllInlineSchemas`, and `inferRunnableSchemaFromFile`
- `lint.ts` left alone: it reads only `Object.keys(...).length`, which is
  language-independent

**Refactor**

- `pushObj`'s six trailing optional positionals collapse into a
  `PushObjOptions` object, removing a four-`undefined` call and naming
  `originalLocalPath` at the two sites that were passing it positionally.

**Test**

- `raw_app_workspace_deps_unit.test.ts`: pins that a file-based raw app's
  `backend/` runnable picks up `dependencies/package.json`.

## Test plan

- [x] `bun test test/raw_app_workspace_deps_unit.test.ts` — fails on `main`
      (app reported up-to-date after the default manifest appears), passes here.
- [x] `UNIT_ONLY=1 bun test test/*_unit*.test.ts` — 991 pass, 0 fail (re-run at
      `bec4de186a`).
- [x] `bunx tsc --noEmit` — no new errors; the two `sync.ts` JSZip errors are
      pre-existing on `main`.
- [x] End-to-end against a local backend + worker, `dependencies/package.json`
      pinning `windmill-client`, raw app runnable at
      `f/example.raw_app/backend/test.ts` importing it:
  - before: lock declares `"windmill-client": "latest"`, resolves `1.775.2`
  - after: lock declares the pinned version — byte-identical to the lock of a
    standalone Bun script with the same import
  - bumping the pin re-marks the app stale and regenerates; a second run reports
    `All metadata up-to-date`
- [x] Legacy raw app (runnables inline in `raw_app.yaml`) and normal app with an
      inline Bun script both still pick up the pinned dependency.
- [x] `defaultTs: deno` workspace: `test.bun.ts` → bun, pinned lock, no
      duplicate file, idempotent; plain `test.ts` → deno, no `package.json`, no
      duplicate. Baseline `031f17d665` produced
      `test.ts + test.bun.ts + test.lock + test.yaml` for the same input.
- [x] Full `wmill sync push` through `pushObj → pushRawApp` after the
      options-object refactor; server confirms the runnable landed as
      `type=inline language=bun` with the pin intact.

## Known deferred

`wmill app push`, `app push-raw` and `app dev` read top-level `defaultTs` via
`mergeConfigWithConfigFile`, which does not apply `workspaces[*].overrides`,
so a per-workspace `defaultTs` override is not honored by those three commands.
This is the existing CLI-wide convention — `wmill script push` resolves it the
same way and already mislabels a bare `.ts` standalone script in that config on
`main` — and `sync push` (the path that has to invert what pull wrote) is
correct, since it threads the effective value. Fixing only the two app commands
would leave `script push` inconsistent, so it belongs in a follow-up that
changes the convention everywhere.

Fixes GIT-939
