### PR TITLE
fix: canonicalize a script module path before the add-file checks

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -43,6 +43,7 @@
 	import { invalidateWorkspacePaths } from './PathNameAutocomplete.svelte'
 	import { notifyContractWarnings } from './assets/AssetGraph/schemaContracts'
 	import ScriptEditor from './ScriptEditor.svelte'
+	import { findModulePathClash } from './scriptModulePath'
 	import { Alert, Button, Drawer, SecondsInput, Tab, TabContent, Tabs } from './common'
 	import LanguageIcon from './common/languageIcons/LanguageIcon.svelte'
 	import type { SupportedLanguage, Schema } from '$lib/common'
@@ -984,7 +985,10 @@
 		// draft that grew modules under another language carries none of what dbt
 		// needs, and the worker refuses a bundle with no `dbt_project.yml` — so
 		// that draft reached dbt in a state it could neither deploy nor run.
-		if (script.modules?.['dbt_project.yml']) return
+		// Matched on the canonical path: a bundle pushed with `./dbt_project.yml`
+		// already has the project file, and seeding a second spelling of it is the
+		// two-keys-one-file collision the editor's add-file checks refuse.
+		if (findModulePathClash(script.modules, 'dbt_project.yml')) return
 		script.modules = {
 			'dbt_project.yml': {
 				content:

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -622,6 +622,13 @@
 		return ''
 	}
 
+	/// A spelling of the name the module already has. Nothing to do, so the button
+	/// that would submit it stays disabled rather than being a dead click.
+	function renameIsNoop(input: string, oldPath: string): boolean {
+		const canonical = canonicalModulePath(input)
+		return 'path' in canonical && canonical.path === oldPath
+	}
+
 	function renameModule(oldPath: string) {
 		if (!renameModuleInput.trim()) return
 		const canonical = canonicalModulePath(renameModuleInput)
@@ -2606,7 +2613,7 @@
 					close()
 				}}
 				disabled={!renameModuleInput.trim() ||
-					renameModuleInput.trim() === oldPath ||
+					renameIsNoop(renameModuleInput, oldPath) ||
 					!!renameModuleError}>Rename</Button
 			>
 		</div>

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -23,6 +23,7 @@
 		dbtFileLang,
 		dbtModelSelector
 	} from '$lib/components/dbt/DbtProjectPanel.svelte'
+	import { canonicalModulePath, findModulePathClash } from './scriptModulePath'
 	import SchemaForm from './SchemaForm.svelte'
 	import PowerShellCommonParams from './PowerShellCommonParams.svelte'
 	import LogPanel from './scriptEditor/LogPanel.svelte'
@@ -533,35 +534,43 @@
 	/// The descriptor is the script's CONTENT, not a module. A module at that same
 	/// path would be a second, independent value for one file: the export writes
 	/// the content there, and the bundle would emit over it.
