### PR TITLE
fix: stop reading a parent-only fork item as deleted in the fork

### DIFF
--- a/backend/.sqlx/query-aba0caddc216e218225d41cc3e14db0d8013ca448ca469f1c8c90965a514a8fb.json
+++ b/backend/.sqlx/query-aba0caddc216e218225d41cc3e14db0d8013ca448ca469f1c8c90965a514a8fb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)\n         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/rt/parent_only', 'http_trigger', 1, 0, true, true, false)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "aba0caddc216e218225d41cc3e14db0d8013ca448ca469f1c8c90965a514a8fb"
+}

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -1759,7 +1759,9 @@ async fn test_compare_workspaces_phantom_trigger_shortfuse(
 /// the fork, a pull of the source's own item included), so it can carry
 /// `behind = 0`. Both `all_behind_items_visible` and `hidden_behind` used to be
 /// derived from the `behind` counters alone, which such a row never moves — so
-/// hiding it left the update direction claiming that nothing was withheld.
+/// hiding it left the update direction claiming that nothing was withheld. The
+/// merge direction is the mirror: it does not carry such a row at all, so hiding
+/// one withholds nothing from it and must not be reported on that side.
 #[sqlx::test(migrations = "../migrations", fixtures("base"))]
 async fn test_compare_workspaces_hidden_source_only_no_behind(
     db: Pool<Postgres>,
@@ -1818,6 +1820,16 @@ async fn test_compare_workspaces_hidden_source_only_no_behind(
         comparison["hidden_behind"]["total"].as_i64(),
         Some(1),
         "a hidden source-only row must be counted as withheld from the update direction: {comparison}"
+    );
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "the merge direction does not carry a source-only row, so hiding one withholds nothing from it: {comparison}"
+    );
+    assert_eq!(
+        comparison["hidden_ahead"]["total"].as_i64(),
+        Some(0),
+        "a source-only row must not be reported as withheld from the merge direction: {comparison}"
     );
 
     Ok(())

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -1754,14 +1754,10 @@ async fn test_compare_workspaces_phantom_trigger_shortfuse(
     Ok(())
 }
 
-/// Regression: a row the source has and the fork lacks is offered to the fork
-/// whatever its counters say (the tally credits `ahead` for every deploy event in
-/// the fork, a pull of the source's own item included), so it can carry
-/// `behind = 0`. Both `all_behind_items_visible` and `hidden_behind` used to be
-/// derived from the `behind` counters alone, which such a row never moves — so
-/// hiding it left the update direction claiming that nothing was withheld. The
-/// merge direction is the mirror: it does not carry such a row at all, so hiding
-/// one withholds nothing from it and must not be reported on that side.
+/// A source-only row is offered to the fork whatever its counters say, so it can
+/// carry `behind = 0` — a `behind`-derived tally never sees it, and hiding one must
+/// still be reported to the update direction. The merge direction does not carry
+/// such a row at all, so hiding one withholds nothing from that side.
 #[sqlx::test(migrations = "../migrations", fixtures("base"))]
 async fn test_compare_workspaces_hidden_source_only_no_behind(
     db: Pool<Postgres>,

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -1754,6 +1754,75 @@ async fn test_compare_workspaces_phantom_trigger_shortfuse(
     Ok(())
 }
 
+/// Regression: a row the source has and the fork lacks is offered to the fork
+/// whatever its counters say (the tally credits `ahead` for every deploy event in
+/// the fork, a pull of the source's own item included), so it can carry
+/// `behind = 0`. Both `all_behind_items_visible` and `hidden_behind` used to be
+/// derived from the `behind` counters alone, which such a row never moves — so
+/// hiding it left the update direction claiming that nothing was withheld.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_compare_workspaces_hidden_source_only_no_behind(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base_url = format!("http://localhost:{port}/api");
+    let non_admin = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN_2".to_string(),
+    );
+
+    sqlx::query!(
+        "INSERT INTO workspace (id, name, owner, parent_workspace_id)
+         VALUES ('wm-fork-test-workspace', 'Fork', 'test-user', 'test-workspace')"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!("INSERT INTO workspace_settings (workspace_id) VALUES ('wm-fork-test-workspace')")
+        .execute(&db)
+        .await?;
+    sqlx::query!(
+        "INSERT INTO workspace_key(workspace_id, kind, key)
+         VALUES ('wm-fork-test-workspace', 'cloud', 'test-key')"
+    )
+    .execute(&db)
+    .await?;
+
+    // Source-only row with no `behind`: the trigger has no backing row, so the
+    // visibility filter drops it exactly as it would an ACL-hidden one.
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)
+         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/rt/parent_only', 'http_trigger', 1, 0, true, true, false)"
+    )
+    .execute(&db)
+    .await?;
+
+    let comparison: serde_json::Value = non_admin
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-test-workspace"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(
+        comparison["all_behind_items_visible"].as_bool(),
+        Some(false),
+        "a hidden source-only row must trip the warning even at behind = 0: {comparison}"
+    );
+    assert_eq!(
+        comparison["hidden_behind"]["total"].as_i64(),
+        Some(1),
+        "a hidden source-only row must be counted as withheld from the update direction: {comparison}"
+    );
+
+    Ok(())
+}
+
 /// Regression: the "sees everything" guard must require admin of BOTH sides, not
 /// just the fork. `filter_visible_diffs` keeps a modified/conflict row (one that
 /// exists in the source AND the fork) only when the caller can see it on both

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -5966,7 +5966,14 @@ async fn clone_scripts(
     .execute(&mut **tx)
     .await?;
 
-    clear_orphaned_compat_address(tx, "script", "hash", source_workspace_id, target_workspace_id).await?;
+    clear_orphaned_compat_address(
+        tx,
+        "script",
+        "hash",
+        source_workspace_id,
+        target_workspace_id,
+    )
+    .await?;
 
     Ok(())
 }
