### PR TITLE
fix: pasting YAML over existing code fails to apply

### DIFF
--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -61,9 +61,8 @@
 
 	/** Trailing debounce window (ms) on Monaco's onDidChangeModelContent. */
 	const CHANGE_TIMEOUT = 200
-	/** Hard ceiling (ms) on how long `updateCode` can be deferred while the user
-	 * types continuously, measured from the leading fire of the burst. */
-	const MAX_CHANGE_TIMEOUT = 1000
+
+	let changeTimeoutId: number | undefined = undefined
 
 	let divEl: HTMLDivElement | null = null
 	let editor = $state<meditor.IStandaloneCodeEditor | null>(null)
@@ -104,7 +103,8 @@
 		readOnly = false,
 		minHeight = 1000,
 		renderLineHighlight = 'none',
-		suggestion
+		suggestion,
+		leadingChangeSync = false
 	}: {
 		lang: string
 		code?: string
@@ -136,6 +136,11 @@
 		minHeight?: number
 		renderLineHighlight?: 'all' | 'line' | 'gutter' | 'none'
 		suggestion?: string
+		/** Materialize `code` on the first change of a burst instead of only after
+		 * the trailing debounce. Set it when a control's enabled state derives from
+		 * `code`; leave it off where each extra sync costs work downstream (an app
+		 * code input feeding an autoRefresh runnable re-runs a job per sync). */
+		leadingChangeSync?: boolean
 	} = $props()
 
 	let yPadding = MONACO_Y_PADDING
@@ -162,8 +167,18 @@
 			code = ncode
 		}
 		editor?.setValue(ncode)
+		// setValue emits a change event of its own; drop the burst it opens so an edit
+		// made right after an authoritative overwrite still counts as a leading change.
+		cancelPendingChanges()
 		if (formatCode) {
 			format()
+		}
+	}
+
+	function cancelPendingChanges(): void {
+		if (changeTimeoutId !== undefined) {
+			clearTimeout(changeTimeoutId)
+			changeTimeoutId = undefined
 		}
 	}
 
@@ -414,28 +429,21 @@
 			pasteListenerCleanup = () => pasteTarget?.removeEventListener('keydown', onPasteKeydown, true)
 		}
 
