### PR TITLE
fix: show the fork banner to a superadmin who is not a workspace member

### DIFF
--- a/backend/.sqlx/query-1c472a4740a41ae8985f865e15b0c4edb4d5af2281c22955121cb794428c3cde.json
+++ b/backend/.sqlx/query-1c472a4740a41ae8985f865e15b0c4edb4d5af2281c22955121cb794428c3cde.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            workspace.id AS \"id!\",\n            workspace.name AS \"name!\",\n            workspace.owner AS \"owner!\",\n            workspace.deleted AS \"deleted!\",\n            workspace.premium AS \"premium!\",\n            workspace_settings.color AS \"color\",\n            workspace.parent_workspace_id AS \"parent_workspace_id\",\n            workspace.is_dev_workspace AS \"is_dev_workspace!\",\n            workspace.dev_workspace_label AS \"dev_workspace_label\"\n        FROM workspace\n        LEFT JOIN workspace_settings ON workspace.id = workspace_settings.workspace_id\n        WHERE workspace.id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "deleted!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "premium!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "parent_workspace_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_dev_workspace!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "dev_workspace_label",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "1c472a4740a41ae8985f865e15b0c4edb4d5af2281c22955121cb794428c3cde"
+}

--- a/backend/.sqlx/query-4f266373d5acdbcedc81e8ed3eb1fb95861ef17ca5570ef06b9903f04e9adb5e.json
+++ b/backend/.sqlx/query-4f266373d5acdbcedc81e8ed3eb1fb95861ef17ca5570ef06b9903f04e9adb5e.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT workspace.id, workspace.name, workspace.owner, workspace.deleted, workspace.premium, workspace_settings.color, workspace.parent_workspace_id, workspace.is_dev_workspace, workspace.dev_workspace_label\n         FROM workspace\n         LEFT JOIN workspace_settings ON workspace.id = workspace_settings.workspace_id\n         JOIN usr ON usr.workspace_id = workspace.id\n         WHERE usr.email = $1 AND workspace.deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "premium",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "parent_workspace_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_dev_workspace",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "dev_workspace_label",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "4f266373d5acdbcedc81e8ed3eb1fb95861ef17ca5570ef06b9903f04e9adb5e"
+}

--- a/backend/.sqlx/query-8c33cbe3dc0a7539835fab61f981f5117da38c3410ad6e34ad67f5441deaf89e.json
+++ b/backend/.sqlx/query-8c33cbe3dc0a7539835fab61f981f5117da38c3410ad6e34ad67f5441deaf89e.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            workspace.id AS \"id!\",\n            workspace.name AS \"name!\",\n            workspace.owner AS \"owner!\",\n            workspace.deleted AS \"deleted!\",\n            workspace.premium AS \"premium!\",\n            workspace_settings.color AS \"color\",\n            workspace.parent_workspace_id AS \"parent_workspace_id\",\n            workspace.is_dev_workspace AS \"is_dev_workspace!\",\n            workspace.dev_workspace_label AS \"dev_workspace_label\"\n        FROM workspace\n        LEFT JOIN workspace_settings ON workspace.id = workspace_settings.workspace_id\n         LIMIT $1 OFFSET $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "deleted!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "premium!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "color",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "parent_workspace_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_dev_workspace!",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "dev_workspace_label",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "8c33cbe3dc0a7539835fab61f981f5117da38c3410ad6e34ad67f5441deaf89e"
+}

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -247,6 +247,8 @@ struct Workspace {
     premium: bool,
     color: Option<String>,
     parent_workspace_id: Option<String>,
+    is_dev_workspace: bool,
+    dev_workspace_label: Option<String>,
 }
 
 #[derive(FromRow, Serialize, Debug)]
