### PR TITLE
fix: re-land vite 8.2.0 with the chunk cycle that broke it

### DIFF
--- a/docs/frontend-import-cycles.md
+++ b/docs/frontend-import-cycles.md
@@ -1,0 +1,111 @@
+# Frontend chunk cycles
+
+If the emitted chunks import each other in a cycle, the app crashes on load with errors
+like `TypeError: be is not a constructor` or `Cannot read properties of undefined
+(reading 'PREPROCESSOR')`, and the user sees SvelteKit's default **"500 / Internal
+Error"** page with nothing in the server log.
+
+The build fails on this now (`assertAcyclicChunks` in `frontend/vite.config.js`), so you
+should never hit it in production again. This document explains the error if you do hit
+it at build time.
+
+## Why a chunk cycle crashes
+
+A chunk's imports are all evaluated before its own body. When chunk A and chunk B import
+each other, entering at A evaluates B's body while **none** of A's body has run. Every
+binding B reads from A is still in its pre-initialization state:
+
+- `function f() {}` — hoisted, so calling it *works*
+- `var X = class {}` / `const X = {...}` — **`undefined`**
+
+So B's module-scope code calls a working function that reaches for an uninitialized class
+and dies. Which member evaluates first depends on which route pulled the chunks in, which
+is why the symptom is route-dependent, looks random, and often disappears on a second page
+load. It is **not** a stale-asset or cache problem — new asset hashes do not change the
+graph.
+
+Anything a module does at evaluation time is exposed:
+
+```ts
+const toolDef = createToolDef(schema, 'x', '...') // calls z.toJSONSchema -> new JSONSchemaGenerator
+const ids = { a: SPECIAL_MODULE_IDS.PREPROCESSOR } // reads an imported const
+```
+
+Making those lazy one at a time does not work — every module-scope read across the cycle
+is a separate landmine, and a new one appears with the next refactor. Break the cycle.
+
+## An acyclic module graph is not enough
+
+This is the part that is easy to get wrong. Chunk *grouping* alone can create a cycle
+where no import cycle exists between modules.
+
+That is exactly what happened on vite 8.2.0 (#10468). `src/lib/gen` is a generated client
+that imports nothing outside itself — a leaf. But the bundler split it: `index.ts` and
+`core/*` landed in one chunk, while the 12k-line `schemas.gen.ts` was grouped into a
+chunk with 53 unrelated copilot/app modules. Since `index.ts` does
+`export * from './schemas.gen'`, the otherwise-pure gen chunk gained an edge into that app
+chunk, which imports back into the copilot core chunk. One split produced **40 chunk
+cycles**, and the copilot tool modules — which call `createToolDef` at module scope — began
+evaluating against an uninitialized zod `JSONSchemaGenerator`.
+
+The fix is to keep that leaf whole, in `frontend/vite.config.js`:
+
+```js
+build: { rollupOptions: { output: {
+  advancedChunks: { groups: [{ name: 'gen', test: /[\\/]src[\\/]lib[\\/]gen[\\/]/ }] }
+} } }
+```
+
+A barrel file (`export * from ...`) over a large generated module is the shape to watch:
+it gives every importer of the barrel an edge to the re-exported module, wherever the
+bundler decides to put it.
+
+## When the build fails
+
+`assertAcyclicChunks` prints the cycle with each chunk's source modules:
+
+```
+Cyclic chunk imports — this ships a runtime crash:
+  _app/immutable/chunks/BdWm9WXx.js
+      lib/gen/core/ApiError.ts, ..., lib/gen/index.ts
+   ->
+  _app/immutable/chunks/BUOJL1Np.js
+      lib/gen/schemas.gen.ts, lib/components/copilot/chat/workspaceTools.ts, +42 more
+   ->
+  ...
+```
+
+Read it as: some module in chunk 1 imports some module in chunk 2, and so on back around.
+To find the offending source edge, look for a module in one chunk that imports a module in
+the next. Then, in order of preference:
+
+1. **Make the import type-only** if only types are used — `import type` is erased and
+   creates no runtime edge (so does a named import where every binding is `type`-prefixed,
+   and `await import()` defers to a separate evaluation).
+2. **Keep a self-contained leaf together** with an `advancedChunks` group, as above.
+3. **Move the offending function to a new module** so the low-level module stops importing
+   the high-level one. `lib/aiStore.ts` (AI model state) imported
+   `components/copilot/lib.ts` (the AI client) for one call in `loadCopilot`, and the
+   client imports the chat modules, which import `aiStore` back; extracting `loadCopilot`
+   into `components/copilot/loadCopilot.ts` left `aiStore` a leaf.
+
+## Reproducing a crash without the right route
+
+Because the crash depends on which route enters the cycle first, it can be hard to trigger
+by clicking. Force the bad entry order instead: build, serve `build/`, and dynamically
+import the chunk that owns the shared bindings. If it is in a cycle, the import throws the
+same error the user reports.
+
+```html
+<script type="module">
+	try {
+		await import('/_app/immutable/chunks/<shared-chunk>.js')
+		document.title = 'OK'
+	} catch (e) {
+		document.title = 'THREW: ' + e.message
+	}
+</script>
+```
+
+Find the chunk by a preserved string literal — minification keeps them, e.g. zod's
+`Error converting schema to JSON.` locates the chunk holding `JSONSchemaGenerator`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -157,7 +157,7 @@
 				"tar": "^7.5.4",
 				"tslib": "^2.6.1",
 				"typescript": "^5.5.0",
-				"vite": "^8.0.13",
+				"vite": "^8.2.0",
 				"vite-plugin-mkcert": "^2.0.0",
 				"vitest": "^4.1.0",
 				"vitest-browser-svelte": "^2.0.1"
@@ -1097,37 +1097,6 @@
 				"@csstools/css-tokenizer": "^2.4.1"
 			}
 		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.9.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -1651,27 +1620,6 @@
 				"@chevrotain/types": "~11.1.1"
 			}
 		},
