### PR TITLE
feat: label ai session preview tabs by item summary

### DIFF
--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -3,6 +3,9 @@
 		/** Stable identifier; used as the `[key]` for dnd and the activeId equality check. */
 		id: string
 		label: string
+		/** Hover title. Labels truncate at 180px, so set this whenever the label can
+		 * be long enough that two tabs would truncate to the same visible text. */
+		title?: string
 		/** Optional lucide-svelte (or compatible) component rendered at 12px before the label. */
 		icon?: any
 		/** Optional class applied to the icon (e.g. `text-accent` to tint it). */
@@ -153,6 +156,7 @@
 	<div
 		role="tab"
 		data-tab-id={tab.id}
+		title={tab.title}
 		aria-selected={isActive}
 		tabindex={isActive ? 0 : -1}
 		class={twMerge(tabClasses(isActive), tab.closable !== false && 'pr-1')}

--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -124,17 +124,17 @@
 		codec: () => codec
 	})
 
-	// Stamp the tab's friendly label once this editor's cell knows the item's
-	// typed/auto name. The page can't read the runtime cell reactively (it lives
-	// outside the page's reactive root), but this editor — handed `runtime` as a
-	// prop — can, so it mirrors the name onto the tab model the page does observe.
-	// The label only applies to a never-deployed item still parked at a
-	// `…/draft_<uuid>` storage path; a deployed/real path keeps the plain
-	// location label.
+	// Stamp the tab's friendly label once this editor's cell knows how to name the
+	// item. The page can't read the runtime cell reactively (it lives outside the
+	// page's reactive root), but this editor — handed `runtime` as a prop — can,
+	// so it mirrors the name onto the tab model the page does observe. The item's
+	// summary names it whenever it has one; failing that, a never-deployed item
+	// still parked at a `…/draft_<uuid>` storage path falls back to its typed/auto
+	// name, and anything else to the plain location label.
 	$effect(() => {
-		const v = cell.store.val as { path?: string; draft_path?: string } | undefined
+		const v = cell.store.val as { path?: string; draft_path?: string; summary?: string } | undefined
 		const friendly = v?.draft_path ?? v?.path
-		const label = draftFriendlyLeaf(path, friendly)
+		const label = v?.summary?.trim() || draftFriendlyLeaf(path, friendly)
 		// The full staged path rides along whenever it differs from the tab's
 		// route (storage) path — not just when it yielded a label: a DEPLOYED
 		// item with a staged rename is also regrouped under the typed folder by

--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -6,7 +6,7 @@
 	import type { SessionRuntime, SessionTargetKind } from './sessionRuntime.svelte'
 	import { useUserDraftSync, type DraftSyncCodec } from './useUserDraftSync.svelte'
 	import { makeFlowCodec, makeScriptCodec, makeRawAppCodec } from './sessionDraftCodecs'
-	import { draftFriendlyLeaf } from './previewRouter'
+	import { itemDisplayName } from './previewRouter'
 	import SessionItemNotFound from './SessionItemNotFound.svelte'
 
 	let {
@@ -134,7 +134,7 @@
 	$effect(() => {
 		const v = cell.store.val as { path?: string; draft_path?: string; summary?: string } | undefined
 		const friendly = v?.draft_path ?? v?.path
-		const label = v?.summary?.trim() || draftFriendlyLeaf(path, friendly)
+		const label = itemDisplayName(path, friendly, v?.summary)
 		// The full staged path rides along whenever it differs from the tab's
 		// route (storage) path — not just when it yielded a label: a DEPLOYED
 		// item with a staged rename is also regrouped under the typed folder by

--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -132,6 +132,9 @@
 	// still parked at a `…/draft_<uuid>` storage path falls back to its typed/auto
 	// name, and anything else to the plain location label.
 	$effect(() => {
+		// Only once the item has landed: stamping empty-handed off an unloaded cell
+		// would claim the tab from the listing-based name the page shows meanwhile.
+		if (slot.loadedPath !== path) return
 		const v = cell.store.val as { path?: string; draft_path?: string; summary?: string } | undefined
 		const friendly = v?.draft_path ?? v?.path
 		const label = itemDisplayName(path, friendly, v?.summary)

--- a/frontend/src/lib/components/sessions/previewRouter.test.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
 	artifactUrl,
 	draftFriendlyLeaf,
+	itemDisplayName,
 	matchReusablePage,
 	parseArtifactRoute,
 	parsePreviewItemRoute,
@@ -72,6 +73,24 @@ describe('draftFriendlyLeaf', () => {
 
 	it('returns undefined for an item already at a named (non-draft) storage path', () => {
 		expect(draftFriendlyLeaf('u/admin/my_app', 'u/admin/renamed')).toBeUndefined()
+	})
+})
+
+describe('itemDisplayName', () => {
+	it('prefers the summary, including for a draft-parked item that also has a typed name', () => {
+		expect(itemDisplayName('u/admin/my_script', undefined, 'Sync users nightly')).toBe(
+			'Sync users nightly'
+		)
+		expect(
+			itemDisplayName('u/admin/draft_abc123', 'u/admin/valuable_script', 'Sync users nightly')
+		).toBe('Sync users nightly')
+	})
+
+	it('falls through a blank summary to the draft leaf, then to nothing', () => {
+		expect(itemDisplayName('u/admin/draft_abc123', 'u/admin/valuable_script', '   ')).toBe(
+			'valuable_script'
+		)
+		expect(itemDisplayName('u/admin/my_script', undefined, '')).toBeUndefined()
 	})
 })
 

--- a/frontend/src/lib/components/sessions/previewRouter.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.ts
@@ -151,6 +151,20 @@ export function draftFriendlyLeaf(
 	return leaf && !leaf.startsWith('draft_') ? leaf : undefined
 }
 
+/** The display name for an item, from what a lister or a live editor cell knows
+ * about it: its summary when set, else the typed/auto name of an item parked at a
+ * `…/draft_<uuid>` storage path. `undefined` when neither applies, leaving the
+ * caller on `previewLocationLabel`. Shared by the live editor's tab stamp and the
+ * sessions page's pre-mount lookup so one tab can't be named two ways depending
+ * on which of them got there first. */
+export function itemDisplayName(
+	storagePath: string,
+	friendlyPath: string | undefined,
+	summary: string | undefined
+): string | undefined {
+	return summary?.trim() || draftFriendlyLeaf(storagePath, friendlyPath)
+}
+
 export type PreviewItemRoute = { kind: WorkspaceItemKind; raw_app: boolean; itemPath: string }
 
 // Parse a preview URL/pathname into the workspace item it edits, or null for a

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -406,8 +406,8 @@ export class SessionPreviewTabs {
 
 	// Stamp the friendly display label (and full friendly path, which scopes the
 	// breadcrumb picker) for the editor tab hosting `target` (the live editor
-	// knows the item's typed/auto name once its cell loads, which the page can't
-	// read reactively from the runtime cell). Matched on the tab's commanded
+	// knows the item's summary / typed name once its cell loads, which the page
+	// can't read reactively from the runtime cell). Matched on the tab's commanded
 	// `url` — the stable per-(kind,path) editor identity. Transient, so no
 	// persist/flush: they're recomputed when the tab remounts.
 	setEditorFriendlyLabel(

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -64,6 +64,7 @@ function retargetTab(tab: SessionPreviewTab, url: string): void {
 	tab.loc = url
 	tab.friendlyLabel = undefined
 	tab.friendlyPath = undefined
+	tab.editorNamed = undefined
 }
 
 // Strip the query params the sessions preview injects into iframe URLs
@@ -409,14 +410,20 @@ export class SessionPreviewTabs {
 	// knows the item's summary / typed name once its cell loads, which the page
 	// can't read reactively from the runtime cell). Matched on the tab's commanded
 	// `url` — the stable per-(kind,path) editor identity. Transient, so no
-	// persist/flush: they're recomputed when the tab remounts.
+	// persist/flush: they're recomputed when the tab remounts. Callers must only
+	// call this once the item has loaded: it also marks the tab as named by its
+	// editor, which stops the page falling back to the workspace listing.
 	setEditorFriendlyLabel(
 		target: SessionTarget,
 		label: string | undefined,
 		friendlyPath?: string
 	): void {
 		const t = this.#tabs.find((x) => isEditorTabFor(x.url, target))
-		if (!t || (t.friendlyLabel === label && t.friendlyPath === friendlyPath)) return
+		if (!t) return
+		// Set before the no-change early return: an item with neither a summary nor
+		// a staged path leaves both fields undefined, and the editor still owns it.
+		t.editorNamed = true
+		if (t.friendlyLabel === label && t.friendlyPath === friendlyPath) return
 		t.friendlyLabel = label
 		t.friendlyPath = friendlyPath
 	}

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -370,6 +370,18 @@ describe('SessionPreviewTabs.navigate', () => {
 		o.navigate(pageTarget)
 		expect(o.tabs[0].friendlyLabel).toBeUndefined()
 		expect(o.tabs[0].friendlyPath).toBeUndefined()
+		expect(o.tabs[0].editorNamed).toBeUndefined()
+	})
+
+	it('claims the tab for its editor even when the editor names nothing', () => {
+		const o = owner()
+		o.open(flowTarget)
+		// A deployed item with no summary reports neither a label nor a staged path
+		// — the same values a never-stamped tab already holds. It must still count
+		// as named, or the sessions page keeps falling back to the workspace
+		// listing and resurrects a summary the user just cleared.
+		o.setEditorFriendlyLabel({ kind: 'flow', path: 'u/me/bar' }, undefined, undefined)
+		expect(o.tabs[0].editorNamed).toBe(true)
 	})
 })
 

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -135,8 +135,9 @@ export type Session = {
 // last observed location (see the sessions page for the url/loc split).
 // `friendlyLabel` / `friendlyPath` are transient overrides the live editor
 // stamps; not persisted (hydrate rebuilds tabs field-by-field), recomputed on
-// next mount. `friendlyLabel` names a never-deployed item parked at
-// `…/draft_<uuid>` (its typed/auto name). `friendlyPath` is the item's full
+// next mount. `friendlyLabel` is the item's display name — its summary, or the
+// typed/auto name of a never-deployed item parked at
+// `…/draft_<uuid>`. `friendlyPath` is the item's full
 // staged path whenever it differs from the tab's route path — draft-parked OR
 // a deployed item with an undeployed rename — and scopes the breadcrumb
 // picker into the folder the picker tree displays the item under.

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -147,6 +147,11 @@ export type SessionPreviewTab = {
 	loc: string
 	friendlyLabel?: string
 	friendlyPath?: string
+	// True once this tab's live editor has loaded its item and reported a name —
+	// or reported that it has none. Until then the sessions page names the tab
+	// from the workspace listing; after, the editor is the only source, else
+	// clearing a summary would fall back to the listing's stale copy of it.
+	editorNamed?: boolean
 }
 
 // Sessions live in one per-user IndexedDB, one record per session in the

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -299,7 +299,7 @@
 	// Adapt the session tab model to DraggableTabs items (labels derived from the
 	// observed location; every tab closable, none pinned).
 	const previewTabItems = $derived<TabItem[]>(
-		(owner?.tabs ?? []).map((t) => ({ id: t.id, label: tabLabelFor(t) }))
+		(owner?.tabs ?? []).map((t) => ({ id: t.id, label: tabLabelFor(t), title: tabTitleFor(t) }))
 	)
 	let newTabOpen = $state(false)
 	// Separate open flag for the empty-state launcher: it can be mounted at the
@@ -554,6 +554,14 @@
 	// back to the plain location label for summary-less items and non-item pages.
 	function tabLabelFor(tab: SessionPreviewTab): string {
 		return tab.friendlyLabel ?? previewLocationLabel(tab.loc)
+	}
+
+	// Hover title for a tab. A summary label is free text the strip truncates, and
+	// it hides the path entirely, so the tooltip carries both.
+	function tabTitleFor(tab: SessionPreviewTab): string {
+		const label = tabLabelFor(tab)
+		const path = tab.friendlyPath ?? parsePreviewItemRoute(tab.loc)?.itemPath
+		return path && path !== label ? `${label}\n${path}` : label
 	}
 
 	// A link click inside a live editor (e.g. a subflow reference) re-points the

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -547,10 +547,11 @@
 		owner?.navigate(target)
 	}
 
-	// Short tab label. A never-deployed item parked at `…/draft_<uuid>` carries a
-	// `friendlyLabel` its live editor stamped (the page can't read the runtime cell
-	// reactively; the editor mirrors the typed/auto name onto the tab model). Falls
-	// back to the plain location label for deployed items and non-item pages.
+	// Short tab label. An item whose live editor is mounted carries a
+	// `friendlyLabel` that editor stamped — its summary, or the typed/auto name of
+	// an item still parked at `…/draft_<uuid>` (the page can't read the runtime
+	// cell reactively, so the editor mirrors the name onto the tab model). Falls
+	// back to the plain location label for summary-less items and non-item pages.
 	function tabLabelFor(tab: SessionPreviewTab): string {
 		return tab.friendlyLabel ?? previewLocationLabel(tab.loc)
 	}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -52,6 +52,7 @@
 	import { base } from '$lib/base'
 	import {
 		artifactKey,
+		itemDisplayName,
 		matchPreviewPage,
 		pageKey,
 		parseArtifactRoute,
@@ -60,7 +61,12 @@
 		type PreviewTarget
 	} from '$lib/components/sessions/previewRouter'
 	import { toolReloadEffect, tabsToReload } from '$lib/components/sessions/previewReload'
-	import { leafKeyFor, type WorkspaceItem } from '$lib/components/workspacePicker'
+	import {
+		leafKeyFor,
+		loadKind,
+		type WorkspaceItem,
+		type WorkspaceItemKind
+	} from '$lib/components/workspacePicker'
 	import { splitterPointerCapture } from '$lib/utils/splitterPointerCapture'
 
 	const globalEnabled = isGlobalAiEnabled()
@@ -299,7 +305,11 @@
 	// Adapt the session tab model to DraggableTabs items (labels derived from the
 	// observed location; every tab closable, none pinned).
 	const previewTabItems = $derived<TabItem[]>(
-		(owner?.tabs ?? []).map((t) => ({ id: t.id, label: tabLabelFor(t), title: tabTitleFor(t) }))
+		(owner?.tabs ?? []).map((t) => ({
+			id: t.id,
+			label: tabLabelFor(t, previewWorkspace ?? ''),
+			title: tabTitleFor(t, previewWorkspace ?? '')
+		}))
 	)
 	let newTabOpen = $state(false)
 	// Separate open flag for the empty-state launcher: it can be mounted at the
@@ -547,20 +557,65 @@
 		owner?.navigate(target)
 	}
 
+	// Names for the active session's item tabs, read from the same workspace
+	// listing the pickers use (module-cached, so an opened picker makes this free).
+	// The mounted editor's stamp is the live source, but it only fires for a tab
+	// the user has visited — without this, restoring a session shows a path leaf on
+	// every unvisited tab, each popping to its real name when first clicked.
+	// Requested keys are tracked outside the state so filling the map can't re-run
+	// the effect that fills it.
+	const listedItemsRequested = new Set<string>()
+	let listedItems = $state<Record<string, WorkspaceItem[]>>({})
+	const listedKey = (workspace: string, kind: WorkspaceItemKind) => `${workspace}:${kind}`
+	$effect(() => {
+		const ws = previewWorkspace
+		if (!ws) return
+		for (const tab of owner?.tabs ?? []) {
+			const route = parsePreviewItemRoute(tab.loc)
+			if (!route) continue
+			const key = listedKey(ws, route.kind)
+			if (listedItemsRequested.has(key)) continue
+			listedItemsRequested.add(key)
+			void loadKind(ws, route.kind).then((items) => {
+				listedItems = { ...listedItems, [key]: items }
+			})
+		}
+	})
+
+	// Keyed by the tab's OWN session workspace, never the active one: every warm
+	// session's tabs are labelled here, and two sessions on different forks can
+	// hold the same item path.
+	function listedItemFor(tab: SessionPreviewTab, workspace: string): WorkspaceItem | undefined {
+		const route = parsePreviewItemRoute(tab.loc)
+		if (!route) return undefined
+		return listedItems[listedKey(workspace, route.kind)]?.find((i) => i.path === route.itemPath)
+	}
+
 	// Short tab label. An item whose live editor is mounted carries a
 	// `friendlyLabel` that editor stamped — its summary, or the typed/auto name of
 	// an item still parked at `…/draft_<uuid>` (the page can't read the runtime
-	// cell reactively, so the editor mirrors the name onto the tab model). Falls
-	// back to the plain location label for summary-less items and non-item pages.
-	function tabLabelFor(tab: SessionPreviewTab): string {
-		return tab.friendlyLabel ?? previewLocationLabel(tab.loc)
+	// cell reactively, so the editor mirrors the name onto the tab model). Before
+	// that, the workspace listing names it. Falls back to the plain location label
+	// for summary-less items and non-item pages.
+	function tabLabelFor(tab: SessionPreviewTab, workspace: string): string {
+		const listed = listedItemFor(tab, workspace)
+		return (
+			tab.friendlyLabel ??
+			(listed && itemDisplayName(listed.path, listed.draftPath, listed.summary)) ??
+			previewLocationLabel(tab.loc)
+		)
 	}
 
 	// Hover title for a tab. A summary label is free text the strip truncates, and
-	// it hides the path entirely, so the tooltip carries both.
-	function tabTitleFor(tab: SessionPreviewTab): string {
-		const label = tabLabelFor(tab)
-		const path = tab.friendlyPath ?? parsePreviewItemRoute(tab.loc)?.itemPath
+	// it hides the path entirely, so the tooltip carries both. The path shown is
+	// the item's staged one when it has one — a draft's `…/draft_<uuid>` storage
+	// path names nothing to the reader.
+	function tabTitleFor(tab: SessionPreviewTab, workspace: string): string {
+		const label = tabLabelFor(tab, workspace)
+		const path =
+			tab.friendlyPath ??
+			listedItemFor(tab, workspace)?.draftPath ??
+			parsePreviewItemRoute(tab.loc)?.itemPath
 		return path && path !== label ? `${label}\n${path}` : label
 	}
 
@@ -900,7 +955,7 @@
 											runtime={rt}
 											active={s.id === activeSession?.id && tab.id === tabs?.activeId}
 											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
-											label={tabLabelFor(tab)}
+											label={tabLabelFor(tab, s.workspace_id ?? '')}
 											darkMode={isDarkMode.val}
 											{fullscreen}
 											onNavigate={navigateEditorTo}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -593,12 +593,15 @@
 	// session's tabs are labelled here, and two sessions on different forks can
 	// hold the same item path.
 	function listedItemFor(tab: SessionPreviewTab, workspace: string): WorkspaceItem | undefined {
+		// A loaded editor supersedes the listing for good — including when it names
+		// nothing, else clearing a summary would resurrect the listing's copy of it.
+		if (tab.editorNamed) return undefined
 		const route = parsePreviewItemRoute(tab.loc)
 		if (!route) return undefined
 		return listedItems[listedKey(workspace, route.kind)]?.find((i) => i.path === route.itemPath)
 	}
 
-	// Short tab label. An item whose live editor is mounted carries a
+	// Short tab label. An item whose live editor has loaded carries a
 	// `friendlyLabel` that editor stamped — its summary, or the typed/auto name of
 	// an item still parked at `…/draft_<uuid>` (the page can't read the runtime
 	// cell reactively, so the editor mirrors the name onto the tab model). Before

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -563,7 +563,9 @@
 	// the user has visited — without this, restoring a session shows a path leaf on
 	// every unvisited tab, each popping to its real name when first clicked.
 	// Requested keys are tracked outside the state so filling the map can't re-run
-	// the effect that fills it.
+	// the effect that fills it, and a key is released again on failure so a
+	// transient network error doesn't strand every unvisited tab on its path leaf
+	// for the lifetime of the page.
 	const listedItemsRequested = new Set<string>()
 	let listedItems = $state<Record<string, WorkspaceItem[]>>({})
 	const listedKey = (workspace: string, kind: WorkspaceItemKind) => `${workspace}:${kind}`
@@ -576,9 +578,14 @@
 			const key = listedKey(ws, route.kind)
 			if (listedItemsRequested.has(key)) continue
 			listedItemsRequested.add(key)
-			void loadKind(ws, route.kind).then((items) => {
-				listedItems = { ...listedItems, [key]: items }
-			})
+			void loadKind(ws, route.kind)
+				.then((items) => {
+					listedItems = { ...listedItems, [key]: items }
+				})
+				.catch((e) => {
+					listedItemsRequested.delete(key)
+					console.error(`Failed to load workspace ${route.kind}s`, e)
+				})
 		}
 	})
 


### PR DESCRIPTION
## Summary

In an AI session's side panel, a preview tab for a script, flow or raw app was labelled by the leaf of its storage path (`test_script`), even when the item carries a human-readable summary. The live editor already stamped a `friendlyLabel` onto its tab, but only for never-deployed items parked at a `…/draft_<uuid>` path — so a summary was never shown.

The editor now stamps the item's summary when it has one, falling back to the existing draft name and then to the plain location label. Because it reads the live editor cell, the label follows summary edits as you type.

Tabs that aren't items — workspace pages, runs, artifacts — keep their location label. A legacy drag-and-drop app renders as an iframe with no live cell to stamp, so it is named from the listing only; a summary edited inside that iframe isn't reflected in the strip until the listing is refetched.

## Changes

- `SessionEditorTarget.svelte`: the friendly-label effect prefers `cell.store.val.summary` (trimmed) over `draftFriendlyLeaf`. All three cell kinds — `Flow`, `NewScript`, `RuntimeRawApp` — carry `summary`, so this covers script, flow and raw-app tabs.
- `DraggableTabs.svelte`: new optional `TabItem.title`, rendered as the tab's hover title. Labels truncate at 180px, and a summary is free text, so two tabs could otherwise truncate to the same visible string.
- Sessions page: `tabTitleFor` supplies that title — the full label plus the item's path, which a summary label otherwise hides.
- Sessions page: item tabs the user hasn't visited yet are named from the workspace listing the pickers already load (module-cached, one request per kind actually referenced by the open tabs). Without it a restored session showed a path leaf on every unvisited tab, each popping to its real name on first click, since only a *mounted* editor stamps a label.
- `previewRouter.ts`: the summary-then-draft-name precedence moved into a shared `itemDisplayName`, so the editor stamp and the listing lookup can't name one tab two ways. Unit-tested there.
- `SessionPreviewTab.editorNamed` marks a tab whose editor has loaded and reported a name — or reported that it has none. The listing is only consulted before that, so clearing a summary falls back to the path leaf instead of resurrecting the listing's stale copy of it.
- Doc comments on `SessionPreviewTab.friendlyLabel` / `setEditorFriendlyLabel` / `tabLabelFor` updated to the new precedence.

## Screenshots

Three tabs open: two items with summaries ("Simple test script in a fork", "Scheduled Discord Notification") and one without, falling back to its path leaf (`beauteous_flow` — its Settings panel shows an empty Summary).

![tabs-summary](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/session-tabs-show-summary/1785761879-tabs-summary.png)

Typing a summary on that same flow renames its tab live:

![tabs-live-rename](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/session-tabs-show-summary/1785761881-tabs-live-rename.png)

A hard reload of a session holding four tabs — every one named without being clicked:

![tabs-after-reload](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/session-tabs-show-summary/1785764065-tabs-after-reload.png)

## Test plan

- [x] Open a session preview tab on a deployed script and on a flow that have summaries — the tab strip shows the summary, not the path leaf
- [x] Open an item with no summary — the tab still shows the path leaf
- [x] Type a summary into an open item — its tab relabels live
- [x] Open a never-deployed item parked at `…/draft_<uuid>` with no summary — the tab still shows its typed/auto name, not the uuid
- [x] Hover a truncated tab — the title reveals the full label and the item's path
- [x] Clear the summary of an open item whose listing entry still has one — the tab falls back to its path leaf
- [x] Fail the initial listing, restore it, then open/close a tab — the labels resolve, with one handled error and no unhandled rejection
- [x] Reload a session holding 3+ tabs — every item tab is named from the listing before its editor mounts, and exactly one `scripts/list` + one `flows/list` request is issued


