### PR TITLE
fix: report why a native trigger service refused instead of a 500

### DIFF
--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -765,21 +765,29 @@ fn test_provider_404_is_recognized() {
 }
 
 /// Sending a user to reconnect their integration is only right when the token endpoint refused
-/// the grant. A busy or broken endpoint has them fix credentials that are fine.
+/// the grant; a busy or broken endpoint has them fix credentials that are fine. And a token
+/// endpoint's status must never reach the trigger's, where 404 means the webhook is gone and
+/// drops the row.
 #[test]
-fn test_only_a_refused_grant_blames_the_credentials() {
-    let rejected = |code: u16| {
-        refresh_failure_status(Some(StatusCode::from_u16(code).unwrap()))
-            == Some(StatusCode::UNAUTHORIZED)
-    };
-    assert!(rejected(400), "invalid_grant answers with 400");
-    assert!(rejected(401));
-    assert!(rejected(403));
-    assert!(!rejected(408), "a timeout is not a credential problem");
-    assert!(!rejected(429), "rate limiting is not a credential problem");
-    assert!(!rejected(503));
+fn test_refresh_failures_blame_only_the_grant_they_refuse() {
+    let status = |code: u16| refresh_failure_status(Some(StatusCode::from_u16(code).unwrap()));
+    for refused in [400, 401, 403] {
+        assert_eq!(status(refused), Some(StatusCode::UNAUTHORIZED), "{refused}");
+    }
+    for other in [404, 408, 429, 500, 503] {
+        assert_eq!(
+            status(other),
+            None,
+            "{other} from the token endpoint says nothing about the trigger"
+        );
+    }
     assert_eq!(refresh_failure_status(None), None);
+}
 
+/// A service that is busy or broken has not refused anything, and callers react differently to
+/// the two.
+#[test]
+fn test_transient_service_failures_are_not_refusals() {
     for transient in [408, 429, 503] {
         let err = nextcloud_error(StatusCode::from_u16(transient).unwrap(), "{}");
         assert!(

--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -23,8 +23,9 @@ use windmill_native_triggers::{
     google::{parse_stop_channel_params, should_renew_channel},
     http_error_status, list_native_triggers, map_external_error,
     nextcloud::NextCloud,
-    require_native_integration_use, store_native_trigger, store_workspace_integration, External,
-    ExternalReadFailure, HttpRequestError, NativeTriggerConfig, OAuthConfig, ServiceName,
+    refresh_failure_status, require_native_integration_use, store_native_trigger,
+    store_workspace_integration, External, ExternalReadFailure, HttpRequestError,
+    NativeTriggerConfig, OAuthConfig, ServiceName,
 };
 
 // ============================================================================
@@ -761,6 +762,31 @@ fn test_provider_404_is_recognized() {
         classify_read_failure(nextcloud_error(StatusCode::NOT_FOUND, "{}")),
         ExternalReadFailure::Missing
     ));
+}
+
+/// Sending a user to reconnect their integration is only right when the token endpoint refused
+/// the grant. A busy or broken endpoint has them fix credentials that are fine.
+#[test]
+fn test_only_a_refused_grant_blames_the_credentials() {
+    let rejected = |code: u16| {
+        refresh_failure_status(Some(StatusCode::from_u16(code).unwrap()))
+            == Some(StatusCode::UNAUTHORIZED)
+    };
+    assert!(rejected(400), "invalid_grant answers with 400");
+    assert!(rejected(401));
+    assert!(rejected(403));
+    assert!(!rejected(408), "a timeout is not a credential problem");
+    assert!(!rejected(429), "rate limiting is not a credential problem");
+    assert!(!rejected(503));
+    assert_eq!(refresh_failure_status(None), None);
+
+    for transient in [408, 429, 503] {
+        let err = nextcloud_error(StatusCode::from_u16(transient).unwrap(), "{}");
+        assert!(
+            matches!(map_external_error(err), Error::BadGateway(_)),
+            "{transient} should read as the service failing to serve, not refusing"
+        );
+    }
 }
 
 /// A service read degrades to the stored configuration, but only for the service's own

--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -798,19 +798,26 @@ fn test_transient_service_failures_are_not_refusals() {
         );
     }
 
-    let throttled = GitHub.external_api_error(HttpRequestError::ApiError {
-        status: StatusCode::FORBIDDEN,
-        body: r#"{"message":"API rate limit exceeded for user ID 1."}"#.to_string(),
-    });
-    let throttled = map_external_error(throttled);
-    assert!(
-        matches!(throttled, Error::BadGateway(_)),
-        "a throttled 403 is the service failing to serve: {throttled:?}"
-    );
-    assert!(
-        !throttled.to_string().contains("admin rights"),
-        "a throttled 403 must not advise about permissions: {throttled}"
-    );
+    // GitHub words its throttle two ways, and neither is a permission problem.
+    for wording in [
+        "API rate limit exceeded for user ID 1.",
+        "You have exceeded a secondary rate limit.",
+        "You have triggered an abuse detection mechanism.",
+    ] {
+        let throttled = GitHub.external_api_error(HttpRequestError::ApiError {
+            status: StatusCode::FORBIDDEN,
+            body: format!(r#"{{"message":"{wording}"}}"#),
+        });
+        let throttled = map_external_error(throttled);
+        assert!(
+            matches!(throttled, Error::BadGateway(_)),
+            "a throttled 403 is the service failing to serve: {throttled:?}"
+        );
+        assert!(
+            !throttled.to_string().contains("admin rights"),
+            "a throttled 403 must not advise about permissions: {throttled}"
+        );
+    }
 
     let refused = GitHub.external_api_error(HttpRequestError::ApiError {
         status: StatusCode::FORBIDDEN,

--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -11,14 +11,20 @@
 use serde_json::json;
 use sqlx::{Pool, Postgres};
 
+use axum::http::StatusCode;
 use windmill_api_auth::ApiAuthed;
-use windmill_common::variables::{build_crypt, encrypt};
+use windmill_common::{
+    error::Error,
+    variables::{build_crypt, encrypt},
+};
 use windmill_native_triggers::{
     decrypt_oauth_data, delete_native_trigger, delete_workspace_integration,
     get_workspace_integration,
     google::{parse_stop_channel_params, should_renew_channel},
-    list_native_triggers, require_native_integration_use, store_native_trigger,
-    store_workspace_integration, NativeTriggerConfig, OAuthConfig, ServiceName,
+    http_error_status, list_native_triggers, map_external_error,
+    nextcloud::NextCloud,
+    require_native_integration_use, store_native_trigger, store_workspace_integration, External,
+    HttpRequestError, NativeTriggerConfig, OAuthConfig, ServiceName,
 };
 
 // ============================================================================
@@ -709,4 +715,46 @@ fn test_parse_stop_channel_params_missing_resource_id() {
     let (channel_id, resource_id, _url) = parse_stop_channel_params(&config);
     assert!(channel_id.is_none());
     assert_eq!(resource_id, "");
+}
+
+// --- provider error reporting ---
+
+fn nextcloud_error(status: StatusCode, body: &str) -> Error {
+    NextCloud.external_api_error(HttpRequestError::ApiError { status, body: body.to_string() })
+}
+
+/// A rejection has to reach the user as the service's own sentence plus what to do about it.
+/// Reported as a 500 carrying the raw OCS envelope, it read as a Windmill outage.
+#[test]
+fn test_provider_rejection_is_readable_and_not_internal() {
+    let err = nextcloud_error(
+        StatusCode::FORBIDDEN,
+        r#"{"ocs":{"meta":{"status":"failure","statuscode":403,"message":"Logged in account must be an admin, a sub admin or gotten special right to access this setting"},"data":[]}}"#,
+    );
+
+    let message = map_external_error(err).to_string();
+    assert!(
+        message.contains("Logged in account must be an admin"),
+        "message={message}"
+    );
+    assert!(
+        !message.contains("\"ocs\""),
+        "the envelope should not reach the user: {message}"
+    );
+    assert!(
+        message.contains("Reconnect the integration"),
+        "message={message}"
+    );
+}
+
+/// Both the "trigger is gone on the service" path and the delete that tolerates an
+/// already-removed webhook branch on this status.
+#[test]
+fn test_provider_404_is_recognized() {
+    let err = nextcloud_error(StatusCode::NOT_FOUND, "{}");
+    assert_eq!(http_error_status(&err), Some(StatusCode::NOT_FOUND));
+    assert!(
+        matches!(map_external_error(err), Error::NotFound(_)),
+        "a missing external trigger must map to NotFound"
+    );
 }

--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -18,8 +18,8 @@ use windmill_common::{
     variables::{build_crypt, encrypt},
 };
 use windmill_native_triggers::{
-    classify_read_failure, decrypt_oauth_data, delete_native_trigger, delete_workspace_integration,
-    get_workspace_integration,
+    body_rejects_grant, classify_read_failure, decrypt_oauth_data, delete_native_trigger,
+    delete_workspace_integration, get_workspace_integration,
     google::{parse_stop_channel_params, should_renew_channel},
     http_error_status, list_native_triggers, map_external_error,
     nextcloud::NextCloud,
@@ -782,6 +782,13 @@ fn test_refresh_failures_blame_only_the_grant_they_refuse() {
         );
     }
     assert_eq!(refresh_failure_status(None), None);
+
+    // GitHub answers `bad_refresh_token` with HTTP 200, so the body is the only tell.
+    assert!(body_rejects_grant(r#"{"error":"bad_refresh_token"}"#));
+    assert!(body_rejects_grant(r#"{"error":"invalid_grant"}"#));
+    assert!(!body_rejects_grant(
+        r#"{"access_token":"t","token_type":"bearer"}"#
+    ));
 }
 
 /// A service that is busy or broken has not refused anything, and callers react differently to

--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -18,12 +18,13 @@ use windmill_common::{
     variables::{build_crypt, encrypt},
 };
 use windmill_native_triggers::{
-    body_rejects_grant, classify_read_failure, decrypt_oauth_data, delete_native_trigger,
+    classify_read_failure, decrypt_oauth_data, delete_native_trigger,
     delete_workspace_integration, get_workspace_integration,
+    github::GitHub,
     google::{parse_stop_channel_params, should_renew_channel},
     http_error_status, list_native_triggers, map_external_error,
     nextcloud::NextCloud,
-    refresh_failure_status, require_native_integration_use, store_native_trigger,
+    grant_refused, require_native_integration_use, store_native_trigger,
     store_workspace_integration, External, ExternalReadFailure, HttpRequestError,
     NativeTriggerConfig, OAuthConfig, ServiceName,
 };
@@ -765,34 +766,28 @@ fn test_provider_404_is_recognized() {
 }
 
 /// Sending a user to reconnect their integration is only right when the token endpoint refused
-/// the grant; a busy or broken endpoint has them fix credentials that are fine. And a token
-/// endpoint's status must never reach the trigger's, where 404 means the webhook is gone and
-/// drops the row.
+/// the grant; a busy or broken endpoint has them fix credentials that are fine.
 #[test]
 fn test_refresh_failures_blame_only_the_grant_they_refuse() {
-    let status = |code: u16| refresh_failure_status(Some(StatusCode::from_u16(code).unwrap()));
-    for refused in [400, 401, 403] {
-        assert_eq!(status(refused), Some(StatusCode::UNAUTHORIZED), "{refused}");
+    let refused = |code: u16| grant_refused(Some(StatusCode::from_u16(code).unwrap()), "");
+    for code in [400, 401, 403] {
+        assert!(refused(code), "{code} refuses the grant");
     }
-    for other in [404, 408, 429, 500, 503] {
-        assert_eq!(
-            status(other),
-            None,
-            "{other} from the token endpoint says nothing about the trigger"
-        );
+    for code in [404, 408, 429, 500, 503] {
+        assert!(!refused(code), "{code} says nothing about the grant");
     }
-    assert_eq!(refresh_failure_status(None), None);
+    assert!(!grant_refused(None, ""));
 
     // GitHub answers `bad_refresh_token` with HTTP 200, so the body is the only tell.
-    assert!(body_rejects_grant(r#"{"error":"bad_refresh_token"}"#));
-    assert!(body_rejects_grant(r#"{"error":"invalid_grant"}"#));
-    assert!(!body_rejects_grant(
-        r#"{"access_token":"t","token_type":"bearer"}"#
-    ));
+    let ok = Some(StatusCode::OK);
+    assert!(grant_refused(ok, r#"{"error":"bad_refresh_token"}"#));
+    assert!(grant_refused(ok, r#"{"error":"invalid_grant"}"#));
+    assert!(!grant_refused(ok, r#"{"access_token":"t","token_type":"bearer"}"#));
 }
 
 /// A service that is busy or broken has not refused anything, and callers react differently to
-/// the two.
+/// the two. GitHub and Google spend a 403 on throttling, where advice about permissions sends
+/// the reader after a problem they do not have.
 #[test]
 fn test_transient_service_failures_are_not_refusals() {
     for transient in [408, 429, 503] {
@@ -802,6 +797,29 @@ fn test_transient_service_failures_are_not_refusals() {
             "{transient} should read as the service failing to serve, not refusing"
         );
     }
+
+    let throttled = GitHub.external_api_error(HttpRequestError::ApiError {
+        status: StatusCode::FORBIDDEN,
+        body: r#"{"message":"API rate limit exceeded for user ID 1."}"#.to_string(),
+    });
+    let throttled = map_external_error(throttled);
+    assert!(
+        matches!(throttled, Error::BadGateway(_)),
+        "a throttled 403 is the service failing to serve: {throttled:?}"
+    );
+    assert!(
+        !throttled.to_string().contains("admin rights"),
+        "a throttled 403 must not advise about permissions: {throttled}"
+    );
+
+    let refused = GitHub.external_api_error(HttpRequestError::ApiError {
+        status: StatusCode::FORBIDDEN,
+        body: r#"{"message":"Must have admin rights to Repository."}"#.to_string(),
+    });
+    assert!(
+        map_external_error(refused).to_string().contains("admin rights"),
+        "a real 403 keeps its guidance"
+    );
 }
 
 /// A service read degrades to the stored configuration, but only for the service's own

--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -18,13 +18,13 @@ use windmill_common::{
     variables::{build_crypt, encrypt},
 };
 use windmill_native_triggers::{
-    decrypt_oauth_data, delete_native_trigger, delete_workspace_integration,
+    classify_read_failure, decrypt_oauth_data, delete_native_trigger, delete_workspace_integration,
     get_workspace_integration,
     google::{parse_stop_channel_params, should_renew_channel},
     http_error_status, list_native_triggers, map_external_error,
     nextcloud::NextCloud,
     require_native_integration_use, store_native_trigger, store_workspace_integration, External,
-    HttpRequestError, NativeTriggerConfig, OAuthConfig, ServiceName,
+    ExternalReadFailure, HttpRequestError, NativeTriggerConfig, OAuthConfig, ServiceName,
 };
 
 // ============================================================================
@@ -723,8 +723,8 @@ fn nextcloud_error(status: StatusCode, body: &str) -> Error {
     NextCloud.external_api_error(HttpRequestError::ApiError { status, body: body.to_string() })
 }
 
-/// A rejection has to reach the user as the service's own sentence plus what to do about it.
-/// Reported as a 500 carrying the raw OCS envelope, it read as a Windmill outage.
+/// A rejection has to reach the user as the service's own sentence plus what to do about it,
+/// never as an internal error carrying the raw envelope.
 #[test]
 fn test_provider_rejection_is_readable_and_not_internal() {
     let err = nextcloud_error(
@@ -742,8 +742,8 @@ fn test_provider_rejection_is_readable_and_not_internal() {
         "the envelope should not reach the user: {message}"
     );
     assert!(
-        message.contains("Reconnect the integration"),
-        "message={message}"
+        message.contains("Workspace settings > Integrations"),
+        "the hint should say what to do: {message}"
     );
 }
 
@@ -756,5 +756,29 @@ fn test_provider_404_is_recognized() {
     assert!(
         matches!(map_external_error(err), Error::NotFound(_)),
         "a missing external trigger must map to NotFound"
+    );
+    assert!(matches!(
+        classify_read_failure(nextcloud_error(StatusCode::NOT_FOUND, "{}")),
+        ExternalReadFailure::Missing
+    ));
+}
+
+/// A service read degrades to the stored configuration, but only for the service's own
+/// failures: `External::get` also runs queries, and reporting one of those as the service's
+/// word would hide a Windmill outage behind a 200.
+#[test]
+fn test_only_service_failures_degrade_the_read() {
+    assert!(matches!(
+        classify_read_failure(nextcloud_error(StatusCode::FORBIDDEN, "{}")),
+        ExternalReadFailure::Unreadable(_)
+    ));
+    assert!(matches!(
+        classify_read_failure(Error::internal_err("connection pool timed out")),
+        ExternalReadFailure::Internal(_)
+    ));
+    let internal = Error::internal_err("connection pool timed out");
+    assert!(
+        matches!(map_external_error(internal), Error::InternalErrLoc { .. }),
+        "a non-provider error must pass through unmapped"
     );
 }

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -33194,6 +33194,12 @@ components:
           type: object
           description: Configuration data from the external service
           additionalProperties: true
+        external_error:
+          type: string
+          nullable: true
+          description: >-
+            Why the external service configuration could not be read. When set,
+            external_data is absent and the stored configuration is returned instead.
       required:
         - external_id
         - workspace_id

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -33192,14 +33192,17 @@ components:
           description: Short summary to be displayed when listed
         external_data:
           type: object
-          description: Configuration data from the external service
+          nullable: true
+          description: >-
+            Configuration data from the external service. Null when the service has no
+            such API, or when it could not be read — see external_error.
           additionalProperties: true
         external_error:
           type: string
           nullable: true
           description: >-
             Why the external service configuration could not be read. When set,
-            external_data is absent and the stored configuration is returned instead.
+            external_data is null and the configuration Windmill stored is returned instead.
       required:
         - external_id
         - workspace_id

--- a/backend/windmill-native-triggers/src/github/external.rs
+++ b/backend/windmill-native-triggers/src/github/external.rs
@@ -305,6 +305,11 @@ impl External for GitHub {
             _ => None,
         }
     }
+
+    /// GitHub answers 403 to both rate limiting and a permission failure.
+    fn is_transient_response(&self, status: StatusCode, body: &str) -> bool {
+        status == StatusCode::FORBIDDEN && body.contains("rate limit")
+    }
 }
 
 impl GitHub {

--- a/backend/windmill-native-triggers/src/github/external.rs
+++ b/backend/windmill-native-triggers/src/github/external.rs
@@ -306,9 +306,15 @@ impl External for GitHub {
         }
     }
 
-    /// GitHub answers 403 to both rate limiting and a permission failure.
+    /// GitHub answers 403 to both throttling and a permission failure, and words the throttle
+    /// two ways: the primary and secondary limits say "rate limit", the older secondary
+    /// response says "abuse detection mechanism".
     fn is_transient_response(&self, status: StatusCode, body: &str) -> bool {
-        status == StatusCode::FORBIDDEN && body.contains("rate limit")
+        if status != StatusCode::FORBIDDEN {
+            return false;
+        }
+        let body = body.to_ascii_lowercase();
+        body.contains("rate limit") || body.contains("abuse detection")
     }
 }
 

--- a/backend/windmill-native-triggers/src/github/external.rs
+++ b/backend/windmill-native-triggers/src/github/external.rs
@@ -232,7 +232,10 @@ impl External for GitHub {
                 Err(e) => {
                     errors.push(crate::sync::SyncError {
                         resource_path: trigger.script_path.clone(),
-                        error_message: format!("Failed to verify GitHub webhook: {}", e),
+                        error_message: format!(
+                            "Failed to verify GitHub webhook: {}",
+                            crate::external_error_message(&e)
+                        ),
                         error_type: "api_error".to_string(),
                     });
                 }
@@ -287,6 +290,20 @@ impl External for GitHub {
 
     fn additional_routes(&self) -> axum::Router {
         routes::github_routes(self.clone())
+    }
+
+    fn error_hint(&self, status: StatusCode) -> Option<&'static str> {
+        match status {
+            StatusCode::UNAUTHORIZED => {
+                Some("reconnect the GitHub integration from Workspace settings > Integrations.")
+            }
+            StatusCode::FORBIDDEN => Some(
+                "managing webhooks needs admin rights on the repository: check that the connected \
+                 GitHub account has them and that the OAuth app is authorized for the \
+                 organization.",
+            ),
+            _ => None,
+        }
     }
 }
 

--- a/backend/windmill-native-triggers/src/github/external.rs
+++ b/backend/windmill-native-triggers/src/github/external.rs
@@ -298,9 +298,9 @@ impl External for GitHub {
                 Some("reconnect the GitHub integration from Workspace settings > Integrations.")
             }
             StatusCode::FORBIDDEN => Some(
-                "managing webhooks needs admin rights on the repository: check that the connected \
-                 GitHub account has them and that the OAuth app is authorized for the \
-                 organization.",
+                "check that the OAuth app is authorized for the organization and that the \
+                 connected GitHub account has the access this needs — managing webhooks requires \
+                 admin rights on the repository.",
             ),
             _ => None,
         }

--- a/backend/windmill-native-triggers/src/github/routes.rs
+++ b/backend/windmill-native-triggers/src/github/routes.rs
@@ -5,7 +5,10 @@ use http::Method;
 use windmill_api_auth::ApiAuthed;
 use windmill_common::{error::JsonResult, DB};
 
-use crate::{get_workspace_integration, require_native_integration_use, External, ServiceName};
+use crate::{
+    get_workspace_integration, map_external_error, require_native_integration_use, External,
+    ServiceName,
+};
 
 use super::{GitHub, GithubApiRepoResponse, GithubRepoEntry};
 
@@ -33,7 +36,8 @@ async fn list_repos(
 
         let repos: Vec<GithubApiRepoResponse> = handler
             .http_client_request::<_, ()>(&url, Method::GET, &workspace_id, &db, None, None)
-            .await?;
+            .await
+            .map_err(map_external_error)?;
 
         let count = repos.len();
         all_entries.extend(repos.into_iter().map(|r| GithubRepoEntry {

--- a/backend/windmill-native-triggers/src/google/external.rs
+++ b/backend/windmill-native-triggers/src/google/external.rs
@@ -213,12 +213,11 @@ impl External for Google {
         }
     }
 
-    /// Google answers 403 to a quota being spent as well as to a permission failure.
+    /// Google answers 403 to a quota being spent as well as to a permission failure. Every
+    /// throttling reason it defines sits in the `usageLimits` domain, so matching the domain
+    /// covers the group without an allowlist to extend each time one is added.
     fn is_transient_response(&self, status: http::StatusCode, body: &str) -> bool {
-        status == http::StatusCode::FORBIDDEN
-            && (body.contains("rateLimitExceeded")
-                || body.contains("userRateLimitExceeded")
-                || body.contains("quotaExceeded"))
+        status == http::StatusCode::FORBIDDEN && body.contains("usageLimits")
     }
 }
 

--- a/backend/windmill-native-triggers/src/google/external.rs
+++ b/backend/windmill-native-triggers/src/google/external.rs
@@ -212,6 +212,14 @@ impl External for Google {
             _ => None,
         }
     }
+
+    /// Google answers 403 to a quota being spent as well as to a permission failure.
+    fn is_transient_response(&self, status: http::StatusCode, body: &str) -> bool {
+        status == http::StatusCode::FORBIDDEN
+            && (body.contains("rateLimitExceeded")
+                || body.contains("userRateLimitExceeded")
+                || body.contains("quotaExceeded"))
+    }
 }
 
 // Helper methods for creating trigger type-specific watches

--- a/backend/windmill-native-triggers/src/google/external.rs
+++ b/backend/windmill-native-triggers/src/google/external.rs
@@ -199,6 +199,19 @@ impl External for Google {
     fn additional_routes(&self) -> axum::Router {
         routes::google_routes(self.clone())
     }
+
+    fn error_hint(&self, status: http::StatusCode) -> Option<&'static str> {
+        match status {
+            http::StatusCode::UNAUTHORIZED => {
+                Some("reconnect the Google integration from Workspace settings > Integrations.")
+            }
+            http::StatusCode::FORBIDDEN => Some(
+                "the connected Google account is missing access to this resource or the scope the \
+                 integration was granted does not cover it.",
+            ),
+            _ => None,
+        }
+    }
 }
 
 // Helper methods for creating trigger type-specific watches
@@ -656,7 +669,10 @@ async fn renew_expiring_channels(
                     workspace_id,
                     ServiceName::Google,
                     &trigger.external_id,
-                    Some(&format!("Channel renewal failed: {}", e)),
+                    Some(&format!(
+                        "Channel renewal failed: {}",
+                        crate::external_error_message(&e)
+                    )),
                 )
                 .await;
 

--- a/backend/windmill-native-triggers/src/google/routes.rs
+++ b/backend/windmill-native-triggers/src/google/routes.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 use windmill_api_auth::ApiAuthed;
 use windmill_common::{error::JsonResult, DB};
 
-use crate::{get_workspace_integration, require_native_integration_use, External, ServiceName};
+use crate::{
+    get_workspace_integration, map_external_error, require_native_integration_use, External,
+    ServiceName,
+};
 
 use super::Google;
 
@@ -100,7 +103,8 @@ async fn list_calendars(
 
     let response: GoogleCalendarListResponse = handler
         .http_client_request::<_, ()>(&url, Method::GET, &workspace_id, &db, None, None)
-        .await?;
+        .await
+        .map_err(map_external_error)?;
 
     let calendars = response
         .items
@@ -153,7 +157,8 @@ async fn list_drive_files(
 
     let response: DriveApiResponse = handler
         .http_client_request::<_, ()>(&url, Method::GET, &workspace_id, &db, None, None)
-        .await?;
+        .await
+        .map_err(map_external_error)?;
 
     let files = response
         .files
@@ -206,7 +211,8 @@ async fn list_shared_drives(
 
     let response: SharedDrivesApiResponse = handler
         .http_client_request::<_, ()>(&url, Method::GET, &workspace_id, &db, None, None)
-        .await?;
+        .await
+        .map_err(map_external_error)?;
 
     let drives = response
         .drives

--- a/backend/windmill-native-triggers/src/handler.rs
+++ b/backend/windmill-native-triggers/src/handler.rs
@@ -1,17 +1,17 @@
 use crate::{
-    decrypt_oauth_data, delete_native_trigger, delete_token_by_hash, external_error_message,
-    get_native_trigger, http_error_status, list_native_triggers, lock::TriggerLock,
-    map_external_error, map_external_error_with, rotate_webhook_token, store_native_trigger,
+    classify_read_failure, decrypt_oauth_data, delete_native_trigger, delete_token_by_hash,
+    get_native_trigger, list_native_triggers, lock::TriggerLock, map_external_error,
+    map_external_error_with, rotate_webhook_token, store_native_trigger,
     sync::EXTERNAL_TRIGGER_MISSING_ERROR, update_native_trigger_error,
     update_native_trigger_if_runnable_unchanged, webhook_token_label, webhook_token_scopes,
-    External, NativeTrigger, NativeTriggerConfig, NativeTriggerData, ServiceName,
+    External, ExternalReadFailure, NativeTrigger, NativeTriggerConfig, NativeTriggerData,
+    ServiceName,
 };
 use axum::{
     extract::{Path, Query},
     routing::{delete, get, post},
     Extension, Json, Router,
 };
-use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use sqlx::PgConnection;
 use std::sync::Arc;
@@ -472,43 +472,45 @@ async fn get_native_trigger_handler<T: External>(
             Some(native_cfg)
         }
         Ok(None) => None,
-        Err(e) if http_error_status(&e) == Some(StatusCode::NOT_FOUND) => {
-            let error_msg = EXTERNAL_TRIGGER_MISSING_ERROR.to_string();
-            tracing::warn!(
-                "Native trigger no longer exists on external service {}, setting error",
-                service_name
-            );
+        Err(e) => match classify_read_failure(e) {
+            ExternalReadFailure::Missing => {
+                let error_msg = EXTERNAL_TRIGGER_MISSING_ERROR.to_string();
+                tracing::warn!(
+                    "Native trigger no longer exists on external service {}, setting error",
+                    service_name
+                );
 
-            update_native_trigger_error(
-                &mut *tx,
-                &workspace_id,
-                service_name,
-                &external_id,
-                Some(&error_msg),
-            )
-            .await?;
+                update_native_trigger_error(
+                    &mut *tx,
+                    &workspace_id,
+                    service_name,
+                    &external_id,
+                    Some(&error_msg),
+                )
+                .await?;
 
-            tx.commit().await?;
+                tx.commit().await?;
 
-            return Err(Error::NotFound(format!(
-                "Trigger '{}' no longer exists on external service {}",
-                external_id, service_name
-            )));
-        }
-        // The service being unreadable says nothing about the trigger Windmill stores, and
-        // failing here would leave the editor with no configuration to show at all. Report what
-        // the service said alongside the stored configuration instead.
-        Err(e) => {
-            let message = external_error_message(&e);
-            tracing::warn!(
-                "Could not read trigger '{}' from {}, returning the stored configuration: {}",
-                external_id,
-                service_name,
-                message
-            );
-            external_error = Some(message);
-            None
-        }
+                return Err(Error::NotFound(format!(
+                    "Trigger '{}' no longer exists on external service {}",
+                    external_id, service_name
+                )));
+            }
+            // The service being unreadable says nothing about the trigger Windmill stores, and
+            // failing here would leave the editor with no configuration to show at all. Report
+            // what the service said alongside the stored configuration instead.
+            ExternalReadFailure::Unreadable(message) => {
+                tracing::warn!(
+                    "Could not read trigger '{}' from {}, returning the stored configuration: {}",
+                    external_id,
+                    service_name,
+                    message
+                );
+                external_error = Some(message);
+                None
+            }
+            ExternalReadFailure::Internal(e) => return Err(e),
+        },
     };
 
     tx.commit().await?;
@@ -559,7 +561,12 @@ async fn delete_native_trigger_handler<T: External>(
         .await
         .map_err(|e| {
             map_external_error_with(e, |m| {
-                format!("{m} The trigger was kept in Windmill, so it can still fire.")
+                let end = if m.ends_with(['.', '!', '?']) {
+                    ""
+                } else {
+                    "."
+                };
+                format!("{m}{end} The trigger was kept in Windmill, so it can still fire.")
             })
         })?;
 

--- a/backend/windmill-native-triggers/src/handler.rs
+++ b/backend/windmill-native-triggers/src/handler.rs
@@ -1,6 +1,7 @@
 use crate::{
-    decrypt_oauth_data, delete_native_trigger, delete_token_by_hash, get_native_trigger,
-    list_native_triggers, lock::TriggerLock, rotate_webhook_token, store_native_trigger,
+    decrypt_oauth_data, delete_native_trigger, delete_token_by_hash, external_error_message,
+    get_native_trigger, http_error_status, list_native_triggers, lock::TriggerLock,
+    map_external_error, map_external_error_with, rotate_webhook_token, store_native_trigger,
     sync::EXTERNAL_TRIGGER_MISSING_ERROR, update_native_trigger_error,
     update_native_trigger_if_runnable_unchanged, webhook_token_label, webhook_token_scopes,
     External, NativeTrigger, NativeTriggerConfig, NativeTriggerData, ServiceName,
@@ -10,6 +11,7 @@ use axum::{
     routing::{delete, get, post},
     Extension, Json, Router,
 };
+use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use sqlx::PgConnection;
 use std::sync::Arc;
@@ -111,6 +113,10 @@ pub struct FullTriggerResponse<T: Serialize> {
     #[serde(flatten)]
     pub windmill_data: NativeTrigger,
     pub external_data: Option<T>,
+    /// Why `external_data` is missing, when the service could not be read. The stored
+    /// configuration is still returned so the trigger stays viewable and editable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_error: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -193,7 +199,8 @@ async fn create_native_trigger<T: External>(
             &db,
             &mut tx,
         )
-        .await?;
+        .await
+        .map_err(map_external_error)?;
 
     let (external_id, _) = handler.external_id_and_metadata_from_response(&resp);
 
@@ -214,7 +221,8 @@ async fn create_native_trigger<T: External>(
                     &db,
                     &mut tx,
                 )
-                .await?
+                .await
+                .map_err(map_external_error)?
         };
 
     let config = NativeTriggerConfig {
@@ -349,7 +357,8 @@ async fn update_native_trigger_handler<T: External>(
             &db,
             &mut tx,
         )
-        .await?;
+        .await
+        .map_err(map_external_error)?;
 
     let config = NativeTriggerConfig {
         script_path: data.script_path.clone(),
@@ -443,6 +452,8 @@ async fn get_native_trigger_handler<T: External>(
         .get(&workspace_id, &oauth_data, &external_id, &db, &mut tx)
         .await;
 
+    let mut external_error = None;
+
     let external_data = match native_trigger {
         Ok(Some(native_cfg)) => {
             // Only the "no longer exists" error is disproven by the trigger being there; other
@@ -461,7 +472,7 @@ async fn get_native_trigger_handler<T: External>(
             Some(native_cfg)
         }
         Ok(None) => None,
-        Err(Error::NotFound(_)) => {
+        Err(e) if http_error_status(&e) == Some(StatusCode::NOT_FOUND) => {
             let error_msg = EXTERNAL_TRIGGER_MISSING_ERROR.to_string();
             tracing::warn!(
                 "Native trigger no longer exists on external service {}, setting error",
@@ -484,12 +495,29 @@ async fn get_native_trigger_handler<T: External>(
                 external_id, service_name
             )));
         }
-        Err(e) => return Err(e),
+        // The service being unreadable says nothing about the trigger Windmill stores, and
+        // failing here would leave the editor with no configuration to show at all. Report what
+        // the service said alongside the stored configuration instead.
+        Err(e) => {
+            let message = external_error_message(&e);
+            tracing::warn!(
+                "Could not read trigger '{}' from {}, returning the stored configuration: {}",
+                external_id,
+                service_name,
+                message
+            );
+            external_error = Some(message);
+            None
+        }
     };
 
     tx.commit().await?;
 
-    let full_resp = Json(FullTriggerResponse { windmill_data: windmill_trigger, external_data });
+    let full_resp = Json(FullTriggerResponse {
+        windmill_data: windmill_trigger,
+        external_data,
+        external_error,
+    });
 
     Ok(full_resp)
 }
@@ -528,7 +556,12 @@ async fn delete_native_trigger_handler<T: External>(
 
     handler
         .delete(&workspace_id, &oauth_data, &external_id, &db, &mut tx)
-        .await?;
+        .await
+        .map_err(|e| {
+            map_external_error_with(e, |m| {
+                format!("{m} The trigger was kept in Windmill, so it can still fire.")
+            })
+        })?;
 
     let deleted =
         delete_native_trigger(&mut *tx, &workspace_id, service_name, &external_id).await?;

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -416,15 +416,8 @@ pub trait External: Send + Sync + 'static {
                 )
                 .await
                 .map_err(|f| {
-                    // Only the token endpoint refusing the grant means the stored credentials
-                    // are at fault. Reached-and-broken or never-reached is an outage, and
-                    // telling the user to reconnect would send them to fix the wrong thing.
-                    let status = match f.status {
-                        Some(s) if s.is_client_error() => Some(StatusCode::UNAUTHORIZED),
-                        other => other,
-                    };
                     self.external_error(
-                        status,
+                        refresh_failure_status(f.status),
                         format!(
                             "the stored credentials could not be refreshed: {}",
                             f.message
@@ -502,7 +495,7 @@ pub struct ExternalApiError {
 impl std::fmt::Display for ExternalApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.status {
-            Some(status) if status.is_server_error() => write!(
+            Some(status) if is_transient(status) => write!(
                 f,
                 "{} failed to serve the request ({}): {}",
                 self.service, status, self.detail
@@ -707,11 +700,21 @@ pub fn map_external_error_with(e: Error, decorate: impl FnOnce(String) -> String
     let message = decorate(message);
     match status {
         Some(StatusCode::NOT_FOUND) => Error::NotFound(message),
-        Some(s) if s.is_server_error() => Error::BadGateway(message),
+        // A refusal is the caller's to fix; being unable to serve the request now is not, and
+        // the two want different reactions from whoever reads it.
+        Some(s) if is_transient(s) => Error::BadGateway(message),
         Some(_) => Error::BadRequest(message),
         // No status at all: the provider was unreachable or answered something undecodable.
         None => Error::BadGateway(message),
     }
+}
+
+fn is_transient(status: StatusCode) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+        )
 }
 
 /// Read OAuth client_id and client_secret from instance-level global settings.
@@ -830,6 +833,21 @@ pub struct RefreshFailure {
 impl RefreshFailure {
     fn rejected(message: String) -> Self {
         RefreshFailure { status: Some(StatusCode::UNAUTHORIZED), message }
+    }
+}
+
+/// How to report a token endpoint's answer to a refresh.
+///
+/// Only the statuses OAuth uses to refuse a grant (RFC 6749 §5.2) mean the stored credentials
+/// are at fault and the user should reconnect. Everything else — a timeout, rate limiting, a
+/// 5xx, no answer at all — is the endpoint failing to serve a grant that may well be valid,
+/// and sending the user off to reconnect would have them fix the wrong thing.
+pub fn refresh_failure_status(status: Option<StatusCode>) -> Option<StatusCode> {
+    match status {
+        Some(StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => {
+            Some(StatusCode::UNAUTHORIZED)
+        }
+        other => other,
     }
 }
 

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -635,7 +635,9 @@ impl HttpRequestError {
     }
 }
 
-fn as_external_api_error(e: &Error) -> Option<&ExternalApiError> {
+/// `Some` only for a failure the service itself produced. Everything else — a query, a
+/// decryption, a serialization — is Windmill's own and must not be reported as the service's.
+pub fn as_external_error(e: &Error) -> Option<&ExternalApiError> {
     match e {
         Error::Anyhow { error, .. } => error.downcast_ref::<ExternalApiError>(),
         _ => None,
@@ -645,13 +647,32 @@ fn as_external_api_error(e: &Error) -> Option<&ExternalApiError> {
 /// Extract the HTTP status code from an error returned by `http_client_request`.
 /// Returns `None` if the error didn't originate from an HTTP call.
 pub fn http_error_status(e: &Error) -> Option<StatusCode> {
-    as_external_api_error(e).and_then(|e| e.status)
+    as_external_error(e).and_then(|e| e.status)
 }
 
 /// The message to show a user for a failed provider call, without the internal decoration
 /// `Error`'s own `Display` adds. Non-provider errors are rendered as-is.
 pub fn external_error_message(e: &Error) -> String {
-    as_external_api_error(e).map_or_else(|| e.to_string(), |ext| ext.to_string())
+    as_external_error(e).map_or_else(|| e.to_string(), |ext| ext.to_string())
+}
+
+/// What a failed read of a trigger from its service means for the response.
+#[derive(Debug)]
+pub enum ExternalReadFailure {
+    /// The service answered that the trigger is gone.
+    Missing,
+    /// The service could not be read, which says nothing about the stored trigger.
+    Unreadable(String),
+    /// Windmill's own failure, wearing no service's name.
+    Internal(Error),
+}
+
+pub fn classify_read_failure(e: Error) -> ExternalReadFailure {
+    match as_external_error(&e) {
+        Some(ext) if ext.status == Some(StatusCode::NOT_FOUND) => ExternalReadFailure::Missing,
+        Some(ext) => ExternalReadFailure::Unreadable(ext.to_string()),
+        None => ExternalReadFailure::Internal(e),
+    }
 }
 
 /// Turn a provider failure into something a client can read and act on.
@@ -666,8 +687,7 @@ pub fn map_external_error(e: Error) -> Error {
 
 /// `map_external_error` with a chance to add what the failure means for Windmill's own state.
 pub fn map_external_error_with(e: Error, decorate: impl FnOnce(String) -> String) -> Error {
-    let Some((status, message)) =
-        as_external_api_error(&e).map(|ext| (ext.status, ext.to_string()))
+    let Some((status, message)) = as_external_error(&e).map(|ext| (ext.status, ext.to_string()))
     else {
         return e;
     };

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -54,7 +54,7 @@ use windmill_common::{
 use windmill_queue::PushArgsOwned;
 
 #[cfg(feature = "native_trigger")]
-use windmill_oauth::{OClient, RefreshToken, Url, OAUTH_HTTP_CLIENT};
+use windmill_oauth::{ExecuteError, OClient, RefreshToken, Url, OAUTH_HTTP_CLIENT};
 
 use windmill_api_auth::ApiAuthed;
 pub mod handler;
@@ -830,9 +830,34 @@ pub struct RefreshFailure {
     pub message: String,
 }
 
+#[cfg(feature = "native_trigger")]
 impl RefreshFailure {
     fn rejected(message: String) -> Self {
         RefreshFailure { status: Some(StatusCode::UNAUTHORIZED), message }
+    }
+}
+
+/// Whether a token endpoint's body says the refresh token itself is no good, which no status
+/// reliably reports: GitHub answers `bad_refresh_token` with HTTP 200.
+pub fn body_rejects_grant(body: &str) -> bool {
+    body.contains("invalid_grant") || body.contains("bad_refresh_token")
+}
+
+#[cfg(feature = "native_trigger")]
+fn refresh_failure_from(e: ExecuteError) -> RefreshFailure {
+    match &e {
+        // A body that would not deserialize is where a refusal hides when the status says
+        // nothing, and it is the only place the reason is written down.
+        ExecuteError::BadResponse { status, body, .. } => {
+            let body = String::from_utf8_lossy(body);
+            let status = if body_rejects_grant(&body) {
+                Some(StatusCode::UNAUTHORIZED)
+            } else {
+                Some(*status)
+            };
+            RefreshFailure { status, message: format!("{status_text}: {body}", status_text = e) }
+        }
+        _ => RefreshFailure { status: e.status(), message: error_source_chain(&e) },
     }
 }
 
@@ -888,9 +913,7 @@ pub async fn refresh_oauth_tokens(
         .with_client(&*OAUTH_HTTP_CLIENT)
         .execute()
         .await
-        // The token endpoint's status is what separates a rejected grant from an outage, and
-        // the reason (`invalid_grant`, …) only lives in the source chain.
-        .map_err(|e| RefreshFailure { status: e.status(), message: error_source_chain(&e) })?;
+        .map_err(refresh_failure_from)?;
 
     Ok(OAuthConfig {
         base_url: oauth_config.base_url.clone(),

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -415,12 +415,20 @@ pub trait External: Send + Sync + 'static {
                     Self::AUTH_ENDPOINT,
                 )
                 .await
-                .map_err(|e| {
-                    // Typed like any other rejection: this is still the service refusing the
-                    // stored credentials, and callers downstream branch on that.
+                .map_err(|f| {
+                    // Only the token endpoint refusing the grant means the stored credentials
+                    // are at fault. Reached-and-broken or never-reached is an outage, and
+                    // telling the user to reconnect would send them to fix the wrong thing.
+                    let status = match f.status {
+                        Some(s) if s.is_client_error() => Some(StatusCode::UNAUTHORIZED),
+                        other => other,
+                    };
                     self.external_error(
-                        Some(StatusCode::UNAUTHORIZED),
-                        format!("the stored credentials could not be refreshed: {e}"),
+                        status,
+                        format!(
+                            "the stored credentials could not be refreshed: {}",
+                            f.message
+                        ),
                     )
                 })?;
 
@@ -494,6 +502,11 @@ pub struct ExternalApiError {
 impl std::fmt::Display for ExternalApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.status {
+            Some(status) if status.is_server_error() => write!(
+                f,
+                "{} failed to serve the request ({}): {}",
+                self.service, status, self.detail
+            )?,
             Some(status) => write!(
                 f,
                 "{} rejected the request ({}): {}",
@@ -805,24 +818,47 @@ struct RefreshTokenResponse {
     refresh_token: Option<String>,
 }
 
+/// Why an OAuth token refresh did not produce a new token.
+#[derive(Debug)]
+pub struct RefreshFailure {
+    /// The token endpoint's own status, when it answered at all. `None` means it was never
+    /// reached, which is an outage rather than a problem with the stored credentials.
+    pub status: Option<StatusCode>,
+    pub message: String,
+}
+
+impl RefreshFailure {
+    fn rejected(message: String) -> Self {
+        RefreshFailure { status: Some(StatusCode::UNAUTHORIZED), message }
+    }
+}
+
 /// Refresh OAuth tokens using windmill-oauth.
 #[cfg(feature = "native_trigger")]
 pub async fn refresh_oauth_tokens(
     oauth_config: &OAuthConfig,
     refresh_endpoint: &str,
     auth_endpoint: &str,
-) -> Result<OAuthConfig> {
+) -> std::result::Result<OAuthConfig, RefreshFailure> {
     let refresh_token_str = oauth_config
         .refresh_token
         .as_ref()
-        .ok_or_else(|| Error::InternalErr("No refresh token available".to_string()))?;
+        .ok_or_else(|| RefreshFailure::rejected("no refresh token is stored".to_string()))?;
 
     // Build OAuth client for token refresh
     // Auth URL is not used for refresh, but required by the client constructor
-    let auth_url = Url::parse(&resolve_endpoint(&oauth_config.base_url, auth_endpoint))
-        .map_err(|e| Error::InternalErr(format!("Invalid auth URL: {}", e)))?;
+    let auth_url =
+        Url::parse(&resolve_endpoint(&oauth_config.base_url, auth_endpoint)).map_err(|e| {
+            RefreshFailure {
+                status: Some(StatusCode::BAD_REQUEST),
+                message: format!("invalid auth URL: {e}"),
+            }
+        })?;
     let token_url = Url::parse(&resolve_endpoint(&oauth_config.base_url, refresh_endpoint))
-        .map_err(|e| Error::InternalErr(format!("Invalid token URL: {}", e)))?;
+        .map_err(|e| RefreshFailure {
+            status: Some(StatusCode::BAD_REQUEST),
+            message: format!("invalid token URL: {e}"),
+        })?;
 
     let mut client = OClient::new(oauth_config.client_id.clone(), auth_url, token_url);
     client.set_client_secret(oauth_config.client_secret.clone());
@@ -832,7 +868,9 @@ pub async fn refresh_oauth_tokens(
         .with_client(&*OAUTH_HTTP_CLIENT)
         .execute()
         .await
-        .map_err(|e| Error::InternalErr(format!("Failed to refresh token: {:?}", e)))?;
+        // The token endpoint's status is what separates a rejected grant from an outage, and
+        // the reason (`invalid_grant`, …) only lives in the source chain.
+        .map_err(|e| RefreshFailure { status: e.status(), message: error_source_chain(&e) })?;
 
     Ok(OAuthConfig {
         base_url: oauth_config.base_url.clone(),
@@ -851,10 +889,11 @@ pub async fn refresh_oauth_tokens(
     _oauth_config: &OAuthConfig,
     _refresh_endpoint: &str,
     _auth_endpoint: &str,
-) -> Result<OAuthConfig> {
-    Err(Error::InternalErr(
-        "Native triggers feature is not enabled".to_string(),
-    ))
+) -> std::result::Result<OAuthConfig, RefreshFailure> {
+    Err(RefreshFailure {
+        status: None,
+        message: "the native_trigger feature is not enabled".to_string(),
+    })
 }
 
 async fn update_oauth_token_resource(

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -365,6 +365,17 @@ pub trait External: Send + Sync + 'static {
         axum::Router::new()
     }
 
+    /// Pull the human-readable message out of an error body, when the service wraps it in an
+    /// envelope. Returning `None` (default) shows the body as-is.
+    fn describe_error_body(&self, _body: &str) -> Option<String> {
+        None
+    }
+
+    /// What the user has to do about a rejection, appended to the service's own message.
+    fn error_hint(&self, _status: StatusCode) -> Option<&'static str> {
+        None
+    }
+
     async fn http_client_request<T: DeserializeOwned + Send, B: Serialize + Send + Sync>(
         &self,
         url: &str,
@@ -388,13 +399,14 @@ pub trait External: Send + Sync + 'static {
 
         match result {
             Ok(response) => Ok(response),
-            Err(err)
-                if err.status() == Some(StatusCode::UNAUTHORIZED)
-                    || err.status() == Some(StatusCode::FORBIDDEN) =>
-            {
+            // Only an expired or revoked token is worth a refresh. A 403 means the account
+            // behind the token is authenticated and still not allowed, which minting a new
+            // token for that same account cannot change; retrying would only burn a refresh
+            // rotation per request and bury the service's own explanation.
+            Err(err) if err.status() == Some(StatusCode::UNAUTHORIZED) => {
                 tracing::info!(
-                    "HTTP auth error ({}), attempting token refresh",
-                    err.status().unwrap()
+                    "HTTP 401 from {}, attempting token refresh",
+                    Self::DISPLAY_NAME
                 );
 
                 let refreshed_oauth_config = refresh_oauth_tokens(
@@ -402,7 +414,14 @@ pub trait External: Send + Sync + 'static {
                     Self::REFRESH_ENDPOINT,
                     Self::AUTH_ENDPOINT,
                 )
-                .await?;
+                .await
+                .map_err(|e| {
+                    Error::BadRequest(format!(
+                        "{} rejected the stored credentials and refreshing them failed: {e}. \
+                         Reconnect the integration from Workspace settings > Integrations.",
+                        Self::DISPLAY_NAME
+                    ))
+                })?;
 
                 task::spawn({
                     let db_clone = db.clone();
@@ -422,7 +441,7 @@ pub trait External: Send + Sync + 'static {
                     }
                 });
 
-                let response = make_http_request(
+                make_http_request(
                     url,
                     method,
                     headers,
@@ -430,11 +449,68 @@ pub trait External: Send + Sync + 'static {
                     &refreshed_oauth_config.access_token,
                 )
                 .await
-                .map_err(to_anyhow)?;
-                Ok(response)
+                .map_err(|e| self.external_api_error(e))
             }
-            Err(e) => Err(to_anyhow(e).into()),
+            Err(e) => Err(self.external_api_error(e)),
         }
+    }
+
+    /// Wrap a failed provider call so the status stays inspectable by internal callers (a 404
+    /// means the trigger is gone, not that the call broke) and the message stays readable by
+    /// the time it reaches a user.
+    fn external_api_error(&self, e: HttpRequestError) -> Error {
+        let status = e.status();
+        let detail = match &e {
+            HttpRequestError::ApiError { body, .. } => self
+                .describe_error_body(body)
+                .unwrap_or_else(|| body.to_string()),
+            other => other.to_string(),
+        };
+        to_anyhow(ExternalApiError {
+            service: Self::DISPLAY_NAME,
+            status,
+            detail: truncate_detail(&detail),
+            hint: status.and_then(|s| self.error_hint(s)),
+        })
+        .into()
+    }
+}
+
+/// A native trigger provider refused or could not serve a request.
+#[derive(Debug)]
+pub struct ExternalApiError {
+    pub service: &'static str,
+    pub status: Option<StatusCode>,
+    pub detail: String,
+    pub hint: Option<&'static str>,
+}
+
+impl std::fmt::Display for ExternalApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.status {
+            Some(status) => write!(
+                f,
+                "{} rejected the request ({}): {}",
+                self.service, status, self.detail
+            )?,
+            None => write!(f, "Could not reach {}: {}", self.service, self.detail)?,
+        }
+        if let Some(hint) = self.hint {
+            write!(f, " — {}", hint)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ExternalApiError {}
+
+/// Provider bodies are unbounded and end up in toasts and `native_trigger.error`.
+fn truncate_detail(detail: &str) -> String {
+    const MAX: usize = 400;
+    let detail = detail.trim();
+    match detail.char_indices().nth(MAX) {
+        Some((idx, _)) => format!("{}…", &detail[..idx]),
+        None => detail.to_string(),
     }
 }
 
@@ -537,14 +613,49 @@ impl HttpRequestError {
     }
 }
 
+fn as_external_api_error(e: &Error) -> Option<&ExternalApiError> {
+    match e {
+        Error::Anyhow { error, .. } => error.downcast_ref::<ExternalApiError>(),
+        _ => None,
+    }
+}
+
 /// Extract the HTTP status code from an error returned by `http_client_request`.
 /// Returns `None` if the error didn't originate from an HTTP call.
-pub fn http_error_status(e: &windmill_common::error::Error) -> Option<StatusCode> {
-    match e {
-        windmill_common::error::Error::Anyhow { error, .. } => error
-            .downcast_ref::<HttpRequestError>()
-            .and_then(|e| e.status()),
-        _ => None,
+pub fn http_error_status(e: &Error) -> Option<StatusCode> {
+    as_external_api_error(e).and_then(|e| e.status)
+}
+
+/// The message to show a user for a failed provider call, without the internal decoration
+/// `Error`'s own `Display` adds. Non-provider errors are rendered as-is.
+pub fn external_error_message(e: &Error) -> String {
+    as_external_api_error(e).map_or_else(|| e.to_string(), |ext| ext.to_string())
+}
+
+/// Turn a provider failure into something a client can read and act on.
+///
+/// Without this every rejection reaches the browser as a 500 carrying a raw upstream body.
+/// The provider's status is deliberately not mirrored: a 401/403 answered by Windmill reads as
+/// a Windmill permission problem, when the account that lacks rights is the one connected to
+/// the *provider*. Errors that did not come from a provider call pass through untouched.
+pub fn map_external_error(e: Error) -> Error {
+    map_external_error_with(e, |message| message)
+}
+
+/// `map_external_error` with a chance to add what the failure means for Windmill's own state.
+pub fn map_external_error_with(e: Error, decorate: impl FnOnce(String) -> String) -> Error {
+    let Some((status, message)) =
+        as_external_api_error(&e).map(|ext| (ext.status, ext.to_string()))
+    else {
+        return e;
+    };
+    let message = decorate(message);
+    match status {
+        Some(StatusCode::NOT_FOUND) => Error::NotFound(message),
+        Some(s) if s.is_server_error() => Error::BadGateway(message),
+        Some(_) => Error::BadRequest(message),
+        // No status at all: the provider was unreachable or answered something undecodable.
+        None => Error::BadGateway(message),
     }
 }
 

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -54,7 +54,7 @@ use windmill_common::{
 use windmill_queue::PushArgsOwned;
 
 #[cfg(feature = "native_trigger")]
-use windmill_oauth::{ExecuteError, OClient, RefreshToken, Url, OAUTH_HTTP_CLIENT};
+use windmill_oauth::{ErrorField, ExecuteError, OClient, RefreshToken, Url, OAUTH_HTTP_CLIENT};
 
 use windmill_api_auth::ApiAuthed;
 pub mod handler;
@@ -879,12 +879,13 @@ impl RefreshFailure {
     }
 }
 
-/// Whether a token endpoint's answer means the grant itself was refused, rather than the
-/// endpoint failing to serve a grant that may well be valid.
+/// Whether a token endpoint's answer means reconnecting the integration is the fix, rather
+/// than the endpoint failing to serve a grant that may well be valid.
 ///
-/// RFC 6749 §5.2 answers a refusal with 400, or 401/403 when it is the client credentials at
-/// fault. The body is checked too because no status reliably reports it: GitHub answers
-/// `bad_refresh_token` with HTTP 200.
+/// Used when the answer carried no OAuth error code to read. The body is checked because no
+/// status reliably reports a refusal: GitHub answers `bad_refresh_token` with HTTP 200. The
+/// status is the last resort — on a token endpoint these three most often mean the stored
+/// grant is spent, and there is nothing better to go on.
 pub fn grant_refused(status: Option<StatusCode>, body: &str) -> bool {
     body.contains("invalid_grant")
         || body.contains("bad_refresh_token")
@@ -894,22 +895,37 @@ pub fn grant_refused(status: Option<StatusCode>, body: &str) -> bool {
         )
 }
 
+/// Whether an OAuth error code (RFC 6749 §5.2) means the credentials Windmill stored are what
+/// needs replacing. The rest — a malformed request, an unsupported grant type, a scope the
+/// server will not grant — are faults in how the integration asks, which reconnecting as the
+/// same user will reproduce exactly.
+#[cfg(feature = "native_trigger")]
+fn code_means_reconnect(code: &ErrorField) -> bool {
+    matches!(code, ErrorField::InvalidGrant | ErrorField::InvalidClient)
+}
+
 #[cfg(feature = "native_trigger")]
 fn refresh_failure_from(e: ExecuteError) -> RefreshFailure {
-    match &e {
+    let rejected = match &e {
+        // A code says exactly what was refused, so nothing else needs guessing at.
+        ExecuteError::ErrorResponse { error, .. } => code_means_reconnect(&error.error),
         // A body that would not deserialize is where a refusal hides when the status says
         // nothing, and it is the only place the reason is written down.
         ExecuteError::BadResponse { status, body, .. } => {
-            let body = String::from_utf8_lossy(body);
-            let message = format!("{e}: {body}");
-            if grant_refused(Some(*status), &body) {
-                RefreshFailure::rejected(message)
-            } else {
-                RefreshFailure::outage(message)
-            }
+            grant_refused(Some(*status), &String::from_utf8_lossy(body))
         }
-        _ if grant_refused(e.status(), "") => RefreshFailure::rejected(error_source_chain(&e)),
-        _ => RefreshFailure::outage(error_source_chain(&e)),
+        _ => grant_refused(e.status(), ""),
+    };
+    let message = match &e {
+        ExecuteError::BadResponse { body, .. } => {
+            format!("{e}: {}", String::from_utf8_lossy(body))
+        }
+        _ => error_source_chain(&e),
+    };
+    if rejected {
+        RefreshFailure::rejected(message)
+    } else {
+        RefreshFailure::outage(message)
     }
 }
 

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -416,11 +416,12 @@ pub trait External: Send + Sync + 'static {
                 )
                 .await
                 .map_err(|e| {
-                    Error::BadRequest(format!(
-                        "{} rejected the stored credentials and refreshing them failed: {e}. \
-                         Reconnect the integration from Workspace settings > Integrations.",
-                        Self::DISPLAY_NAME
-                    ))
+                    // Typed like any other rejection: this is still the service refusing the
+                    // stored credentials, and callers downstream branch on that.
+                    self.external_error(
+                        Some(StatusCode::UNAUTHORIZED),
+                        format!("the stored credentials could not be refreshed: {e}"),
+                    )
                 })?;
 
                 task::spawn({
@@ -459,13 +460,18 @@ pub trait External: Send + Sync + 'static {
     /// means the trigger is gone, not that the call broke) and the message stays readable by
     /// the time it reaches a user.
     fn external_api_error(&self, e: HttpRequestError) -> Error {
-        let status = e.status();
         let detail = match &e {
             HttpRequestError::ApiError { body, .. } => self
                 .describe_error_body(body)
                 .unwrap_or_else(|| body.to_string()),
-            other => other.to_string(),
+            // A reqwest error names the request it was making, never why it failed: the reason
+            // (refused, DNS, TLS) lives one link down the source chain.
+            other => error_source_chain(other),
         };
+        self.external_error(e.status(), detail)
+    }
+
+    fn external_error(&self, status: Option<StatusCode>, detail: String) -> Error {
         to_anyhow(ExternalApiError {
             service: Self::DISPLAY_NAME,
             status,
@@ -493,7 +499,9 @@ impl std::fmt::Display for ExternalApiError {
                 "{} rejected the request ({}): {}",
                 self.service, status, self.detail
             )?,
-            None => write!(f, "Could not reach {}: {}", self.service, self.detail)?,
+            // No status covers both never reaching the service and not being able to read what
+            // it answered, so the wording may not commit to either.
+            None => write!(f, "Request to {} failed: {}", self.service, self.detail)?,
         }
         if let Some(hint) = self.hint {
             write!(f, " — {}", hint)?;
@@ -503,6 +511,20 @@ impl std::fmt::Display for ExternalApiError {
 }
 
 impl std::error::Error for ExternalApiError {}
+
+fn error_source_chain(e: &dyn std::error::Error) -> String {
+    let mut msg = e.to_string();
+    let mut source = e.source();
+    while let Some(cause) = source {
+        let cause = cause.to_string();
+        // reqwest repeats "error sending request for url (…)" at two levels of the chain.
+        if !msg.contains(&cause) {
+            msg.push_str(&format!(": {cause}"));
+        }
+        source = source.and_then(|c| c.source());
+    }
+    msg
+}
 
 /// Provider bodies are unbounded and end up in toasts and `native_trigger.error`.
 fn truncate_detail(detail: &str) -> String {

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -838,16 +838,18 @@ impl RefreshFailure {
 
 /// How to report a token endpoint's answer to a refresh.
 ///
-/// Only the statuses OAuth uses to refuse a grant (RFC 6749 §5.2) mean the stored credentials
-/// are at fault and the user should reconnect. Everything else — a timeout, rate limiting, a
-/// 5xx, no answer at all — is the endpoint failing to serve a grant that may well be valid,
-/// and sending the user off to reconnect would have them fix the wrong thing.
+/// The status on an `ExternalApiError` says what the call for the *trigger* answered, and 404
+/// there means the trigger is gone — it records that on the row and lets a delete drop it. A
+/// token endpoint's status carries none of that meaning (a wrong base URL 404s it while the
+/// webhook is perfectly alive), so only a refused grant is translated, to the 401 that earns
+/// the reconnect hint. Everything else is reported with no status, as the outage it is.
 pub fn refresh_failure_status(status: Option<StatusCode>) -> Option<StatusCode> {
     match status {
+        // RFC 6749 §5.2: a refused grant answers 400, or 401/403 for client authentication.
         Some(StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => {
             Some(StatusCode::UNAUTHORIZED)
         }
-        other => other,
+        _ => None,
     }
 }
 

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -376,6 +376,12 @@ pub trait External: Send + Sync + 'static {
         None
     }
 
+    /// Whether the service is telling us it cannot serve the request right now, when the
+    /// status alone would read as a refusal. GitHub and Google both answer 403 to throttling.
+    fn is_transient_response(&self, _status: StatusCode, _body: &str) -> bool {
+        false
+    }
+
     async fn http_client_request<T: DeserializeOwned + Send, B: Serialize + Send + Sync>(
         &self,
         url: &str,
@@ -417,7 +423,7 @@ pub trait External: Send + Sync + 'static {
                 .await
                 .map_err(|f| {
                     self.external_error(
-                        refresh_failure_status(f.status),
+                        f.rejected.then_some(StatusCode::UNAUTHORIZED),
                         format!(
                             "the stored credentials could not be refreshed: {}",
                             f.message
@@ -461,23 +467,41 @@ pub trait External: Send + Sync + 'static {
     /// means the trigger is gone, not that the call broke) and the message stays readable by
     /// the time it reaches a user.
     fn external_api_error(&self, e: HttpRequestError) -> Error {
-        let detail = match &e {
-            HttpRequestError::ApiError { body, .. } => self
-                .describe_error_body(body)
-                .unwrap_or_else(|| body.to_string()),
+        let (detail, transient) = match &e {
+            HttpRequestError::ApiError { status, body } => (
+                self.describe_error_body(body)
+                    .unwrap_or_else(|| body.to_string()),
+                self.is_transient_response(*status, body),
+            ),
             // A reqwest error names the request it was making, never why it failed: the reason
             // (refused, DNS, TLS) lives one link down the source chain.
-            other => error_source_chain(other),
+            other => (error_source_chain(other), false),
         };
-        self.external_error(e.status(), detail)
+        self.external_error_inner(e.status(), detail, transient)
     }
 
     fn external_error(&self, status: Option<StatusCode>, detail: String) -> Error {
+        self.external_error_inner(status, detail, false)
+    }
+
+    fn external_error_inner(
+        &self,
+        status: Option<StatusCode>,
+        detail: String,
+        transient: bool,
+    ) -> Error {
         to_anyhow(ExternalApiError {
             service: Self::DISPLAY_NAME,
             status,
             detail: truncate_detail(&detail),
-            hint: status.and_then(|s| self.error_hint(s)),
+            // Guidance about permissions on a throttled request sends the reader after a
+            // problem they do not have.
+            hint: if transient {
+                None
+            } else {
+                status.and_then(|s| self.error_hint(s))
+            },
+            transient,
         })
         .into()
     }
@@ -490,12 +514,21 @@ pub struct ExternalApiError {
     pub status: Option<StatusCode>,
     pub detail: String,
     pub hint: Option<&'static str>,
+    /// The service could not serve the request now, whatever the status suggests: providers
+    /// overload 403 for throttling, and a refusal and an outage want opposite reactions.
+    pub transient: bool,
+}
+
+impl ExternalApiError {
+    fn is_transient(&self) -> bool {
+        self.transient || self.status.is_some_and(is_transient_status)
+    }
 }
 
 impl std::fmt::Display for ExternalApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.status {
-            Some(status) if is_transient(status) => write!(
+            Some(status) if self.is_transient() => write!(
                 f,
                 "{} failed to serve the request ({}): {}",
                 self.service, status, self.detail
@@ -693,23 +726,24 @@ pub fn map_external_error(e: Error) -> Error {
 
 /// `map_external_error` with a chance to add what the failure means for Windmill's own state.
 pub fn map_external_error_with(e: Error, decorate: impl FnOnce(String) -> String) -> Error {
-    let Some((status, message)) = as_external_error(&e).map(|ext| (ext.status, ext.to_string()))
+    let Some((status, transient, message)) =
+        as_external_error(&e).map(|ext| (ext.status, ext.is_transient(), ext.to_string()))
     else {
         return e;
     };
     let message = decorate(message);
     match status {
-        Some(StatusCode::NOT_FOUND) => Error::NotFound(message),
         // A refusal is the caller's to fix; being unable to serve the request now is not, and
         // the two want different reactions from whoever reads it.
-        Some(s) if is_transient(s) => Error::BadGateway(message),
+        _ if transient => Error::BadGateway(message),
+        Some(StatusCode::NOT_FOUND) => Error::NotFound(message),
         Some(_) => Error::BadRequest(message),
         // No status at all: the provider was unreachable or answered something undecodable.
         None => Error::BadGateway(message),
     }
 }
 
-fn is_transient(status: StatusCode) -> bool {
+fn is_transient_status(status: StatusCode) -> bool {
     status.is_server_error()
         || matches!(
             status,
@@ -824,23 +858,40 @@ struct RefreshTokenResponse {
 /// Why an OAuth token refresh did not produce a new token.
 #[derive(Debug)]
 pub struct RefreshFailure {
-    /// The token endpoint's own status, when it answered at all. `None` means it was never
-    /// reached, which is an outage rather than a problem with the stored credentials.
-    pub status: Option<StatusCode>,
+    /// The token endpoint refused the grant, so the stored credentials are what to fix.
+    ///
+    /// Nothing else about the answer is carried further. The status a caller reads off an
+    /// `ExternalApiError` says what the call for the *trigger* answered, and 404 there means
+    /// the trigger is gone — it records that on the row and lets a delete drop it. A wrong
+    /// base URL 404s the token endpoint while the webhook is perfectly alive.
+    pub rejected: bool,
     pub message: String,
 }
 
 #[cfg(feature = "native_trigger")]
 impl RefreshFailure {
     fn rejected(message: String) -> Self {
-        RefreshFailure { status: Some(StatusCode::UNAUTHORIZED), message }
+        RefreshFailure { rejected: true, message }
+    }
+
+    fn outage(message: String) -> Self {
+        RefreshFailure { rejected: false, message }
     }
 }
 
-/// Whether a token endpoint's body says the refresh token itself is no good, which no status
-/// reliably reports: GitHub answers `bad_refresh_token` with HTTP 200.
-pub fn body_rejects_grant(body: &str) -> bool {
-    body.contains("invalid_grant") || body.contains("bad_refresh_token")
+/// Whether a token endpoint's answer means the grant itself was refused, rather than the
+/// endpoint failing to serve a grant that may well be valid.
+///
+/// RFC 6749 §5.2 answers a refusal with 400, or 401/403 when it is the client credentials at
+/// fault. The body is checked too because no status reliably reports it: GitHub answers
+/// `bad_refresh_token` with HTTP 200.
+pub fn grant_refused(status: Option<StatusCode>, body: &str) -> bool {
+    body.contains("invalid_grant")
+        || body.contains("bad_refresh_token")
+        || matches!(
+            status,
+            Some(StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+        )
 }
 
 #[cfg(feature = "native_trigger")]
@@ -850,31 +901,15 @@ fn refresh_failure_from(e: ExecuteError) -> RefreshFailure {
         // nothing, and it is the only place the reason is written down.
         ExecuteError::BadResponse { status, body, .. } => {
             let body = String::from_utf8_lossy(body);
-            let status = if body_rejects_grant(&body) {
-                Some(StatusCode::UNAUTHORIZED)
+            let message = format!("{e}: {body}");
+            if grant_refused(Some(*status), &body) {
+                RefreshFailure::rejected(message)
             } else {
-                Some(*status)
-            };
-            RefreshFailure { status, message: format!("{status_text}: {body}", status_text = e) }
+                RefreshFailure::outage(message)
+            }
         }
-        _ => RefreshFailure { status: e.status(), message: error_source_chain(&e) },
-    }
-}
-
-/// How to report a token endpoint's answer to a refresh.
-///
-/// The status on an `ExternalApiError` says what the call for the *trigger* answered, and 404
-/// there means the trigger is gone — it records that on the row and lets a delete drop it. A
-/// token endpoint's status carries none of that meaning (a wrong base URL 404s it while the
-/// webhook is perfectly alive), so only a refused grant is translated, to the 401 that earns
-/// the reconnect hint. Everything else is reported with no status, as the outage it is.
-pub fn refresh_failure_status(status: Option<StatusCode>) -> Option<StatusCode> {
-    match status {
-        // RFC 6749 §5.2: a refused grant answers 400, or 401/403 for client authentication.
-        Some(StatusCode::BAD_REQUEST | StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) => {
-            Some(StatusCode::UNAUTHORIZED)
-        }
-        _ => None,
+        _ if grant_refused(e.status(), "") => RefreshFailure::rejected(error_source_chain(&e)),
+        _ => RefreshFailure::outage(error_source_chain(&e)),
     }
 }
 
@@ -892,18 +927,10 @@ pub async fn refresh_oauth_tokens(
 
     // Build OAuth client for token refresh
     // Auth URL is not used for refresh, but required by the client constructor
-    let auth_url =
-        Url::parse(&resolve_endpoint(&oauth_config.base_url, auth_endpoint)).map_err(|e| {
-            RefreshFailure {
-                status: Some(StatusCode::BAD_REQUEST),
-                message: format!("invalid auth URL: {e}"),
-            }
-        })?;
+    let auth_url = Url::parse(&resolve_endpoint(&oauth_config.base_url, auth_endpoint))
+        .map_err(|e| RefreshFailure::outage(format!("invalid auth URL: {e}")))?;
     let token_url = Url::parse(&resolve_endpoint(&oauth_config.base_url, refresh_endpoint))
-        .map_err(|e| RefreshFailure {
-            status: Some(StatusCode::BAD_REQUEST),
-            message: format!("invalid token URL: {e}"),
-        })?;
+        .map_err(|e| RefreshFailure::outage(format!("invalid token URL: {e}")))?;
 
     let mut client = OClient::new(oauth_config.client_id.clone(), auth_url, token_url);
     client.set_client_secret(oauth_config.client_secret.clone());
@@ -934,7 +961,7 @@ pub async fn refresh_oauth_tokens(
     _auth_endpoint: &str,
 ) -> std::result::Result<OAuthConfig, RefreshFailure> {
     Err(RefreshFailure {
-        status: None,
+        rejected: false,
         message: "the native_trigger feature is not enabled".to_string(),
     })
 }

--- a/backend/windmill-native-triggers/src/nextcloud/external.rs
+++ b/backend/windmill-native-triggers/src/nextcloud/external.rs
@@ -315,19 +315,18 @@ impl External for NextCloud {
         Some(ocs.ocs.meta.message).filter(|m| !m.is_empty())
     }
 
+    /// Appended to every failed call of this service, so a hint may not assert what the caller
+    /// was doing — only name the requirement that most often explains the status.
     fn error_hint(&self, status: StatusCode) -> Option<&'static str> {
         match status {
             StatusCode::UNAUTHORIZED => {
                 Some("reconnect the Nextcloud integration from Workspace settings > Integrations.")
             }
             StatusCode::FORBIDDEN => Some(
-                "only a Nextcloud administrator may manage webhook listeners, and being a \
-                 Windmill admin does not count. Reconnect the integration from Workspace \
-                 settings > Integrations as a Nextcloud account that is an admin there or holds \
-                 delegated admin rights for the Webhooks setting.",
-            ),
-            StatusCode::NOT_FOUND => Some(
-                "the webhook no longer exists in Nextcloud and can be recreated from Windmill.",
+                "Nextcloud grants webhook management to administrators only, and a Windmill \
+                 admin is a different thing. If the connected Nextcloud account is not an admin \
+                 there and holds no delegated admin rights for the Webhooks setting, reconnect \
+                 the integration from Workspace settings > Integrations with one that does.",
             ),
             _ => None,
         }

--- a/backend/windmill-native-triggers/src/nextcloud/external.rs
+++ b/backend/windmill-native-triggers/src/nextcloud/external.rs
@@ -317,7 +317,10 @@ impl External for NextCloud {
 
     fn error_hint(&self, status: StatusCode) -> Option<&'static str> {
         match status {
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Some(
+            StatusCode::UNAUTHORIZED => {
+                Some("reconnect the Nextcloud integration from Workspace settings > Integrations.")
+            }
+            StatusCode::FORBIDDEN => Some(
                 "only a Nextcloud administrator may manage webhook listeners, and being a \
                  Windmill admin does not count. Reconnect the integration from Workspace \
                  settings > Integrations as a Nextcloud account that is an admin there or holds \

--- a/backend/windmill-native-triggers/src/nextcloud/external.rs
+++ b/backend/windmill-native-triggers/src/nextcloud/external.rs
@@ -9,13 +9,14 @@ use windmill_common::{
 };
 
 use crate::{
-    generate_webhook_service_url,
+    generate_webhook_service_url, http_error_status,
     nextcloud::{
         routes, NextCloud, NextCloudOAuthData, NextCloudTriggerData, NextcloudServiceConfig,
         OcsResponse,
     },
     External, NativeTriggerData, ServiceName,
 };
+use http::StatusCode;
 
 lazy_static::lazy_static! {
     pub static ref TOKEN_NEEDED: Box<serde_json::value::RawValue> = to_raw_value(&serde_json::json!({
@@ -235,11 +236,13 @@ impl External for NextCloud {
         let mut headers = HashMap::new();
         headers.insert("OCS-APIRequest".to_string(), "true".to_string());
 
+        // A webhook already removed in Nextcloud is the outcome this call wants, so only 404 is
+        // swallowed; anything else would leave a live webhook behind while Windmill forgets it.
         let _: serde_json::Value = self
             .http_client_request::<_, ()>(&url, Method::DELETE, w_id, db, Some(headers), None)
             .await
-            .or_else(|e| match &e {
-                Error::InternalErr(msg) if msg.contains("404") => Ok(serde_json::Value::Null),
+            .or_else(|e| match http_error_status(&e) {
+                Some(StatusCode::NOT_FOUND) => Ok(serde_json::Value::Null),
                 _ => Err(e),
             })?;
 
@@ -265,7 +268,10 @@ impl External for NextCloud {
                 );
                 errors.push(crate::sync::SyncError {
                     resource_path: format!("workspace:{}", workspace_id),
-                    error_message: format!("Failed to fetch external triggers: {}", e),
+                    error_message: format!(
+                        "Failed to fetch external triggers: {}",
+                        crate::external_error_message(&e)
+                    ),
                     error_type: "external_service_error".to_string(),
                 });
                 return;
@@ -302,6 +308,26 @@ impl External for NextCloud {
 
     fn additional_routes(&self) -> axum::Router {
         routes::nextcloud_routes(self.clone())
+    }
+
+    fn describe_error_body(&self, body: &str) -> Option<String> {
+        let ocs: OcsResponse<serde_json::Value> = serde_json::from_str(body).ok()?;
+        Some(ocs.ocs.meta.message).filter(|m| !m.is_empty())
+    }
+
+    fn error_hint(&self, status: StatusCode) -> Option<&'static str> {
+        match status {
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Some(
+                "only a Nextcloud administrator may manage webhook listeners, and being a \
+                 Windmill admin does not count. Reconnect the integration from Workspace \
+                 settings > Integrations as a Nextcloud account that is an admin there or holds \
+                 delegated admin rights for the Webhooks setting.",
+            ),
+            StatusCode::NOT_FOUND => Some(
+                "the webhook no longer exists in Nextcloud and can be recreated from Windmill.",
+            ),
+            _ => None,
+        }
     }
 }
 

--- a/backend/windmill-native-triggers/src/nextcloud/routes.rs
+++ b/backend/windmill-native-triggers/src/nextcloud/routes.rs
@@ -10,7 +10,7 @@ use windmill_common::{
 use windmill_api_auth::ApiAuthed;
 
 use crate::{
-    get_workspace_integration,
+    get_workspace_integration, map_external_error,
     nextcloud::{NextCloudEventType, OcsResponse},
     require_native_integration_use, External, ServiceName,
 };
@@ -47,7 +47,8 @@ async fn list_available_events<T: External>(
             Some(headers),
             None,
         )
-        .await?;
+        .await
+        .map_err(map_external_error)?;
 
     let events = serde_json::from_str(&ocs_response.ocs.data)
         .map_err(|e| Error::InternalErr(format!("Failed to parse NextCloud events data: {}", e)))?;

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -32,7 +32,8 @@ pub type DB = sqlx::Pool<sqlx::Postgres>;
 
 // Re-export oauth2 types that consumers need (also used internally)
 pub use oauth2::{
-    helpers, AccessToken, AuthType, Client as OClient, RefreshToken, Scope, State, Url,
+    helpers, AccessToken, AuthType, Client as OClient, ExecuteError, RefreshToken, Scope, State,
+    Url,
 };
 
 // Re-export reqwest Client (version 0.12 compatible with async-oauth2)

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -32,8 +32,8 @@ pub type DB = sqlx::Pool<sqlx::Postgres>;
 
 // Re-export oauth2 types that consumers need (also used internally)
 pub use oauth2::{
-    helpers, AccessToken, AuthType, Client as OClient, ExecuteError, RefreshToken, Scope, State,
-    Url,
+    helpers, AccessToken, AuthType, Client as OClient, ErrorField, ExecuteError, RefreshToken,
+    Scope, State, Url,
 };
 
 // Re-export reqwest Client (version 0.12 compatible with async-oauth2)

--- a/frontend/src/lib/components/triggers/native/NativeTriggerEditor.svelte
+++ b/frontend/src/lib/components/triggers/native/NativeTriggerEditor.svelte
@@ -14,7 +14,7 @@
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import Drawer from '$lib/components/common/drawer/Drawer.svelte'
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
-	import { Loader2, Save } from 'lucide-svelte'
+	import { Loader2, RefreshCw, Save } from 'lucide-svelte'
 	import ScriptPicker from '$lib/components/ScriptPicker.svelte'
 	import Section from '$lib/components/Section.svelte'
 	import Required from '$lib/components/Required.svelte'
@@ -25,6 +25,7 @@
 	import { handleConfigChange, type Trigger } from '$lib/components/triggers/utils'
 	import { deepEqual } from 'fast-equals'
 	import type { Snippet } from 'svelte'
+	import Alert from '$lib/components/common/alert/Alert.svelte'
 
 	interface Props {
 		service: NativeServiceName
@@ -103,6 +104,8 @@
 	let can_write = $state(true)
 	let originalConfig = $state<Record<string, any> | undefined>(undefined)
 	let initialConfig = $state<Record<string, any> | undefined>(undefined)
+	let loadError = $state<string | undefined>(undefined)
+	let externalError = $state<string | undefined>(undefined)
 
 	export function openNew(
 		nis_flow?: boolean,
@@ -129,6 +132,8 @@
 		originalConfig = undefined
 		initialConfig = undefined
 		summary = ''
+		loadError = undefined
+		externalError = undefined
 	}
 
 	export function openRecreate(nativeTrigger: ExtendedNativeTrigger) {
@@ -153,6 +158,8 @@
 		originalConfig = undefined
 		initialConfig = undefined
 		summary = nativeTrigger.summary ?? ''
+		loadError = undefined
+		externalError = undefined
 	}
 
 	export async function openEdit(
@@ -177,6 +184,14 @@
 		originalConfig = undefined
 		initialConfig = undefined
 		itemKind = nis_flow ? 'flow' : 'script'
+		loadError = undefined
+		externalError = undefined
+		// A failed load must not leave the previously edited trigger's target and config in the
+		// form, where saving would silently repoint this trigger at them.
+		serviceConfig = {}
+		scriptPath = ''
+		initialScriptPath = ''
+		summary = ''
 
 		try {
 			const fullTrigger = await NativeTriggerService.getNativeTrigger({
@@ -191,6 +206,7 @@
 			can_write = canWrite(fullTrigger.script_path, {}, $userStore)
 			summary = fullTrigger.summary ?? ''
 			externalData = fullTrigger.external_data
+			externalError = fullTrigger.external_error ?? undefined
 
 			// Apply default values if provided (for draft triggers)
 			if (defaultValues) {
@@ -198,7 +214,8 @@
 				externalData = { ...externalData, ...defaultValues }
 			}
 		} catch (err: any) {
-			sendUserToast(`Failed to load trigger configuration: ${err}`, true)
+			loadError = err.body ?? err.message ?? String(err)
+			sendUserToast(`Failed to load trigger configuration: ${loadError}`, true)
 			externalData = null
 		} finally {
 			clearTimeout(loadingTimeout)
@@ -256,7 +273,8 @@
 			loadingConfig ||
 			loadingForm ||
 			!can_write ||
-			!hasChanged
+			!hasChanged ||
+			loadError !== undefined
 	)
 	const saveCfg = $derived.by(getSaveCfg)
 
@@ -388,12 +406,36 @@
 {#snippet content()}
 	{#if loadingConfig && showLoading}
 		<Loader2 class="animate-spin" />
+	{:else if loadError}
+		<Alert type="error" title="Could not load this {serviceInfo?.serviceDisplayName} trigger">
+			<div class="flex flex-col gap-2 items-start">
+				<span>{loadError}</span>
+				<Button
+					size="xs"
+					variant="subtle"
+					startIcon={{ icon: RefreshCw }}
+					on:click={() => externalId && openEdit(externalId, isFlow)}
+				>
+					Retry
+				</Button>
+			</div>
+		</Alert>
 	{:else}
 		<div class="flex flex-col gap-4">
 			{#if description}
 				{@render description()}
 			{/if}
 		</div>
+		{#if externalError}
+			<div class="mt-4">
+				<Alert
+					type="warning"
+					title="Could not read this trigger from {serviceInfo?.serviceDisplayName}"
+				>
+					{externalError} The configuration below is the one Windmill last saved.
+				</Alert>
+			</div>
+		{/if}
 		<div class="flex flex-col gap-12 mt-6">
 			<Section headless>
 				<div class="flex flex-col gap-6">

--- a/frontend/src/lib/components/triggers/native/NativeTriggerEditor.svelte
+++ b/frontend/src/lib/components/triggers/native/NativeTriggerEditor.svelte
@@ -106,6 +106,7 @@
 	let initialConfig = $state<Record<string, any> | undefined>(undefined)
 	let loadError = $state<string | undefined>(undefined)
 	let externalError = $state<string | undefined>(undefined)
+	let retryEdit = $state<(() => void) | undefined>(undefined)
 
 	export function openNew(
 		nis_flow?: boolean,
@@ -134,6 +135,7 @@
 		summary = ''
 		loadError = undefined
 		externalError = undefined
+		retryEdit = undefined
 	}
 
 	export function openRecreate(nativeTrigger: ExtendedNativeTrigger) {
@@ -160,6 +162,7 @@
 		summary = nativeTrigger.summary ?? ''
 		loadError = undefined
 		externalError = undefined
+		retryEdit = undefined
 	}
 
 	export async function openEdit(
@@ -186,6 +189,7 @@
 		itemKind = nis_flow ? 'flow' : 'script'
 		loadError = undefined
 		externalError = undefined
+		retryEdit = undefined
 		// A failed load must not leave the previously edited trigger's target and config in the
 		// form, where saving would silently repoint this trigger at them.
 		serviceConfig = {}
@@ -217,6 +221,11 @@
 			loadError = err.body ?? err.message ?? String(err)
 			sendUserToast(`Failed to load trigger configuration: ${loadError}`, true)
 			externalData = null
+			// The service form is not rendered in the error state, so nothing else will ever
+			// clear its loading flag or narrow the permission left over from the last trigger.
+			loadingForm = false
+			can_write = false
+			retryEdit = () => openEdit(externalIdOrPath, nis_flow, defaultValues)
 		} finally {
 			clearTimeout(loadingTimeout)
 			loadingConfig = false
@@ -407,14 +416,18 @@
 	{#if loadingConfig && showLoading}
 		<Loader2 class="animate-spin" />
 	{:else if loadError}
-		<Alert type="error" title="Could not load this {serviceInfo?.serviceDisplayName} trigger">
+		<Alert
+			type="error"
+			title="Could not load this {serviceInfo?.serviceDisplayName} trigger"
+			descriptionClass="break-words"
+		>
 			<div class="flex flex-col gap-2 items-start">
 				<span>{loadError}</span>
 				<Button
 					size="xs"
 					variant="subtle"
 					startIcon={{ icon: RefreshCw }}
-					on:click={() => externalId && openEdit(externalId, isFlow)}
+					on:click={() => retryEdit?.()}
 				>
 					Retry
 				</Button>
@@ -431,6 +444,7 @@
 				<Alert
 					type="warning"
 					title="Could not read this trigger from {serviceInfo?.serviceDisplayName}"
+					descriptionClass="break-words"
 				>
 					{externalError} The configuration below is the one Windmill last saved.
 				</Alert>

--- a/frontend/src/lib/components/triggers/native/services/nextcloud/NextcloudTriggerForm.svelte
+++ b/frontend/src/lib/components/triggers/native/services/nextcloud/NextcloudTriggerForm.svelte
@@ -35,6 +35,7 @@
 
 	let availableEvents = $state<NextCloudEventType[]>([])
 	let serviceSchema = $state<any>(null)
+	let eventsError = $state<string | undefined>(undefined)
 
 	async function loadAvailableEvents() {
 		if (!$workspaceStore) {
@@ -43,6 +44,7 @@
 		}
 
 		loading = true
+		eventsError = undefined
 		try {
 			const events = await NativeTriggerService.listNextCloudEvents({
 				workspace: $workspaceStore!
@@ -51,7 +53,8 @@
 			serviceSchema = getNextcloudSchema(events)
 		} catch (err: any) {
 			console.error('Failed to load NextCloud events:', err)
-			sendUserToast(`Failed to load available events: ${err.body || err.message}`, true)
+			eventsError = err.body || err.message || String(err)
+			sendUserToast(`Failed to load available events: ${eventsError}`, true)
 			availableEvents = []
 		} finally {
 			loading = false
@@ -108,9 +111,13 @@
 		</div>
 	{:else if availableEvents.length === 0}
 		<div class="text-red-500 text-xs space-y-2">
-			<div
-				>No events available. Please ensure your workspace has a connected Nextcloud integration.</div
-			>
+			{#if eventsError}
+				<div>Could not load the available events: {eventsError}</div>
+			{:else}
+				<div
+					>No events available. Please ensure your workspace has a connected Nextcloud integration.</div
+				>
+			{/if}
 			<div class="flex gap-2">
 				<Button variant="default" on:click={loadAvailableEvents} {disabled}>
 					Retry loading events

--- a/frontend/src/lib/components/triggers/native/services/nextcloud/NextcloudTriggerForm.svelte
+++ b/frontend/src/lib/components/triggers/native/services/nextcloud/NextcloudTriggerForm.svelte
@@ -112,7 +112,7 @@
 	{:else if availableEvents.length === 0}
 		<div class="text-red-500 text-xs space-y-2">
 			{#if eventsError}
-				<div>Could not load the available events: {eventsError}</div>
+				<div class="break-words">Could not load the available events: {eventsError}</div>
 			{:else}
 				<div
 					>No events available. Please ensure your workspace has a connected Nextcloud integration.</div


### PR DESCRIPTION
## Summary

Fixes the reporting side of #10461.

The reported failure is **not a Windmill bug**: every method of Nextcloud's `webhook_listeners`
OCS API carries `#[AuthorizedAdminSetting(settings: Admin::class)]`, so the *Nextcloud* account
behind the workspace integration must be a Nextcloud admin (or hold delegated admin rights for
the Webhooks setting). Being a Windmill superadmin or workspace admin is unrelated — which is
exactly where the reporter got stuck ("I am still the SuperAdmin for it"). An expired or revoked
token would have produced 401 (`NotLoggedInException`), so the 403 is a genuine authorization
failure on that instance.

What Windmill owns is everything about how that fact reached the user: nothing. The UI said
`ApiError: Internal Server Error`, the trigger became uneditable, and the only actionable text
lived in a server log. This PR makes provider rejections legible and non-fatal, and fixes three
defects found on the way.

## Changes

**Provider errors are typed and readable**
- New `ExternalApiError { service, status, detail, hint }` in `windmill-native-triggers`,
  produced by every `External::http_client_request` failure. It stays downcastable so internal
  callers can still branch on the status, and renders as one sentence for the user.
- Two defaulted `External` hooks: `describe_error_body` (Nextcloud unwraps the OCS envelope so
  the user reads `Logged in account must be an admin…` instead of the raw JSON) and `error_hint`
  (per service, per status — Nextcloud's 403 hint names the actual requirement and says in so
  many words that a Windmill admin is a different thing).
- `map_external_error` at every handler and route boundary: upstream 404 → `NotFound`,
  5xx/transport → `BadGateway`, other 4xx → `BadRequest`. The provider's status is deliberately
  **not** mirrored — a 401/403 answered by Windmill reads as a Windmill permission problem.
- Transport failures keep their source chain, so `Connection refused` survives instead of being
  swallowed by reqwest's `Display`.

**A rejection no longer takes the trigger down with it**
- `GET /native_triggers/{svc}/get/{id}` degrades: on any non-404 provider failure it returns
  200 with the stored `service_config` and a new `external_error` field, instead of failing the
  request outright. The editor opens on the last saved configuration with a warning banner.

**Two dead 404 checks, now live**
- `handler.rs` matched `Err(Error::NotFound(_))` and `nextcloud/external.rs` matched
  `Error::InternalErr(msg) if msg.contains("404")` — neither could ever match, because the error
  was an `Error::Anyhow`. So the "trigger no longer exists on external service" state was never
  recorded from a GET, and a trigger whose webhook had already been removed in Nextcloud could
  not be deleted from Windmill at all (500). Both now use `http_error_status`, matching how the
  GitHub service already did it.

**The OAuth refresh-and-retry is restricted to 401**
- 403 means the account is authenticated and still not allowed; minting a new token for the same
  account cannot fix it. Nextcloud rotates its refresh token on every use and the store-back runs
  in a detached task, so a 403 loop burned a rotation per request and buried the real reason. All
  three providers answer 401 for an expired or revoked token.

**Frontend**
- `NativeTriggerEditor` shows `external_error` as a warning above an editable form, and a hard
  load failure as an error alert with a Retry button *in place of* the form — a config that
  could not be loaded must not be savable. `openEdit` resets the form up front so a failure
  cannot leave the previously edited trigger's target and config behind.
- The Nextcloud event picker shows the actual API error instead of telling a user with a
  perfectly connected integration to go check their integration.

## Screenshots

Provider rejects the read (403) — editor opens on the saved config with the reason and the fix:

![after-403-warning](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/10461-trigger-error-dx/1785751569-after-403-warning-v2.png)

Webhook gone on the service (404) — recorded as missing, with a working retry:

![after-404-loaderror](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/10461-trigger-error-dx/1785750649-after-404-loaderror.png)

Service unreachable — the transport cause survives, and the event picker says what really happened:

![service-down](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/10461-trigger-error-dx/1785750651-service-down.png)

Healthy trigger, unchanged:

![healthy](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/10461-trigger-error-dx/1785750653-healthy.png)

## Test plan

Exercised end to end against a mock Nextcloud (OAuth token endpoint, `cloud/user`,
`integration_windmill` events, and `webhook_listeners` CRUD with a switchable 200/403/404 mode),
with the integration connected through the real OAuth callback flow:

- [x] 403 on read → `200` with `external_error` carrying the OCS message + hint (was `500` with the raw envelope)
- [x] 403 on save → `400` with the same message (was `500`)
- [x] 403 on delete → `400`, and the message says the trigger was kept in Windmill
- [x] 404 on read → `404`, `native_trigger.error` set to "no longer exists on external service" (this path was unreachable before)
- [x] 404 on delete → trigger actually deleted (was `500`, leaving an undeletable row)
- [x] Service down → `502` on the events route, `Connection refused` preserved in the message
- [x] All four states verified in the browser via Playwright (screenshots above)
- [x] `cargo check --features native_trigger`, `cargo test -p windmill-api-integration-tests --test native_triggers` (21 passed), `npm run check` (0 errors)

Two regression tests added, pinning what was silently broken: a provider 403 reaches the user as
the service's own sentence plus the hint rather than a 500 with a JSON envelope, and a provider
404 is recognized by `http_error_status`/`map_external_error` — the contract both the
missing-trigger branch and the delete 404-swallow depend on.

**Note on a deliberate non-change:** any upstream 404 on the read path is treated as "the trigger
is gone", so a 404 from a wrong `base_url` or a disabled `webhook_listeners` app is reported as a
missing webhook. That matches how the GitHub service has always classified 404s, is self-healing
on the next successful read, and distinguishing the two would mean threading "did the body parse
as the service's own envelope" through the generic handler. Called out rather than silently left.
Per-service `error_hint`s are worded so they never assert *which* call was refused, since one is
appended to every failed call of that service.

Fixes #10461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show clear provider errors for native triggers instead of 500s, and keep triggers editable when providers reject or are unreachable. Treat timeouts, throttling, and refresh outages correctly; addresses #10461.

- **Bug Fixes**
  - Map provider failures to readable messages via `ExternalApiError` with per‑service hints; 5xx/408/429 and throttled 403s → BadGateway, other 4xx → BadRequest; preserve transport causes; unwrap Nextcloud OCS messages; detect throttled 403s via `is_transient_response` (GitHub: “rate limit” and “abuse detection mechanism”; Google: `usageLimits` domain).
  - Degrade reads only for provider errors: `GET /native_triggers/{svc}/get/{id}` returns 200 with stored config and `external_error`; upstream 404 marks the trigger missing; internal failures still error.
  - OAuth: refresh only on 401; classify a rejected refresh by OAuth error code (`invalid_grant`/`invalid_client`) or body (e.g., GitHub `bad_refresh_token` with 200); treat others as outages; do not mirror token endpoint status into trigger responses; show reconnect hints only on refused grants.
  - Routes/UI/OpenAPI/Tests: GitHub/Google/Nextcloud routes wrap errors with `map_external_error`; editor shows `external_error` above an editable form and hard load failures with a Retry button; Nextcloud event picker shows the real API error; OpenAPI adds nullable `external_data` and `external_error`; tests cover readable errors, 404 recognition, throttling vs. refusal (incl. GitHub “abuse detection”), provider‑only read degradation, and refresh refusal by code.

<sup>Written for commit fd1d12cdb3edbaf2d56f5f1813208df0ef953c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