@@ -6204,7 +6211,8 @@ async fn clone_flows(
     .execute(&mut **tx)
     .await?;
 
-    clear_orphaned_compat_address(tx, "flow", "path", source_workspace_id, target_workspace_id).await?;
+    clear_orphaned_compat_address(tx, "flow", "path", source_workspace_id, target_workspace_id)
+        .await?;
 
     // Then clone flow versions
     let flow_versions = sqlx::query!(
@@ -9576,11 +9584,22 @@ async fn compare_workspaces(
             .iter()
             .map(|s| s.ahead)
             .fold(0, |acc, s| acc + s.try_into().unwrap_or(0));
+    // An item the source has and the fork does not is offered to the fork whatever
+    // its `behind` counter says (the tally credits `ahead` for every deploy event in
+    // the fork, a pull of the source's own item included), so such a row can carry
+    // `behind = 0` and be dropped by the filter without moving either sum. Count the
+    // rows themselves, else a hidden one leaves the update direction claiming that
+    // nothing is withheld.
+    let source_only = |d: &WorkspaceDiffRow| {
+        d.exists_in_source.unwrap_or(false) && !d.exists_in_fork.unwrap_or(false)
+    };
     let all_behind_items_visible = summary.total_behind
         == confirmed_diffs
             .iter()
             .map(|s| s.behind)
-            .fold(0, |acc, s| acc + s.try_into().unwrap_or(0));
+            .fold(0, |acc, s| acc + s.try_into().unwrap_or(0))
+        && visible_diffs.iter().filter(|d| source_only(d)).count()
+            == confirmed_diffs.iter().filter(|d| source_only(d)).count();
 
     // Blast-radius guard for the "changes not visible to your user" warning
     // (which hides the deploy button). The flag is a pure visibility guarantee —
@@ -9629,7 +9648,10 @@ async fn compare_workspaces(
                     .push(HiddenItem { kind: d.kind.clone(), path: d.path.clone() });
             }
         }
-        if d.behind > 0 {
+        // `source_only` for the same reason it gates the flag above: such a row is
+        // offered to the fork on its existence alone, so a hidden one is withheld
+        // from the update direction even at `behind = 0`.
+        if d.behind > 0 || source_only(d) {
             hidden_behind.total += 1;
             *hidden_behind.by_kind.entry(d.kind.clone()).or_default() += 1;
             if sees_all_items {

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -9579,18 +9579,25 @@ async fn compare_workspaces(
             .count(),
     };
 
-    let all_ahead_items_visible = summary.total_ahead
-        == confirmed_diffs
-            .iter()
-            .map(|s| s.ahead)
-            .fold(0, |acc, s| acc + s.try_into().unwrap_or(0));
-    // The fork is offered an item the source has and it lacks whatever the counters
-    // say, so such a row can carry `behind = 0` and be dropped by the filter without
-    // moving either sum. Count the rows themselves, else a hidden one leaves the
-    // update direction claiming nothing is withheld.
+    // A row the source has and the fork lacks is not something the fork can push, so
+    // the lineage merge leaves it out (see the frontend's `diffActionableInDirection`)
+    // and a hidden one withholds nothing from that direction. An arbitrary pair does
+    // carry it — that comparison is an explicit one-way sync — hence the lineage test.
+    // Conversely the fork is offered such a row whatever the counters say, so it can
+    // carry `behind = 0` and be dropped without moving either sum: the update side
+    // counts the rows themselves, else a hidden one leaves that direction claiming
+    // nothing is withheld.
     let source_only = |d: &WorkspaceDiffRow| {
         d.exists_in_source.unwrap_or(false) && !d.exists_in_fork.unwrap_or(false)
     };
+    let merge_carries = |d: &WorkspaceDiffRow| !is_lineage_pair || !source_only(d);
+    let ahead_sum = |rows: &[WorkspaceDiffRow]| {
+        rows.iter()
+            .filter(|d| merge_carries(d))
+            .map(|s| s.ahead)
+            .fold(0i64, |acc, s| acc + i64::from(s))
+    };
+    let all_ahead_items_visible = ahead_sum(&visible_diffs) == ahead_sum(&confirmed_diffs);
     let all_behind_items_visible = summary.total_behind
         == confirmed_diffs
             .iter()
@@ -9637,7 +9644,9 @@ async fn compare_workspaces(
         if visible_keys.contains(&(d.kind.as_str(), d.path.as_str())) {
             continue;
         }
-        if d.ahead > 0 {
+        // Both sides mirror the flags above: a row is only withheld from a direction
+        // that would have carried it.
+        if d.ahead > 0 && merge_carries(d) {
             hidden_ahead.total += 1;
             *hidden_ahead.by_kind.entry(d.kind.clone()).or_default() += 1;
             if sees_all_items {
@@ -9646,9 +9655,6 @@ async fn compare_workspaces(
                     .push(HiddenItem { kind: d.kind.clone(), path: d.path.clone() });
             }
         }
-        // `source_only` for the same reason it gates the flag above: such a row is
-        // offered to the fork on its existence alone, so a hidden one is withheld
-        // from the update direction even at `behind = 0`.
         if d.behind > 0 || source_only(d) {
             hidden_behind.total += 1;
             *hidden_behind.by_kind.entry(d.kind.clone()).or_default() += 1;

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -9584,12 +9584,10 @@ async fn compare_workspaces(
             .iter()
             .map(|s| s.ahead)
             .fold(0, |acc, s| acc + s.try_into().unwrap_or(0));
-    // An item the source has and the fork does not is offered to the fork whatever
-    // its `behind` counter says (the tally credits `ahead` for every deploy event in
-    // the fork, a pull of the source's own item included), so such a row can carry
-    // `behind = 0` and be dropped by the filter without moving either sum. Count the
-    // rows themselves, else a hidden one leaves the update direction claiming that
-    // nothing is withheld.
+    // The fork is offered an item the source has and it lacks whatever the counters
+    // say, so such a row can carry `behind = 0` and be dropped by the filter without
+    // moving either sum. Count the rows themselves, else a hidden one leaves the
+    // update direction claiming nothing is withheld.
     let source_only = |d: &WorkspaceDiffRow| {
         d.exists_in_source.unwrap_or(false) && !d.exists_in_fork.unwrap_or(false)
     };

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -9579,14 +9579,10 @@ async fn compare_workspaces(
             .count(),
     };
 
-    // A row the source has and the fork lacks is not something the fork can push, so
-    // the lineage merge leaves it out (see the frontend's `diffActionableInDirection`)
-    // and a hidden one withholds nothing from that direction. An arbitrary pair does
-    // carry it — that comparison is an explicit one-way sync — hence the lineage test.
-    // Conversely the fork is offered such a row whatever the counters say, so it can
-    // carry `behind = 0` and be dropped without moving either sum: the update side
-    // counts the rows themselves, else a hidden one leaves that direction claiming
-    // nothing is withheld.
+    // Each direction accounts for what it carries (see the frontend's
+    // `diffActionableInDirection`): a lineage merge leaves out a row the fork lacks,
+    // while the update takes it whatever the counters say — and since it can carry
+    // `behind = 0`, that side counts rows rather than sums.
     let source_only = |d: &WorkspaceDiffRow| {
         d.exists_in_source.unwrap_or(false) && !d.exists_in_fork.unwrap_or(false)
     };

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -410,7 +410,9 @@
 	let canPreserveOnBehalfOf = $derived(mergeIntoParent ? canPreserveInParent : canPreserveInCurrent)
 
 	let selectableDiffs = $derived(
-		comparison?.diffs.filter((diff) => diffActionableInDirection(diff, mergeIntoParent)) ?? []
+		comparison?.diffs.filter((diff) =>
+			diffActionableInDirection(diff, mergeIntoParent, isArbitraryTarget)
+		) ?? []
 	)
 
 	let selectedItems = $state<string[]>([])
@@ -454,10 +456,17 @@
 		}) ?? []
 	)
 
+	// Gates the "update before deploying" alert, so it counts what a merge would
+	// actually carry — not every row with an `ahead` counter, which includes the
+	// parent-only ones the merge direction leaves out.
 	let itemsWithAheadChanges = $derived(
 		comparison?.diffs.filter((diff) => {
 			const status = deploymentStatus[getItemKey(diff)]?.status
-			return diff && diff.ahead > 0 && !(status && status == 'deployed')
+			return (
+				diff &&
+				diffActionableInDirection(diff, true, isArbitraryTarget) &&
+				!(status && status == 'deployed')
+			)
 		}) ?? []
 	)
 

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -43,6 +43,9 @@
 		checkDeployPermission,
 		deployItem,
 		deleteItemInWorkspace,
+		diffActionableInDirection,
+		diffCreatesInTarget,
+		diffRemovesInTarget,
 		getItemValue,
 		getOnBehalfOf,
 		type DeployPermission,
@@ -407,13 +410,7 @@
 	let canPreserveOnBehalfOf = $derived(mergeIntoParent ? canPreserveInParent : canPreserveInCurrent)
 
 	let selectableDiffs = $derived(
-		comparison?.diffs.filter((diff) => {
-			if (mergeIntoParent) {
-				return diff.ahead > 0
-			} else {
-				return diff.behind > 0
-			}
-		}) ?? []
+		comparison?.diffs.filter((diff) => diffActionableInDirection(diff, mergeIntoParent)) ?? []
 	)
 
 	let selectedItems = $state<string[]>([])
@@ -477,6 +474,7 @@
 	let onBehalfOfChoice = $state<Record<string, OnBehalfOfChoice>>({})
 	let customOnBehalfOf = $state<Record<string, OnBehalfOfDetails>>({})
 	let deployTargetWorkspace = $derived(mergeIntoParent ? parentWorkspaceId : currentWorkspaceId)
+	let deploySourceWorkspace = $derived(mergeIntoParent ? currentWorkspaceId : parentWorkspaceId)
 
 	function getItemKey(diff: WorkspaceItemDiff): string {
 		return `${diff.kind}:${diff.path}`
@@ -641,12 +639,10 @@
 
 	// All *diff* items selected. Trigger items are opt-in and don't count
 	// toward "all selected" — see item merge below in deployableItems.
-	// Deploying a row the current workspace lacks deletes it in the target. Against
-	// the parent that is a real deletion to propagate and is selected like anything
-	// else; against an arbitrary target the two workspaces were simply never in sync,
-	// so it takes an explicit act on that row. No bulk action may sweep one in.
+	// A row whose deploy deletes in the target takes an explicit tick (see
+	// `diffRemovesInTarget`); no bulk action may sweep one in.
 	function removesInTarget(diff: WorkspaceItemDiff): boolean {
-		return isArbitraryTarget && diff.exists_in_fork === false
+		return diffRemovesInTarget(diff, mergeIntoParent)
 	}
 	let bulkSelectableDiffs = $derived(selectableDiffs.filter((d) => !removesInTarget(d)))
 
@@ -691,17 +687,14 @@
 	) {
 		deploymentStatus[statusKey] = { status: 'loading' }
 
-		// Check if the item was deleted in the source workspace.
-		// If so, archive/delete it in the target workspace instead of copying.
+		// The workspace this deploy reads from doesn't have the item: archive/delete
+		// it in the target instead of copying. Same predicate as the row's badge and
+		// its exclusion from bulk selection, so what the row says is what it does.
 		const diff = comparison?.diffs.find((d) => getItemKey(d) === statusKey)
-		const itemDeletedInSource = diff
-			? mergeIntoParent
-				? diff.exists_in_fork === false
-				: diff.exists_in_source === false
-			: false
+		const removes = diff ? removesInTarget(diff) : false
 
 		let result: DeployResult
-		if (itemDeletedInSource) {
+		if (removes) {
 			result = await deleteItemInWorkspace(kind, path, workspaceToDeployTo)
 		} else {
 			result = await deployItem({
@@ -1565,39 +1558,20 @@
 							<AlertTriangle class="w-3 h-3 inline mr-0.5" />+Draft
 						</Badge>
 					{/if}
-					<!-- Status badges -->
-					{#if !diff.exists_in_fork && diff.exists_in_source && diff.ahead == 0 && diff.behind > 0}
+					<!-- Status badges. An item on one side only states the effect of
+					     deploying it, never which side moved — the comparison cannot know
+					     (see `diffRemovesInTarget`). -->
+					{#if diffCreatesInTarget(diff, mergeIntoParent)}
 						<Badge
-							title="This item was newly created in the parent workspace '{parentWorkspaceId}'"
+							title="This item exists in '{deploySourceWorkspace}' but not in '{deployTargetWorkspace}' — deploying it creates it there"
 							color="indigo"
 							size="xs">New</Badge
 						>
-					{/if}
-					{#if !diff.exists_in_fork && diff.exists_in_source && diff.ahead > 0}
-						<!-- Same row, two readings: against the parent the fork deleted the
-						     item, while against an arbitrary target it may simply never have
-						     existed here. Deploying removes it there either way — say that
-						     rather than asserting a deletion that may not have happened. -->
+					{:else if removesInTarget(diff)}
 						<Badge
-							title={isArbitraryTarget
-								? `This item exists only in '${parentWorkspaceId}' — deploying it removes it there`
-								: `This item was deleted in '${currentWorkspaceId}'`}
+							title="This item exists in '{deployTargetWorkspace}' but not in '{deploySourceWorkspace}' — deploying it removes it there"
 							color="red"
-							size="xs">{isArbitraryTarget ? 'Removes in target' : 'Deleted'}</Badge
-						>
-					{/if}
-					{#if diff.exists_in_fork && !diff.exists_in_source && diff.behind > 0}
-						<Badge
-							title="This item was deleted in the parent workspace '{parentWorkspaceId}'"
-							color="red"
-							size="xs">Deleted</Badge
-						>
-					{/if}
-					{#if diff.exists_in_fork && !diff.exists_in_source && diff.ahead > 0 && diff.behind == 0}
-						<Badge
-							title="This item was newly created in '{currentWorkspaceId}'"
-							color="indigo"
-							size="xs">New</Badge
+							size="xs">Removes in {deployTargetWorkspace}</Badge
 						>
 					{/if}
 					{@const ciStatus = getCiTestStatus(diff)}

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -995,11 +995,9 @@
 	let removalKeys = new Set<string>()
 	$effect(() => {
 		const diffs = comparison?.diffs
-		// Which rows are removals depends on the direction, so a flip has to refresh
-		// the set: keeping the other direction's would make every row of the new one
-		// look freshly flipped and revoke the opt-in this guard exists to protect.
-		// Re-running on the flip is otherwise a no-op — the direction toggle already
-		// deselects, and the default selection never picks a removal.
+		// Removals are direction-dependent, so a flip must refresh the set: keeping the
+		// other direction's would make every row of the new one look freshly flipped
+		// and revoke the opt-in this guard protects.
 		;[mergeIntoParent]
 		if (!diffs) return
 		untrack(() => {

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -892,9 +892,15 @@
 		const filtered = bulkSelectableDiffs.filter(
 			(d) => !isTriggerOrScheduleKind(d.kind) && !hasDraft(d)
 		)
+		// The update direction leaves out two ambiguous shapes, both still one click
+		// away through "Select all": a conflict, and a parent-only row the fork has
+		// deploy events for — the fork may have dropped it on purpose, and a routine
+		// update must not silently bring it back.
 		const conflictSafe = mergeIntoParent
 			? filtered
-			: filtered.filter((d) => !(d.ahead > 0 && d.behind > 0))
+			: filtered.filter(
+					(d) => !(d.ahead > 0 && d.behind > 0) && !(d.ahead > 0 && diffCreatesInTarget(d, false))
+				)
 		// When reached from a session's Review, narrow the default to this chat's items.
 		const scoped = chatMask ? conflictSafe.filter((d) => diffInMask(d, chatMask)) : conflictSafe
 		selectedItems = scoped
@@ -980,6 +986,12 @@
 	let removalKeys = new Set<string>()
 	$effect(() => {
 		const diffs = comparison?.diffs
+		// Which rows are removals depends on the direction, so a flip has to refresh
+		// the set: keeping the other direction's would make every row of the new one
+		// look freshly flipped and revoke the opt-in this guard exists to protect.
+		// Re-running on the flip is otherwise a no-op — the direction toggle already
+		// deselects, and the default selection never picks a removal.
+		;[mergeIntoParent]
 		if (!diffs) return
 		untrack(() => {
 			const current = new Set(diffs.filter(removesInTarget).map((d) => getItemKey(d)))

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -84,9 +84,9 @@
 	}
 
 	// Opens the direction the button offers, so the label and the list agree: a fork
-	// with nothing to deploy lands on the update side rather than on an empty deploy
-	// list. Both read `comparisonLoaded` — an absent comparison counts zero of
-	// everything, which is indistinguishable from "nothing to deploy".
+	// with nothing to deploy lands on the update side, not on an empty deploy list.
+	// Both read `comparisonLoaded` — an unknown comparison counts zero of everything,
+	// which is indistinguishable from "nothing to deploy".
 	function openComparisonDrawer() {
 		if (parentWorkspaceId && $workspaceStore) {
 			const dir = comparisonLoaded && changesAhead === 0 ? '&dir=update' : ''
@@ -161,7 +161,9 @@
 	function countDir(c: WorkspaceComparison | undefined, mergeIntoParent: boolean): number {
 		return c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent)).length ?? 0
 	}
-	const comparisonLoaded = $derived(comparison !== undefined)
+	// A comparison in flight is not an answer: on a fork switch the component stays
+	// mounted and `comparison` still holds the previous fork's rows.
+	const comparisonLoaded = $derived(!loading && comparison !== undefined)
 	const changesAhead = $derived(countDir(comparison, true))
 	const changesBehind = $derived(countDir(comparison, false))
 

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -9,6 +9,7 @@
 	import { onMount, untrack } from 'svelte'
 	import { useWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
 	import { devLabelWord } from '$lib/utils/devWorkspaceLabel'
+	import { diffActionableInDirection } from '$lib/utils_workspace_deploy'
 
 	let loading = $state(false)
 	let comparison: WorkspaceComparison | undefined = $state(undefined)
@@ -148,6 +149,16 @@
 		return () => clearInterval(interval)
 	})
 
+	// Counted with the compare page's own predicate so the banner never advertises a
+	// direction whose list is empty: the `ahead`/`behind` sums in the summary include
+	// rows a direction does not carry, and miss a parent-only row that the update
+	// direction carries at `behind = 0`.
+	function countDir(c: WorkspaceComparison | undefined, mergeIntoParent: boolean): number {
+		return c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent)).length ?? 0
+	}
+	const changesAhead = $derived(countDir(comparison, true))
+	const changesBehind = $derived(countDir(comparison, false))
+
 	function forkAheadBehindMessage(changesAhead: number, changesBehind: number) {
 		let msg: string[] = []
 		if (changesAhead > 0 || changesBehind > 0) {
@@ -189,10 +200,7 @@
 						<div class="flex items-center gap-4 text-xs">
 							{#if comparison.summary.total_diffs > 0}
 								<span class="text-blue-700 dark:text-blue-100">
-									{forkAheadBehindMessage(
-										comparison.summary.total_ahead,
-										comparison.summary.total_behind
-									)}
+									{forkAheadBehindMessage(changesAhead, changesBehind)}
 									<span class="font-semibold underline">{parentWorkspaceId}</span> over {comparison
 										.summary.total_diffs} items:
 								</span>
@@ -324,7 +332,7 @@
 					>
 						{#if showDraftsOnly}
 							Review & deploy drafts
-						{:else if (comparison?.summary.total_ahead ?? 0) > 0}
+						{:else if changesAhead > 0}
 							Review & Deploy Changes
 						{:else}
 							Review & Update fork

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -83,9 +83,13 @@
 		}
 	}
 
+	// Opens the direction the button offers, so the label and the list agree: a fork
+	// with nothing to deploy lands on the update side rather than on an empty deploy
+	// list.
 	function openComparisonDrawer() {
 		if (parentWorkspaceId && $workspaceStore) {
-			goto('/forks/compare?workspace_id=' + encodeURIComponent($workspaceStore), {
+			const dir = changesAhead > 0 ? '' : '&dir=update'
+			goto('/forks/compare?workspace_id=' + encodeURIComponent($workspaceStore) + dir, {
 				replaceState: true
 			})
 		}

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -85,10 +85,11 @@
 
 	// Opens the direction the button offers, so the label and the list agree: a fork
 	// with nothing to deploy lands on the update side rather than on an empty deploy
-	// list.
+	// list. Both read `comparisonLoaded` — an absent comparison counts zero of
+	// everything, which is indistinguishable from "nothing to deploy".
 	function openComparisonDrawer() {
 		if (parentWorkspaceId && $workspaceStore) {
-			const dir = changesAhead > 0 ? '' : '&dir=update'
+			const dir = comparisonLoaded && changesAhead === 0 ? '&dir=update' : ''
 			goto('/forks/compare?workspace_id=' + encodeURIComponent($workspaceStore) + dir, {
 				replaceState: true
 			})
@@ -160,6 +161,7 @@
 	function countDir(c: WorkspaceComparison | undefined, mergeIntoParent: boolean): number {
 		return c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent)).length ?? 0
 	}
+	const comparisonLoaded = $derived(comparison !== undefined)
 	const changesAhead = $derived(countDir(comparison, true))
 	const changesBehind = $derived(countDir(comparison, false))
 
@@ -336,7 +338,7 @@
 					>
 						{#if showDraftsOnly}
 							Review & deploy drafts
-						{:else if changesAhead > 0}
+						{:else if !comparisonLoaded || changesAhead > 0}
 							Review & Deploy Changes
 						{:else}
 							Review & Update fork

--- a/frontend/src/lib/components/WorkspaceDeployLayout.svelte
+++ b/frontend/src/lib/components/WorkspaceDeployLayout.svelte
@@ -85,7 +85,10 @@
 	}: Props = $props()
 
 	let selectableItems = $derived(items.filter(selectablePredicate))
-	let hasSelectableItems = $derived(selectableItems.length > 0)
+	// "Select all" is a bulk action, so it lives or dies by the bulk-selectable set:
+	// a list of nothing but bulk-excluded rows would otherwise offer an enabled
+	// control that selects nothing. Each such row is still selectable on its own.
+	let hasSelectableItems = $derived(selectableItems.some((i) => !bulkExcluded(i)))
 
 	// Plain row click and the checkbox both toggle this row in/out — multi-select
 	// is the default, no modifier needed.

--- a/frontend/src/lib/components/WorkspaceDeployLayout.svelte
+++ b/frontend/src/lib/components/WorkspaceDeployLayout.svelte
@@ -195,6 +195,13 @@
 					{#if showGroupHeaders}
 						{@const selectable = groupSelectable(group)}
 						{@const selectedCount = selectable.filter((i) => selectedItems.includes(i.key)).length}
+						<!-- The label counts every ticked row, bulk-excluded ones included: those
+						     are deployed like any other, and reporting only the bulk-selectable
+						     ones would contradict the deploy button. The checkbox above keeps its
+						     own count, which must ignore them to reach a full-checked state. -->
+						{@const selectedInGroup = group.items.filter((i) =>
+							selectedItems.includes(i.key)
+						).length}
 						<!-- The disabled-state hint lives on the row: a disabled Checkbox is
 						     pointer-events-none, so a title on the input would never show. -->
 						<div
@@ -219,8 +226,8 @@
 							{/if}
 							<span class="text-xs font-semibold text-secondary truncate">{group.label}</span>
 							<span class="text-2xs text-tertiary whitespace-nowrap">
-								{group.items.length} item{group.items.length !== 1 ? 's' : ''}{selectedCount > 0
-									? ` · ${selectedCount} selected`
+								{group.items.length} item{group.items.length !== 1 ? 's' : ''}{selectedInGroup > 0
+									? ` · ${selectedInGroup} selected`
 									: ''}
 							</span>
 							{#if groupActions}

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -6014,8 +6014,8 @@ function formatForkIndexEntry(e: ForkDiffEntryView): string {
 	switch (e.status) {
 		case 'only_in_fork':
 			return `- ${name} — only in fork (${e.patchLineCount} lines)${draftFlag}`
-		case 'deleted_in_fork':
-			return `- ${name} — deleted in fork, still in parent${draftFlag}`
+		case 'only_in_parent':
+			return `- ${name} — only in parent, not in fork${draftFlag}`
 		case 'modified':
 			return `- ${name} — differs (${aheadBehind}; ${e.patchLineCount} diff lines)${draftFlag}`
 		case 'unchanged':
@@ -6193,8 +6193,8 @@ function renderForkEntrySection(
 	const header =
 		entry.status === 'only_in_fork'
 			? `${entry.kind} "${path}" exists only in the fork — not in parent "${parent}". Full content:\n\n`
-			: entry.status === 'deleted_in_fork'
-				? `${entry.kind} "${path}" was deleted in the fork but still exists in parent "${parent}". Removed content:\n\n`
+			: entry.status === 'only_in_parent'
+				? `${entry.kind} "${path}" exists only in parent "${parent}" — not in the fork. Parent content:\n\n`
 				: `Fork changes vs parent "${parent}" for ${entry.kind} "${path}":\n\n`
 	if (args.file !== undefined && !entry.files) {
 		throw new Error(

--- a/frontend/src/lib/components/copilot/chat/global/diffSnapshot.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/diffSnapshot.test.ts
@@ -465,7 +465,7 @@ describe('fork mode', () => {
 		expect(byPath['f/a/b'].status).toBe('modified')
 		expect(byPath['f/a/new'].status).toBe('only_in_fork')
 		expect(byPath['f/a/new'].patch).not.toContain('parent-ws')
-		expect(byPath['f/a/gone'].status).toBe('deleted_in_fork')
+		expect(byPath['f/a/gone'].status).toBe('only_in_parent')
 		// One-sided entries fetch only the existing side: 2 + 1 + 1 calls.
 		expect(getItemValue).toHaveBeenCalledTimes(4)
 	})

--- a/frontend/src/lib/components/copilot/chat/global/diffSnapshot.ts
+++ b/frontend/src/lib/components/copilot/chat/global/diffSnapshot.ts
@@ -620,7 +620,7 @@ const FORK_COMPARISON_REUSE_MS = 30_000
 export type ForkDiffStatus =
 	| 'modified'
 	| 'only_in_fork'
-	| 'deleted_in_fork'
+	| 'only_in_parent'
 	| 'unchanged'
 	| 'pending'
 	| 'error'
@@ -657,7 +657,7 @@ export interface ForkDiffIndexView {
 }
 
 interface ForkMaterialized {
-	status: 'modified' | 'only_in_fork' | 'deleted_in_fork' | 'unchanged' | 'error'
+	status: 'modified' | 'only_in_fork' | 'only_in_parent' | 'unchanged' | 'error'
 	patch: string
 	lineCount: number
 	files?: Record<string, DiffFileView>
@@ -1023,7 +1023,7 @@ async function materializeFork(
 			const forkValue = forkSide?.value
 			const valueMasked = parentSide?.valueMasked === true || forkSide?.valueMasked === true
 			const oneSidedStatus = !entry.existsInFork
-				? 'deleted_in_fork'
+				? 'only_in_parent'
 				: !entry.existsInParent
 					? 'only_in_fork'
 					: undefined

--- a/frontend/src/lib/utils_workspace_deploy.test.ts
+++ b/frontend/src/lib/utils_workspace_deploy.test.ts
@@ -20,9 +20,11 @@ describe('deploy direction of a one-sided diff row', () => {
 		expect(diffRemovesInTarget(parentOnly, false)).toBe(false)
 	})
 
-	it('reads the same row as a removal when merging into the parent', () => {
+	it('keeps a parent-only row out of a merge into the parent, whatever its ahead count', () => {
+		expect(diffActionableInDirection(parentOnly, true)).toBe(false)
+		// An arbitrary target has no tally behind it and does propagate the removal.
+		expect(diffActionableInDirection(parentOnly, true, true)).toBe(true)
 		expect(diffRemovesInTarget(parentOnly, true)).toBe(true)
-		expect(diffCreatesInTarget(parentOnly, true)).toBe(false)
 	})
 
 	it('does not resurrect a fork-only item into an update of the fork', () => {

--- a/frontend/src/lib/utils_workspace_deploy.test.ts
+++ b/frontend/src/lib/utils_workspace_deploy.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import {
+	diffActionableInDirection,
+	diffCreatesInTarget,
+	diffRemovesInTarget
+} from './utils_workspace_deploy'
+
+/** The row shape the fork comparison returns for an item the parent has and the
+ * fork does not. `ahead = 1, behind = 0` is what the tally leaves after the fork
+ * pulled the parent's item in and then lost it (a delete, a git-sync revert):
+ * every deploy event in the fork counts as `ahead`, whatever wrote it. */
+const parentOnly = { ahead: 1, behind: 0, exists_in_source: true, exists_in_fork: false }
+const forkOnly = { ahead: 1, behind: 0, exists_in_source: false, exists_in_fork: true }
+const bothSides = { ahead: 1, behind: 1, exists_in_source: true, exists_in_fork: true }
+
+describe('deploy direction of a one-sided diff row', () => {
+	it('offers a parent-only item to the fork even with no behind count', () => {
+		expect(diffActionableInDirection(parentOnly, false)).toBe(true)
+		expect(diffCreatesInTarget(parentOnly, false)).toBe(true)
+		expect(diffRemovesInTarget(parentOnly, false)).toBe(false)
+	})
+
+	it('reads the same row as a removal when merging into the parent', () => {
+		expect(diffRemovesInTarget(parentOnly, true)).toBe(true)
+		expect(diffCreatesInTarget(parentOnly, true)).toBe(false)
+	})
+
+	it('does not resurrect a fork-only item into an update of the fork', () => {
+		expect(diffActionableInDirection(forkOnly, false)).toBe(false)
+		expect(diffCreatesInTarget(forkOnly, true)).toBe(true)
+	})
+
+	it('keeps a two-sided row on its counters', () => {
+		expect(diffActionableInDirection(bothSides, true)).toBe(true)
+		expect(diffActionableInDirection({ ...bothSides, behind: 0 }, false)).toBe(false)
+		expect(diffCreatesInTarget(bothSides, true)).toBe(false)
+		expect(diffRemovesInTarget(bothSides, false)).toBe(false)
+	})
+})

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -382,17 +382,11 @@ export function diffRemovesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: b
 }
 
 /**
- * Rows a deploy in this direction can act on.
- *
- * A merge into the parent carries what the fork *has*: an item only the parent has
- * is not a fork change, whatever `ahead` says (see `diffRemovesInTarget`), so it is
- * left out rather than offered as a removal nobody asked for. An arbitrary target
- * keeps them — that comparison is an explicit one-way sync with no tally behind it,
- * where a target-only item genuinely means "remove there".
- *
- * The update direction mirrors it: the fork takes any item the parent has and it
- * lacks, whatever the counters say, since such a row can carry `behind = 0` and
- * would else be unpullable.
+ * Rows a deploy in this direction can act on. A merge carries what the fork *has*,
+ * so an item only the parent has is left out whatever `ahead` says — it is no fork
+ * change (see `diffRemovesInTarget`). An arbitrary target keeps it: that one-way
+ * sync has no tally, so target-only really does mean "remove there". The update
+ * direction takes any such row, which can carry `behind = 0` and would else be lost.
  */
 export function diffActionableInDirection(
 	diff: WorkspaceDiffSides,

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -355,6 +355,57 @@ export async function deployItem(params: DeployItemParams): Promise<DeployResult
 }
 
 /**
+ * The two sides of a `workspace_diff` row a deploy direction reads:
+ * `exists_in_source` is the parent (or arbitrary target) side, `exists_in_fork`
+ * the current workspace.
+ */
+type WorkspaceDiffSides = {
+	ahead: number
+	behind: number
+	exists_in_source: boolean
+	exists_in_fork: boolean
+}
+
+/** Deploying this row creates the item in the target, which does not have it. */
+export function diffCreatesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: boolean): boolean {
+	return mergeIntoParent ? diff.exists_in_source === false : diff.exists_in_fork === false
+}
+
+/**
+ * Deploying this row removes the item in the target, the only side that has it.
+ *
+ * Which side dropped it is unknowable from the comparison: `ahead`/`behind`
+ * count deploy events on a side, and pulling the parent's own item into the fork
+ * or a git-sync revert leaves the same trace a deliberate delete does. So a row
+ * may only ever be described by what deploying it does, never by a deletion that
+ * may not have happened — and, being destructive, it takes an explicit act to
+ * select.
+ */
+export function diffRemovesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: boolean): boolean {
+	return mergeIntoParent ? diff.exists_in_fork === false : diff.exists_in_source === false
+}
+
+/**
+ * Rows a deploy in this direction can act on.
+ *
+ * The counters pick the rows flowing fork → parent. In the other direction the
+ * fork can additionally take any item the parent has and it lacks, whatever the
+ * counters say — a parent-only item can carry `behind = 0` (see
+ * `diffRemovesInTarget`) and would otherwise be unpullable. The mirror case is
+ * deliberately left out: a fork-only item with no `ahead` means the parent
+ * dropped it, and an update must not resurrect it there.
+ */
+export function diffActionableInDirection(
+	diff: WorkspaceDiffSides,
+	mergeIntoParent: boolean
+): boolean {
+	if (mergeIntoParent) {
+		return diff.ahead > 0
+	}
+	return diff.behind > 0 || diffCreatesInTarget(diff, mergeIntoParent)
+}
+
+/**
  * Delete/archive an item in a workspace.
  * Used when deploying a deletion from one workspace to another.
  * Scripts and flows are archived (reversible). Other types are deleted.

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -382,11 +382,10 @@ export function diffRemovesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: b
 }
 
 /**
- * Rows a deploy in this direction can act on. A merge carries what the fork *has*,
- * so an item only the parent has is left out whatever `ahead` says — it is no fork
- * change (see `diffRemovesInTarget`). An arbitrary target keeps it: that one-way
- * sync has no tally, so target-only really does mean "remove there". The update
- * direction takes any such row, which can carry `behind = 0` and would else be lost.
+ * Rows a deploy in this direction can act on. A merge carries what the fork *has*:
+ * an item only the parent has is no fork change (see `diffRemovesInTarget`), while
+ * the update direction takes it whatever the counters say. Only an arbitrary target
+ * merges one — that one-way sync has no tally, so target-only does mean "remove".
  */
 export function diffActionableInDirection(
 	diff: WorkspaceDiffSides,

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -382,17 +382,27 @@ export function diffRemovesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: b
 }
 
 /**
- * Rows a deploy in this direction can act on. The fork can take any item the
- * parent has and it lacks whatever the counters say — a parent-only row can carry
- * `behind = 0` (see `diffRemovesInTarget`) and would else be unpullable. The merge
- * direction is not mirrored: a fork-only row with no `ahead` is one the parent
- * dropped, and merging must not re-create it there.
+ * Rows a deploy in this direction can act on.
+ *
+ * A merge into the parent carries what the fork *has*: an item only the parent has
+ * is not a fork change, whatever `ahead` says (see `diffRemovesInTarget`), so it is
+ * left out rather than offered as a removal nobody asked for. An arbitrary target
+ * keeps them — that comparison is an explicit one-way sync with no tally behind it,
+ * where a target-only item genuinely means "remove there".
+ *
+ * The update direction mirrors it: the fork takes any item the parent has and it
+ * lacks, whatever the counters say, since such a row can carry `behind = 0` and
+ * would else be unpullable.
  */
 export function diffActionableInDirection(
 	diff: WorkspaceDiffSides,
-	mergeIntoParent: boolean
+	mergeIntoParent: boolean,
+	isArbitraryTarget: boolean = false
 ): boolean {
 	if (mergeIntoParent) {
+		if (!isArbitraryTarget && diff.exists_in_fork === false) {
+			return false
+		}
 		return diff.ahead > 0
 	}
 	return diff.behind > 0 || diffCreatesInTarget(diff, mergeIntoParent)

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -373,27 +373,19 @@ export function diffCreatesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: b
 
 /**
  * Deploying this row removes the item in the target, the only side that has it.
- *
- * Which side dropped it is unknowable from the comparison: `ahead`/`behind`
- * count deploy events on a side, and pulling the parent's own item into the fork
- * or a git-sync revert leaves the same trace a deliberate delete does. So a row
- * may only ever be described by what deploying it does, never by a deletion that
- * may not have happened — and, being destructive, it takes an explicit act to
- * select.
+ * Which side dropped it is unknowable — `ahead`/`behind` count deploy events on a
+ * side, and a pull into the fork or a git-sync revert leaves the trace a delete
+ * does — so a row states what deploying does, and a removal is never bulk-selected.
  */
 export function diffRemovesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: boolean): boolean {
 	return mergeIntoParent ? diff.exists_in_fork === false : diff.exists_in_source === false
 }
 
 /**
- * Rows a deploy in this direction can act on.
- *
- * The counters pick the rows flowing fork → parent. In the other direction the
- * fork can additionally take any item the parent has and it lacks, whatever the
- * counters say — a parent-only item can carry `behind = 0` (see
- * `diffRemovesInTarget`) and would otherwise be unpullable. The mirror case is
- * deliberately left out: a fork-only item with no `ahead` means the parent
- * dropped it, and an update must not resurrect it there.
+ * Rows a deploy in this direction can act on. The fork can take any item the
+ * parent has and it lacks whatever the counters say — a parent-only row can carry
+ * `behind = 0` (see `diffRemovesInTarget`) and would else be unpullable. Not
+ * mirrored: a fork-only row with no `ahead` means the parent dropped it.
  */
 export function diffActionableInDirection(
 	diff: WorkspaceDiffSides,

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -384,8 +384,9 @@ export function diffRemovesInTarget(diff: WorkspaceDiffSides, mergeIntoParent: b
 /**
  * Rows a deploy in this direction can act on. The fork can take any item the
  * parent has and it lacks whatever the counters say — a parent-only row can carry
- * `behind = 0` (see `diffRemovesInTarget`) and would else be unpullable. Not
- * mirrored: a fork-only row with no `ahead` means the parent dropped it.
+ * `behind = 0` (see `diffRemovesInTarget`) and would else be unpullable. The merge
+ * direction is not mirrored: a fork-only row with no `ahead` is one the parent
+ * dropped, and merging must not re-create it there.
  */
 export function diffActionableInDirection(
 	diff: WorkspaceDiffSides,

--- a/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
@@ -10,6 +10,7 @@
 		reconcileAfterWorkspaceChange
 	} from '$lib/components/sessions/sessionState.svelte'
 	import { useWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
+	import { diffActionableInDirection } from '$lib/utils_workspace_deploy'
 	import { page } from '$app/state'
 	import { userWorkspaces, workspaceStore } from '$lib/stores'
 	import { onDestroy, untrack } from 'svelte'
@@ -149,17 +150,18 @@
 	)
 
 	// Per-direction counts for the merged toggle badges. Deployable = items ahead
-	// (fork has changes the parent lacks); updateable = items behind. Computed
-	// here so they show on the toggle in draft mode too (where CompareDrafts has
-	// no comparison data of its own). Typed helpers avoid a $state `never`
-	// inference quirk on `comparison` inside $derived. A conflict (ahead AND
-	// behind) is intentionally counted in both directions — it's actionable either
-	// way.
-	function countDir(c: WorkspaceComparison | undefined, dir: 'ahead' | 'behind'): number {
-		return c?.diffs.filter((d) => d[dir] > 0).length ?? 0
+	// (fork has changes the parent lacks); updateable = items behind, plus what the
+	// parent has and the fork does not. Same predicate as the deploy list, so the
+	// badge never counts rows the list won't show. Computed here so they show on the
+	// toggle in draft mode too (where CompareDrafts has no comparison data of its
+	// own). Typed helpers avoid a $state `never` inference quirk on `comparison`
+	// inside $derived. A conflict (ahead AND behind) is intentionally counted in both
+	// directions — it's actionable either way.
+	function countDir(c: WorkspaceComparison | undefined, mergeIntoParent: boolean): number {
+		return c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent)).length ?? 0
 	}
-	const deployCount = $derived(countDir(comparison, 'ahead'))
-	const updateCount = $derived(countDir(comparison, 'behind'))
+	const deployCount = $derived(countDir(comparison, true))
+	const updateCount = $derived(countDir(comparison, false))
 
 	$effect(() => {
 		if (modeResolved || !currentWorkspaceData) return

--- a/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
@@ -158,7 +158,10 @@
 	// inside $derived. A conflict (ahead AND behind) is intentionally counted in both
 	// directions — it's actionable either way.
 	function countDir(c: WorkspaceComparison | undefined, mergeIntoParent: boolean): number {
-		return c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent)).length ?? 0
+		return (
+			c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent, isArbitraryTarget))
+				.length ?? 0
+		)
 	}
 	const deployCount = $derived(countDir(comparison, true))
 	const updateCount = $derived(countDir(comparison, false))

--- a/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
@@ -66,7 +66,11 @@
 	// Which fork direction to restore when switching back from draft mode. The
 	// merged toggle (CompareModeToggle, rendered inside each card) reports its
 	// selection here; the page only swaps which comparison component is shown.
-	let forkDirection = $state<'deploy_to' | 'update'>('deploy_to')
+	// `?dir=update` opens on the other one, for callers that already know which
+	// direction has something in it (the fork banner's CTA).
+	let forkDirection = $state<'deploy_to' | 'update'>(
+		page.url.searchParams.get('dir') === 'update' ? 'update' : 'deploy_to'
+	)
 
 	// Explicit preselection via `?items=<kind:path,...>` (built by the chat's
 	// open_page tool). Parsed synchronously from the live URL so it can never race


### PR DESCRIPTION
## Summary

On the fork **Compare & Deploy** page, items that exist in the parent and not in the fork were badged **"Deleted"**, swept into "Select all" in the deploy direction (where deploying them *deletes them in the parent*), and were **entirely absent from the "Update fork" list**, so they could not be pulled.

The page inferred "the fork deleted this" from the `ahead`/`behind` counters, but the tally increments `ahead` on **every** deploy event in the fork at that path — including a deploy that pulled the parent's own item in, and including the removal a git-sync auto-pull performs when its branch doesn't have the item yet. A parent-only row can therefore carry `ahead = 1, behind = 0` with no fork-side intent behind it.

Reproduced on a live fork: 23 scripts were pulled from the parent into the fork, a git-sync auto-pull removed them ~90s later, and both halves of that round trip credited `ahead`. The result was 26 rows offering to delete live parent items, while the update direction showed nothing to pull.

Since the counters cannot say which side moved, the merge direction no longer offers such a row at all: **a fork can only push what it has**, and an item only the parent has is not a fork change. It stays fully available in the "Update fork" direction, where taking it is what the fork actually wants.

## Changes

- **`utils_workspace_deploy.ts`** — three pure predicates shared by the page and the component: `diffCreatesInTarget`, `diffRemovesInTarget`, `diffActionableInDirection`.
- **Listing** — the merge direction carries only what the fork has: a parent-only row is excluded whatever its `ahead` count. The update direction gained the mirror, listing parent-only rows whatever their counters say (previously `behind > 0` only), so a parent addition is always pullable. An **arbitrary target** keeps its removal rows — that comparison is an explicit one-way sync with no tally behind it, where a target-only item genuinely means "remove there".
- **Badges** — direction-aware and effect-based: `New` when the deploy creates the item in the target, `Removes in <target>` when it deletes it there. The `Deleted` wording is gone; `deploy()` derives its delete-vs-copy branch from the same predicate, so the row's label always matches what it does.
- **Selection** — any row whose deploy removes in the target is opt-in (this now only arises in the update direction and for arbitrary targets). The update direction also leaves a parent-only row with `ahead > 0` out of the *default* selection: the fork may have dropped it deliberately, and a routine update must not silently bring it back. Both are still one click away via "Select all".
- **Backend** (`compare_workspaces`) — the visibility accounting follows the same rule on both sides: `all_behind_items_visible` / `hidden_behind` count source-only rows (invisible to the counter sums), while `all_ahead_items_visible` / `hidden_ahead` skip them for a lineage pair, since that direction no longer carries them. Otherwise each direction could warn about items it never offered, or stay silent about ones it did.
- **Group header count** — reports every ticked row, opt-in ones included, so it no longer contradicts the deploy button.
- **`Select all`** — disabled when every listed row is bulk-excluded, instead of offering an enabled control that selects nothing. Each such row stays selectable on its own.
- **AI chat fork diff** — `deleted_in_fork` → `only_in_parent`, with prompt wording to match; the chat was asserting the same unprovable deletion to the model.

## Why this rule, and not another

`ahead` and `behind` are **counts of writes on a side, not of changes originating on that side**. The tally increments on every deploy event at a path — create, update, delete, both halves of a rename — and syncing counts as a write on the receiving side: pulling parent→fork bumps `ahead`, merging fork→parent bumps `behind` for that fork and every sibling.

So for an item present on one side only, the counters cannot say who caused the absence. Mechanically the inference is sound in both directions (`ahead > 0` with the fork lacking the item does mean the fork had it and lost it), but it cannot distinguish an **authored** removal from one applied by a **sync** — a git-sync auto-pull, a reverted deploy, or the old half of a rename. The incident above is exactly that: a real delete, performed by an automated sync.

The two directions therefore treat the same evidence differently, and that asymmetry is a blast-radius decision rather than an epistemic one:

- **Update (parent → fork)** acts on an existence mismatch freely. It writes to the fork, which is the disposable side, and refusing would leave a parent addition unpullable.
- **Merge (fork → parent)** writes to prod, so it carries only what the fork *has and has touched*, and never infers a deletion.

That collapses to one sentence: **a merge carries what the fork has; an update carries what the parent has.**

## Every row shape, and what each direction does with it

A returned row always has `has_changes`, at least one side present, and at least one counter > 0 — rows that compare equal are deleted, and no path decrements. That yields nine shapes:

| Sides | ahead | behind | What happened | Merge | Update |
|---|---|---|---|---|---|
| both | >0 | 0 | fork edited it | listed | — |
| both | 0 | >0 | parent edited it | — | listed |
| both | >0 | >0 | both edited — conflict | listed + gated | listed (opt-in) |
| fork only | >0 | 0 | fork created it | "New" | — |
| fork only | 0 | >0 | parent deleted it | — | "Removes in fork" (opt-in) |
| fork only | >0 | >0 | fork edited, parent deleted | "New" (re-creates) | "Removes in fork" (opt-in) |
| **parent only** | **>0** | **0** | **ambiguous — parent added it, or fork deleted it** | **excluded** | **"New" (opt-in)** |
| parent only | 0 | >0 | parent added/edited it | — | "New" (selected) |
| parent only | >0 | >0 | fork deleted, parent edited | excluded | "New" (opt-in) |

The bolded row is the reported bug. It used to be badged "Deleted", swept into "Select all" on the merge side, and absent from the update side.

**Coverage:** every row lands in at least one direction, and only genuine conflicts land in both. If the fork has the item and `ahead = 0`, then `behind > 0`, so it is in Update; if `ahead > 0` it is in Merge; if the fork lacks it, the parent has it, so it is in Update. No row can go invisible.

## Known gaps this creates

Excluding parent-only rows from the merge also removes the only path for propagating a fork-side deletion, since "the fork deleted it" and "the parent added it" are the same row:

- Deleting an item in a fork no longer removes it in the parent on merge.
- Merging a **rename** creates the new path in the parent but leaves the old one behind (same for an app → raw_app conversion).
- A fork deletion that collides with a parent edit resolves silently as "parent wins".

All three need evidence the tally doesn't record. Follow-up filed as **WIN-2289**: record the event kind (`create`/`update`/`delete`/`rename_from`) *and* an authored-vs-sync origin flag, so the merge can offer a removal on evidence instead of inference. The origin flag is the load-bearing half — recording `kind = delete` alone would classify this incident's git-sync revert as a fork deletion and reproduce the bug.

## Screenshots

Fixture: `added_on_root` (`ahead=1, behind=0` — the reported shape), `added_on_root_clean_tally` (`ahead=0, behind=1`), `deleted_in_root` (parent deleted it), `added_on_fork` (fork-only).

**Before** — deploy direction: parent-only item badged "Deleted" and **ticked by "Select all"**, so deploying would delete it in `admins`:

![before-deploy-direction-deleted](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-deletion-phantom/1785754133-before-deploy-direction-deleted.png)

**Before** — update direction: only 1 of the 2 parent additions is listed; the `ahead=1` one cannot be pulled at all:

![before-update-direction-missing](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-deletion-phantom/1785754138-before-update-direction-missing.png)

**After** — deploy direction: only the fork's own item is listed. Both parent-only rows are gone from the merge entirely:

![v2-deploy-direction](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-deletion-phantom/1785779746-v2-deploy-direction.png)

**After** — update direction: both parent additions listed as "New" (the unambiguous one preselected, the `ahead > 0` one opt-in), and the parent-deleted row as an opt-in "Removes in wm-fork-demo":

![v2-update-direction](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-deletion-phantom/1785779749-v2-update-direction.png)

**After** — the fork banner, on a fork whose only diff is a parent-only row (`ahead=1, behind=0`): reads "1 change behind" and offers "Review & Update fork", which opens `&dir=update`. It previously read "1 change ahead — Review & Deploy Changes" and opened an empty deploy list:

![v2-banner](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-deletion-phantom/1785779751-v2-banner.png)

## Test plan

- [x] `frontend/src/lib/utils_workspace_deploy.test.ts` — the four row shapes across both directions, including the deliberate asymmetry
- [x] `npm run check` — 0 errors; `vitest` — 38 tests pass (incl. the updated `diffSnapshot.test.ts`)
- [x] Browser: all four row shapes render the right badge and selection state in both directions; "Select all" picks up the opt-in creates but never a removal
- [x] Browser: the fork banner's label, counts and destination on a parent-only-diff fork (clicked through to `&dir=update`)
- [x] Banner falls back to the deploy direction while the comparison is still loading, so an early click can't land somewhere the label didn't promise
- [x] Browser: pulled a parent-only `ahead=1, behind=0` row into the fork — the script is created there and the row drops out of the comparison on recompute
- [x] Backend rebuilt clean under cargo-watch; compare endpoint unchanged for the admin path
- [x] `test_compare_workspaces_hidden_source_only_no_behind` — a hidden source-only row at `behind = 0`; verified it fails on `main`'s version of the flag (`all_behind_items_visible: true, hidden_behind.total: 0`) and passes with the fix
- [x] Browser: a removal-only list disables "Select all" and its group checkbox while the row stays individually tickable
- [ ] Not reproduced in-browser: the stale-`removalKeys`-on-direction-flip fix (needs a comparison refetch mid-session); fixed by tracking `mergeIntoParent` in the effect and verified by inspection

## Consequence: no deletion propagation from the merge UI

Dropping parent-only rows from the merge list also drops the one way the page had to propagate a deletion fork → parent, because "the fork deleted it" and "the parent added it" are the same row. Two things change:

- Deleting an item in a fork no longer removes it in the parent on merge; do that in the parent directly.
- Merging a **rename** creates the new path in the parent but leaves the old one behind, where the old-path removal row used to clean it up.

Both need evidence the counters don't carry. The durable fix is to record the *kind* of event in the tally (deleted / renamed-from) so the merge UI can offer a removal on evidence rather than inference — happy to do that as a follow-up.

## Note (not fixed here)

The live incident's proximate cause is a **git-sync auto-pull racing a deploy**: items deployed into the fork at 08:06 were removed at 08:08 by a `pull: true` git-sync job whose branch did not have them yet. That is a separate subsystem and left untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Compare & Deploy mislabeling parent-only items as “Deleted”, keeps them out of fork→parent merges, makes parent additions always pullable, and opens the compare page in the direction that actually has items. Badges, counts, selection, and deploy actions now use the same rules, so what you see is what deploy will do.

- **Bug Fixes**
  - Fork→parent merge: parent-only rows aren’t listed; the “update before deploying” alert and toggle counts use the same predicate as the list.
  - Update list shows parent-only items even when behind=0, so new parent items are always pullable.
  - Direction-aware badges: “New” when deployment creates in the target, “Removes in <target>” when it deletes there; removed “Deleted”. Deploy and selection use the same rule.
  - Bulk selection never includes removals; Update defaults skip conflicts and parent-only rows with ahead>0. “Select all” is disabled on removal-only lists; group headers count all ticked rows.
  - Backend compare: visibility flags and hidden counts are direction-aware; source-only rows are counted as withheld from Update even at behind=0, and never from Merge; integration test added.
  - Copilot fork diff: `deleted_in_fork` → `only_in_parent`, with wording updated.
  - Fork banner: ahead/behind and CTA use the same predicate as Compare, the CTA opens that direction (`?dir=update`), treats an in-flight comparison as unknown, and no longer reads a loading/stale comparison as “nothing to deploy”.

- **Refactors**
  - Added `diffCreatesInTarget`, `diffRemovesInTarget`, and `diffActionableInDirection`; reused across UI and deploy; refreshed removal tracking on direction flips.
  - Tests added for one‑sided rows and compare visibility; snapshots updated; cached `.sqlx` query for the source-only visibility test.

<sup>Written for commit d42e2b98019779107fd37d2b51bcab3aacbfc4b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

