### PR TITLE
fix: keep uri and method on request logs under RUST_LOG=error

### DIFF
--- a/backend/windmill-api/src/tracing_init.rs
+++ b/backend/windmill-api/src/tracing_init.rs
@@ -79,7 +79,11 @@ impl<B> MakeSpan<B> for MyMakeSpan {
             .get(TRACING_HEADER.as_str())
             .and_then(|x| x.to_str().map(|x| x.to_string()).ok())
             .unwrap_or(Uuid::new_v4().to_string());
-        tracing::info_span!(
+        // ERROR level, not INFO: a span is only recorded by a layer whose filter
+        // enables it, so under RUST_LOG=error/warn an INFO span is dropped and the
+        // 4xx/5xx `response` events in `MyOnResponse` print with no uri, method or
+        // traceId.
+        tracing::error_span!(
             "request",
             method = %request.method(),
             uri = %request.uri(),


### PR DESCRIPTION
## Summary

`method`, `uri` and `traceId` are fields of the axum `request` span, not of the `response` event. tracing-subscriber only records a span's fields for a layer whose filter enabled that span at creation time, so with `RUST_LOG=error` (or `warn`) the INFO-level span is dropped and every 4xx/5xx line prints with nothing identifying the request:

```
RUST_LOG=error   ERROR windmill-api/src/tracing_init.rs:53: response latency=0 status=401
```

Raising the span to ERROR level makes it survive any filter that lets the error event through, so the fields come back:

```
RUST_LOG=error   ERROR request: windmill-api/src/tracing_init.rs:53: response latency=0 status=401 method=GET uri=/api/w/admins/scripts/list traceId="62db3316-..."
RUST_LOG=info    unchanged
```

This also restores context on every other event emitted inside the request scope under a low `RUST_LOG`, notably the `AppError` 500 line in `windmill-common/src/error.rs`, and makes the `Span::current().record("username" | "email" | "workspace_id", ..)` calls in `windmill-api-auth/src/auth.rs` land instead of no-op.

The alternative (stamping `method`/`uri` onto the error events from the existing `LogContext` task-local) was rejected: it duplicates both fields on the default INFO config where the span already prints them, and it fixes only the `response` line.

## Changes

- `backend/windmill-api/src/tracing_init.rs`: `MyMakeSpan::make_span` builds the `request` span with `error_span!` instead of `info_span!`, with a comment recording why the level is load-bearing.

## Tradeoffs

- The span is now created on every request even under `RUST_LOG=error`, where it was previously skipped entirely: one registry allocation plus the `method`/`uri`/`traceId` field records per request.
- An EE deployment running OTEL tracing with `RUST_LOG=error` exported no HTTP request spans at all before (the OTEL layer shares the same `RUST_LOG`-derived filter) and now exports one per request. That is the point of the change rather than a regression, but it is a jump in export volume for those instances.
- No effect on the default configuration: `RUST_LOG` defaults to `info` (`backend/src/main.rs`), where output is byte-identical to before.

## Test plan

- [x] `cargo check -p windmill-api` passes.
- [x] Booted the API against a dev database with `RUST_LOG=error` and hit an unauthenticated endpoint. Before this change the line was `ERROR windmill-api/src/tracing_init.rs:53: response latency=0 status=401`; now:
  ```
  ERROR request: windmill-api/src/tracing_init.rs:53: response latency=0 status=401 method=GET uri=/api/w/admins/scripts/list traceId="62db3316-5f18-4bb1-ae62-423a6f69bc74"
  ```
- [x] Same boot with `RUST_LOG=info`: output unchanged, both levels still carry the span.
  ```
  ERROR request: windmill-api/src/tracing_init.rs:53: response latency=0 status=401 method=GET uri=/api/w/admins/scripts/list traceId="591f91d2-..."
   INFO request: windmill-api/src/tracing_init.rs:49: response latency=0 status=200 method=GET uri=/api/version traceId="2bfb51f1-..."
  ```
- [x] `JSON_FMT=true` with `RUST_LOG=error`: the `span` object is present and the rest of the record shape is unchanged.
  ```json
  {"timestamp":"...","level":"ERROR","message":"response","latency":"0","status":401,"target":"windmill_api::tracing_init","span":{"method":"GET","traceId":"20b80374-...","uri":"/api/w/admins/scripts/list","name":"request"}}
  ```
- [x] Cross-checked the mechanism on a standalone harness rebuilding the exact layer stack of `windmill-common/src/tracing_init.rs` on tracing-subscriber 0.3.23 (the version in `Cargo.lock`): the fields are absent at `RUST_LOG=error`/`warn` before and present after.

No test added: the behavior lives in tracing-subscriber's per-layer filter and formatter machinery, and there is no existing harness capturing formatted log output. A test asserting the macro name would be ceremonial.