### PR TITLE
perf: serve the rare schedule options on demand instead of inlining them

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -567,6 +567,40 @@
     - passes dry_run as true
     - leaves only the schedule draft for review
 
+- id: global-test29-schedule-with-retry-and-error-handler
+  prompt: |-
+    The workspace already has a report digest helper.
+    Schedule it every morning at 6am UTC with `dry_run` on, and have it retry twice
+    if it fails. Run it on our `nightly` worker group.
+    Draft only, I'll review before deploying.
+  initial: ai_evals/fixtures/frontend/global/initial/report_digest_script.json
+  runtime:
+    maxTurns: 8
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: schedule
+        pathIncludes:
+          - digest
+        valueIncludes:
+          - f/evals/global/send_report_digest
+          - attempts
+          - nightly
+  toolExpect:
+    requiredToolsUsed:
+      - write_schedule
+      - get_schedule_schema
+    forbiddenToolsUsed:
+      - write_script
+      - write_flow
+      - deploy_workspace_item
+  judgeChecklist:
+    - finds the existing report digest helper rather than creating a new script or flow
+    - creates one schedule draft for that helper running daily around 06:00 UTC
+    - configures a retry policy with two attempts
+    - routes the schedule to the nightly worker tag
+    - leaves the schedule as a draft without deploying
+
 - id: global-test18-human-slack-resource-with-secret
   prompt: |-
     I'm preparing Slack notifications for eval failures.

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -534,6 +534,56 @@ describe('global AI tools', () => {
 		).toBeUndefined()
 	})
 
+	// The same option is legal at the top level, where the bag-only check never saw it.
+	it('catches a stripped schedule option passed outside advanced', async () => {
+		await expect(
+			callGlobalTool('write_schedule', {
+				path: 'f/schedules/toplevel',
+				schedule: '0 0 6 * * *',
+				timezone: 'UTC',
+				script_path: 'f/scripts/run',
+				is_flow: false,
+				args: {},
+				retry: { constant: { attempts: 2, seconds_typo: 30 } }
+			})
+		).rejects.toThrow(/retry\.constant\.seconds_typo/)
+	})
+
+	// A non-object `advanced` spreads to index keys that zod strips, so the options the
+	// model meant to set vanish. Rejecting beats writing a schedule missing all of them.
+	it('rejects a non-object advanced container', async () => {
+		await expect(
+			callGlobalTool('write_schedule', {
+				path: 'f/schedules/strbag',
+				schedule: '0 0 6 * * *',
+				timezone: 'UTC',
+				script_path: 'f/scripts/run',
+				is_flow: false,
+				args: {},
+				advanced: 'retry=2'
+			})
+		).rejects.toThrow(/not recognized/)
+	})
+
+	// `args` is a real object-valued argument, not an advanced option: repeating it must
+	// not be reported as a dropped option just because the named one outranks the bag.
+	it('does not flag a duplicated object argument as dropped', async () => {
+		await callGlobalTool('write_schedule', {
+			path: 'f/schedules/dupargs',
+			schedule: '0 0 6 * * *',
+			timezone: 'UTC',
+			script_path: 'f/scripts/run',
+			is_flow: false,
+			args: { a: 1 },
+			advanced: { args: { b: 2 }, tag: 'nightly' }
+		})
+
+		const draft = getBackendDraft<any>('trigger_schedule', 'f/schedules/dupargs', {
+			workspace: WORKSPACE
+		})
+		expect(draft).toMatchObject({ args: { a: 1 }, tag: 'nightly' })
+	})
+
 	it('rejects a trigger config that does not match the declared kind', async () => {
 		const error = await callGlobalTool('write_trigger', {
 			kind: 'kafka',

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -562,7 +562,24 @@ describe('global AI tools', () => {
 				args: {},
 				advanced: 'retry=2'
 			})
-		).rejects.toThrow(/not recognized/)
+		).rejects.toThrow(/not schedule fields/)
+	})
+
+	// A key that is not a schedule field cannot be explained by the lookup, so the error
+	// must not send the model there for it.
+	it('separates unknown keys from mis-shaped schedule options', async () => {
+		const error = await callGlobalTool('write_schedule', {
+			path: 'f/schedules/mixed',
+			schedule: '0 0 6 * * *',
+			timezone: 'UTC',
+			script_path: 'f/scripts/run',
+			is_flow: false,
+			args: {},
+			advanced: { retry: { constant: { seconds_typo: 1 } }, not_a_field: true }
+		}).catch((err) => (err as Error).message)
+
+		expect(error).toMatch(/retry\.constant\.seconds_typo.*get_schedule_schema/s)
+		expect(error).toMatch(/not schedule fields: not_a_field/)
 	})
 
 	// `args` is a real object-valued argument, not an advanced option: repeating it must

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -455,6 +455,53 @@ describe('global AI tools', () => {
 		})
 	})
 