-		let timeoutModel: number | undefined = undefined
-		let changeChainStart: number | undefined = undefined
 		editor.onDidChangeModelContent(() => {
-			// Leading fire on the first change of a burst: a paste is a single change,
-			// and consumers gate controls on `code` (FlowYamlEditor disables "Apply
-			// changes" until it differs from a snapshot), so a trailing-only sync
-			// swallows clicks landing before it fires.
-			const now = Date.now()
-			if (changeChainStart === undefined) {
+			// A paste is a single change, so under a trailing-only sync `code` stays
+			// stale for CHANGE_TIMEOUT after it: a consumer gating a control on `code`
+			// (FlowYamlEditor disables "Apply changes" until it differs from a snapshot)
+			// then swallows a click made in that window. Schedule before firing so a
+			// re-entrant change from a consumer does not count as leading too.
+			const leading = leadingChangeSync && changeTimeoutId === undefined
+			cancelPendingChanges()
+			changeTimeoutId = setTimeout(() => {
+				changeTimeoutId = undefined
 				updateCode()
-				changeChainStart = now
+			}, CHANGE_TIMEOUT)
+			if (leading) {
+				updateCode()
 			}
-			timeoutModel && clearTimeout(timeoutModel)
-			const fireAt = Math.min(now + CHANGE_TIMEOUT, changeChainStart + MAX_CHANGE_TIMEOUT)
-			timeoutModel = setTimeout(
-				() => {
-					updateCode()
-					timeoutModel = undefined
-					changeChainStart = undefined
-				},
-				Math.max(0, fireAt - now)
-			)
 		})
 		editor.onDidChangeCursorPosition((event) => {
 			if (key) editorPositionMap[key] = event.position
@@ -643,6 +651,7 @@
 	onDestroy(() => {
 		try {
 			valueAfterDispose = getCode()
+			cancelPendingChanges()
 			pasteListenerCleanup?.()
 			vimDisposable?.dispose()
 			model && model.dispose()

--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -59,6 +59,12 @@
 	// import { createConfiguredEditor } from 'vscode/monaco'
 	// import type { IStandaloneCodeEditor } from 'vscode/vscode/vs/editor/standalone/browser/standaloneCodeEditor'
 
+	/** Trailing debounce window (ms) on Monaco's onDidChangeModelContent. */
+	const CHANGE_TIMEOUT = 200
+	/** Hard ceiling (ms) on how long `updateCode` can be deferred while the user
+	 * types continuously, measured from the leading fire of the burst. */
+	const MAX_CHANGE_TIMEOUT = 1000
+
 	let divEl: HTMLDivElement | null = null
 	let editor = $state<meditor.IStandaloneCodeEditor | null>(null)
 	let model: meditor.ITextModel
@@ -409,11 +415,31 @@
 		}
 
 		let timeoutModel: number | undefined = undefined
-		editor.onDidChangeModelContent((event) => {
-			timeoutModel && clearTimeout(timeoutModel)
-			timeoutModel = setTimeout(() => {
+		let changeChainStart: number | undefined = undefined
+		editor.onDidChangeModelContent(() => {
+			// Leading fire on the first change of a burst so `code` is current within
+			// the same tick. A paste is a single change, and consumers that gate a
+			// control on `code` (an "Apply changes" button disabled until it differs
+			// from a snapshot) would otherwise swallow a click made before the
+			// trailing update lands — the click hits a still-disabled button and the
+			// paste appears to do nothing. Continuous typing stays trailing-only,
+			// capped at MAX_CHANGE_TIMEOUT from the leading fire so `code` can never
+			// be held stale indefinitely.
+			const now = Date.now()
+			if (changeChainStart === undefined) {
 				updateCode()
-			}, 200)
+				changeChainStart = now
+			}
+			timeoutModel && clearTimeout(timeoutModel)
+			const fireAt = Math.min(now + CHANGE_TIMEOUT, changeChainStart + MAX_CHANGE_TIMEOUT)
+			timeoutModel = setTimeout(
+				() => {
+					updateCode()
+					timeoutModel = undefined
+					changeChainStart = undefined
+				},
+				Math.max(0, fireAt - now)
+			)
 		})
 		editor.onDidChangeCursorPosition((event) => {
 			if (key) editorPositionMap[key] = event.position

--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -417,14 +417,10 @@
 		let timeoutModel: number | undefined = undefined
 		let changeChainStart: number | undefined = undefined
 		editor.onDidChangeModelContent(() => {
-			// Leading fire on the first change of a burst so `code` is current within
-			// the same tick. A paste is a single change, and consumers that gate a
-			// control on `code` (an "Apply changes" button disabled until it differs
-			// from a snapshot) would otherwise swallow a click made before the
-			// trailing update lands — the click hits a still-disabled button and the
-			// paste appears to do nothing. Continuous typing stays trailing-only,
-			// capped at MAX_CHANGE_TIMEOUT from the leading fire so `code` can never
-			// be held stale indefinitely.
+			// Leading fire on the first change of a burst: a paste is a single change,
+			// and consumers gate controls on `code` (FlowYamlEditor disables "Apply
+			// changes" until it differs from a snapshot), so a trailing-only sync
+			// swallows clicks landing before it fires.
 			const now = Date.now()
 			if (changeChainStart === undefined) {
 				updateCode()

--- a/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
+++ b/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
@@ -104,6 +104,7 @@
 						minHeight={editorHeight}
 						bind:code
 						lang="yaml"
+						leadingChangeSync
 					/>
 				</div>
 			{/await}

--- a/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
+++ b/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
@@ -31,6 +31,23 @@
 		editor?.setCode(code)
 	}
 
+	/** `value` is assigned unconditionally below and `FlowEditor` dereferences
+	 * `flowStore.val.value.modules`, so an OpenFlow document missing it takes the
+	 * whole editor down mid-render — after the toast has already claimed success.
+	 * Reject it up front instead. */
+	function validateShape(parsed: unknown) {
+		if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+			throw new Error('the document must be a mapping (key: value)')
+		}
+		const value = (parsed as Record<string, unknown>).value
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+			throw new Error("missing 'value' - paste a whole OpenFlow document, not just its value")
+		}
+		if (!Array.isArray((value as Record<string, unknown>).modules)) {
+			throw new Error("'value.modules' must be a list")
+		}
+	}
+
 	function validateGroups(groups: { start_id: string; end_id: string }[] | undefined) {
 		if (!groups) return
 		const seen = new Set<string>()
@@ -46,6 +63,7 @@
 	function apply() {
 		try {
 			const parsed = YAML.parse(code)
+			validateShape(parsed)
 			validateGroups(parsed.value?.groups)
 			if (parsed.summary && typeof parsed.summary === 'string') {
 				flowStore.val.summary = parsed.summary

--- a/frontend/src/lib/components/raw_apps/RawAppYamlEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppYamlEditor.svelte
@@ -25,14 +25,7 @@
 		onApply: (update: RawAppYamlUpdate) => void
 	}
 
-	let {
-		drawer = $bindable(),
-		summary,
-		files,
-		runnables,
-		data,
-		onApply
-	}: Props = $props()
+	let { drawer = $bindable(), summary, files, runnables, data, onApply }: Props = $props()
 
 	let code = $state('')
 	let initialCode = $state('')
@@ -106,6 +99,7 @@
 					minHeight={editorHeight}
 					bind:code
 					lang="yaml"
+					leadingChangeSync
 				/>
 			</div>
 		{/await}

--- a/frontend/src/lib/components/triggers/http/RoutesGenerator.svelte
+++ b/frontend/src/lib/components/triggers/http/RoutesGenerator.svelte
@@ -289,7 +289,7 @@
 							{/if}
 							{#if selected === 'OpenAPI' || (selected === 'OpenAPI_File' && !emptyStringTrimmed(openApiFile)) || (selected === 'OpenAPI_URL' && !emptyStringTrimmed(openApiUrl))}
 								{#key forceRerender}
-									<SimpleEditor class="h-96" {lang} bind:code />
+									<SimpleEditor class="h-96" {lang} bind:code leadingChangeSync />
 								{/key}
 							{/if}
 							<Button

--- a/frontend/src/routes/(root)/(logged)/workers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workers/+page.svelte
@@ -624,6 +624,7 @@
 			lang="yaml"
 			class="h-full"
 			fixedOverflowWidgets={false}
+			leadingChangeSync
 		/>
 		{#snippet actions()}
 			<Button
@@ -676,6 +677,7 @@
 				lang="yaml"
 				class="h-full"
 				fixedOverflowWidgets={false}
+				leadingChangeSync
 			/>
 		{/if}
 		{#snippet actions()}


### PR DESCRIPTION
## Summary

Fixes GIT-947.

Selecting all and pasting a new YAML over the existing one in the OpenFlow drawer appeared to do nothing — the canvas and flow state stayed on the old YAML. Clearing the editor first and *then* pasting worked.

Validating this turned up **two independent defects** that produce that same symptom. Both are fixed here.

### 1. A ~200 ms window where the Apply button is stale (the reported bug)

`SimpleEditor` synced its bindable `code` prop with a pure *trailing* 200 ms debounce on `onDidChangeModelContent`. `FlowYamlEditor` gates its buttons on that prop (`disabled={!hasChanges}`). A paste is a **single** change event, so for ~200 ms the new YAML is on screen while `code` — and the button — is still stale. A disabled button takes no pointer events, so a click in that window fires neither `click` **nor** a Monaco blur, which means the `onDidBlurEditorText → updateCode()` escape hatch never runs either. Both the action and its safety net are suppressed.

That also explains the reported workaround exactly: after clearing, `code` already differs from the snapshot, so the button is *already* enabled — the click lands and the mousedown-blur flushes the pasted text before `apply()` reads it.

Measured pre-fix by clicking at a controlled delay after the paste visibly lands:

| delay after paste | button disabled? | applied? |
|---|---|---|
| 0 / 50 / 150 ms | yes | ❌ |
| 250 / 500 / 1000 / 3000 ms | no | ✅ |

A step function at the debounce boundary. Post-fix all delays including 0 ms apply. The window does **not** grow with document size — a 36 KB / 80-module paste measured 195 ms.

### 2. A malformed-shape paste crashes the editor after reporting success

Independent of timing. `apply()` assigned `flowStore.val.value = parsed.value` unconditionally. Paste a YAML that isn't a whole OpenFlow document — e.g. just the `value:` block — and `value` becomes `undefined`; `FlowEditor.svelte:138` then dereferences `flowStore.val.value.modules` during re-render and throws. The throw happens *after* the synchronous `try` block, so the existing `catch` cannot cover it and `sendUserToast('Changes applied')` has already fired. The user sees "Changes applied" and an unchanged canvas.

This one does **not** explain the reported workaround (clearing first wouldn't help a malformed document), so it is a separate bug that merely shares the symptom.

## Changes

- `SimpleEditor.svelte`: new opt-in `leadingChangeSync` prop — the first change of a burst materializes `code` synchronously; the trailing debounce still coalesces the rest.
- `SimpleEditor.svelte`: `setCode()` cancels the burst its own `editor.setValue()` opens, so an edit right after an authoritative overwrite still counts as leading (otherwise pasting within 200 ms of the drawer re-opening still hit the bug). Pending timer also cleared on destroy.
- Enabled `leadingChangeSync` on every editor gating a control on `code`: `FlowYamlEditor`, `RawAppYamlEditor`, `workers/+page.svelte` ×2, `RoutesGenerator.svelte`.
- `FlowYamlEditor.svelte`: `validateShape()` rejects a document without an object `value` holding a `modules` list, before anything is assigned. `FlowValue.modules` is non-optional in the generated OpenFlow types, so this cannot reject a legitimate document.

### Why opt-in rather than a global default

The first iteration changed the sync policy for all ~59 `SimpleEditor` consumers. Review surfaced a real cost, confirmed in the source: `AppCodeInputComponent` writes `code` into `outputs.result`, which reaches `RunnableComponent.refreshIfAutoRefresh('arg changed')` → `setDebouncedExecute()` → **a backend job**. Extra syncs there multiply job executions while typing, in the deployed app viewer and not just the editor. Scoping to the editors that actually gate a control on `code` — none on a job-triggering path — fixes the bug with no blast radius.

A simpler alternative (drop `disabled={!hasChanges}` entirely) was tested and does work — forcing the button enabled inside the dead window applies fresh content, because the blur flush covers it. It was rejected as a UX downgrade that removes the symptom's trigger rather than the stale-prop root cause.

## Screenshots

Select-all → paste → click Apply immediately. Header summary, canvas, and editor all reflect the pasted YAML:

![final-drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-947-bug-pasting-yaml-over-existing-code-fails-to-trigger-state/1785617672-final-drawer.png)

Before and after applying a 3-step YAML paste:

![before-canvas](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-947-bug-pasting-yaml-over-existing-code-fails-to-trigger-state/1785616696-before-canvas.png)

![after-canvas](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-947-bug-pasting-yaml-over-existing-code-fails-to-trigger-state/1785616701-after-canvas.png)

## Test plan

Driven with Playwright against the running dev server, reverting the fix to establish each baseline:

- [x] **Delay sweep, pre-fix vs post-fix** — the table above. Pre-fix fails at 0/50/150 ms and passes from 250 ms; post-fix passes at every delay.
- [x] **Window does not scale with size** — 36 KB / 80-module paste: 195 ms.
- [x] **Drawer re-open race** — re-open the drawer (so `reload()` calls `setCode`), paste as soon as the editor mounts, Apply: applies correctly.
- [x] **Workers YAML config drawer** — paste + immediate `Review & Save`: 0 ms gap, click lands (backed out without saving).
- [x] **Continuous typing** — ~2 s of typing then Apply with zero settle applies the latest content.
- [x] **Malformed shapes** — no `value`, non-list `modules`, and a bare scalar are each rejected with a specific error, the flow is left untouched, no crash, and a valid paste immediately after still applies.
- [x] `npm run check` — 0 errors (65 pre-existing warnings, none in the touched files).

No automated test: this is Monaco event-ordering with no extractable pure logic, and the repo has no Svelte component test convention — per AGENTS.md, better no test than a ceremonial one.

Not exercised in a browser: the raw-app YAML drawer, the workers import-config drawer, and the OpenAPI routes generator. All share `SimpleEditor` and the same gating as the surfaces verified above.