### PR TITLE
fix: anchor overlays to their preview tab instead of the viewport

### DIFF
--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -13,6 +13,7 @@
 	import DropdownV2Inner from './DropdownV2Inner.svelte'
 	import { pointerDownOutside } from '$lib/utils'
 	import { createDropdownMenu, melt, createSync } from '@melt-ui/svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import type { MenubarMenuElements } from '@melt-ui/svelte'
 	import ResolveOpen from '$lib/components/common/menu/ResolveOpen.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
@@ -86,12 +87,18 @@
 
 	let buttonEl: HTMLButtonElement | undefined = $state(undefined)
 
+	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
+	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	const hostPortal = overlayPortalTarget('body')
+
 	const {
 		elements: { menu: menuEl, item, trigger },
 		builders,
 		states,
+		options: { portal: portalOption },
 		ids: { menu: dropdownId }
 	} = createDropdownMenu({
+		portal: untrack(() => hostPortal()),
 		positioning: {
 			placement: untrack(() => placement)
 		},
@@ -112,6 +119,12 @@
 			}
 			return next
 		}
+	})
+
+	// melt's `portal` is a store, and the host element only binds once its children have
+	// initialised — a creation-time value alone would always miss it.
+	$effect(() => {
+		$portalOption = hostPortal()
 	})
 
 	const sync = createSync(states)

--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -87,8 +87,7 @@
 
 	let buttonEl: HTMLButtonElement | undefined = $state(undefined)
 
-	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
-	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	// Overlays belong to the enclosing pane when there is one — see overlayHost.
 	const hostPortal = overlayPortalTarget('body')
 
 	const {
@@ -121,8 +120,6 @@
 		}
 	})
 
-	// melt's `portal` is a store, and the host element only binds once its children have
-	// initialised — a creation-time value alone would always miss it.
 	$effect(() => {
 		$portalOption = hostPortal()
 	})

--- a/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
+++ b/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { classNames } from '$lib/utils'
+	import ConditionalPortal from '$lib/components/common/drawer/ConditionalPortal.svelte'
 	import {
 		getOverlayHost,
 		overlayHostActive,
@@ -46,11 +47,13 @@
 	}: Props = $props()
 	const type = $derived(_type ?? 'danger')
 
-	// Anchored to the enclosing pane when there is one (see overlayHost) so the dialog
-	// covers that pane rather than the whole app, matching Drawer.
+	// Anchored to the enclosing pane when there is one (see overlayHost): portalled into it
+	// and positioned against it, so the dialog covers that pane rather than the whole app.
+	// Both halves are required — `absolute` resolves against the nearest positioned DOM
+	// ancestor, which without the portal is whatever box the caller happens to sit in.
 	const overlayHost = getOverlayHost()
-	const hosted = $derived(!!overlayHost?.el())
-	const posClass = $derived(hosted ? 'absolute' : 'fixed')
+	const hostEl = $derived(overlayHost?.el())
+	const posClass = $derived(hostEl ? 'absolute' : 'fixed')
 
 	// Enter here confirms, so an open dialog buried under another overlay must not answer
 	// for it — only the topmost overlay handles keys.