+	// The rare schedule fields reach the draft through `advanced` instead of the tool
+	// definition, so the merge back into the persisted value is what has to hold.
+	it('folds advanced schedule options into the draft', async () => {
+		const advanced = JSON.parse(await callGlobalTool('get_schedule_schema', {}))
+		expect(Object.keys(advanced.properties)).toEqual(
+			expect.arrayContaining(['retry', 'paused_until', 'no_flow_overlap'])
+		)
+		expect(advanced.properties).not.toHaveProperty('schedule')
+
+		await callGlobalTool('write_schedule', {
+			path: 'f/schedules/adv',
+			schedule: '0 0 9 * * *',
+			timezone: 'UTC',
+			script_path: 'f/scripts/run',
+			is_flow: false,
+			args: {},
+			advanced: { no_flow_overlap: true, tag: 'nightly' }
+		})
+
+		const draft = getBackendDraft<any>('trigger_schedule', 'f/schedules/adv', {
+			workspace: WORKSPACE
+		})
+		expect(draft).toMatchObject({ no_flow_overlap: true, tag: 'nightly' })
+		expect(draft).not.toHaveProperty('advanced')
+	})
+
+	// Every sub-field of `retry` is optional, so a guessed shape validates clean and
+	// strips to `{}`. Saving a schedule with no retry policy and reporting success is
+	// the failure the on-demand schema makes reachable.
+	it('refuses to save a mis-shaped advanced schedule option', async () => {
+		await expect(
+			callGlobalTool('write_schedule', {
+				path: 'f/schedules/badretry',
+				schedule: '0 0 6 * * *',
+				timezone: 'UTC',
+				script_path: 'f/scripts/run',
+				is_flow: false,
+				args: {},
+				advanced: { retry: { attempts: 2, seconds: 30 } }
+			})
+		).rejects.toThrow(/get_schedule_schema/)
+
+		expect(
+			getBackendDraft('trigger_schedule', 'f/schedules/badretry', { workspace: WORKSPACE })
+		).toBeUndefined()
+	})
+
 	it('rejects a trigger config that does not match the declared kind', async () => {
 		const error = await callGlobalTool('write_trigger', {
 			kind: 'kafka',

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -481,6 +481,25 @@ describe('global AI tools', () => {
 		expect(draft).not.toHaveProperty('advanced')
 	})
 
+	// `advanced` is the fallback for fields the definition no longer lists; a duplicate
+	// inside it must not quietly win over the argument the model actually passed.
+	it('lets a real schedule argument win over the same key inside advanced', async () => {
+		await callGlobalTool('write_schedule', {
+			path: 'f/schedules/prec',
+			schedule: '0 0 9 * * *',
+			timezone: 'UTC',
+			script_path: 'f/scripts/run',
+			is_flow: false,
+			args: {},
+			advanced: { timezone: 'Europe/Paris', tag: 'nightly' }
+		})
+
+		const draft = getBackendDraft<any>('trigger_schedule', 'f/schedules/prec', {
+			workspace: WORKSPACE
+		})
+		expect(draft).toMatchObject({ timezone: 'UTC', tag: 'nightly' })
+	})
+
 	// Every sub-field of `retry` is optional, so a guessed shape validates clean and
 	// strips to `{}`. Saving a schedule with no retry policy and reporting success is
 	// the failure the on-demand schema makes reachable.

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -481,8 +481,7 @@ describe('global AI tools', () => {
 		expect(draft).not.toHaveProperty('advanced')
 	})
 
-	// `advanced` is the fallback for fields the definition no longer lists; a duplicate
-	// inside it must not quietly win over the argument the model actually passed.
+	// A duplicate inside `advanced` must not quietly outrank the named argument.
 	it('lets a real schedule argument win over the same key inside advanced', async () => {
 		await callGlobalTool('write_schedule', {
 			path: 'f/schedules/prec',
@@ -515,6 +514,20 @@ describe('global AI tools', () => {
 				advanced: { retry: { attempts: 2, seconds: 30 } }
 			})
 		).rejects.toThrow(/get_schedule_schema/)
+
+		// A misspelled key beside a valid sibling leaves `retry` non-empty, so only a
+		// recursive check catches it. The backend would default the lost delay to zero.
+		await expect(
+			callGlobalTool('write_schedule', {
+				path: 'f/schedules/badretry',
+				schedule: '0 0 6 * * *',
+				timezone: 'UTC',
+				script_path: 'f/scripts/run',
+				is_flow: false,
+				args: {},
+				advanced: { retry: { constant: { attempts: 2, seconds_typo: 30 } } }
+			})
+		).rejects.toThrow(/retry\.constant\.seconds_typo/)
 
 		expect(
 			getBackendDraft('trigger_schedule', 'f/schedules/badretry', { workspace: WORKSPACE })

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -86,6 +86,7 @@ import type {
 import { z } from 'zod'
 import {
 	createToolDef,
+	droppedOptionKeys,
 	createSearchHubScriptsTool,
 	executeFlowStepTestRun,
 	executeTestRun,
@@ -558,6 +559,51 @@ function flowDraftAsEditableInput(flowDraft: FlowDraftValue): {
 }
 
 const writeScheduleSchema = scheduleRequestSchema.extend({ override: draftOverrideField })
+
+// Schedule fields common enough that a lookup round trip would cost more than carrying
+// them. Everything else reaches the same validation through `advanced`, whose shape
+// get_schedule_schema serves on demand: `retry` alone is a quarter of this schema and
+// is asked for far more rarely than a plain cron.
+const COMMON_SCHEDULE_FIELDS = [
+	'path',
+	'schedule',
+	'timezone',
+	'script_path',
+	'is_flow',
+	'args',
+	'enabled',
+	'summary',
+	'description',
+	'on_failure',
+	'on_recovery',
+	'on_success'
+] as const
+
+const writeScheduleToolSchema = scheduleRequestSchema
+	.pick(Object.fromEntries(COMMON_SCHEDULE_FIELDS.map((f) => [f, true])) as any)
+	.extend({
+		advanced: z
+			.record(z.string(), z.any())
+			.optional()
+			.describe(
+				'Less common schedule options: retry, paused_until, tag, labels, no_flow_overlap, dynamic_skip, permissioned_as, cron_version, error-handler tuning (on_failure_times, on_failure_exact, *_extra_args). Call get_schedule_schema for their exact shape.'
+			),
+		override: draftOverrideField
+	})
+
+const advancedScheduleShape = () => {
+	const common = new Set<string>(COMMON_SCHEDULE_FIELDS)
+	const full = z.toJSONSchema(scheduleRequestSchema) as {
+		properties?: Record<string, unknown>
+		required?: string[]
+	}
+	return {
+		type: 'object',
+		properties: Object.fromEntries(
+			Object.entries(full.properties ?? {}).filter(([field]) => !common.has(field))
+		)
+	}
+}
 
 // The tool definition keeps `config` open-ended on purpose. Inlining the eleven
 // per-kind request schemas serializes to ~44k characters of JSON Schema, on its own
@@ -2928,7 +2974,7 @@ export const globalTools: Tool<{}>[] = [
 	},
 	{
 		def: createToolDef(
-			writeScheduleSchema,
+			writeScheduleToolSchema,
 			'write_schedule',
 			'Create or overwrite a draft schedule.',
 			{ strict: false }
@@ -2937,7 +2983,15 @@ export const globalTools: Tool<{}>[] = [
 		streamArguments: true,
 		showFade: true,
 		fn: async (ctx) => {
-			const parsed = writeScheduleSchema.parse(ctx.args)
+			const { advanced, ...rest } = (ctx.args ?? {}) as Record<string, unknown>
+			const supplied = (advanced as Record<string, unknown>) ?? {}
+			const parsed = writeScheduleSchema.parse({ ...rest, ...supplied })
+			const dropped = droppedOptionKeys(supplied, parsed as Record<string, unknown>)
+			if (dropped.length) {
+				throw new Error(
+					`Call get_schedule_schema for the exact shape: these options did not match it and would have been saved empty: ${dropped.join(', ')}.`
+				)
+			}
 			return writeScheduleDraft(parsed, ctx)
 		}
 	},
@@ -2978,6 +3032,14 @@ export const globalTools: Tool<{}>[] = [
 			const { kind } = getTriggerSchemaSchema.parse(ctx.args)
 			return triggerConfigJsonSchema(kind)
 		}
+	},
+	{
+		def: createToolDef(
+			z.object({}),
+			'get_schedule_schema',
+			"Get the shape of write_schedule's `advanced` object: retry, pausing, tags, and error-handler tuning."
+		),
+		fn: async () => JSON.stringify(advancedScheduleShape(), null, 2)
 	},
 	{
 		def: createToolDef(

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2942,14 +2942,16 @@ export const globalTools: Tool<{}>[] = [
 		showFade: true,
 		fn: async (ctx) => {
 			const { advanced, ...rest } = (ctx.args ?? {}) as Record<string, unknown>
-			const supplied = (advanced as Record<string, unknown>) ?? {}
 			// `advanced` carries what the definition does not list, so a named argument
-			// outranks a duplicate of the same key inside the bag.
-			const parsed = writeScheduleSchema.parse({ ...supplied, ...rest })
-			const dropped = droppedOptionKeys(supplied, parsed)
+			// outranks a duplicate of the same key inside the bag. The whole merged object
+			// is checked for stripped keys, not just the bag: an advanced option passed at
+			// the top level instead would otherwise be dropped without a word.
+			const merged = { ...((advanced as Record<string, unknown>) ?? {}), ...rest }
+			const parsed = writeScheduleSchema.parse(merged)
+			const dropped = droppedOptionKeys(merged, parsed)
 			if (dropped.length) {
 				throw new Error(
-					`Call get_schedule_schema for the exact shape: these options did not match it and would have been saved empty: ${dropped.join(', ')}.`
+					`These schedule options were not recognized and would have been dropped: ${dropped.join(', ')}. Call get_schedule_schema for the exact shape of the advanced options.`
 				)
 			}
 			return writeScheduleDraft(parsed, ctx)

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -84,6 +84,7 @@ import type {
 	ChatCompletionUserMessageParam
 } from 'openai/resources/chat/completions.mjs'
 import { z } from 'zod'
+import { advancedScheduleShape, buildScheduleToolSchema } from '../scheduleToolSchema'
 import {
 	createToolDef,
 	droppedOptionKeys,
@@ -560,50 +561,7 @@ function flowDraftAsEditableInput(flowDraft: FlowDraftValue): {
 
 const writeScheduleSchema = scheduleRequestSchema.extend({ override: draftOverrideField })
 
-// Schedule fields common enough that a lookup round trip would cost more than carrying
-// them. Everything else reaches the same validation through `advanced`, whose shape
-// get_schedule_schema serves on demand: `retry` alone is a quarter of this schema and
-// is asked for far more rarely than a plain cron.
-const COMMON_SCHEDULE_FIELDS = [
-	'path',
-	'schedule',
-	'timezone',
-	'script_path',
-	'is_flow',
-	'args',
-	'enabled',
-	'summary',
-	'description',
-	'on_failure',
-	'on_recovery',
-	'on_success'
-] as const
-
-const writeScheduleToolSchema = scheduleRequestSchema
-	.pick(Object.fromEntries(COMMON_SCHEDULE_FIELDS.map((f) => [f, true])) as any)
-	.extend({
-		advanced: z
-			.record(z.string(), z.any())
-			.optional()
-			.describe(
-				'Less common schedule options: retry, paused_until, tag, labels, no_flow_overlap, dynamic_skip, permissioned_as, cron_version, error-handler tuning (on_failure_times, on_failure_exact, *_extra_args). Call get_schedule_schema for their exact shape.'
-			),
-		override: draftOverrideField
-	})
-
-const advancedScheduleShape = () => {
-	const common = new Set<string>(COMMON_SCHEDULE_FIELDS)
-	const full = z.toJSONSchema(scheduleRequestSchema) as {
-		properties?: Record<string, unknown>
-		required?: string[]
-	}
-	return {
-		type: 'object',
-		properties: Object.fromEntries(
-			Object.entries(full.properties ?? {}).filter(([field]) => !common.has(field))
-		)
-	}
-}
+const writeScheduleToolSchema = buildScheduleToolSchema().extend({ override: draftOverrideField })
 
 // The tool definition keeps `config` open-ended on purpose. Inlining the eleven
 // per-kind request schemas serializes to ~44k characters of JSON Schema, on its own
@@ -2985,11 +2943,10 @@ export const globalTools: Tool<{}>[] = [
 		fn: async (ctx) => {
 			const { advanced, ...rest } = (ctx.args ?? {}) as Record<string, unknown>
 			const supplied = (advanced as Record<string, unknown>) ?? {}
-			// `advanced` is a fallback for what the definition no longer lists, so a field
-			// the model also passed as a real argument keeps the argument's value rather
-			// than being silently overwritten by a duplicate inside the bag.
+			// `advanced` carries what the definition does not list, so a named argument
+			// outranks a duplicate of the same key inside the bag.
 			const parsed = writeScheduleSchema.parse({ ...supplied, ...rest })
-			const dropped = droppedOptionKeys(supplied, parsed as Record<string, unknown>)
+			const dropped = droppedOptionKeys(supplied, parsed)
 			if (dropped.length) {
 				throw new Error(
 					`Call get_schedule_schema for the exact shape: these options did not match it and would have been saved empty: ${dropped.join(', ')}.`

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -84,7 +84,11 @@ import type {
 	ChatCompletionUserMessageParam
 } from 'openai/resources/chat/completions.mjs'
 import { z } from 'zod'
-import { advancedScheduleShape, buildScheduleToolSchema } from '../scheduleToolSchema'
+import {
+	advancedScheduleShape,
+	buildScheduleToolSchema,
+	describeDroppedScheduleOptions
+} from '../scheduleToolSchema'
 import {
 	createToolDef,
 	droppedOptionKeys,
@@ -2951,7 +2955,7 @@ export const globalTools: Tool<{}>[] = [
 			const dropped = droppedOptionKeys(merged, parsed)
 			if (dropped.length) {
 				throw new Error(
-					`These schedule options were not recognized and would have been dropped: ${dropped.join(', ')}. Call get_schedule_schema for the exact shape of the advanced options.`
+					describeDroppedScheduleOptions(dropped)
 				)
 			}
 			return writeScheduleDraft(parsed, ctx)

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2985,7 +2985,10 @@ export const globalTools: Tool<{}>[] = [
 		fn: async (ctx) => {
 			const { advanced, ...rest } = (ctx.args ?? {}) as Record<string, unknown>
 			const supplied = (advanced as Record<string, unknown>) ?? {}
-			const parsed = writeScheduleSchema.parse({ ...rest, ...supplied })
+			// `advanced` is a fallback for what the definition no longer lists, so a field
+			// the model also passed as a real argument keeps the argument's value rather
+			// than being silently overwritten by a duplicate inside the bag.
+			const parsed = writeScheduleSchema.parse({ ...supplied, ...rest })
 			const dropped = droppedOptionKeys(supplied, parsed as Record<string, unknown>)
 			if (dropped.length) {
 				throw new Error(

--- a/frontend/src/lib/components/copilot/chat/scheduleToolSchema.ts
+++ b/frontend/src/lib/components/copilot/chat/scheduleToolSchema.ts
@@ -52,3 +52,27 @@ export function buildScheduleToolSchema(opts: ScheduleToolOptions = {}) {
 				)
 		})
 }
+
+/**
+ * Explains keys a strip-mode parse discarded. A mis-shaped real field is recoverable by
+ * fetching its schema; a key that is not a schedule field at all is not, and pointing
+ * the model at the lookup for it would send it somewhere with no answer.
+ */
+export function describeDroppedScheduleOptions(dropped: string[]): string {
+	const fields = new Set(
+		Object.keys(
+			(z.toJSONSchema(scheduleRequestSchema) as { properties?: Record<string, unknown> })
+				.properties ?? {}
+		)
+	)
+	const misshaped = dropped.filter((path) => fields.has(path.split('.')[0]))
+	const unknown = dropped.filter((path) => !fields.has(path.split('.')[0]))
+	return [
+		misshaped.length
+			? `These schedule options do not match their schema and would have been dropped: ${misshaped.join(', ')}. Call get_schedule_schema for their exact shape.`
+			: '',
+		unknown.length ? `These are not schedule fields: ${unknown.join(', ')}.` : ''
+	]
+		.filter(Boolean)
+		.join(' ')
+}

--- a/frontend/src/lib/components/copilot/chat/scheduleToolSchema.ts
+++ b/frontend/src/lib/components/copilot/chat/scheduleToolSchema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+import { scheduleRequestSchema } from './workspaceToolsZod.gen'
+
+// Fields common enough that a lookup round trip would cost more than carrying them.
+// The rest reach the same validation through `advanced`, whose shape get_schedule_schema
+// serves on demand: `retry` alone is a quarter of this schema and is asked for far more
+// rarely than a plain cron.
+const COMMON_SCHEDULE_FIELDS = [
+	'path',
+	'schedule',
+	'timezone',
+	'script_path',
+	'is_flow',
+	'args',
+	'enabled',
+	'summary',
+	'description',
+	'on_failure',
+	'on_recovery',
+	'on_success'
+] as const
+
+/** Fields the caller supplies itself, so the model must neither set nor see them. */
+export type ScheduleToolOptions = { hidden?: readonly string[] }
+
+function commonFields({ hidden = [] }: ScheduleToolOptions): string[] {
+	return COMMON_SCHEDULE_FIELDS.filter((field) => !hidden.includes(field))
+}
+
+/** The `advanced` shape get_schedule_schema serves: everything not already inline. */
+export function advancedScheduleShape(opts: ScheduleToolOptions = {}) {
+	const inline = new Set([...commonFields(opts), ...(opts.hidden ?? [])])
+	const full = z.toJSONSchema(scheduleRequestSchema) as { properties?: Record<string, unknown> }
+	return {
+		type: 'object',
+		properties: Object.fromEntries(
+			Object.entries(full.properties ?? {}).filter(([field]) => !inline.has(field))
+		)
+	}
+}
+
+export function buildScheduleToolSchema(opts: ScheduleToolOptions = {}) {
+	const advancedNames = Object.keys(advancedScheduleShape(opts).properties).join(', ')
+	return scheduleRequestSchema
+		.pick(Object.fromEntries(commonFields(opts).map((f) => [f, true])) as any)
+		.extend({
+			advanced: z
+				.record(z.string(), z.any())
+				.optional()
+				.describe(
+					`Less common schedule options (${advancedNames}). Call get_schedule_schema for their exact shape.`
+				)
+		})
+}

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -149,6 +149,16 @@ describe('createToolDef', () => {
 			expect(served.properties?.is_flow).toBeUndefined()
 			expect(served.properties?.path).toBeUndefined()
 		}
+
+		// Same for the schedule options served on demand. The runnable target still wins
+		// on merge, so this is about not advertising a field the model cannot influence.
+		const getScheduleSchema = createWorkspaceMutationTools().find(
+			(tool) => tool.def.function.name === 'get_schedule_schema'
+		)!
+		const schedule = JSON.parse(await getScheduleSchema.fn({ args: {} } as any))
+		expect(schedule.properties?.script_path).toBeUndefined()
+		expect(schedule.properties?.is_flow).toBeUndefined()
+		expect(schedule.properties).toHaveProperty('retry')
 	})
 })
 

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -429,6 +429,89 @@ describe('processToolCall', () => {
 		expect(requestConfirmation).not.toHaveBeenCalled()
 	})
 
+	// create_schedule duplicates the global `advanced` merge and guard, so it needs its
+	// own coverage: the fold must reach the request body and a mis-shape must stop the
+	// write rather than create a schedule with an inert policy.
+	it('folds advanced schedule options into create_schedule and refuses a mis-shaped one', async () => {
+		const gen = (await import('$lib/gen')) as any
+		const { processToolCall } = await import('./shared')
+		const { createWorkspaceMutationTools } = await import('./workspaceTools')
+		const workspaceMutationTools = createWorkspaceMutationTools()
+
+		gen.ScheduleService.previewSchedule.mockReset()
+		gen.ScheduleService.createSchedule.mockReset()
+		gen.ScheduleService.previewSchedule.mockResolvedValue({})
+		gen.ScheduleService.createSchedule.mockResolvedValue('schedule-created')
+
+		const target = {
+			getWorkspaceMutationTarget: () => ({
+				kind: 'script' as const,
+				path: 'f/scripts/current',
+				deployed: true
+			})
+		}
+		const callbacks = () => ({
+			setToolStatus: vi.fn(),
+			removeToolStatus: vi.fn(),
+			requestConfirmation: vi.fn().mockResolvedValue(true)
+		})
+
+		await processToolCall({
+			tools: workspaceMutationTools,
+			toolCall: {
+				id: 'call_adv',
+				type: 'function',
+				function: {
+					name: 'create_schedule',
+					arguments: JSON.stringify({
+						path: 'f/schedules/adv',
+						schedule: '0 0 12 * * *',
+						timezone: 'UTC',
+						args: null,
+						advanced: { tag: 'nightly', retry: { constant: { attempts: 2, seconds: 30 } } }
+					})
+				}
+			},
+			helpers: target,
+			workspace: 'test-workspace',
+			toolCallbacks: callbacks()
+		})
+
+		expect(gen.ScheduleService.createSchedule).toHaveBeenCalledWith({
+			workspace: 'test-workspace',
+			requestBody: expect.objectContaining({
+				tag: 'nightly',
+				retry: { constant: { attempts: 2, seconds: 30 } }
+			})
+		})
+
+		gen.ScheduleService.createSchedule.mockReset()
+		const badStatus = vi.fn()
+		await processToolCall({
+			tools: workspaceMutationTools,
+			toolCall: {
+				id: 'call_bad',
+				type: 'function',
+				function: {
+					name: 'create_schedule',
+					arguments: JSON.stringify({
+						path: 'f/schedules/bad',
+						schedule: '0 0 12 * * *',
+						timezone: 'UTC',
+						args: null,
+						advanced: { retry: { constant: { attempts: 2, seconds_typo: 30 } } }
+					})
+				}
+			},
+			helpers: target,
+			workspace: 'test-workspace',
+			toolCallbacks: { ...callbacks(), setToolStatus: badStatus }
+		})
+
+		expect(gen.ScheduleService.createSchedule).not.toHaveBeenCalled()
+		expect(JSON.stringify(badStatus.mock.calls)).toContain('get_schedule_schema')
+	})
+
 	it('injects runnable target fields into schedule and trigger requests', async () => {
 		const gen = (await import('$lib/gen')) as any
 		const { processToolCall } = await import('./shared')

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -717,23 +717,25 @@ async function callTool<T>({
 
 type MaybePromise<T> = T | Promise<T>
 
-const isEmptyValue = (value: unknown): boolean =>
-	value === undefined ||
-	(typeof value === 'object' && value !== null && Object.keys(value).length === 0)
-
 /**
- * Names the options a strip-mode parse accepted but emptied. Every sub-field of a
- * schedule's `retry` is optional, so a guessed `{attempts: 2}` validates clean and comes
- * back as `{}` — a schedule written with no retry policy at all, reported as a success.
- * The shapes these options need are served on demand rather than carried in the tool
- * definition, so the model cannot check itself and has to be told.
+ * Key paths present in `supplied` that a strip-mode parse discarded. Sub-fields of a
+ * schedule's `retry` are all optional, so a guessed shape validates clean, loses the
+ * misspelled keys and saves a policy that does nothing. Recursive because dropping one
+ * nested key leaves the parent non-empty.
  */
 export function droppedOptionKeys(
-	supplied: Record<string, unknown>,
-	parsed: Record<string, unknown>
+	supplied: unknown,
+	parsed: unknown,
+	prefix = ''
 ): string[] {
-	return Object.keys(supplied).filter(
-		(key) => !isEmptyValue(supplied[key]) && isEmptyValue(parsed[key])
+	if (supplied === null || typeof supplied !== 'object' || Array.isArray(supplied)) {
+		return parsed === undefined && prefix ? [prefix] : []
+	}
+	if (parsed === null || typeof parsed !== 'object') {
+		return Object.keys(supplied).length && prefix ? [prefix] : []
+	}
+	return Object.entries(supplied).flatMap(([key, value]) =>
+		droppedOptionKeys(value, (parsed as Record<string, unknown>)[key], prefix ? `${prefix}.${key}` : key)
 	)
 }
 

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -717,11 +717,6 @@ async function callTool<T>({
 
 type MaybePromise<T> = T | Promise<T>
 
-const MAX_TOOL_ERROR_LENGTH = 2000
-
-/** ApiError from the generated client carries the server's message in `body`,
- * not `message` — dig it out so tool failures show the real cause. Capped so a
- * verbose error body (e.g. an HTML error page) can't flood the chat context. */
 const isEmptyValue = (value: unknown): boolean =>
 	value === undefined ||
 	(typeof value === 'object' && value !== null && Object.keys(value).length === 0)
@@ -742,6 +737,11 @@ export function droppedOptionKeys(
 	)
 }
 
+const MAX_TOOL_ERROR_LENGTH = 2000
+
+/** ApiError from the generated client carries the server's message in `body`,
+ * not `message` — dig it out so tool failures show the real cause. Capped so a
+ * verbose error body (e.g. an HTML error page) can't flood the chat context. */
 export function formatToolError(error: any): string {
 	const bodyMessage =
 		error?.body?.error?.message ??

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -722,6 +722,26 @@ const MAX_TOOL_ERROR_LENGTH = 2000
 /** ApiError from the generated client carries the server's message in `body`,
  * not `message` — dig it out so tool failures show the real cause. Capped so a
  * verbose error body (e.g. an HTML error page) can't flood the chat context. */
+const isEmptyValue = (value: unknown): boolean =>
+	value === undefined ||
+	(typeof value === 'object' && value !== null && Object.keys(value).length === 0)
+
+/**
+ * Names the options a strip-mode parse accepted but emptied. Every sub-field of a
+ * schedule's `retry` is optional, so a guessed `{attempts: 2}` validates clean and comes
+ * back as `{}` — a schedule written with no retry policy at all, reported as a success.
+ * The shapes these options need are served on demand rather than carried in the tool
+ * definition, so the model cannot check itself and has to be told.
+ */
+export function droppedOptionKeys(
+	supplied: Record<string, unknown>,
+	parsed: Record<string, unknown>
+): string[] {
+	return Object.keys(supplied).filter(
+		(key) => !isEmptyValue(supplied[key]) && isEmptyValue(parsed[key])
+	)
+}
+
 export function formatToolError(error: any): string {
 	const bodyMessage =
 		error?.body?.error?.message ??

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -32,7 +32,11 @@ import {
 	triggerRequestSchemas
 } from './workspaceToolsZod.gen'
 import { z } from 'zod'
-import { advancedScheduleShape, buildScheduleToolSchema } from './scheduleToolSchema'
+import {
+	advancedScheduleShape,
+	buildScheduleToolSchema,
+	describeDroppedScheduleOptions
+} from './scheduleToolSchema'
 import {
 	createToolDef,
 	droppedOptionKeys,
@@ -329,7 +333,7 @@ const createScheduleTool: Tool<any> = {
 			const dropped = droppedOptionKeys(merged, requestBody)
 			if (dropped.length) {
 				throw new Error(
-					`These schedule options were not recognized and would have been dropped: ${dropped.join(', ')}. Call get_schedule_schema for the exact shape of the advanced options.`
+					describeDroppedScheduleOptions(dropped)
 				)
 			}
 

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -32,6 +32,7 @@ import {
 	triggerRequestSchemas
 } from './workspaceToolsZod.gen'
 import { z } from 'zod'
+import { advancedScheduleShape, buildScheduleToolSchema } from './scheduleToolSchema'
 import {
 	createToolDef,
 	droppedOptionKeys,
@@ -70,33 +71,11 @@ type WorkspaceMutationHelpers = {
 	getWorkspaceMutationTarget?: () => WorkspaceMutationTarget
 }
 
-// Only the fields a schedule request usually carries. The rest reach the same
-// validation through `advanced`, whose shape get_schedule_schema serves on demand:
-// inlined, `retry` alone is a quarter of this schema and is asked for far more rarely
-// than a plain cron. script_path/is_flow come from the runnable, not the model.
-const COMMON_SCHEDULE_FIELDS = [
-	'path',
-	'schedule',
-	'timezone',
-	'args',
-	'enabled',
-	'summary',
-	'description',
-	'on_failure',
-	'on_recovery',
-	'on_success'
-] as const
+// script_path/is_flow come from the runnable being edited, so they are hidden from the
+// model in both the tool schema and what get_schedule_schema serves.
+const SCHEDULE_TOOL_OPTIONS = { hidden: ['script_path', 'is_flow'] } as const
 
-const createScheduleToolSchema = scheduleRequestSchema
-	.pick(Object.fromEntries(COMMON_SCHEDULE_FIELDS.map((f) => [f, true])) as any)
-	.extend({
-		advanced: z
-			.record(z.string(), z.any())
-			.optional()
-			.describe(
-				'Less common schedule options: retry, paused_until, tag, labels, no_flow_overlap, dynamic_skip, cron_version, error-handler tuning (on_failure_times, on_failure_exact, *_extra_args). Call get_schedule_schema for their exact shape.'
-			)
-	})
+const createScheduleToolSchema = buildScheduleToolSchema(SCHEDULE_TOOL_OPTIONS)
 
 const getScheduleSchemaTool: Tool<any> = {
 	def: createToolDef(
@@ -104,24 +83,7 @@ const getScheduleSchemaTool: Tool<any> = {
 		'get_schedule_schema',
 		"Get the shape of create_schedule's `advanced` object: retry, pausing, tags, and error-handler tuning."
 	),
-	fn: async () => {
-		const common = new Set<string>(COMMON_SCHEDULE_FIELDS)
-		const full = z.toJSONSchema(scheduleRequestSchema) as {
-			properties?: Record<string, unknown>
-		}
-		return JSON.stringify(
-			{
-				type: 'object',
-				properties: Object.fromEntries(
-					Object.entries(full.properties ?? {}).filter(
-						([field]) => !common.has(field) && field !== 'script_path' && field !== 'is_flow'
-					)
-				)
-			},
-			null,
-			2
-		)
-	}
+	fn: async () => JSON.stringify(advancedScheduleShape(SCHEDULE_TOOL_OPTIONS), null, 2)
 }
 
 function getWorkspaceMutationTarget(helpers: unknown): WorkspaceMutationTarget | undefined {
@@ -168,7 +130,7 @@ function getWorkspaceMutationTargetFields(
 const createScheduleToolDef = createToolDef(
 	createScheduleToolSchema,
 	'create_schedule',
-	'Create a schedule for the current script or flow.',
+	'Create a schedule for the current script or flow. For anything beyond a plain cron (retry, pausing, tags, error-handler tuning), call get_schedule_schema first and pass those through `advanced`.',
 	{ strict: false }
 )
 
@@ -354,16 +316,15 @@ const createScheduleTool: Tool<any> = {
 			const requestBody = parseWithExplicitErrors(
 				scheduleRequestSchema as z.ZodType<NewSchedule>,
 				{
-					// `advanced` is a fallback for what the definition no longer lists, so a real
-					// argument wins over a duplicate inside the bag, and the runnable target wins
-					// over both.
+					// `advanced` carries what the definition does not list: a named argument
+					// outranks a duplicate inside the bag, and the runnable target outranks both.
 					...supplied,
 					...rest,
 					...getWorkspaceMutationTargetFields(helpers)
 				},
 				'Schedule'
 			)
-			const dropped = droppedOptionKeys(supplied, requestBody as Record<string, unknown>)
+			const dropped = droppedOptionKeys(supplied, requestBody)
 			if (dropped.length) {
 				throw new Error(
 					`Call get_schedule_schema for the exact shape: these options did not match it and would have been saved empty: ${dropped.join(', ')}.`

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -312,22 +312,24 @@ const createScheduleTool: Tool<any> = {
 	fn: async ({ args, workspace, helpers, toolCallbacks, toolId }) => {
 		try {
 			const { advanced, ...rest } = (args ?? {}) as Record<string, unknown>
-			const supplied = (advanced as Record<string, unknown>) ?? {}
+			// `advanced` carries what the definition does not list: a named argument outranks
+			// a duplicate inside the bag, and the runnable target outranks both. The whole
+			// merged object is checked for stripped keys, not just the bag: an advanced option
+			// passed at the top level instead would otherwise be dropped without a word.
+			const merged = {
+				...((advanced as Record<string, unknown>) ?? {}),
+				...rest,
+				...getWorkspaceMutationTargetFields(helpers)
+			}
 			const requestBody = parseWithExplicitErrors(
 				scheduleRequestSchema as z.ZodType<NewSchedule>,
-				{
-					// `advanced` carries what the definition does not list: a named argument
-					// outranks a duplicate inside the bag, and the runnable target outranks both.
-					...supplied,
-					...rest,
-					...getWorkspaceMutationTargetFields(helpers)
-				},
+				merged,
 				'Schedule'
 			)
-			const dropped = droppedOptionKeys(supplied, requestBody)
+			const dropped = droppedOptionKeys(merged, requestBody)
 			if (dropped.length) {
 				throw new Error(
-					`Call get_schedule_schema for the exact shape: these options did not match it and would have been saved empty: ${dropped.join(', ')}.`
+					`These schedule options were not recognized and would have been dropped: ${dropped.join(', ')}. Call get_schedule_schema for the exact shape of the advanced options.`
 				)
 			}
 

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -354,8 +354,11 @@ const createScheduleTool: Tool<any> = {
 			const requestBody = parseWithExplicitErrors(
 				scheduleRequestSchema as z.ZodType<NewSchedule>,
 				{
-					...rest,
+					// `advanced` is a fallback for what the definition no longer lists, so a real
+					// argument wins over a duplicate inside the bag, and the runnable target wins
+					// over both.
 					...supplied,
+					...rest,
 					...getWorkspaceMutationTargetFields(helpers)
 				},
 				'Schedule'

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -34,6 +34,7 @@ import {
 import { z } from 'zod'
 import {
 	createToolDef,
+	droppedOptionKeys,
 	formatToolError,
 	type CreatedResourceTriggerKind,
 	type Tool,
@@ -69,7 +70,59 @@ type WorkspaceMutationHelpers = {
 	getWorkspaceMutationTarget?: () => WorkspaceMutationTarget
 }
 
-const createScheduleToolSchema = scheduleRequestSchema.omit({ script_path: true, is_flow: true })
+// Only the fields a schedule request usually carries. The rest reach the same
+// validation through `advanced`, whose shape get_schedule_schema serves on demand:
+// inlined, `retry` alone is a quarter of this schema and is asked for far more rarely
+// than a plain cron. script_path/is_flow come from the runnable, not the model.
+const COMMON_SCHEDULE_FIELDS = [
+	'path',
+	'schedule',
+	'timezone',
+	'args',
+	'enabled',
+	'summary',
+	'description',
+	'on_failure',
+	'on_recovery',
+	'on_success'
+] as const
+
+const createScheduleToolSchema = scheduleRequestSchema
+	.pick(Object.fromEntries(COMMON_SCHEDULE_FIELDS.map((f) => [f, true])) as any)
+	.extend({
+		advanced: z
+			.record(z.string(), z.any())
+			.optional()
+			.describe(
+				'Less common schedule options: retry, paused_until, tag, labels, no_flow_overlap, dynamic_skip, cron_version, error-handler tuning (on_failure_times, on_failure_exact, *_extra_args). Call get_schedule_schema for their exact shape.'
+			)
+	})
+
+const getScheduleSchemaTool: Tool<any> = {
+	def: createToolDef(
+		z.object({}),
+		'get_schedule_schema',
+		"Get the shape of create_schedule's `advanced` object: retry, pausing, tags, and error-handler tuning."
+	),
+	fn: async () => {
+		const common = new Set<string>(COMMON_SCHEDULE_FIELDS)
+		const full = z.toJSONSchema(scheduleRequestSchema) as {
+			properties?: Record<string, unknown>
+		}
+		return JSON.stringify(
+			{
+				type: 'object',
+				properties: Object.fromEntries(
+					Object.entries(full.properties ?? {}).filter(
+						([field]) => !common.has(field) && field !== 'script_path' && field !== 'is_flow'
+					)
+				)
+			},
+			null,
+			2
+		)
+	}
+}
 
 function getWorkspaceMutationTarget(helpers: unknown): WorkspaceMutationTarget | undefined {
 	return (helpers as WorkspaceMutationHelpers | undefined)?.getWorkspaceMutationTarget?.()
@@ -296,14 +349,23 @@ const createScheduleTool: Tool<any> = {
 	validateBeforeConfirmation: ({ helpers }) => validateWorkspaceMutationTarget(helpers),
 	fn: async ({ args, workspace, helpers, toolCallbacks, toolId }) => {
 		try {
+			const { advanced, ...rest } = (args ?? {}) as Record<string, unknown>
+			const supplied = (advanced as Record<string, unknown>) ?? {}
 			const requestBody = parseWithExplicitErrors(
 				scheduleRequestSchema as z.ZodType<NewSchedule>,
 				{
-					...args,
+					...rest,
+					...supplied,
 					...getWorkspaceMutationTargetFields(helpers)
 				},
 				'Schedule'
 			)
+			const dropped = droppedOptionKeys(supplied, requestBody as Record<string, unknown>)
+			if (dropped.length) {
+				throw new Error(
+					`Call get_schedule_schema for the exact shape: these options did not match it and would have been saved empty: ${dropped.join(', ')}.`
+				)
+			}
 
 			toolCallbacks.setToolStatus(toolId, {
 				content: `Validating schedule "${requestBody.path}"...`
@@ -472,7 +534,12 @@ const createTriggerTool: Tool<any> = {
 	}
 }
 
-const workspaceMutationTools = [createScheduleTool, createTriggerTool, getTriggerSchemaTool]
+const workspaceMutationTools = [
+	createScheduleTool,
+	createTriggerTool,
+	getTriggerSchemaTool,
+	getScheduleSchemaTool
+]
 
 export function createWorkspaceMutationTools<T>(): Tool<T>[] {
 	return workspaceMutationTools as Tool<T>[]


### PR DESCRIPTION
## Summary

Follow-up to #10481, which removed the inlined per-kind trigger schemas. The same pathology remained in schedules: `write_schedule` (global mode) inlined the full 6,376-character schedule request schema and `create_schedule` (script and flow modes) inlined 5,883, on every request, whether or not a schedule ever came up. `retry` alone was 1,489 characters, 24% of the tool.

Common fields stay inline. The rest reach the same validation through an `advanced` object whose shape a new `get_schedule_schema` tool serves on demand.

`write_schedule`: **6,376 → 2,418 characters**. Global tool payload: **55,706 → 52,030**.

## Changes

- `write_schedule` and `create_schedule` carry only the fields a schedule request usually has (path, schedule, timezone, args, enabled, summary, description, on_failure/on_recovery/on_success, plus script_path/is_flow in global mode). Everything else goes through `advanced`.
- New `get_schedule_schema` in both tool sets, serving the non-common fields. The workspace-mode variant additionally filters `script_path` / `is_flow`, which come from the runnable rather than the model.
- `droppedOptionKeys` in `shared.ts` guards the merge. Every sub-field of `retry` is optional, so a guessed `{attempts: 2, seconds: 30}` validates clean and strips to `{}`. Without the guard that writes a schedule with no retry policy and reports success, and the shape is no longer in the tool definition for the model to check itself against. Now it fails with a message naming `get_schedule_schema`.
- New eval case `global-test29-schedule-with-retry-and-error-handler` pinning that the model performs the lookup and produces a real retry policy and worker tag.

## `open_page` deliberately untouched

It is the other large tool, but it is navigation rather than a domain: almost any conversation can end in "show me the failed runs". A lookup round trip would tax the most common action. It also already prunes its fields per workspace and permission through `OPEN_PAGE_FIELD_PAGES` / `allowedOpenPages`.

## `ai_evals` A/B (global, sonnet)

| case | `finalContextTokens` base → head | verdict |
|---|---|---|
| `global-test17` (plain schedule) | 21,418 → **20,258** (-5.4%) | 3/3 pass both sides |
| `global-test29` (advanced schedule, new) | 21,531 → 22,436 (+905) | 3/3 pass, judge 88-90, lookup 3/3 |

The honest trade: ~900 tokens saved on every iteration of every conversation, ~900 paid once in the rarer conversation that needs advanced schedule options. Break-even at one iteration, so positive, but a thinner win than the trigger change.

A judge dip on `global-test17` initially looked like a regression. It is not: every attempt on both sides satisfied the full checklist, and the numeric wobble tracks `u//` paths. **No case in `global.yaml` seeds a username**, so `prepareGlobalSystemMessage` falls back to an empty one and the path-convention block reads `u//<name>`. `globalEvalRunner.ts` has a `GlobalUserFixture` for exactly this and nothing uses it. That is pre-existing noise across all global evals and is not addressed here, since fixing it moves every case's baseline.

## Screenshots

No visible UI effect: tool schemas and request construction only.

## Test plan

- [x] `npm run check`: 0 errors
- [x] `chat/global/core.test.ts` 181 passed (2 new: `advanced` folds into the draft; a mis-shaped option is refused and no draft is written)
- [x] `chat/shared.test.ts` 51 passed (target-field assertion extended to the served schedule schema)
- [x] `global-test29` 3/3 on head, `get_schedule_schema` called every time
- [ ] In a script or flow chat, ask for a schedule with a retry policy on a deployed runnable and confirm the Retries tab shows the attempts requested; no automated test covers the `create_schedule` merge end to end
- [ ] Run `global-test29` against a second model to confirm the lookup is not Sonnet-specific

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve rare schedule options on demand via a new `get_schedule_schema` tool, trimming the inlined schedule schema while keeping common fields inline. This cuts context size each turn (`write_schedule` 6,376 → 2,418 chars; global payload 55,706 → 52,030) with a one-time ~+900 token lookup when advanced options are used.

- **New Features**
  - Added `get_schedule_schema` (global and workspace) to return the JSON schema for advanced options (e.g., `retry`, `paused_until`, `tag`); the workspace version omits `script_path`/`is_flow`.
  - `write_schedule` and `create_schedule` accept common fields directly plus an `advanced` object; the workspace version derives the runnable target.
  - Shared builder (`buildScheduleToolSchema` / `advancedScheduleShape`) generates the tool’s common-field schema and the on-demand advanced shape, keeping definitions in sync; new eval `global-test29-schedule-with-retry-and-error-handler`.

- **Bug Fixes**
  - Real schedule arguments now win over duplicates inside `advanced` for both `write_schedule` and `create_schedule`.
  - Dropped-option detection checks the entire request, rejecting mis-shaped or misplaced advanced options (nested typos, advanced fields passed at the top level, or a non-object `advanced`) with guidance to call `get_schedule_schema`.
  - Unknown keys are now called out as “not schedule fields” and no longer point to the schema lookup.

<sup>Written for commit 939c61cb047e2512bab880c122aa2abe016ac8b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

