### PR TITLE
fix: repair the two CI jobs that fail on a release tag

### DIFF
--- a/.github/scripts/check-docs-links.mjs
+++ b/.github/scripts/check-docs-links.mjs
@@ -15,6 +15,17 @@ const CONCURRENCY = 24
 const TIMEOUT_MS = 20000
 const RETRIES = 2
 
+// Links whose target page is written but not yet deployed on windmill.dev: the app
+// link is already the final slug, so a 404 is expected until the docs side ships.
+// Every entry is still fetched — one that starts resolving is reported so the entry
+// gets dropped, because a stale entry silently hides a genuinely dead link.
+const PENDING_DEPLOY = new Map([
+	[
+		'https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt',
+		'windmilldocs#1625 (dbt runtime quickstart)'
+	]
+])
+
 async function walk(dir) {
 	const out = []
 	for (const entry of await readdir(dir, { withFileTypes: true })) {
@@ -111,9 +122,23 @@ async function worker() {
 }
 await Promise.all(Array.from({ length: CONCURRENCY }, worker))
 
-const failures = results.filter((r) => !r.ok)
+const pending = results.filter((r) => PENDING_DEPLOY.has(r.url))
+if (pending.length) {
+	console.log(`\n⏳ ${pending.length} link(s) waiting on a docs deploy:`)
+	for (const p of pending.sort((a, b) => a.url.localeCompare(b.url))) {
+		const state = p.ok ? 'LIVE — remove from PENDING_DEPLOY' : `not live yet (${p.status})`
+		console.log(`   ${p.url}\n     ${PENDING_DEPLOY.get(p.url)} — ${state}`)
+	}
+}
+for (const url of PENDING_DEPLOY.keys()) {
+	if (!urls.has(url)) {
+		console.log(`\n⏳ ${url} is in PENDING_DEPLOY but no longer referenced — remove the entry.`)
+	}
+}
+
+const failures = results.filter((r) => !r.ok && !PENDING_DEPLOY.has(r.url))
 if (failures.length === 0) {
-	console.log(`\n✅ All ${allUrls.length} docs links are reachable.`)
+	console.log(`\n✅ No broken docs links (${allUrls.length} checked).`)
 	process.exit(0)
 }
 

--- a/.github/scripts/check-docs-links.mjs
+++ b/.github/scripts/check-docs-links.mjs
@@ -17,8 +17,7 @@ const RETRIES = 2
 
 // Links whose target page is written but not yet deployed on windmill.dev: the app
 // link is already the final slug, so a 404 is expected until the docs side ships.
-// Every entry is still fetched — one that starts resolving is reported so the entry
-// gets dropped, because a stale entry silently hides a genuinely dead link.
+// The value is why the entry exists, for whoever has to judge whether it still should.
 const PENDING_DEPLOY = new Map([
 	[
 		'https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt',
@@ -123,29 +122,39 @@ async function worker() {
 await Promise.all(Array.from({ length: CONCURRENCY }, worker))
 
 const pending = results.filter((r) => PENDING_DEPLOY.has(r.url))
-if (pending.length) {
-	console.log(`\n⏳ ${pending.length} link(s) waiting on a docs deploy:`)
-	for (const p of pending.sort((a, b) => a.url.localeCompare(b.url))) {
-		const state = p.ok ? 'LIVE — remove from PENDING_DEPLOY' : `not live yet (${p.status})`
-		console.log(`   ${p.url}\n     ${PENDING_DEPLOY.get(p.url)} — ${state}`)
-	}
-}
-for (const url of PENDING_DEPLOY.keys()) {
-	if (!urls.has(url)) {
-		console.log(`\n⏳ ${url} is in PENDING_DEPLOY but no longer referenced — remove the entry.`)
+const waiting = pending.filter((p) => !p.ok)
+if (waiting.length) {
+	console.log(`\n⏳ ${waiting.length} link(s) waiting on a docs deploy:`)
+	for (const p of waiting.sort((a, b) => a.url.localeCompare(b.url))) {
+		console.log(`   ${p.url}\n     ${PENDING_DEPLOY.get(p.url)} — not live yet (${p.status})`)
 	}
 }
 
+// An entry that outlived its reason exempts a URL from the check forever, so a stale
+// one has to fail the job: a line in a green log is not read at release time.
+const stale = [
+	...pending.filter((p) => p.ok).map((p) => [p.url, 'the page is live']),
+	...[...PENDING_DEPLOY.keys()].filter((u) => !urls.has(u)).map((u) => [u, 'nothing references it'])
+]
+
 const failures = results.filter((r) => !r.ok && !PENDING_DEPLOY.has(r.url))
-if (failures.length === 0) {
+if (failures.length === 0 && stale.length === 0) {
 	console.log(`\n✅ No broken docs links (${allUrls.length} checked).`)
 	process.exit(0)
 }
 
-console.log(`\n❌ ${failures.length} broken docs link(s):`)
-for (const f of failures.sort((a, b) => a.url.localeCompare(b.url))) {
-	console.log(`\n  ${f.url}`)
-	console.log(`    status: ${f.error ? `error (${f.error})` : f.status}`)
-	for (const file of urls.get(f.url)) console.log(`    ↳ ${file}`)
+if (failures.length) {
+	console.log(`\n❌ ${failures.length} broken docs link(s):`)
+	for (const f of failures.sort((a, b) => a.url.localeCompare(b.url))) {
+		console.log(`\n  ${f.url}`)
+		console.log(`    status: ${f.error ? `error (${f.error})` : f.status}`)
+		for (const file of urls.get(f.url)) console.log(`    ↳ ${file}`)
+	}
+}
+if (stale.length) {
+	console.log(`\n❌ ${stale.length} PENDING_DEPLOY entr(ies) to delete from this script:`)
+	for (const [url, why] of stale.sort((a, b) => a[0].localeCompare(b[0]))) {
+		console.log(`\n  ${url}\n    ${why}`)
+	}
 }
 process.exit(1)

--- a/.github/scripts/check-docs-links.mjs
+++ b/.github/scripts/check-docs-links.mjs
@@ -121,8 +121,13 @@ async function worker() {
 }
 await Promise.all(Array.from({ length: CONCURRENCY }, worker))
 
+// An entry claims one thing — the page is not published yet — and 404 is the only
+// answer that means it. A timeout, 403 or 5xx on the same URL is a real fault, and
+// suppressing it would also read as "still waiting" and defer the staleness check.
+const isPendingDeploy = (r) => PENDING_DEPLOY.has(r.url) && r.status === 404
+
 const pending = results.filter((r) => PENDING_DEPLOY.has(r.url))
-const waiting = pending.filter((p) => !p.ok)
+const waiting = results.filter(isPendingDeploy)
 if (waiting.length) {
 	console.log(`\n⏳ ${waiting.length} link(s) waiting on a docs deploy:`)
 	for (const p of waiting.sort((a, b) => a.url.localeCompare(b.url))) {
@@ -137,7 +142,7 @@ const stale = [
 	...[...PENDING_DEPLOY.keys()].filter((u) => !urls.has(u)).map((u) => [u, 'nothing references it'])
 ]
 
-const failures = results.filter((r) => !r.ok && !PENDING_DEPLOY.has(r.url))
+const failures = results.filter((r) => !r.ok && !isPendingDeploy(r))
 if (failures.length === 0 && stale.length === 0) {
 	console.log(`\n✅ No broken docs links (${allUrls.length} checked).`)
 	process.exit(0)

--- a/backend/windmill-worker/src/dbt_profiles.rs
+++ b/backend/windmill-worker/src/dbt_profiles.rs
@@ -679,9 +679,11 @@ mod tests {
         .unwrap();
         // Absolute: dbt runs with the PROJECT as its cwd and hands this to the
         // driver unchanged, so a profiles-relative path would never be found.
+        let cert_path = std::path::Path::new("/tmp/p").join(ROOT_CERT_FILENAME);
         assert!(
             p.yaml.contains(&format!(
-                "      sslrootcert: \"/tmp/p/{ROOT_CERT_FILENAME}\"\n"
+                "      sslrootcert: {}\n",
+                yaml_scalar(&cert_path.to_string_lossy())
             )),
             "{}",
             p.yaml


### PR DESCRIPTION
## Summary

Two workflows that only trigger on `v*` tags went red on `v1.776.0` ([backend-test-windows](https://github.com/windmill-labs/windmill/actions/runs/30713348717), [check-docs-links](https://github.com/windmill-labs/windmill/actions/runs/30713348758)). Neither failure is a product defect — one is a test that assumed a POSIX path separator, the other a docs link that is correct but points at a page that has not deployed yet.

**Windows integration tests.** `dbt_profiles::tests::postgres_forwards_its_root_certificate` hardcoded a forward slash in the expected `sslrootcert` value, while `render_profile` builds it with `profiles_dir.join(ROOT_CERT_FILENAME)`. On Windows that renders `"/tmp/p\\server-ca.pem"`, so the emitted profile was right and only the assertion was wrong (342 passed, 1 failed). The assertion now goes through the same `Path::join` + `yaml_scalar` pair, so it matches by construction on either platform while still pinning that the value is `profiles_dir`-joined, escaped rather than bare, and at the right key — a relative `ROOT_CERT_FILENAME` still fails it.

**Docs link check.** `https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt`, referenced from `DbtSettings.svelte`, 404s because the page exists only in the unmerged windmill-labs/windmilldocs#1625. The slug in the app is already the final one, so rather than retarget a link that is about to be correct, the checker gets a small `PENDING_DEPLOY` allowlist.

The allowlist is deliberately narrow in both directions, so it cannot become a permanent exemption:

- It suppresses **only a 404**, the one answer that means "not published yet". A timeout, 403, 429 or 5xx on the same URL is a real fault and still fails the run — suppressing those would also read as "still waiting" and defer the staleness check below by a release cycle.
- An entry that outlives its reason — the page went live, or nothing in `frontend/src` references the URL any more — **fails** the job and names the entry to delete. A line in a green log would never be read at release time, so nothing would force the entry out.

## Changes

- `backend/windmill-worker/src/dbt_profiles.rs`: build the expected `sslrootcert` value with `Path::join` + `yaml_scalar` instead of a hardcoded `/`, so the assertion holds on Windows.
- `.github/scripts/check-docs-links.mjs`: add `PENDING_DEPLOY`, an exact-URL map of links awaiting a docs deploy, with the reason as the value. A suppressed URL is reported as `⏳ waiting on a docs deploy`.
- `.github/scripts/check-docs-links.mjs`: restrict the exemption to a 404 response, so every other failure mode on an allowlisted URL still fails.
- `.github/scripts/check-docs-links.mjs`: fail the run on a stale entry — page live, or URL unreferenced — naming what to delete.
- `.github/scripts/check-docs-links.mjs`: reword the success line to `No broken docs links (N checked)`, since `All N docs links are reachable` is untrue once a 404 is suppressed.

## Test plan

- [x] `cargo test -p windmill-worker --lib dbt_profiles::` — 10 passed, 0 failed (Linux; the Windows rendering is what the next tag run exercises)
- [x] `node .github/scripts/check-docs-links.mjs` — 174 links checked, dbt link reported `not live yet (404)`, exit 0
- [x] Allowlisted URL returns 503 — exit 1, listed as a broken link
- [x] Allowlisted URL times out (status 0) — exit 1, listed as a broken link
- [x] Allowlisted page live (200) — exit 1, `the page is live`
- [x] Allowlisted URL unreferenced — exit 1, `nothing references it`, and the dbt link reverts to a hard failure, confirming suppression is exact-key
- [ ] Next `v*` tag: both workflows green

Once windmilldocs#1625 deploys, the next run of this job fails with `the page is live`, and the `PENDING_DEPLOY` entry should be deleted.

No frontend source changed (the `.mjs` is a CI script), so there is no UI surface to screenshot.