-		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
-			"integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tybys/wasm-util": "^0.10.3"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.13.0 || >=23.5.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-				"@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
-			}
-		},
 		"node_modules/@noble/hashes": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1724,9 +1672,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"version": "0.142.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+			"integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"funding": {
@@ -1800,9 +1748,9 @@
 			"license": "SEE LICENSE IN LICENSE"
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-			"integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.2.tgz",
+			"integrity": "sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1816,9 +1764,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-			"integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.2.tgz",
+			"integrity": "sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1832,9 +1780,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-			"integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.2.tgz",
+			"integrity": "sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1848,9 +1796,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-			"integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.2.tgz",
+			"integrity": "sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1864,9 +1812,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-			"integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.2.tgz",
+			"integrity": "sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==",
 			"cpu": [
 				"arm"
 			],
@@ -1880,9 +1828,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-			"integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.2.tgz",
+			"integrity": "sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1899,9 +1847,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-			"integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.2.tgz",
+			"integrity": "sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1918,9 +1866,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-			"integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.2.tgz",
+			"integrity": "sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1937,9 +1885,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-			"integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.2.tgz",
+			"integrity": "sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==",
 			"cpu": [
 				"s390x"
 			],
@@ -1956,9 +1904,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-			"integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.2.tgz",
+			"integrity": "sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==",
 			"cpu": [
 				"x64"
 			],
@@ -1975,9 +1923,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-			"integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.2.tgz",
+			"integrity": "sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==",
 			"cpu": [
 				"x64"
 			],
@@ -1994,9 +1942,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-			"integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.2.tgz",
+			"integrity": "sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2009,28 +1957,10 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
-		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-			"integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
-			"cpu": [
-				"wasm32"
-			],
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "1.10.0",
-				"@emnapi/runtime": "1.10.0",
-				"@napi-rs/wasm-runtime": "^1.1.4"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			}
-		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-			"integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.2.tgz",
+			"integrity": "sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==",
 			"cpu": [
 				"arm64"
 			],
