### PR TITLE
feat: show an on-behalf-of badge on the script and flow detail pages

### DIFF
--- a/frontend/src/lib/components/details/OnBehalfOfBadge.svelte
+++ b/frontend/src/lib/components/details/OnBehalfOfBadge.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { UserCog } from 'lucide-svelte'
+	import Badge from '$lib/components/common/badge/Badge.svelte'
+	import Tooltip from '$lib/components/meltComponents/Tooltip.svelte'
+
+	interface Props {
+		/** Authorization identity the runnable runs as: `u/{username}`, `g/{group}`, or a bare email. */
+		onBehalfOf: string | undefined
+		/** Address of the account `onBehalfOf` names, derived from it server-side. */
+		onBehalfOfEmail: string | undefined
+		kind: 'script' | 'flow'
+	}
+
+	let { onBehalfOf, onBehalfOfEmail, kind }: Props = $props()
+
+	// Rows written before the identity half existed carry only the address, so fall back
+	// to it rather than showing nothing for a runnable that does run on behalf of someone.
+	let identity = $derived(onBehalfOf ?? onBehalfOfEmail)
+	let detailed = $derived(
+		onBehalfOfEmail != undefined && onBehalfOfEmail !== identity
+			? `${identity} (${onBehalfOfEmail})`
+			: identity
+	)
+</script>
+
+{#if identity}
+	<Tooltip>
+		{#snippet text()}
+			Every run of this {kind} is permissioned as {detailed}, whoever starts it.
+		{/snippet}
+		<Badge color="violet" icon={{ icon: UserCog, position: 'left' }}>
+			<span class="truncate max-w-40">On behalf of {identity}</span>
+		</Badge>
+	</Tooltip>
+{/if}

--- a/frontend/src/lib/components/details/OnBehalfOfBadge.svelte
+++ b/frontend/src/lib/components/details/OnBehalfOfBadge.svelte
@@ -6,30 +6,29 @@
 	interface Props {
 		/** Authorization identity the runnable runs as: `u/{username}`, `g/{group}`, or a bare email. */
 		onBehalfOf: string | undefined
-		/** Address of the account `onBehalfOf` names, derived from it server-side. */
+		/** Address of the account `onBehalfOf` names, derived from it on the read paths. */
 		onBehalfOfEmail: string | undefined
 		kind: 'script' | 'flow'
 	}
 
 	let { onBehalfOf, onBehalfOfEmail, kind }: Props = $props()
 
-	// Rows written before the identity half existed carry only the address, so fall back
-	// to it rather than showing nothing for a runnable that does run on behalf of someone.
-	let identity = $derived(onBehalfOf ?? onBehalfOfEmail)
+	// The address is a display detail; it is only ever present alongside the identity, and
+	// it repeats it when the identity is itself an email.
 	let detailed = $derived(
-		onBehalfOfEmail != undefined && onBehalfOfEmail !== identity
-			? `${identity} (${onBehalfOfEmail})`
-			: identity
+		onBehalfOfEmail != undefined && onBehalfOfEmail !== onBehalfOf
+			? `${onBehalfOf} (${onBehalfOfEmail})`
+			: onBehalfOf
 	)
 </script>
 
-{#if identity}
+{#if onBehalfOf}
 	<Tooltip>
 		{#snippet text()}
 			Every run of this {kind} is permissioned as {detailed}, whoever starts it.
 		{/snippet}
 		<Badge color="violet" icon={{ icon: UserCog, position: 'left' }}>
-			<span class="truncate max-w-40">On behalf of {identity}</span>
+			<span class="truncate max-w-40">On behalf of {onBehalfOf}</span>
 		</Badge>
 	</Tooltip>
 {/if}

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -21,6 +21,7 @@
 	import { isDeployable, ALL_DEPLOYABLE } from '$lib/utils_deployable'
 
 	import DetailPageLayout from '$lib/components/details/DetailPageLayout.svelte'
+	import OnBehalfOfBadge from '$lib/components/details/OnBehalfOfBadge.svelte'
 	import { goto } from '$lib/navigation'
 	import { base } from '$lib/base'
 	import { Badge as HeaderBadge, Alert } from '$lib/components/common'
@@ -600,6 +601,11 @@
 			{#if $workspaceStore && flow}
 				<Star kind="flow" path={flow.path} summary={flow.summary} />
 			{/if}
+			<OnBehalfOfBadge
+				onBehalfOf={flow?.on_behalf_of}
+				onBehalfOfEmail={flow?.on_behalf_of_email}
+				kind="flow"
+			/>
 			{#if flow?.value?.priority != undefined}
 				<div class="hidden md:block">
 					<HeaderBadge color="blue" variant="outlined" size="xs">

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -50,6 +50,7 @@
 
 	import SavedInputsV2 from '$lib/components/SavedInputsV2.svelte'
 	import DetailPageLayout from '$lib/components/details/DetailPageLayout.svelte'
+	import OnBehalfOfBadge from '$lib/components/details/OnBehalfOfBadge.svelte'
 	import DetailPageHeader from '$lib/components/details/DetailPageHeader.svelte'
 	import {
 		Activity,
@@ -792,6 +793,11 @@
 						></Badge
 					>
 				{/if}
+				<OnBehalfOfBadge
+					onBehalfOf={script?.on_behalf_of}
+					onBehalfOfEmail={script?.on_behalf_of_email}
+					kind="script"
+				/>
 				{#if script?.priority != undefined}
 					<div class="hidden md:block">
 						<Badge color="blue" variant="outlined" size="xs">
@@ -821,12 +827,7 @@
 			</div>
 			{#if script}
 				{@const showsDbtGraph = script.language === 'dbt' && !!script.path}
-				<div
-					class={twMerge(
-						'flex flex-col',
-						isWac || showsDbtGraph ? 'h-full divide-y' : ''
-					)}
-				>
+				<div class={twMerge('flex flex-col', isWac || showsDbtGraph ? 'h-full divide-y' : '')}>
 					<div
 						class={twMerge(
 							'p-8 w-full max-w-3xl overflow-y-auto mx-auto flex flex-col relative',
@@ -942,7 +943,9 @@
 									<Alert type="info" size="xs" title="This rebuilds the whole project">
 										<div class="flex flex-row gap-2 items-center flex-wrap">
 											<span>
-												The run you came from failed part-way. <span class="font-mono">dbt retry</span>
+												The run you came from failed part-way. <span class="font-mono"
+													>dbt retry</span
+												>
 												rebuilds only its failed and skipped nodes, with the arguments it ran with.
 											</span>
 											<Button size="xs" variant="border" color="light" on:click={useDbtRetry}>


### PR DESCRIPTION
## Summary

`on_behalf_of` was only visible from inside the script/flow editor's settings panel. Anyone reading a runnable's detail page — including operators, who cannot open the editor — had no way to tell that its runs are permissioned as someone other than whoever starts them. This adds a badge to the detail page header stating the identity.

## Changes

- New `frontend/src/lib/components/details/OnBehalfOfBadge.svelte`: a violet `Badge` reading `On behalf of u/<user>`, with a tooltip spelling out the consequence and the resolved address (`Every run of this script is permissioned as u/admin (admin@windmill.dev), whoever starts it.`). It keys off `on_behalf_of`, the half that actually drives authorization, and renders nothing when unset.
- Render it in the `DetailPageHeader` of `scripts/get/[...hash]` and `flows/get/[...path]`, alongside the existing priority / concurrency / bundle badges.

No backend change: both fields were already in the `GET` payloads and already rendered by the editor, so this surfaces nothing a reader could not previously reach.

## Screenshots

Script detail page, badge and tooltip:

![script-detail-badge](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-e44f58f7/1785617123-script-detail-badge.png)

Flow detail page:

![flow-detail-badge](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-e44f58f7/1785617123-flow-detail-badge.png)

Narrow viewport (the badge is not hidden below `md`, unlike the priority/concurrency badges, since the permission it names matters at any width):

![flow-badge-narrow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-e44f58f7/1785617123-flow-badge-narrow.png)

## Test plan

- [x] Deploy a script with "Run on behalf of a specified user" enabled → badge appears in the header of `/scripts/get/<hash>`; hovering shows the identity and resolved email
- [x] Create a flow with `on_behalf_of` set → same badge on `/flows/get/<path>`. The flow row stores only `on_behalf_of` (email column NULL) and the tooltip still shows the address, exercising the derived-email read path
- [x] A script with the setting off renders no badge
- [x] A long `g/<group>` identity truncates inside the badge instead of stretching the header; header wraps cleanly at 480px
- [x] `npx svelte-check` — 0 errors

No automated test: this is a presentational component with two one-line `$derived` expressions and no pure-logic utility to pin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an “On behalf of” badge on script and flow detail pages so readers can see the effective run identity without opening the editor. This makes permissioning clear to operators and anyone viewing the page.

- **New Features**
  - Added `OnBehalfOfBadge.svelte`: a violet “On behalf of {identity}” badge with a tooltip explaining the effective permissions (includes resolved email when different).
  - Rendered in the headers of `/scripts/get/[...hash]` and `/flows/get/[...path]`, alongside existing badges, and visible at all widths.
  - Renders only when `on_behalf_of` is set; no backend changes.

<sup>Written for commit 8c6f060ce128ca8219be3e32b42c17fc7d37829d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

