### PR TITLE
fix: return result.json and stdout results from sandboxed containers

### DIFF
--- a/backend/windmill-worker/nsjail/run.docker.config.proto
+++ b/backend/windmill-worker/nsjail/run.docker.config.proto
@@ -46,6 +46,17 @@ gidmap {
 # and avoid it. Generated from the extracted rootfs.
 {ROOTFS_MOUNTS}
 
+# `./result.json` (relative to the image's WorkingDir) bound to a host file outside the
+# image rootfs, so the JSON result the container writes flows back to the job without the
+# worker ever reading a path the image controls.
+#
+# Placed immediately after the rootfs binds and BEFORE every other mount: nsjail resolves
+# a mount destination against its temporary root before pivot_root, so whatever is mounted
+# earlier can steer where this lands. Keeping only the rootfs ahead of it means the image
+# is the single influence on that resolution — and `result_mount_dst` verifies the whole
+# path against the extracted rootfs on the host. Empty when it can't be verified.
+{RESULT_MOUNT}
+
 # Pseudo-filesystems the image expects. /tmp honors the same instance settings as
 # every other nsjail job (nsjail_tmp_backing tmpfs/disk, nsjail_tmpfs_size_mb);
 # /dev gets the standard nodes; /proc comes from mount_proc (the jail's own pid ns).
@@ -104,12 +115,6 @@ mount {
 # rootfs binds and the tmpfs /tmp so a volume target overrides any colliding image
 # path and isn't shadowed by the tmpfs. Empty when there are no volumes.
 {SHARED_MOUNT}
-
-# `./result.json` (relative to the image's WorkingDir) bound to a host file outside
-# the image rootfs, so the JSON result the container writes flows back to the job
-# without the worker ever reading a path the image controls. Mounted last so it wins
-# over any colliding image path or `# volume`.
-{RESULT_MOUNT}
 
 iface_no_lo: true
 

--- a/backend/windmill-worker/nsjail/run.docker.config.proto
+++ b/backend/windmill-worker/nsjail/run.docker.config.proto
@@ -105,6 +105,12 @@ mount {
 # path and isn't shadowed by the tmpfs. Empty when there are no volumes.
 {SHARED_MOUNT}
 
+# `./result.json` (relative to the image's WorkingDir) bound to a host file outside
+# the image rootfs, so the JSON result the container writes flows back to the job
+# without the worker ever reading a path the image controls. Mounted last so it wins
+# over any colliding image path or `# volume`.
+{RESULT_MOUNT}
+
 iface_no_lo: true
 
 #{DEV}

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -194,15 +194,27 @@ fn proto_str(s: &str) -> String {
 }
 
 /// In-jail destination for the `./result.json` bind — `{working_dir}/result.json` — or
-/// `None` when the image's `WorkingDir` cannot be proven to stay inside the jail.
+/// `None` when the image's `WorkingDir` cannot be proven to keep it inside the jail.
 ///
 /// nsjail resolves a mount destination against its temporary root *before* pivot_root,
-/// with ordinary path resolution: a `WorkingDir` that walks out of that root — via `..`,
-/// or via a symlink planted in the image rootfs — makes nsjail create, and mount over, a
-/// path on the *host*, as the worker user. So only a destination with no relative
-/// components and no symlink anywhere along its path inside the rootfs is accepted.
-/// `/tmp`, `/proc`, `/dev` and `/sys` come from the jail profile rather than the image,
-/// so there is nothing image-controlled to traverse under them.
+/// with ordinary path resolution, and then creates it. A destination that walks out of
+/// that root therefore has nsjail create — and mount over — a path on the *host*, as the
+/// worker user. The profile places this mount directly after the rootfs binds and before
+/// every other mount, so the extracted rootfs is the only thing that can steer the
+/// resolution, and this walks the whole destination against it on the host:
+///
+/// - relative components (`..`) are rejected outright — they escape a fresh tmpfs too;
+/// - `/tmp`, `/proc`, `/dev` and `/sys` are mounted *after* this one (or aren't writable),
+///   so a destination under them would be shadowed rather than collected — rejected so
+///   the job says so instead of silently dropping the result;
+/// - every remaining component, **including the final `result.json`**, must exist as a
+///   non-symlink or not exist at all. The first absent component ends the walk: nsjail
+///   creates the rest as real directories under a parent already proven non-symlink.
+///   Any other error (an unreadable mode-000 directory the jail's uid 0 could still
+///   traverse) is treated as unsafe.
+///
+/// Nothing mutates the rootfs between this walk and the mount — extraction is finished and
+/// the container has not started — so there is no window to swap a component.
 async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Option<String> {
     if !working_dir.starts_with('/') {
         return None;
@@ -215,24 +227,24 @@ async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Option<String> {
             _ => components.push(c),
         }
     }
-    let jail_provided = matches!(
+    if matches!(
         components.first(),
-        None | Some(&"tmp") | Some(&"proc") | Some(&"dev") | Some(&"sys")
-    );
-    if !jail_provided {
-        let mut path = std::path::PathBuf::from(format!("{job_dir}/rootfs"));
-        for c in &components {
-            path.push(c);
-            match tokio::fs::symlink_metadata(&path).await {
-                Ok(m) if m.is_symlink() => return None,
-                Ok(_) => {}
-                // Absent from here down: nsjail creates real directories under a
-                // non-symlink parent, which cannot escape.
-                Err(_) => break,
-            }
-        }
+        Some(&"tmp") | Some(&"proc") | Some(&"dev") | Some(&"sys")
+    ) {
+        return None;
     }
     components.push("result.json");
+
+    let mut path = std::path::PathBuf::from(format!("{job_dir}/rootfs"));
+    for c in &components {
+        path.push(c);
+        match tokio::fs::symlink_metadata(&path).await {
+            Ok(m) if m.is_symlink() => return None,
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => break,
+            Err(_) => return None,
+        }
+    }
     Some(format!("/{}", components.join("/")))
 }
 
@@ -789,8 +801,9 @@ pub async fn handle_docker_v2_job(
             &job.id,
             &job.workspace_id,
             format!(
-                "WARNING: the image's WorkingDir ({working_dir}) does not resolve inside the \
-                container root, so `./result.json` will not be collected for this job\n"
+                "WARNING: `./result.json` will not be collected for this job: the image's \
+                WorkingDir ({working_dir}) cannot be proven to resolve inside the container \
+                root\n"
             ),
             conn,
         )
@@ -923,11 +936,8 @@ mod tests {
             ("/app/sub", "/app/sub/result.json"),
             ("/", "/result.json"),
             ("/app/", "/app/result.json"),
-            // The jail provides /tmp, so no image path is walked and a not-yet-existing
-            // directory under it is still fine.
-            ("/tmp/work", "/tmp/work/result.json"),
-            // As is one absent from the rootfs — nsjail creates it as real directories
-            // under a non-symlink parent.
+            // Absent from the rootfs — nsjail creates it as real directories under a
+            // parent already proven non-symlink.
             ("/app/new/deep", "/app/new/deep/result.json"),
         ] {
             assert_eq!(
@@ -943,9 +953,15 @@ mod tests {
         let job = tempfile::tempdir().unwrap();
         let job_dir = job.path().to_str().unwrap();
         std::fs::create_dir_all(format!("{job_dir}/rootfs/app")).unwrap();
-        // An image rootfs entry that points out of the rootfs, at both depths.
+        std::fs::create_dir_all(format!("{job_dir}/rootfs/wd")).unwrap();
+        // Image rootfs entries pointing out of the rootfs: as a directory component at
+        // both depths, and as the final `result.json` element itself (top level, and
+        // inside the WorkingDir).
         std::os::unix::fs::symlink("/etc", format!("{job_dir}/rootfs/evil")).unwrap();
         std::os::unix::fs::symlink("/etc", format!("{job_dir}/rootfs/app/evil")).unwrap();
+        std::os::unix::fs::symlink("/etc/passwd", format!("{job_dir}/rootfs/result.json")).unwrap();
+        std::os::unix::fs::symlink("/etc/passwd", format!("{job_dir}/rootfs/wd/result.json"))
+            .unwrap();
 
         // nsjail resolves the mount dst against its temp root *before* pivot_root, so
         // each of these would otherwise have it create a file on the host.
@@ -956,6 +972,14 @@ mod tests {
             "/evil/deeper",
             "/app/evil",
             "relative/path",
+            "/",   // the rootfs ships `result.json` as a symlink
+            "/wd", // ...and so does this WorkingDir
+            // Mounted after the result bind (or not writable), so a destination there
+            // would be shadowed rather than collected.
+            "/tmp/work",
+            "/proc/x",
+            "/dev/x",
+            "/sys/x",
         ] {
             assert!(
                 result_mount_dst(job_dir, wd).await.is_none(),

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -193,8 +193,15 @@ fn proto_str(s: &str) -> String {
     out
 }
 
-/// In-jail destination for the `./result.json` bind — `{working_dir}/result.json` — or
-/// `None` when the image's `WorkingDir` cannot be proven to keep it inside the jail.
+/// Why `./result.json` can't be collected, phrased for the job log.
+const UNVERIFIABLE_DST: &str =
+    "it cannot be proven to resolve inside the container root (a `..` component, or a \
+    symlink in the image rootfs)";
+const SHADOWED_DST: &str =
+    "it is under /tmp, /proc, /dev or /sys, which are mounted over the result file";
+
+/// In-jail destination for the `./result.json` bind — `{working_dir}/result.json` — or the
+/// reason the image's `WorkingDir` makes it uncollectable.
 ///
 /// nsjail resolves a mount destination against its temporary root *before* pivot_root,
 /// with ordinary path resolution, and then creates it. A destination that walks out of
@@ -215,15 +222,15 @@ fn proto_str(s: &str) -> String {
 ///
 /// Nothing mutates the rootfs between this walk and the mount — extraction is finished and
 /// the container has not started — so there is no window to swap a component.
-async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Option<String> {
+async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Result<String, &'static str> {
     if !working_dir.starts_with('/') {
-        return None;
+        return Err(UNVERIFIABLE_DST);
     }
     let mut components = Vec::new();
     for c in working_dir.split('/') {
         match c {
             "" | "." => continue,
-            ".." => return None,
+            ".." => return Err(UNVERIFIABLE_DST),
             _ => components.push(c),
         }
     }
@@ -231,7 +238,7 @@ async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Option<String> {
         components.first(),
         Some(&"tmp") | Some(&"proc") | Some(&"dev") | Some(&"sys")
     ) {
-        return None;
+        return Err(SHADOWED_DST);
     }
     components.push("result.json");
 
@@ -239,13 +246,13 @@ async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Option<String> {
     for c in &components {
         path.push(c);
         match tokio::fs::symlink_metadata(&path).await {
-            Ok(m) if m.is_symlink() => return None,
+            Ok(m) if m.is_symlink() => return Err(UNVERIFIABLE_DST),
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => break,
-            Err(_) => return None,
+            Err(_) => return Err(UNVERIFIABLE_DST),
         }
     }
-    Some(format!("/{}", components.join("/")))
+    Ok(format!("/{}", components.join("/")))
 }
 
 /// Render the nsjail mount that exposes `{job_dir}/result.json` inside the container at
@@ -796,14 +803,13 @@ pub async fn handle_docker_v2_job(
     // Bind source for `./result.json` inside the container; empty means "no result".
     write_file(job_dir, "result.json", "")?;
     let result_dst = result_mount_dst(job_dir, working_dir).await;
-    if result_dst.is_none() {
+    if let Err(reason) = result_dst {
         append_logs(
             &job.id,
             &job.workspace_id,
             format!(
                 "WARNING: `./result.json` will not be collected for this job: the image's \
-                WorkingDir ({working_dir}) cannot be proven to resolve inside the container \
-                root\n"
+                WorkingDir ({working_dir}) is unusable because {reason}\n"
             ),
             conn,
         )
@@ -921,7 +927,7 @@ pub async fn handle_docker_v2_job(
 mod tests {
     use super::{
         digest_key, proto_str, ref_key, registry_qualified, render_envars, render_result_mount,
-        result_mount_dst,
+        result_mount_dst, SHADOWED_DST, UNVERIFIABLE_DST,
     };
 
     #[tokio::test]
@@ -942,12 +948,15 @@ mod tests {
         ] {
             assert_eq!(
                 result_mount_dst(job_dir, wd).await.as_deref(),
-                Some(expected),
+                Ok(expected),
                 "{wd}"
             );
         }
     }
 
+    // The rootfs symlinks this plants have no Windows equivalent; the runtime is
+    // Linux-only (nsjail) anyway.
+    #[cfg(unix)]
     #[tokio::test]
     async fn result_mount_dst_rejects_escapes() {
         let job = tempfile::tempdir().unwrap();
@@ -974,16 +983,21 @@ mod tests {
             "relative/path",
             "/",   // the rootfs ships `result.json` as a symlink
             "/wd", // ...and so does this WorkingDir
-            // Mounted after the result bind (or not writable), so a destination there
-            // would be shadowed rather than collected.
-            "/tmp/work",
-            "/proc/x",
-            "/dev/x",
-            "/sys/x",
         ] {
-            assert!(
-                result_mount_dst(job_dir, wd).await.is_none(),
-                "{wd} should be rejected"
+            assert_eq!(
+                result_mount_dst(job_dir, wd).await,
+                Err(UNVERIFIABLE_DST),
+                "{wd} should be rejected as unverifiable"
+            );
+        }
+
+        // Mounted over the result file rather than escaping it — the job log must not
+        // blame a symlink that isn't there.
+        for wd in ["/tmp/work", "/proc/x", "/dev/x", "/sys/x"] {
+            assert_eq!(
+                result_mount_dst(job_dir, wd).await,
+                Err(SHADOWED_DST),
+                "{wd} should be rejected as shadowed"
             );
         }
     }

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -170,6 +170,10 @@ struct OciConfig {
 /// directives and break out of the sandbox. Every byte is emitted as a printable
 /// ASCII char or a valid protobuf escape (`\"`, `\\`, `\n`/`\r`/`\t`, or 3-digit
 /// octal `\NNN` for control/non-ASCII bytes), so the result always parses.
+///
+/// `{` and `}` are escaped too: the profile is rendered by substituting `{PLACEHOLDER}`
+/// tokens one after another, so a value that still contained braces could smuggle in a
+/// later placeholder's expansion — and `{ENVARS}` expands to unquoted directives.
 fn proto_str(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('"');
@@ -180,6 +184,7 @@ fn proto_str(s: &str) -> String {
             b'\n' => out.push_str("\\n"),
             b'\r' => out.push_str("\\r"),
             b'\t' => out.push_str("\\t"),
+            b'{' | b'}' => out.push_str(&format!("\\{b:03o}")),
             0x20..=0x7e => out.push(b as char),
             _ => out.push_str(&format!("\\{b:03o}")),
         }
@@ -188,20 +193,61 @@ fn proto_str(s: &str) -> String {
     out
 }
 
-/// Render the nsjail mount that exposes `{job_dir}/result.json` inside the container
-/// at `{working_dir}/result.json`, i.e. the `./result.json` a bash script writes.
+/// In-jail destination for the `./result.json` bind — `{working_dir}/result.json` — or
+/// `None` when the image's `WorkingDir` cannot be proven to stay inside the jail.
+///
+/// nsjail resolves a mount destination against its temporary root *before* pivot_root,
+/// with ordinary path resolution: a `WorkingDir` that walks out of that root — via `..`,
+/// or via a symlink planted in the image rootfs — makes nsjail create, and mount over, a
+/// path on the *host*, as the worker user. So only a destination with no relative
+/// components and no symlink anywhere along its path inside the rootfs is accepted.
+/// `/tmp`, `/proc`, `/dev` and `/sys` come from the jail profile rather than the image,
+/// so there is nothing image-controlled to traverse under them.
+async fn result_mount_dst(job_dir: &str, working_dir: &str) -> Option<String> {
+    if !working_dir.starts_with('/') {
+        return None;
+    }
+    let mut components = Vec::new();
+    for c in working_dir.split('/') {
+        match c {
+            "" | "." => continue,
+            ".." => return None,
+            _ => components.push(c),
+        }
+    }
+    let jail_provided = matches!(
+        components.first(),
+        None | Some(&"tmp") | Some(&"proc") | Some(&"dev") | Some(&"sys")
+    );
+    if !jail_provided {
+        let mut path = std::path::PathBuf::from(format!("{job_dir}/rootfs"));
+        for c in &components {
+            path.push(c);
+            match tokio::fs::symlink_metadata(&path).await {
+                Ok(m) if m.is_symlink() => return None,
+                Ok(_) => {}
+                // Absent from here down: nsjail creates real directories under a
+                // non-symlink parent, which cannot escape.
+                Err(_) => break,
+            }
+        }
+    }
+    components.push("result.json");
+    Some(format!("/{}", components.join("/")))
+}
+
+/// Render the nsjail mount that exposes `{job_dir}/result.json` inside the container at
+/// `dst`, i.e. the `./result.json` a bash script writes.
 ///
 /// The host side deliberately sits *outside* `{job_dir}/rootfs`: the worker reads the
 /// result from a path it created itself, never one the image could have planted as a
 /// symlink to a host file. The container can't swap it either — unlinking a
 /// bind-mount point fails.
-fn render_result_mount(job_dir: &str, working_dir: &str) -> String {
-    let dst = format!("{}/result.json", working_dir.trim_end_matches('/'));
+fn render_result_mount(job_dir: &str, dst: &str) -> String {
     format!(
         "mount {{\n  src: {}\n  dst: {}\n  is_bind: true\n  rw: true\n  mandatory: false\n}}\n",
         proto_str(&format!("{job_dir}/result.json")),
-        // WorkingDir is image-controlled — escape it like every other dst.
-        proto_str(&dst),
+        proto_str(dst),
     )
 }
 
@@ -737,6 +783,19 @@ pub async fn handle_docker_v2_job(
     let rootfs_mounts = generate_rootfs_mounts(&rootfs).await?;
     // Bind source for `./result.json` inside the container; empty means "no result".
     write_file(job_dir, "result.json", "")?;
+    let result_dst = result_mount_dst(job_dir, working_dir).await;
+    if result_dst.is_none() {
+        append_logs(
+            &job.id,
+            &job.workspace_id,
+            format!(
+                "WARNING: the image's WorkingDir ({working_dir}) does not resolve inside the \
+                container root, so `./result.json` will not be collected for this job\n"
+            ),
+            conn,
+        )
+        .await;
+    }
     write_file(
         job_dir,
         "run.docker.config.proto",
@@ -753,7 +812,13 @@ pub async fn handle_docker_v2_job(
             )
             // `# volume` mounts + same-worker shared folder (empty if none).
             .replace("{SHARED_MOUNT}", shared_mount)
-            .replace("{RESULT_MOUNT}", &render_result_mount(job_dir, working_dir))
+            .replace(
+                "{RESULT_MOUNT}",
+                &result_dst
+                    .as_deref()
+                    .map(|dst| render_result_mount(job_dir, dst))
+                    .unwrap_or_default(),
+            )
             // Image env as `envar:` directives (child-only), so it never touches
             // nsjail's process env.
             .replace("{ENVARS}", &envars)
@@ -843,20 +908,68 @@ pub async fn handle_docker_v2_job(
 mod tests {
     use super::{
         digest_key, proto_str, ref_key, registry_qualified, render_envars, render_result_mount,
+        result_mount_dst,
     };
 
-    #[test]
-    fn result_mount_targets_working_dir() {
+    #[tokio::test]
+    async fn result_mount_dst_targets_working_dir() {
+        let job = tempfile::tempdir().unwrap();
+        let job_dir = job.path().to_str().unwrap();
+        std::fs::create_dir_all(format!("{job_dir}/rootfs/app/sub")).unwrap();
+
         // `./result.json` relative to the image's WorkingDir, with no doubled slash
-        // when WorkingDir is the root.
-        assert!(render_result_mount("/j", "/app").contains("dst: \"/app/result.json\""));
-        assert!(render_result_mount("/j", "/").contains("dst: \"/result.json\""));
-        assert!(render_result_mount("/j", "/app/").contains("dst: \"/app/result.json\""));
+        // when WorkingDir is the root and no trailing-slash artifact.
+        for (wd, expected) in [
+            ("/app/sub", "/app/sub/result.json"),
+            ("/", "/result.json"),
+            ("/app/", "/app/result.json"),
+            // The jail provides /tmp, so no image path is walked and a not-yet-existing
+            // directory under it is still fine.
+            ("/tmp/work", "/tmp/work/result.json"),
+            // As is one absent from the rootfs — nsjail creates it as real directories
+            // under a non-symlink parent.
+            ("/app/new/deep", "/app/new/deep/result.json"),
+        ] {
+            assert_eq!(
+                result_mount_dst(job_dir, wd).await.as_deref(),
+                Some(expected),
+                "{wd}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn result_mount_dst_rejects_escapes() {
+        let job = tempfile::tempdir().unwrap();
+        let job_dir = job.path().to_str().unwrap();
+        std::fs::create_dir_all(format!("{job_dir}/rootfs/app")).unwrap();
+        // An image rootfs entry that points out of the rootfs, at both depths.
+        std::os::unix::fs::symlink("/etc", format!("{job_dir}/rootfs/evil")).unwrap();
+        std::os::unix::fs::symlink("/etc", format!("{job_dir}/rootfs/app/evil")).unwrap();
+
+        // nsjail resolves the mount dst against its temp root *before* pivot_root, so
+        // each of these would otherwise have it create a file on the host.
+        for wd in [
+            "/../../../etc",
+            "/app/../../etc",
+            "/evil",
+            "/evil/deeper",
+            "/app/evil",
+            "relative/path",
+        ] {
+            assert!(
+                result_mount_dst(job_dir, wd).await.is_none(),
+                "{wd} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn result_mount_renders_escaped() {
         // The host side is the worker-created file, never a path inside the rootfs.
-        assert!(render_result_mount("/j", "/app").contains("src: \"/j/result.json\""));
-        // An image WorkingDir trying to inject extra directives is escaped.
-        let evil = render_result_mount("/j", "/x\"\nmount { src: \"/\" dst: \"/host\" }\n#");
-        assert!(!evil.contains("\ndst: \"/host\""));
+        let m = render_result_mount("/j", "/app/result.json");
+        assert!(m.contains("src: \"/j/result.json\""));
+        assert!(m.contains("dst: \"/app/result.json\""));
     }
 
     #[test]
@@ -928,6 +1041,9 @@ mod tests {
                                           // a raw byte or an invalid `\u{..}` that nsjail's parser would reject).
         assert_eq!(proto_str("a\u{1b}b"), "\"a\\033b\""); // ESC (0x1b)
         assert_eq!(proto_str("é"), "\"\\303\\251\""); // UTF-8 bytes 0xc3 0xa9
+                                                      // Braces are escaped so a value can never survive as a `{PLACEHOLDER}` token for
+                                                      // a later substitution pass to expand (`{ENVARS}` expands to unquoted directives).
+        assert_eq!(proto_str("/{ENVARS}"), "\"/\\173ENVARS\\175\"");
     }
 
     #[test]

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -32,8 +32,9 @@ use windmill_queue::{append_logs, CanceledBy, MiniPulledJob};
 
 use crate::{
     common::{
-        build_args_map, get_reserved_variables, raw_to_string, read_file, resolve_nsjail_timeout,
-        resolve_nsjail_tmp_mount_block, start_child_process, OccupancyMetrics, DEV_CONF_NSJAIL,
+        build_args_map, get_reserved_variables, raw_to_string, read_and_check_file,
+        resolve_nsjail_timeout, resolve_nsjail_tmp_mount_block, start_child_process,
+        OccupancyMetrics, DEV_CONF_NSJAIL,
     },
     get_proxy_envs_for_lang,
     handle_child::handle_child,
@@ -813,13 +814,20 @@ pub async fn handle_docker_v2_job(
     .await?;
 
     // Same result conventions as a plain bash script: a non-empty `./result.json`
-    // wins, otherwise the last line of output, otherwise a completion message.
+    // wins, otherwise the last line of stdout, otherwise a completion message.
     let result_json_path = format!("{job_dir}/result.json");
     if tokio::fs::metadata(&result_json_path)
         .await
         .is_ok_and(|m| m.len() > 0)
     {
-        return read_file(&result_json_path).await;
+        // Checked, not `read_file`: the container is untrusted, and handing malformed
+        // JSON to `unsafe_raw` is undefined behavior.
+        return read_and_check_file(&result_json_path).await.map_err(|e| {
+            Error::ExecutionErr(format!(
+                "the `./result.json` written by the sandboxed container is not a valid \
+                JSON result: {e}"
+            ))
+        });
     }
 
     if let Some(last_line) = child_result.last_line {

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -32,7 +32,7 @@ use windmill_queue::{append_logs, CanceledBy, MiniPulledJob};
 
 use crate::{
     common::{
-        build_args_map, get_reserved_variables, raw_to_string, resolve_nsjail_timeout,
+        build_args_map, get_reserved_variables, raw_to_string, read_file, resolve_nsjail_timeout,
         resolve_nsjail_tmp_mount_block, start_child_process, OccupancyMetrics, DEV_CONF_NSJAIL,
     },
     get_proxy_envs_for_lang,
@@ -185,6 +185,23 @@ fn proto_str(s: &str) -> String {
     }
     out.push('"');
     out
+}
+
+/// Render the nsjail mount that exposes `{job_dir}/result.json` inside the container
+/// at `{working_dir}/result.json`, i.e. the `./result.json` a bash script writes.
+///
+/// The host side deliberately sits *outside* `{job_dir}/rootfs`: the worker reads the
+/// result from a path it created itself, never one the image could have planted as a
+/// symlink to a host file. The container can't swap it either — unlinking a
+/// bind-mount point fails.
+fn render_result_mount(job_dir: &str, working_dir: &str) -> String {
+    let dst = format!("{}/result.json", working_dir.trim_end_matches('/'));
+    format!(
+        "mount {{\n  src: {}\n  dst: {}\n  is_bind: true\n  rw: true\n  mandatory: false\n}}\n",
+        proto_str(&format!("{job_dir}/result.json")),
+        // WorkingDir is image-controlled — escape it like every other dst.
+        proto_str(&dst),
+    )
 }
 
 /// Render container env vars as nsjail `envar:` directives (one per line). Each
@@ -717,6 +734,8 @@ pub async fn handle_docker_v2_job(
     // Render the nsjail profile: dynamic per-entry rootfs binds + image WorkingDir.
     let nsjail_timeout = resolve_nsjail_timeout(conn, &job.workspace_id, job.id, job.timeout).await;
     let rootfs_mounts = generate_rootfs_mounts(&rootfs).await?;
+    // Bind source for `./result.json` inside the container; empty means "no result".
+    write_file(job_dir, "result.json", "")?;
     write_file(
         job_dir,
         "run.docker.config.proto",
@@ -733,6 +752,7 @@ pub async fn handle_docker_v2_job(
             )
             // `# volume` mounts + same-worker shared folder (empty if none).
             .replace("{SHARED_MOUNT}", shared_mount)
+            .replace("{RESULT_MOUNT}", &render_result_mount(job_dir, working_dir))
             // Image env as `envar:` directives (child-only), so it never touches
             // nsjail's process env.
             .replace("{ENVARS}", &envars)
@@ -774,7 +794,7 @@ pub async fn handle_docker_v2_job(
         .stderr(Stdio::piped());
     let child = start_child_process(nsjail_cmd, NSJAIL_PATH.as_str(), false).await?;
 
-    handle_child(
+    let child_result = handle_child(
         &job.id,
         conn,
         mem_peak,
@@ -792,6 +812,20 @@ pub async fn handle_docker_v2_job(
     )
     .await?;
 
+    // Same result conventions as a plain bash script: a non-empty `./result.json`
+    // wins, otherwise the last line of output, otherwise a completion message.
+    let result_json_path = format!("{job_dir}/result.json");
+    if tokio::fs::metadata(&result_json_path)
+        .await
+        .is_ok_and(|m| m.len() > 0)
+    {
+        return read_file(&result_json_path).await;
+    }
+
+    if let Some(last_line) = child_result.last_line {
+        return Ok(to_raw_value(&json!(last_line.trim())));
+    }
+
     Ok(to_raw_value(&json!(format!(
         "sandboxed container ({image}) completed successfully"
     ))))
@@ -799,7 +833,23 @@ pub async fn handle_docker_v2_job(
 
 #[cfg(test)]
 mod tests {
-    use super::{digest_key, proto_str, ref_key, registry_qualified, render_envars};
+    use super::{
+        digest_key, proto_str, ref_key, registry_qualified, render_envars, render_result_mount,
+    };
+
+    #[test]
+    fn result_mount_targets_working_dir() {
+        // `./result.json` relative to the image's WorkingDir, with no doubled slash
+        // when WorkingDir is the root.
+        assert!(render_result_mount("/j", "/app").contains("dst: \"/app/result.json\""));
+        assert!(render_result_mount("/j", "/").contains("dst: \"/result.json\""));
+        assert!(render_result_mount("/j", "/app/").contains("dst: \"/app/result.json\""));
+        // The host side is the worker-created file, never a path inside the rootfs.
+        assert!(render_result_mount("/j", "/app").contains("src: \"/j/result.json\""));
+        // An image WorkingDir trying to inject extra directives is escaped.
+        let evil = render_result_mount("/j", "/x\"\nmount { src: \"/\" dst: \"/host\" }\n#");
+        assert!(!evil.contains("\ndst: \"/host\""));
+    }
 
     #[test]
     fn digest_key_is_filesystem_safe() {

--- a/backend/windmill-worker/src/handle_child.rs
+++ b/backend/windmill-worker/src/handle_child.rs
@@ -89,6 +89,10 @@ async fn kill_process_tree(pid: Option<u32>) -> Result<(), String> {
 
 pub struct HandleChildResult {
     pub result_stream: Option<String>,
+    /// Last non-empty line the child wrote to stdout/stderr, for executors whose
+    /// result convention is "last line of output" and that have no wrapper script
+    /// to tee it to a file (sandboxed containers).
+    pub last_line: Option<String>,
 }
 
 /// - wait until child exits and return with exit status
@@ -311,6 +315,7 @@ pub async fn handle_child(
     };
 
     let mut stream_result = Vec::new();
+    let mut last_line = String::new();
     /* a future that reads output from the child and appends to the database */
     let lines = write_lines(
         output,
@@ -325,6 +330,7 @@ pub async fn handle_child(
         child_name,
         &mut stream_result,
         stream_notifier,
+        Some(&mut last_line),
     )
     .instrument(trace_span!("child_lines"));
 
@@ -339,7 +345,10 @@ pub async fn handle_child(
         _ if *too_many_logs.borrow() => Err(Error::ExecutionErr(format!(
             "logs or result reached limit. (current max size: {MAX_RESULT_SIZE} characters)"
         ))),
-        Ok(Ok(status)) => process_status(&child_name, status, stream_result),
+        Ok(Ok(status)) => process_status(&child_name, status, stream_result).map(|mut r| {
+            r.last_line = (!last_line.is_empty()).then_some(last_line);
+            r
+        }),
         Ok(Err(kill_reason)) => match kill_reason {
             KillReason::AlreadyCompleted => {
                 Err(Error::AlreadyCompleted("Job already completed".to_string()))
@@ -367,6 +376,7 @@ pub async fn write_lines(
     child_name: &str,
     stream_result: &mut Vec<String>,
     stream_notifier: Option<StreamNotifier>,
+    mut last_line: Option<&mut String>,
 ) {
     let max_log_size = if *CLOUD_HOSTED {
         MAX_RESULT_SIZE
@@ -474,6 +484,12 @@ pub async fn write_lines(
                             log_remaining = 0;
                         }
                     } else {
+                        if let Some(buf) = last_line.as_mut() {
+                            if !line.trim().is_empty() {
+                                buf.clear();
+                                buf.push_str(&line);
+                            }
+                        }
                         append_with_limit(&mut joined, &line, &mut log_remaining);
                     }
                     if log_remaining == 0 {
@@ -1073,6 +1089,7 @@ pub fn process_status(
             } else {
                 Some(stream_result.join(""))
             },
+            last_line: None,
         })
     } else if let Some(code) = status.code() {
         Err(error::Error::ExitStatus(program.to_string(), code))

--- a/backend/windmill-worker/src/handle_child.rs
+++ b/backend/windmill-worker/src/handle_child.rs
@@ -50,7 +50,7 @@ use futures::{
 };
 
 use crate::common::{resolve_job_timeout, OccupancyMetrics, StreamNotifier};
-use crate::job_logger::{append_job_logs, append_result_stream, append_with_limit};
+use crate::job_logger::{append_job_logs, append_result_stream, append_with_limit, strip_nul};
 use crate::job_logger_oss::process_streaming_log_lines;
 use crate::worker_utils::{ping_job_status, update_worker_ping_from_job};
 use crate::{MAX_RESULT_SIZE, MAX_WAIT_FOR_SIGINT, MAX_WAIT_FOR_SIGTERM};
@@ -89,10 +89,18 @@ async fn kill_process_tree(pid: Option<u32>) -> Result<(), String> {
 
 pub struct HandleChildResult {
     pub result_stream: Option<String>,
-    /// Last non-empty line the child wrote to stdout/stderr, for executors whose
-    /// result convention is "last line of output" and that have no wrapper script
-    /// to tee it to a file (sandboxed containers).
+    /// Last non-empty line the child wrote to **stdout**, unmasked, for executors
+    /// whose result convention is "last line of stdout" and that have no wrapper
+    /// script to tee it to a file (sandboxed containers). stderr is excluded: the two
+    /// pipes are merged by a fair `select`, so their relative order is arbitrary — a
+    /// diagnostic on stderr must not be able to win over the real result.
     pub last_line: Option<String>,
+}
+
+/// A line read from a child, tagged with the pipe it came from.
+struct OutputLine {
+    stderr: bool,
+    line: String,
 }
 
 /// - wait until child exits and return with exit status
@@ -363,8 +371,8 @@ pub async fn handle_child(
 
 pub const WAC_STEP_PREFIX: &str = "WM_WAC_STEP: ";
 
-pub async fn write_lines(
-    output: impl stream::Stream<Item = io::Result<String>> + Send,
+async fn write_lines(
+    output: impl stream::Stream<Item = io::Result<OutputLine>> + Send,
     job_id: &Uuid,
     w_id: &str,
     worker: &str,
@@ -444,24 +452,26 @@ pub async fn write_lines(
 
         while let Some(line) = read_lines.next().await {
             match line {
-                Ok(line) => {
+                Ok(OutputLine { stderr, line }) => {
                     if line.is_empty() {
                         continue;
                     }
-                    let line = if let Some(ref snap) = mask_snapshot {
-                        match snap.mask(&line) {
-                            std::borrow::Cow::Owned(masked) => masked,
-                            std::borrow::Cow::Borrowed(_) => line,
-                        }
-                    } else {
-                        line
-                    };
+                    // Masking is a log concern only: `mask` also appends a multi-line
+                    // notice, which would end up inside a captured result. Keep `line`
+                    // raw and log `logged`.
+                    let masked = mask_snapshot
+                        .as_ref()
+                        .and_then(|snap| match snap.mask(&line) {
+                            std::borrow::Cow::Owned(masked) => Some(masked),
+                            std::borrow::Cow::Borrowed(_) => None,
+                        });
+                    let logged = masked.as_deref().unwrap_or(line.as_str());
                     if *OTEL_JOB_LOGS {
-                        if let Some(otel_suffix) = line.strip_prefix(OTEL_PREFIX) {
+                        if let Some(otel_suffix) = logged.strip_prefix(OTEL_PREFIX) {
                             tracing::event!(tracing::Level::INFO, otel_suffix);
                         }
                     }
-                    if let Some(step_json) = line.strip_prefix(WAC_STEP_PREFIX) {
+                    if let Some(step_json) = logged.strip_prefix(WAC_STEP_PREFIX) {
                         // Real-time WAC step start marker — fire-and-forget DB write
                         let conn = conn.clone();
                         let job_id = job_id.clone();
@@ -474,7 +484,7 @@ pub async fn write_lines(
                         });
                         continue;
                     }
-                    if let Some(stream) = extract_stream_from_logs(&line) {
+                    if let Some(stream) = extract_stream_from_logs(logged) {
                         let len = stream.len();
                         if log_remaining >= len {
                             log_remaining -= len;
@@ -485,12 +495,14 @@ pub async fn write_lines(
                         }
                     } else {
                         if let Some(buf) = last_line.as_mut() {
-                            if !line.trim().is_empty() {
+                            if !stderr && !line.trim().is_empty() {
                                 buf.clear();
-                                buf.push_str(&line);
+                                // Same NUL scrub the log path applies: Postgres rejects
+                                // a NUL in the resulting jsonb too.
+                                buf.push_str(&strip_nul(&line));
                             }
                         }
-                        append_with_limit(&mut joined, &line, &mut log_remaining);
+                        append_with_limit(&mut joined, logged, &mut log_remaining);
                     }
                     if log_remaining == 0 {
                         tracing::info!(%job_id, "Too many logs lines for job {job_id}");
@@ -1045,7 +1057,7 @@ fn child_joined_output_stream(
     child: &mut Box<dyn TokioChildWrapper>,
     job_id: Uuid,
     w_id: String,
-) -> impl stream::FusedStream<Item = io::Result<String>> {
+) -> impl stream::FusedStream<Item = io::Result<OutputLine>> {
     let stderr = child
         .stderr()
         .take()
@@ -1059,8 +1071,10 @@ fn child_joined_output_stream(
     let stdout = BufReader::new(stdout).lines();
     let stderr = BufReader::new(stderr).lines();
     stream::select(
-        lines_to_stream(stderr, true, job_id.clone(), w_id.clone()),
-        lines_to_stream(stdout, false, job_id, w_id),
+        lines_to_stream(stderr, true, job_id.clone(), w_id.clone())
+            .map(|l| l.map(|line| OutputLine { stderr: true, line })),
+        lines_to_stream(stdout, false, job_id, w_id)
+            .map(|l| l.map(|line| OutputLine { stderr: false, line })),
     )
 }
 

--- a/backend/windmill-worker/src/job_logger.rs
+++ b/backend/windmill-worker/src/job_logger.rs
@@ -143,6 +143,11 @@ lazy_static::lazy_static! {
     static ref RE_00: Regex = Regex::new('\u{00}'.to_string().as_str()).unwrap();
     pub static ref NO_LOGS_AT_ALL: bool = std::env::var("NO_LOGS_AT_ALL").ok().is_some_and(|x| x == "1" || x == "true");
 }
+/// Drop NUL bytes: Postgres rejects them in both `text` logs and a `jsonb` result.
+pub fn strip_nul(src: &str) -> std::borrow::Cow<'_, str> {
+    RE_00.replace_all(src, "")
+}
+
 // as a detail, `BufReader::lines()` removes \n and \r\n from the strings it yields,
 // so this pushes \n to thd destination string in each call
 pub fn append_with_limit(dst: &mut String, src: &str, limit: &mut usize) {
@@ -152,7 +157,7 @@ pub fn append_with_limit(dst: &mut String, src: &str, limit: &mut usize) {
 
     let src_str;
     let src = {
-        src_str = RE_00.replace_all(src, "");
+        src_str = strip_nul(src);
         src_str.as_ref()
     };
     if !*CLOUD_HOSTED {

--- a/docs/docker-v2-runtime.md
+++ b/docs/docker-v2-runtime.md
@@ -39,11 +39,14 @@ python3 -c "import sys; print('hello', sys.argv[1])" "$name"
 Same conventions as a plain bash script, in this order:
 
 1. `./result.json` (relative to the image's `WorkingDir`) if non-empty → returned as
-   the JSON result. It is a host file bind-mounted into the container, so it works
-   whatever the `WorkingDir` is — including `/` and paths under the tmpfs `/tmp`,
-   which otherwise wouldn't flow back to the job. Being a bind-mount point, it must
-   be written in place (`> ./result.json`); a write-temp-then-`rename` fails.
-2. Otherwise the last non-empty line of output, returned as a string.
+   the JSON result; malformed JSON fails the job. It is a host file bind-mounted into
+   the container, so it works whatever the `WorkingDir` is — including `/` and paths
+   under the tmpfs `/tmp`, which otherwise wouldn't flow back to the job. Being a
+   bind-mount point, it must be written in place (`> ./result.json`); a
+   write-temp-then-`rename` fails.
+2. Otherwise the last non-empty line of **stdout**, returned as a string. stderr is
+   excluded on purpose: the two pipes are merged by a fair `select`, so a diagnostic
+   on stderr could otherwise beat a block-buffered stdout result.
 3. Otherwise a completion message.
 
 ## How it works

--- a/docs/docker-v2-runtime.md
+++ b/docs/docker-v2-runtime.md
@@ -40,14 +40,18 @@ Same conventions as a plain bash script, in this order:
 
 1. `./result.json` (relative to the image's `WorkingDir`) if non-empty → returned as
    the JSON result; malformed JSON fails the job. It is a host file bind-mounted into
-   the container, so it works whatever the `WorkingDir` is — including `/` and paths
-   under the tmpfs `/tmp`, which otherwise wouldn't flow back to the job. Being a
-   bind-mount point, it must be written in place (`> ./result.json`); a
-   write-temp-then-`rename` fails. Skipped, with a warning in the job logs, when the
-   image's `WorkingDir` doesn't provably resolve inside the container root (`..`, or a
-   symlink planted in the image rootfs) — nsjail resolves a mount destination before
-   `pivot_root`, so such a path would have it create a file on the *host*. A `# volume`
-   mounted at the `WorkingDir` gets the (empty) mount point materialized inside it.
+   the container, so it works for `WorkingDir: ""` (→ `/`) too, which otherwise lands in
+   nsjail's ephemeral root and never reaches the job. Being a bind-mount point, it must
+   be written in place (`> ./result.json`); a write-temp-then-`rename` fails.
+
+   The bind is skipped, with a warning in the job logs, when the destination can't be
+   proven to stay inside the container: a `WorkingDir` with `..`, one whose path in the
+   extracted rootfs crosses a symlink, or one under `/tmp`, `/proc`, `/dev` or `/sys`
+   (mounted after this bind, so a result there would be shadowed anyway). nsjail resolves
+   a mount destination *before* `pivot_root`, so an unverified path would have it create
+   a file on the **host**. For the same reason the bind is applied directly after the
+   rootfs binds — a `# volume` mounted over the `WorkingDir` therefore hides it, and the
+   result falls through to the stdout rule below.
 2. Otherwise the last non-empty line of **stdout**, returned as a string. stderr is
    excluded on purpose: the two pipes are merged by a fair `select`, so a diagnostic
    on stderr could otherwise beat a block-buffered stdout result.

--- a/docs/docker-v2-runtime.md
+++ b/docs/docker-v2-runtime.md
@@ -43,7 +43,11 @@ Same conventions as a plain bash script, in this order:
    the container, so it works whatever the `WorkingDir` is — including `/` and paths
    under the tmpfs `/tmp`, which otherwise wouldn't flow back to the job. Being a
    bind-mount point, it must be written in place (`> ./result.json`); a
-   write-temp-then-`rename` fails.
+   write-temp-then-`rename` fails. Skipped, with a warning in the job logs, when the
+   image's `WorkingDir` doesn't provably resolve inside the container root (`..`, or a
+   symlink planted in the image rootfs) — nsjail resolves a mount destination before
+   `pivot_root`, so such a path would have it create a file on the *host*. A `# volume`
+   mounted at the `WorkingDir` gets the (empty) mount point materialized inside it.
 2. Otherwise the last non-empty line of **stdout**, returned as a string. stderr is
    excluded on purpose: the two pipes are merged by a fair `select`, so a diagnostic
    on stderr could otherwise beat a block-buffered stdout result.

--- a/docs/docker-v2-runtime.md
+++ b/docs/docker-v2-runtime.md
@@ -34,6 +34,18 @@ python3 -c "import sys; print('hello', sys.argv[1])" "$name"
 - The image's `Env`, `WorkingDir` are applied; the windmill reserved variables
   (`WM_TOKEN`, `BASE_INTERNAL_URL`, …) are injected so `wmill`/API calls work.
 
+## Result
+
+Same conventions as a plain bash script, in this order:
+
+1. `./result.json` (relative to the image's `WorkingDir`) if non-empty → returned as
+   the JSON result. It is a host file bind-mounted into the container, so it works
+   whatever the `WorkingDir` is — including `/` and paths under the tmpfs `/tmp`,
+   which otherwise wouldn't flow back to the job. Being a bind-mount point, it must
+   be written in place (`> ./result.json`); a write-temp-then-`rename` fails.
+2. Otherwise the last non-empty line of output, returned as a string.
+3. Otherwise a completion message.
+
 ## How it works
 
 1. **Pull/extract** ([`crane`](https://github.com/google/go-containerregistry), no
@@ -101,7 +113,6 @@ the container inherits exactly the job's confinement:
 - Images that drop to a non-root uid or chown to arbitrary uids inside need a
   subuid **range** in the jail (single-uid only today — follow-up: `newuidmap`
   range mapping).
-- The script result is a completion message; capture output via stdout/logs.
 
 ## Follow-ups
 


### PR DESCRIPTION
## Summary

Fixes GIT-948.

A `# sandbox <image>` (daemonless container / nsjail) bash script could not return a
structured result: `handle_docker_v2_job` returned the hardcoded string
`"sandboxed container (<image>) completed successfully"` no matter what the script
wrote, so neither documented bash result mechanism (`./result.json`, or the last line
of stdout) worked. That made image-sandbox jobs unusable as flow steps, app data
sources, or typed API responses.

### `./result.json` had nowhere to land

The container is chrooted into the extracted image rootfs. Writes to the image's
`WorkingDir` do flow back to `{job_dir}/rootfs/...`, but the most common case doesn't:
`WorkingDir: ""` → `/`, which is nsjail's own ephemeral tmpfs root. So the file the script
wrote was simply discarded. The fix bind-mounts a worker-created host file at
`{WorkingDir}/result.json` inside the jail.

The host side deliberately sits *outside* `{job_dir}/rootfs`, so the worker never reads
a path the image controls — a hostile image can't plant `result.json` as a symlink to a
host file and have the worker return its contents. The container can't swap it either:
unlinking a bind-mount point fails. Since the content is fully container-authored it is
parsed with `read_and_check_file`, not the `unsafe_raw`-based `read_file`.

### The mount destination is image-controlled, so it is contained

nsjail resolves a mount destination against its temporary root *before* `pivot_root`,
using ordinary path resolution, then creates it. I confirmed against raw nsjail that an
unverified destination makes it create the file on the **host**, as the worker user —
arbitrary file/directory creation anywhere the worker can write. Two properties contain
it:

- **The profile applies this mount directly after the rootfs binds, before every other
  mount.** Only the image rootfs can then influence the resolution — not the tmpfs `/tmp`,
  not `# volume` / same-worker shared mounts, which are applied later.
- **`result_mount_dst` walks the entire destination against the extracted rootfs on the
  host**, including the final `result.json` element: `..` is rejected, any symlink
  component is rejected, and any stat error other than `NotFound` is rejected (an
  unreadable mode-000 directory the jail's uid 0 could still traverse must not read as
  "fine"). The first absent component ends the walk — nsjail creates the rest as real
  directories under a parent already proven non-symlink. `/tmp`, `/proc`, `/dev` and
  `/sys` are rejected outright: mounted after this bind, a result there would be shadowed
  anyway, so the job says so rather than silently dropping it.

Relatedly, `proto_str` now escapes `{`/`}` so an image value can never survive as a
`{PLACEHOLDER}` token for a later substitution pass to expand — `{ENVARS}` expands to
*unquoted* directives, so that was a config-injection route (pre-existing via
`{WORKDIR}`, widened by the new mount).

### The last line of stdout wasn't captured

The bash executor gets this from its `wrapper.sh` (`tee` into `result2.out`), but
`docker_v2` runs the image's own command with no wrapper — and writing a wrapper script
into the image-controlled rootfs is exactly what this module avoids for sandbox-boundary
reasons. Instead, `handle_child` now records the last non-empty **stdout** line it already
streams to the logs and returns it in `HandleChildResult`. This requires no image tooling,
so it also works for shell-less entrypoint-only images.

Two properties that capture has to get right, and that plain bash gets for free from its
single `2>&1 | tee` pipe:

- **stdout only.** `child_joined_output_stream` merges the two pipes with a fair
  `stream::select`, so their relative order is arbitrary — and a piped stdout is
  block-buffered while stderr is not. Capturing the merged stream would let a stderr
  diagnostic beat the real result nondeterministically. `OutputLine` now carries which
  pipe a line came from, and only stdout feeds the capture.
- **unmasked.** `sensitive_log_masks` rewrites secrets *and appends a multi-line notice*.
  That belongs in logs, not in a result, so masking is now applied to the logged copy
  only and the captured line stays raw (with the same NUL scrub the log path applies,
  since Postgres rejects a NUL in `jsonb` too).

Note this is a visible behavior change for existing `# sandbox <image>` jobs that print
output: they now return their last stdout line instead of the canned completion message.
That is the point of the fix and matches plain bash — worth a release-note mention for
anyone branching on the old string.

## Changes

- `docker_v2.rs`: `result_mount_dst()` validates the image `WorkingDir` against the
  extracted rootfs and yields the in-jail destination (or `None` + a job-log warning);
  `render_result_mount()` renders the nsjail bind of `{job_dir}/result.json` → that
  destination. After `handle_child`, resolve the result as bash does: non-empty
  `result.json` → checked JSON result (malformed JSON fails the job with a clear message);
  else last stdout line → string result; else the completion message. `proto_str` escapes
  `{`/`}`.
- `run.docker.config.proto`: new `{RESULT_MOUNT}` placeholder, immediately after
  `{ROOTFS_MOUNTS}` and before every other mount.
- `handle_child.rs`: lines carry their pipe (`OutputLine`); `HandleChildResult` gains
  `last_line` (stdout-only, unmasked, NUL-scrubbed), captured next to the existing log
  append so it also works under `NO_LOGS_AT_ALL`. Masking now applies to the logged copy
  only. No other executor reads `last_line`, so nothing else changes behavior.
- `job_logger.rs`: the NUL scrub inside `append_with_limit` is extracted as `strip_nul` and
  reused by the capture.
- `docs/docker-v2-runtime.md`: document the result convention and when the bind is
  skipped; drop the now-stale "the script result is a completion message" limitation.

## Test plan

Exercised against a real worker (nsjail + crane, `cargo watch` backend), one job per case.
Hostile images are built with `crane mutate --workdir` / `crane append` and served from a
local `crane registry serve`.

Result resolution:
- [x] `printf '{"greeting":"hello"}' > ./result.json` on `alpine:latest` (`WorkingDir` `/`)
      → result `{"greeting":"hello"}`
- [x] `httpd:2.4-alpine` (`WorkingDir` `/usr/local/apache2`) → result `{"cwd_result":true}`
- [x] malformed `./result.json` → job fails with "the `./result.json` written by the
      sandboxed container is not a valid JSON result: …" (no `unsafe_raw` on bad input)
- [x] last-line fallback → result `"{\"greeting\":\"from stdout\"}"` (string, as in bash)
- [x] stdout result + stderr noise, repeated runs → stably returns the stdout line
- [x] secret-valued last line → masked (with notice) in the logs, returned **raw and
      uncorrupted** as the result
- [x] NUL byte in the last line → stripped, job completes (would otherwise be rejected as
      `jsonb`)
- [x] no output at all → unchanged `"sandboxed container (alpine:latest) completed successfully"`
- [x] shell-less entrypoint-only image (`hello-world`) → last line returned
- [x] failing container (`exit 3`) → still fails with the exit code and log tail
- [x] 20k output lines → correct last line, no worker panic/stack overflow

Escape containment — each first reproduced against raw nsjail to confirm it *does* create a
host path without the guard, then run as a real job with the guard. In every case the mount
is dropped, the warning appears in the job logs, and the target host directory is untouched:
- [x] `WorkingDir: /../../../../../..<host path>`
- [x] rootfs symlink `app -> <host path>` with `WorkingDir: /app`
- [x] rootfs symlink `result.json -> <host path>` with `WorkingDir: ""` (final component,
      the case a prefix-only walk missed)
- [x] `WorkingDir: /tmp/work` (the region same-worker shared mounts live in)

Regressions on the shared `handle_child` path:
- [x] plain bash, `# sandbox` bash (`result.json` + last line), a bun job, and `WM_STREAM: `
      result streaming (merged into the result, still excluded from the logs) all unchanged

- [x] `cargo test -p windmill-worker --lib docker_v2` — 8 passed, incl.
      `result_mount_dst_targets_working_dir`, `result_mount_dst_rejects_escapes` (`..`,
      relative paths, directory symlinks at two depths, final-component symlinks at two
      depths, and the `/tmp` `/proc` `/dev` `/sys` regions) and brace escaping in
      `proto_str_escapes_injection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)