@@ -2044,9 +1974,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-			"integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.2.tgz",
+			"integrity": "sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==",
 			"cpu": [
 				"x64"
 			],
@@ -2336,16 +2266,6 @@
 			},
 			"peerDependencies": {
 				"svelte": "^5.0.0"
-			}
-		},
-		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@types/chai": {
@@ -12171,13 +12091,13 @@
 			"license": "Unlicense"
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-			"integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
+			"integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.130.0",
+				"@oxc-project/types": "=0.142.0",
 				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
@@ -12187,21 +12107,20 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.1",
-				"@rolldown/binding-darwin-arm64": "1.0.1",
-				"@rolldown/binding-darwin-x64": "1.0.1",
-				"@rolldown/binding-freebsd-x64": "1.0.1",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.1",
-				"@rolldown/binding-linux-arm64-musl": "1.0.1",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-gnu": "1.0.1",
-				"@rolldown/binding-linux-x64-musl": "1.0.1",
-				"@rolldown/binding-openharmony-arm64": "1.0.1",
-				"@rolldown/binding-wasm32-wasi": "1.0.1",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.1",
-				"@rolldown/binding-win32-x64-msvc": "1.0.1"
+				"@rolldown/binding-android-arm64": "1.2.2",
+				"@rolldown/binding-darwin-arm64": "1.2.2",
+				"@rolldown/binding-darwin-x64": "1.2.2",
+				"@rolldown/binding-freebsd-x64": "1.2.2",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.2.2",
+				"@rolldown/binding-linux-arm64-gnu": "1.2.2",
+				"@rolldown/binding-linux-arm64-musl": "1.2.2",
+				"@rolldown/binding-linux-ppc64-gnu": "1.2.2",
+				"@rolldown/binding-linux-s390x-gnu": "1.2.2",
+				"@rolldown/binding-linux-x64-gnu": "1.2.2",
+				"@rolldown/binding-linux-x64-musl": "1.2.2",
+				"@rolldown/binding-openharmony-arm64": "1.2.2",
+				"@rolldown/binding-win32-arm64-msvc": "1.2.2",
+				"@rolldown/binding-win32-x64-msvc": "1.2.2"
 			}
 		},
 		"node_modules/roughjs": {
@@ -14334,17 +14253,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.13",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-			"integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+			"integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
-				"postcss": "^8.5.14",
-				"rolldown": "1.0.1",
-				"tinyglobby": "^0.2.16"
+				"lightningcss": "^1.33.0",
+				"picomatch": "^4.0.5",
+				"postcss": "^8.5.23",
+				"rolldown": "~1.2.0",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -14360,7 +14279,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.18",
+				"@vitejs/devtools": "^0.4.0",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
 		"tar": "^7.5.4",
 		"tslib": "^2.6.1",
 		"typescript": "^5.5.0",
-		"vite": "^8.0.13",
+		"vite": "^8.2.0",
 		"vite-plugin-mkcert": "^2.0.0",
 		"vitest": "^4.1.0",
 		"vitest-browser-svelte": "^2.0.1"

--- a/frontend/src/lib/aiStore.ts
+++ b/frontend/src/lib/aiStore.ts
@@ -1,6 +1,9 @@
+// Keep this module a leaf: it holds AI model *state* only, and must not import the AI
+// client (`components/copilot/lib`) or anything under `components/copilot/chat` — those
+// import aiStore back, and such a cycle crashes the app once the bundler splits it across
+// chunks (docs/frontend-import-cycles.md; the build fails on the chunk cycle, not on this).
 import { writable, get } from 'svelte/store'
-import { workspaceAIClients } from './components/copilot/lib'
-import { type AIProviderModel, type AIProvider, WorkspaceService, type AIConfig } from './gen'
+import { type AIProviderModel, type AIProvider, type AIConfig } from './gen'
 import {
 	aiUserDisabled,
 	COPILOT_SESSION_MODEL_SETTING_NAME,
@@ -77,31 +80,10 @@ function dedupeModels(models: AIProviderModel[]): AIProviderModel[] {
 	})
 }
 
