### PR TITLE
ci: run ai evals on node 24 so npm ci accepts the npm 11 lockfile

### DIFF
--- a/.github/workflows/ai-evals-test.yml
+++ b/.github/workflows/ai-evals-test.yml
@@ -77,9 +77,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          # Node 22.19+ is required by the frontend's undici 8.x, which the
+          # Node 24 ships npm 11, which frontend/package-lock.json is authored
+          # with; npm 10 rejects it ("Missing: picomatch@4.0.5 from lock file").
+          # Node must also stay >= 22.19 for the frontend's undici 8.x, which the
           # Vitest bridge loads; Node 20 fails with markAsUncloneable.
-          node-version: "22"
+          node-version: "24"
 
       # CE build used only as the AI proxy (login, workspace, provider resource,
       # /ai/proxy). No worker execution or MCP needed — global tools/drafts run


### PR DESCRIPTION
## Summary

`ai_evals_global` has been red on every open PR (and on main) since #10468, failing before it runs a single eval:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync
npm error Missing: picomatch@4.0.5 from lock file
```

Nothing is wrong with the lockfile. `frontend/package-lock.json` records `picomatch@4.0.5` only as nested entries under `tinyglobby`, `vite` and `vitest` — how npm 11 writes it — and npm 10 does not accept that as satisfying the tree. `.github/workflows/ai-evals-test.yml` pinned `node-version: "22"` (npm 10); `frontend-check.yml` already uses Node 24 (npm 11) against the same lockfile and passes.

The Node 22 pin was only ever a stated *minimum* — "Node 22.19+ is required by the frontend's undici 8.x" — so Node 24 still satisfies it. Node affects only the `npm ci` + `generate-backend-client` step here; the evals themselves run under bun.

Not fixed by regenerating the lockfile with npm 10: that works, but the resulting diff strips the `libc` glibc/musl markers npm 11 emits on optional platform deps.

## Changes

- `.github/workflows/ai-evals-test.yml`: `node-version: "22"` → `"24"`, with the comment now recording both constraints (npm 11 for the lockfile, >= 22.19 for undici).

## Test plan

- [x] `npx npm@10 ci --dry-run --ignore-scripts` from `frontend/` reproduces `Missing: picomatch@4.0.5 from lock file`
- [x] `npx npm@11 ci --dry-run --ignore-scripts` from `frontend/` is clean (`changed 10 packages`)
- [x] Bisected the breakage to `d7ef71f0b7` (#10468): clean at `d7ef71f0b7^`, broken at it and every commit since
- [ ] `ai_evals_global` goes green on this PR

No frontend code changed, so there is no UI to screenshot.