### PR TITLE
fix(cli): stop a deleted raw-app .lock from dropping the whole app push

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -5004,9 +5004,9 @@ export async function push(
               changes = [deleteRawApp];
             } else {
               // The app is one bundle, so a single change re-pushes all of it.
-              // Whichever change survives here is the only one the loop sees:
-              // every branch below must turn any raw-app path into a whole-app
-              // push, or the entire app is silently dropped from the push.
+              // That leaves the loop exactly one change: any skip it takes for
+              // a raw-app path drops the whole app from the push, and nothing
+              // downstream records that as a failure.
               changes.splice(1, changes.length - 1);
             }
           }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -5003,6 +5003,10 @@ export async function push(
             if (deleteRawApp) {
               changes = [deleteRawApp];
             } else {
+              // The app is one bundle, so a single change re-pushes all of it.
+              // Whichever change survives here is the only one the loop sees:
+              // every branch below must turn any raw-app path into a whole-app
+              // push, or the entire app is silently dropped from the push.
               changes.splice(1, changes.length - 1);
             }
           }
@@ -5331,8 +5335,14 @@ export async function push(
               }
             } else if (change.name === "deleted") {
               // Same as the added branch: a dbt project's own `.lock` is one of
-              // its files, so deleting it has to reach the parent script.
-              if (change.path.endsWith(".lock") && !isDbtModulePath(change.path)) {
+              // its files, so deleting it has to reach the parent script. A raw
+              // app's `.lock` is part of its bundle, and a raw-app group is
+              // collapsed to one change, so skipping it drops the whole app.
+              if (
+                !isRawAppFile(change.path) &&
+                change.path.endsWith(".lock") &&
+                !isDbtModulePath(change.path)
+              ) {
                 continue;
               }
               if (isScriptModulePath(change.path)) {

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -464,6 +464,75 @@ excludes: []`, "utf-8");
     });
 });
 
+test("Raw App: deleted .lock sorting first does not short-circuit the app push", async () => {
+    // Regression: raw-app changes collapse to a single representative change
+    // (changes[0]), and deletes sort before adds/edits, so removing a backend
+    // runnable made its `.lock` the representative. The deleted branch skipped
+    // every `.lock` before it could reach the raw_app case, so the loop
+    // `continue`d and the whole app was never pushed, while the CLI reported
+    // "All N changes pushed".
+    await withTestBackend(async (backend, tempDir) => {
+      const testWorkspace = {
+        remote: backend.baseUrl,
+        workspaceId: backend.workspace,
+        name: "raw_app_lock_first_test",
+        token: backend.token
+      };
+      await addWorkspace(testWorkspace, { force: true, configDir: backend.testConfigDir });
+
+      await writeFile(`${tempDir}/wmill.yaml`, `defaultTs: bun
+includes:
+  - "**"
+excludes: []`, "utf-8");
+
+      const appDir = path.join(tempDir, "f", "test", "lock_first_app.raw_app");
+      await mkdir(path.join(tempDir, "f", "test"), { recursive: true });
+      await createRawAppOnDisk(appDir, true);
+
+      // A backend runnable's lockfile. Among the app's files it sorts first,
+      // so once deleted it becomes changes[0] for the whole group.
+      const queryLockPath = path.join(appDir, "backend", "query.lock");
+      await writeFile(queryLockPath, INLINE_SCRIPT_A_LOCK, "utf-8");
+
+      const pushResult1 = await backend.runCLICommand(
+        ['sync', 'push', '--yes'],
+        tempDir, "raw_app_lock_first_test"
+      );
+      expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
+
+      // Remove the backend runnable (lock included) and edit a frontend file.
+      await rm(queryLockPath);
+      await rm(path.join(appDir, "backend", "query.ts"));
+      await rm(path.join(appDir, "backend", "query.yaml"));
+      const appTsxPath = path.join(appDir, "App.tsx");
+      const appTsxContent = await readFileContent(appTsxPath);
+      await writeFile(
+        appTsxPath,
+        appTsxContent.replace("hello world", "REGRESSION MARKER"),
+        "utf-8"
+      );
+
+      const pushResult2 = await backend.runCLICommand(
+        ['sync', 'push', '--yes'],
+        tempDir, "raw_app_lock_first_test"
+      );
+      expect(pushResult2.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
+
+      // The edit must have reached the remote bundle, and the removed runnable
+      // must be gone from it.
+      const appResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/apps/get/p/f/test/lock_first_app`
+      );
+      expect(appResp.status).toEqual(200);
+      const appJson = await appResp.json();
+      const files = appJson?.value?.files ?? {};
+      expect(files["/App.tsx"]).toContain("REGRESSION MARKER");
+      expect(files["/backend/query.ts"]).toBeUndefined();
+    });
+});
+
 test("Raw App: delete file and push", async () => {
     await withTestBackend(async (backend, tempDir) => {
       // Set up workspace

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -465,12 +465,10 @@ excludes: []`, "utf-8");
 });
 
 test("Raw App: deleted .lock sorting first does not short-circuit the app push", async () => {
-    // Regression: raw-app changes collapse to a single representative change
-    // (changes[0]), and deletes sort before adds/edits, so removing a backend
-    // runnable made its `.lock` the representative. The deleted branch skipped
-    // every `.lock` before it could reach the raw_app case, so the loop
-    // `continue`d and the whole app was never pushed, while the CLI reported
-    // "All N changes pushed".
+    // Regression: raw-app changes collapse to one representative change and
+    // deletes sort first, so removing a backend runnable makes its `.lock` the
+    // representative. Skipping a `.lock` there drops the whole app while the
+    // push still reports success.
     await withTestBackend(async (backend, tempDir) => {
       const testWorkspace = {
         remote: backend.baseUrl,
@@ -529,7 +527,8 @@ excludes: []`, "utf-8");
       const appJson = await appResp.json();
       const files = appJson?.value?.files ?? {};
       expect(files["/App.tsx"]).toContain("REGRESSION MARKER");
-      expect(files["/backend/query.ts"]).toBeUndefined();
+      // Backend runnables live in value.runnables, not in the bundled files.
+      expect(appJson?.value?.runnables?.query).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
## Summary

A git-sync **Pull from repo** reported `All 38 changes pushed` and deployed nothing.
Re-running the preview showed the same 38 changes every time. All 38 lived in one raw
app, and the job result carried `"duration_ms": 10`, which is the tell: 38 changes
cannot deploy in 10ms.

Three things in `push()` (`cli/src/commands/sync/sync.ts`) combine into a silent
whole-app drop:

1. **Ordering** (`sync.ts:2655`): changes sort by entity type, then deletes before
   adds/edits, then alphabetically. Every path inside a raw app is type `raw_app`, so
   the group's first entry is the alphabetically-first deletion. For a removed backend
   runnable that is its `.lock` (`catalog.lock` sorts before `catalog.py`).
2. **Raw-app collapse** (`sync.ts:4996`): a raw app deploys as one bundle, so the group
   is collapsed to a single representative change via
   `changes.splice(1, changes.length - 1)`, keeping `changes[0]`. Every branch is
   expected to turn that one change into a whole-app `pushObj`.
3. **The hole** (`sync.ts:5335`): the `deleted` branch skipped every `.lock` before it
   could reach `case "raw_app"` (`sync.ts:5505`), which is what re-pushes the bundle.

The representative change was consumed by `continue`, the group ended, no API call was
made, `failedChanges` stayed empty, and the push reported success.

The `added` branch already carries the correct exemption (`sync.ts:5248`,
`!isRawAppFile(change.path)`, added in #9442) and `edited` has no `.lock` skip at all,
so both already fall through to `pushObj`. Only `deleted` missed it.

**Not a regression from the auto-pull work.** The collapse landed in raw apps v2
(#7251, 2025-11-29), which is when a single skipped change became fatal for a whole
app. #9442 fixed this exact shape in the `added` branch six months later and left
`deleted` untouched.

**Impact.** Every repo to workspace path runs this same code, so all of them silently
dropped the affected raw app while reporting success: manual Pull from repo, auto-pull
(polling and webhook), a customer's own `wmill sync push` GitHub Action, and promotion
and fork deploys. Auto-pull amplifies it: `reconcile_and_enqueue_pull` advances
`last_synced_sha` optimistically at enqueue, so the commit is recorded as synced and is
never retried. Bounded to raw apps; scripts, flows and regular apps are unaffected.

## Changes

- `cli/src/commands/sync/sync.ts`: exempt raw-app files from the `.lock` skip in the
  `deleted` branch, mirroring the `added` branch. A deleted `.lock` now reaches
  `case "raw_app"` and re-pushes the whole bundle, which is what the collapse expects.
- `cli/src/commands/sync/sync.ts`: record the invariant at the collapse site, since it
  is what makes any skip in a downstream branch silently fatal.
- `cli/test/raw_app_sync.test.ts`: regression test that removes a raw app's backend
  runnable (lock included) while editing a frontend file, then asserts the edit reached
  the remote bundle and the runnable is gone from it.

## Shipping note

Merging this does not fix anything for customers on its own. **Pull from repo** runs
hub script `hub/28808/git-sync-init-repository-windmill`, which bundles a *published*
`windmill-cli` (currently pinned to `1.769.1`). Delivery needs the usual chain: publish
a new `windmill-cli`, bump the hub script's pin and republish it, then move
`GIT_SYNC_PULL_SCRIPT_PATH` (`backend/windmill-common/src/workspaces.rs`) and
`gitInitRepo` (`frontend/src/lib/hubPaths.json`) to the new hub id. Automatic auto-pull
runs the same pinned script and has the same requirement.

## Test plan

- [x] `bun test test/raw_app_sync.test.ts -t "sorting first"` passes (2 tests) with the fix
- [x] Same test reverted against the unfixed `sync.ts`: fails exactly like the report,
      push exits 0 but the remote bundle still holds the pre-edit `App.tsx`
- [x] `bun run check`: 18 pre-existing type errors before and after, none in the
      touched files
- [ ] `git-sync-test.yml` e2e green

No frontend changes, so no screenshots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where deleting a raw app’s `.lock` file caused the entire app to be skipped during push while reporting success. Raw-app bundles now re-push correctly on delete, with a regression test that verifies the edit is applied and the removed runnable is gone.

- **Bug Fixes**
  - In `push()` (`cli/src/commands/sync/sync.ts`), stop skipping deleted `.lock` files inside raw apps so the change reaches `raw_app` and re-pushes the bundle.
  - Document the raw-app collapse invariant to prevent silent drops when a representative change is skipped.
  - Add a regression test that removes a backend runnable (lock included) and edits a frontend file; asserts the bundle updates and the runnable is absent.

- **Migration**
  - Publish a new `windmill-cli`, bump the pinned hub script, then update `GIT_SYNC_PULL_SCRIPT_PATH` and `gitInitRepo` to the new hub id.

<sup>Written for commit 87d54fc9c439c7f2dceacdac5faeca2c3d002f77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

