### PR TITLE
fix: bind the fork banner's comparison to the workspace it describes

### DIFF
--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -162,11 +162,15 @@
 			.filter((d) => d.kind === 'script' || d.kind === 'flow' || d.kind === 'resource')
 			.map((d) => ({ path: d.path, kind: d.kind as 'script' | 'flow' | 'resource' }))
 		if (items.length === 0) return
+		// Counted for the comparison current at call time — the poll below outlives a
+		// fork switch, and a slow batch for the fork we left would repaint this one's.
+		const seq = requestSeq
 		try {
 			const batch = await ScriptService.getCiTestResultsBatch({
 				workspace: $workspaceStore,
 				requestBody: { items }
 			})
+			if (seq !== requestSeq) return
 			let passing = 0
 			let failing = 0
 			let running = 0

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -34,25 +34,34 @@
 	const drafts = useWorkspaceDrafts(() => (isFork ? ($workspaceStore ?? undefined) : undefined))
 	const draftCount = $derived(drafts.count)
 
-	// What the banner is allowed to answer from. Anything else — in flight, failed, or a
-	// tally that was skipped outright — counts zero of everything, which is
-	// indistinguishable from "nothing to deploy" and would send the user to the wrong
-	// direction. Typed helpers avoid the `never`-inference quirk on `$state` in `$derived`.
+	// Every read of `comparison` that decides what the banner says or where its button
+	// goes must go through this: anything else — in flight, failed, or a tally skipped
+	// outright — counts zero of everything, which is indistinguishable from "nothing to
+	// deploy". Typed helper avoids the `never`-inference quirk on `$state` in `$derived`.
 	function isAnswerable(c: WorkspaceComparison | undefined, isLoading: boolean): boolean {
 		return !isLoading && !!c && !c.skipped_comparison
 	}
-	const comparisonLoaded = $derived(isAnswerable(comparison, loading))
+	const hasAnswer = $derived(isAnswerable(comparison, loading))
 
 	// Fork is fully in sync with its parent (comparison ran, no ahead/behind diffs).
-	// Gated on `comparisonLoaded` for the reason above: it also selects the drafts CTA,
-	// which would otherwise win over the deploy/update one mid-load.
 	function isUpToDate(c: WorkspaceComparison | undefined): boolean {
 		return !!c && !c.skipped_comparison && c.summary.total_diffs === 0
 	}
-	let upToDate = $derived(comparisonLoaded && isUpToDate(comparison))
+	let upToDate = $derived(hasAnswer && isUpToDate(comparison))
 	// Up to date with the parent but local drafts are pending — show the draft
 	// state (same text + CTA as the draft banner) instead of "Everything is up to date".
 	let showDraftsOnly = $derived(upToDate && draftCount > 0)
+
+	// Leaving for a workspace with no comparison of its own has to invalidate whatever
+	// is in flight too, or that response lands as this one's answer — and its CI counts
+	// would be fetched for paths this workspace may not even have.
+	function dropComparison() {
+		requestSeq++
+		comparison = undefined
+		comparisonFor = undefined
+		loading = false
+		resetCiTestSummary()
+	}
 
 	$effect(() => {
 		;[$workspaceStore, parentWorkspaceId]
@@ -60,7 +69,7 @@
 			if (isFork && $workspaceStore) {
 				checkForChanges()
 			} else {
-				comparison = undefined
+				dropComparison()
 			}
 		})
 	})
@@ -69,7 +78,7 @@
 		if (isFork && $workspaceStore) {
 			checkForChanges()
 		} else {
-			comparison = undefined
+			dropComparison()
 		}
 	})
 
@@ -88,6 +97,7 @@
 		if (comparisonFor !== ws) {
 			comparison = undefined
 			comparisonFor = undefined
+			resetCiTestSummary()
 		}
 		const seq = ++requestSeq
 		loading = true
@@ -116,11 +126,9 @@
 
 	// Opens the direction the button offers, so the label and the list agree: a fork
 	// with nothing to deploy lands on the update side, not on an empty deploy list.