@@ -60,8 +63,7 @@
 	const dispatch = createEventDispatcher()
 
 	function onKeyDown(event: KeyboardEvent) {
-		// A host that is off screen keeps its overlays mounted; they must not answer for
-		// the pane the user is actually looking at (see overlayHost).
+		// Hidden hosts stay mounted and still receive window keys — see overlayHost.
 		if (!hostActive()) return
 		if (open && keyListen && overlay.isTopmost()) {
 			// Only intercept Enter/Escape (without modifiers) so shortcuts like
@@ -124,81 +126,83 @@
 
 <svelte:window onkeydowncapture={onKeyDown} />
 
-{#if open}
-	<div
-		transition:fadeFast|local
-		class={twMerge(posClass, 'top-0 bottom-0 left-0 right-0', zIndexClass)}
-		role="dialog"
-		{id}
-	>
+<ConditionalPortal condition={!!hostEl} target={hostEl} class="contents">
+	{#if open}
 		<div
-			class={classNames(
-				posClass,
-				'inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
-				open ? 'ease-out duration-300 opacity-100' : 'ease-in duration-200 opacity-0'
-			)}
-		></div>
+			transition:fadeFast|local
+			class={twMerge(posClass, 'top-0 bottom-0 left-0 right-0', zIndexClass)}
+			role="dialog"
+			{id}
+		>
+			<div
+				class={classNames(
+					posClass,
+					'inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
+					open ? 'ease-out duration-300 opacity-100' : 'ease-in duration-200 opacity-0'
+				)}
+			></div>
 
-		<div class="{posClass} inset-0 z-10 overflow-y-auto">
-			<div class="flex min-h-full items-center justify-center p-4">
-				<div
-					class={classNames(
-						'relative transform overflow-hidden rounded-lg bg-surface px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6',
-						open
-							? 'ease-out duration-300 opacity-100 translate-y-0 sm:scale-100'
-							: 'ease-in duration-200 opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
-					)}
-				>
-					<div class="flex">
-						{#if showIcon}
-							<div
-								class={`flex h-12 w-12 items-center justify-center rounded-full ${theme[type].classes.iconWrapper}`}
-							>
-								<Icon class={theme[type].classes.icon} />
-							</div>
-						{/if}
-						<div class={twMerge('ml-0 text-left flex-1 ', showIcon ? 'ml-4' : '')}>
-							<h3 class="text-lg font-medium text-primary">
-								{title}
-							</h3>
-							<div class="mt-2 text-sm text-secondary">
-								{@render children?.()}
-							</div>
-							{#if trashbin}
-								<p class="mt-3 text-xs text-tertiary"
-									>This item will be moved to the trashbin and can be restored by a workspace admin
-									within 3 days.</p
+			<div class="{posClass} inset-0 z-10 overflow-y-auto">
+				<div class="flex min-h-full items-center justify-center p-4">
+					<div
+						class={classNames(
+							'relative transform overflow-hidden rounded-lg bg-surface px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6',
+							open
+								? 'ease-out duration-300 opacity-100 translate-y-0 sm:scale-100'
+								: 'ease-in duration-200 opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+						)}
+					>
+						<div class="flex">
+							{#if showIcon}
+								<div
+									class={`flex h-12 w-12 items-center justify-center rounded-full ${theme[type].classes.iconWrapper}`}
 								>
+									<Icon class={theme[type].classes.icon} />
+								</div>
 							{/if}
+							<div class={twMerge('ml-0 text-left flex-1 ', showIcon ? 'ml-4' : '')}>
+								<h3 class="text-lg font-medium text-primary">
+									{title}
+								</h3>
+								<div class="mt-2 text-sm text-secondary">
+									{@render children?.()}
+								</div>
+								{#if trashbin}
+									<p class="mt-3 text-xs text-tertiary"
+										>This item will be moved to the trashbin and can be restored by a workspace
+										admin within 3 days.</p
+									>
+								{/if}
+							</div>
 						</div>
-					</div>
-					<div class="flex items-center space-x-2 flex-row-reverse space-x-reverse mt-4">
-						<Button
-							disabled={loading}
-							on:click={() => (dispatch('confirmed'), onConfirmed?.())}
-							color={theme[type].color}
-							size="sm"
-							shortCut={{ Icon: CornerDownLeft, hide: !keyListen, withoutModifier: true }}
-							variant="accent"
-							destructive={type === 'danger'}
-						>
-							{#if loading}
-								<Loader2 class="animate-spin" />
-							{/if}
-							<span class="min-w-20">{confirmationText} </span>
-						</Button>
-						<Button
-							disabled={loading}
-							on:click={() => (dispatch('canceled'), onCanceled?.())}
-							variant="default"
-							size="sm"
-							shortCut={{ key: 'Esc', hide: !keyListen, withoutModifier: true }}
-						>
-							Cancel
-						</Button>
+						<div class="flex items-center space-x-2 flex-row-reverse space-x-reverse mt-4">
+							<Button
+								disabled={loading}
+								on:click={() => (dispatch('confirmed'), onConfirmed?.())}
+								color={theme[type].color}
+								size="sm"
+								shortCut={{ Icon: CornerDownLeft, hide: !keyListen, withoutModifier: true }}
+								variant="accent"
+								destructive={type === 'danger'}
+							>
+								{#if loading}
+									<Loader2 class="animate-spin" />
+								{/if}
+								<span class="min-w-20">{confirmationText} </span>
+							</Button>
+							<Button
+								disabled={loading}
+								on:click={() => (dispatch('canceled'), onCanceled?.())}
+								variant="default"
+								size="sm"
+								shortCut={{ key: 'Esc', hide: !keyListen, withoutModifier: true }}
+							>
+								Cancel
+							</Button>
+						</div>
 					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-{/if}
+	{/if}
+</ConditionalPortal>

--- a/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
+++ b/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
@@ -56,8 +56,10 @@
 	const posClass = $derived(hostEl ? 'absolute' : 'fixed')
 
 	// Enter here confirms, so an open dialog buried under another overlay must not answer
-	// for it — only the topmost overlay handles keys.
-	const overlay = useOverlayStack(() => open)
+	// for it — only the topmost overlay handles keys. A dialog that has opted out of key
+	// handling must stay off the stack entirely, or it would take the top spot and decline,
+	// leaving Escape dead for the drawer it sits in.
+	const overlay = useOverlayStack(() => open && keyListen)
 	const hostActive = overlayHostActive()
 
 	const dispatch = createEventDispatcher()

--- a/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
+++ b/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 	import { classNames } from '$lib/utils'
+	import {
+		getOverlayHost,
+		overlayHostActive,
+		useOverlayStack
+	} from '$lib/components/common/overlayHost.svelte'
 	import { createEventDispatcher, type Snippet } from 'svelte'
 	import { fade } from 'svelte/transition'
 	import Button from '../button/Button.svelte'
@@ -41,10 +46,24 @@
 	}: Props = $props()
 	const type = $derived(_type ?? 'danger')
 
+	// Anchored to the enclosing pane when there is one (see overlayHost) so the dialog
+	// covers that pane rather than the whole app, matching Drawer.
+	const overlayHost = getOverlayHost()
+	const hosted = $derived(!!overlayHost?.el())
+	const posClass = $derived(hosted ? 'absolute' : 'fixed')
+
+	// Enter here confirms, so an open dialog buried under another overlay must not answer
+	// for it — only the topmost overlay handles keys.
+	const overlay = useOverlayStack(() => open)
+	const hostActive = overlayHostActive()
+
 	const dispatch = createEventDispatcher()
 
 	function onKeyDown(event: KeyboardEvent) {
-		if (open && keyListen) {
+		// A host that is off screen keeps its overlays mounted; they must not answer for
+		// the pane the user is actually looking at (see overlayHost).
+		if (!hostActive()) return
+		if (open && keyListen && overlay.isTopmost()) {
 			// Only intercept Enter/Escape (without modifiers) so shortcuts like
 			// Cmd/Ctrl+C and Cmd/Ctrl+V keep working inside the modal.
 			if (event.metaKey || event.ctrlKey || event.altKey) {
@@ -108,18 +127,19 @@
 {#if open}
 	<div
 		transition:fadeFast|local
-		class={twMerge('fixed top-0 bottom-0 left-0 right-0', zIndexClass)}
+		class={twMerge(posClass, 'top-0 bottom-0 left-0 right-0', zIndexClass)}
 		role="dialog"
 		{id}
 	>
 		<div
 			class={classNames(
-				'fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
+				posClass,
+				'inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
 				open ? 'ease-out duration-300 opacity-100' : 'ease-in duration-200 opacity-0'
 			)}
 		></div>
 
-		<div class="fixed inset-0 z-10 overflow-y-auto">
+		<div class="{posClass} inset-0 z-10 overflow-y-auto">
 			<div class="flex min-h-full items-center justify-center p-4">
 				<div
 					class={classNames(

--- a/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
+++ b/frontend/src/lib/components/common/confirmationModal/ConfirmationModal.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import { classNames } from '$lib/utils'
 	import ConditionalPortal from '$lib/components/common/drawer/ConditionalPortal.svelte'
-	import {
-		getOverlayHost,
-		overlayHostActive,
-		useOverlayStack
-	} from '$lib/components/common/overlayHost.svelte'
+	import { getOverlayHost, overlayHostActive } from '$lib/components/common/overlayHost.svelte'
 	import { createEventDispatcher, type Snippet } from 'svelte'
 	import { fade } from 'svelte/transition'
 	import Button from '../button/Button.svelte'
@@ -55,11 +51,6 @@
 	const hostEl = $derived(overlayHost?.el())
 	const posClass = $derived(hostEl ? 'absolute' : 'fixed')
 
-	// Enter here confirms, so an open dialog buried under another overlay must not answer
-	// for it — only the topmost overlay handles keys. A dialog that has opted out of key
-	// handling must stay off the stack entirely, or it would take the top spot and decline,
-	// leaving Escape dead for the drawer it sits in.
-	const overlay = useOverlayStack(() => open && keyListen)
 	const hostActive = overlayHostActive()
 
 	const dispatch = createEventDispatcher()
@@ -67,7 +58,7 @@
 	function onKeyDown(event: KeyboardEvent) {
 		// Hidden hosts stay mounted and still receive window keys — see overlayHost.
 		if (!hostActive()) return
-		if (open && keyListen && overlay.isTopmost()) {
+		if (open && keyListen) {
 			// Only intercept Enter/Escape (without modifiers) so shortcuts like
 			// Cmd/Ctrl+C and Cmd/Ctrl+V keep working inside the modal.
 			if (event.metaKey || event.ctrlKey || event.altKey) {

--- a/frontend/src/lib/components/common/contextmenu/ContextMenu.svelte
+++ b/frontend/src/lib/components/common/contextmenu/ContextMenu.svelte
@@ -44,8 +44,7 @@
 		closeOnOutsideClick = true
 	}: Props = $props()
 
-	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
-	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	// Overlays belong to the enclosing pane when there is one — see overlayHost.
 	const hostPortal = overlayPortalTarget('body')
 
 	const {
@@ -61,8 +60,6 @@
 		portal: untrack(() => hostPortal())
 	})
 
-	// melt's `portal` is a store, and the host element only binds once its children have
-	// initialised — a creation-time value alone would always miss it.
 	$effect(() => {
 		$portalOption = hostPortal()
 	})

--- a/frontend/src/lib/components/common/contextmenu/ContextMenu.svelte
+++ b/frontend/src/lib/components/common/contextmenu/ContextMenu.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { createContextMenu, melt } from '@melt-ui/svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { fly } from 'svelte/transition'
 	import { twMerge } from 'tailwind-merge'
-	import type { Snippet } from 'svelte'
+	import { untrack, type Snippet } from 'svelte'
 	import { pointerDownOutside } from '$lib/utils'
 	import {
 		getContextMenuContainerClass,
@@ -43,15 +44,27 @@
 		closeOnOutsideClick = true
 	}: Props = $props()
 
+	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
+	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	const hostPortal = overlayPortalTarget('body')
+
 	const {
 		elements: { menu: menuElement, item, trigger },
-		states: { open }
+		states: { open },
+		options: { portal: portalOption }
 	} = createContextMenu({
 		positioning: {
 			placement: 'right-start'
 		},
 		preventScroll: true,
-		closeOnOutsideClick: false
+		closeOnOutsideClick: false,
+		portal: untrack(() => hostPortal())
+	})
+
+	// melt's `portal` is a store, and the host element only binds once its children have
+	// initialised — a creation-time value alone would always miss it.
+	$effect(() => {
+		$portalOption = hostPortal()
 	})
 
 	function handleItemClick(menuItem: ContextMenuItem) {

--- a/frontend/src/lib/components/common/drawer/ConditionalPortal.svelte
+++ b/frontend/src/lib/components/common/drawer/ConditionalPortal.svelte
@@ -5,6 +5,7 @@
 		condition?: boolean
 		target?: string | HTMLElement | undefined
 		name?: string
+		class?: string | undefined
 		children?: import('svelte').Snippet
 	}
 
@@ -12,12 +13,13 @@
 		condition = false,
 		target = undefined,
 		name = 'conditional-portal',
+		class: clazz = undefined,
 		children
 	}: Props = $props()
 </script>
 
 {#if condition}
-	<Portal {name} {target}>{@render children?.()}</Portal>
+	<Portal {name} {target} class={clazz}>{@render children?.()}</Portal>
 {:else}
 	{@render children?.()}
 {/if}

--- a/frontend/src/lib/components/common/drawer/Disposable.svelte
+++ b/frontend/src/lib/components/common/drawer/Disposable.svelte
@@ -1,6 +1,4 @@
 <script lang="ts" module>
-	export let openedDrawers: { val: string[] } = $state({ val: [] })
-
 	// When a disposable with minZIndex is open, all disposables use that as
 	// their z-index base so that overlays opened on top (e.g. a Drawer from
 	// inside a Modal) stack correctly above it.
@@ -15,7 +13,11 @@
 
 <script lang="ts">
 	import { zIndexes } from '$lib/zIndexes'
-	import { untrack } from 'svelte'
+	import { onDestroy, untrack } from 'svelte'
+	import { overlayHostActive, overlayStack } from '../overlayHost.svelte'
+
+	const stack = overlayStack()
+	const hostActive = overlayHostActive()
 
 	interface Props {
 		open?: boolean
@@ -59,21 +61,29 @@
 
 	export function openDrawer() {
 		open = true
-		if (openedDrawers.val.includes(id)) {
+		if (stack.val.includes(id)) {
 			return
 		}
-		openedDrawers.val.push(id)
-		offset = initialOffset + openedDrawers.val.length
+		stack.val.push(id)
+		offset = initialOffset + stack.val.length
 		if (minZIndex > 0) {
 			minZIndexEntries[id] = minZIndex
 		}
 	}
 
+	// A disposable can be unmounted while still open, by an ancestor that tears its whole
+	// subtree down. Its id would then sit on the stack forever, and since the topmost entry
+	// arbitrates Escape, every overlay opened afterwards would stop answering it.
+	onDestroy(() => {
+		stack.val = stack.val.filter((drawer) => drawer !== id)
+		delete minZIndexEntries[id]
+	})
+
 	export function closeDrawer() {
 		open = false
 		offset = initialOffset
-		if (openedDrawers.val.includes(id)) {
-			openedDrawers.val = openedDrawers.val.filter((drawer) => drawer !== id)
+		if (stack.val.includes(id)) {
+			stack.val = stack.val.filter((drawer) => drawer !== id)
 			if (minZIndex > 0) {
 				delete minZIndexEntries[id]
 			}
@@ -85,7 +95,7 @@
 	}
 
 	function handleClickAway(e) {
-		const last = openedDrawers.val[openedDrawers.val.length - 1]
+		const last = stack.val[stack.val.length - 1]
 		if (last === id) {
 			e.stopPropagation()
 			closeDrawer()
@@ -93,15 +103,14 @@
 	}
 
 	function onKeyDown(event: KeyboardEvent) {
+		// A host that is off screen keeps its overlays mounted; they must not answer for
+		// the pane the user is actually looking at (see overlayHost).
+		if (!hostActive()) return
 		if (open) {
 			switch (event.key) {
 				case 'Escape':
-					if (
-						(id == openedDrawers.val[openedDrawers.val.length - 1] ||
-							openedDrawers.val.length == 0) &&
-						!preventEscape
-					) {
-						openedDrawers.val.pop()
+					if ((id == stack.val[stack.val.length - 1] || stack.val.length == 0) && !preventEscape) {
+						stack.val.pop()
 						event.preventDefault()
 						event.stopPropagation()
 						event.stopImmediatePropagation()
@@ -113,8 +122,8 @@
 	}
 
 	if (open) {
-		openedDrawers.val.push(untrack(() => id))
-		offset = untrack(() => initialOffset) + openedDrawers.val.length
+		stack.val.push(untrack(() => id))
+		offset = untrack(() => initialOffset) + stack.val.length
 		if (minZIndex > 0) {
 			minZIndexEntries[untrack(() => id)] = minZIndex
 		}
@@ -145,5 +154,5 @@
 	zIndex,
 	closeDrawer,
 	open,
-	isTop: openedDrawers.val[openedDrawers.val.length - 1] == id
+	isTop: stack.val[stack.val.length - 1] == id
 })}

--- a/frontend/src/lib/components/common/drawer/Disposable.svelte
+++ b/frontend/src/lib/components/common/drawer/Disposable.svelte
@@ -103,8 +103,7 @@
 	}
 
 	function onKeyDown(event: KeyboardEvent) {
-		// A host that is off screen keeps its overlays mounted; they must not answer for
-		// the pane the user is actually looking at (see overlayHost).
+		// Hidden hosts stay mounted and still receive window keys — see overlayHost.
 		if (!hostActive()) return
 		if (open) {
 			switch (event.key) {

--- a/frontend/src/lib/components/common/drawer/Drawer.svelte
+++ b/frontend/src/lib/components/common/drawer/Drawer.svelte
@@ -5,12 +5,16 @@
 	import ConditionalPortal from './ConditionalPortal.svelte'
 	import { chatState } from '$lib/components/copilot/chat/sharedChatState.svelte'
 	import { useReducedMotion } from '$lib/svelte5Utils.svelte'
+	import { getOverlayHost } from '../overlayHost.svelte'
 
 	interface Props {
 		open?: boolean
 		duration?: number
 		placement?: string
 		size?: string
+		/** Pixel floor for a percentage `size`, so the drawer stays usable in a narrow
+		 *  container. Never grows past the container itself. */
+		minSize?: string
 		alwaysOpen?: boolean
 		shouldUsePortal?: boolean
 		offset?: number
@@ -27,6 +31,7 @@
 		duration: _duration = 0.3,
 		placement = 'right',
 		size = '600px',
+		minSize = '600px',
 		alwaysOpen = false,
 		shouldUsePortal = true,
 		offset = 0,
@@ -72,7 +77,12 @@
 	let mounted = false
 	const dispatch = createEventDispatcher()
 
-	let style = $derived(`--duration: ${duration}s; --size: ${size};`)
+	// A percentage size follows its container, which — anchored in a pane rather than the
+	// viewport — can leave the drawer too narrow to use. Pixel sizes already state their
+	// intent, so only percentages take the floor.
+	const floor = $derived(size.trim().endsWith('%') ? `min(${minSize}, 100%)` : '0px')
+
+	let style = $derived(`--duration: ${duration}s; --size: ${size}; --min-size: ${floor};`)
 
 	function scrollLock(open: boolean) {
 		if (BROWSER) {
@@ -103,10 +113,19 @@
 		mounted = true
 	})
 
-	const aiChatOpen = $derived(chatState.size > 0)
+	// An enclosing pane can claim the drawer (see overlayHost): it is then portalled
+	// into that element and positioned against it rather than the viewport. The
+	// global-chat offset is the viewport's business, so it doesn't apply there.
+	const overlayHost = getOverlayHost()
+	const host = $derived(shouldUsePortal ? overlayHost?.el() : undefined)
+	const posClass = $derived(positionClass ?? (host ? '!absolute' : undefined))
+
+	const aiChatOpen = $derived(chatState.size > 0 && !host)
 </script>
 
-<ConditionalPortal condition={shouldUsePortal}>
+<!-- `contents` keeps the portal's wrapper from becoming a stray flex item of the
+     host it is appended to; the drawer inside positions against the host itself. -->
+<ConditionalPortal condition={shouldUsePortal} target={host} class={host ? 'contents' : undefined}>
 	<Disposable
 		initialOffset={offset}
 		bind:open
@@ -118,7 +137,7 @@
 		{#snippet children({ handleClickAway, zIndex, isTop })}
 			<aside
 				class="drawer windmill-app windmill-drawer {name ? `windmill-drawer-${name}` : ''} {clazz ??
-					''} {positionClass ?? ''} {aiChatOpen ? 'respect-global-chat' : ''}"
+					''} {posClass ?? ''} {aiChatOpen ? 'respect-global-chat' : ''}"
 				class:open
 				class:close={!open && timeout}
 				class:global-chat-open={aiChatOpen}
@@ -126,8 +145,8 @@
 			>
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div class="overlay {positionClass ?? ''}" onclick={handleClickAway}></div>
-				<div class="panel {placement} {positionClass}" class:size>
+				<div class="overlay {posClass ?? ''}" onclick={handleClickAway}></div>
+				<div class="panel {placement} {posClass ?? ''}" class:size>
 					{#if open || !timeout || alwaysOpen}
 						{@render children_render?.({ open, isTop })}
 					{/if}
@@ -183,6 +202,8 @@
 
 	.drawer.close > .panel {
 		height: 0;
+		/* The size floor must not keep a closed panel expanded. */
+		min-height: 0;
 		overflow: hidden;
 	}
 
@@ -226,11 +247,13 @@
 	.panel.left.size,
 	.panel.right.size {
 		max-width: var(--size);
+		min-width: var(--min-size);
 	}
 
 	.panel.top.size,
 	.panel.bottom.size {
 		max-height: var(--size);
+		min-height: var(--min-size);
 	}
 
 	.drawer.open > .panel {

--- a/frontend/src/lib/components/common/drawer/Drawer.svelte
+++ b/frontend/src/lib/components/common/drawer/Drawer.svelte
@@ -77,13 +77,6 @@
 	let mounted = false
 	const dispatch = createEventDispatcher()
 
-	// A percentage size follows its container, which — anchored in a pane rather than the
-	// viewport — can leave the drawer too narrow to use. Pixel sizes already state their
-	// intent, so only percentages take the floor.
-	const floor = $derived(size.trim().endsWith('%') ? `min(${minSize}, 100%)` : '0px')
-
-	let style = $derived(`--duration: ${duration}s; --size: ${size}; --min-size: ${floor};`)
-
 	function scrollLock(open: boolean) {
 		if (BROWSER) {
 			const body = document.querySelector('body')
@@ -119,6 +112,13 @@
 	const overlayHost = getOverlayHost()
 	const host = $derived(shouldUsePortal ? overlayHost?.el() : undefined)
 	const posClass = $derived(positionClass ?? (host ? '!absolute' : undefined))
+
+	// A percentage size follows its container, and a pane is far narrower than the viewport
+	// the percentage was chosen against, so it can leave the drawer unusably thin. Pixel
+	// sizes already state their intent, and unhosted drawers keep the size they always had.
+	const floor = $derived(host && size.trim().endsWith('%') ? `min(${minSize}, 100%)` : '0px')
+
+	let style = $derived(`--duration: ${duration}s; --size: ${size}; --min-size: ${floor};`)
 
 	const aiChatOpen = $derived(chatState.size > 0 && !host)
 </script>

--- a/frontend/src/lib/components/common/drawer/Drawer.svelte
+++ b/frontend/src/lib/components/common/drawer/Drawer.svelte
@@ -1,5 +1,11 @@
+<script lang="ts" module>
+	/** Whether the enclosing drawer is anchored to a pane rather than the viewport. Set by
+	 *  Drawer, read by its content, so the two can never disagree on the answer. */
+	export const DRAWER_ANCHORED = Symbol('drawerAnchored')
+</script>
+
 <script lang="ts">
-	import { onMount, createEventDispatcher, untrack } from 'svelte'
+	import { onMount, createEventDispatcher, setContext, untrack } from 'svelte'
 	import { BROWSER } from 'esm-env'
 	import Disposable from './Disposable.svelte'
 	import ConditionalPortal from './ConditionalPortal.svelte'
@@ -12,9 +18,6 @@
 		duration?: number
 		placement?: string
 		size?: string
-		/** Pixel floor for a percentage `size`, so the drawer stays usable in a narrow
-		 *  container. Never grows past the container itself. */
-		minSize?: string
 		alwaysOpen?: boolean
 		shouldUsePortal?: boolean
 		offset?: number
@@ -31,7 +34,6 @@
 		duration: _duration = 0.3,
 		placement = 'right',
 		size = '600px',
-		minSize = '600px',
 		alwaysOpen = false,
 		shouldUsePortal = true,
 		offset = 0,
@@ -112,11 +114,16 @@
 	const overlayHost = getOverlayHost()
 	const host = $derived(shouldUsePortal ? overlayHost?.el() : undefined)
 	const posClass = $derived(positionClass ?? (host ? '!absolute' : undefined))
+	setContext(DRAWER_ANCHORED, () => !!host)
 
 	// A percentage size follows its container, and a pane is far narrower than the viewport
-	// the percentage was chosen against, so it can leave the drawer unusably thin. Pixel
-	// sizes already state their intent, and unhosted drawers keep the size they always had.
-	const floor = $derived(host && size.trim().endsWith('%') ? `min(${minSize}, 100%)` : '0px')
+	// that percentage was chosen against, so it can leave the drawer unusably thin. Below a
+	// 600px pane this wins over `--size` outright and the drawer covers the pane; that is the
+	// point. Pixel sizes already state their intent, and unhosted drawers are unaffected.
+	const MIN_ANCHORED_SIZE = '600px'
+	const floor = $derived(
+		host && size.trim().endsWith('%') ? `min(${MIN_ANCHORED_SIZE}, 100%)` : '0px'
+	)
 
 	let style = $derived(`--duration: ${duration}s; --size: ${size}; --min-size: ${floor};`)
 

--- a/frontend/src/lib/components/common/drawer/DrawerContent.svelte
+++ b/frontend/src/lib/components/common/drawer/DrawerContent.svelte
@@ -6,6 +6,7 @@
 	import { createEventDispatcher } from 'svelte'
 	import EEOnly from '$lib/components/EEOnly.svelte'
 	import { enterpriseLicense } from '$lib/stores'
+	import { getOverlayHost } from '../overlayHost.svelte'
 
 	interface Props {
 		aiId?: string | undefined
@@ -53,10 +54,18 @@
 	}: Props = $props()
 
 	const dispatch = createEventDispatcher()
+
+	// A drawer anchored to a pane (see overlayHost) is as tall as that pane, so
+	// sizing against the viewport would overflow it.
+	const overlayHost = getOverlayHost()
+	const anchored = $derived(!!overlayHost?.el())
 </script>
 
 <div
-	class={classNames('flex flex-col divide-y', fullScreen ? 'h-screen max-h-screen' : 'h-full')}
+	class={classNames(
+		'flex flex-col divide-y',
+		fullScreen && !anchored ? 'h-screen max-h-screen' : 'h-full'
+	)}
 	{id}
 >
 	<div class="flex justify-between w-full items-center pl-2 pr-4 py-2 gap-2">

--- a/frontend/src/lib/components/common/drawer/DrawerContent.svelte
+++ b/frontend/src/lib/components/common/drawer/DrawerContent.svelte
@@ -3,10 +3,10 @@
 	import { classNames } from '$lib/utils'
 	import CloseButton from '../CloseButton.svelte'
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
-	import { createEventDispatcher } from 'svelte'
+	import { createEventDispatcher, getContext } from 'svelte'
 	import EEOnly from '$lib/components/EEOnly.svelte'
 	import { enterpriseLicense } from '$lib/stores'
-	import { getOverlayHost } from '../overlayHost.svelte'
+	import { DRAWER_ANCHORED } from './Drawer.svelte'
 
 	interface Props {
 		aiId?: string | undefined
@@ -55,10 +55,11 @@
 
 	const dispatch = createEventDispatcher()
 
-	// A drawer anchored to a pane (see overlayHost) is as tall as that pane, so
-	// sizing against the viewport would overflow it.
-	const overlayHost = getOverlayHost()
-	const anchored = $derived(!!overlayHost?.el())
+	// A drawer anchored to a pane (see overlayHost) is as tall as that pane, so sizing
+	// against the viewport would overflow it. Asking the drawer rather than the host keeps
+	// this in step with `shouldUsePortal`, which decides whether it is anchored at all.
+	const drawerAnchored = getContext<(() => boolean) | undefined>(DRAWER_ANCHORED)
+	const anchored = $derived(drawerAnchored?.() ?? false)
 </script>
 
 <div

--- a/frontend/src/lib/components/common/modal/Modal.svelte
+++ b/frontend/src/lib/components/common/modal/Modal.svelte
@@ -9,6 +9,7 @@
 	import { twMerge } from 'tailwind-merge'
 	import CloseButton from '../CloseButton.svelte'
 	import Disposable from '../drawer/Disposable.svelte'
+	import ConditionalPortal from '../drawer/ConditionalPortal.svelte'
 	import { zIndexes } from '$lib/zIndexes'
 	import { chatState } from '$lib/components/copilot/chat/sharedChatState.svelte'
 
@@ -41,11 +42,13 @@
 		actions
 	}: Props = $props()
 
-	// Anchored to the enclosing pane when there is one (see overlayHost) so the dialog
-	// covers that pane rather than the whole app, matching Drawer.
+	// Anchored to the enclosing pane when there is one (see overlayHost): portalled into it
+	// and positioned against it, so the dialog covers that pane rather than the whole app.
+	// Both halves are required — `absolute` resolves against the nearest positioned DOM
+	// ancestor, which without the portal is whatever box the caller happens to sit in.
 	const overlayHost = getOverlayHost()
-	const hosted = $derived(!!overlayHost?.el())
-	const posClass = $derived(hosted ? 'absolute' : 'fixed')
+	const hostEl = $derived(overlayHost?.el())
+	const posClass = $derived(hostEl ? 'absolute' : 'fixed')
 	const hostActive = overlayHostActive()
 
 	const dispatch = createEventDispatcher()
@@ -68,8 +71,7 @@
 	})
 
 	function onKeyDown(event: KeyboardEvent) {
-		// A host that is off screen keeps its overlays mounted; they must not answer for
-		// the pane the user is actually looking at (see overlayHost).
+		// Hidden hosts stay mounted and still receive window keys — see overlayHost.
 		if (!hostActive()) return
 		if (open) {
 			switch (event.key) {
@@ -96,75 +98,77 @@
 
 <Disposable bind:open bind:this={disposable} preventEscape {minZIndex}>
 	{#snippet children({ zIndex })}
-		{#if open}
-			<!-- svelte-ignore a11y_click_events_have_key_events -->
-			<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-			<div
-				onclick={() => (open = false)}
-				transition:fadeFast|local
-				class="{posClass} top-0 bottom-0 left-0 right-0"
-				style="z-index: {zIndex}"
-				role="dialog"
-				tabindex="-1"
-			>
+		<ConditionalPortal condition={!!hostEl} target={hostEl} class="contents">
+			{#if open}
+				<!-- svelte-ignore a11y_click_events_have_key_events -->
+				<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 				<div
-					class={twMerge(
-						posClass,
-						'inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
-						open ? 'ease-out duration-300 opacity-100' : 'ease-in duration-200 opacity-0'
-					)}
-				></div>
+					onclick={() => (open = false)}
+					transition:fadeFast|local
+					class="{posClass} top-0 bottom-0 left-0 right-0"
+					style="z-index: {zIndex}"
+					role="dialog"
+					tabindex="-1"
+				>
+					<div
+						class={twMerge(
+							posClass,
+							'inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
+							open ? 'ease-out duration-300 opacity-100' : 'ease-in duration-200 opacity-0'
+						)}
+					></div>
 
-				<div class="{posClass} inset-0 z-10 overflow-y-auto">
-					<div class="flex min-h-full items-center justify-center p-4">
-						<!-- svelte-ignore a11y_no_static_element_interactions -->
-						<div
-							onclick={stopPropagation(bubble('click'))}
-							class={twMerge(
-								'relative transform overflow-hidden rounded-md bg-surface px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6',
-								c,
-								open
-									? 'ease-out duration-300 opacity-100 translate-y-0 sm:scale-100'
-									: 'ease-in duration-200 opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
-							)}
-							{style}
-						>
-							{#if kind == 'X'}
-								<div class="absolute top-4 right-4"
-									><CloseButton on:close={() => (open = false)} /></div
-								>
-							{/if}
-							<div class="flex">
-								<div class="text-left flex-1">
-									<div class="flex flex-row items-center justify-between">
-										<h3 class="text-emphasis text-lg font-semibold">{title}</h3>
-										{@render settings?.()}
-									</div>
-
-									<div class="mt-4 text-sm text-primary">
-										{@render children_render?.()}
-									</div>
-								</div>
-							</div>
-							{#if kind == 'button'}
-								<div class="flex items-center space-x-2 flex-row-reverse space-x-reverse mt-4">
-									{@render actions?.()}
-									<Button
-										on:click={() => {
-											dispatch('canceled')
-											open = false
-										}}
-										color="light"
-										size="sm"
+					<div class="{posClass} inset-0 z-10 overflow-y-auto">
+						<div class="flex min-h-full items-center justify-center p-4">
+							<!-- svelte-ignore a11y_no_static_element_interactions -->
+							<div
+								onclick={stopPropagation(bubble('click'))}
+								class={twMerge(
+									'relative transform overflow-hidden rounded-md bg-surface px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6',
+									c,
+									open
+										? 'ease-out duration-300 opacity-100 translate-y-0 sm:scale-100'
+										: 'ease-in duration-200 opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+								)}
+								{style}
+							>
+								{#if kind == 'X'}
+									<div class="absolute top-4 right-4"
+										><CloseButton on:close={() => (open = false)} /></div
 									>
-										{cancelText ?? 'Cancel'}
-									</Button>
+								{/if}
+								<div class="flex">
+									<div class="text-left flex-1">
+										<div class="flex flex-row items-center justify-between">
+											<h3 class="text-emphasis text-lg font-semibold">{title}</h3>
+											{@render settings?.()}
+										</div>
+
+										<div class="mt-4 text-sm text-primary">
+											{@render children_render?.()}
+										</div>
+									</div>
 								</div>
-							{/if}
+								{#if kind == 'button'}
+									<div class="flex items-center space-x-2 flex-row-reverse space-x-reverse mt-4">
+										{@render actions?.()}
+										<Button
+											on:click={() => {
+												dispatch('canceled')
+												open = false
+											}}
+											color="light"
+											size="sm"
+										>
+											{cancelText ?? 'Cancel'}
+										</Button>
+									</div>
+								{/if}
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
-		{/if}
+			{/if}
+		</ConditionalPortal>
 	{/snippet}
 </Disposable>

--- a/frontend/src/lib/components/common/modal/Modal.svelte
+++ b/frontend/src/lib/components/common/modal/Modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { createBubbler, stopPropagation } from 'svelte/legacy'
+	import { getOverlayHost, overlayHostActive } from '$lib/components/common/overlayHost.svelte'
 
 	const bubble = createBubbler()
 	import { createEventDispatcher, untrack } from 'svelte'
@@ -40,6 +41,13 @@
 		actions
 	}: Props = $props()
 
+	// Anchored to the enclosing pane when there is one (see overlayHost) so the dialog
+	// covers that pane rather than the whole app, matching Drawer.
+	const overlayHost = getOverlayHost()
+	const hosted = $derived(!!overlayHost?.el())
+	const posClass = $derived(hosted ? 'absolute' : 'fixed')
+	const hostActive = overlayHostActive()
+
 	const dispatch = createEventDispatcher()
 
 	let disposable: Disposable | undefined = $state(undefined)
@@ -60,6 +68,9 @@
 	})
 
 	function onKeyDown(event: KeyboardEvent) {
+		// A host that is off screen keeps its overlays mounted; they must not answer for
+		// the pane the user is actually looking at (see overlayHost).
+		if (!hostActive()) return
 		if (open) {
 			switch (event.key) {
 				case 'Enter':
@@ -91,19 +102,20 @@
 			<div
 				onclick={() => (open = false)}
 				transition:fadeFast|local
-				class="fixed top-0 bottom-0 left-0 right-0"
+				class="{posClass} top-0 bottom-0 left-0 right-0"
 				style="z-index: {zIndex}"
 				role="dialog"
 				tabindex="-1"
 			>
 				<div
 					class={twMerge(
-						'fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
+						posClass,
+						'inset-0 bg-gray-500 bg-opacity-75 transition-opacity',
 						open ? 'ease-out duration-300 opacity-100' : 'ease-in duration-200 opacity-0'
 					)}
 				></div>
 
-				<div class="fixed inset-0 z-10 overflow-y-auto">
+				<div class="{posClass} inset-0 z-10 overflow-y-auto">
 					<div class="flex min-h-full items-center justify-center p-4">
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div

--- a/frontend/src/lib/components/common/overlayHost.svelte.ts
+++ b/frontend/src/lib/components/common/overlayHost.svelte.ts
@@ -1,5 +1,4 @@
-import { getContext, setContext, untrack } from 'svelte'
-import { randomUUID } from '$lib/utils/uuid'
+import { getContext, setContext } from 'svelte'
 
 export type OverlayStack = { val: string[] }
 
@@ -72,33 +71,4 @@ export function overlayPortalTarget(fallback: string): () => HTMLElement | strin
 export function overlayHostActive(): () => boolean {
 	const host = getOverlayHost()
 	return () => host?.active() ?? true
-}
-
-/**
- * Take a place on this subtree's overlay stack while open, and report whether this overlay
- * is the topmost one.
- *
- * Escape belongs to whatever is on top, and every handler involved listens on `window`, so
- * none can stop another — the stack is the only arbiter. Joining it is what makes the
- * ordering work in both directions: a drawer opened from inside this overlay outranks it,
- * while the drawer this overlay is nested in does not.
- */
-export function useOverlayStack(isOpen: () => boolean) {
-	const id = randomUUID()
-	const openedDrawers = overlayStack()
-
-	$effect(() => {
-		if (isOpen()) {
-			// untrack: `push` reads `length` through the state proxy, so a tracked write here
-			// marks this very effect dirty and re-runs it until Svelte's loop guard throws.
-			untrack(() => openedDrawers.val.push(id))
-			return () => {
-				openedDrawers.val = openedDrawers.val.filter((d) => d !== id)
-			}
-		}
-	})
-
-	return {
-		isTopmost: () => openedDrawers.val.at(-1) === id
-	}
 }

--- a/frontend/src/lib/components/common/overlayHost.svelte.ts
+++ b/frontend/src/lib/components/common/overlayHost.svelte.ts
@@ -1,0 +1,97 @@
+import { getContext, setContext, untrack } from 'svelte'
+import { randomUUID } from '$lib/utils/uuid'
+
+export type OverlayStack = { val: string[] }
+
+/** Overlays that answer to the viewport share this one. */
+const globalOverlayStack: OverlayStack = $state({ val: [] })
+
+/** Where overlays opened from this subtree (drawers, modals, popovers) belong. A host that
+ *  embeds an editor in its own box provides one so its overlays stay inside that box — one
+ *  tab's drawer must never cover a sibling tab or the chrome around it. */
+export type OverlayHostContext = {
+	/** Element the overlays anchor to instead of the viewport. */
+	el: () => HTMLElement | undefined
+	/** Stack this host arbitrates Escape and click-away on. */
+	drawers: OverlayStack
+	/** Whether this host is the one on screen. Hosts stay mounted while hidden, and
+	 *  `opacity: 0` / `pointer-events: none` do not stop keyboard events from reaching a
+	 *  `svelte:window` listener — so key handlers must ask before acting. */
+	active: () => boolean
+}
+
+const OVERLAY_HOST_KEY = 'overlayHost'
+
+export function setOverlayHost(host: OverlayHostContext) {
+	setContext<OverlayHostContext>(OVERLAY_HOST_KEY, host)
+}
+
+export function getOverlayHost(): OverlayHostContext | undefined {
+	return getContext<OverlayHostContext | undefined>(OVERLAY_HOST_KEY)
+}
+
+/**
+ * The stack this component's overlays belong to. An enclosing pane keeps its own, because
+ * it stays mounted while hidden: on the shared stack, an overlay left open in a hidden pane
+ * would outrank — and swallow the Escape of — the pane the user is looking at.
+ *
+ * Reads context, so call it during component initialisation.
+ */
+export function overlayStack(): OverlayStack {
+	return getOverlayHost()?.drawers ?? globalOverlayStack
+}
+
+/**
+ * Portal target for an overlay: the host pane when one encloses this component, else the
+ * given fallback.
+ *
+ * An id fallback such as `#flow-editor` is not necessarily unique — a session keeps every
+ * visited tab mounted, so querySelector would drop the overlay into whichever editor came
+ * first in the DOM. That tab is `opacity-0 pointer-events-none`, so the overlay renders
+ * invisibly.
+ *
+ * Reads context, so call it during component initialisation; call the returned getter
+ * where the target is used, to stay reactive as the host element mounts.
+ */
+export function overlayPortalTarget(fallback: string): () => HTMLElement | string {
+	const host = getOverlayHost()
+	return () => host?.el() ?? fallback
+}
+
+/**
+ * Whether this component's overlays should respond to window-level keys. False only for
+ * overlays living in a host that is currently hidden; true everywhere outside a host.
+ */
+export function overlayHostActive(): () => boolean {
+	const host = getOverlayHost()
+	return () => host?.active() ?? true
+}
+
+/**
+ * Take a place on this subtree's overlay stack while open, and report whether this overlay
+ * is the topmost one.
+ *
+ * Escape belongs to whatever is on top, and every handler involved listens on `window`, so
+ * none can stop another — the stack is the only arbiter. Joining it is what makes the
+ * ordering work in both directions: a drawer opened from inside this overlay outranks it,
+ * while the drawer this overlay is nested in does not.
+ */
+export function useOverlayStack(isOpen: () => boolean) {
+	const id = randomUUID()
+	const openedDrawers = overlayStack()
+
+	$effect(() => {
+		if (isOpen()) {
+			// untrack: `push` reads `length` through the state proxy, so a tracked write here
+			// marks this very effect dirty and re-runs it until Svelte's loop guard throws.
+			untrack(() => openedDrawers.val.push(id))
+			return () => {
+				openedDrawers.val = openedDrawers.val.filter((d) => d !== id)
+			}
+		}
+	})
+
+	return {
+		isTopmost: () => openedDrawers.val.at(-1) === id
+	}
+}

--- a/frontend/src/lib/components/common/overlayHost.svelte.ts
+++ b/frontend/src/lib/components/common/overlayHost.svelte.ts
@@ -42,20 +42,27 @@ export function overlayStack(): OverlayStack {
 }
 
 /**
- * Portal target for an overlay: the host pane when one encloses this component, else the
- * given fallback.
+ * Portal target for an overlay: the caller's own `fallback` container, resolved within the
+ * enclosing host pane when there is one.
  *
- * An id fallback such as `#flow-editor` is not necessarily unique — a session keeps every
- * visited tab mounted, so querySelector would drop the overlay into whichever editor came
- * first in the DOM. That tab is `opacity-0 pointer-events-none`, so the overlay renders
- * invisibly.
+ * An id fallback such as `#flow-editor` is not unique — a session keeps every visited tab
+ * mounted, so a document-wide querySelector would drop the overlay into whichever editor
+ * came first in the DOM. That tab is `opacity-0 pointer-events-none`, so the overlay
+ * renders invisibly. Scoping the lookup to the host keeps the caller's chosen container
+ * (which sets the overlay's offset parent and clipping) while picking this tab's copy of
+ * it; a fallback that names nothing inside the host, such as `body`, falls back to the
+ * host itself.
  *
  * Reads context, so call it during component initialisation; call the returned getter
  * where the target is used, to stay reactive as the host element mounts.
  */
 export function overlayPortalTarget(fallback: string): () => HTMLElement | string {
 	const host = getOverlayHost()
-	return () => host?.el() ?? fallback
+	return () => {
+		const el = host?.el()
+		if (!el) return fallback
+		return el.querySelector<HTMLElement>(fallback) ?? el
+	}
 }
 
 /**

--- a/frontend/src/lib/components/copilot/FlowCopilotInputsModal.svelte
+++ b/frontend/src/lib/components/copilot/FlowCopilotInputsModal.svelte
@@ -3,19 +3,21 @@
 	import { Button, Badge } from '../common'
 	import Modal from '../common/modal/Modal.svelte'
 	import Portal from '../Portal.svelte'
-
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 
 	interface Props {
-		open?: boolean;
-		inputs?: string[];
+		open?: boolean
+		inputs?: string[]
 	}
 
-	let { open = $bindable(false), inputs = [] }: Props = $props();
+	let { open = $bindable(false), inputs = [] }: Props = $props()
 
 	const dispatch = createEventDispatcher()
+
+	const portalTarget = overlayPortalTarget('body')
 </script>
 
-<Portal>
+<Portal target={portalTarget()}>
 	<Modal
 		bind:open
 		on:confirmed={() => {
@@ -32,8 +34,7 @@
 		</ul>
 
 		{#snippet actions()}
-				<Button
-				
+			<Button
 				on:click={() => {
 					open = false
 					dispatch('confirmed')
@@ -43,6 +44,6 @@
 			>
 				<span class="inline-flex gap-2">Add <Badge color="dark-green">Enter</Badge></span>
 			</Button>
-			{/snippet}
+		{/snippet}
 	</Modal>
 </Portal>

--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -23,6 +23,7 @@
 	import { push } from '$lib/history.svelte'
 	import ConfirmationModal from '$lib/components/common/confirmationModal/ConfirmationModal.svelte'
 	import Portal from '$lib/components/Portal.svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 
 	import { locateModules, groupByParent } from '../multiSelectUtils'
 	import { workspaceStore } from '$lib/stores'
@@ -488,9 +489,11 @@
 	$effect(() => {
 		sidebarMode == 'graph' ? (sidebarSize = 40) : (sidebarSize = 20)
 	})
+
+	const portalTarget = overlayPortalTarget('body')
 </script>
 
-<Portal name="flow-module">
+<Portal name="flow-module" target={portalTarget()}>
 	<ConfirmationModal
 		title="Confirm deleting step with dependents"
 		confirmationText="Delete step"

--- a/frontend/src/lib/components/flows/map/InsertModulePopover.svelte
+++ b/frontend/src/lib/components/flows/map/InsertModulePopover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import InsertModuleInner from './InsertModuleInner.svelte'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 
 	import type { Placement } from '@floating-ui/core'
 
@@ -23,6 +24,8 @@
 		gutter = 0
 	}: Props = $props()
 
+	const portalTarget = overlayPortalTarget('#flow-editor')
+
 	let popover: Popover
 
 	$effect(() => {
@@ -32,7 +35,7 @@
 
 <Popover
 	bind:this={popover}
-	portal="#flow-editor"
+	portal={portalTarget()}
 	contentClasses="p-2 max-w-lg h-[400px] !resize bg-surface"
 	class="inline-block"
 	usePointerDownOutside

--- a/frontend/src/lib/components/flows/propPicker/OutputPicker.svelte
+++ b/frontend/src/lib/components/flows/propPicker/OutputPicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { twMerge } from 'tailwind-merge'
 	import { getContext, onMount } from 'svelte'
 	import type { PropPickerContext } from '$lib/components/prop_picker'
@@ -39,6 +40,9 @@
 		loopStatus,
 		onEditInput
 	}: Props = $props()
+
+	// Sized and positioned against the graph pane, so that stays the fallback.
+	const portalTarget = overlayPortalTarget('#flow-graph-v2')
 
 	const context = getContext<PropPickerContext>('PropPickerContext')
 	const flowPropPickerConfig = context?.flowPropPickerConfig
@@ -159,7 +163,7 @@
 					class="flex-1 h-full"
 					bind:isOpen={inputOpen}
 					bind:this={inputPopover}
-					portal="#flow-graph-v2"
+					portal={portalTarget()}
 				>
 					{#snippet trigger({ isOpen })}
 						<Button
@@ -207,7 +211,7 @@
 				closeOnOtherPopoverOpen
 				class="flex-1 h-full"
 				bind:isOpen={outputOpen}
-				portal="#flow-graph-v2"
+				portal={portalTarget()}
 			>
 				{#snippet trigger({ isOpen })}
 					<AnimatedButton

--- a/frontend/src/lib/components/graph/PaneContextMenu.svelte
+++ b/frontend/src/lib/components/graph/PaneContextMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { useSvelteFlow } from '@xyflow/svelte'
 	import { getOverlayHost } from '$lib/components/common/overlayHost.svelte'
+	import ConditionalPortal from '$lib/components/common/drawer/ConditionalPortal.svelte'
 	import { StickyNote } from 'lucide-svelte'
 	import { getNoteEditorContext } from './noteEditor.svelte'
 	import { DEFAULT_NOTE_COLOR } from './noteColors'
@@ -27,9 +28,11 @@
 	let contextMenuPosition = $state<{ x: number; y: number }>({ x: 0, y: 0 })
 	let pendingFlowPosition = $state<{ x: number; y: number } | null>(null)
 
-	// Coordinates come from the pointer event, so they are viewport-relative. Inside a
-	// pane the menu is positioned against the pane instead, or its click-catcher would
-	// blanket the app chrome around it.
+	// Coordinates come from the pointer event, so they are viewport-relative. Inside a pane
+	// the menu is portalled into it and positioned against it, or its click-catcher would
+	// blanket the app chrome around it. The portal is what makes the pane the offset parent
+	// the coordinates are then rebased onto — this component otherwise renders inside the
+	// graph's `overflow-clip` box, which would both displace and clip the menu.
 	const overlayHost = getOverlayHost()
 	const hostEl = $derived(overlayHost?.el())
 	const posClass = $derived(hostEl ? 'absolute' : 'fixed')
@@ -85,44 +88,46 @@
 	}
 </script>
 
-{#if contextMenuVisible}
-	<!-- Context menu -->
-	<div
-		class="{posClass} {getContextMenuContainerClass('z-[9999]')}"
-		style="left: {contextMenuPosition.x - menuOrigin.x}px; top: {contextMenuPosition.y -
-			menuOrigin.y}px;"
-		transition:fly={{ duration: 150, y: -10 }}
-		role="menu"
-		tabindex="-1"
-		onclick={(e) => {
-			e.stopPropagation()
-		}}
-		onkeydown={(e) => {
-			if (e.key === 'Escape') {
-				contextMenuVisible = false
-			}
-		}}
-	>
-		<button
-			class="{CONTEXT_MENU_ITEM_BASE_CLASS} {CONTEXT_MENU_ITEM_HOVER_CLASS}"
-			onclick={handleAddStickyNote}
-			type="button"
+<ConditionalPortal condition={!!hostEl} target={hostEl} class="contents">
+	{#if contextMenuVisible}
+		<!-- Context menu -->
+		<div
+			class="{posClass} {getContextMenuContainerClass('z-[9999]')}"
+			style="left: {contextMenuPosition.x - menuOrigin.x}px; top: {contextMenuPosition.y -
+				menuOrigin.y}px;"
+			transition:fly={{ duration: 150, y: -10 }}
+			role="menu"
+			tabindex="-1"
+			onclick={(e) => {
+				e.stopPropagation()
+			}}
+			onkeydown={(e) => {
+				if (e.key === 'Escape') {
+					contextMenuVisible = false
+				}
+			}}
 		>
-			<StickyNote size={14} class="mr-2" />
-			<span>Add sticky note</span>
-		</button>
-	</div>
+			<button
+				class="{CONTEXT_MENU_ITEM_BASE_CLASS} {CONTEXT_MENU_ITEM_HOVER_CLASS}"
+				onclick={handleAddStickyNote}
+				type="button"
+			>
+				<StickyNote size={14} class="mr-2" />
+				<span>Add sticky note</span>
+			</button>
+		</div>
 
-	<!-- Invisible click catcher to close context menu -->
-	<div
-		class="{posClass} inset-0 z-[9998]"
-		role="presentation"
-		onclick={() => {
-			contextMenuVisible = false
-		}}
-		oncontextmenu={(e) => {
-			e.preventDefault()
-			contextMenuVisible = false
-		}}
-	></div>
-{/if}
+		<!-- Invisible click catcher to close context menu -->
+		<div
+			class="{posClass} inset-0 z-[9998]"
+			role="presentation"
+			onclick={() => {
+				contextMenuVisible = false
+			}}
+			oncontextmenu={(e) => {
+				e.preventDefault()
+				contextMenuVisible = false
+			}}
+		></div>
+	{/if}
+</ConditionalPortal>

--- a/frontend/src/lib/components/graph/PaneContextMenu.svelte
+++ b/frontend/src/lib/components/graph/PaneContextMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { useSvelteFlow } from '@xyflow/svelte'
+	import { getOverlayHost } from '$lib/components/common/overlayHost.svelte'
 	import { StickyNote } from 'lucide-svelte'
 	import { getNoteEditorContext } from './noteEditor.svelte'
 	import { DEFAULT_NOTE_COLOR } from './noteColors'
@@ -25,6 +26,17 @@
 	let contextMenuVisible = $state(false)
 	let contextMenuPosition = $state<{ x: number; y: number }>({ x: 0, y: 0 })
 	let pendingFlowPosition = $state<{ x: number; y: number } | null>(null)
+
+	// Coordinates come from the pointer event, so they are viewport-relative. Inside a
+	// pane the menu is positioned against the pane instead, or its click-catcher would
+	// blanket the app chrome around it.
+	const overlayHost = getOverlayHost()
+	const hostEl = $derived(overlayHost?.el())
+	const posClass = $derived(hostEl ? 'absolute' : 'fixed')
+	const menuOrigin = $derived.by(() => {
+		const rect = contextMenuVisible ? hostEl?.getBoundingClientRect() : undefined
+		return { x: rect?.left ?? 0, y: rect?.top ?? 0 }
+	})
 
 	function handlePaneContextMenu(event: MouseEvent) {
 		// Only show context menu in edit mode
@@ -76,8 +88,9 @@
 {#if contextMenuVisible}
 	<!-- Context menu -->
 	<div
-		class="fixed {getContextMenuContainerClass('z-[9999]')}"
-		style="left: {contextMenuPosition.x}px; top: {contextMenuPosition.y}px;"
+		class="{posClass} {getContextMenuContainerClass('z-[9999]')}"
+		style="left: {contextMenuPosition.x - menuOrigin.x}px; top: {contextMenuPosition.y -
+			menuOrigin.y}px;"
 		transition:fly={{ duration: 150, y: -10 }}
 		role="menu"
 		tabindex="-1"
@@ -102,7 +115,7 @@
 
 	<!-- Invisible click catcher to close context menu -->
 	<div
-		class="fixed inset-0 z-[9998]"
+		class="{posClass} inset-0 z-[9998]"
 		role="presentation"
 		onclick={() => {
 			contextMenuVisible = false

--- a/frontend/src/lib/components/graph/renderers/nodes/NewAIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/NewAIToolNode.svelte
@@ -3,6 +3,7 @@
 	import InsertModuleInner from '$lib/components/flows/map/InsertModuleInner.svelte'
 	import { Plus } from 'lucide-svelte'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { Button } from '$lib/components/common'
 	import { getGraphContext } from '../../graphContext'
 
@@ -16,13 +17,14 @@
 	let isMoving = $derived(!!moveManager?.dragging || !!moveManager?.movingModuleId)
 
 	let open = $state(false)
+	const portalTarget = overlayPortalTarget('#flow-editor')
 </script>
 
 {#if !isMoving}
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <Popover
 	bind:isOpen={open}
-	portal="#flow-editor"
+	portal={portalTarget()}
 	contentClasses="p-2 max-w-lg h-[400px] bg-surface"
 	class="inline-block"
 	usePointerDownOutside

--- a/frontend/src/lib/components/graph/renderers/triggers/TriggersWrapper.svelte
+++ b/frontend/src/lib/components/graph/renderers/triggers/TriggersWrapper.svelte
@@ -8,6 +8,7 @@
 	import AddTriggersButton from '$lib/components/triggers/AddTriggersButton.svelte'
 	import { twMerge } from 'tailwind-merge'
 	import Portal from '$lib/components/Portal.svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { flip, offset } from 'svelte-floating-ui/dom'
 	import { createFloatingActions, type ComputeConfig } from 'svelte-floating-ui'
 
@@ -36,6 +37,8 @@
 	}: Props = $props()
 
 	let showTriggerScriptPicker = $state(false)
+
+	const pickerTarget = overlayPortalTarget('#flow-editor')
 	let numberOfTriggers = $state(0)
 
 	const dispatch = createEventDispatcher()
@@ -99,7 +102,7 @@
 </div>
 
 {#if showTriggerScriptPicker}
-	<Portal target="#flow-editor">
+	<Portal target={pickerTarget()}>
 		<div
 			class="border rounded-lg shadow-lg bg-surface z5000"
 			style="position:absolute"

--- a/frontend/src/lib/components/meltComponents/Menu.svelte
+++ b/frontend/src/lib/components/meltComponents/Menu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { createBubbler } from 'svelte/legacy'
 
 	const bubble = createBubbler()
@@ -54,8 +55,13 @@
 		children
 	}: Props = $props()
 
+	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
+	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	const hostPortal = overlayPortalTarget('body')
+
 	// Use the passed createMenu function
 	const menu = untrack(() => createMenu)({
+		portal: untrack(() => hostPortal()),
 		positioning: {
 			placement: untrack(() => placement),
 			fitViewport: true,
@@ -76,8 +82,15 @@
 	const {
 		elements: { trigger, menu: menuElement, item },
 		builders,
-		states
+		states,
+		options: { portal: portalOption }
 	} = menu
+
+	// melt's `portal` is a store, and the host element only binds once its children have
+	// initialised — a creation-time value alone would always miss it.
+	$effect(() => {
+		$portalOption = hostPortal()
+	})
 
 	const sync = createSync(states)
 	watch(

--- a/frontend/src/lib/components/meltComponents/Menu.svelte
+++ b/frontend/src/lib/components/meltComponents/Menu.svelte
@@ -55,8 +55,7 @@
 		children
 	}: Props = $props()
 
-	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
-	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	// Overlays belong to the enclosing pane when there is one — see overlayHost.
 	const hostPortal = overlayPortalTarget('body')
 
 	// Use the passed createMenu function
@@ -86,8 +85,6 @@
 		options: { portal: portalOption }
 	} = menu
 
-	// melt's `portal` is a store, and the host element only binds once its children have
-	// initialised — a creation-time value alone would always miss it.
 	$effect(() => {
 		$portalOption = hostPortal()
 	})

--- a/frontend/src/lib/components/meltComponents/Popover.svelte
+++ b/frontend/src/lib/components/meltComponents/Popover.svelte
@@ -17,6 +17,7 @@
 	import { debounce, pointerDownOutside } from '$lib/utils'
 	import { twMerge } from 'tailwind-merge'
 	import { createEventDispatcher, untrack } from 'svelte'
+	import { getOverlayHost, overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { Button } from '$lib/components/common'
 	import DocLink from '$lib/components/apps/editor/settingsPanel/DocLink.svelte'
 	import type { FloatingConfig } from '@melt-ui/svelte/internal/actions/floating'
@@ -89,7 +90,7 @@
 		closeOnOutsideClick = true,
 		contentClasses = '',
 		contentStyle = '',
-		portal = 'body',
+		portal = undefined,
 		closeOnOtherPopoverOpen = false,
 		allowFullScreen = false,
 		extraProps = {},
@@ -110,8 +111,16 @@
 		content
 	}: Props = $props()
 
-	// Dynamic portal: use 'body' when fullscreen, otherwise use the provided portal
-	let dynamicPortal = $derived(fullScreen ? 'body' : portal)
+	// Fullscreen abandons the trigger-relative positioning for a container of its own:
+	// the host pane when this popover is enclosed in one (so it covers that pane, like a
+	// drawer), else the document.
+	const overlayHost = getOverlayHost()
+	const hostPortal = overlayPortalTarget('body')
+	const fullScreenHost = $derived(fullScreen ? overlayHost?.el() : undefined)
+	// `null` is melt's "render in place" and must survive; only an absent prop defers to the host.
+	let dynamicPortal = $derived(
+		fullScreen ? (fullScreenHost ?? 'body') : portal === undefined ? hostPortal() : portal
+	)
 
 	const {
 		elements: { trigger: _trigger, content: _content, arrow, close: closeElement, overlay },
@@ -251,7 +260,8 @@
 </button>
 
 {#if fullScreen && isOpen && !disablePopup}
-	<div use:melt={$overlay} class="fixed inset-0 z-10 bg-black/50"></div>
+	<div use:melt={$overlay} class="{fullScreenHost ? 'absolute' : 'fixed'} inset-0 z-10 bg-black/50"
+	></div>
 {/if}
 
 {#if isOpen && !disablePopup}
@@ -268,14 +278,18 @@
 		class={twMerge(
 			'relative dark:border rounded-md bg-surface-tertiary shadow-lg',
 			fullScreen
-				? `fixed !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !resize-none`
+				? `${fullScreenHost ? 'absolute' : 'fixed'} !top-1/2 !left-1/2 !-translate-x-1/2 !-translate-y-1/2 !resize-none`
 				: 'w-fit',
 			contentClasses,
 			`z-[5001]`
 		)}
 		data-popover
 		{...extraProps}
-		style={fullScreen ? `width: 90vw; max-width: 800px; height: 90vh;` : contentStyle}
+		style={fullScreen
+			? `width: ${fullScreenHost ? '90%' : '90vw'}; max-width: 800px; height: ${
+					fullScreenHost ? '90%' : '90vh'
+				};`
+			: contentStyle}
 	>
 		{#if displayArrow}
 			<div use:melt={$arrow}></div>

--- a/frontend/src/lib/components/meltComponents/Tooltip.svelte
+++ b/frontend/src/lib/components/meltComponents/Tooltip.svelte
@@ -46,8 +46,7 @@
 		text
 	}: Props = $props()
 
-	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
-	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	// Overlays belong to the enclosing pane when there is one — see overlayHost.
 	// `null` is melt's "render in place" and must survive; only an absent prop defers to the host.
 	const hostPortal = overlayPortalTarget('body')
 	const effectivePortal = () => (portal === undefined ? hostPortal() : portal)
@@ -66,8 +65,6 @@
 		portal: untrack(() => effectivePortal())
 	})
 
-	// melt's `portal` is a store, and the host element only binds once its children have
-	// initialised — a creation-time value alone would always miss it.
 	$effect(() => {
 		$portalOption = effectivePortal()
 	})

--- a/frontend/src/lib/components/meltComponents/Tooltip.svelte
+++ b/frontend/src/lib/components/meltComponents/Tooltip.svelte
@@ -5,6 +5,7 @@
 	import { zIndexes } from '$lib/zIndexes'
 
 	import { createTooltip, melt } from '@melt-ui/svelte'
+	import { overlayPortalTarget } from '$lib/components/common/overlayHost.svelte'
 	import { fade } from 'svelte/transition'
 	import TooltipInner from '../TooltipInner.svelte'
 
@@ -36,7 +37,7 @@
 		disablePopup = false,
 		openDelay = 300,
 		closeDelay = 0,
-		portal = 'body',
+		portal = undefined,
 		customBgClass = undefined,
 		style = '',
 		class: className = '',
@@ -45,9 +46,16 @@
 		text
 	}: Props = $props()
 
+	// An enclosing pane claims the overlays opened inside it (see overlayHost), so they
+	// stay in that pane instead of covering the app; elsewhere this is the document body.
+	// `null` is melt's "render in place" and must survive; only an absent prop defers to the host.
+	const hostPortal = overlayPortalTarget('body')
+	const effectivePortal = () => (portal === undefined ? hostPortal() : portal)
+
 	const {
 		elements: { trigger, content },
-		states: { open }
+		states: { open },
+		options: { portal: portalOption }
 	} = createTooltip({
 		positioning: {
 			placement: untrack(() => placement)
@@ -55,7 +63,13 @@
 		openDelay: untrack(() => openDelay),
 		closeDelay: untrack(() => closeDelay),
 		group: true,
-		portal: untrack(() => portal)
+		portal: untrack(() => effectivePortal())
+	})
+
+	// melt's `portal` is a store, and the host element only binds once its children have
+	// initialised — a creation-time value alone would always miss it.
+	$effect(() => {
+		$portalOption = effectivePortal()
 	})
 
 	// Cursor anchoring: floating-ui positions against `reference.getBoundingClientRect()`.

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -19,6 +19,7 @@
 		session,
 		runtime,
 		active,
+		collapsed = false,
 		mounted,
 		label,
 		darkMode,
@@ -31,6 +32,9 @@
 		runtime: SessionRuntime | undefined
 		/** Visible tab — only one is at a time; the rest stay mounted but hidden. */
 		active: boolean
+		/** Preview panel is collapsed to zero width. The panel is never unmounted, so
+		 * this is the difference between the active tab and a tab on screen. */
+		collapsed?: boolean
 		/** Preview panel is in full screen — forwarded to editor views so a script
 		 * editor reopens its test pane when there's room. */
 		fullscreen?: boolean
@@ -123,7 +127,13 @@
 	// shared stack would let its overlays arbitrate Escape for the tab the user is looking at.
 	let editorEl: HTMLDivElement | undefined = $state()
 	let hostDrawers = $state({ val: [] as string[] })
-	setOverlayHost({ el: () => editorEl, drawers: hostDrawers, active: () => active })
+	setOverlayHost({
+		el: () => editorEl,
+		drawers: hostDrawers,
+		// Collapsing resizes the panel to zero rather than unmounting it, so the active
+		// tab of a collapsed panel is still as invisible as a background tab.
+		active: () => active && !collapsed
+	})
 
 	let flashing = $state(false)
 	let flashTimer: ReturnType<typeof setTimeout> | undefined

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -12,6 +12,7 @@
 	import { resolvePreviewTab, parsePreviewItemRoute } from './previewRouter'
 	import { withMenuHidden } from './sessionMode.svelte'
 	import ArtifactViewer from '../copilot/chat/artifacts/ArtifactViewer.svelte'
+	import { setOverlayHost } from '../common/overlayHost.svelte'
 
 	let {
 		tab,
@@ -116,6 +117,14 @@
 		active ? 'z-10 opacity-100 pointer-events-auto' : 'z-0 opacity-0 pointer-events-none'
 	)
 
+	// Overlays the editor opens (drawers, modals, popovers) anchor here rather than to the
+	// document, so they stay within this tab and hide with it when another tab takes over.
+	// The stack is per-tab for the same reason: this host stays mounted while hidden, and a
+	// shared stack would let its overlays arbitrate Escape for the tab the user is looking at.
+	let editorEl: HTMLDivElement | undefined = $state()
+	let hostDrawers = $state({ val: [] as string[] })
+	setOverlayHost({ el: () => editorEl, drawers: hostDrawers, active: () => active })
+
 	let flashing = $state(false)
 	let flashTimer: ReturnType<typeof setTimeout> | undefined
 	// Guard against the effect's non-pulse reruns (tab/runtime changes) firing a flash.
@@ -152,7 +161,11 @@
 {/snippet}
 
 {#if slot.kind === 'editor' && mounted && runtime}
-	<div class="absolute inset-0 flex flex-col min-h-0 bg-surface {visibility}" aria-hidden={!active}>
+	<div
+		bind:this={editorEl}
+		class="absolute inset-0 flex flex-col min-h-0 bg-surface {visibility}"
+		aria-hidden={!active}
+	>
 		<!-- Dynamic imports: the live editors pull in the heaviest module graphs in
 		     the app (FlowBuilder, ScriptBuilder/Monaco, the raw-app editor, the
 		     pipeline graph). Loading them only when an editor tab first mounts keeps

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -32,8 +32,10 @@
 		runtime: SessionRuntime | undefined
 		/** Visible tab — only one is at a time; the rest stay mounted but hidden. */
 		active: boolean
-		/** Preview panel is collapsed to zero width. The panel is never unmounted, so
-		 * this is the difference between the active tab and a tab on screen. */
+		/** Preview panel is not on screen — collapsed, and not overridden by full screen.
+		 * The panel is never unmounted, so this is the difference between the active tab
+		 * and a tab the user can actually see. Resolved by the page, which owns the
+		 * collapse/full-screen precedence. */
 		collapsed?: boolean
 		/** Preview panel is in full screen — forwarded to editor views so a script
 		 * editor reopens its test pane when there's room. */
@@ -130,8 +132,8 @@
 	setOverlayHost({
 		el: () => editorEl,
 		drawers: hostDrawers,
-		// Collapsing resizes the panel to zero rather than unmounting it, so the active
-		// tab of a collapsed panel is still as invisible as a background tab.
+		// The panel is resized rather than unmounted, so the active tab of a panel that
+		// is off screen is as invisible as a background tab.
 		active: () => active && !collapsed
 	})
 

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -890,6 +890,7 @@
 											session={s}
 											runtime={rt}
 											active={s.id === activeSession?.id && tab.id === tabs?.activeId}
+											collapsed={tabs?.collapsed ?? false}
 											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
 											label={tabLabelFor(tab)}
 											darkMode={isDarkMode.val}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -890,7 +890,7 @@
 											session={s}
 											runtime={rt}
 											active={s.id === activeSession?.id && tab.id === tabs?.activeId}
-											collapsed={tabs?.collapsed ?? false}
+											collapsed={(tabs?.collapsed ?? false) && !fullscreen}
 											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
 											label={tabLabelFor(tab)}
 											darkMode={isDarkMode.val}


### PR DESCRIPTION
## Summary

`/sessions` keeps every visited preview tab mounted, hidden behind `opacity-0 pointer-events-none`. Neither property stops keyboard events reaching a `svelte:window` listener, so a confirmation dialog or drawer left open in a hidden tab still answers **Enter/Escape for the tab the user is actually looking at** — Enter silently confirms a dialog nobody can see. The same mounting scheme breaks portals: overlays targeting hardcoded ids like `#flow-editor` land in whichever mounted editor comes first in the DOM, which is usually a hidden one, so they render invisibly.

Both reproduce on `main` today — the flow editor already runs inside a session tab. This PR introduces an **overlay host**: an enclosing pane can claim the overlays opened inside it, so they anchor to that pane, hide with it, and stay silent while it is off screen.

Everything routes through `getOverlayHost()`, which returns `undefined` outside a host, so behaviour off `/sessions` is unchanged.

## Changes

- **New `common/overlayHost.svelte.ts`** — a context with three capabilities: `el()` (the anchor overlays portal into and position against), `drawers` (a per-host overlay stack, replacing the module-global one in `Disposable`), and `active()` (whether this host is the one on screen). Plus `useOverlayStack()` for overlays that need to know they are topmost.
- **`PreviewTabHost`** provides the host, bound to the tab's editor element.
- **Key gating** — `ConfirmationModal`, `Modal` and `Disposable` return early from their window key handlers when their host is hidden. `ConfirmationModal` additionally requires being topmost, so a dialog buried under a later overlay stops answering for it.
- **Anchoring** — hosted `Drawer`, `Modal` and `ConfirmationModal` are portalled into the host *and* positioned against it. Both halves are required: `absolute` alone resolves against whatever positioned ancestor happens to enclose the caller.
- **Host-aware portals** for `Popover`, `Tooltip`, `Menu`, `DropdownV2`, `ContextMenu`, and the five hardcoded `#flow-editor` / `#flow-graph-v2` targets. The fallback selector is now resolved *within* the host, so a caller that deliberately names the graph box keeps that box (and its clipping) rather than being promoted to the whole tab.
- **`Disposable`** drops its module-global `openedDrawers` export for the context-resolved stack, and cleans its entry up on unmount — a leaked id would otherwise block Escape for every overlay opened afterwards.
- **`Drawer`** gains a `minSize` floor so a percentage size stays usable inside a narrow pane. Gated on being hosted, so unhosted drawers keep the size they always had.

## Screenshots

The flow editor's Diff drawer, opened inside a session preview tab.

**Before** — the drawer escapes to `body` and covers the whole app, burying the chat pane and the sidebar:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-confirmation-in-tabs/1785771196-shot-before.png)

**After** — it stays inside the tab that opened it:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-confirmation-in-tabs/1785771198-after-drawer.png)

A hosted confirmation dialog covers its whole tab and only its tab — it is portalled into the pane, so `absolute` resolves against the pane rather than the Splitpanes box the caller sits in:

![confirmation dialog anchored to its tab](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-confirmation-in-tabs/1785771201-after-confirm.png)

## Test plan

Exercised in a browser against a `/sessions` flow preview tab:

- [x] Open the Diff drawer in a flow tab — it stays inside the tab, chat pane untouched
- [x] Trigger the "Enable Chat Mode?" confirmation in a flow tab — dialog and backdrop cover the whole tab, not half of it
- [x] Leave that dialog open, switch to a second preview tab, press **Enter** — the hidden dialog does **not** confirm
- [x] Switch back to the first tab, press **Escape** — the dialog cancels, so the gate is not permanently dead
- [x] Outside `/sessions` (Compare & Deploy → Discard drafts) — dialog still renders `fixed`, Escape still cancels, nothing discarded

Checks:

- [x] `svelte-fast-check` clean over all 1737 `.svelte` files (non-incremental)
- [x] Vitest: 2222 pass. The 8 failures in 4 files are pre-existing — verified identical on clean `origin/main`

Still worth a look from a reviewer:

- [ ] A `Popover` using `portal={null}` (`FilterSearchbar`, `AssetsOverflowedNode`) — melt's "render in place" is preserved by falling back only on `undefined`, but it is the subtlest edge in the diff
- [ ] Right-click the graph pane in edit mode inside a session tab — the sticky-note menu should appear under the cursor, unclipped