-// copilotInfo/copilotSessionModel are global, so concurrent loads (e.g. a fast
-// session switch between workspaces) race: an earlier call resolving last would
-// clobber the active workspace's config. Apply only the most recent call's
-// result via a monotonic token — last invocation wins regardless of resolution
-// order. init() is synchronous so its ordering already matches.
-let loadCopilotToken = 0
 // The workspace copilotInfo currently reflects. A session send awaits this
 // matching its committed workspace so getCurrentModel() can't read the previous
 // workspace's provider/model while the scoped load is still in flight.
 export const copilotWorkspace = writable<string | undefined>(undefined)
-export async function loadCopilot(workspace: string) {
-	const token = ++loadCopilotToken
-	workspaceAIClients.init(workspace)
-	try {
-		const info = await WorkspaceService.getCopilotInfo({ workspace })
-		if (token !== loadCopilotToken) return
-		setCopilotInfo(info)
-		copilotWorkspace.set(workspace)
-	} catch (err) {
-		if (token !== loadCopilotToken) return
-		setCopilotInfo({})
-		copilotWorkspace.set(workspace)
-		console.error('Could not get copilot info', err)
-	}
-}
 
 export function setCopilotInfo(aiConfig: AIConfig) {
 	if (Object.keys(aiConfig.providers ?? {}).length > 0) {

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -6,7 +6,7 @@
 	import { zIndexes } from '$lib/zIndexes'
 	import { userStore, workspaceStore } from '$lib/stores'
 	import { chatState } from './sharedChatState.svelte'
-	import { loadCopilot } from '$lib/aiStore'
+	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
 	import { aiChatManager } from './AIChatManager.svelte'
 	import { onDestroy } from 'svelte'
 	import Button from '$lib/components/common/button/Button.svelte'

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -5,6 +5,11 @@ import type {
 } from 'openai/resources/chat/completions.mjs'
 import type { UserDraftItemKind } from '$lib/gen'
 
+// The tool modules that import this one (workspaceTools, flow/core, global/core, ...)
+// call createToolDef and read SPECIAL_MODULE_IDS at *module scope*, so if a chunk cycle
+// ever reaches this file they evaluate against uninitialized bindings and the app dies
+// on load. Keep the import list here shallow. See docs/frontend-import-cycles.md.
+
 /**
  * Special module IDs used throughout the flow system
  */

--- a/frontend/src/lib/components/copilot/loadCopilot.ts
+++ b/frontend/src/lib/components/copilot/loadCopilot.ts
@@ -1,0 +1,29 @@
+import { WorkspaceService } from '$lib/gen'
+import { copilotWorkspace, setCopilotInfo } from '$lib/aiStore'
+import { workspaceAIClients } from './lib'
+
+// Lives here, not in $lib/aiStore, purely so that module needs no import of the AI
+// client — it is the one thing that wanted both. Moving it back recreates the
+// aiStore -> copilot/lib -> copilot/chat/shared -> aiStore cycle.
+
+// copilotInfo/copilotSessionModel are global, so concurrent loads (e.g. a fast
+// session switch between workspaces) race: an earlier call resolving last would
+// clobber the active workspace's config. Apply only the most recent call's
+// result via a monotonic token — last invocation wins regardless of resolution
+// order. init() is synchronous so its ordering already matches.
+let loadCopilotToken = 0
+export async function loadCopilot(workspace: string) {
+	const token = ++loadCopilotToken
+	workspaceAIClients.init(workspace)
+	try {
+		const info = await WorkspaceService.getCopilotInfo({ workspace })
+		if (token !== loadCopilotToken) return
+		setCopilotInfo(info)
+		copilotWorkspace.set(workspace)
+	} catch (err) {
+		if (token !== loadCopilotToken) return
+		setCopilotInfo({})
+		copilotWorkspace.set(workspace)
+		console.error('Could not get copilot info', err)
+	}
+}

--- a/frontend/src/lib/components/sessions/SessionWrapper.svelte
+++ b/frontend/src/lib/components/sessions/SessionWrapper.svelte
@@ -13,7 +13,8 @@
 	import { WorkspaceService } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
 	import Toggle from '$lib/components/Toggle.svelte'
-	import { copilotInfo, loadCopilot } from '$lib/aiStore'
+	import { copilotInfo } from '$lib/aiStore'
+	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
 	import {
 		Archive,
 		ArchiveRestore,

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -26,7 +26,8 @@ type SavedFlow = Omit<Flow & UserDraftOverlay, 'draft'> & { draft?: Flow }
 import type { HiddenRunnable } from '$lib/components/apps/types'
 import { type RawAppData, DEFAULT_DATA } from '$lib/components/raw_apps/dataTableRefUtils'
 import { userWorkspaces, workspaceStore } from '$lib/stores'
-import { loadCopilot, copilotWorkspace } from '$lib/aiStore'
+import { copilotWorkspace } from '$lib/aiStore'
+import { loadCopilot } from '$lib/components/copilot/loadCopilot'
 import { emptySchema, type StateStore } from '$lib/utils'
 import {
 	commitSessionWorkspace,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,6 +16,63 @@ const uiBuilderStaticPresent = existsSync(
 	fileURLToPath(new URL('static/ui_builder/app-preview.html', import.meta.url))
 )
 
+/**
+ * Fail the build if the emitted chunks import each other in a cycle.
+ *
+ * A chunk's imports all evaluate before its own body, so in a cycle one member runs
+ * while another has initialized nothing: its `const`/`class` exports read as
+ * `undefined` and the app dies on load with "X is not a constructor" behind
+ * SvelteKit's default 500 page. The module graph being acyclic is not enough —
+ * chunk *grouping* alone can create one. See docs/frontend-import-cycles.md.
+ */
+function assertAcyclicChunks() {
+	return {
+		name: 'wm-assert-acyclic-chunks',
+		generateBundle(_options, bundle) {
+			const imports = new Map()
+			for (const [file, chunk] of Object.entries(bundle)) {
+				if (chunk.type === 'chunk') imports.set(file, chunk.imports ?? [])
+			}
+			const state = new Map() // file -> 'visiting' | 'done'
+			const describe = (file) => {
+				const chunk = bundle[file]
+				const ids = chunk.moduleIds ?? Object.keys(chunk.modules ?? {})
+				const own = ids.filter((id) => id.includes('/src/')).map((id) => id.split('/src/')[1])
+				const shown = own.slice(0, 6).join(', ')
+				return `  ${file}\n      ${shown}${own.length > 6 ? `, +${own.length - 6} more` : ''}`
+			}
+			for (const root of imports.keys()) {
+				if (state.get(root)) continue
+				const stack = [[root, 0]]
+				const path = [root]
+				state.set(root, 'visiting')
+				while (stack.length) {
+					const frame = stack[stack.length - 1]
+					const deps = imports.get(frame[0]) ?? []
+					if (frame[1] >= deps.length) {
+						state.set(path.pop(), 'done')
+						stack.pop()
+						continue
+					}
+					const dep = deps[frame[1]++]
+					if (state.get(dep) === 'visiting') {
+						const cycle = path.slice(path.indexOf(dep)).concat(dep)
+						this.error(
+							`Cyclic chunk imports — this ships a runtime crash, see docs/frontend-import-cycles.md:\n` +
+								cycle.map(describe).join('\n   ->\n')
+						)
+					}
+					if (!state.has(dep) && imports.has(dep)) {
+						state.set(dep, 'visiting')
+						path.push(dep)
+						stack.push([dep, 0])
+					}
+				}
+			}
+		}
+	}
+}
+
 const remoteUrl =
 	process.env.REMOTE ??
 	(process.env.BACKEND_PORT
@@ -127,7 +184,12 @@ const config = {
 		}
 	},
 	preview: { port: 3001 },
-	plugins: [sveltekit(), ...(process.env.HTTPS === 'true' ? [mkcert()] : []), plugin],
+	plugins: [
+		sveltekit(),
+		...(process.env.HTTPS === 'true' ? [mkcert()] : []),
+		plugin,
+		assertAcyclicChunks()
+	],
 	define: { __pkg__: version },
 	optimizeDeps: {
 		include: ['highlight.js', 'highlight.js/lib/core', 'monaco-vim'],
@@ -147,6 +209,19 @@ const config = {
 		dedupe: ['vscode', 'monaco-editor']
 	},
 	assetsInclude: ['**/*.wasm'],
+	build: {
+		rollupOptions: {
+			output: {
+				// src/lib/gen is a self-contained generated client and a leaf of the module
+				// graph. Left alone the bundler splits it — index.ts in one chunk, the
+				// 12k-line schemas.gen.ts in another beside app code that imports back —
+				// which makes the *chunk* graph cyclic where the module graph is not, and
+				// modules then evaluate against uninitialized bindings. See
+				// docs/frontend-import-cycles.md.
+				advancedChunks: { groups: [{ name: 'gen', test: /[\\/]src[\\/]lib[\\/]gen[\\/]/ }] }
+			}
+		}
+	},
 	test: {
 		expect: { requireAssertions: true },
 		projects: [


### PR DESCRIPTION
## Summary

Restores the `vite` 8.2.0 bump reverted in #10468, and fixes the actual defect it exposed.

8.2.0 did not have a bundler bug. It grouped modules differently, and that grouping turned a
latent shape in our source into a **cycle in the emitted chunk graph** — which crashes the app
at load with `TypeError: be is not a constructor` behind SvelteKit's default 500 page.

### Root cause

`src/lib/gen` is a generated API client that imports nothing outside itself — a leaf. 8.2.0
split it: `index.ts` and `core/*` in one chunk, the 12k-line `schemas.gen.ts` in **another
chunk alongside 53 unrelated copilot/app modules**. Because `index.ts` does
`export * from './schemas.gen'`, the otherwise-pure gen chunk gained an edge into that app
chunk, which imports back into the copilot core chunk.

A chunk's imports all evaluate before its own body, so entering that cycle ran the copilot
tool modules while `chat/shared.ts` had initialized nothing. Their module-scope
`createToolDef(...)` calls then reached zod's `JSONSchemaGenerator`, emitted as
`var X = class {}` and therefore still `undefined`.

One split produced **40 chunk cycles**. Keeping the leaf whole removes all 40.

## Changes

- `vite.config.js`: `advancedChunks` group keeping `src/lib/gen` in one chunk.
- `vite.config.js`: `assertAcyclicChunks()` — **fails the build** on any chunk cycle, printing
  the cycle with each chunk's source modules. This is the guard that makes the class of bug
  impossible to ship again; verified it fires by disabling the group.
- `aiStore.ts` / new `copilot/loadCopilot.ts`: removes a real runtime import cycle
  (`chat/shared -> aiStore -> copilot/lib -> chat/shared`) by moving the one function that
  wanted both. Defense in depth — **not** required for the fix; the cycle predates 1.776.0 and
  is harmless while those modules share a chunk.
- `docs/frontend-import-cycles.md` + short comments at the two places someone would
  reintroduce this.
- `package.json` / lockfile: `vite` back to `^8.2.0`.

## Verification

Built each combination and forced the bad cycle-entry order in a real browser:

| source cycle | vite | gen group | chunk cycles | probe |
| --- | --- | --- | --- | --- |
| present | 8.2.0 | no | 40 | throws `be is not a constructor` (the reported error) |
| removed | 8.2.0 | no | 40 | throws `ye is not a constructor` |
| present | 8.0.13 | no | 0 | OK |
| present | **8.2.0** | **yes** | **0** | **OK** |

Row 2 is why this PR fixes the chunking rather than the source cycle: removing the cycle does
not help on 8.2.0.

Exhaustive where it can be:
- **Chunk cycles**: 0 across all 837 chunks, checked statically over the whole graph, now enforced at build time.
- **Module coverage**: 8143 modules, **0 dropped and 0 added** vs the 8.0.13 build — nothing tree-shaken away by the new bundler.
- **Duplication**: 0 modules in more than one chunk, both builds.
- **Assets**: wasm 16/16, css 59→60, json/ttf/html identical.
- `npm run test:unit`: 2222 pass; the 8 failures are pre-existing and identical on 8.0.13.
- `npm run check:fast`: error count and file:line list identical to main.
- Real app: logged in and opened the flow editor against a live backend — **0 console errors**, and the log line came from the copilot tools chunk that used to crash.

## Load impact

Cold cache is a wash; hot cache improves. Both measured on real builds (gzip).

| | S: 8.0.13 (ships today) | P: 8.2.0 + gen group |
| --- | --- | --- |
| total raw | 33.08 MB | 33.08 MB |
| total gzip | 9.22 MB | 9.24 MB (+0.2%) |
| chunks | 776 | 837 |
| duplicated modules | 0 | 0 |
| cold: login/root | 58 kB | 60 kB |
| cold: median route | 3457 kB | 3462 kB (+0.15%) |
| cold: heaviest route (app editor) | 5537 kB | 5548 kB (+0.2%) |

In-session navigation is unchanged: after the flow editor, moving to the app editor costs
397 kB (S) vs 396 kB (P).

Redeploy churn — edit one string in one feature file, then count what a returning user must
re-download:

| | chunks re-downloaded | bytes | still cached |
| --- | --- | --- | --- |
| S: 8.0.13, no group | 181 / 776 | 3344 kB (36.3%) | 595 |
| P: 8.2.0 + group | **170 / 837** | **2834 kB (30.7%)** | **667** |

So the finer, purer chunking re-downloads **510 kB less (−15%)** per upgrade. Separately,
regenerating the API client is now free: `schemas.gen.ts` is almost entirely tree-shaken, and
with it isolated in its own chunk a regeneration no longer perturbs the 53 app modules it used
to share a chunk with.

Cold-load figures are static-import closures (upper bounds); the S-vs-P comparison is the
meaningful part.

## Test plan

- [x] Build succeeds; guard reports 0 chunk cycles
- [x] Guard fails the build when the gen group is removed
- [x] Browser probe forcing the bad entry order returns OK
- [x] Flow editor loads clean against a live backend
- [x] Unit tests + typecheck show no new failures
- [ ] Confirm on a self-hosted instance that the random 500 page stays gone

No screenshots of a UI change: this is build configuration with no visible UI effect. The
flow-editor capture above is evidence the bundle loads, not a design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-landed `vite` 8.2.0 safely by fixing a bundling-induced chunk cycle that caused random 500s. Kept `src/lib/gen` in one chunk and added a build guard to fail on cyclic chunk imports. Fixes WIN-2287.

- **Bug Fixes**
  - Added `assertAcyclicChunks()` in `vite.config.js` to fail the build on cyclic chunk imports and print the cycle.
  - Used `advancedChunks` to keep `src/lib/gen` together, removing 40 chunk cycles.
  - Moved `loadCopilot` to `components/copilot/loadCopilot.ts` and updated imports to break the `aiStore` ↔ chat cycle; added `docs/frontend-import-cycles.md`.

- **Dependencies**
  - Restored `vite` to `^8.2.0` and updated the lockfile (including `rolldown` bindings).

<sup>Written for commit e695a181eb658f73f15b8d2dd1fb26dffaeb0cf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Fixes WIN-2287