-	// Both read `comparisonLoaded` — an unknown comparison counts zero of everything,
-	// which is indistinguishable from "nothing to deploy".
 	function openComparisonDrawer() {
 		if (parentWorkspaceId && $workspaceStore) {
-			const dir = comparisonLoaded && changesAhead === 0 ? '&dir=update' : ''
+			const dir = hasAnswer && changesAhead === 0 ? '&dir=update' : ''
 			goto('/forks/compare?workspace_id=' + encodeURIComponent($workspaceStore) + dir, {
 				replaceState: true
 			})
@@ -139,6 +147,14 @@
 	let ciTestFailing = $state(0)
 	let ciTestRunning = $state(0)
 	let ciTestTotal = $state(0)
+
+	// These describe the rows of one comparison, so they are dropped with it.
+	function resetCiTestSummary() {
+		ciTestPassing = 0
+		ciTestFailing = 0
+		ciTestRunning = 0
+		ciTestTotal = 0
+	}
 
 	async function fetchCiTestSummary() {
 		if (!$workspaceStore || !comparison?.diffs) return
@@ -387,7 +403,7 @@
 					>
 						{#if showDraftsOnly}
 							Review & deploy drafts
-						{:else if !comparisonLoaded || changesAhead > 0}
+						{:else if !hasAnswer || changesAhead > 0}
 							Review & Deploy Changes
 						{:else}
 							Review & Update fork

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -13,6 +13,9 @@
 
 	let loading = $state(false)
 	let comparison: WorkspaceComparison | undefined = $state(undefined)
+	/** Workspace `comparison` describes; control flow only, never rendered. */
+	let comparisonFor: string | undefined = undefined
+	let requestSeq = 0
 	let error: string | undefined = $state(undefined)
 
 	let currentWorkspaceData = $derived($userWorkspaces.find((w) => w.id === $workspaceStore))
@@ -31,12 +34,22 @@
 	const drafts = useWorkspaceDrafts(() => (isFork ? ($workspaceStore ?? undefined) : undefined))
 	const draftCount = $derived(drafts.count)
 
+	// What the banner is allowed to answer from. Anything else — in flight, failed, or a
+	// tally that was skipped outright — counts zero of everything, which is
+	// indistinguishable from "nothing to deploy" and would send the user to the wrong
+	// direction. Typed helpers avoid the `never`-inference quirk on `$state` in `$derived`.
+	function isAnswerable(c: WorkspaceComparison | undefined, isLoading: boolean): boolean {
+		return !isLoading && !!c && !c.skipped_comparison
+	}
+	const comparisonLoaded = $derived(isAnswerable(comparison, loading))
+
 	// Fork is fully in sync with its parent (comparison ran, no ahead/behind diffs).
-	// Typed helper avoids the $state `never`-inference quirk on `comparison` in $derived.
+	// Gated on `comparisonLoaded` for the reason above: it also selects the drafts CTA,
+	// which would otherwise win over the deploy/update one mid-load.
 	function isUpToDate(c: WorkspaceComparison | undefined): boolean {
 		return !!c && !c.skipped_comparison && c.summary.total_diffs === 0
 	}
-	let upToDate = $derived(isUpToDate(comparison))
+	let upToDate = $derived(comparisonLoaded && isUpToDate(comparison))
 	// Up to date with the parent but local drafts are pending — show the draft
 	// state (same text + CTA as the draft banner) instead of "Everything is up to date".
 	let showDraftsOnly = $derived(upToDate && draftCount > 0)
@@ -61,25 +74,43 @@
 	})
 
 	async function checkForChanges() {
-		if (!$workspaceStore || !parentWorkspaceId) {
+		const ws = $workspaceStore
+		const parent = parentWorkspaceId
+		if (!ws || !parent) {
 			return
 		}
 
+		// A comparison only ever describes the workspace it was requested for. The
+		// component survives a fork switch, so drop the previous fork's rows before
+		// fetching rather than let them answer for this one, and let only the newest
+		// request write — responses can land out of order, and a late one would
+		// otherwise paint another fork's counts over the current answer.
+		if (comparisonFor !== ws) {
+			comparison = undefined
+			comparisonFor = undefined
+		}
+		const seq = ++requestSeq
 		loading = true
 		error = undefined
 
 		try {
 			// Compare with parent workspace (shared single-flight fetch — the chat
 			// diff tool reuses this result instead of recomputing the comparison)
-			const result = await fetchWorkspaceComparison(parentWorkspaceId, $workspaceStore)
+			const result = await fetchWorkspaceComparison(parent, ws)
 
+			if (seq !== requestSeq) return
 			comparison = result
+			comparisonFor = ws
 		} catch (e) {
+			if (seq !== requestSeq) return
 			console.error('Failed to compare workspaces:', e)
 			error = `Failed to check for changes: ${e}`
-			// Still show banner if there's an error, but with error message
+			// Show the banner with the error rather than the rows we failed to refresh:
+			// on a switch those belong to the fork we just left.
+			comparison = undefined
+			comparisonFor = undefined
 		} finally {
-			loading = false
+			if (seq === requestSeq) loading = false
 		}
 	}
 
@@ -161,9 +192,6 @@
 	function countDir(c: WorkspaceComparison | undefined, mergeIntoParent: boolean): number {
 		return c?.diffs.filter((d) => diffActionableInDirection(d, mergeIntoParent)).length ?? 0
 	}
-	// A comparison in flight is not an answer: on a fork switch the component stays
-	// mounted and `comparison` still holds the previous fork's rows.
-	const comparisonLoaded = $derived(!loading && comparison !== undefined)
 	const changesAhead = $derived(countDir(comparison, true))
 	const changesBehind = $derived(countDir(comparison, false))
 


### PR DESCRIPTION
## Summary

Follow-up to #10467. That PR gated the fork banner's CTA on `!loading && comparison !== undefined`, which closed the fork-switch window it was aimed at but left the underlying problem: **`comparison` is not bound to the workspace it describes**, so several paths can still answer for the wrong fork — or answer at all when there is no answer.

Found by the post-merge review of the last commit, which landed without a CI verdict (the merge cancelled the round).

## Changes

- **`comparison` is now scoped to a workspace.** `checkForChanges` captures the workspace it was issued for, clears the previous fork's rows before fetching a different one, and stamps `comparisonFor` on success.
- **Only the newest request writes.** A monotonic `requestSeq` drops superseded responses. Previously two overlapping fetches shared one `loading` flag and an unguarded assignment, so switching A → B could resolve out of order and leave fork A's counts painted over fork B — permanently, until the next switch.
- **A failed refresh no longer keeps the previous fork's rows.** The `catch` clears `comparison`; before, the banner body hid them behind the error branch while the CTA still routed on them.
- **A skipped tally is not "nothing to deploy".** `skipped_comparison` returns `diffs: []` with a zeroed summary, which is indistinguishable from a fork with nothing ahead; the CTA claimed pending updates next to text saying the changes can't be displayed.
- **`upToDate` / `showDraftsOnly` are gated too.** They read `comparison` directly and take precedence over the CTA, so a fork with drafts *and* real diffs showed the drafts CTA for the whole load window.
- **Leaving a fork invalidates what's in flight.** The non-fork branch cleared `comparison` but not the pending request, so a late response landed on a workspace with no fork banner — and dragged a cross-workspace `getCiTestResultsBatch` POST with it.
- **The CI summary is bound to its comparison.** Its counters are dropped with the comparison, and its own async write is guarded — the 3s poll outlives a fork switch, so a slow batch for the fork you left would otherwise repaint the current one's CI line.

All five collapse into one rule, which the helper now states once: the banner answers only from a comparison that is loaded, for this workspace, and not skipped.

## Test plan

- [x] `npm run check` — 0 errors
- [x] Browser: fork with only a parent-only diff still reads "1 change behind" → "Review & Update fork" → opens `&dir=update`
- [x] Browser: switching from an update-only fork to an ahead-only fork shows that fork's own counts and lands on Deploy with its ahead row (the case the review predicted would still fail)
- [x] Browser: switching back and forth between the two forks shows each one's own counts and CTA with no carry-over
- [ ] Not exercised in-browser: the out-of-order response race and the error path — both need injected latency/failure; verified by inspection against the `requestSeq` guard

## Note

`frontend/src/lib/gen` is gitignored, so a stale local client shows up as type errors in `stores.ts` / `NativeTriggerEditor.svelte` (`Workspace.is_dev_workspace` and friends). `npm run generate-backend-client` clears them — not a repo breakage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the fork banner’s comparison and CI summaries to the active workspace and invalidate in‑flight fetches during fork switches, so counts and CTAs always reflect the right fork.

- **Bug Fixes**
  - Scope `comparison` per workspace using `comparisonFor`; clear stale rows on switch.
  - Cancel in-flight on switch; sequence writes; reset CI counts; drop superseded CI summaries.
  - Treat in-flight, failed, or skipped comparisons as non‑answerable; gate CTA, `upToDate`, and drafts.
  - On fetch error, clear `comparison` to avoid showing the previous fork’s rows.
  - Distinguish skipped tallies from “nothing to deploy” to avoid misleading CTAs.

<sup>Written for commit 1d31fda9684a8acd222e37045b43177ff19b0bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