@@ -749,7 +751,7 @@ async fn list_workspaces(
     let mut tx = user_db.begin(&authed).await?;
     let workspaces = sqlx::query_as!(
         Workspace,
-        "SELECT workspace.id, workspace.name, workspace.owner, workspace.deleted, workspace.premium, workspace_settings.color, workspace.parent_workspace_id
+        "SELECT workspace.id, workspace.name, workspace.owner, workspace.deleted, workspace.premium, workspace_settings.color, workspace.parent_workspace_id, workspace.is_dev_workspace, workspace.dev_workspace_label
          FROM workspace
          LEFT JOIN workspace_settings ON workspace.id = workspace_settings.workspace_id
          JOIN usr ON usr.workspace_id = workspace.id
@@ -4827,7 +4829,9 @@ async fn get_workspace_as_superadmin(
             workspace.deleted AS \"deleted!\",
             workspace.premium AS \"premium!\",
             workspace_settings.color AS \"color\",
-            workspace.parent_workspace_id AS \"parent_workspace_id\"
+            workspace.parent_workspace_id AS \"parent_workspace_id\",
+            workspace.is_dev_workspace AS \"is_dev_workspace!\",
+            workspace.dev_workspace_label AS \"dev_workspace_label\"
         FROM workspace
         LEFT JOIN workspace_settings ON workspace.id = workspace_settings.workspace_id
         WHERE workspace.id = $1",
@@ -4861,7 +4865,9 @@ async fn list_workspaces_as_super_admin(
             workspace.deleted AS \"deleted!\",
             workspace.premium AS \"premium!\",
             workspace_settings.color AS \"color\",
-            workspace.parent_workspace_id AS \"parent_workspace_id\"
+            workspace.parent_workspace_id AS \"parent_workspace_id\",
+            workspace.is_dev_workspace AS \"is_dev_workspace!\",
+            workspace.dev_workspace_label AS \"dev_workspace_label\"
         FROM workspace
         LEFT JOIN workspace_settings ON workspace.id = workspace_settings.workspace_id
          LIMIT $1 OFFSET $2",
@@ -5966,7 +5972,14 @@ async fn clone_scripts(
     .execute(&mut **tx)
     .await?;
 
-    clear_orphaned_compat_address(tx, "script", "hash", source_workspace_id, target_workspace_id).await?;
+    clear_orphaned_compat_address(
+        tx,
+        "script",
+        "hash",
+        source_workspace_id,
+        target_workspace_id,
+    )
+    .await?;
 
     Ok(())
 }
@@ -6204,7 +6217,8 @@ async fn clone_flows(
     .execute(&mut **tx)
     .await?;
 
-    clear_orphaned_compat_address(tx, "flow", "path", source_workspace_id, target_workspace_id).await?;
+    clear_orphaned_compat_address(tx, "flow", "path", source_workspace_id, target_workspace_id)
+        .await?;
 
     // Then clone flow versions
     let flow_versions = sqlx::query!(

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -30923,6 +30923,12 @@ components:
         parent_workspace_id:
           type: string
           nullable: true
+        is_dev_workspace:
+          type: boolean
+        dev_workspace_label:
+          type: string
+          nullable: true
+          description: "Cosmetic display label of the dev workspace ('dev' | 'staging'); null defaults to 'dev'"
       required:
         - id
         - name

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -30923,6 +30923,9 @@ components:
         parent_workspace_id:
           type: string
           nullable: true
+        deleted:
+          type: boolean
+          description: "Archived (soft-deleted) workspace"
         is_dev_workspace:
           type: boolean
         dev_workspace_label:

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -167,15 +167,21 @@
 	     stays aligned with it instead of bleeding to the viewport edges. -->
 	<div class="w-full text-xs max-w-7xl mx-auto px-4 sm:px-8 pt-2">
 		<div class="bg-blue-50 dark:bg-blue-900 rounded-md px-4 py-2">
-			<div class="flex items-center justify-between">
-				<div class="flex items-center gap-3">
-					<GitFork class="w-4 h-4 text-accent" />
-					<div class="text-sm">
+			<!-- The summary wraps inside its own column while the CTA keeps its width and
+			     stays on the first line: laid out as one non-wrapping row, the summary is
+			     long enough on a laptop-width viewport to push the button out of the
+			     banner instead of getting shorter. -->
+			<div class="flex items-center justify-between gap-x-3">
+				<div class="flex items-center flex-wrap gap-x-3 gap-y-1 min-w-0">
+					<GitFork class="w-4 h-4 text-accent shrink-0" />
+					<div class="text-sm min-w-0">
 						<span class="font-medium text-blue-900 dark:text-blue-100">
 							{isDevWorkspace
 								? `${devLabelWord(currentWorkspaceData?.dev_workspace_label)} workspace of`
 								: 'Fork of'}
-							<b>{parentWorkspaceData?.name}</b> ({parentWorkspaceId})
+							<b>{parentWorkspaceData?.name}</b
+							>{#if parentWorkspaceData?.name !== parentWorkspaceId}
+								({parentWorkspaceId}){/if}
 						</span>
 					</div>
 
@@ -186,7 +192,7 @@
 							{error}
 						</span>
 					{:else if comparison}
-						<div class="flex items-center gap-4 text-xs">
+						<div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-xs min-w-0">
 							{#if comparison.summary.total_diffs > 0}
 								<span class="text-blue-700 dark:text-blue-100">
 									{forkAheadBehindMessage(
@@ -194,9 +200,14 @@
 										comparison.summary.total_behind
 									)}
 									<span class="font-semibold underline">{parentWorkspaceId}</span> over {comparison
-										.summary.total_diffs} items:
+										.summary.total_diffs} items<span class="hidden lg:inline">:</span>
 								</span>
-								<div class="flex items-center gap-2">
+								<!-- The per-kind breakdown is the first thing to go on a narrow
+								     viewport: the item total above already sizes the change set, and
+								     the compare page carries the detail. -->
+								<div
+									class="hidden lg:flex items-center flex-wrap gap-x-2 gap-y-1 whitespace-nowrap"
+								>
 									{#if comparison.summary.scripts_changed > 0}
 										<span class="text-blue-700 dark:text-blue-100">
 											{comparison.summary.scripts_changed} script{comparison.summary
@@ -272,17 +283,23 @@
 								{#if ciTestTotal > 0}
 									-
 									{#if ciTestFailing > 0}
-										<div class="flex items-center gap-1 text-red-600 dark:text-red-400">
+										<div
+											class="flex items-center gap-1 text-red-600 dark:text-red-400 whitespace-nowrap"
+										>
 											<CircleX class="w-3 h-3" />
 											<span>CI: {ciTestFailing} failing</span>
 										</div>
 									{:else if ciTestRunning > 0}
-										<div class="flex items-center gap-1 text-yellow-600 dark:text-yellow-400">
+										<div
+											class="flex items-center gap-1 text-yellow-600 dark:text-yellow-400 whitespace-nowrap"
+										>
 											<Loader2 class="w-3 h-3 animate-spin" />
 											<span>CI: {ciTestRunning} running</span>
 										</div>
 									{:else}
-										<div class="flex items-center gap-1 text-green-600 dark:text-green-400">
+										<div
+											class="flex items-center gap-1 text-green-600 dark:text-green-400 whitespace-nowrap"
+										>
 											<CircleCheck class="w-3 h-3" />
 											<span>CI: {ciTestPassing} passing</span>
 										</div>
@@ -291,7 +308,9 @@
 
 								{#if comparison.summary.conflicts > 0}
 									-
-									<div class="flex items-center gap-1 text-orange-600 dark:text-orange-400">
+									<div
+										class="flex items-center gap-1 text-orange-600 dark:text-orange-400 whitespace-nowrap"
+									>
 										<AlertTriangle class="w-3 h-3" />
 										<span
 											>{comparison.summary.conflicts} conflict{comparison.summary.conflicts !== 1
@@ -316,7 +335,7 @@
 					{/if}
 				</div>
 
-				<div class="flex items-center gap-2">
+				<div class="flex items-center gap-2 shrink-0">
 					<Button
 						variant="default"
 						unifiedSize="sm"

--- a/frontend/src/lib/components/WorkspaceDraftsBanner.svelte
+++ b/frontend/src/lib/components/WorkspaceDraftsBanner.svelte
@@ -33,9 +33,9 @@
 	     stays aligned with it instead of bleeding to the viewport edges. -->
 	<div class="w-full text-xs max-w-7xl mx-auto px-4 sm:px-8 pt-2">
 		<div class="bg-blue-50 dark:bg-blue-900 rounded-md px-4 py-2">
-			<div class="flex items-center justify-between">
-				<div class="flex items-center gap-3">
-					<Pencil class="w-4 h-4 text-accent" />
+			<div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+				<div class="flex items-center gap-3 min-w-0">
+					<Pencil class="w-4 h-4 text-accent shrink-0" />
 					<span class="text-xs font-medium text-blue-900 dark:text-blue-100">
 						This workspace has {draftCount} draft{draftCount !== 1 ? 's' : ''}
 					</span>

--- a/frontend/src/lib/nonMemberWorkspaces.test.ts
+++ b/frontend/src/lib/nonMemberWorkspaces.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { get } from 'svelte/store'
+import {
+	nonMemberWorkspaces,
+	setNonMemberWorkspaces,
+	superadmin,
+	userWorkspaces,
+	usersWorkspaceStore
+} from './stores'
+import type { Workspace } from './gen'
+
+function workspace(id: string, extra: Partial<Workspace> = {}): Workspace {
+	return { id, name: id, owner: 'admin@windmill.dev', ...extra } as Workspace
+}
+
+beforeEach(() => {
+	usersWorkspaceStore.set(undefined)
+	superadmin.set(undefined)
+	setNonMemberWorkspaces([])
+})
+
+describe('setNonMemberWorkspaces', () => {
+	it('merges the resolved workspaces into userWorkspaces with their fork lineage', () => {
+		setNonMemberWorkspaces([
+			workspace('dev', { parent_workspace_id: 'prod', is_dev_workspace: true })
+		])
+		expect(get(userWorkspaces)).toMatchObject([
+			{ id: 'dev', parent_workspace_id: 'prod', is_dev_workspace: true }
+		])
+	})
+
+	it('never offers an archived workspace', () => {
+		setNonMemberWorkspaces([workspace('archived-fork', { deleted: true })])
+		expect(get(userWorkspaces)).toEqual([])
+	})
+
+	it('replaces the previous set rather than accumulating across workspace switches', () => {
+		setNonMemberWorkspaces([workspace('fork-a')])
+		setNonMemberWorkspaces([workspace('fork-b')])
+		expect(get(userWorkspaces).map((w) => w.id)).toEqual(['fork-b'])
+	})
+
+	// Effects that resolve the current workspace depend on `userWorkspaces`; re-emitting
+	// an unchanged set would re-run them, which re-resolves, which emits again.
+	it('keeps the same object when the ids are unchanged', () => {
+		setNonMemberWorkspaces([workspace('fork-a')])
+		const first = get(nonMemberWorkspaces)
+		setNonMemberWorkspaces([workspace('fork-a')])
+		expect(get(nonMemberWorkspaces)).toBe(first)
+	})
+
+	it('does not duplicate a workspace the user is a member of', () => {
+		usersWorkspaceStore.set({
+			email: 'admin@windmill.dev',
+			workspaces: [{ id: 'dev', name: 'dev', username: 'admin', color: '', disabled: false }]
+		} as any)
+		setNonMemberWorkspaces([workspace('dev')])
+		expect(get(userWorkspaces).map((w) => w.id)).toEqual(['dev'])
+	})
+})

--- a/frontend/src/lib/nonMemberWorkspaces.test.ts
+++ b/frontend/src/lib/nonMemberWorkspaces.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { get } from 'svelte/store'
 import {
+	clearNonMemberWorkspaces,
 	nonMemberWorkspaces,
 	setNonMemberWorkspaces,
 	superadmin,
@@ -16,37 +17,32 @@ function workspace(id: string, extra: Partial<Workspace> = {}): Workspace {
 beforeEach(() => {
 	usersWorkspaceStore.set(undefined)
 	superadmin.set(undefined)
-	setNonMemberWorkspaces([])
+	nonMemberWorkspaces.set(undefined)
 })
 
-describe('setNonMemberWorkspaces', () => {
+describe('nonMemberWorkspaces', () => {
 	it('merges the resolved workspaces into userWorkspaces with their fork lineage', () => {
-		setNonMemberWorkspaces([
-			workspace('dev', { parent_workspace_id: 'prod', is_dev_workspace: true })
+		setNonMemberWorkspaces('dev', [
+			workspace('dev', { parent_workspace_id: 'prod', is_dev_workspace: true }),
+			workspace('prod')
 		])
 		expect(get(userWorkspaces)).toMatchObject([
-			{ id: 'dev', parent_workspace_id: 'prod', is_dev_workspace: true }
+			{ id: 'dev', parent_workspace_id: 'prod', is_dev_workspace: true },
+			{ id: 'prod' }
 		])
 	})
 
-	it('never offers an archived workspace', () => {
-		setNonMemberWorkspaces([workspace('archived-fork', { deleted: true })])
+	it('never offers an archived workspace, and still marks it resolved', () => {
+		setNonMemberWorkspaces('archived-fork', [workspace('archived-fork', { deleted: true })])
 		expect(get(userWorkspaces)).toEqual([])
+		// Without this the layout re-fetches the archived workspace on every effect pass.
+		expect(get(nonMemberWorkspaces)?.forWorkspace).toBe('archived-fork')
 	})
 
-	it('replaces the previous set rather than accumulating across workspace switches', () => {
-		setNonMemberWorkspaces([workspace('fork-a')])
-		setNonMemberWorkspaces([workspace('fork-b')])
+	it('replaces the previous workspace set rather than accumulating across switches', () => {
+		setNonMemberWorkspaces('fork-a', [workspace('fork-a')])
+		setNonMemberWorkspaces('fork-b', [workspace('fork-b')])
 		expect(get(userWorkspaces).map((w) => w.id)).toEqual(['fork-b'])
-	})
-
-	// Effects that resolve the current workspace depend on `userWorkspaces`; re-emitting
-	// an unchanged set would re-run them, which re-resolves, which emits again.
-	it('keeps the same object when the ids are unchanged', () => {
-		setNonMemberWorkspaces([workspace('fork-a')])
-		const first = get(nonMemberWorkspaces)
-		setNonMemberWorkspaces([workspace('fork-a')])
-		expect(get(nonMemberWorkspaces)).toBe(first)
 	})
 
 	it('does not duplicate a workspace the user is a member of', () => {
@@ -54,7 +50,21 @@ describe('setNonMemberWorkspaces', () => {
 			email: 'admin@windmill.dev',
 			workspaces: [{ id: 'dev', name: 'dev', username: 'admin', color: '', disabled: false }]
 		} as any)
-		setNonMemberWorkspaces([workspace('dev')])
+		setNonMemberWorkspaces('dev', [workspace('dev')])
 		expect(get(userWorkspaces).map((w) => w.id)).toEqual(['dev'])
+	})
+
+	// The layout effect that fills this store also reads it, and its member path — every
+	// ordinary user, every pass — clears it. So the empty state must be one Svelte won't
+	// re-notify for: an object value always notifies, however equal, and the effect would
+	// then invalidate itself forever.
+	it('does not notify when clearing an already empty store', () => {
+		let notifications = 0
+		const unsubscribe = userWorkspaces.subscribe(() => notifications++)
+		notifications = 0
+		clearNonMemberWorkspaces()
+		clearNonMemberWorkspaces()
+		expect(notifications).toBe(0)
+		unsubscribe()
 	})
 })

--- a/frontend/src/lib/storeUtils.ts
+++ b/frontend/src/lib/storeUtils.ts
@@ -4,6 +4,7 @@ import {
 	workspaceStore,
 	userStore,
 	usersWorkspaceStore,
+	nonMemberWorkspaces,
 	superadmin,
 	devopsRole,
 	clearWorkspaceFromStorage
@@ -36,6 +37,7 @@ export function clearStores(): void {
 	userStore.set(undefined)
 	workspaceStore.set(undefined)
 	usersWorkspaceStore.set(undefined)
+	nonMemberWorkspaces.set({})
 	refreshSuperadmin.cancel()
 	superadmin.set(undefined)
 	devopsRole.set(undefined)

--- a/frontend/src/lib/storeUtils.ts
+++ b/frontend/src/lib/storeUtils.ts
@@ -37,7 +37,7 @@ export function clearStores(): void {
 	userStore.set(undefined)
 	workspaceStore.set(undefined)
 	usersWorkspaceStore.set(undefined)
-	nonMemberWorkspaces.set({})
+	nonMemberWorkspaces.set(undefined)
 	refreshSuperadmin.cancel()
 	superadmin.set(undefined)
 	devopsRole.set(undefined)

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -93,35 +93,39 @@ export const lspTokenStore = writable<string | undefined>(undefined)
 export const hubBaseUrlStore = writable<string>(DEFAULT_HUB_BASE_URL)
 export const wsBaseUrlStore = writable<string | undefined>(undefined)
 export const disableHubStore = writable<boolean>(false)
-// Workspaces a superadmin opened without being a member of them. `listUserWorkspaces`
-// is membership-gated, so they are absent from `usersWorkspaceStore` and every
-// `$userWorkspaces` lookup for the current workspace comes back undefined — which
-// reads as "root workspace with no parent", hiding the fork banner and leaving the
-// compare page without a deploy target. Filled in on demand from
-// `getWorkspaceAsSuperAdmin` (see the logged layout).
+// The workspace a superadmin is currently in without being a member of it, plus its
+// parent — `listUserWorkspaces` is membership-gated, so `$userWorkspaces` would miss
+// them and every fork lookup would read the workspace as a parentless root. Holds only
+// what the current workspace needs: entries kept past a switch would go on presenting
+// themselves as memberships (workspace picker, workspace-family lookups).
 export const nonMemberWorkspaces = writable<Record<string, UserWorkspace>>({})
 
-/** Idempotent so repeated resolutions of the same workspace don't churn `userWorkspaces`. */
-export function rememberNonMemberWorkspace(workspace: Workspace): void {
-	nonMemberWorkspaces.update((cur) =>
-		cur[workspace.id]
-			? cur
-			: {
-					...cur,
-					[workspace.id]: {
-						id: workspace.id,
-						name: workspace.name,
-						// No `usr` row here, hence no per-workspace username — same stand-in
-						// as the synthetic `admins` entry below.
-						username: 'superadmin',
-						color: workspace.color,
-						parent_workspace_id: workspace.parent_workspace_id,
-						is_dev_workspace: workspace.is_dev_workspace,
-						dev_workspace_label: workspace.dev_workspace_label,
-						disabled: false
-					}
-				}
-	)
+/**
+ * Replaces the set, dropping archived/deleted workspaces — `userWorkspaces` must never
+ * offer one. A no-op when the same ids are already held, so re-resolving cannot loop
+ * against effects that depend on `userWorkspaces`.
+ */
+export function setNonMemberWorkspaces(workspaces: Workspace[]): void {
+	nonMemberWorkspaces.update((cur) => {
+		const next: Record<string, UserWorkspace> = {}
+		for (const w of workspaces.filter((w) => !w.deleted)) {
+			next[w.id] = {
+				id: w.id,
+				name: w.name,
+				// No `usr` row here, hence no per-workspace username — same stand-in as the
+				// synthetic `admins` entry below.
+				username: 'superadmin',
+				color: w.color,
+				parent_workspace_id: w.parent_workspace_id,
+				is_dev_workspace: w.is_dev_workspace,
+				dev_workspace_label: w.dev_workspace_label,
+				disabled: false
+			}
+		}
+		const curIds = Object.keys(cur)
+		const nextIds = Object.keys(next)
+		return curIds.length === nextIds.length && nextIds.every((id) => id in cur) ? cur : next
+	})
 }
 
 export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -93,25 +93,56 @@ export const lspTokenStore = writable<string | undefined>(undefined)
 export const hubBaseUrlStore = writable<string>(DEFAULT_HUB_BASE_URL)
 export const wsBaseUrlStore = writable<string | undefined>(undefined)
 export const disableHubStore = writable<boolean>(false)
-export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(
-	[usersWorkspaceStore, superadmin],
-	([store, superadmin]) => {
-		const originalWorkspaces = store?.workspaces ?? []
-		if (superadmin) {
-			return [
-				...originalWorkspaces.filter((x) => x.id != 'admins'),
-				{
-					id: 'admins',
-					name: 'Admins',
-					username: 'superadmin',
-					color: undefined,
-					operator_settings: undefined,
-					disabled: false
+// Workspaces a superadmin opened without being a member of them. `listUserWorkspaces`
+// is membership-gated, so they are absent from `usersWorkspaceStore` and every
+// `$userWorkspaces` lookup for the current workspace comes back undefined — which
+// reads as "root workspace with no parent", hiding the fork banner and leaving the
+// compare page without a deploy target. Filled in on demand from
+// `getWorkspaceAsSuperAdmin` (see the logged layout).
+export const nonMemberWorkspaces = writable<Record<string, UserWorkspace>>({})
+
+/** Idempotent so repeated resolutions of the same workspace don't churn `userWorkspaces`. */
+export function rememberNonMemberWorkspace(workspace: Workspace): void {
+	nonMemberWorkspaces.update((cur) =>
+		cur[workspace.id]
+			? cur
+			: {
+					...cur,
+					[workspace.id]: {
+						id: workspace.id,
+						name: workspace.name,
+						// No `usr` row here, hence no per-workspace username — same stand-in
+						// as the synthetic `admins` entry below.
+						username: 'superadmin',
+						color: workspace.color,
+						parent_workspace_id: workspace.parent_workspace_id,
+						is_dev_workspace: workspace.is_dev_workspace,
+						dev_workspace_label: workspace.dev_workspace_label,
+						disabled: false
+					}
 				}
-			]
-		} else {
-			return originalWorkspaces
-		}
+	)
+}
+
+export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(
+	[usersWorkspaceStore, superadmin, nonMemberWorkspaces],
+	([store, superadmin, nonMember]) => {
+		const originalWorkspaces = store?.workspaces ?? []
+		const workspaces = superadmin
+			? [
+					...originalWorkspaces.filter((x) => x.id != 'admins'),
+					{
+						id: 'admins',
+						name: 'Admins',
+						username: 'superadmin',
+						color: undefined,
+						operator_settings: undefined,
+						disabled: false
+					}
+				]
+			: originalWorkspaces
+		const extra = Object.values(nonMember).filter((w) => !workspaces.some((x) => x.id === w.id))
+		return extra.length > 0 ? [...workspaces, ...extra] : workspaces
 	}
 )
 

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -1,5 +1,5 @@
 import { BROWSER } from 'esm-env'
-import { derived, type Readable, writable } from 'svelte/store'
+import { derived, get, type Readable, writable } from 'svelte/store'
 
 import type { IntrospectionQuery } from 'graphql'
 import {
@@ -93,23 +93,26 @@ export const lspTokenStore = writable<string | undefined>(undefined)
 export const hubBaseUrlStore = writable<string>(DEFAULT_HUB_BASE_URL)
 export const wsBaseUrlStore = writable<string | undefined>(undefined)
 export const disableHubStore = writable<boolean>(false)
-// The workspace a superadmin is currently in without being a member of it, plus its
-// parent — `listUserWorkspaces` is membership-gated, so `$userWorkspaces` would miss
-// them and every fork lookup would read the workspace as a parentless root. Holds only
-// what the current workspace needs: entries kept past a switch would go on presenting
-// themselves as memberships (workspace picker, workspace-family lookups).
-export const nonMemberWorkspaces = writable<Record<string, UserWorkspace>>({})
+// What a superadmin standing in a workspace they are not a member of needs to see it as a
+// fork: the workspace itself and its parent. `listUserWorkspaces` is membership-gated, so
+// `$userWorkspaces` would miss them and every fork lookup would read the workspace as a
+// parentless root. Owned by exactly one workspace (`forWorkspace`) — held past a switch,
+// these would go on presenting themselves as memberships (picker, workspace-family lookups).
+export const nonMemberWorkspaces = writable<
+	{ forWorkspace: string; workspaces: UserWorkspace[] } | undefined
+>(undefined)
 
 /**
- * Replaces the set, dropping archived/deleted workspaces — `userWorkspaces` must never
- * offer one. A no-op when the same ids are already held, so re-resolving cannot loop
- * against effects that depend on `userWorkspaces`.
+ * Records what was resolved for `forWorkspace`, dropping archived workspaces —
+ * `userWorkspaces` must never offer one. An archived workspace therefore resolves to an
+ * empty set, which still marks it as resolved and stops it being fetched again.
  */
-export function setNonMemberWorkspaces(workspaces: Workspace[]): void {
-	nonMemberWorkspaces.update((cur) => {
-		const next: Record<string, UserWorkspace> = {}
-		for (const w of workspaces.filter((w) => !w.deleted)) {
-			next[w.id] = {
+export function setNonMemberWorkspaces(forWorkspace: string, workspaces: Workspace[]): void {
+	nonMemberWorkspaces.set({
+		forWorkspace,
+		workspaces: workspaces
+			.filter((w) => !w.deleted)
+			.map((w) => ({
 				id: w.id,
 				name: w.name,
 				// No `usr` row here, hence no per-workspace username — same stand-in as the
@@ -120,12 +123,17 @@ export function setNonMemberWorkspaces(workspaces: Workspace[]): void {
 				is_dev_workspace: w.is_dev_workspace,
 				dev_workspace_label: w.dev_workspace_label,
 				disabled: false
-			}
-		}
-		const curIds = Object.keys(cur)
-		const nextIds = Object.keys(next)
-		return curIds.length === nextIds.length && nextIds.every((id) => id in cur) ? cur : next
+			}))
 	})
+}
+
+export function clearNonMemberWorkspaces(): void {
+	// A Svelte store notifies on every write of an object value, so clearing an already
+	// empty store is not free: the layout effect that fills this one also reads it, and
+	// would re-run itself forever.
+	if (get(nonMemberWorkspaces) != undefined) {
+		nonMemberWorkspaces.set(undefined)
+	}
 }
 
 export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(
@@ -145,7 +153,9 @@ export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(
 					}
 				]
 			: originalWorkspaces
-		const extra = Object.values(nonMember).filter((w) => !workspaces.some((x) => x.id === w.id))
+		const extra = (nonMember?.workspaces ?? []).filter(
+			(w) => !workspaces.some((x) => x.id === w.id)
+		)
 		return extra.length > 0 ? [...workspaces, ...extra] : workspaces
 	}
 )

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -43,6 +43,7 @@
 		globalS3FilePickerExplorer,
 		nonMemberWorkspaces,
 		setNonMemberWorkspaces,
+		clearNonMemberWorkspaces,
 		type UserWorkspace
 	} from '$lib/stores'
 	import CenteredModal from '$lib/components/CenteredModal.svelte'
@@ -707,9 +708,9 @@
 		const ws = $workspaceStore
 		const list = $userWorkspaces
 		const memberships = $usersWorkspaceStore?.workspaces
-		const resolved = Object.keys($nonMemberWorkspaces)
+		const resolvedFor = $nonMemberWorkspaces?.forWorkspace
 		const isSuperadmin = $superadmin
-		untrack(() => void resolveCurrentWorkspace(ws, list, memberships, resolved, isSuperadmin))
+		untrack(() => void resolveCurrentWorkspace(ws, list, memberships, resolvedFor, isSuperadmin))
 	})
 
 	// A superadmin can open a fork they aren't a member of, including a prefixless dev
@@ -721,7 +722,7 @@
 		ws: string | undefined,
 		list: typeof $userWorkspaces,
 		memberships: UserWorkspace[] | undefined,
-		resolved: string[],
+		resolvedFor: string | undefined,
 		isSuperadmin: string | false | undefined
 	): Promise<void> {
 		if (!ws) return
@@ -729,14 +730,14 @@
 			recordForkParent(ws, list)
 		}
 		// Absence from a list that hasn't arrived yet says nothing about membership.
-		if (memberships == undefined) return
+		if (memberships == undefined || resolvedFor === ws) return
 		if (memberships.some((w) => w.id === ws)) {
-			setNonMemberWorkspaces([])
+			clearNonMemberWorkspaces()
 			return
 		}
-		// The effect re-runs several times before the first fetch lands (each store this
-		// depends on settles separately), and none of those passes can see the result yet.
-		if (!isSuperadmin || resolved.includes(ws) || resolvingWorkspace === ws) return
+		// This effect re-runs while a fetch is in flight, and no such pass can see the
+		// result yet.
+		if (!isSuperadmin || resolvingWorkspace === ws) return
 		resolvingWorkspace = ws
 		try {
 			const workspace = await WorkspaceService.getWorkspaceAsSuperAdmin({ workspace: ws })
@@ -750,7 +751,7 @@
 			// A switch during the fetch already resolved (or cleared) the store for the
 			// workspace now open; this answer describes the one we left.
 			if ($workspaceStore !== ws) return
-			setNonMemberWorkspaces(parent ? [workspace, parent] : [workspace])
+			setNonMemberWorkspaces(ws, parent ? [workspace, parent] : [workspace])
 			if (parentId) {
 				rememberForkParent(ws, parentId)
 			}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -725,7 +725,13 @@
 		resolvedFor: string | undefined,
 		isSuperadmin: string | false | undefined
 	): Promise<void> {
-		if (!ws) return
+		// Leaving every workspace (deleting the one you were in) has to drop the cache too:
+		// the other two paths below only fire once another workspace is open, and until then
+		// the workspace picker would keep offering the one that just went away.
+		if (!ws) {
+			clearNonMemberWorkspaces()
+			return
+		}
 		if (list.some((w) => w.id === ws)) {
 			recordForkParent(ws, list)
 		}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -41,7 +41,9 @@
 		globalDbManagerDrawer,
 		globalForkModal,
 		globalS3FilePickerExplorer,
-		rememberNonMemberWorkspace
+		nonMemberWorkspaces,
+		setNonMemberWorkspaces,
+		type UserWorkspace
 	} from '$lib/stores'
 	import CenteredModal from '$lib/components/CenteredModal.svelte'
 	import { afterNavigate, beforeNavigate } from '$app/navigation'
@@ -704,47 +706,64 @@
 	$effect(() => {
 		const ws = $workspaceStore
 		const list = $userWorkspaces
-		const membershipsLoaded = $usersWorkspaceStore != undefined
+		const memberships = $usersWorkspaceStore?.workspaces
+		const resolved = Object.keys($nonMemberWorkspaces)
 		const isSuperadmin = $superadmin
-		untrack(() => void resolveCurrentWorkspace(ws, list, membershipsLoaded, isSuperadmin))
+		untrack(() => void resolveCurrentWorkspace(ws, list, memberships, resolved, isSuperadmin))
 	})
 
-	// A superadmin can open a fork they aren't a member of, including a prefixless
-	// dev workspace. The membership-gated list omits it, so the workspace has to be
-	// fetched directly: without it the deleted-fork recovery loses the parent, and
-	// every `$userWorkspaces` lookup misses, which the fork UI (banner, compare
-	// page, dev badge) reads as an ordinary root workspace.
+	// A superadmin can open a fork they aren't a member of, including a prefixless dev
+	// workspace, and only `getWorkspaceAsSuperAdmin` will hand back its lineage (see
+	// `nonMemberWorkspaces`). Membership is decided against the raw list, not
+	// `$userWorkspaces`: that one already carries what this resolves, so checking it
+	// would clear and re-fetch the entry on every pass.
 	async function resolveCurrentWorkspace(
 		ws: string | undefined,
 		list: typeof $userWorkspaces,
-		membershipsLoaded: boolean,
+		memberships: UserWorkspace[] | undefined,
+		resolved: string[],
 		isSuperadmin: string | false | undefined
 	): Promise<void> {
 		if (!ws) return
 		if (list.some((w) => w.id === ws)) {
 			recordForkParent(ws, list)
+		}
+		// Absence from a list that hasn't arrived yet says nothing about membership.
+		if (memberships == undefined) return
+		if (memberships.some((w) => w.id === ws)) {
+			setNonMemberWorkspaces([])
 			return
 		}
-		// Absent from a list that hasn't arrived yet says nothing about membership.
-		if (!membershipsLoaded || !isSuperadmin) return
+		// The effect re-runs several times before the first fetch lands (each store this
+		// depends on settles separately), and none of those passes can see the result yet.
+		if (!isSuperadmin || resolved.includes(ws) || resolvingWorkspace === ws) return
+		resolvingWorkspace = ws
 		try {
 			const workspace = await WorkspaceService.getWorkspaceAsSuperAdmin({ workspace: ws })
-			rememberNonMemberWorkspace(workspace)
 			const parentId = workspace.parent_workspace_id
-			if (!parentId) return
-			rememberForkParent(ws, parentId)
-			// The fork UI names the parent, which a superadmin is just as likely not to
-			// be a member of. One hop only: nothing above the parent is displayed.
-			if (!list.some((w) => w.id === parentId)) {
-				rememberNonMemberWorkspace(
-					await WorkspaceService.getWorkspaceAsSuperAdmin({ workspace: parentId })
-				)
+			// The fork UI names the parent, which a superadmin is just as likely not to be
+			// a member of. One hop only: nothing above the parent is displayed.
+			const parent =
+				parentId && !memberships.some((w) => w.id === parentId)
+					? await WorkspaceService.getWorkspaceAsSuperAdmin({ workspace: parentId })
+					: undefined
+			// A switch during the fetch already resolved (or cleared) the store for the
+			// workspace now open; this answer describes the one we left.
+			if ($workspaceStore !== ws) return
+			setNonMemberWorkspaces(parent ? [workspace, parent] : [workspace])
+			if (parentId) {
+				rememberForkParent(ws, parentId)
 			}
 		} catch {
 			// Best-effort: if we can't resolve the workspace, recovery falls back to the
 			// workspace picker rather than the parent redirect.
+		} finally {
+			if (resolvingWorkspace === ws) {
+				resolvingWorkspace = undefined
+			}
 		}
 	}
+	let resolvingWorkspace: string | undefined = undefined
 	$effect(() => {
 		$workspaceStore && untrack(() => onLoad())
 	})

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -29,6 +29,7 @@
 		userStore,
 		workspaceStore,
 		userWorkspaces,
+		usersWorkspaceStore,
 		type UserExt,
 		defaultScripts,
 		hubBaseUrlStore,
@@ -39,7 +40,8 @@
 		whitelabelNameStore,
 		globalDbManagerDrawer,
 		globalForkModal,
-		globalS3FilePickerExplorer
+		globalS3FilePickerExplorer,
+		rememberNonMemberWorkspace
 	} from '$lib/stores'
 	import CenteredModal from '$lib/components/CenteredModal.svelte'
 	import { afterNavigate, beforeNavigate } from '$app/navigation'
@@ -702,16 +704,20 @@
 	$effect(() => {
 		const ws = $workspaceStore
 		const list = $userWorkspaces
+		const membershipsLoaded = $usersWorkspaceStore != undefined
 		const isSuperadmin = $superadmin
-		untrack(() => void recordCurrentForkParent(ws, list, isSuperadmin))
+		untrack(() => void resolveCurrentWorkspace(ws, list, membershipsLoaded, isSuperadmin))
 	})
 
 	// A superadmin can open a fork they aren't a member of, including a prefixless
-	// dev workspace. The membership-gated list omits it, so `recordForkParent` can't
-	// see its parent — fetch it directly so the deleted-fork recovery still works.
-	async function recordCurrentForkParent(
+	// dev workspace. The membership-gated list omits it, so the workspace has to be
+	// fetched directly: without it the deleted-fork recovery loses the parent, and
+	// every `$userWorkspaces` lookup misses, which the fork UI (banner, compare
+	// page, dev badge) reads as an ordinary root workspace.
+	async function resolveCurrentWorkspace(
 		ws: string | undefined,
 		list: typeof $userWorkspaces,
+		membershipsLoaded: boolean,
 		isSuperadmin: string | false | undefined
 	): Promise<void> {
 		if (!ws) return
@@ -719,14 +725,23 @@
 			recordForkParent(ws, list)
 			return
 		}
-		if (!isSuperadmin) return
+		// Absent from a list that hasn't arrived yet says nothing about membership.
+		if (!membershipsLoaded || !isSuperadmin) return
 		try {
 			const workspace = await WorkspaceService.getWorkspaceAsSuperAdmin({ workspace: ws })
-			if (workspace.parent_workspace_id) {
-				rememberForkParent(ws, workspace.parent_workspace_id)
+			rememberNonMemberWorkspace(workspace)
+			const parentId = workspace.parent_workspace_id
+			if (!parentId) return
+			rememberForkParent(ws, parentId)
+			// The fork UI names the parent, which a superadmin is just as likely not to
+			// be a member of. One hop only: nothing above the parent is displayed.
+			if (!list.some((w) => w.id === parentId)) {
+				rememberNonMemberWorkspace(
+					await WorkspaceService.getWorkspaceAsSuperAdmin({ workspace: parentId })
+				)
 			}
 		} catch {
-			// Best-effort: if we can't resolve the parent, recovery falls back to the
+			// Best-effort: if we can't resolve the workspace, recovery falls back to the
 			// workspace picker rather than the parent redirect.
 		}
 	}


### PR DESCRIPTION
## Summary

Two fixes to the fork banner on the home page.

**It was invisible to a superadmin viewing a workspace they never joined.** `GET /workspaces/users` joins `usr ON usr.email = $1`, so a non-member superadmin has no row for the workspace in `$userWorkspaces`. `ForkWorkspaceBanner` derives `isFork` from that list, so it rendered nothing — and `/forks/compare` had no deploy target either ("this workspace has no parent workspace"), so the whole fork surface silently degraded to "ordinary root workspace". The logged layout already fetched the workspace via `getWorkspaceAsSuperAdmin` for deleted-fork recovery; that result now also feeds `$userWorkspaces`.

**It overflowed at laptop widths.** The banner was a single non-wrapping flex row, so past ~1000px the "Review & Deploy Changes" button was clipped off the right edge and per-kind chips broke mid-phrase ("1 resource / type").

## Changes

- `Workspace` (struct + openapi schema) gains `is_dev_workspace`, `dev_workspace_label` and `deleted`, so a resolved non-member workspace is complete enough to render (dev-workspace wording, dev badge) and archived ones can be recognised. Three `query_as!(Workspace, …)` sites updated.
- New `nonMemberWorkspaces` store merged into the `userWorkspaces` derived — same precedent as the synthetic `admins` entry that store already fabricates for superadmins. It holds **only** the current workspace and one parent hop, is cleared when the current workspace is a member, and never accepts an archived workspace: entries kept past a switch would go on presenting themselves as memberships to the workspace picker and the workspace-family lookups, and a fork archived from the compare page would otherwise be re-injected right after `reconcileAfterWorkspaceChange()` dropped it.
- The layout's resolution decides membership against the raw `usersWorkspaceStore` list (checking `$userWorkspaces` would clear and re-fetch its own entry every pass), waits for that list to load (absence from a list that has not arrived says nothing about membership), dedupes in-flight fetches, and discards a response whose workspace is no longer open.
- `ForkWorkspaceBanner`: summary wraps in a `min-w-0` column while the CTA stays `shrink-0` on the first line; per-kind breakdown hides below `lg`; `whitespace-nowrap` on the chip / CI / conflict groups; the parent id in parentheses is dropped when it equals the parent name. Same wrap/shrink treatment on the sibling `WorkspaceDraftsBanner`.

Two pre-existing duplicates of this same "resolve a non-member workspace" fetch remain and are left alone: `useForkableWorkspaces` self-disables once the store fills the entry, and `workspaceColor` keeps its own fetch because it derives on `usersWorkspaceStore` rather than `userWorkspaces`. Both are follow-up candidates.

## Screenshots

Superadmin (not a member of `dev`, a dev workspace forked from `prod`) on the home page — the banner and its CTA were entirely absent before this PR:

920px — breakdown hidden, one line:
![pr-banner-920](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/forks-workspace-id-param/1785754026-pr-banner-920.png)

1024px — breakdown shown, CTA pinned on the first line:
![pr-banner-1024](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/forks-workspace-id-param/1785754028-pr-banner-1024.png)

1440px — single line:
![pr-banner-1440](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/forks-workspace-id-param/1785754029-pr-banner-1440.png)

The CTA now lands on a compare page that resolves the parent as the deploy target:
![pr-compare-nonmember](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/forks-workspace-id-param/1785754030-pr-compare-nonmember.png)

## Test plan

- [x] As a superadmin with the `usr` row for a dev workspace deleted, open it: banner reads "Dev workspace of **prod**", sidebar shows the dev badge, and "Review & Deploy Changes" opens a compare page targeting `prod` (15 deployable, 4 conflicts)
- [x] Same workspace with `deleted = true`: no banner, and the workspace is not offered in the picker
- [x] Switch from the non-member workspace to a member one: the non-member entry disappears from `/user/workspaces`
- [x] Member case unchanged (no duplicate entry, same banner)
- [x] Banner at 920 / 1024 / 1280 / 1440 with the sidebar expanded and collapsed: nothing clipped
- [x] `npm run check` (0 errors), `nonMemberWorkspaces.test.ts`, `SQLX_OFFLINE=true cargo check --workspace --features all_sqlx_features`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the fork banner and correct compare target for superadmins viewing a workspace they haven’t joined, and fix the banner layout so it doesn’t clip on laptop-width screens.

- **Bug Fixes**
  - Backend: extend `Workspace` and OpenAPI with `is_dev_workspace`, `dev_workspace_label`, and `deleted` so non-member and archived workspaces render correctly.
  - Superadmin resolution: in the logged layout, resolve the current workspace (and one parent hop) via `getWorkspaceAsSuperAdmin`; merge into `$userWorkspaces` through a scoped `nonMemberWorkspaces` cache that owns exactly one workspace, replaces on switch, clears when no workspace is open, ignores archived, waits for memberships to load, dedupes requests, drops stale responses, and avoids notifying when clearing an already empty store.
  - UI: make `ForkWorkspaceBanner` text wrap while keeping the CTA pinned; hide per-kind breakdown below `lg`; keep chips/CI/conflict groups on one line; omit parent id when it equals the name. Apply the same wrap/shrink pattern to `WorkspaceDraftsBanner`.
  - Tests: add `nonMemberWorkspaces.test.ts` to cover merging into `$userWorkspaces`, single-workspace scoping and replacement across switches, archived filtering, de-duplication, and no-op clears.

<sup>Written for commit 317ccee395f3465f77534045c90d7c3b17926aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

