### PR TITLE
fix: report a missing worker tag instead of spinning in data table UIs

### DIFF
--- a/frontend/src/lib/components/DBManagerContent.svelte
+++ b/frontend/src/lib/components/DBManagerContent.svelte
@@ -94,7 +94,13 @@
 	// owns its slot so neither can clear the other's error on a refetch.
 	let schemaError = $state<string | undefined>(undefined)
 	let colDefsError = $state<string | undefined>(undefined)
-	let loadError = $derived(schemaError ?? colDefsError)
+	let loadError = $derived(
+		schemaError
+			? { title: 'Could not load the database schema', message: schemaError }
+			: colDefsError
+				? { title: 'Could not load the tables of this database', message: colDefsError }
+				: undefined
+	)
 
 	let colDefs = resource(
 		() => [input, ws],
@@ -158,7 +164,7 @@
 	const SLOW_LOAD_MS = 10_000
 	let slowLoad = $state(false)
 	$effect(() => {
-		if (!dbSchemasPromise.loading) {
+		if (!isLoading()) {
 			slowLoad = false
 			return
 		}
@@ -200,8 +206,8 @@
 {#if loadError}
 	<div class="h-full w-full flex flex-col items-center justify-center gap-3 p-8">
 		<div class="max-w-2xl w-full flex flex-col gap-3">
-			<Alert type="error" title="Could not load the database schema" size="xs">
-				{loadError}
+			<Alert type="error" title={loadError.title} size="xs">
+				{loadError.message}
 			</Alert>
 			<div class="self-start">
 				<Button size="xs" color="light" startIcon={{ icon: RefreshCcw }} on:click={() => refresh()}>

--- a/frontend/src/lib/components/DBManagerContent.svelte
+++ b/frontend/src/lib/components/DBManagerContent.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { dbSchemas, workspaceStore, type DBSchema } from '$lib/stores'
-	import { sendUserToast, sortArray } from '$lib/utils'
-	import { Loader2 } from 'lucide-svelte'
+	import { sortArray } from '$lib/utils'
+	import { Loader2, RefreshCcw } from 'lucide-svelte'
+	import Alert from './common/alert/Alert.svelte'
+	import Button from './common/button/Button.svelte'
 	import { dbSupportsSchemas } from './apps/components/display/dbtable/utils'
 	import DbManager from './DBManager.svelte'
 	import {
@@ -89,23 +91,38 @@
 			return await loadAllTablesMetaData(ws, input)
 		}
 	)
+	// Reported in place of the loading spinner: the schema query runs as a job, so
+	// anything from a bad connection to a tag no worker serves surfaces here
+	// instead of leaving the manager spinning with no explanation.
+	let schemaError = $state<string | undefined>(undefined)
+
 	let dbSchemasPromise = resource(
 		() => [input, ws],
 		async () => {
+			schemaError = undefined
 			if (!input) return
 			const dbSchemasPath = schemaCacheKey(input)
 			if (input.type == 'database') {
-				$dbSchemas[dbSchemasPath] = await getDbSchemas(
+				const schema = await getDbSchemas(
 					input.resourceType,
 					input.resourcePath,
 					ws,
-					(message: string) => sendUserToast(message, true)
+					(message: string) => (schemaError = message)
 				)
+				if (!schema) {
+					schemaError ??= 'The schema query returned no schema'
+					return
+				}
+				$dbSchemas[dbSchemasPath] = schema
 			} else if (input.type == 'ducklake') {
-				$dbSchemas[dbSchemasPath] = await getDucklakeSchema({
-					workspace: ws!,
-					ducklake: input.ducklake
-				})
+				try {
+					$dbSchemas[dbSchemasPath] = await getDucklakeSchema({
+						workspace: ws!,
+						ducklake: input.ducklake
+					})
+				} catch (e) {
+					schemaError = 'Error fetching schema: ' + ((e as Error)?.message || e)
+				}
 			}
 		}
 	)
@@ -116,6 +133,19 @@
 	export function isLoading() {
 		return colDefs.loading || dbSchemasPromise.loading
 	}
+
+	// A job queued behind busy workers still loads eventually, so this is a hint
+	// rather than an error. The no-worker-at-all case fails outright instead.
+	const SLOW_LOAD_MS = 10_000
+	let slowLoad = $state(false)
+	$effect(() => {
+		if (!dbSchemasPromise.loading) {
+			slowLoad = false
+			return
+		}
+		const t = setTimeout(() => (slowLoad = true), SLOW_LOAD_MS)
+		return () => clearTimeout(t)
+	})
 
 	let replPanelSize = $state(36)
 	const REPL_MIN_SIZE = 1.5
@@ -236,10 +266,29 @@
 			</Pane>
 		{/if}
 	</Splitpanes>
+{:else if schemaError}
+	<div class="h-full w-full flex flex-col items-center justify-center gap-3 p-8">
+		<div class="max-w-2xl w-full flex flex-col gap-3">
+			<Alert type="error" title="Could not load the database schema" size="xs">
+				{schemaError}
+			</Alert>
+			<div class="self-start">
+				<Button size="xs" color="light" startIcon={{ icon: RefreshCcw }} on:click={() => refresh()}>
+					Retry
+				</Button>
+			</div>
+		</div>
+	</div>
 {:else}
 	<Splitpanes>
-		<Pane class="relative flex justify-center items-center">
+		<Pane class="relative flex flex-col justify-center items-center gap-3">
 			<Loader2 class="animate-spin" size={32} />
+			{#if slowLoad}
+				<span class="text-xs text-tertiary max-w-md text-center">
+					The schema query is taking a while. It runs as a job, so it waits for a worker serving its
+					tag to be free.
+				</span>
+			{/if}
 		</Pane>
 	</Splitpanes>
 {/if}

--- a/frontend/src/lib/components/DBManagerContent.svelte
+++ b/frontend/src/lib/components/DBManagerContent.svelte
@@ -4,8 +4,12 @@
 	import { Loader2, RefreshCcw } from 'lucide-svelte'
 	import Alert from './common/alert/Alert.svelte'
 	import Button from './common/button/Button.svelte'
-	import { dbSupportsSchemas } from './apps/components/display/dbtable/utils'
+	import {
+		dbSupportsSchemas,
+		getLanguageByResourceType
+	} from './apps/components/display/dbtable/utils'
 	import DbManager from './DBManager.svelte'
+	import MissingWorkerTagAlert from './jobs/MissingWorkerTagAlert.svelte'
 	import {
 		dbSchemaOpsWithPreviewScripts,
 		dbTableOpsWithPreviewScripts,
@@ -144,6 +148,11 @@
 		return colDefs.loading || dbSchemasPromise.loading
 	}
 
+	// Tag the schema/metadata jobs run on: for every DB the manager supports, the
+	// language name is the tag, which is what makes the missing-worker hint below
+	// possible without waiting for the poller to give up.
+	let jobTag = $derived(input ? getLanguageByResourceType(getDbType(input)) : undefined)
+
 	// A job queued behind busy workers still loads eventually, so this is a hint
 	// rather than an error. The no-worker-at-all case fails outright instead.
 	const SLOW_LOAD_MS = 10_000
@@ -185,7 +194,23 @@
 	}}
 />
 
-{#if dbSchema && ws && input}
+<!-- The error branch comes first on purpose: `dbSchema` is read from a cache that
+	survives a failed refetch, so ordering it first would hide the failure behind
+	stale content. -->
+{#if loadError}
+	<div class="h-full w-full flex flex-col items-center justify-center gap-3 p-8">
+		<div class="max-w-2xl w-full flex flex-col gap-3">
+			<Alert type="error" title="Could not load the database schema" size="xs">
+				{loadError}
+			</Alert>
+			<div class="self-start">
+				<Button size="xs" color="light" startIcon={{ icon: RefreshCcw }} on:click={() => refresh()}>
+					Retry
+				</Button>
+			</div>
+		</div>
+	</div>
+{:else if dbSchema && ws && input}
 	{@const _input = input}
 	{@const dbType = getDbType(_input)}
 	<Splitpanes horizontal>
@@ -276,28 +301,23 @@
 			</Pane>
 		{/if}
 	</Splitpanes>
-{:else if loadError}
-	<div class="h-full w-full flex flex-col items-center justify-center gap-3 p-8">
-		<div class="max-w-2xl w-full flex flex-col gap-3">
-			<Alert type="error" title="Could not load the database schema" size="xs">
-				{loadError}
-			</Alert>
-			<div class="self-start">
-				<Button size="xs" color="light" startIcon={{ icon: RefreshCcw }} on:click={() => refresh()}>
-					Retry
-				</Button>
-			</div>
-		</div>
-	</div>
 {:else}
 	<Splitpanes>
-		<Pane class="relative flex flex-col justify-center items-center gap-3">
+		<Pane class="relative flex flex-col justify-center items-center gap-3 p-8">
 			<Loader2 class="animate-spin" size={32} />
 			{#if slowLoad}
 				<span class="text-xs text-tertiary max-w-md text-center">
 					The schema query is taking a while. It runs as a job, so it waits for a worker serving its
 					tag to be free.
 				</span>
+				{#if jobTag}
+					<MissingWorkerTagAlert
+						tag={jobTag}
+						subject="Database queries"
+						workspace={ws}
+						class="max-w-2xl w-full"
+					/>
+				{/if}
 			{/if}
 		</Pane>
 	</Splitpanes>

--- a/frontend/src/lib/components/DBManagerContent.svelte
+++ b/frontend/src/lib/components/DBManagerContent.svelte
@@ -84,17 +84,27 @@
 		return `${ws}:${getDbSchemasPath(input)}`
 	}
 
+	// Reported in place of the loading spinner: both queries run as jobs, so
+	// anything from a bad connection to a tag no worker serves surfaces here
+	// instead of leaving the manager spinning with no explanation. Each query
+	// owns its slot so neither can clear the other's error on a refetch.
+	let schemaError = $state<string | undefined>(undefined)
+	let colDefsError = $state<string | undefined>(undefined)
+	let loadError = $derived(schemaError ?? colDefsError)
+
 	let colDefs = resource(
 		() => [input, ws],
 		async () => {
+			colDefsError = undefined
 			if (!input) return
-			return await loadAllTablesMetaData(ws, input)
+			try {
+				return await loadAllTablesMetaData(ws, input)
+			} catch (e) {
+				colDefsError = 'Error loading tables metadata: ' + ((e as Error)?.message || e)
+				return
+			}
 		}
 	)
-	// Reported in place of the loading spinner: the schema query runs as a job, so
-	// anything from a bad connection to a tag no worker serves surfaces here
-	// instead of leaving the manager spinning with no explanation.
-	let schemaError = $state<string | undefined>(undefined)
 
 	let dbSchemasPromise = resource(
 		() => [input, ws],
@@ -266,11 +276,11 @@
 			</Pane>
 		{/if}
 	</Splitpanes>
-{:else if schemaError}
+{:else if loadError}
 	<div class="h-full w-full flex flex-col items-center justify-center gap-3 p-8">
 		<div class="max-w-2xl w-full flex flex-col gap-3">
 			<Alert type="error" title="Could not load the database schema" size="xs">
-				{schemaError}
+				{loadError}
 			</Alert>
 			<div class="self-start">
 				<Button size="xs" color="light" startIcon={{ icon: RefreshCcw }} on:click={() => refresh()}>

--- a/frontend/src/lib/components/DBTable.svelte
+++ b/frontend/src/lib/components/DBTable.svelte
@@ -70,8 +70,8 @@
 								.then(() => {
 									sendUserToast('Value updated')
 								})
-								.catch(() => {
-									sendUserToast('Error updating value', true)
+								.catch((e) => {
+									sendUserToast('Error updating value: ' + ((e as Error)?.message || e), true)
 									refresh?.()
 								})
 						}

--- a/frontend/src/lib/components/DatatableSchemaDiff.svelte
+++ b/frontend/src/lib/components/DatatableSchemaDiff.svelte
@@ -228,14 +228,17 @@
 					throw runErr
 				}
 			} else {
-				await runScriptAndPollResult({
-					workspace: targetWorkspace,
-					requestBody: {
-						args: { database: `datatable://${dtName}` },
-						language: 'postgresql',
-						content: migrationSql
-					}
-				})
+				await runScriptAndPollResult(
+					{
+						workspace: targetWorkspace,
+						requestBody: {
+							args: { database: `datatable://${dtName}` },
+							language: 'postgresql',
+							content: migrationSql
+						}
+					},
+					{ sideEffecting: true }
+				)
 			}
 		} catch (e: any) {
 			sendUserToast(e?.body ?? e?.message ?? String(e), true)

--- a/frontend/src/lib/components/DatatableSchemaDiff.svelte
+++ b/frontend/src/lib/components/DatatableSchemaDiff.svelte
@@ -14,6 +14,7 @@
 	import { sendUserToast } from '$lib/toast'
 	import { userWorkspaces } from '$lib/stores'
 	import { runScriptAndPollResult } from '$lib/components/jobs/utils'
+	import { writingJobOptions } from '$lib/components/jobs/writingJob'
 	import YAML from 'yaml'
 	import DrawerContent from './common/drawer/DrawerContent.svelte'
 	import ConfirmationModal from './common/confirmationModal/ConfirmationModal.svelte'
@@ -237,7 +238,7 @@
 							content: migrationSql
 						}
 					},
-					{ sideEffecting: true }
+					writingJobOptions
 				)
 			}
 		} catch (e: any) {

--- a/frontend/src/lib/components/SqlRepl.svelte
+++ b/frontend/src/lib/components/SqlRepl.svelte
@@ -2,6 +2,7 @@
 	import { CornerDownLeft, Loader2 } from 'lucide-svelte'
 	import Button from './common/button/Button.svelte'
 	import { runScriptAndPollResult } from './jobs/utils'
+	import { NoWorkerForTagError } from './jobs/missingWorker'
 	import { workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { untrack } from 'svelte'
@@ -159,7 +160,15 @@
 			else sendUserToast('Query executed')
 		} catch (e) {
 			console.error(e)
-			if (dbType === 'postgresql' && !doPostgresRowToJsonFix) {
+			// The row_to_json fix rewrites a query the server rejected. A job no worker
+			// picked up was never rejected — resubmitting it would run the same
+			// (possibly writing) SQL a second time and hide the cause for another
+			// confirmation window.
+			if (
+				dbType === 'postgresql' &&
+				!doPostgresRowToJsonFix &&
+				!(e instanceof NoWorkerForTagError)
+			) {
 				console.error('Error running query, trying with row_to_json fix')
 				isRunning = false
 				return await run({ doPostgresRowToJsonFix: true })

--- a/frontend/src/lib/components/SqlRepl.svelte
+++ b/frontend/src/lib/components/SqlRepl.svelte
@@ -2,7 +2,7 @@
 	import { CornerDownLeft, Loader2 } from 'lucide-svelte'
 	import Button from './common/button/Button.svelte'
 	import { runScriptAndPollResult } from './jobs/utils'
-	import { NoWorkerForTagError } from './jobs/missingWorker'
+	import { writingJobOptions } from './jobs/writingJob'
 	import { workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { untrack } from 'svelte'
@@ -125,7 +125,7 @@
 					}
 				},
 				// The user types arbitrary SQL here, so treat every run as a write.
-				{ withJobData: true, sideEffecting: true }
+				{ withJobData: true, ...writingJobOptions }
 			)) as any
 			if (statements.length > 1) {
 				result = result[result.length - 1]
@@ -160,15 +160,7 @@
 			else sendUserToast('Query executed')
 		} catch (e) {
 			console.error(e)
-			// The row_to_json fix rewrites a query the server rejected. A job no worker
-			// picked up was never rejected — resubmitting it would run the same
-			// (possibly writing) SQL a second time and hide the cause for another
-			// confirmation window.
-			if (
-				dbType === 'postgresql' &&
-				!doPostgresRowToJsonFix &&
-				!(e instanceof NoWorkerForTagError)
-			) {
+			if (dbType === 'postgresql' && !doPostgresRowToJsonFix) {
 				console.error('Error running query, trying with row_to_json fix')
 				isRunning = false
 				return await run({ doPostgresRowToJsonFix: true })

--- a/frontend/src/lib/components/SqlRepl.svelte
+++ b/frontend/src/lib/components/SqlRepl.svelte
@@ -123,7 +123,8 @@
 						args: dbArg
 					}
 				},
-				{ withJobData: true }
+				// The user types arbitrary SQL here, so treat every run as a write.
+				{ withJobData: true, sideEffecting: true }
 			)) as any
 			if (statements.length > 1) {
 				result = result[result.length - 1]

--- a/frontend/src/lib/components/WorkerRepl.svelte
+++ b/frontend/src/lib/components/WorkerRepl.svelte
@@ -106,7 +106,7 @@
 			})
 
 			// The shell tag is the worker's name prefix, which its shell loop pulls
-			// directly instead of advertising it in `worker_ping` — the missing-worker
+			// directly instead of advertising it in `worker_ping`, so the missing-worker
 			// check would read it as unserved.
 			let result: any = await pollJobResult(jobId, $workspaceStore!, {
 				failIfNoWorkerForTag: false

--- a/frontend/src/lib/components/WorkerRepl.svelte
+++ b/frontend/src/lib/components/WorkerRepl.svelte
@@ -105,7 +105,12 @@
 				}
 			})
 
