### PR TITLE
fix: confirm step delete consequences in a single dialog

### DIFF
--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -307,19 +307,33 @@
 		}
 	}
 
-	type PendingDeleteConfirmation = {
-		plan: DeletePlan
-	}
-
-	type PendingGroupAction = {
-		groups: FlowGroup[]
+	// A single delete can have several consequences at once (emptied groups *and*
+	// dependent steps); they are confirmed together so one user action never raises
+	// more than one dialog.
+	type PendingModuleAction = {
 		label: 'delete' | 'move'
+		stepCount: number
+		groups: FlowGroup[]
+		dependents: Record<string, string[]>
 		confirm: () => void
 		cancel?: () => void
 	}
 
-	let pendingDeleteConfirmation: PendingDeleteConfirmation | undefined = $state(undefined)
-	let pendingGroupAction: PendingGroupAction | undefined = $state(undefined)
+	// The modal keeps rendering `pendingModuleAction` while it fades out, so visibility is
+	// driven by `moduleActionOpen` rather than by clearing the value — clearing it would
+	// blank the dialog mid-transition. `moduleActionOpen` also makes confirm/cancel
+	// one-shot: the buttons stay clickable until the fade ends.
+	let pendingModuleAction: PendingModuleAction | undefined = $state(undefined)
+	let moduleActionOpen = $state(false)
+
+	function askModuleAction(action: PendingModuleAction) {
+		pendingModuleAction = action
+		moduleActionOpen = true
+	}
+
+	function stepNoun(action: PendingModuleAction | undefined) {
+		return (action?.stepCount ?? 1) > 1 ? 'steps' : 'step'
+	}
 
 	let graph: FlowGraphV2 | undefined = $state(undefined)
 	let noteMode = $state(false)
@@ -362,23 +376,20 @@
 			return
 		}
 
