### PR TITLE
feat: azure workload identity auth for mssql and postgres resources

### DIFF
--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -22,8 +22,9 @@ pub const AZURE_OSSRDBMS_SCOPE: &str = "https://ossrdbms-aad.database.windows.ne
 /// Renew an access token this long before it expires.
 const TOKEN_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
 
-/// A token with less life than this left is not worth handing to a connection.
-const TOKEN_MIN_LIFETIME: Duration = Duration::from_secs(30);
+/// A token with less life than this left is not worth handing to a connection: opening
+/// one takes up to 20 seconds, and it authenticates at the far end of that.
+const TOKEN_MIN_LIFETIME: Duration = Duration::from_secs(60);
 
 /// How long a failed renewal suppresses the next attempt, as long as the current token
 /// still works. Without it every queued job retries the exchange in turn, so a
@@ -172,7 +173,9 @@ impl WorkloadIdentityConfig {
             }
             Err(e) => {
                 *last_failure = Some(Instant::now());
-                match usable {
+                // Check again rather than trusting the pre-request value: a request that
+                // times out eats 20 seconds of whatever the token had left.
+                match slot.token_valid_for(TOKEN_MIN_LIFETIME) {
                     Some(token) => {
                         tracing::warn!("Keeping the current Entra ID token, renewal failed: {e:#}");
                         Ok(token)

--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -5,7 +5,7 @@
 //! Nothing long-lived is stored on the Windmill instance.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use serde_json::Value;
@@ -22,9 +22,21 @@ pub const AZURE_OSSRDBMS_SCOPE: &str = "https://ossrdbms-aad.database.windows.ne
 /// Renew an access token this long before it expires.
 const TOKEN_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
 
+/// A token with less life than this left is not worth handing to a connection.
+const TOKEN_MIN_LIFETIME: Duration = Duration::from_secs(30);
+
 lazy_static::lazy_static! {
     /// Access tokens keyed by identity and scope, shared by every job on the worker.
-    static ref TOKEN_CACHE: Mutex<HashMap<String, CachedToken>> = Mutex::new(HashMap::new());
+    static ref TOKEN_CACHE: Mutex<HashMap<String, Arc<TokenSlot>>> = Mutex::new(HashMap::new());
+}
+
+#[derive(Default)]
+struct TokenSlot {
+    /// Read on the hit path, so it must never be held across the exchange.
+    token: RwLock<Option<CachedToken>>,
+    /// Held for the whole exchange, so a burst of jobs on a cold or expiring entry
+    /// makes one request to Entra ID instead of one per job.
+    refreshing: tokio::sync::Mutex<()>,
 }
 
 struct CachedToken {
@@ -32,9 +44,19 @@ struct CachedToken {
     expires_at: Instant,
 }
 
+impl TokenSlot {
+    fn token_valid_for(&self, remaining: Duration) -> Option<String> {
+        let cached = self.token.read().unwrap();
+        cached
+            .as_ref()
+            .filter(|cached| Instant::now() + remaining < cached.expires_at)
+            .map(|cached| cached.token.clone())
+    }
+}
+
 /// The federated credentials of the identity the worker authenticates as. The Azure
-/// workload identity webhook injects all of them as env vars; a resource may override
-/// them so one worker can reach databases behind distinct identities.
+/// workload identity webhook injects them as env vars; a resource may override the
+/// tenant and client so one worker can reach databases behind distinct identities.
 pub struct WorkloadIdentityConfig {
     tenant_id: String,
     client_id: String,
@@ -43,33 +65,40 @@ pub struct WorkloadIdentityConfig {
 }
 
 impl WorkloadIdentityConfig {
-    pub fn resolve(
-        tenant_id: Option<&str>,
-        client_id: Option<&str>,
-        federated_token_file: Option<&str>,
-    ) -> Result<Self> {
+    pub fn resolve(tenant_id: Option<&str>, client_id: Option<&str>) -> Result<Self> {
+        fn from_env(env_var: &str) -> Option<String> {
+            std::env::var(env_var).ok().filter(|v| !v.is_empty())
+        }
+
+        fn missing(env_var: &str, overridable: bool) -> Error {
+            Error::BadConfig(format!(
+                "Workload identity authentication requires the {} env var on the worker \
+                 (injected by the Azure workload identity webhook){}",
+                env_var,
+                if overridable {
+                    " or the matching field on the resource"
+                } else {
+                    ""
+                }
+            ))
+        }
+
         fn resolve_field(resource: Option<&str>, env_var: &str) -> Result<String> {
             resource
                 .filter(|v| !v.is_empty())
                 .map(str::to_string)
-                .or_else(|| std::env::var(env_var).ok().filter(|v| !v.is_empty()))
-                .ok_or_else(|| {
-                    Error::BadConfig(format!(
-                        "Workload identity authentication requires the {} env var on the worker \
-                         (injected by the Azure workload identity webhook) or the matching field \
-                         on the resource",
-                        env_var
-                    ))
-                })
+                .or_else(|| from_env(env_var))
+                .ok_or_else(|| missing(env_var, true))
         }
 
         Ok(Self {
             tenant_id: resolve_field(tenant_id, "AZURE_TENANT_ID")?,
             client_id: resolve_field(client_id, "AZURE_CLIENT_ID")?,
-            federated_token_file: resolve_field(
-                federated_token_file,
-                "AZURE_FEDERATED_TOKEN_FILE",
-            )?,
+            // Deliberately env-only: the projected token's path is the webhook's to
+            // choose, and a resource-supplied path would let whoever runs a script
+            // probe the worker filesystem through the resulting error.
+            federated_token_file: from_env("AZURE_FEDERATED_TOKEN_FILE")
+                .ok_or_else(|| missing("AZURE_FEDERATED_TOKEN_FILE", false))?,
             authority_host: std::env::var("AZURE_AUTHORITY_HOST")
                 .ok()
                 .filter(|v| !v.is_empty())
@@ -83,8 +112,8 @@ impl WorkloadIdentityConfig {
 
     fn cache_key(&self, scope: &str) -> String {
         format!(
-            "{}|{}|{}|{}|{}",
-            self.authority_host, self.tenant_id, self.client_id, self.federated_token_file, scope
+            "{}|{}|{}|{}",
+            self.authority_host, self.tenant_id, self.client_id, scope
         )
     }
 
@@ -101,11 +130,46 @@ impl WorkloadIdentityConfig {
 
     /// An Entra ID access token for `scope`, reusing the cached one while it is valid.
     pub async fn access_token(&self, scope: &str) -> Result<String> {
-        let cache_key = self.cache_key(scope);
-        if let Some(token) = cached_token(&cache_key) {
+        let slot = self.slot(scope);
+        if let Some(token) = slot.token_valid_for(TOKEN_REFRESH_BUFFER) {
             return Ok(token);
         }
 
+        let _refreshing = slot.refreshing.lock().await;
+        // Whoever held the lock may have just refreshed it.
+        if let Some(token) = slot.token_valid_for(TOKEN_REFRESH_BUFFER) {
+            return Ok(token);
+        }
+
+        match self.request_token(scope).await {
+            Ok(fresh) => {
+                let token = fresh.token.clone();
+                *slot.token.write().unwrap() = Some(fresh);
+                Ok(token)
+            }
+            // Inside the refresh buffer the previous token still works, and Entra ID
+            // throttles bursts: a failed renewal must not fail an otherwise fine job.
+            Err(e) => match slot.token_valid_for(TOKEN_MIN_LIFETIME) {
+                Some(token) => {
+                    tracing::warn!("Keeping the current Entra ID token, renewal failed: {e:#}");
+                    Ok(token)
+                }
+                None => Err(e),
+            },
+        }
+    }
+
+    fn slot(&self, scope: &str) -> Arc<TokenSlot> {
+        let mut cache = TOKEN_CACHE.lock().unwrap();
+        // Identities come off resources, so the key space is caller-controlled: drop
+        // what has expired and that no in-flight request is holding.
+        cache.retain(|_, slot| {
+            Arc::strong_count(slot) > 1 || slot.token_valid_for(TOKEN_MIN_LIFETIME).is_some()
+        });
+        cache.entry(self.cache_key(scope)).or_default().clone()
+    }
+
+    async fn request_token(&self, scope: &str) -> Result<CachedToken> {
         // The projected token rotates on disk, so it must be re-read on every exchange.
         let assertion = tokio::fs::read_to_string(&self.federated_token_file)
             .await
@@ -161,24 +225,8 @@ impl WorkloadIdentityConfig {
             .to_string();
         let expires_in = body["expires_in"].as_u64().unwrap_or(3600);
 
-        TOKEN_CACHE.lock().unwrap().insert(
-            cache_key,
-            CachedToken {
-                token: token.clone(),
-                expires_at: Instant::now() + Duration::from_secs(expires_in),
-            },
-        );
-
-        Ok(token)
+        Ok(CachedToken { token, expires_at: Instant::now() + Duration::from_secs(expires_in) })
     }
-}
-
-fn cached_token(cache_key: &str) -> Option<String> {
-    let cache = TOKEN_CACHE.lock().unwrap();
-    cache
-        .get(cache_key)
-        .filter(|cached| Instant::now() + TOKEN_REFRESH_BUFFER < cached.expires_at)
-        .map(|cached| cached.token.clone())
 }
 
 #[cfg(test)]
@@ -214,6 +262,23 @@ mod tests {
         assert_ne!(
             config.cache_key(AZURE_SQL_SCOPE),
             config.cache_key(AZURE_OSSRDBMS_SCOPE)
+        );
+    }
+
+    /// A token inside the refresh buffer is no longer served as fresh, but is still
+    /// good enough to fall back on when the renewal itself fails.
+    #[test]
+    fn test_token_within_refresh_buffer_is_stale_but_usable() {
+        let slot = TokenSlot::default();
+        *slot.token.write().unwrap() = Some(CachedToken {
+            token: "tok".to_string(),
+            expires_at: Instant::now() + TOKEN_REFRESH_BUFFER - Duration::from_secs(60),
+        });
+
+        assert_eq!(slot.token_valid_for(TOKEN_REFRESH_BUFFER), None);
+        assert_eq!(
+            slot.token_valid_for(TOKEN_MIN_LIFETIME),
+            Some("tok".to_string())
         );
     }
 }

--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -24,7 +24,9 @@ pub const AZURE_OSSRDBMS_SCOPE: &str = "https://ossrdbms-aad.database.windows.ne
 /// database. Carrying the mode in the password is what lets an existing deployment turn
 /// it on: the resource type schemas live on the hub, and every database form already has
 /// a password field. Anyone whose password is literally this string authenticates as the
-/// worker's identity instead of failing to log in.
+/// worker's identity instead of failing to log in, which is why it is deliberately less
+/// password-shaped than the instance's `entraid`: that one is set by whoever runs the
+/// instance, this one sits where users keep their own secrets.
 pub const WORKLOAD_IDENTITY_PASSWORD: &str = "ms_entraid";
 
 /// Renew an access token this long before it expires.

--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -19,6 +19,14 @@ pub const AZURE_SQL_SCOPE: &str = "https://database.windows.net/.default";
 /// Entra ID scope of Azure Database for PostgreSQL / MySQL.
 pub const AZURE_OSSRDBMS_SCOPE: &str = "https://ossrdbms-aad.database.windows.net/.default";
 
+/// A database resource whose password is this authenticates as the worker's workload
+/// identity, the way a `DATABASE_URL` whose password is `entraid` does for the instance
+/// database. Carrying the mode in the password is what lets an existing deployment turn
+/// it on: the resource type schemas live on the hub, and every database form already has
+/// a password field. Anyone whose password is literally this string authenticates as the
+/// worker's identity instead of failing to log in.
+pub const WORKLOAD_IDENTITY_PASSWORD: &str = "ms_entraid";
+
 /// Renew an access token this long before it expires.
 const TOKEN_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
 
@@ -70,9 +78,9 @@ fn should_attempt_refresh(last_failure: Option<Instant>, has_usable_token: bool)
     }
 }
 
-/// The federated credentials of the identity the worker authenticates as. The Azure
-/// workload identity webhook injects them as env vars; a resource may override the
-/// tenant and client so one worker can reach databases behind distinct identities.
+/// The federated credentials of the identity the worker authenticates as, all injected
+/// into the pod by the Azure workload identity webhook. The identity is the worker's,
+/// not the resource's: reaching two databases as two identities means two worker groups.
 pub struct WorkloadIdentityConfig {
     tenant_id: String,
     client_id: String,
@@ -81,40 +89,24 @@ pub struct WorkloadIdentityConfig {
 }
 
 impl WorkloadIdentityConfig {
-    pub fn resolve(tenant_id: Option<&str>, client_id: Option<&str>) -> Result<Self> {
-        fn from_env(env_var: &str) -> Option<String> {
-            std::env::var(env_var).ok().filter(|v| !v.is_empty())
-        }
-
-        fn missing(env_var: &str, overridable: bool) -> Error {
-            Error::BadConfig(format!(
-                "Workload identity authentication requires the {} env var on the worker \
-                 (injected by the Azure workload identity webhook){}",
-                env_var,
-                if overridable {
-                    " or the matching field on the resource"
-                } else {
-                    ""
-                }
-            ))
-        }
-
-        fn resolve_field(resource: Option<&str>, env_var: &str) -> Result<String> {
-            resource
+    pub fn resolve() -> Result<Self> {
+        fn required(env_var: &str) -> Result<String> {
+            std::env::var(env_var)
+                .ok()
                 .filter(|v| !v.is_empty())
-                .map(str::to_string)
-                .or_else(|| from_env(env_var))
-                .ok_or_else(|| missing(env_var, true))
+                .ok_or_else(|| {
+                    Error::BadConfig(format!(
+                        "Workload identity authentication requires the {} env var on the worker, \
+                         injected by the Azure workload identity webhook",
+                        env_var
+                    ))
+                })
         }
 
         Ok(Self {
-            tenant_id: resolve_field(tenant_id, "AZURE_TENANT_ID")?,
-            client_id: resolve_field(client_id, "AZURE_CLIENT_ID")?,
-            // Deliberately env-only: the projected token's path is the webhook's to
-            // choose, and a resource-supplied path would let whoever runs a script
-            // probe the worker filesystem through the resulting error.
-            federated_token_file: from_env("AZURE_FEDERATED_TOKEN_FILE")
-                .ok_or_else(|| missing("AZURE_FEDERATED_TOKEN_FILE", false))?,
+            tenant_id: required("AZURE_TENANT_ID")?,
+            client_id: required("AZURE_CLIENT_ID")?,
+            federated_token_file: required("AZURE_FEDERATED_TOKEN_FILE")?,
             authority_host: std::env::var("AZURE_AUTHORITY_HOST")
                 .ok()
                 .filter(|v| !v.is_empty())
@@ -188,8 +180,7 @@ impl WorkloadIdentityConfig {
 
     fn slot(&self, scope: &str) -> Arc<TokenSlot> {
         let mut cache = TOKEN_CACHE.lock().unwrap();
-        // Identities come off resources, so the key space is caller-controlled: drop
-        // what has expired and that no in-flight request is holding.
+        // Drop what has expired and that no in-flight request is holding.
         cache.retain(|_, slot| {
             Arc::strong_count(slot) > 1 || slot.token_valid_for(TOKEN_MIN_LIFETIME).is_some()
         });
@@ -293,7 +284,7 @@ mod tests {
     }
 
     /// A recent failure must not be re-attempted by every job queued behind the
-    /// refresh lock — but only while there is a token left to serve them.
+    /// refresh lock, but only while there is a token left to serve them.
     #[test]
     fn test_failed_refresh_is_not_retried_by_every_caller() {
         assert!(!should_attempt_refresh(Some(Instant::now()), true));

--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -25,6 +25,11 @@ const TOKEN_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
 /// A token with less life than this left is not worth handing to a connection.
 const TOKEN_MIN_LIFETIME: Duration = Duration::from_secs(30);
 
+/// How long a failed renewal suppresses the next attempt, as long as the current token
+/// still works. Without it every queued job retries the exchange in turn, so a
+/// throttling Entra ID would cost each of them the request's full latency.
+const REFRESH_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+
 lazy_static::lazy_static! {
     /// Access tokens keyed by identity and scope, shared by every job on the worker.
     static ref TOKEN_CACHE: Mutex<HashMap<String, Arc<TokenSlot>>> = Mutex::new(HashMap::new());
@@ -35,8 +40,9 @@ struct TokenSlot {
     /// Read on the hit path, so it must never be held across the exchange.
     token: RwLock<Option<CachedToken>>,
     /// Held for the whole exchange, so a burst of jobs on a cold or expiring entry
-    /// makes one request to Entra ID instead of one per job.
-    refreshing: tokio::sync::Mutex<()>,
+    /// makes one request to Entra ID instead of one per job. Guards the time of the
+    /// last failed exchange, which is what the waiting jobs need to see.
+    refreshing: tokio::sync::Mutex<Option<Instant>>,
 }
 
 struct CachedToken {
@@ -51,6 +57,15 @@ impl TokenSlot {
             .as_ref()
             .filter(|cached| Instant::now() + remaining < cached.expires_at)
             .map(|cached| cached.token.clone())
+    }
+}
+
+/// Whether to go to Entra ID, given the last failed exchange and whether the current
+/// token would still serve. A cold slot always tries: there is nothing to fall back on.
+fn should_attempt_refresh(last_failure: Option<Instant>, has_usable_token: bool) -> bool {
+    match last_failure {
+        Some(at) if has_usable_token => at.elapsed() >= REFRESH_RETRY_BACKOFF,
+        _ => true,
     }
 }
 
@@ -135,27 +150,36 @@ impl WorkloadIdentityConfig {
             return Ok(token);
         }
 
-        let _refreshing = slot.refreshing.lock().await;
+        let mut last_failure = slot.refreshing.lock().await;
         // Whoever held the lock may have just refreshed it.
         if let Some(token) = slot.token_valid_for(TOKEN_REFRESH_BUFFER) {
             return Ok(token);
+        }
+
+        // Inside the refresh buffer the previous token still works, and Entra ID
+        // throttles bursts: a failed renewal must not fail an otherwise fine job.
+        let usable = slot.token_valid_for(TOKEN_MIN_LIFETIME);
+        if !should_attempt_refresh(*last_failure, usable.is_some()) {
+            return Ok(usable.unwrap());
         }
 
         match self.request_token(scope).await {
             Ok(fresh) => {
                 let token = fresh.token.clone();
                 *slot.token.write().unwrap() = Some(fresh);
+                *last_failure = None;
                 Ok(token)
             }
-            // Inside the refresh buffer the previous token still works, and Entra ID
-            // throttles bursts: a failed renewal must not fail an otherwise fine job.
-            Err(e) => match slot.token_valid_for(TOKEN_MIN_LIFETIME) {
-                Some(token) => {
-                    tracing::warn!("Keeping the current Entra ID token, renewal failed: {e:#}");
-                    Ok(token)
+            Err(e) => {
+                *last_failure = Some(Instant::now());
+                match usable {
+                    Some(token) => {
+                        tracing::warn!("Keeping the current Entra ID token, renewal failed: {e:#}");
+                        Ok(token)
+                    }
+                    None => Err(e),
                 }
-                None => Err(e),
-            },
+            }
         }
     }
 
@@ -263,6 +287,19 @@ mod tests {
             config.cache_key(AZURE_SQL_SCOPE),
             config.cache_key(AZURE_OSSRDBMS_SCOPE)
         );
+    }
+
+    /// A recent failure must not be re-attempted by every job queued behind the
+    /// refresh lock — but only while there is a token left to serve them.
+    #[test]
+    fn test_failed_refresh_is_not_retried_by_every_caller() {
+        assert!(!should_attempt_refresh(Some(Instant::now()), true));
+        assert!(should_attempt_refresh(Some(Instant::now()), false));
+        assert!(should_attempt_refresh(
+            Instant::now().checked_sub(REFRESH_RETRY_BACKOFF),
+            true
+        ));
+        assert!(should_attempt_refresh(None, true));
     }
 
     /// A token inside the refresh buffer is no longer served as fresh, but is still

--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -1,0 +1,219 @@
+//! Azure Workload Identity Federation.
+//!
+//! The Kubernetes-projected service account token of the pod is exchanged with Entra
+//! ID for an access token, which Azure-hosted databases accept in place of a password.
+//! Nothing long-lived is stored on the Windmill instance.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+use crate::utils::HTTP_CLIENT;
+
+/// Entra ID scope of Azure SQL / SQL Server.
+pub const AZURE_SQL_SCOPE: &str = "https://database.windows.net/.default";
+
+/// Entra ID scope of Azure Database for PostgreSQL / MySQL.
+pub const AZURE_OSSRDBMS_SCOPE: &str = "https://ossrdbms-aad.database.windows.net/.default";
+
+/// Renew an access token this long before it expires.
+const TOKEN_REFRESH_BUFFER: Duration = Duration::from_secs(5 * 60);
+
+lazy_static::lazy_static! {
+    /// Access tokens keyed by identity and scope, shared by every job on the worker.
+    static ref TOKEN_CACHE: Mutex<HashMap<String, CachedToken>> = Mutex::new(HashMap::new());
+}
+
+struct CachedToken {
+    token: String,
+    expires_at: Instant,
+}
+
+/// The federated credentials of the identity the worker authenticates as. The Azure
+/// workload identity webhook injects all of them as env vars; a resource may override
+/// them so one worker can reach databases behind distinct identities.
+pub struct WorkloadIdentityConfig {
+    tenant_id: String,
+    client_id: String,
+    federated_token_file: String,
+    authority_host: String,
+}
+
+impl WorkloadIdentityConfig {
+    pub fn resolve(
+        tenant_id: Option<&str>,
+        client_id: Option<&str>,
+        federated_token_file: Option<&str>,
+    ) -> Result<Self> {
+        fn resolve_field(resource: Option<&str>, env_var: &str) -> Result<String> {
+            resource
+                .filter(|v| !v.is_empty())
+                .map(str::to_string)
+                .or_else(|| std::env::var(env_var).ok().filter(|v| !v.is_empty()))
+                .ok_or_else(|| {
+                    Error::BadConfig(format!(
+                        "Workload identity authentication requires the {} env var on the worker \
+                         (injected by the Azure workload identity webhook) or the matching field \
+                         on the resource",
+                        env_var
+                    ))
+                })
+        }
+
+        Ok(Self {
+            tenant_id: resolve_field(tenant_id, "AZURE_TENANT_ID")?,
+            client_id: resolve_field(client_id, "AZURE_CLIENT_ID")?,
+            federated_token_file: resolve_field(
+                federated_token_file,
+                "AZURE_FEDERATED_TOKEN_FILE",
+            )?,
+            authority_host: std::env::var("AZURE_AUTHORITY_HOST")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| "login.microsoftonline.com".to_string()),
+        })
+    }
+
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    fn cache_key(&self, scope: &str) -> String {
+        format!(
+            "{}|{}|{}|{}|{}",
+            self.authority_host, self.tenant_id, self.client_id, self.federated_token_file, scope
+        )
+    }
+
+    /// AZURE_AUTHORITY_HOST is injected with a scheme and a trailing slash
+    /// (`https://login.microsoftonline.com/`), neither of which belongs in the path.
+    fn token_endpoint(&self) -> String {
+        let authority = self
+            .authority_host
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches('/');
+        format!("https://{}/{}/oauth2/v2.0/token", authority, self.tenant_id)
+    }
+
+    /// An Entra ID access token for `scope`, reusing the cached one while it is valid.
+    pub async fn access_token(&self, scope: &str) -> Result<String> {
+        let cache_key = self.cache_key(scope);
+        if let Some(token) = cached_token(&cache_key) {
+            return Ok(token);
+        }
+
+        // The projected token rotates on disk, so it must be re-read on every exchange.
+        let assertion = tokio::fs::read_to_string(&self.federated_token_file)
+            .await
+            .map_err(|e| {
+                Error::ExecutionErr(format!(
+                    "Failed to read the federated token at {}: {}",
+                    self.federated_token_file, e
+                ))
+            })?;
+
+        let url = self.token_endpoint();
+        let response = HTTP_CLIENT
+            .post(&url)
+            .form(&[
+                ("grant_type", "client_credentials"),
+                ("client_id", self.client_id.as_str()),
+                (
+                    "client_assertion_type",
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                ),
+                ("client_assertion", assertion.trim()),
+                ("scope", scope),
+            ])
+            .send()
+            .await
+            .map_err(|e| {
+                Error::ExecutionErr(format!(
+                    "Failed to request an Entra ID token from {url}: {e}"
+                ))
+            })?;
+
+        let status = response.status();
+        let body: Value = response.json().await.map_err(|e| {
+            Error::ExecutionErr(format!("Failed to parse the Entra ID token response: {e}"))
+        })?;
+
+        if !status.is_success() {
+            return Err(Error::ExecutionErr(format!(
+                "Entra ID token request failed ({}): {} - {}",
+                status,
+                body["error"].as_str().unwrap_or("unknown"),
+                body["error_description"]
+                    .as_str()
+                    .unwrap_or("no description")
+            )));
+        }
+
+        let token = body["access_token"]
+            .as_str()
+            .ok_or_else(|| {
+                Error::ExecutionErr("Entra ID token response is missing access_token".to_string())
+            })?
+            .to_string();
+        let expires_in = body["expires_in"].as_u64().unwrap_or(3600);
+
+        TOKEN_CACHE.lock().unwrap().insert(
+            cache_key,
+            CachedToken {
+                token: token.clone(),
+                expires_at: Instant::now() + Duration::from_secs(expires_in),
+            },
+        );
+
+        Ok(token)
+    }
+}
+
+fn cached_token(cache_key: &str) -> Option<String> {
+    let cache = TOKEN_CACHE.lock().unwrap();
+    cache
+        .get(cache_key)
+        .filter(|cached| Instant::now() + TOKEN_REFRESH_BUFFER < cached.expires_at)
+        .map(|cached| cached.token.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(authority_host: &str) -> WorkloadIdentityConfig {
+        WorkloadIdentityConfig {
+            tenant_id: "tenant".to_string(),
+            client_id: "client".to_string(),
+            federated_token_file: "/var/run/secrets/azure/tokens/azure-identity-token".to_string(),
+            authority_host: authority_host.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_token_endpoint() {
+        let expected = "https://login.microsoftonline.com/tenant/oauth2/v2.0/token";
+        assert_eq!(
+            config("login.microsoftonline.com").token_endpoint(),
+            expected
+        );
+        // The shape the workload identity webhook actually injects.
+        assert_eq!(
+            config("https://login.microsoftonline.com/").token_endpoint(),
+            expected
+        );
+    }
+
+    #[test]
+    fn test_cache_key_is_scoped() {
+        let config = config("login.microsoftonline.com");
+        assert_ne!(
+            config.cache_key(AZURE_SQL_SCOPE),
+            config.cache_key(AZURE_OSSRDBMS_SCOPE)
+        );
+    }
+}

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -29,6 +29,7 @@ use sqlx::{Acquire, Postgres};
 pub mod agent_workers;
 pub mod apps;
 pub mod assets;
+pub mod azure_workload_identity;
 pub mod dbt_manifest;
 pub mod audit;
 pub mod auth;
@@ -706,6 +707,10 @@ ta9ELulniZau8zUAtwqwecxodzl+KO8NYj0a9PGgAM64dMqkRtRA8P4UP350Nag3\n\
             accept_invalid_certs: None,
             use_iam_auth: None,
             region: None,
+            use_workload_identity: None,
+            tenant_id: None,
+            client_id: None,
+            federated_token_file: None,
         }
     }
 
@@ -824,8 +829,21 @@ pub struct PgDatabase {
     /// certificate is present — so resources that predate this flag (including
     /// git-synced ones, whose source never sets it) keep working unchanged.
     pub accept_invalid_certs: Option<bool>,
+    /// AWS RDS IAM authentication, with `region` as its only parameter.
     pub use_iam_auth: Option<bool>,
     pub region: Option<String>,
+    /// Azure Entra ID authentication (Azure Database for PostgreSQL): the worker's
+    /// federated identity is exchanged for an access token used as the password.
+    /// The `tenant_id` / `client_id` / `federated_token_file` below override the
+    /// env vars the Azure workload identity webhook injects into the pod.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_workload_identity: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub federated_token_file: Option<String>,
 }
 
 // Wrapper enum to hold either Tls or NoTls connection
@@ -1053,9 +1071,6 @@ impl PgDatabase {
     pub async fn connect_with_iam(
         &self,
     ) -> Result<(tokio_postgres::Client, TokioPgConnection), error::Error> {
-        use native_tls::TlsConnector;
-        use postgres_native_tls::MakeTlsConnector;
-
         // Resolve region: resource field takes priority, then env var
         let region = match self.region.as_deref() {
             Some(r) => r.to_string(),
@@ -1075,7 +1090,45 @@ impl PgDatabase {
                 error::Error::InternalErr(format!("IAM token generation failed: {e:#}"))
             })?;
 
-        // RDS IAM auth requires SSL.
+        self.connect_with_token("IAM RDS", &token).await
+    }
+
+    /// Connect to Azure Database for PostgreSQL as the worker's federated identity.
+    /// The Entra ID access token replaces the password; `user` must be the Entra
+    /// principal name the server knows the identity by.
+    #[cfg(feature = "enterprise")]
+    pub async fn connect_with_workload_identity(
+        &self,
+    ) -> Result<(tokio_postgres::Client, TokioPgConnection), error::Error> {
+        let workload_identity = azure_workload_identity::WorkloadIdentityConfig::resolve(
+            self.tenant_id.as_deref(),
+            self.client_id.as_deref(),
+            self.federated_token_file.as_deref(),
+        )?;
+        let token = workload_identity
+            .access_token(azure_workload_identity::AZURE_OSSRDBMS_SCOPE)
+            .await?;
+
+        self.connect_with_token("Azure workload identity", &token)
+            .await
+    }
+
+    /// Connect with an externally issued access token in place of the password.
+    /// Both issuers (AWS IAM, Entra ID) mandate TLS, so encryption is forced on
+    /// regardless of the resource's sslmode; the sslmode still selects how far the
+    /// server's certificate is verified.
+    #[cfg(feature = "enterprise")]
+    async fn connect_with_token(
+        &self,
+        auth_kind: &str,
+        token: &str,
+    ) -> Result<(tokio_postgres::Client, TokioPgConnection), error::Error> {
+        use native_tls::TlsConnector;
+        use postgres_native_tls::MakeTlsConnector;
+
+        let port = self.port.unwrap_or(5432);
+        let user = self.user.as_deref().unwrap_or("postgres");
+
         let mut connector = TlsConnector::builder();
         let verified = Self::configure_pg_tls_verification(
             &mut connector,
@@ -1084,19 +1137,19 @@ impl PgDatabase {
             self.accept_invalid_certs,
         )?;
         if !verified {
-            tracing::warn!("IAM RDS auth without certificate verification: TLS certificate verification is disabled. Provide root_certificate_pem (and set sslmode=verify-full) to enforce verification.");
+            tracing::warn!("{auth_kind} auth without certificate verification: TLS certificate verification is disabled. Provide root_certificate_pem (and set sslmode=verify-full) to enforce verification.");
         }
 
-        tracing::info!("Creating new IAM RDS connection to {}", &self.host);
+        tracing::info!("Creating new {auth_kind} connection to {}", &self.host);
 
-        // Use Config builder directly to pass the IAM token as the password.
+        // Use Config builder directly to pass the token as the password.
         // This avoids needing to URL-encode the token into a connection string.
         let mut config = tokio_postgres::Config::new();
         config
             .host(&self.host)
             .port(port as u16)
             .user(user)
-            .password(&token)
+            .password(token)
             .dbname(&self.dbname)
             .ssl_mode(tokio_postgres::config::SslMode::Require);
 
@@ -1152,6 +1205,10 @@ impl PgDatabase {
             accept_invalid_certs: None,
             use_iam_auth: None,
             region: None,
+            use_workload_identity: None,
+            tenant_id: None,
+            client_id: None,
+            federated_token_file: None,
         })
     }
 }

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -710,7 +710,6 @@ ta9ELulniZau8zUAtwqwecxodzl+KO8NYj0a9PGgAM64dMqkRtRA8P4UP350Nag3\n\
             use_workload_identity: None,
             tenant_id: None,
             client_id: None,
-            federated_token_file: None,
         }
     }
 
@@ -834,16 +833,14 @@ pub struct PgDatabase {
     pub region: Option<String>,
     /// Azure Entra ID authentication (Azure Database for PostgreSQL): the worker's
     /// federated identity is exchanged for an access token used as the password.
-    /// The `tenant_id` / `client_id` / `federated_token_file` below override the
-    /// env vars the Azure workload identity webhook injects into the pod.
+    /// The `tenant_id` / `client_id` below override the env vars the Azure workload
+    /// identity webhook injects into the pod.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_workload_identity: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tenant_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub federated_token_file: Option<String>,
 }
 
 // Wrapper enum to hold either Tls or NoTls connection
@@ -1103,7 +1100,6 @@ impl PgDatabase {
         let workload_identity = azure_workload_identity::WorkloadIdentityConfig::resolve(
             self.tenant_id.as_deref(),
             self.client_id.as_deref(),
-            self.federated_token_file.as_deref(),
         )?;
         let token = workload_identity
             .access_token(azure_workload_identity::AZURE_OSSRDBMS_SCOPE)
@@ -1208,7 +1204,6 @@ impl PgDatabase {
             use_workload_identity: None,
             tenant_id: None,
             client_id: None,
-            federated_token_file: None,
         })
     }
 }

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -837,9 +837,19 @@ pub struct PgDatabase {
     /// identity webhook injects into the pod.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_workload_identity: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // A blank field means "not set" — it must not read as a distinct identity, which
+    // would key its own entry in the connection cache.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::utils::empty_as_none"
+    )]
     pub tenant_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::utils::empty_as_none"
+    )]
     pub client_id: Option<String>,
 }
 

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -707,9 +707,6 @@ ta9ELulniZau8zUAtwqwecxodzl+KO8NYj0a9PGgAM64dMqkRtRA8P4UP350Nag3\n\
             accept_invalid_certs: None,
             use_iam_auth: None,
             region: None,
-            use_workload_identity: None,
-            tenant_id: None,
-            client_id: None,
         }
     }
 
@@ -828,29 +825,8 @@ pub struct PgDatabase {
     /// certificate is present — so resources that predate this flag (including
     /// git-synced ones, whose source never sets it) keep working unchanged.
     pub accept_invalid_certs: Option<bool>,
-    /// AWS RDS IAM authentication, with `region` as its only parameter.
     pub use_iam_auth: Option<bool>,
     pub region: Option<String>,
-    /// Azure Entra ID authentication (Azure Database for PostgreSQL): the worker's
-    /// federated identity is exchanged for an access token used as the password.
-    /// The `tenant_id` / `client_id` below override the env vars the Azure workload
-    /// identity webhook injects into the pod.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub use_workload_identity: Option<bool>,
-    // A blank field means "not set" — it must not read as a distinct identity, which
-    // would key its own entry in the connection cache.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::utils::empty_as_none"
-    )]
-    pub tenant_id: Option<String>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::utils::empty_as_none"
-    )]
-    pub client_id: Option<String>,
 }
 
 // Wrapper enum to hold either Tls or NoTls connection
@@ -1107,10 +1083,7 @@ impl PgDatabase {
     pub async fn connect_with_workload_identity(
         &self,
     ) -> Result<(tokio_postgres::Client, TokioPgConnection), error::Error> {
-        let workload_identity = azure_workload_identity::WorkloadIdentityConfig::resolve(
-            self.tenant_id.as_deref(),
-            self.client_id.as_deref(),
-        )?;
+        let workload_identity = azure_workload_identity::WorkloadIdentityConfig::resolve()?;
         let token = workload_identity
             .access_token(azure_workload_identity::AZURE_OSSRDBMS_SCOPE)
             .await?;
@@ -1211,9 +1184,6 @@ impl PgDatabase {
             accept_invalid_certs: None,
             use_iam_auth: None,
             region: None,
-            use_workload_identity: None,
-            tenant_id: None,
-            client_id: None,
         })
     }
 }

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -55,8 +55,6 @@ struct MssqlDatabase {
     tenant_id: Option<String>,
     #[serde(default, deserialize_with = "empty_as_none")]
     client_id: Option<String>,
-    #[serde(default, deserialize_with = "empty_as_none")]
-    federated_token_file: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -160,7 +158,6 @@ pub async fn do_mssql(
         let workload_identity = WorkloadIdentityConfig::resolve(
             database.tenant_id.as_deref(),
             database.client_id.as_deref(),
-            database.federated_token_file.as_deref(),
         )?;
         let logs = format!(
             "\nUsing Azure Workload Identity (client id {})",

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -11,7 +11,9 @@ use tiberius::{
 use tokio::net::TcpStream;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
 use uuid::Uuid;
-use windmill_common::azure_workload_identity::{WorkloadIdentityConfig, AZURE_SQL_SCOPE};
+use windmill_common::azure_workload_identity::{
+    WorkloadIdentityConfig, AZURE_SQL_SCOPE, WORKLOAD_IDENTITY_PASSWORD,
+};
 use windmill_common::utils::merge_raw_values_to_object;
 use windmill_common::worker::SqlResultCollectionStrategy;
 use windmill_common::{
@@ -50,11 +52,6 @@ struct MssqlDatabase {
     ca_cert: Option<String>,
     encrypt: Option<bool>,
     integrated_auth: Option<bool>,
-    workload_identity: Option<bool>,
-    #[serde(default, deserialize_with = "empty_as_none")]
-    tenant_id: Option<String>,
-    #[serde(default, deserialize_with = "empty_as_none")]
-    client_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -154,11 +151,8 @@ pub async fn do_mssql(
                 "Integrated authentication is not available in this build. Requires mssql-kerberos (Linux) or mssql-winauth (Windows) feature.".to_string(),
             ));
         }
-    } else if database.workload_identity.unwrap_or(false) {
-        let workload_identity = WorkloadIdentityConfig::resolve(
-            database.tenant_id.as_deref(),
-            database.client_id.as_deref(),
-        )?;
+    } else if database.password.as_deref() == Some(WORKLOAD_IDENTITY_PASSWORD) {
+        let workload_identity = WorkloadIdentityConfig::resolve()?;
         let logs = format!(
             "\nUsing Azure Workload Identity (client id {})",
             workload_identity.client_id()
@@ -178,7 +172,7 @@ pub async fn do_mssql(
         config.authentication(AuthMethod::sql_server(user.clone(), password.clone()));
     } else {
         return Err(Error::BadRequest(
-            "No authentication method configured. Set integrated_auth, workload_identity, aad_token, or user/password.".to_string(),
+            "No authentication method configured. Set integrated_auth, aad_token, or user/password (password `ms_entraid` for Azure workload identity).".to_string(),
         ));
     }
 

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -122,10 +122,10 @@ pub async fn do_mssql(
     let port_ref = database.port;
 
     config.host(host_ref.clone());
-    config.database(&database.dbname);
+    config.database(database.dbname);
     let use_instance_name = database.instance_name.as_ref().is_some_and(|x| x != "");
     if use_instance_name {
-        config.instance_name(database.instance_name.as_deref().unwrap_or_default());
+        config.instance_name(database.instance_name.unwrap());
     }
     if let Some(port) = database.port {
         config.port(port);

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -11,6 +11,7 @@ use tiberius::{
 use tokio::net::TcpStream;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
 use uuid::Uuid;
+use windmill_common::azure_workload_identity::{WorkloadIdentityConfig, AZURE_SQL_SCOPE};
 use windmill_common::utils::merge_raw_values_to_object;
 use windmill_common::worker::SqlResultCollectionStrategy;
 use windmill_common::{
@@ -49,6 +50,13 @@ struct MssqlDatabase {
     ca_cert: Option<String>,
     encrypt: Option<bool>,
     integrated_auth: Option<bool>,
+    workload_identity: Option<bool>,
+    #[serde(default, deserialize_with = "empty_as_none")]
+    tenant_id: Option<String>,
+    #[serde(default, deserialize_with = "empty_as_none")]
+    client_id: Option<String>,
+    #[serde(default, deserialize_with = "empty_as_none")]
+    federated_token_file: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -114,10 +122,10 @@ pub async fn do_mssql(
     let port_ref = database.port;
 
     config.host(host_ref.clone());
-    config.database(database.dbname);
+    config.database(&database.dbname);
     let use_instance_name = database.instance_name.as_ref().is_some_and(|x| x != "");
     if use_instance_name {
-        config.instance_name(database.instance_name.unwrap());
+        config.instance_name(database.instance_name.as_deref().unwrap_or_default());
     }
     if let Some(port) = database.port {
         config.port(port);
@@ -148,6 +156,19 @@ pub async fn do_mssql(
                 "Integrated authentication is not available in this build. Requires mssql-kerberos (Linux) or mssql-winauth (Windows) feature.".to_string(),
             ));
         }
+    } else if database.workload_identity.unwrap_or(false) {
+        let workload_identity = WorkloadIdentityConfig::resolve(
+            database.tenant_id.as_deref(),
+            database.client_id.as_deref(),
+            database.federated_token_file.as_deref(),
+        )?;
+        let logs = format!(
+            "\nUsing Azure Workload Identity (client id {})",
+            workload_identity.client_id()
+        );
+        append_logs(&job.id, &job.workspace_id, logs, conn).await;
+        let token = workload_identity.access_token(AZURE_SQL_SCOPE).await?;
+        config.authentication(AuthMethod::aad_token(token));
     } else if let Some(token_value) = &database.aad_token {
         if let Some(token) = &token_value.token {
             config.authentication(AuthMethod::aad_token(token));
@@ -160,7 +181,7 @@ pub async fn do_mssql(
         config.authentication(AuthMethod::sql_server(user.clone(), password.clone()));
     } else {
         return Err(Error::BadRequest(
-            "No authentication method configured. Set integrated_auth, aad_token, or user/password.".to_string(),
+            "No authentication method configured. Set integrated_auth, workload_identity, aad_token, or user/password.".to_string(),
         ));
     }
 

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -22,6 +22,7 @@ use tokio_postgres::{
     Column,
 };
 use uuid::Uuid;
+use windmill_common::azure_workload_identity::WORKLOAD_IDENTITY_PASSWORD;
 use windmill_common::error::to_anyhow;
 use windmill_common::error::{self, Error};
 use windmill_common::worker::{
@@ -68,7 +69,7 @@ pub async fn clear_pg_cache() {
 /// How the connection authenticates, which also keys the connection cache: a
 /// connection established under one mode must never be handed to a request asking
 /// for another.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum PgAuthMode {
     Password,
     /// AWS RDS IAM.
@@ -79,12 +80,10 @@ enum PgAuthMode {
 
 impl PgAuthMode {
     fn of(database: &PgDatabase) -> error::Result<Self> {
-        match (
-            database.use_iam_auth == Some(true),
-            database.use_workload_identity == Some(true),
-        ) {
+        let workload_identity = database.password.as_deref() == Some(WORKLOAD_IDENTITY_PASSWORD);
+        match (database.use_iam_auth == Some(true), workload_identity) {
             (true, true) => Err(Error::BadRequest(
-                "Set only one of use_iam_auth and use_workload_identity on the resource"
+                "IAM RDS authentication cannot use the Azure workload identity password"
                     .to_string(),
             )),
             (true, false) => Ok(PgAuthMode::Iam),
@@ -93,20 +92,12 @@ impl PgAuthMode {
         }
     }
 
-    /// The identity has to be part of the key too, not just the mode: `to_uri()` carries
-    /// the one password auth uses, and nothing carries the Entra one, so without this two
-    /// resources differing only by `client_id` would share a connection.
-    fn cache_key_segment(&self, database: &PgDatabase) -> String {
+    fn cache_key_segment(&self) -> &'static str {
         match self {
-            PgAuthMode::Password => String::new(),
-            PgAuthMode::Iam => "&iam=true".to_string(),
-            PgAuthMode::WorkloadIdentity => {
-                use std::hash::{Hash, Hasher};
-                let mut h = std::collections::hash_map::DefaultHasher::new();
-                database.tenant_id.hash(&mut h);
-                database.client_id.hash(&mut h);
-                format!("&workload_identity={:x}", h.finish())
-            }
+            // Workload identity needs no segment of its own: what selects it, the
+            // sentinel password, is already part of to_uri().
+            PgAuthMode::Password | PgAuthMode::WorkloadIdentity => "",
+            PgAuthMode::Iam => "&iam=true",
         }
     }
 }
@@ -728,7 +719,7 @@ pub async fn do_postgresql(
     let database_string = format!(
         "{}{}&tls={tls_disc:x}",
         database.to_uri(),
-        auth_mode.cache_key_segment(&database)
+        auth_mode.cache_key_segment()
     );
     let database_string_clone = database_string.clone();
 
@@ -2118,6 +2109,23 @@ impl FromSql<'_> for StringCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The sentinel password is the whole opt-in: nothing else marks the resource, so a
+    /// resource carrying it must not fall through to password auth.
+    #[test]
+    fn test_workload_identity_password_selects_the_auth_mode() {
+        let db = |password: &str| {
+            PgDatabase::parse_uri(&format!("postgres://someuser:{password}@host:5432/db")).unwrap()
+        };
+        assert_eq!(
+            PgAuthMode::of(&db(WORKLOAD_IDENTITY_PASSWORD)).unwrap(),
+            PgAuthMode::WorkloadIdentity
+        );
+        assert_eq!(
+            PgAuthMode::of(&db("hunter2")).unwrap(),
+            PgAuthMode::Password
+        );
+    }
 
     #[test]
     fn test_map_s3object_jsonb_overflow() {

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -696,6 +696,18 @@ pub async fn do_postgresql(
 
     let auth_mode = PgAuthMode::of(&database)?;
 
+    // The sentinel password is easy to set by accident, so say in the job logs which
+    // identity the query actually ran as rather than only in the worker logs.
+    if matches!(auth_mode, PgAuthMode::WorkloadIdentity) {
+        windmill_queue::append_logs(
+            &job.id,
+            &job.workspace_id,
+            "Using Azure Workload Identity\n",
+            conn,
+        )
+        .await;
+    }
+
     // Include the auth mode in the cache key to distinguish connections to the same host
     // authenticated differently. The cache key is static (doesn't include the token), which
     // is correct because PostgreSQL connections remain valid after initial auth — fresh

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -65,24 +65,70 @@ pub async fn clear_pg_cache() {
     CONNECTION_COUNTER.write().await.clear();
 }
 
+/// How the connection authenticates, which also keys the connection cache: a
+/// connection established under one mode must never be handed to a request asking
+/// for another.
+#[derive(Clone, Copy)]
+enum PgAuthMode {
+    Password,
+    /// AWS RDS IAM.
+    Iam,
+    /// Azure Entra ID, via the worker's federated identity.
+    WorkloadIdentity,
+}
+
+impl PgAuthMode {
+    fn of(database: &PgDatabase) -> Self {
+        if database.use_iam_auth == Some(true) {
+            PgAuthMode::Iam
+        } else if database.use_workload_identity == Some(true) {
+            PgAuthMode::WorkloadIdentity
+        } else {
+            PgAuthMode::Password
+        }
+    }
+
+    fn cache_key_segment(&self) -> &'static str {
+        match self {
+            PgAuthMode::Password => "",
+            PgAuthMode::Iam => "&iam=true",
+            PgAuthMode::WorkloadIdentity => "&workload_identity=true",
+        }
+    }
+}
+
 async fn new_pg_connection(
     database: &PgDatabase,
-    _use_iam_auth: bool,
+    auth_mode: PgAuthMode,
     main_db: Option<&DB>,
 ) -> error::Result<(tokio_postgres::Client, tokio::task::JoinHandle<()>)> {
-    let (client, connection) = if _use_iam_auth {
-        #[cfg(all(feature = "enterprise", feature = "private"))]
-        {
-            database.connect_with_iam().await?
+    let (client, connection) = match auth_mode {
+        PgAuthMode::Iam => {
+            #[cfg(all(feature = "enterprise", feature = "private"))]
+            {
+                database.connect_with_iam().await?
+            }
+            #[cfg(not(all(feature = "enterprise", feature = "private")))]
+            {
+                return Err(Error::ExecutionErr(
+                    "IAM RDS authentication requires Windmill Enterprise Edition".to_string(),
+                ));
+            }
         }
-        #[cfg(not(all(feature = "enterprise", feature = "private")))]
-        {
-            return Err(Error::ExecutionErr(
-                "IAM RDS authentication requires Windmill Enterprise Edition".to_string(),
-            ));
+        PgAuthMode::WorkloadIdentity => {
+            #[cfg(feature = "enterprise")]
+            {
+                database.connect_with_workload_identity().await?
+            }
+            #[cfg(not(feature = "enterprise"))]
+            {
+                return Err(Error::ExecutionErr(
+                    "Azure workload identity authentication requires Windmill Enterprise Edition"
+                        .to_string(),
+                ));
+            }
         }
-    } else {
-        database.connect(main_db).await?
+        PgAuthMode::Password => database.connect(main_db).await?,
     };
     let handle = tokio::spawn(async move {
         if let Err(e) = connection.await {
@@ -643,11 +689,12 @@ pub async fn do_postgresql(
         annotations.result_collection
     };
 
-    let use_iam_auth = database.use_iam_auth == Some(true);
+    let auth_mode = PgAuthMode::of(&database);
 
-    // Include use_iam_auth in cache key to distinguish IAM vs non-IAM connections to the same host.
-    // The cache key is static (doesn't include the token), which is correct because PostgreSQL
-    // connections remain valid after initial auth — fresh tokens are generated on cache miss.
+    // Include the auth mode in the cache key to distinguish connections to the same host
+    // authenticated differently. The cache key is static (doesn't include the token), which
+    // is correct because PostgreSQL connections remain valid after initial auth — fresh
+    // tokens are generated on cache miss.
     //
     // to_uri() collapses require/verify-ca/verify-full to the same string, so the TLS verification
     // inputs are folded into the key separately. Without this a connection established under a
@@ -664,11 +711,11 @@ pub async fn do_postgresql(
     // to_uri() already ends with `?sslmode=...`, so append further key segments
     // with `&` to keep database_string a well-formed URI (it is only ever a cache
     // key, but a malformed one would mislead anyone who later logs or parses it).
-    let database_string = if use_iam_auth {
-        format!("{}&iam=true&tls={tls_disc:x}", database.to_uri())
-    } else {
-        format!("{}&tls={tls_disc:x}", database.to_uri())
-    };
+    let database_string = format!(
+        "{}{}&tls={tls_disc:x}",
+        database.to_uri(),
+        auth_mode.cache_key_segment()
+    );
     let database_string_clone = database_string.clone();
 
     let cached_client;
@@ -748,18 +795,18 @@ pub async fn do_postgresql(
                 }
                 drop(guard);
                 cached_client = None;
-                new_client = Some(new_pg_connection(&database, use_iam_auth, conn.as_sql()).await?);
+                new_client = Some(new_pg_connection(&database, auth_mode, conn.as_sql()).await?);
             }
         } else {
             // Release the lock before connecting so the post-query caching
             // code can re-acquire it.
             drop(guard);
             cached_client = None;
-            new_client = Some(new_pg_connection(&database, use_iam_auth, conn.as_sql()).await?);
+            new_client = Some(new_pg_connection(&database, auth_mode, conn.as_sql()).await?);
         }
     } else {
         cached_client = None;
-        new_client = Some(new_pg_connection(&database, use_iam_auth, conn.as_sql()).await?);
+        new_client = Some(new_pg_connection(&database, auth_mode, conn.as_sql()).await?);
     }
 
     let (mut sig, _) = parse_pgsql_sig_with_typed_schema(&query)

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -78,21 +78,35 @@ enum PgAuthMode {
 }
 
 impl PgAuthMode {
-    fn of(database: &PgDatabase) -> Self {
-        if database.use_iam_auth == Some(true) {
-            PgAuthMode::Iam
-        } else if database.use_workload_identity == Some(true) {
-            PgAuthMode::WorkloadIdentity
-        } else {
-            PgAuthMode::Password
+    fn of(database: &PgDatabase) -> error::Result<Self> {
+        match (
+            database.use_iam_auth == Some(true),
+            database.use_workload_identity == Some(true),
+        ) {
+            (true, true) => Err(Error::BadRequest(
+                "Set only one of use_iam_auth and use_workload_identity on the resource"
+                    .to_string(),
+            )),
+            (true, false) => Ok(PgAuthMode::Iam),
+            (false, true) => Ok(PgAuthMode::WorkloadIdentity),
+            (false, false) => Ok(PgAuthMode::Password),
         }
     }
 
-    fn cache_key_segment(&self) -> &'static str {
+    /// The identity has to be part of the key too, not just the mode: `to_uri()` carries
+    /// the one password auth uses, and nothing carries the Entra one, so without this two
+    /// resources differing only by `client_id` would share a connection.
+    fn cache_key_segment(&self, database: &PgDatabase) -> String {
         match self {
-            PgAuthMode::Password => "",
-            PgAuthMode::Iam => "&iam=true",
-            PgAuthMode::WorkloadIdentity => "&workload_identity=true",
+            PgAuthMode::Password => String::new(),
+            PgAuthMode::Iam => "&iam=true".to_string(),
+            PgAuthMode::WorkloadIdentity => {
+                use std::hash::{Hash, Hasher};
+                let mut h = std::collections::hash_map::DefaultHasher::new();
+                database.tenant_id.hash(&mut h);
+                database.client_id.hash(&mut h);
+                format!("&workload_identity={:x}", h.finish())
+            }
         }
     }
 }
@@ -689,7 +703,7 @@ pub async fn do_postgresql(
         annotations.result_collection
     };
 
-    let auth_mode = PgAuthMode::of(&database);
+    let auth_mode = PgAuthMode::of(&database)?;
 
     // Include the auth mode in the cache key to distinguish connections to the same host
     // authenticated differently. The cache key is static (doesn't include the token), which
@@ -714,7 +728,7 @@ pub async fn do_postgresql(
     let database_string = format!(
         "{}{}&tls={tls_disc:x}",
         database.to_uri(),
-        auth_mode.cache_key_segment()
+        auth_mode.cache_key_segment(&database)
     );
     let database_string_clone = database_string.clone();
 


### PR DESCRIPTION
## Summary

Lets `ms_sql_server` and `postgresql` resources authenticate as the worker's **Azure
Workload Identity**, so a Windmill deployment on AKS can reach Azure SQL and Azure
Database for PostgreSQL Flexible Server with no password or hand-pasted AAD token stored
in the workspace.

**The mode is selected by a sentinel password, `ms_entraid`** — the same convention the
instance database already uses (`DATABASE_URL` with password `entraid` / `iamrds`,
`windmill-common/src/lib.rs`). That means **no resource type schema change on the hub**:
every database form already has a password field, so this reaches an existing deployment
the moment the worker is upgraded, rather than waiting on a hub schema round trip.

```jsonc
// ms_sql_server
{ "host": "myserver.database.windows.net", "dbname": "mydb",
  "password": "ms_entraid", "encrypt": true, "trust_cert": false }

// postgresql — user must be the Entra principal name the server knows
{ "host": "myserver.postgres.database.azure.com", "dbname": "mydb",
  "user": "windmill-worker-identity", "sslmode": "require", "password": "ms_entraid" }
```

The identity itself is the worker pod's: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
`AZURE_FEDERATED_TOKEN_FILE` and `AZURE_AUTHORITY_HOST`, all injected by the Azure
workload identity webhook. The projected service-account token is exchanged with Entra ID
for an access token that replaces the password. Reaching two databases as two identities
means two worker groups, which is the same answer Kubernetes gives.

Fixes WIN-2286

## Changes

- New `windmill_common::azure_workload_identity`: reads the webhook-injected env, performs
  the client-credentials + client-assertion exchange, and caches the access token per
  identity and scope. Renewal is single-flighted per identity, expired entries are
  evicted, a failed renewal falls back to the still-valid token rather than failing the
  job (Entra ID throttles bursts), and a recent failure suppresses retries for 30s so a
  queue of jobs does not each pay the request latency.
- MSSQL: a resource whose password is `ms_entraid` authenticates with an Entra token
  (scope `https://database.windows.net/.default`) passed to tiberius as
  `AuthMethod::aad_token`, slotted into the existing
  `integrated_auth` → `aad_token` → user/password chain.
- Postgres: same sentinel, scope `https://ossrdbms-aad.database.windows.net/.default`,
  token used as the password. The native postgres resource previously only offered AWS
  RDS IAM auth.
- `pg_executor`: the ad-hoc `use_iam_auth` boolean becomes a `PgAuthMode` enum that also
  keys the connection cache, so a connection opened under one auth mode is never handed
  to a request asking for another. `use_iam_auth` combined with the sentinel is an
  explicit error rather than a silent precedence rule.
- `PgDatabase::connect_with_iam` and the new `connect_with_workload_identity` share one
  `connect_with_token` helper (TLS forced on, sslmode still selects verification depth).

### Judgment calls

- **Sentinel over new resource fields.** An explicit `workload_identity: true` boolean is
  more discoverable, but it is invisible until the hub schemas carry it, and `postgresql`
  lists `password` as required, so that route also needs the hub `required` relaxed. The
  sentinel needs neither and matches the existing instance-database convention. The cost:
  anyone whose password is literally `ms_entraid` authenticates as the worker identity
  instead of failing to log in. The job log prints `Using Azure Workload Identity
  (client id ...)` so the mode is never silent.
- **The postgres path is gated behind `enterprise`**, matching the existing IAM RDS auth;
  CE returns an explicit "requires Windmill Enterprise Edition" error. The MSSQL executor
  module is already `enterprise`-only, so it needed no extra gate.
- The Entra ID **scope is fixed per database kind** rather than configurable; sovereign
  clouds change the authority host (read from `AZURE_AUTHORITY_HOST`) but would also need
  a different scope, worth adding only if someone asks.

## Test plan

- [x] `cargo check` (CE) and `cargo check -p windmill-worker --features mssql,enterprise`
- [x] Unit tests: token endpoint built correctly from the scheme+trailing-slash form the
      webhook injects; cache key is per-scope; a token inside the refresh buffer is stale
      for serving but usable as the renewal-failure fallback; a recent failure is not
      retried by every queued caller; the sentinel password selects `PgAuthMode::WorkloadIdentity`
- [x] Real jobs on a worker with the webhook env simulated (`AZURE_TENANT_ID`,
      `AZURE_CLIENT_ID`, `AZURE_FEDERATED_TOKEN_FILE` pointing at a dummy projected token):
      MSSQL and Postgres resources with `password: "ms_entraid"` both reach Entra ID, and
      its rejection of the dummy assertion surfaces verbatim (`AADSTS5002723: Invalid JWT
      token...`), proving endpoint/form/parse/error paths end to end
- [x] Worker without the env vars → config error naming the missing var
- [x] MSSQL with no auth method at all → unchanged error, now mentioning the sentinel
- [x] Postgres with `use_iam_auth` plus the sentinel → explicit error
- [x] Postgres with a real password → still returns rows (regression on the `PgAuthMode`
      and cache-key refactor); on a CE build the sentinel returns the EE-gate error
- [ ] Not covered: a real AKS federated identity against a real Azure SQL / Azure
      PostgreSQL Flexible Server, for lack of Azure credentials here. Everything up to the
      token being handed to the driver is exercised above; the remaining hop can be
      checked independently by pasting an `az account get-access-token` token into the
      existing `aad_token` field.