-			let result: any = await pollJobResult(jobId, $workspaceStore!)
+			// The shell tag is the worker's name prefix, which its shell loop pulls
+			// directly instead of advertising it in `worker_ping` — the missing-worker
+			// check would read it as unserved.
+			let result: any = await pollJobResult(jobId, $workspaceStore!, {
+				failIfNoWorkerForTag: false
+			})
 
 			if (isOnlyCdCommand) {
 				working_directory = (result as string).replace(/(\r\n|\n|\r)/g, '')
@@ -365,9 +370,10 @@
 					>
 						Full path
 
-						<Tooltip
-							class="absolute top-0.5"
-						>Commands run in the default directory. Run a standalone ‘cd’ to change it. Chained or invalid ‘cd’ commands won’t apply.</Tooltip>
+						<Tooltip class="absolute top-0.5"
+							>Commands run in the default directory. Run a standalone ‘cd’ to change it. Chained or
+							invalid ‘cd’ commands won’t apply.</Tooltip
+						>
 					</Badge>
 				</div>
 				<input type="text" disabled bind:value={working_directory} />

--- a/frontend/src/lib/components/apps/components/display/dbtable/AppDbExplorer.svelte
+++ b/frontend/src/lib/components/apps/components/display/dbtable/AppDbExplorer.svelte
@@ -399,7 +399,13 @@
 			resolvedConfig.type.configuration[selected].table
 		)
 