-		const proceed = () => {
-			if (request.needsDependencyConfirmation) {
-				pendingDeleteConfirmation = { plan: request.plan }
-			} else {
-				applyDeletePlan(request.plan)
-			}
+		const affectedGroups = request.plan.structureDelete?.affectedGroups ?? []
+
+		if (affectedGroups.length === 0 && !request.needsDependencyConfirmation) {
+			applyDeletePlan(request.plan)
+			return
 		}
 
-		if ((request.plan.structureDelete?.affectedGroups.length ?? 0) > 0) {
-			pendingGroupAction = {
-				groups: request.plan.structureDelete!.affectedGroups,
-				label: 'delete',
-				confirm: proceed
-			}
-		} else {
-			proceed()
-		}
+		askModuleAction({
+			label: 'delete',
+			stepCount: request.plan.targets.length,
+			groups: affectedGroups,
+			dependents: request.plan.dependents,
+			confirm: () => applyDeletePlan(request.plan)
+		})
 	}
 
 	export function deleteMultiple(ids: string[]) {
@@ -492,61 +503,58 @@
 
 <Portal name="flow-module">
 	<ConfirmationModal
-		title="Confirm deleting step with dependents"
-		confirmationText="Delete step"
-		open={Boolean(pendingDeleteConfirmation)}
+		title={`${pendingModuleAction?.label === 'move' ? 'Move' : 'Delete'} ${stepNoun(
+			pendingModuleAction
+		)}?`}
+		confirmationText={`${pendingModuleAction?.label === 'move' ? 'Move' : 'Delete'} ${stepNoun(
+			pendingModuleAction
+		)}`}
+		open={moduleActionOpen}
 		on:confirmed={() => {
-			if (pendingDeleteConfirmation) {
-				applyDeletePlan(pendingDeleteConfirmation.plan)
-				pendingDeleteConfirmation = undefined
-			}
+			if (!moduleActionOpen) return
+			moduleActionOpen = false
+			pendingModuleAction?.confirm()
 		}}
 		on:canceled={() => {
-			pendingDeleteConfirmation = undefined
+			if (!moduleActionOpen) return
+			moduleActionOpen = false
+			pendingModuleAction?.cancel?.()
 		}}
 	>
-		<div class="text-primary pb-2"
-			>Found the following steps that will require changes after this step is deleted:</div
-		>
-		{#each Object.entries(pendingDeleteConfirmation?.plan.dependents ?? {}) as [k, v]}
-			<div class="pb-3">
-				<h3 class="text-secondary font-semibold">{k}</h3>
-				<ul class="text-sm">
-					{#each v as dep}
-						<li>{dep}</li>
+		{#if pendingModuleAction}
+			{@const action = pendingModuleAction}
+			{@const dependents = Object.entries(action.dependents)}
+			{#if action.groups.length === 1}
+				{@const group = action.groups[0]}
+				<p
+					>The group{group.summary ? ` "${group.summary}"` : ''} will be removed (empty or duplicate).</p
+				>
+			{:else if action.groups.length > 1}
+				<p>The following groups will be removed (empty or duplicate):</p>
+				<ul class="list-disc pl-4 mt-1">
+					{#each action.groups as group}
+						<li>{group.summary || `${group.start_id} → ${group.end_id}`}</li>
 					{/each}
 				</ul>
-			</div>
-		{/each}
-	</ConfirmationModal>
-
-	<ConfirmationModal
-		title={pendingGroupAction?.groups.length === 1 ? 'Remove group?' : 'Remove groups?'}
-		confirmationText={pendingGroupAction?.label === 'delete' ? 'Delete step' : 'Move step'}
-		open={Boolean(pendingGroupAction)}
-		on:confirmed={() => {
-			pendingGroupAction?.confirm()
-			pendingGroupAction = undefined
-		}}
-		on:canceled={() => {
-			pendingGroupAction?.cancel?.()
-			pendingGroupAction = undefined
-		}}
-	>
-		{#if pendingGroupAction?.groups.length === 1}
-			{@const group = pendingGroupAction.groups[0]}
-			<p
-				>The group{group.summary ? ` "${group.summary}"` : ''} will be removed (empty or duplicate).
-				Are you sure you want to {pendingGroupAction.label} the step?</p
-			>
-		{:else}
-			<p>The following groups will be removed (empty or duplicate):</p>
-			<ul class="list-disc pl-4 mt-1">
-				{#each pendingGroupAction?.groups ?? [] as group}
-					<li>{group.summary || `${group.start_id} → ${group.end_id}`}</li>
-				{/each}
-			</ul>
-			<p class="mt-2">Are you sure you want to {pendingGroupAction?.label} the step?</p>
+			{/if}
+			{#if dependents.length > 0}
+				<p class={action.groups.length > 0 ? 'mt-3' : ''}
+					>The following steps will require changes afterwards:</p
+				>
+				<div class="mt-1">
+					{#each dependents as [k, v]}
+						<div class="pb-2">
+							<h3 class="text-secondary font-semibold">{k}</h3>
+							<ul class="text-sm">
+								{#each v as dep}
+									<li>{dep}</li>
+								{/each}
+							</ul>
+						</div>
+					{/each}
+				</div>
+			{/if}
+			<p class="mt-2">Are you sure you want to {action.label} the {stepNoun(action)}?</p>
 		{/if}
 	</ConfirmationModal>
 </Portal>
@@ -689,12 +697,14 @@
 					}
 
 					if (affectedGroups.length > 0) {
-						pendingGroupAction = {
-							groups: affectedGroups,
+						askModuleAction({
 							label: 'move',
+							stepCount: movedIds.length,
+							groups: affectedGroups,
+							dependents: {},
 							confirm: doMove,
 							cancel: () => moveManager.clearMoving()
-						}
+						})
 					} else {
 						doMove()
 					}


### PR DESCRIPTION
## Summary

Deleting a step could raise two confirmation dialogs in sequence for one user action: when the step both emptied a group *and* had dependents, confirming "Remove group?" opened "Confirm deleting step with dependents", which had to be confirmed too. The second dialog appeared exactly where the first had been, so it read as the first click not registering.

The two consequences are now computed up front and confirmed together in one dialog that names all of them.

## Changes

- Collapsed `pendingDeleteConfirmation` and `pendingGroupAction` into a single `pendingModuleAction` (`label`, `stepCount`, `groups`, `dependents`, `confirm`, `cancel`), rendered by one `ConfirmationModal` instead of two.
- `requestDelete` no longer chains callbacks: it applies the plan immediately when there is neither an affected group nor a dependent, and otherwise raises one confirmation carrying both. `request.plan` already exposed `structureDelete.affectedGroups` and `dependents`, so nothing new is derived.
- The move entry point feeds the same state, so "move" and "delete" stay consistent — the move dialog is unchanged in content but now shares one code path.
- Title and button follow the action (`Delete step?` / `Move step?`) and pluralise on the number of steps; the body enumerates the groups being removed and the steps needing changes.
- Modal visibility is driven by a separate `moduleActionOpen` flag rather than by clearing the action. `ConfirmationModal` renders its children through a 100ms fade-out, so clearing the value blanked the dialog mid-transition (and, on the move path, flipped the title to the delete wording). Both handlers early-return when already closed, keeping confirm one-shot while the buttons remain clickable during the fade.

## Screenshots

Delete of a step that is both a group's only member and referenced downstream — previously two dialogs, now one:

![delete-confirmation](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/step-delete-modal/1785782204-delete-confirmation.png)

Multi-select delete, pluralised:

![multi-select](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/step-delete-modal/1785782383-multi-select.png)

Move path, sharing the same dialog:

![move-confirmation](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/step-delete-modal/1785782207-move-confirmation.png)

## Test plan

Exercised in the flow editor against a local backend:

- [x] Step alone in a group + a downstream dependent → one dialog listing both; a single confirm deletes the step and removes the group
- [x] Dependents only, no group → dependents section only
- [x] Group only, no dependents → group section only
- [x] Multi-select two steps in a group with a downstream dependent → `Delete steps?` / `Delete steps` / "delete the steps?"
- [x] Move a step out of a group it empties → `Move step?`; confirming commits the move
- [x] Cancelling the move dialog clears the pending move (no stuck "Cancel move" state) and leaves the flow unchanged
- [x] Dialog text sampled every frame across the fade-out after confirming: stable, no blank or wrong-verb frame
- [x] Double-clicking confirm during the fade deletes exactly one step
- [x] `npm run check:fast` clean; `flowDeleteUtils.test.ts` passes

No test added: the delete-plan logic is untouched (and already covered by `flowDeleteUtils.test.ts`) — this is a presentation change in a Svelte component.