-	function reservedDbtPath(path: string): string | undefined {
-		return lang === 'dbt' && path.trim() === 'wm_dbt.yaml'
+	function reservedDbtPath(canonicalPath: string): string | undefined {
+		return lang === 'dbt' && canonicalPath === 'wm_dbt.yaml'
 			? `wm_dbt.yaml is the descriptor, edited from the tree — it cannot also be a file`
 			: undefined
 	}
 
 	function validateModulePath(path: string): string {
 		if (!path.trim()) return ''
-		const reserved = reservedDbtPath(path)
+		const canonical = canonicalModulePath(path)
+		if ('error' in canonical) return canonical.error
+		const reserved = reservedDbtPath(canonical.path)
 		if (reserved) return reserved
-		const moduleLang = inferModuleLang(path)
+		const moduleLang = inferModuleLang(canonical.path)
 		if (!moduleLang) {
 			const exts = allowedModuleExtensions.join(', ')
 			return `File must end with a supported extension: ${exts}`
 		}
-		const matchedExt = allowedModuleExtensions.find((ext) => path.endsWith(ext))
+		const matchedExt = allowedModuleExtensions.find((ext) => canonical.path.endsWith(ext))
 		if (!matchedExt) {
 			const exts = allowedModuleExtensions.join(', ')
 			return `File must end with a supported extension for this language: ${exts}`
 		}
-		if (modules?.[path.trim()]) {
-			return `Module ${path.trim()} already exists`
+		const clash = findModulePathClash(modules, canonical.path)
+		if (clash) {
+			return `Module ${clash} already exists`
 		}
 		return ''
 	}
 
 	function addModule() {
-		const modulePath = modulePathInput.trim()
-		if (!modulePath) return
+		if (!modulePathInput.trim()) return
+		const canonical = canonicalModulePath(modulePathInput)
+		if ('error' in canonical) {
+			modulePathError = canonical.error
+			return
+		}
+		const modulePath = canonical.path
 		const error = validateModulePath(modulePath)
 		if (error) {
 			modulePathError = error
@@ -592,29 +601,36 @@
 
 	function validateRenameModulePath(newPath: string, oldPath: string): string {
 		if (!newPath.trim()) return ''
-		const reserved = reservedDbtPath(newPath)
+		const canonical = canonicalModulePath(newPath)
+		if ('error' in canonical) return canonical.error
+		const reserved = reservedDbtPath(canonical.path)
 		if (reserved) return reserved
-		const moduleLang = inferModuleLang(newPath)
+		const moduleLang = inferModuleLang(canonical.path)
 		if (!moduleLang) {
 			const exts = allowedModuleExtensions.join(', ')
 			return `File must end with a supported extension: ${exts}`
 		}
-		const matchedExt = allowedModuleExtensions.find((ext) => newPath.endsWith(ext))
+		const matchedExt = allowedModuleExtensions.find((ext) => canonical.path.endsWith(ext))
 		if (!matchedExt) {
 			const exts = allowedModuleExtensions.join(', ')
 			return `File must end with a supported extension for this language: ${exts}`
 		}
-		if (newPath.trim() !== oldPath && modules?.[newPath.trim()]) {
-			return `Module ${newPath.trim()} already exists`
+		const clash = findModulePathClash(modules, canonical.path, oldPath)
+		if (clash) {
+			return `Module ${clash} already exists`
 		}
 		return ''
 	}
 
 	function renameModule(oldPath: string) {
-		const newPath = renameModuleInput.trim()
-		if (!newPath || newPath === oldPath) {
+		if (!renameModuleInput.trim()) return
+		const canonical = canonicalModulePath(renameModuleInput)
+		if ('error' in canonical) {
+			renameModuleError = canonical.error
 			return
 		}
+		const newPath = canonical.path
+		if (newPath === oldPath) return
 		const error = validateRenameModulePath(newPath, oldPath)
 		if (error) {
 			renameModuleError = error

--- a/frontend/src/lib/components/scriptModulePath.test.ts
+++ b/frontend/src/lib/components/scriptModulePath.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalModulePath, findModulePathClash } from './scriptModulePath'
+
+describe('canonicalModulePath', () => {
+	// The pair the duplicate and reserved-name checks exist to catch: both
+	// spellings resolve to the same file in the job directory.
+	it('rewrites a redundant spelling to the file it names', () => {
+		expect(canonicalModulePath('./dbt_project.yml')).toEqual({ path: 'dbt_project.yml' })
+		expect(canonicalModulePath('models//x.sql')).toEqual({ path: 'models/x.sql' })
+		expect(canonicalModulePath('  ./models/./sub//x.sql  ')).toEqual({
+			path: 'models/sub/x.sql'
+		})
+		expect(canonicalModulePath('models/x.sql')).toEqual({ path: 'models/x.sql' })
+	})
+
+	it('refuses a path that leaves the bundle', () => {
+		expect(canonicalModulePath('../x.sql')).toHaveProperty('error')
+		expect(canonicalModulePath('models/../../x.sql')).toHaveProperty('error')
+		expect(canonicalModulePath('/etc/x.sql')).toHaveProperty('error')
+		expect(canonicalModulePath('./')).toHaveProperty('error')
+	})
+
+	// Matches the worker's own rule: `..` is traversal only as a whole segment.
+	it('takes dots inside a name as part of the name', () => {
+		expect(canonicalModulePath('models/weird..name.sql')).toEqual({
+			path: 'models/weird..name.sql'
+		})
+	})
+})
+
+describe('findModulePathClash', () => {
+	// A bundle pushed by the CLI can hold a non-canonical key, so the clash has to
+	// be found from either side, and named the way the tree shows it.
+	it('finds a key that resolves to the same file, however either is spelled', () => {
+		const modules = { './dbt_project.yml': {}, 'models/x.sql': {} }
+		expect(findModulePathClash(modules, 'dbt_project.yml')).toBe('./dbt_project.yml')
+		expect(findModulePathClash(modules, 'models/x.sql')).toBe('models/x.sql')
+		expect(findModulePathClash(modules, 'models/y.sql')).toBeUndefined()
+		expect(findModulePathClash(undefined, 'models/x.sql')).toBeUndefined()
+	})
+
+	// A rename must not stop at the module being renamed: with both spellings in
+	// the bundle, that would hide the other one and overwrite its content.
+	it('keeps looking past the key being renamed', () => {
+		const modules = { './models/x.sql': {}, 'models/x.sql': {} }
+		expect(findModulePathClash(modules, 'models/x.sql', './models/x.sql')).toBe('models/x.sql')
+		expect(
+			findModulePathClash({ './models/x.sql': {} }, 'models/x.sql', './models/x.sql')
+		).toBeUndefined()
+	})
+})

--- a/frontend/src/lib/components/scriptModulePath.test.ts
+++ b/frontend/src/lib/components/scriptModulePath.test.ts
@@ -39,6 +39,12 @@ describe('findModulePathClash', () => {
 		expect(findModulePathClash(undefined, 'models/x.sql')).toBeUndefined()
 	})
 
+	// The worker does not trim path components, so an imported `x.sql ` is its
+	// own file and must not stand in the way of adding `x.sql`.
+	it('does not fold a key whose name carries whitespace', () => {
+		expect(findModulePathClash({ 'models/x.sql ': {} }, 'models/x.sql')).toBeUndefined()
+	})
+
 	// A rename must not stop at the module being renamed: with both spellings in
 	// the bundle, that would hide the other one and overwrite its content.
 	it('keeps looking past the key being renamed', () => {

--- a/frontend/src/lib/components/scriptModulePath.ts
+++ b/frontend/src/lib/components/scriptModulePath.ts
@@ -1,0 +1,55 @@
+/**
+ * The canonical spelling of a script module's path (the key of the module
+ * bundle), or the reason it cannot be one.
+ *
+ * The worker resolves `.` and `//` away when it materialises the bundle into
+ * the job directory, so `./dbt_project.yml` and `dbt_project.yml` are two keys
+ * for one file on disk; the bundle is a Rust `HashMap`, so which content lands
+ * there is undefined. Canonicalising before the duplicate and reserved-name
+ * checks is what keeps them from being walked past.
+ *
+ * Redundant spellings are rewritten rather than refused: they name the file the
+ * user meant, and the tree shows the canonical form regardless. `..` and
+ * absolute paths name a file OUTSIDE the bundle, which has no canonical form
+ * inside it, so they are refused here — the worker drops them, which would
+ * otherwise show up as a file that was added and then silently never written.
+ */
+export function canonicalModulePath(path: string): { path: string } | { error: string } {
+	const trimmed = path.trim()
+	if (trimmed.startsWith('/')) {
+		return { error: `File path must be relative, without a leading /` }
+	}
+	const segments = trimmed.split('/').filter((s) => s !== '' && s !== '.')
+	if (segments.includes('..')) {
+		return { error: `File path cannot contain ..` }
+	}
+	if (segments.length === 0) {
+		return { error: `File name cannot be empty` }
+	}
+	return { path: segments.join('/') }
+}
+
+/**
+ * The existing module key that would land on the same file as `canonicalPath`,
+ * spelled as the bundle holds it (which is what the file tree shows).
+ *
+ * Keys already in the bundle are not canonical either: nothing on the push path
+ * rewrites them, so a project imported with `./dbt_project.yml` in it must still
+ * refuse a second `dbt_project.yml`.
+ *
+ * `ignoreKey` is the module being renamed. It has to be skipped inside the
+ * search rather than compared against the result: a bundle can hold BOTH
+ * spellings, and stopping at the renamed one would hide the other and let the
+ * rename overwrite it.
+ */
+export function findModulePathClash(
+	modules: Record<string, unknown> | null | undefined,
+	canonicalPath: string,
+	ignoreKey?: string
+): string | undefined {
+	return Object.keys(modules ?? {}).find((key) => {
+		if (key === ignoreKey) return false
+		const canonical = canonicalModulePath(key)
+		return 'path' in canonical && canonical.path === canonicalPath
+	})
+}

--- a/frontend/src/lib/components/scriptModulePath.ts
+++ b/frontend/src/lib/components/scriptModulePath.ts
@@ -1,3 +1,17 @@
+function canonicalize(path: string): { path: string } | { error: string } {
+	if (path.startsWith('/')) {
+		return { error: `File path must be relative, without a leading /` }
+	}
+	const segments = path.split('/').filter((s) => s !== '' && s !== '.')
+	if (segments.includes('..')) {
+		return { error: `File path cannot contain ..` }
+	}
+	if (segments.length === 0) {
+		return { error: `File name cannot be empty` }
+	}
+	return { path: segments.join('/') }
+}
+
 /**
  * The canonical spelling of a script module's path (the key of the module
  * bundle), or the reason it cannot be one.
@@ -13,20 +27,13 @@
  * absolute paths name a file OUTSIDE the bundle, which has no canonical form
  * inside it, so they are refused here — the worker drops them, which would
  * otherwise show up as a file that was added and then silently never written.
+ *
+ * Surrounding whitespace is dropped because this is what someone typed into a
+ * text box. A key already in a bundle gets no such courtesy — see
+ * `findModulePathClash`.
  */
 export function canonicalModulePath(path: string): { path: string } | { error: string } {
-	const trimmed = path.trim()
-	if (trimmed.startsWith('/')) {
-		return { error: `File path must be relative, without a leading /` }
-	}
-	const segments = trimmed.split('/').filter((s) => s !== '' && s !== '.')
-	if (segments.includes('..')) {
-		return { error: `File path cannot contain ..` }
-	}
-	if (segments.length === 0) {
-		return { error: `File name cannot be empty` }
-	}
-	return { path: segments.join('/') }
+	return canonicalize(path.trim())
 }
 
 /**
@@ -35,7 +42,9 @@ export function canonicalModulePath(path: string): { path: string } | { error: s
  *
  * Keys already in the bundle are not canonical either: nothing on the push path
  * rewrites them, so a project imported with `./dbt_project.yml` in it must still
- * refuse a second `dbt_project.yml`.
+ * refuse a second `dbt_project.yml`. They are matched WITHOUT trimming, because
+ * the worker does not trim path components: an imported `x.sql ` is its own file
+ * on disk and must not stand in the way of adding `x.sql`.
  *
  * `ignoreKey` is the module being renamed. It has to be skipped inside the
  * search rather than compared against the result: a bundle can hold BOTH
@@ -49,7 +58,7 @@ export function findModulePathClash(
 ): string | undefined {
 	return Object.keys(modules ?? {}).find((key) => {
 		if (key === ignoreKey) return false
-		const canonical = canonicalModulePath(key)
+		const canonical = canonicalize(key)
 		return 'path' in canonical && canonical.path === canonicalPath
 	})
 }


### PR DESCRIPTION
## Summary

The add-file flow in `ScriptEditor.svelte` compared the typed module path as a raw
string, so a non-canonical spelling walked past both the duplicate check and the
reserved-name check: `./dbt_project.yml` beside the seeded `dbt_project.yml`, or
`models//x.sql` beside `models/x.sql`. The worker resolves `.` components away when it
materialises the bundle (`is_contained_relative_path` accepts `Component::CurDir`), so
both keys land on one file on disk — and the bundle is a Rust `HashMap`, so which
content survives is undefined.

Closes WIN-2273 (review follow-up from #10326, deliberately left out of that PR).

**Normalize rather than refuse, for the spellings that name the same file.** `./` and
`//` denote the file the user meant and the tree shows the canonical form anyway, so
rewriting them is what every file tree does; refusing would be pedantry over a typo.
`..` and absolute paths denote a file *outside* the bundle, which has no canonical form
inside it and which the worker silently drops, so those are refused with a message. The
rationale is recorded on the normalizer itself.

Both checks now also canonicalize the keys *already in the bundle*: nothing on the push
path rewrites them, so a project imported by the CLI carrying `./dbt_project.yml` must
still refuse a second `dbt_project.yml`.

## Changes

- New `frontend/src/lib/components/scriptModulePath.ts`:
  - `canonicalModulePath` — strips `./`, collapses `//`, refuses `..` segments and
    absolute paths. Mirrors the worker's rule that `..` is traversal only as a whole
    segment (`weird..name.sql` is a filename).
  - `findModulePathClash` — the existing key that resolves to the same file, spelled as
    the bundle holds it. `ignoreKey` (the module being renamed) is skipped *inside* the
    search: a bundle can hold both spellings, and stopping at the renamed one would hide
    the other and let the rename overwrite it.
- `ScriptEditor.svelte`: add and rename both canonicalize before the duplicate,
  reserved-name and extension checks, and store the canonical key.
- `ScriptEditor.svelte`: the Rename button is disabled for a spelling of the name the
  module already has, so it no longer offers a click that silently does nothing.
- `ScriptBuilder.svelte`: `seedDbtProject`'s guard matches the canonical path, so a bundle
  pushed with `./dbt_project.yml` is not given a second spelling of the project file.
- Unit tests on the normalizer and the clash search — these checks are what keep
  `dbt_project.yml` and the `wm_dbt.yaml` descriptor from being shadowed.

Existing bundle keys are matched **without** trimming: the worker does not trim path
components, so an imported `x.sql ` is its own file on disk and must not stand in the way
of adding `x.sql`. Trimming stays on the typed input, where it is a text-box courtesy.

Not dbt-specific: the same form backs the WAC module strip, which had the same hole.

## Test plan

- [x] `npx vitest run src/lib/components/scriptModulePath.test.ts` — 5 passing
- [x] `npm run check` — 0 errors
- [x] dbt `+` flow driven in a real browser against the dev server, every case below
- [x] rename with both spellings present, on a bundle created through the API
- [x] rename cases on a single-module bundle: `./inner/a.ts` and `inner//a.ts` over
      `inner/a.ts` leave Rename disabled; `inner/b.ts` keeps it enabled

| typed | result |
|---|---|
| `./dbt_project.yml` | `Module dbt_project.yml already exists`, Add disabled |
| `models//example.sql` | `Module models/example.sql already exists`, Add disabled |
| `../escape.sql` | `File path cannot contain ..`, Add disabled |
| `/etc/passwd.sql` | `File path must be relative, without a leading /`, Add disabled |
| `./wm_dbt.yaml` | reserved-descriptor message, Add disabled |
| `./models/new_model.sql` | accepted, stored as `models/new_model.sql` |

The last row is the one that proves the rewrite rather than a refusal: the tree renders
one node per path segment, and it shows `models/` → `new_model.sql` with no `.` folder.

## Screenshots

`./dbt_project.yml` caught by the duplicate check, named by its canonical spelling:

![dbt-dup-canonical](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-canonical-paths/1785588152-dbt-dup-canonical.png)

`../escape.sql` refused:

![dbt-traversal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-canonical-paths/1785588154-dbt-traversal.png)

`./models/new_model.sql` added, canonical, in the tree (no `.` folder):

![dbt-added](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-canonical-paths/1785588157-dbt-added.png)

A bundle holding both `./inner/a.ts` and `inner/a.ts` (created through the API, as a CLI
push could): renaming the first onto the second is refused instead of overwriting it:

![wac-rename-clash](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-canonical-paths/1785588159-wac-rename-clash.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes script module paths before add/rename validation so duplicate and reserved-name checks catch equivalent spellings and align with worker resolution. Also avoids whitespace-folding in clash detection and disables no-op renames to prevent shadowing/overwrites. Addresses WIN-2273.

- **Bug Fixes**
  - Added `canonicalModulePath` to normalize paths (strip `./`, collapse `//`, refuse `..`/leading `/`, enforce non-empty).
  - Updated `findModulePathClash` to match via canonical paths without trimming existing keys and skip the key being renamed.
  - Disabled rename when the canonical input equals the current path; store the canonical key on add/rename.
  - Used clash detection when seeding `dbt_project.yml` to avoid duplicates if `./dbt_project.yml` already exists.
  - Added unit tests for normalization, non-trim clash matching, and rename collision handling.

<sup>Written for commit 7493b96181320f0b5392a3d0c2852113d25c5c6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Renaming `inner/a.ts` to a spelling of the name it already has leaves Rename disabled
rather than offering a dead click:

![wac-rename-noop](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-canonical-paths/1785588954-wac-rename-noop.png)