-		if (!tableMetadata) return
+		if (!tableMetadata) {
+			//@ts-ignore
+			gridItem.data.configuration.columnDefs.loading = false
+			gridItem.data = gridItem.data
+			$app = $app
+			return
+		}
 
 		let old: TableMetadata = (columnDefs?.value as TableMetadata) ?? []
 		if (!Array.isArray(old)) {

--- a/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
@@ -1,5 +1,3 @@
-import { JobService } from '$lib/gen'
-
 import { runScriptAndPollResult } from '$lib/components/jobs/utils'
 import type { DbInput } from '$lib/components/dbTypes'
 import {
@@ -43,48 +41,29 @@ export async function loadTableMetaData(
 	// back to `DATABASE()`), so we don't read the resource value client-side for it.
 	const content = makeMetadataMarker('LOAD_TABLE_METADATA', { table }, ducklake)
 
-	const job = await JobService.runScriptPreview({
-		workspace,
-		requestBody: { language, content, args: dbArg }
-	})
+	try {
+		const rows = (await runScriptAndPollResult({
+			workspace,
+			requestBody: { language, content, args: dbArg }
+		})) as Record<string, any>[]
+		const result = rows.map(lowercaseKeys)
 
-	const maxRetries = 8
-	let attempts = 0
-	while (attempts < maxRetries) {
-		try {
-			await new Promise((resolve) => setTimeout(resolve, 1000 * (attempts || 0.6)))
-
-			const testResult = (await JobService.getCompletedJob({
-				workspace,
-				id: job
-			})) as any
-
-			if (testResult.success) {
-				attempts = maxRetries
-
-				const result = testResult.result.map(lowercaseKeys)
-
-				// For Snowflake, fetch primary keys separately
-				if (
-					input.type === 'database' &&
-					(input.resourceType === 'snowflake' || (input.resourceType as any) === 'snowflake_oauth')
-				) {
-					const map: Record<string, TableMetadata> = { [table]: result }
-					await fetchAndAddSnowflakePrimaryKeysInMap(map, input, workspace, table)
-					return map[table]
-				}
-
-				return result
-			} else {
-				attempts++
-			}
-		} catch (error) {
-			attempts++
+		// For Snowflake, fetch primary keys separately
+		if (
+			input.type === 'database' &&
+			(input.resourceType === 'snowflake' || (input.resourceType as any) === 'snowflake_oauth')
+		) {
+			const map: Record<string, TableMetadata> = { [table]: result }
+			await fetchAndAddSnowflakePrimaryKeysInMap(map, input, workspace, table)
+			return map[table]
 		}
-	}
 
-	console.error('Failed to load table metadata after maximum retries.')
-	return undefined
+		return result
+	} catch (e) {
+		console.error('Failed to load table metadata', e)
+		sendUserToast('Error loading table metadata: ' + ((e as Error)?.message || e), true)
+		return undefined
+	}
 }
 
 export async function loadAllTablesMetaData(
@@ -120,7 +99,7 @@ export async function loadAllTablesMetaData(
 
 		return map
 	} catch (e) {
-		sendUserToast('Error loading tables metadata: ' + e, 'error')
+		sendUserToast('Error loading tables metadata: ' + ((e as Error)?.message || e), 'error')
 		throw e
 	}
 }
@@ -171,7 +150,7 @@ async function fetchSnowflakePrimaryKeys(
 	const payload: Record<string, unknown> = {}
 	if (tableKey) payload.table = tableKey
 	const content = makeMetadataMarker('SNOWFLAKE_PRIMARY_KEYS', payload, undefined)
-	return (await JobService.runScriptPreviewAndWaitResult({
+	return (await runScriptAndPollResult({
 		workspace,
 		requestBody: {
 			language: 'snowflake',
@@ -206,7 +185,7 @@ export async function getDbSchemas(
 
 	let result: unknown
 	try {
-		result = await JobService.runScriptPreviewAndWaitResult({
+		result = await runScriptAndPollResult({
 			workspace,
 			requestBody: {
 				language: sqlScript.lang as Preview['language'],

--- a/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
@@ -66,6 +66,8 @@ export async function loadTableMetaData(
 	}
 }
 
+/** Throws on failure without reporting it: every caller renders the error in its
+ * own pane, so toasting here would double-report it. */
 export async function loadAllTablesMetaData(
 	workspace: string | undefined,
 	input: DbInput
@@ -99,7 +101,7 @@ export async function loadAllTablesMetaData(
 
 		return map
 	} catch (e) {
-		sendUserToast('Error loading tables metadata: ' + ((e as Error)?.message || e), 'error')
+		console.error('Failed to load tables metadata', e)
 		throw e
 	}
 }

--- a/frontend/src/lib/components/assets/AssetGraph/DataTablePreview.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DataTablePreview.svelte
@@ -102,6 +102,11 @@
 			: undefined
 	)
 
+	// Kept apart from "no columns for this table": a failed metadata read says
+	// nothing about whether the table exists, so reporting it as missing would
+	// point the user at the wrong problem.
+	let colDefsError = $state<string | undefined>(undefined)
+
 	// Metadata for every table in the datatable. We query the lot rather
 	// than just the one we care about because `loadAllTablesMetaData` is
 	// what `dbTableOpsWithPreviewScripts` and the rest of the DB manager
@@ -111,14 +116,12 @@
 	let colDefs = resource(
 		() => [input, refreshKey],
 		async ([_input]) => {
+			colDefsError = undefined
 			if (!_input || !$workspaceStore) return undefined
 			try {
 				return await loadAllTablesMetaData($workspaceStore, _input)
-			} catch {
-				// Connection/permission errors look identical to "table
-				// missing" from the user's POV inside the preview pane;
-				// the full error is surfaced via the existing sendUserToast
-				// path inside loadAllTablesMetaData.
+			} catch (e) {
+				colDefsError = (e as Error)?.message || String(e)
 				return undefined
 			}
 		}
@@ -186,6 +189,12 @@
 	{:else if colDefs.loading && !colDefs.current}
 		<div class="absolute inset-0 flex items-center justify-center text-tertiary">
 			<Loader2 class="animate-spin" size={20} />
+		</div>
+	{:else if colDefsError}
+		<div class="absolute inset-0 flex flex-col items-center justify-center gap-2 p-6 text-center">
+			<AlertTriangle size={20} class="text-red-500" />
+			<span class="text-sm font-medium text-emphasis">Could not read the datatable</span>
+			<span class="text-2xs text-tertiary max-w-md">{colDefsError}</span>
 		</div>
 	{:else if !tableColDefs}
 		<!-- Datatable exists but the specific table doesn't — most often

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeResultPreview.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeResultPreview.svelte
@@ -53,15 +53,19 @@
 		scoped && partition ? `_wm_partition = '${partition.replaceAll("'", "''")}'` : undefined
 	)
 
+	// Distinct from "no columns for this table": a failed metadata read says
+	// nothing about whether the table exists.
+	let colDefsError = $state<string | undefined>(undefined)
+
 	let colDefs = resource(
 		() => [input, refreshKey] as const,
 		async ([_input]) => {
+			colDefsError = undefined
 			if (!_input || !$workspaceStore) return undefined
 			try {
 				return await loadAllTablesMetaData($workspaceStore, _input)
-			} catch {
-				// A load failure reads the same as "table missing" from the preview's
-				// POV; the underlying error is surfaced by loadAllTablesMetaData.
+			} catch (e) {
+				colDefsError = (e as Error)?.message || String(e)
 				return undefined
 			}
 		}
@@ -118,6 +122,11 @@
 	{#if colDefs.loading && !colDefs.current}
 		<div class="flex items-center justify-center p-4 text-tertiary">
 			<Loader2 class="animate-spin" size={18} />
+		</div>
+	{:else if colDefsError}
+		<div class="flex items-start gap-2 p-3 text-2xs text-tertiary">
+			<AlertTriangle size={14} class="text-red-500 shrink-0 mt-0.5" />
+			{colDefsError}
 		</div>
 	{:else if !tableColDefs}
 		<div class="flex items-center gap-2 p-3 text-2xs text-tertiary">

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -5,6 +5,7 @@ import {
 	type TableMetadata
 } from './apps/components/display/dbtable/utils'
 import { runScriptAndPollResult } from './jobs/utils'
+import { writingJobOptions } from './jobs/writingJob'
 import type { DBSchema, SQLSchema } from '$lib/stores'
 import { stringifySchema } from './copilot/lib'
 import type { DbInput, DbType } from './dbTypes'
@@ -123,21 +124,21 @@ export function dbTableOpsWithPreviewScripts({
 						content
 					}
 				},
-				{ sideEffecting: true }
+				writingJobOptions
 			)
 		},
 		onDelete: async ({ values }) => {
 			const content = makeMarker('DELETE', { table: tableKey, columns: colDefs })
 			await runScriptAndPollResult(
 				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content } },
-				{ sideEffecting: true }
+				writingJobOptions
 			)
 		},
 		onInsert: async ({ values }) => {
 			const content = makeMarker('INSERT', { table: tableKey, columns: colDefs })
 			await runScriptAndPollResult(
 				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content } },
-				{ sideEffecting: true }
+				writingJobOptions
 			)
 		}
 	}
@@ -345,7 +346,7 @@ export function dbSchemaOpsWithPreviewScripts({
 		if (!datatableName || !status?.enabled) {
 			await runScriptAndPollResult(
 				{ workspace, requestBody: { args: dbArg, content, language } },
-				{ sideEffecting: true }
+				writingJobOptions
 			)
 			return
 		}

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -114,28 +114,31 @@ export function dbTableOpsWithPreviewScripts({
 				column: colDef,
 				columns: colDefs
 			})
-			await runScriptAndPollResult({
-				workspace,
-				requestBody: {
-					args: { ...dbArg, value_to_update: newValue, ...values },
-					language,
-					content
-				}
-			})
+			await runScriptAndPollResult(
+				{
+					workspace,
+					requestBody: {
+						args: { ...dbArg, value_to_update: newValue, ...values },
+						language,
+						content
+					}
+				},
+				{ sideEffecting: true }
+			)
 		},
 		onDelete: async ({ values }) => {
 			const content = makeMarker('DELETE', { table: tableKey, columns: colDefs })
-			await runScriptAndPollResult({
-				workspace,
-				requestBody: { args: { ...dbArg, ...values }, language, content }
-			})
+			await runScriptAndPollResult(
+				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content } },
+				{ sideEffecting: true }
+			)
 		},
 		onInsert: async ({ values }) => {
 			const content = makeMarker('INSERT', { table: tableKey, columns: colDefs })
-			await runScriptAndPollResult({
-				workspace,
-				requestBody: { args: { ...dbArg, ...values }, language, content }
-			})
+			await runScriptAndPollResult(
+				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content } },
+				{ sideEffecting: true }
+			)
 		}
 	}
 }
@@ -340,7 +343,10 @@ export function dbSchemaOpsWithPreviewScripts({
 			? await WorkspaceService.getDatatableMigrationsStatus({ workspace, datatableName })
 			: undefined
 		if (!datatableName || !status?.enabled) {
-			await runScriptAndPollResult({ workspace, requestBody: { args: dbArg, content, language } })
+			await runScriptAndPollResult(
+				{ workspace, requestBody: { args: dbArg, content, language } },
+				{ sideEffecting: true }
+			)
 			return
 		}
 		// The new migration gets the highest timestamp, so any still-pending

--- a/frontend/src/lib/components/jobs/MissingWorkerTagAlert.svelte
+++ b/frontend/src/lib/components/jobs/MissingWorkerTagAlert.svelte
@@ -34,10 +34,14 @@
 
 {#if served.current === false}
 	<div class={className}>
-		<Alert type="warning" title="No worker serves the &quot;{tag}&quot; tag" size="xs">
-			{subject} run as Windmill jobs tagged <b>{tag}</b>. No worker currently listens to that tag,
-			so they stay queued instead of running. Add <b>{tag}</b> to the worker tags of one of your
-			worker groups on the <a href="{base}/workers">workers page</a>.
+		<!-- Deliberately not phrased as "this tag is not configured": a correctly
+			tagged group sitting at zero replicas is indistinguishable from one in
+			`worker_ping`, and queueing a job is what scales it back up. -->
+		<Alert type="warning" title="No worker is running for the &quot;{tag}&quot; tag" size="xs">
+			{subject} run as Windmill jobs tagged <b>{tag}</b>, and no worker is currently listening to
+			that tag, so they stay queued until one is. If no worker group is meant to serve it, add
+			<b>{tag}</b>
+			to a group's worker tags on the <a href="{base}/workers">workers page</a>.
 		</Alert>
 	</div>
 {/if}

--- a/frontend/src/lib/components/jobs/MissingWorkerTagAlert.svelte
+++ b/frontend/src/lib/components/jobs/MissingWorkerTagAlert.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { base } from '$app/paths'
+	import Alert from '$lib/components/common/alert/Alert.svelte'
+	import { WorkerService } from '$lib/gen'
+	import { workspaceStore } from '$lib/stores'
+	import { resource } from 'runed'
+	import { hasWorkerForTag } from './missingWorker'
+
+	interface Props {
+		/** Worker tag the feature's jobs run on. */
+		tag: string
+		/** What breaks without it, used as the sentence subject, e.g. "Data table queries". */
+		subject: string
+		workspace?: string
+		class?: string
+	}
+
+	let { tag, subject, workspace = undefined, class: className = '' }: Props = $props()
+
+	let ws = $derived(workspace ?? $workspaceStore)
+
+	// With per-workspace default tags, jobs run on a workspace-suffixed variant of
+	// `tag`, so probing the bare tag would warn about a tag nothing uses. The
+	// in-flight check in `pollJobResult` reads the job's real tag and still covers
+	// those instances.
+	const served = resource(
+		() => [ws, tag] as const,
+		async ([ws, tag]) => {
+			if (!ws || (await WorkerService.isDefaultTagsPerWorkspace())) return true
+			return await hasWorkerForTag(ws, tag)
+		}
+	)
+</script>
+
+{#if served.current === false}
+	<div class={className}>
+		<Alert type="warning" title="No worker serves the &quot;{tag}&quot; tag" size="xs">
+			{subject} run as Windmill jobs tagged <b>{tag}</b>. No worker currently listens to that tag,
+			so they stay queued instead of running. Add <b>{tag}</b> to the worker tags of one of your
+			worker groups on the <a href="{base}/workers">workers page</a>.
+		</Alert>
+	</div>
+{/if}

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -47,26 +47,16 @@ afterEach(() => {
 const PAST_CONFIRMATION_WINDOW_MS = 120_000
 
 describe('pollJobResult', () => {
-	it('cancels and reports a queued job whose tag stays unserved', async () => {
+	it('reports a queued job whose tag stays unserved without cancelling it', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
 
 		const promise = pollJobResult('job-1', 'ws')
 		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
 		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
 		await rejects
-		expect(cancelQueuedJob).toHaveBeenCalledWith(
-			expect.objectContaining({ id: 'job-1', workspace: 'ws' })
-		)
-	})
-
-	it('says the job is still queued when the cancel is refused', async () => {
-		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
-		cancelQueuedJob.mockRejectedValue(new Error('nope'))
-
-		const promise = pollJobResult('job-1', 'ws')
-		const rejects = expect(promise).rejects.toThrow(/stays queued/)
-		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
-		await rejects
+		// The backlog is what the autoscaler scales up on: cancelling would stop a
+		// group coming back from zero from ever recovering.
+		expect(cancelQueuedJob).not.toHaveBeenCalled()
 	})
 
 	it('does not give up while a worker group could still be coming up', async () => {

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -59,46 +59,25 @@ describe('pollJobResult', () => {
 		expect(cancelQueuedJob).not.toHaveBeenCalled()
 	})
 
-	it('cancels a queued write before reporting it, so it cannot apply later', async () => {
+	it('never abandons a write, and reports once why it is waiting', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
-		cancelQueuedJob.mockImplementation(async () => {
-			getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: false })
-		})
+		const onNoWorkerForTag = vi.fn()
 
-		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
-		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
-		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
-		await rejects
-		expect(cancelQueuedJob).toHaveBeenCalledWith(
-			expect.objectContaining({ id: 'job-1', workspace: 'ws' })
-		)
-	})
-
-	it('returns the result of a write a worker completed as the cancel was sent', async () => {
-		// `cancelQueuedJob` answers 200 for an already-completed job too, so treating
-		// the request as proof would report a mutation that actually landed as failed
-		// and invite the user to run it twice.
-		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
-		cancelQueuedJob.mockImplementation(async () => {
-			getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 7 })
-		})
-
-		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
-		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
-		await expect(promise).resolves.toBe(7)
-	})
-
-	it('keeps waiting on a write the server would not cancel', async () => {
-		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
-		cancelQueuedJob.mockRejectedValue(new Error('nope'))
-
-		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
+		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true, onNoWorkerForTag })
 		const tracker = settlementTracker(promise)
 
-		// Reporting failure on a write that is still executable would let it apply
-		// itself after the caller gave up, and duplicate on retry.
 		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS * 3)
+		// Reporting failure while the write stays executable would let it apply after
+		// the caller gave up and duplicate on retry; cancelling it first cannot be
+		// done atomically from the client.
 		expect(tracker.settled).toBe(false)
+		expect(cancelQueuedJob).not.toHaveBeenCalled()
+		expect(onNoWorkerForTag).toHaveBeenCalledTimes(1)
+		expect(onNoWorkerForTag).toHaveBeenCalledWith('postgresql')
+
+		getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 7 })
+		await vi.advanceTimersByTimeAsync(3_000)
+		await expect(promise).resolves.toBe(7)
 	})
 
 	it('does not give up while a worker group could still be coming up', async () => {

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
 const getCompletedJobResultMaybe = vi.fn()
 const getJob = vi.fn()
+const cancelQueuedJob = vi.fn()
 const existsWorkersWithTags = vi.fn()
 
 vi.mock('$lib/gen', () => ({
 	JobService: {
 		getCompletedJobResultMaybe: (...a: unknown[]) => getCompletedJobResultMaybe(...(a as [])),
-		getJob: (...a: unknown[]) => getJob(...(a as []))
+		getJob: (...a: unknown[]) => getJob(...(a as [])),
+		cancelQueuedJob: (...a: unknown[]) => cancelQueuedJob(...(a as []))
 	},
 	WorkerService: {
 		existsWorkersWithTags: (...a: unknown[]) => existsWorkersWithTags(...(a as []))
@@ -17,12 +19,23 @@ vi.mock('$lib/gen', () => ({
 import { pollJobResult } from './utils'
 import { NoWorkerForTagError } from './missingWorker'
 
+function settlementTracker(promise: Promise<unknown>) {
+	const state = { settled: false }
+	promise.then(
+		() => (state.settled = true),
+		() => (state.settled = true)
+	)
+	return state
+}
+
 beforeEach(() => {
 	getCompletedJobResultMaybe.mockReset()
 	getJob.mockReset()
+	cancelQueuedJob.mockReset()
 	existsWorkersWithTags.mockReset()
 	getCompletedJobResultMaybe.mockResolvedValue({ completed: false })
 	getJob.mockResolvedValue({ type: 'QueuedJob', running: false, tag: 'postgresql' })
+	cancelQueuedJob.mockResolvedValue(undefined)
 	vi.useFakeTimers()
 })
 
@@ -31,30 +44,41 @@ afterEach(() => {
 })
 
 describe('pollJobResult', () => {
-	it('reports the tag of a queued job no worker serves instead of polling forever', async () => {
+	it('cancels and reports a queued job whose tag stays unserved', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
 
 		const promise = pollJobResult('job-1', 'ws')
 		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
-		await vi.advanceTimersByTimeAsync(15_000)
+		await vi.advanceTimersByTimeAsync(30_000)
 		await rejects
+		expect(cancelQueuedJob).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'job-1', workspace: 'ws' })
+		)
+	})
+
+	it('does not give up on a single unserved reading, as workers may be scaling up', async () => {
+		existsWorkersWithTags.mockResolvedValueOnce({ postgresql: false })
+		existsWorkersWithTags.mockResolvedValue({ postgresql: true })
+
+		const promise = pollJobResult('job-1', 'ws')
+		const tracker = settlementTracker(promise)
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(tracker.settled).toBe(false)
+		expect(cancelQueuedJob).not.toHaveBeenCalled()
 	})
 
 	it('keeps waiting on a job queued behind a busy worker that serves its tag', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: true })
 
 		const promise = pollJobResult('job-1', 'ws')
-		let settled = false
-		promise.then(
-			() => (settled = true),
-			() => (settled = true)
-		)
+		const tracker = settlementTracker(promise)
 
 		await vi.advanceTimersByTimeAsync(60_000)
-		expect(settled).toBe(false)
+		expect(tracker.settled).toBe(false)
 
 		getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 42 })
-		await vi.advanceTimersByTimeAsync(1_000)
+		await vi.advanceTimersByTimeAsync(3_000)
 		await expect(promise).resolves.toBe(42)
 	})
 })

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -43,27 +43,43 @@ afterEach(() => {
 	vi.useRealTimers()
 })
 
+// Long enough for the whole confirmation window (first probe + 2 intervals).
+const PAST_CONFIRMATION_WINDOW_MS = 120_000
+
 describe('pollJobResult', () => {
 	it('cancels and reports a queued job whose tag stays unserved', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
 
 		const promise = pollJobResult('job-1', 'ws')
 		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
-		await vi.advanceTimersByTimeAsync(30_000)
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
 		await rejects
 		expect(cancelQueuedJob).toHaveBeenCalledWith(
 			expect.objectContaining({ id: 'job-1', workspace: 'ws' })
 		)
 	})
 
-	it('does not give up on a single unserved reading, as workers may be scaling up', async () => {
+	it('says the job is still queued when the cancel is refused', async () => {
+		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
+		cancelQueuedJob.mockRejectedValue(new Error('nope'))
+
+		const promise = pollJobResult('job-1', 'ws')
+		const rejects = expect(promise).rejects.toThrow(/stays queued/)
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
+		await rejects
+	})
+
+	it('does not give up while a worker group could still be coming up', async () => {
+		// A worker group booting is absent from worker_ping exactly like an unserved
+		// tag; only a run of empty lookups distinguishes them.
+		existsWorkersWithTags.mockResolvedValueOnce({ postgresql: false })
 		existsWorkersWithTags.mockResolvedValueOnce({ postgresql: false })
 		existsWorkersWithTags.mockResolvedValue({ postgresql: true })
 
 		const promise = pollJobResult('job-1', 'ws')
 		const tracker = settlementTracker(promise)
 
-		await vi.advanceTimersByTimeAsync(60_000)
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
 		expect(tracker.settled).toBe(false)
 		expect(cancelQueuedJob).not.toHaveBeenCalled()
 	})
@@ -74,7 +90,7 @@ describe('pollJobResult', () => {
 		const promise = pollJobResult('job-1', 'ws')
 		const tracker = settlementTracker(promise)
 
-		await vi.advanceTimersByTimeAsync(60_000)
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
 		expect(tracker.settled).toBe(false)
 
 		getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 42 })

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -61,6 +61,9 @@ describe('pollJobResult', () => {
 
 	it('cancels a queued write before reporting it, so it cannot apply later', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
+		cancelQueuedJob.mockImplementation(async () => {
+			getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: false })
+		})
 
 		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
 		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
@@ -69,6 +72,20 @@ describe('pollJobResult', () => {
 		expect(cancelQueuedJob).toHaveBeenCalledWith(
 			expect.objectContaining({ id: 'job-1', workspace: 'ws' })
 		)
+	})
+
+	it('returns the result of a write a worker completed as the cancel was sent', async () => {
+		// `cancelQueuedJob` answers 200 for an already-completed job too, so treating
+		// the request as proof would report a mutation that actually landed as failed
+		// and invite the user to run it twice.
+		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
+		cancelQueuedJob.mockImplementation(async () => {
+			getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 7 })
+		})
+
+		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
+		await expect(promise).resolves.toBe(7)
 	})
 
 	it('keeps waiting on a write the server would not cancel', async () => {

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -17,7 +17,7 @@ vi.mock('$lib/gen', () => ({
 }))
 
 import { pollJobResult } from './utils'
-import { NoWorkerForTagError } from './missingWorker'
+import { hasWorkerForTag, NoWorkerForTagError } from './missingWorker'
 
 function settlementTracker(promise: Promise<unknown>) {
 	const state = { settled: false }
@@ -47,7 +47,7 @@ afterEach(() => {
 const PAST_CONFIRMATION_WINDOW_MS = 120_000
 
 describe('pollJobResult', () => {
-	it('reports a queued job whose tag stays unserved without cancelling it', async () => {
+	it('reports a queued read whose tag stays unserved without cancelling it', async () => {
 		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
 
 		const promise = pollJobResult('job-1', 'ws')
@@ -57,6 +57,31 @@ describe('pollJobResult', () => {
 		// The backlog is what the autoscaler scales up on: cancelling would stop a
 		// group coming back from zero from ever recovering.
 		expect(cancelQueuedJob).not.toHaveBeenCalled()
+	})
+
+	it('cancels a queued write before reporting it, so it cannot apply later', async () => {
+		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
+
+		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
+		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS)
+		await rejects
+		expect(cancelQueuedJob).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'job-1', workspace: 'ws' })
+		)
+	})
+
+	it('keeps waiting on a write the server would not cancel', async () => {
+		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
+		cancelQueuedJob.mockRejectedValue(new Error('nope'))
+
+		const promise = pollJobResult('job-1', 'ws', { sideEffecting: true })
+		const tracker = settlementTracker(promise)
+
+		// Reporting failure on a write that is still executable would let it apply
+		// itself after the caller gave up, and duplicate on retry.
+		await vi.advanceTimersByTimeAsync(PAST_CONFIRMATION_WINDOW_MS * 3)
+		expect(tracker.settled).toBe(false)
 	})
 
 	it('does not give up while a worker group could still be coming up', async () => {
@@ -86,5 +111,15 @@ describe('pollJobResult', () => {
 		getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 42 })
 		await vi.advanceTimersByTimeAsync(3_000)
 		await expect(promise).resolves.toBe(42)
+	})
+})
+
+describe('hasWorkerForTag', () => {
+	it('treats an answer it did not get as a worker being there', async () => {
+		// `existsWorkersWithTags` returns an empty map when TAGS_ARE_SENSITIVE hides
+		// the tag from the caller. Reading that as "unserved" would diagnose a
+		// perfectly healthy instance.
+		existsWorkersWithTags.mockResolvedValue({})
+		await expect(hasWorkerForTag('ws', 'postgresql')).resolves.toBe(true)
 	})
 })

--- a/frontend/src/lib/components/jobs/missingWorker.test.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const getCompletedJobResultMaybe = vi.fn()
+const getJob = vi.fn()
+const existsWorkersWithTags = vi.fn()
+
+vi.mock('$lib/gen', () => ({
+	JobService: {
+		getCompletedJobResultMaybe: (...a: unknown[]) => getCompletedJobResultMaybe(...(a as [])),
+		getJob: (...a: unknown[]) => getJob(...(a as []))
+	},
+	WorkerService: {
+		existsWorkersWithTags: (...a: unknown[]) => existsWorkersWithTags(...(a as []))
+	}
+}))
+
+import { pollJobResult } from './utils'
+import { NoWorkerForTagError } from './missingWorker'
+
+beforeEach(() => {
+	getCompletedJobResultMaybe.mockReset()
+	getJob.mockReset()
+	existsWorkersWithTags.mockReset()
+	getCompletedJobResultMaybe.mockResolvedValue({ completed: false })
+	getJob.mockResolvedValue({ type: 'QueuedJob', running: false, tag: 'postgresql' })
+	vi.useFakeTimers()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe('pollJobResult', () => {
+	it('reports the tag of a queued job no worker serves instead of polling forever', async () => {
+		existsWorkersWithTags.mockResolvedValue({ postgresql: false })
+
+		const promise = pollJobResult('job-1', 'ws')
+		const rejects = expect(promise).rejects.toBeInstanceOf(NoWorkerForTagError)
+		await vi.advanceTimersByTimeAsync(15_000)
+		await rejects
+	})
+
+	it('keeps waiting on a job queued behind a busy worker that serves its tag', async () => {
+		existsWorkersWithTags.mockResolvedValue({ postgresql: true })
+
+		const promise = pollJobResult('job-1', 'ws')
+		let settled = false
+		promise.then(
+			() => (settled = true),
+			() => (settled = true)
+		)
+
+		await vi.advanceTimersByTimeAsync(60_000)
+		expect(settled).toBe(false)
+
+		getCompletedJobResultMaybe.mockResolvedValue({ completed: true, success: true, result: 42 })
+		await vi.advanceTimersByTimeAsync(1_000)
+		await expect(promise).resolves.toBe(42)
+	})
+})

--- a/frontend/src/lib/components/jobs/missingWorker.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.ts
@@ -12,19 +12,25 @@ import { JobService, WorkerService } from '$lib/gen'
 export class NoWorkerForTagError extends Error {
 	tag: string
 
-	constructor(tag: string, cancelled: boolean) {
+	constructor(tag: string) {
 		super(
 			`No worker has been listening to the tag "${tag}" while this job waited, so it was never ` +
-				`picked up and ${
-					cancelled
-						? 'has been cancelled'
-						: 'stays queued — it will run once a worker with that tag comes online'
-				}. Add "${tag}" to the worker tags of one of your worker groups (Workers page), or run ` +
-				`a worker that serves it.`
+				`picked up. It stays queued and will run once a worker with that tag comes online. ` +
+				`Add "${tag}" to the worker tags of one of your worker groups (Workers page), or run a ` +
+				`worker that serves it.`
 		)
 		this.name = 'NoWorkerForTagError'
 		this.tag = tag
 	}
+}
+
+/** Shown while a write waits, which is never abandoned (see `sideEffecting`). */
+export function queuedWithoutWorkerMessage(tag: string): string {
+	return (
+		`No worker is listening to the tag "${tag}", so this operation is queued and will only run ` +
+		`once one is. Add "${tag}" to the worker tags of one of your worker groups (Workers page), ` +
+		`or run a worker that serves it.`
+	)
 }
 
 /** How long a job may sit un-started before the first lookup for a worker serving its tag. */

--- a/frontend/src/lib/components/jobs/missingWorker.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.ts
@@ -12,15 +12,12 @@ import { JobService, WorkerService } from '$lib/gen'
 export class NoWorkerForTagError extends Error {
 	tag: string
 
-	constructor(tag: string, cancelled: boolean) {
+	constructor(tag: string) {
 		super(
 			`No worker has been listening to the tag "${tag}" while this job waited, so it was never ` +
-				`picked up and ${
-					cancelled
-						? 'has been cancelled'
-						: 'could not be cancelled — it stays queued and will run if a worker with that tag comes online'
-				}. Add "${tag}" to the worker tags of one of your worker groups (Workers page), ` +
-				`or run a worker that serves it.`
+				`picked up. It stays queued and will run once a worker with that tag comes online. ` +
+				`Add "${tag}" to the worker tags of one of your worker groups (Workers page), or run a ` +
+				`worker that serves it.`
 		)
 		this.name = 'NoWorkerForTagError'
 		this.tag = tag
@@ -32,10 +29,10 @@ export const NO_WORKER_FIRST_PROBE_MS = 10_000
 /** How long to wait between lookups while the job stays queued. */
 export const NO_WORKER_PROBE_INTERVAL_MS = 40_000
 /**
- * How many consecutive lookups must come back empty before the job is given up
- * on. A worker group scaling from zero, or every worker down for a rollout, is
- * indistinguishable from an unserved tag in any single lookup — only a tag that
- * stays unserved across the whole window (~90s) is reported.
+ * How many consecutive lookups must come back empty before the caller stops
+ * waiting. A worker group scaling from zero, or every worker down for a rollout,
+ * is indistinguishable from an unserved tag in any single lookup, so no single
+ * empty reading is acted on.
  */
 export const NO_WORKER_CONFIRMATIONS = 3
 

--- a/frontend/src/lib/components/jobs/missingWorker.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.ts
@@ -12,21 +12,32 @@ import { JobService, WorkerService } from '$lib/gen'
 export class NoWorkerForTagError extends Error {
 	tag: string
 
-	constructor(tag: string) {
+	constructor(tag: string, cancelled: boolean) {
 		super(
-			`No worker is currently listening to the tag "${tag}", so this job was not picked up ` +
-				`and has been cancelled. Add "${tag}" to the worker tags of one of your worker groups ` +
-				`(Workers page), or run a worker that serves it.`
+			`No worker has been listening to the tag "${tag}" while this job waited, so it was never ` +
+				`picked up and ${
+					cancelled
+						? 'has been cancelled'
+						: 'could not be cancelled — it stays queued and will run if a worker with that tag comes online'
+				}. Add "${tag}" to the worker tags of one of your worker groups (Workers page), ` +
+				`or run a worker that serves it.`
 		)
 		this.name = 'NoWorkerForTagError'
 		this.tag = tag
 	}
 }
 
-/** How long a job may sit un-started before we look for a worker serving its tag. */
-export const NO_WORKER_GRACE_MS = 8_000
-/** How long to wait before repeating the lookup while the job stays queued. */
-export const NO_WORKER_RECHECK_MS = 8_000
+/** How long a job may sit un-started before the first lookup for a worker serving its tag. */
+export const NO_WORKER_FIRST_PROBE_MS = 10_000
+/** How long to wait between lookups while the job stays queued. */
+export const NO_WORKER_PROBE_INTERVAL_MS = 40_000
+/**
+ * How many consecutive lookups must come back empty before the job is given up
+ * on. A worker group scaling from zero, or every worker down for a rollout, is
+ * indistinguishable from an unserved tag in any single lookup — only a tag that
+ * stays unserved across the whole window (~90s) is reported.
+ */
+export const NO_WORKER_CONFIRMATIONS = 3
 
 /**
  * Whether any worker pinged in the last minute declares `tag`. Unknown answers

--- a/frontend/src/lib/components/jobs/missingWorker.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.ts
@@ -1,0 +1,59 @@
+import { JobService, WorkerService } from '$lib/gen'
+
+/**
+ * A queued job whose tag no running worker serves is never picked up: without
+ * this the UI polls until the server-side `run_wait_result` timeout (10min by
+ * default) or, for the client-side pollers, forever.
+ *
+ * The most common cause is a language that defaults to a native tag
+ * (`postgresql`, `mysql`, `bigquery`, …) on an instance whose worker groups
+ * only declare the default tags.
+ */
+export class NoWorkerForTagError extends Error {
+	tag: string
+
+	constructor(tag: string) {
+		super(
+			`No worker is listening to the tag "${tag}", so this job can never start. ` +
+				`Add "${tag}" to the worker tags of one of your worker groups (Workers page), ` +
+				`or run a worker that serves it.`
+		)
+		this.name = 'NoWorkerForTagError'
+		this.tag = tag
+	}
+}
+
+/** How long a job may sit un-started before we look for a worker serving its tag. */
+export const NO_WORKER_GRACE_MS = 10_000
+/** How often the lookup is repeated while the job stays queued. */
+export const NO_WORKER_RECHECK_MS = 15_000
+
+/**
+ * Whether any worker pinged in the last minute declares `tag`. Unknown answers
+ * (the endpoint returns an empty map when tags are sensitive and the caller may
+ * not see them) count as "yes", so an opaque instance never gets a wrong
+ * diagnosis.
+ */
+export async function hasWorkerForTag(workspace: string, tag: string): Promise<boolean> {
+	const existing = await WorkerService.existsWorkersWithTags({ workspace, tags: tag })
+	return existing[tag] !== false
+}
+
+/**
+ * The tag of `jobId` when it is still queued and no worker serves it, else
+ * undefined. Never throws: a failed lookup means "can't tell", and the caller
+ * keeps waiting rather than reporting a cause it did not establish.
+ */
+export async function missingWorkerTagOfQueuedJob(
+	workspace: string,
+	jobId: string
+): Promise<string | undefined> {
+	try {
+		const job = await JobService.getJob({ workspace, id: jobId, noCode: true, noLogs: true })
+		if (job.type !== 'QueuedJob' || job.running || !job.tag) return undefined
+		return (await hasWorkerForTag(workspace, job.tag)) ? undefined : job.tag
+	} catch (err) {
+		console.warn('Could not determine whether a worker serves the job tag', err)
+		return undefined
+	}
+}

--- a/frontend/src/lib/components/jobs/missingWorker.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.ts
@@ -12,12 +12,15 @@ import { JobService, WorkerService } from '$lib/gen'
 export class NoWorkerForTagError extends Error {
 	tag: string
 
-	constructor(tag: string) {
+	constructor(tag: string, cancelled: boolean) {
 		super(
 			`No worker has been listening to the tag "${tag}" while this job waited, so it was never ` +
-				`picked up. It stays queued and will run once a worker with that tag comes online. ` +
-				`Add "${tag}" to the worker tags of one of your worker groups (Workers page), or run a ` +
-				`worker that serves it.`
+				`picked up and ${
+					cancelled
+						? 'has been cancelled'
+						: 'stays queued — it will run once a worker with that tag comes online'
+				}. Add "${tag}" to the worker tags of one of your worker groups (Workers page), or run ` +
+				`a worker that serves it.`
 		)
 		this.name = 'NoWorkerForTagError'
 		this.tag = tag

--- a/frontend/src/lib/components/jobs/missingWorker.ts
+++ b/frontend/src/lib/components/jobs/missingWorker.ts
@@ -14,9 +14,9 @@ export class NoWorkerForTagError extends Error {
 
 	constructor(tag: string) {
 		super(
-			`No worker is listening to the tag "${tag}", so this job can never start. ` +
-				`Add "${tag}" to the worker tags of one of your worker groups (Workers page), ` +
-				`or run a worker that serves it.`
+			`No worker is currently listening to the tag "${tag}", so this job was not picked up ` +
+				`and has been cancelled. Add "${tag}" to the worker tags of one of your worker groups ` +
+				`(Workers page), or run a worker that serves it.`
 		)
 		this.name = 'NoWorkerForTagError'
 		this.tag = tag
@@ -24,9 +24,9 @@ export class NoWorkerForTagError extends Error {
 }
 
 /** How long a job may sit un-started before we look for a worker serving its tag. */
-export const NO_WORKER_GRACE_MS = 10_000
-/** How often the lookup is repeated while the job stays queued. */
-export const NO_WORKER_RECHECK_MS = 15_000
+export const NO_WORKER_GRACE_MS = 8_000
+/** How long to wait before repeating the lookup while the job stays queued. */
+export const NO_WORKER_RECHECK_MS = 8_000
 
 /**
  * Whether any worker pinged in the last minute declares `tag`. Unknown answers

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -18,6 +18,15 @@ type RunScriptOptions = {
 	withJobData?: boolean
 	/** Set to false to keep polling a job that no worker can pick up. */
 	failIfNoWorkerForTag?: boolean
+	/**
+	 * The job writes (insert/update/delete, DDL, arbitrary SQL). Such a job must
+	 * never stay executable once its caller has handled it as failed, or a later
+	 * pickup plus a retry applies it twice — so it is cancelled before the
+	 * missing-worker error is reported, and the poll keeps waiting if the cancel
+	 * is refused. Reads are abandoned queued instead, which leaves the autoscaler
+	 * the backlog it scales up on.
+	 */
+	sideEffecting?: boolean
 }
 
 /**
@@ -61,7 +70,12 @@ function pollDelayMs(poll: number): number {
 export async function pollJobResult(
 	uuid: string,
 	workspace: string,
-	{ maxRetries = 7, withJobData, failIfNoWorkerForTag = true }: RunScriptOptions = {}
+	{
+		maxRetries = 7,
+		withJobData,
+		failIfNoWorkerForTag = true,
+		sideEffecting = false
+	}: RunScriptOptions = {}
 ): Promise<unknown> {
 	let attempts = 0
 	let polls = 0
@@ -97,10 +111,24 @@ export async function pollJobResult(
 				noWorkerProbeAt = Date.now() + NO_WORKER_PROBE_INTERVAL_MS
 				unservedProbes = tag ? unservedProbes + 1 : 0
 				if (tag && unservedProbes >= NO_WORKER_CONFIRMATIONS) {
-					// Only the wait is given up on — the job is left queued. Cancelling it
-					// would remove the very backlog the autoscaler scales up on, so a group
-					// coming back from zero (300s cooldown by default) would never recover.
-					throw new NoWorkerForTagError(tag)
+					if (!sideEffecting) {
+						// Only the wait is given up on — the job is left queued. Cancelling a
+						// read would remove the very backlog the autoscaler scales up on, so a
+						// group coming back from zero (300s cooldown) would never recover.
+						throw new NoWorkerForTagError(tag, false)
+					}
+					const cancelled = await JobService.cancelQueuedJob({
+						workspace,
+						id: uuid,
+						requestBody: {}
+					}).then(
+						() => true,
+						(err) => (console.warn('Could not cancel the unpickable job', err), false)
+					)
+					if (cancelled) throw new NoWorkerForTagError(tag, true)
+					// A write the server would not cancel is still executable: keep waiting
+					// rather than report a failure that can later apply itself anyway.
+					unservedProbes = 0
 				}
 			}
 		} catch (e) {

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -97,18 +97,10 @@ export async function pollJobResult(
 				noWorkerProbeAt = Date.now() + NO_WORKER_PROBE_INTERVAL_MS
 				unservedProbes = tag ? unservedProbes + 1 : 0
 				if (tag && unservedProbes >= NO_WORKER_CONFIRMATIONS) {
-					// Leaving it queued would let it run long after the caller reported it
-					// as failed, and every retry would pile on another orphan. A cancel the
-					// server refuses is reported as such rather than claimed.
-					const cancelled = await JobService.cancelQueuedJob({
-						workspace,
-						id: uuid,
-						requestBody: {}
-					}).then(
-						() => true,
-						(err) => (console.warn('Could not cancel the unpickable job', err), false)
-					)
-					throw new NoWorkerForTagError(tag, cancelled)
+					// Only the wait is given up on — the job is left queued. Cancelling it
+					// would remove the very backlog the autoscaler scales up on, so a group
+					// coming back from zero (300s cooldown by default) would never recover.
+					throw new NoWorkerForTagError(tag)
 				}
 			}
 		} catch (e) {

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -19,14 +19,16 @@ type RunScriptOptions = {
 	/** Set to false to keep polling a job that no worker can pick up. */
 	failIfNoWorkerForTag?: boolean
 	/**
-	 * The job writes (insert/update/delete, DDL, arbitrary SQL). Such a job must
-	 * never stay executable once its caller has handled it as failed, or a later
-	 * pickup plus a retry applies it twice — so it is cancelled before the
-	 * missing-worker error is reported, and the poll keeps waiting if the cancel
-	 * is refused. Reads are abandoned queued instead, which leaves the autoscaler
-	 * the backlog it scales up on.
+	 * The job writes (insert/update/delete, DDL, arbitrary SQL). Such a job is
+	 * never given up on: reporting it as failed while it stays executable invites
+	 * a duplicate retry, and cancelling it first is not something the client can
+	 * do atomically: a worker can claim it between the tag probe and the cancel,
+	 * and a soft-cancelled statement may already have committed. `onNoWorkerForTag`
+	 * is what tells the user why it is waiting.
 	 */
 	sideEffecting?: boolean
+	/** Called once when the job has stayed queued on a tag no worker serves. */
+	onNoWorkerForTag?: (tag: string) => void
 }
 
 /**
@@ -74,20 +76,19 @@ export async function pollJobResult(
 		maxRetries = 7,
 		withJobData,
 		failIfNoWorkerForTag = true,
-		sideEffecting = false
+		sideEffecting = false,
+		onNoWorkerForTag
 	}: RunScriptOptions = {}
 ): Promise<unknown> {
 	let attempts = 0
 	let polls = 0
 	// `attempts` only advances on errors, so a queued job would poll forever. The
 	// one case that never resolves on its own is a tag no worker serves, which
-	// takes NO_WORKER_CONFIRMATIONS consecutive empty lookups to establish — a
-	// worker group booting reads like an unserved tag in any single one.
+	// takes NO_WORKER_CONFIRMATIONS consecutive empty lookups to establish, since
+	// a worker group booting reads like an unserved tag in any single one.
 	let noWorkerProbeAt = Date.now() + NO_WORKER_FIRST_PROBE_MS
 	let unservedProbes = 0
-	// Set once a cancel has been *requested* for an unserved write, so the loop
-	// can name the cause when the job turns out to have ended cancelled.
-	let cancelRequestedForTag: string | undefined = undefined
+	let reportedNoWorker = false
 	while (attempts < maxRetries) {
 		try {
 			await new Promise((resolve) =>
@@ -105,9 +106,6 @@ export async function pollJobResult(
 				}
 			} else if (job.completed) {
 				attempts = maxRetries
-				if (cancelRequestedForTag) {
-					throw new NoWorkerForTagError(cancelRequestedForTag, true)
-				}
 				let errorMsg: string | undefined = (job?.result as any)?.error?.message
 				if (typeof errorMsg !== 'string') errorMsg = undefined
 				console.error('JOB FAILED', job.result)
@@ -117,22 +115,15 @@ export async function pollJobResult(
 				noWorkerProbeAt = Date.now() + NO_WORKER_PROBE_INTERVAL_MS
 				unservedProbes = tag ? unservedProbes + 1 : 0
 				if (tag && unservedProbes >= NO_WORKER_CONFIRMATIONS) {
-					if (!sideEffecting) {
-						// Only the wait is given up on — the job is left queued. Cancelling a
-						// read would remove the very backlog the autoscaler scales up on, so a
-						// group coming back from zero (300s cooldown) would never recover.
-						throw new NoWorkerForTagError(tag, false)
+					if (!reportedNoWorker) {
+						reportedNoWorker = true
+						onNoWorkerForTag?.(tag)
 					}
-					// A write must not stay executable once its caller has handled it as
-					// failed. The cancel is only a request though: it answers 200 for a job
-					// a worker claimed and completed in the meantime too, so the outcome is
-					// read from the next poll — a write that actually landed still returns
-					// its result above.
-					await JobService.cancelQueuedJob({ workspace, id: uuid, requestBody: {} }).then(
-						() => (cancelRequestedForTag = tag),
-						(err) => console.warn('Could not cancel the unpickable job', err)
-					)
-					unservedProbes = 0
+					// Reads give up the wait but leave the job queued: cancelling one would
+					// remove the very backlog the autoscaler scales up on, so a group coming
+					// back from zero (300s cooldown) would never recover. Writes keep
+					// waiting instead (see `sideEffecting`).
+					if (!sideEffecting) throw new NoWorkerForTagError(tag)
 				}
 			}
 		} catch (e) {

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -1,4 +1,10 @@
 import { JobService, type RunScriptByPathData, type RunScriptPreviewData } from '$lib/gen'
+import {
+	missingWorkerTagOfQueuedJob,
+	NoWorkerForTagError,
+	NO_WORKER_GRACE_MS,
+	NO_WORKER_RECHECK_MS
+} from './missingWorker'
 
 function isRunScriptByPathData(
 	arg: RunScriptPreviewData | RunScriptByPathData
@@ -9,13 +15,15 @@ function isRunScriptByPathData(
 type RunScriptOptions = {
 	maxRetries?: number
 	withJobData?: boolean
+	/** Set to false to keep polling a job that no worker can pick up. */
+	failIfNoWorkerForTag?: boolean
 }
 
 /**
  * @function runScript
  * @param {RunScriptPreviewData | RunScriptByPathData} data - Data for running the script.
  * @returns {Promise<string>} A UUID representing the running script.
- * 
+ *
  * @example
  * const uuid = await runScript(data)
  */
@@ -36,16 +44,21 @@ export async function runScript(data: RunScriptPreviewData | RunScriptByPathData
  * @param {string} workspace - Workspace identifier.
  * @param {RunScriptOptions} [options] - Optional settings like retries and job data inclusion.
  * @returns {Promise<unknown>} Final job result or throws error if it fails.
- * 
+ *
  * @example
  * const result = await pollJobResult(uuid, 'my-workspace', { maxRetries: 5, withJobData: true });
  */
 export async function pollJobResult(
 	uuid: string,
 	workspace: string,
-	{ maxRetries = 7, withJobData }: RunScriptOptions = {}
+	{ maxRetries = 7, withJobData, failIfNoWorkerForTag = true }: RunScriptOptions = {}
 ): Promise<unknown> {
 	let attempts = 0
+	// A job that never completes leaves `attempts` untouched, so the loop below is
+	// unbounded by design (a running job may take arbitrarily long). This deadline
+	// is what turns a job no worker can ever pick up, which would otherwise poll
+	// forever, into a reported error.
+	let noWorkerCheckAt = Date.now() + NO_WORKER_GRACE_MS
 	while (attempts < maxRetries) {
 		try {
 			await new Promise((resolve) => setTimeout(resolve, 500 * (attempts || 0.75)))
@@ -65,8 +78,15 @@ export async function pollJobResult(
 				if (typeof errorMsg !== 'string') errorMsg = undefined
 				console.error('JOB FAILED', job.result)
 				throw new Error(errorMsg ?? 'Job failed')
+			} else if (failIfNoWorkerForTag && Date.now() >= noWorkerCheckAt) {
+				const tag = await missingWorkerTagOfQueuedJob(workspace, uuid)
+				if (tag) throw new NoWorkerForTagError(tag)
+				noWorkerCheckAt = Date.now() + NO_WORKER_RECHECK_MS
 			}
 		} catch (e) {
+			if (e instanceof NoWorkerForTagError) {
+				throw e
+			}
 			if (attempts == maxRetries) {
 				throw e
 			}

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -37,6 +37,15 @@ export async function runScript(data: RunScriptPreviewData | RunScriptByPathData
 	return uuid
 }
 
+/** Tight at first so a quick job feels instant, then slower: a schema
+ * introspection or a DDL migration can run for minutes, and a fixed sub-second
+ * tick would cost hundreds of round-trips for it. */
+function pollDelayMs(poll: number): number {
+	if (poll < 4) return 375
+	if (poll < 12) return 750
+	return 2000
+}
+
 /**
  * @function pollJobResult
  * @description Polls a job result by UUID until success, failure, or max retries reached.
@@ -54,14 +63,18 @@ export async function pollJobResult(
 	{ maxRetries = 7, withJobData, failIfNoWorkerForTag = true }: RunScriptOptions = {}
 ): Promise<unknown> {
 	let attempts = 0
-	// A job that never completes leaves `attempts` untouched, so the loop below is
-	// unbounded by design (a running job may take arbitrarily long). This deadline
-	// is what turns a job no worker can ever pick up, which would otherwise poll
-	// forever, into a reported error.
+	let polls = 0
+	// `attempts` only advances on errors, so a queued job would poll forever. The
+	// one case that never resolves on its own is a tag no worker serves, and a
+	// single negative lookup is not proof of it (a group scaled to zero reads the
+	// same), so only a second negative one recheck later is acted on.
 	let noWorkerCheckAt = Date.now() + NO_WORKER_GRACE_MS
+	let unservedTag: string | undefined = undefined
 	while (attempts < maxRetries) {
 		try {
-			await new Promise((resolve) => setTimeout(resolve, 500 * (attempts || 0.75)))
+			await new Promise((resolve) =>
+				setTimeout(resolve, attempts ? 500 * attempts : pollDelayMs(polls++))
+			)
 			const job = await JobService.getCompletedJobResultMaybe({
 				id: uuid,
 				workspace
@@ -80,7 +93,15 @@ export async function pollJobResult(
 				throw new Error(errorMsg ?? 'Job failed')
 			} else if (failIfNoWorkerForTag && Date.now() >= noWorkerCheckAt) {
 				const tag = await missingWorkerTagOfQueuedJob(workspace, uuid)
-				if (tag) throw new NoWorkerForTagError(tag)
+				if (tag && tag === unservedTag) {
+					// Leaving it queued would let it run long after the caller reported it
+					// as failed, and every retry would pile on another orphan.
+					await JobService.cancelQueuedJob({ workspace, id: uuid, requestBody: {} }).catch((err) =>
+						console.warn('Could not cancel the unpickable job', err)
+					)
+					throw new NoWorkerForTagError(tag)
+				}
+				unservedTag = tag
 				noWorkerCheckAt = Date.now() + NO_WORKER_RECHECK_MS
 			}
 		} catch (e) {

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -85,6 +85,9 @@ export async function pollJobResult(
 	// worker group booting reads like an unserved tag in any single one.
 	let noWorkerProbeAt = Date.now() + NO_WORKER_FIRST_PROBE_MS
 	let unservedProbes = 0
+	// Set once a cancel has been *requested* for an unserved write, so the loop
+	// can name the cause when the job turns out to have ended cancelled.
+	let cancelRequestedForTag: string | undefined = undefined
 	while (attempts < maxRetries) {
 		try {
 			await new Promise((resolve) =>
@@ -102,6 +105,9 @@ export async function pollJobResult(
 				}
 			} else if (job.completed) {
 				attempts = maxRetries
+				if (cancelRequestedForTag) {
+					throw new NoWorkerForTagError(cancelRequestedForTag, true)
+				}
 				let errorMsg: string | undefined = (job?.result as any)?.error?.message
 				if (typeof errorMsg !== 'string') errorMsg = undefined
 				console.error('JOB FAILED', job.result)
@@ -117,17 +123,15 @@ export async function pollJobResult(
 						// group coming back from zero (300s cooldown) would never recover.
 						throw new NoWorkerForTagError(tag, false)
 					}
-					const cancelled = await JobService.cancelQueuedJob({
-						workspace,
-						id: uuid,
-						requestBody: {}
-					}).then(
-						() => true,
-						(err) => (console.warn('Could not cancel the unpickable job', err), false)
+					// A write must not stay executable once its caller has handled it as
+					// failed. The cancel is only a request though: it answers 200 for a job
+					// a worker claimed and completed in the meantime too, so the outcome is
+					// read from the next poll — a write that actually landed still returns
+					// its result above.
+					await JobService.cancelQueuedJob({ workspace, id: uuid, requestBody: {} }).then(
+						() => (cancelRequestedForTag = tag),
+						(err) => console.warn('Could not cancel the unpickable job', err)
 					)
-					if (cancelled) throw new NoWorkerForTagError(tag, true)
-					// A write the server would not cancel is still executable: keep waiting
-					// rather than report a failure that can later apply itself anyway.
 					unservedProbes = 0
 				}
 			}

--- a/frontend/src/lib/components/jobs/utils.ts
+++ b/frontend/src/lib/components/jobs/utils.ts
@@ -2,8 +2,9 @@ import { JobService, type RunScriptByPathData, type RunScriptPreviewData } from 
 import {
 	missingWorkerTagOfQueuedJob,
 	NoWorkerForTagError,
-	NO_WORKER_GRACE_MS,
-	NO_WORKER_RECHECK_MS
+	NO_WORKER_CONFIRMATIONS,
+	NO_WORKER_FIRST_PROBE_MS,
+	NO_WORKER_PROBE_INTERVAL_MS
 } from './missingWorker'
 
 function isRunScriptByPathData(
@@ -65,11 +66,11 @@ export async function pollJobResult(
 	let attempts = 0
 	let polls = 0
 	// `attempts` only advances on errors, so a queued job would poll forever. The
-	// one case that never resolves on its own is a tag no worker serves, and a
-	// single negative lookup is not proof of it (a group scaled to zero reads the
-	// same), so only a second negative one recheck later is acted on.
-	let noWorkerCheckAt = Date.now() + NO_WORKER_GRACE_MS
-	let unservedTag: string | undefined = undefined
+	// one case that never resolves on its own is a tag no worker serves, which
+	// takes NO_WORKER_CONFIRMATIONS consecutive empty lookups to establish — a
+	// worker group booting reads like an unserved tag in any single one.
+	let noWorkerProbeAt = Date.now() + NO_WORKER_FIRST_PROBE_MS
+	let unservedProbes = 0
 	while (attempts < maxRetries) {
 		try {
 			await new Promise((resolve) =>
@@ -91,18 +92,24 @@ export async function pollJobResult(
 				if (typeof errorMsg !== 'string') errorMsg = undefined
 				console.error('JOB FAILED', job.result)
 				throw new Error(errorMsg ?? 'Job failed')
-			} else if (failIfNoWorkerForTag && Date.now() >= noWorkerCheckAt) {
+			} else if (failIfNoWorkerForTag && Date.now() >= noWorkerProbeAt) {
 				const tag = await missingWorkerTagOfQueuedJob(workspace, uuid)
-				if (tag && tag === unservedTag) {
+				noWorkerProbeAt = Date.now() + NO_WORKER_PROBE_INTERVAL_MS
+				unservedProbes = tag ? unservedProbes + 1 : 0
+				if (tag && unservedProbes >= NO_WORKER_CONFIRMATIONS) {
 					// Leaving it queued would let it run long after the caller reported it
-					// as failed, and every retry would pile on another orphan.
-					await JobService.cancelQueuedJob({ workspace, id: uuid, requestBody: {} }).catch((err) =>
-						console.warn('Could not cancel the unpickable job', err)
+					// as failed, and every retry would pile on another orphan. A cancel the
+					// server refuses is reported as such rather than claimed.
+					const cancelled = await JobService.cancelQueuedJob({
+						workspace,
+						id: uuid,
+						requestBody: {}
+					}).then(
+						() => true,
+						(err) => (console.warn('Could not cancel the unpickable job', err), false)
 					)
-					throw new NoWorkerForTagError(tag)
+					throw new NoWorkerForTagError(tag, cancelled)
 				}
-				unservedTag = tag
-				noWorkerCheckAt = Date.now() + NO_WORKER_RECHECK_MS
 			}
 		} catch (e) {
 			if (e instanceof NoWorkerForTagError) {

--- a/frontend/src/lib/components/jobs/writingJob.ts
+++ b/frontend/src/lib/components/jobs/writingJob.ts
@@ -1,0 +1,12 @@
+import { sendUserToast } from '$lib/toast'
+import { queuedWithoutWorkerMessage } from './missingWorker'
+
+/**
+ * Poll options for a job that writes (row edits, DDL, arbitrary SQL). Such a job
+ * is never abandoned (see `sideEffecting` in `pollJobResult`), so this is what
+ * explains the wait when it sits on a tag no worker serves.
+ */
+export const writingJobOptions = {
+	sideEffecting: true,
+	onNoWorkerForTag: (tag: string) => sendUserToast(queuedWithoutWorkerMessage(tag), true)
+}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -54,6 +54,7 @@
 	} from 'lucide-svelte'
 	import DraggableTabs, { type TabItem } from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import { runScriptAndPollResult } from '../jobs/utils'
+	import { writingJobOptions } from '../jobs/writingJob'
 	import { RawAppHistoryManager } from './RawAppHistoryManager.svelte'
 	import { sendUserToast } from '$lib/utils'
 	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
@@ -1029,7 +1030,7 @@
 								args: { database: `datatable://${datatableName}` }
 							}
 						},
-						{ sideEffecting: true }
+						writingJobOptions
 					)
 
 					// If newTable was specified and the query succeeded, add it to data.tables

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1020,14 +1020,17 @@
 				}
 
 				try {
-					const result = await runScriptAndPollResult({
-						workspace: opWorkspace,
-						requestBody: {
-							language: 'postgresql',
-							content: sql,
-							args: { database: `datatable://${datatableName}` }
-						}
-					})
+					const result = await runScriptAndPollResult(
+						{
+							workspace: opWorkspace,
+							requestBody: {
+								language: 'postgresql',
+								content: sql,
+								args: { database: `datatable://${datatableName}` }
+							}
+						},
+						{ sideEffecting: true }
+					)
 
 					// If newTable was specified and the query succeeded, add it to data.tables
 					if (newTable) {

--- a/frontend/src/lib/components/workspaceSettings/DataTableMigrationsButton.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DataTableMigrationsButton.svelte
@@ -25,6 +25,7 @@
 	import Tooltip from '../Tooltip.svelte'
 	import Portal from '$lib/components/Portal.svelte'
 	import DropdownV2 from '../DropdownV2.svelte'
+	import MissingWorkerTagAlert from '../jobs/MissingWorkerTagAlert.svelte'
 	import { superadmin, userStore } from '$lib/stores'
 
 	let {
@@ -422,6 +423,7 @@
 				{/if}
 			</div>
 		{:else}
+			<MissingWorkerTagAlert tag="postgresql" subject="Migrations" {workspace} class="mb-2" />
 			{#if loadError}
 				<div class="text-xs text-red-500">
 					Could not read applied status from the data table: {loadError}

--- a/frontend/src/lib/components/workspaceSettings/DataTableSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DataTableSettings.svelte
@@ -87,6 +87,7 @@
 	import { clone } from '$lib/utils'
 	import SettingsFooter from './SettingsFooter.svelte'
 	import Alert from '../common/alert/Alert.svelte'
+	import MissingWorkerTagAlert from '../jobs/MissingWorkerTagAlert.svelte'
 	import { isCloudHosted } from '$lib/cloud'
 
 	type Props = {
@@ -251,6 +252,8 @@
 		or Neon) instead.
 	</Alert>
 {/if}
+
+<MissingWorkerTagAlert tag="postgresql" subject="Browsing and querying data tables" class="mb-4" />
 
 <DataTable>
 	<Head>

--- a/frontend/src/lib/components/workspaceSettings/projectInstall.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectInstall.ts
@@ -23,6 +23,7 @@ import { updateRawAppPolicy } from '$lib/sharedUtils'
 import { apiErrorMessage as errorMessage } from '$lib/utils'
 import type { App } from '$lib/components/apps/types'
 import { runScriptAndPollResult } from '$lib/components/jobs/utils'
+import { writingJobOptions } from '$lib/components/jobs/writingJob'
 import {
 	classifyPath,
 	collectExportVarPaths,
@@ -242,7 +243,7 @@ async function applyOneMigration(
 					args: { database: `datatable://${m.datatable_name}` }
 				}
 			},
-			{ sideEffecting: true }
+			writingJobOptions
 		)
 	}
 }

--- a/frontend/src/lib/components/workspaceSettings/projectInstall.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectInstall.ts
@@ -233,14 +233,17 @@ async function applyOneMigration(
 			only: created.timestamp
 		})
 	} else {
-		await runScriptAndPollResult({
-			workspace,
-			requestBody: {
-				language: 'postgresql',
-				content: m.sql,
-				args: { database: `datatable://${m.datatable_name}` }
-			}
-		})
+		await runScriptAndPollResult(
+			{
+				workspace,
+				requestBody: {
+					language: 'postgresql',
+					content: m.sql,
+					args: { database: `datatable://${m.datatable_name}` }
+				}
+			},
+			{ sideEffecting: true }
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes WIN-2276.

Every data table / Database Manager operation runs as a Windmill job on a native tag
(`postgresql`). On an instance whose worker groups only declare the default tags, that job
is queued and never picked up — and the UI had no way to say so:

- `pollJobResult` (behind `dbOps`, the SQL REPL, table metadata, DDL) only advanced its
  retry counter on *exceptions*, so a job that stays queued polled forever.
- `getDbSchemas` used the blocking `run_wait_result` endpoint, which hangs for the full
  server timeout (10 min by default) and then reports `timeout after 600s`.
- `DBManagerContent` rendered a spinner whenever the schema was undefined, with no error
  branch — so even after the failure landed the drawer kept spinning.

The result was the reported symptom: an endless spinner on
`/workspace_settings?tab=windmill_data_tables&dbm=datatable~…`, with nothing pointing at
the missing worker.

## Changes

**Detection (`frontend/src/lib/components/jobs/missingWorker.ts`)**
- `missingWorkerTagOfQueuedJob(workspace, jobId)` reads the queued job's *actual* tag and
  asks `WorkerService.existsWorkersWithTags` whether any worker serves it. Never throws:
  an inconclusive lookup means "keep waiting", so an instance with `TAGS_ARE_SENSITIVE`
  (empty response) never gets a wrong diagnosis.

**Poller (`frontend/src/lib/components/jobs/utils.ts`)**
- A job that has never started is probed at 10s, then every 40s. A worker group booting is
  indistinguishable from an unserved tag in any single probe, so it takes **three
  consecutive empty probes (~90s)** before the caller is told. A running job is never
  touched, and no single negative reading acts on anything.
- What happens then depends on whether the job writes, because the two failure modes pull
  in opposite directions:
  - **Reads** (schema, metadata, count, select) stop waiting and report the tag, leaving the
    job *queued*. Cancelling them would delete the very backlog the autoscaler scales up on;
    with a 300s cooldown, a group returning from zero would never recover.
  - **Writes** (insert/update/delete, DDL, REPL SQL, migration SQL) are **never abandoned**.
    Reporting one as failed while it stays executable invites a duplicate retry, and
    cancelling it first cannot be done atomically from the client: a worker can claim it
    between the tag probe and the cancel, and a soft-cancelled statement may already have
    committed. Instead `onNoWorkerForTag` toasts why the operation is waiting, and the poll
    continues until the job actually resolves.
- The poll backs off (375ms → 750ms → 2s) instead of a fixed 375ms tick, so a minutes-long
  introspection or DDL no longer costs hundreds of round-trips.
- `failIfNoWorkerForTag: false` opts out; the Worker REPL uses it because its tag is a
  worker-name prefix pulled directly by the shell loop, not advertised in `worker_ping`.

**Reporting**
- `DBManagerContent` replaces the eternal spinner with an error panel + Retry, fed by both
  the schema and the table-metadata query and titled for whichever failed. The error branch
  is ordered **before** the cached-schema branch: `dbSchemas` is a store that survives a
  failed refetch, so the other order would hide a failure behind stale content.
- After 10s of either query loading, the drawer shows the missing-worker warning inline
  while the job is still queued, so the cause is visible long before the poller gives up.
- `getDbSchemas`, `loadTableMetaData` and `fetchSnowflakePrimaryKeys` moved from
  `runScriptPreviewAndWaitResult` to `runScriptAndPollResult`, so they inherit the check
  instead of blocking on the server-side timeout.
- `DataTablePreview` / `DucklakeResultPreview` distinguish "metadata read failed" from
  "table doesn't exist yet" instead of showing the latter for both.
- `loadAllTablesMetaData` no longer toasts (it always rethrows); each caller renders the
  error in its own pane, so a failure is reported once rather than twice. `DBTable`'s
  cell-edit path surfaces the message instead of discarding it.
- `AppDbExplorer` clears `columnDefs.loading` when metadata fails, instead of leaving the
  component's own spinner up forever.

**Proactive warning (`MissingWorkerTagAlert.svelte`)**
- Shown on the Data tables settings tab, in the migrations modal, and in the DB manager's
  slow-load state, so the question in the ticket ("will data tables work without a native
  worker?") is answered before anything is clicked. Worded as "no worker is running for
  this tag" rather than "this tag is not configured", since a correctly tagged group at
  zero replicas looks the same in `worker_ping` and queueing a job is what scales it up.
  Skipped when per-workspace default tags are on — the effective tag is then
  workspace-suffixed and resolves through fork ancestry, so probing the bare tag could warn
  about a tag that is in fact served.

## Screenshots

Data tables settings, on an instance whose worker group does not declare `postgresql`:

![settings](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785661656-settings-final.png)

Database Manager after 10s — the cause is named while the job is still queued:

![db manager hint](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785662945-dbm-hint.png)

After the confirmation window, for a read (job left queued):

![db manager error](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785664712-dbm-error-nocancel.png)

A write is never abandoned: this insert waited out a missing worker, then completed on its
own once the tag was served again.

![write resolved](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785666612-write-resolved.png)

A failed *refresh* of an already-loaded manager reports the error instead of leaving the
stale schema on screen:

![cached schema error](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785662945-cached-schema-error.png)

Migrations modal:

![migrations](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785661656-migrations-final.png)

After adding `postgresql` to the worker group, unchanged behavior:

![db manager healthy](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2276-an-user-had-trouble-setting-datatable-i-dont-have-a-native/1785662945-dbm-ok-final.png)

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npx vitest run src/lib/components/jobs/missingWorker.test.ts` — 5 passed: a read
      whose tag stays unserved is reported without being cancelled; a write is never
      abandoned, reports once why it waits, and still resolves; a run of empty probes that
      recovers never gives up; a job queued behind a busy worker keeps waiting and still
      resolves; an inconclusive tag lookup counts as "served"
- [x] Removed `postgresql` from the worker group's tags: the DB manager names the tag
      inline at ~10s and reports the terminal error after the confirmation window
- [x] Confirmed in the DB that the *read* jobs from that attempt stay queued and uncancelled
      (`v2_job_queue`), so the backlog the autoscaler needs survives
- [x] Inserted a row on the same instance: the `WM_INTERNAL_DB_INSERT` job stays queued and
      uncancelled while the UI explains why. Restoring the worker tag then let that exact
      job run to `success`, and the grid picked the row up on its own — the write is neither
      lost nor duplicated
- [x] Loaded the manager successfully (schema cached), then removed the tag and hit Refresh
      — the error panel replaces the stale manager rather than hiding behind it
- [x] Data tables settings tab and migrations modal show the warning banner
- [x] Re-added `postgresql`: schema, table list, row reads, `CREATE TABLE` via migration
      and the migrations list all work as before

## Not covered

The `run_datatable_migrations` endpoint waits server-side (`run_wait_result_internal`), so
a migration run on an instance without a `postgresql` worker still blocks until the server
timeout. The banner in the migrations modal explains the cause up front; changing the
job-waiting semantics in the backend was left out deliberately, since a fail-fast there
would also break autoscaling-from-zero for every other `run_wait_result` caller.
