### PR TITLE
chore: pin git-sync scripts to hub 28870/28871 (cli 1.777.2-gitsync.0)

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -167,7 +167,7 @@ pub enum ObjectType {
     DatatableMigration,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28809/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28871/sync-script-to-git-repo-windmill";
 
 /// Hub script that applies a repository's state back into a workspace
 /// (the repo → Windmill / "pull" direction). Same script the UI runs from

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -175,7 +175,7 @@ pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28809/sync-script-to-git-repo
 /// ignores the slug, so the slug is kept free of characters that would be
 /// percent-encoded into the run URL (a `:` becomes `%3A`, which some hardened
 /// reverse proxies reject as double-encoding when the client re-encodes it).
-pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28808/git-sync-init-repository-windmill";
+pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28870/git-sync-init-repository-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,6 +1,6 @@
 {
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28808/git-sync-init-repository-windmill",
+	"gitInitRepo": "hub/28870/git-sync-init-repository-windmill",
 	"slackErrorHandler": "hub/28794/workspace-or-schedule-error-handler-slack",
 	"emailErrorHandler": "hub/19795/workspace-or-error-handler-email",
 	"slackRecoveryHandler": "hub/28791/slack/schedule-recovery-handler-slack",


### PR DESCRIPTION
## Summary

Delivery half of #10473. That PR fixed the CLI bug where a git-sync **Pull from repo**
reported `All N changes pushed` and deployed nothing whenever a raw app had a backend
runnable removed (its `.lock` sorted first among the deletions and was skipped, which
dropped the collapsed whole-app push).

Merging the fix alone changed nothing for customers: the git-sync hub scripts bundle a
*published* `windmill-cli`, and both were pinned to `1.769.1`, from before the fix.

Chain walked for this PR:

1. Published `windmill-cli@1.777.2-gitsync.0` from `main` (which contains the fix),
   under the existing **`gitsync` dist-tag**. `latest` stays at `1.777.1`, and the
   `1.777.2` that release-please wants next is left free.
   Verified the published tarball carries the fix, not just the version bump:
   `package/esm/main.js` contains
   `!isRawAppFile(change.path) && change.path.endsWith(".lock")`.
2. Bumped both git-sync hub scripts' imports and regenerated their embedded lockfiles
   (windmill-integrations `6679dae2d`, `30575f493`). CI republished them as
   **hub 28870** (init/pull, ask 13952) and **hub 28871** (sync/deploy, ask 6943).
   Confirmed each resolves `windmill-cli@1.777.2-gitsync.0` in both its source and its
   embedded lockfile.
3. This PR moves the three pins onto them.

## Changes

- `backend/windmill-common/src/workspaces.rs`: `GIT_SYNC_PULL_SCRIPT_PATH` 28808 -> 28870
- `backend/windmill-common/src/workspaces.rs`: `LATEST_GIT_SYNC_SCRIPT_PATH` 28809 -> 28871
- `frontend/src/lib/hubPaths.json`: `gitInitRepo` 28808 -> 28870 (must match the backend pin)

## Scope note

The raw-app bug itself only reaches the **pull** direction: 13952 is the script that runs
`sync push` (repo -> workspace), and 6943 runs none of the sync subcommands. 6943 is bumped
to keep both git-sync scripts on one CLI version rather than letting them drift.

Worth knowing when reading the e2e result: 6943 had been on `1.769.1`, so this moves the
workspace -> git deploy path across every CLI change between `1.769.1` and
`1.777.2-gitsync.0`. `git-sync-test.yml` exercises that path and is the signal here.

`gitSyncTest` (ask 6996) is left at hub 28184 even though the hub's latest for that ask is
now 28800. Unrelated to this fix; bumping it is its own change.

Both `is_script_meets_min_version` floors in use (28796 and 28103) sit below 28870, so
they keep passing.

## Test plan

- [x] `cargo check -p windmill-common`
- [x] hub 28870 + 28871 verified to resolve `windmill-cli@1.777.2-gitsync.0` (source + lockfile)
- [x] npm `latest` still `1.777.1`; `gitsync` tag now `1.777.2-gitsync.0`
- [ ] `git-sync-test.yml` e2e green (triggered by the `workspaces.rs` change) — covers both
      directions, and is the check that matters for the 6943 version jump
- [ ] Manual: **Pull from repo** on a workspace whose repo has a raw app with a backend
      runnable removed. Applying should deploy the app, and a re-preview should drop to
      zero changes rather than repeating the same list.

Frontend change is a pinned hub id in a JSON data file, no visible UI effect, so no
screenshots.