### PR TITLE
fix(dbt): a project does not collide with its own descriptor

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -365,11 +365,17 @@ export async function handleFile(
 
     // Before anything is written: this path may also be a dbt project's, and
     // pushing here would deploy this file over it.
-    const collidingProject = await collidingDbtProject(
-      removeExtensionToPath(path)
-    );
-    if (collidingProject) {
-      throw dbtPathCollisionError(collidingProject, path);
+    //
+    // The descriptor is exempt because it IS that project's content file — its
+    // base resolves to the same `<base>__dbt/dbt_project.yml`, so the project
+    // would be found colliding with itself and every dbt push would fail.
+    if (!isDbtDescriptorPath(path)) {
+      const collidingProject = await collidingDbtProject(
+        removeExtensionToPath(path)
+      );
+      if (collidingProject) {
+        throw dbtPathCollisionError(collidingProject, path);
+      }
     }
 
     const language = inferContentTypeFromFilePath(path, opts?.defaultTs);

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -363,19 +363,20 @@ export async function handleFile(
     alreadySynced.push(path);
     const remotePath = scriptPathToRemotePath(path);
 
-    // Before anything is written: this path may also be a dbt project's, and
-    // pushing here would deploy this file over it.
-    //
-    // The descriptor is exempt because it IS that project's content file — its
-    // base resolves to the same `<base>__dbt/dbt_project.yml`, so the project
-    // would be found colliding with itself and every dbt push would fail.
-    if (!isDbtDescriptorPath(path)) {
-      const collidingProject = await collidingDbtProject(
-        removeExtensionToPath(path)
-      );
-      if (collidingProject) {
-        throw dbtPathCollisionError(collidingProject, path);
-      }
+    // Before anything is written: `<base>.py` and `<base>__dbt/` deploy to ONE
+    // remote path, so whichever is pushed last replaces the other's script.
+    // Refused from either side — the descriptor is exempt only from finding its
+    // OWN project (it is that project's content file, so its base resolves to
+    // the same `dbt_project.yml`), never from an ordinary sibling.
+    const base = removeExtensionToPath(path);
+    const isDescriptor = isDbtDescriptorPath(path);
+    const other = isDescriptor
+      ? await collidingOrdinaryScript(base)
+      : await collidingDbtProject(base);
+    if (other) {
+      throw isDescriptor
+        ? dbtPathCollisionError(path, other)
+        : dbtPathCollisionError(other, path);
     }
 
     const language = inferContentTypeFromFilePath(path, opts?.defaultTs);
@@ -1025,6 +1026,28 @@ export async function collidingDbtProject(
   return (await stat(project).then(() => true).catch(() => false))
     ? project
     : undefined;
+}
+
+/**
+ * The ordinary script file sharing a base with a dbt project, if there is one —
+ * the same collision as [`collidingDbtProject`], seen from the dbt side.
+ *
+ * Needed because a descriptor may be pushed DIRECTLY (`wmill script push
+ * <base>__dbt/wm_dbt.yaml`), which never passes through the metadata resolution
+ * that would otherwise catch it.
+ */
+export async function collidingOrdinaryScript(
+  basePath: string
+): Promise<string | undefined> {
+  for (const ext of exts) {
+    if (ext === "__dbt/" + DBT_DESCRIPTOR_NAME) continue;
+    const candidate = basePath + ext;
+    const isFile = await stat(candidate)
+      .then((s) => s.isFile())
+      .catch(() => false);
+    if (isFile) return candidate;
+  }
+  return undefined;
 }
 
 export function dbtPathCollisionError(

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -368,7 +368,14 @@ export async function handleFile(
     // Refused from either side — the descriptor is exempt only from finding its
     // OWN project (it is that project's content file, so its base resolves to
     // the same `dbt_project.yml`), never from an ordinary sibling.
-    const base = removeExtensionToPath(path);
+    // A folder-layout script is `<base>__mod/script.ts`, so stripping its
+    // extension yields `<base>__mod/script`, not the base both layouts deploy
+    // to. Wrong base, and the probe below looks in a directory that cannot
+    // exist — which is how a `__mod` script and a dbt project at one path were
+    // both pushed, each replacing the other.
+    const base = isScriptModulePath(path)
+      ? getScriptBasePathFromModulePath(path) ?? removeExtensionToPath(path)
+      : removeExtensionToPath(path);
     const isDescriptor = isDbtDescriptorPath(path);
     const other = isDescriptor
       ? await collidingOrdinaryScript(base)
@@ -1041,11 +1048,17 @@ export async function collidingOrdinaryScript(
 ): Promise<string | undefined> {
   for (const ext of exts) {
     if (ext === "__dbt/" + DBT_DESCRIPTOR_NAME) continue;
-    const candidate = basePath + ext;
-    const isFile = await stat(candidate)
-      .then((s) => s.isFile())
-      .catch(() => false);
-    if (isFile) return candidate;
+    // Both layouts, because both deploy to `basePath`: the flat file, and the
+    // folder layout's entry point.
+    for (const candidate of [
+      basePath + ext,
+      `${basePath}${getModuleFolderSuffix()}/script${ext}`,
+    ]) {
+      const isFile = await stat(candidate)
+        .then((s) => s.isFile())
+        .catch(() => false);
+      if (isFile) return candidate;
+    }
   }
   return undefined;
 }

--- a/cli/test/dbt_optional_descriptor_unit.test.ts
+++ b/cli/test/dbt_optional_descriptor_unit.test.ts
@@ -145,6 +145,49 @@ describe("a dbt project without a descriptor", () => {
     }
   });
 
+  // The guard above must not fire on the project's OWN descriptor: that file is
+  // the dbt script's content, and its base resolves to the same
+  // `<base>__dbt/dbt_project.yml` — so a naive check finds the project
+  // colliding with itself and every dbt push fails before deploying anything.
+  test("a project does not collide with itself", async () => {
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const remote = { workspaceId: "w", remote: "http://127.0.0.1:1", name: "w", token: "t" };
+    const push = (p: string) =>
+      handleFile(p, remote as any, [], undefined, undefined, {}, []).then(
+        () => undefined,
+        (e) => e as Error,
+      );
+    try {
+      // Descriptor-less: the fixture's project, pushed through the module path.
+      const nodesc = await pushParentScriptForModule(
+        "f/analytics/analytics__dbt/models/stg_orders.sql",
+        remote as any,
+        [],
+        undefined,
+        undefined,
+        {},
+        [],
+      ).then(
+        () => undefined,
+        (e) => e as Error,
+      );
+      expect(nodesc).not.toBeInstanceOf(DbtPathCollisionError);
+
+      // Descriptor present, pushed directly. Both reach the network — which is
+      // unreachable here on purpose — so anything BUT the collision is a pass.
+      fs.writeFileSync(
+        path.join(dir, "f/analytics/analytics__dbt/wm_dbt.yaml"),
+        "profile: {}\n",
+      );
+      expect(await push("f/analytics/analytics__dbt/wm_dbt.yaml")).not.toBeInstanceOf(
+        DbtPathCollisionError,
+      );
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
   // The two sides spell "absent" differently — nothing on disk, nothing in the
   // export — so without one normalization a descriptor-less project reads as an
   // addition on every push and a deletion on every pull, forever.

--- a/cli/test/dbt_optional_descriptor_unit.test.ts
+++ b/cli/test/dbt_optional_descriptor_unit.test.ts
@@ -220,6 +220,43 @@ describe("a dbt project without a descriptor", () => {
     }
   });
 
+  // Both layouts deploy to the same remote path, and the folder layout is the
+  // one whose base is NOT its filename: `<base>__mod/script.ts` deploys to
+  // `<base>`, exactly where the dbt project goes.
+  test("the collision holds for a folder-layout script too", async () => {
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const remote = { workspaceId: "w", remote: "http://127.0.0.1:1", name: "w", token: "t" };
+    const push = (p: string) =>
+      handleFile(p, remote as any, [], undefined, undefined, {}, []).then(
+        () => undefined,
+        (e) => e as Error,
+      );
+    try {
+      fs.mkdirSync(path.join(dir, "f/analytics/analytics__mod"), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "f/analytics/analytics__mod/script.ts"),
+        "export async function main() {}",
+      );
+      fs.writeFileSync(
+        path.join(dir, "f/analytics/analytics__dbt/wm_dbt.yaml"),
+        "profile: {}\n",
+      );
+
+      // From the dbt side: the descriptor must find the `__mod` entry point.
+      const fromDbt = await push("f/analytics/analytics__dbt/wm_dbt.yaml");
+      expect(fromDbt).toBeInstanceOf(DbtPathCollisionError);
+      expect(fromDbt?.message).toContain("analytics__mod/script.ts");
+
+      // And from the ordinary side, whose base is not its filename.
+      const fromMod = await push("f/analytics/analytics__mod/script.ts");
+      expect(fromMod).toBeInstanceOf(DbtPathCollisionError);
+      expect(fromMod?.message).toContain("analytics__dbt/dbt_project.yml");
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
   // The two sides spell "absent" differently — nothing on disk, nothing in the
   // export — so without one normalization a descriptor-less project reads as an
   // addition on every push and a deletion on every pull, forever.

--- a/cli/test/dbt_optional_descriptor_unit.test.ts
+++ b/cli/test/dbt_optional_descriptor_unit.test.ts
@@ -188,6 +188,38 @@ describe("a dbt project without a descriptor", () => {
     }
   });
 
+  // The exemption above is only for the project's OWN marker. A descriptor
+  // pushed DIRECTLY never passes through the metadata resolution that catches
+  // the collision, so without this it would deploy over the ordinary script
+  // sitting at the same remote path.
+  test("but a descriptor still refuses an ordinary script at its path", async () => {
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      fs.writeFileSync(
+        path.join(dir, "f/analytics/analytics__dbt/wm_dbt.yaml"),
+        "profile: {}\n",
+      );
+      fs.writeFileSync(path.join(dir, "f/analytics/analytics.py"), "def main(): ...");
+      const err = await handleFile(
+        "f/analytics/analytics__dbt/wm_dbt.yaml",
+        { workspaceId: "w", remote: "http://127.0.0.1:1", name: "w", token: "t" } as any,
+        [],
+        undefined,
+        undefined,
+        {},
+        [],
+      ).then(
+        () => undefined,
+        (e) => e as Error,
+      );
+      expect(err).toBeInstanceOf(DbtPathCollisionError);
+      expect(err?.message).toContain("f/analytics/analytics.py");
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
   // The two sides spell "absent" differently — nothing on disk, nothing in the
   // export — so without one normalization a descriptor-less project reads as an
   // addition on every push and a deletion on every pull, forever.


### PR DESCRIPTION
## Summary

Regression from #10326, on `main` now: **every dbt push fails.**

The path-collision guard added late in that PR runs in `handleFile` for every script content path — including a dbt project's own descriptor. For `f/x/y__dbt/wm_dbt.yaml`, `removeExtensionToPath` returns `f/x/y`, and the probe then finds that same project's required `f/x/y__dbt/dbt_project.yml`. The project is reported as colliding with itself:

```
f/a/a__dbt/dbt_project.yml and f/a/a__dbt/wm_dbt.yaml deploy to the same path,
so pushing either one replaces the other's script.
```

Direct `wmill script push` of the descriptor, model-triggered `wmill sync push` (which resolves to the descriptor and calls `handleFile` with it), and descriptor-less projects all funnel through that path, so all of them fail before deploying.

The descriptor is now exempt: it *is* that project's content file, so the project it "collides" with is itself. The guard still fires for an ordinary script (`f/x/y.py`) sharing a base with a dbt project, which is what it exists for.

## Test plan

- New regression: a descriptor-less project pushed through `pushParentScriptForModule`, and a descriptor-present project pushed directly, both assert the error is **not** `DbtPathCollisionError` (they reach an intentionally unreachable remote, so anything else is a pass).
- The existing test that both push paths *do* refuse a real `foo.py` / `foo__dbt` collision still passes.
- 1038 CLI unit tests pass.

Reproduced before and after with a throwaway fixture: before, `DbtPathCollisionError`; after, the push proceeds to the network call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that made every dbt push fail by treating a project's own descriptor as a collision. Collisions are now judged on the shared deploy path, skipping self-collision while still blocking real base-name conflicts from both sides.

- **Bug Fixes**
  - Normalize the collision base to the deploy path for both layouts; folder-layout entry points (`<base>__mod/script.ts`) correctly collide with dbt projects.
  - Descriptors skip only their own project; they still refuse a sibling ordinary script via `collidingOrdinaryScript(base)`.
  - Ordinary scripts still guard via `collidingDbtProject(base)`; both sides throw `DbtPathCollisionError`.
  - Added tests for self-collision exemption, descriptor vs ordinary script, and folder-layout collisions.

<sup>Written for commit 579d9cbfc49f8031b58d8b85a8810eadc10eaef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

