### PR TITLE
fix: base a new fork on the dev workspace when forking from one

### DIFF
--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -12,6 +12,7 @@
 	import {
 		findWorkspaceDescendants,
 		findCanonicalDevWorkspace,
+		findDefaultForkBase,
 		findWorkspaceRoot,
 		buildWorkspaceHierarchy
 	} from '$lib/utils/workspaceHierarchy'
@@ -107,6 +108,9 @@
 	const devOfRoot = $derived(
 		root ? findCanonicalDevWorkspace(root.id, forkableWorkspaces) : undefined
 	)
+	// Base a new fork gets by default: the dev workspace when the selection sits in its subtree, the
+	// family root otherwise.
+	const defaultForkBase = $derived(findDefaultForkBase(effectiveId, forkableWorkspaces))
 	const createForkLabel = 'Create new fork…'
 	// Candidate bases ("targets") for a new fork: the root plus every fork/dev in the family, so a fork
 	// can itself be the base — i.e. a fork of a fork. Root first, matching the list order below.
@@ -205,8 +209,8 @@
 	// Bare fork id, without the wm-fork- prefix. Forks have no separate display
 	// name — the id is the name (it also becomes the git branch).
 	let newForkId = $state('')
-	// The base ("target") a new fork will branch from. Defaults to the root; the user can pick any fork
-	// in the family (via the inline target selector) to create a fork of a fork.
+	// The base ("target") a new fork will branch from. Defaults to `defaultForkBase`; the user can pick
+	// any fork in the family (via the inline target selector) to create a fork of a fork.
 	let createForkBaseId = $state<string | undefined>(undefined)
 
 	// Manual keyboard navigation, modelled after SelectDropdown. melt's
@@ -266,8 +270,8 @@
 	}
 
 	function enterCreateMode(initialId?: string, baseId?: string) {
-		// Default the target to the root; the user can switch to any fork in the family (fork of a fork).
-		createForkBaseId = baseId ?? root?.id
+		// The user can switch to any fork in the family (fork of a fork).
+		createForkBaseId = baseId ?? defaultForkBase?.id
 		creatingFork = true
 		newForkId = initialId ?? defaultForkId()
 		// Focus + select is handled by the input's own autofocus (it mounts with
@@ -338,8 +342,8 @@
 		const wasOpen = lastDropdownOpen
 		lastDropdownOpen = dropdownOpen
 		if (dropdownOpen && !wasOpen && pendingFork && !creatingFork && showCreateFork) {
-			// Preserve the base the fork was staged from; without this the re-entry defaults to the root
-			// and silently re-parents a fork that was staged off another fork.
+			// Preserve the base the fork was staged from; without this the re-entry falls back to the
+			// default base and silently re-parents a fork that was staged off another workspace.
 			void enterCreateMode(
 				pendingFork.id.startsWith(WM_FORK_PREFIX)
 					? pendingFork.id.slice(WM_FORK_PREFIX.length)

--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -479,8 +479,8 @@
 			{#if showCreateFork}
 				<div class="my-1 border-t border-border-light shrink-0"></div>
 				{#if creatingFork}
-					<!-- Small inline form with labels: fork id + base ("target") workspace. The base
-							     defaults to the root; picking a fork there creates a fork of a fork. -->
+					<!-- Small inline form with labels: fork id + base ("target") workspace. Picking a
+							     fork as the base creates a fork of a fork. -->
 					<div class="flex flex-col gap-2 px-2.5 py-2">
 						<div class="flex flex-col gap-0.5">
 							<span class="text-2xs font-normal text-hint">Fork ID</span>

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -24,7 +24,8 @@
 	import {
 		workspaceIsFork,
 		findWorkspaceRoot,
-		findWorkspaceDescendants
+		findWorkspaceDescendants,
+		findDefaultForkBase
 	} from '$lib/utils/workspaceHierarchy'
 	import { useForkableWorkspaces } from '$lib/utils/useForkableWorkspaces.svelte'
 	import {
@@ -115,7 +116,9 @@
 			subtitle: w.is_dev_workspace ? 'dev workspace' : w.id === familyRoot?.id ? undefined : 'fork'
 		}))
 	)
-	let defaultBaseWorkspaceId = $derived(familyRoot?.id)
+	let defaultBaseWorkspaceId = $derived(
+		findDefaultForkBase($workspaceStore, forkableWorkspaces)?.id
+	)
 	// Seed the base once the family is known; keep an explicit user choice as long as it stays valid.
 	$effect(() => {
 		if (!isFork) return
@@ -896,8 +899,8 @@
 						{#if createAsDevWorkspace}
 							A dev workspace is always based on the root workspace.
 						{:else}
-							Workspace to fork from. Defaults to the root; pick an existing fork to create a fork
-							of a fork (the new branch is based on the selected workspace's branch).
+							Workspace to fork from: the new branch is based on the selected workspace's branch.
+							Pick an existing fork to create a fork of a fork.
 						{/if}
 					</span>
 					<Select

--- a/frontend/src/lib/utils/useForkableWorkspaces.svelte.ts
+++ b/frontend/src/lib/utils/useForkableWorkspaces.svelte.ts
@@ -42,6 +42,10 @@ export function useForkableWorkspaces(args: {
 					username: '',
 					color: w.color ?? undefined,
 					parent_workspace_id: w.parent_workspace_id,
+					// Dev-ness travels with the entry: the fork-base default and the "dev" badge both read
+					// it off the list, and a synthesized entry missing it reads as an ordinary fork.
+					is_dev_workspace: w.is_dev_workspace,
+					dev_workspace_label: w.dev_workspace_label,
 					disabled: false
 				}
 			]

--- a/frontend/src/lib/utils/workspaceHierarchy.test.ts
+++ b/frontend/src/lib/utils/workspaceHierarchy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { findDefaultForkBase } from './workspaceHierarchy'
+import type { UserWorkspace } from '../stores'
+
+function ws(id: string, parent?: string, extra: Partial<UserWorkspace> = {}): UserWorkspace {
+	return { id, name: id, username: 'u', parent_workspace_id: parent, disabled: false, ...extra }
+}
+
+const root = ws('prod')
+const dev = ws('devws', 'prod', { is_dev_workspace: true })
+const forkOfDev = ws('wm-fork-a', 'devws')
+const forkOfRoot = ws('wm-fork-b', 'prod')
+const family = [root, dev, forkOfDev, forkOfRoot]
+
+describe('findDefaultForkBase', () => {
+	it('bases a fork on the dev workspace from inside its subtree', () => {
+		expect(findDefaultForkBase('devws', family)?.id).toBe('devws')
+		expect(findDefaultForkBase('wm-fork-a', family)?.id).toBe('devws')
+	})
+
+	it('bases a fork on the root outside the dev subtree', () => {
+		expect(findDefaultForkBase('prod', family)?.id).toBe('prod')
+		expect(findDefaultForkBase('wm-fork-b', family)?.id).toBe('prod')
+	})
+
+	it('skips a dev workspace the user is disabled in', () => {
+		const disabledDev = [root, { ...dev, disabled: true }, forkOfDev]
+		expect(findDefaultForkBase('wm-fork-a', disabledDev)?.id).toBe('prod')
+	})
+})

--- a/frontend/src/lib/utils/workspaceHierarchy.ts
+++ b/frontend/src/lib/utils/workspaceHierarchy.ts
@@ -169,6 +169,31 @@ export function findCanonicalDevWorkspace(
 }
 
 /**
+ * The workspace a new fork should branch from by default. Inside a dev workspace's subtree the base is
+ * that dev workspace, not the family root: the dev workspace carries the changes being worked on, and
+ * a prod locked against forking (`lock_prod_forking`) rejects a root-based fork outright. Anywhere
+ * else it is the family root, so an ad-hoc fork branches from prod rather than from whichever
+ * throwaway fork happens to be open. A dev workspace the user is disabled in is skipped — forking from
+ * it would fail — and the walk continues upwards.
+ */
+export function findDefaultForkBase(
+	currentWorkspaceId: string | undefined,
+	allWorkspaces: UserWorkspace[]
+): UserWorkspace | undefined {
+	let current = allWorkspaces.find((w) => w.id === currentWorkspaceId)
+	while (current) {
+		if (current.is_dev_workspace && !current.disabled) return current
+		if (!current.parent_workspace_id) break
+		const parent: UserWorkspace | undefined = allWorkspaces.find(
+			(w) => w.id === current!.parent_workspace_id
+		)
+		if (!parent) break
+		current = parent
+	}
+	return findWorkspaceRoot(currentWorkspaceId, allWorkspaces)
+}
+
+/**
  * Helper function to find all descendants of a workspace
  */
 export function findWorkspaceDescendants(


### PR DESCRIPTION
## Summary

Creating a fork from inside a dev workspace based the new fork on the **family root**, not on the dev workspace the user was actually in. That silently drops everything the dev workspace holds, and where the prod root is locked with `lock_prod_forking` the backend rejects the create outright — the create-fork affordance is deliberately kept open on a locked prod *because* a dev exists to fork from, but the base still preselected the locked root.

The base now defaults to the dev workspace whenever the current workspace is inside that dev workspace's subtree, and to the family root everywhere else (so an ad-hoc fork still branches from prod rather than from whichever throwaway fork happens to be open). The base picker is unchanged — only the preselected value moves.

## Changes

- New `findDefaultForkBase(currentWorkspaceId, allWorkspaces)` in `frontend/src/lib/utils/workspaceHierarchy.ts`: walks up from the current workspace and returns the nearest dev workspace at-or-above it, skipping any the user is disabled in (forking from one would fail); falls back to the family root.
- `CreateWorkspaceInner.svelte` (global fork modal / `/user/fork_workspace`): `defaultBaseWorkspaceId` uses the helper instead of `familyRoot?.id`. The "Base workspace" caption claimed "Defaults to the root", which is no longer unconditionally true — reworded to describe what the field does.
- `WorkspaceFamilyPicker.svelte` (sessions workspace bar / sidebar scope picker): the inline create-fork target seeds from the same helper. The pending-fork re-entry path still passes its staged base explicitly, so a fork staged off a non-default base is not silently re-parented.
- `useForkableWorkspaces.svelte.ts`: the entry synthesized for a superadmin-visited, non-member workspace dropped `is_dev_workspace` / `dev_workspace_label`, so such a workspace read as an ordinary fork — the new default (and the picker's "dev" badge) would have silently missed it. Both fields now travel with the entry.

## Screenshots

Local instance with `prod` (root) → `devws` (dev workspace) → `wm-fork-scratch` (fork of the dev workspace).

From the dev workspace — base preselects **Dev** (was: Prod):

![fork-base-from-dev](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-base-defaults-to-dev-workspace/1785796987-fork-base-from-dev.png)

From a fork *of* the dev workspace — still **Dev**:

![fork-base-from-fork-of-dev](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-base-defaults-to-dev-workspace/1785796988-fork-base-from-fork-of-dev.png)

From the root — unchanged, **Prod (root)**:

![fork-base-from-root](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-base-defaults-to-dev-workspace/1785796989-fork-base-from-root.png)

## Test plan

- [x] `frontend/src/lib/utils/workspaceHierarchy.test.ts` — dev subtree (self and descendant) resolves to the dev workspace, outside the subtree (root and a fork of the root) resolves to the root, a dev the user is disabled in is skipped. 3/3 pass.
- [x] `npm run check:fast` clean.
- [x] Global fork modal exercised in a browser against a local instance from all three positions (screenshots above).
- [ ] **Not verified:** the `WorkspaceFamilyPicker` inline create-fork row. It was a CE build, and the client-side CE cap (`ceWorkspaceCapReached`, 2 non-admin workspaces) hides that row once `prod` + `devws` exist, so only the global modal could be driven. Both surfaces read the same helper for their default.

## Known gap (pre-existing, not addressed)

Standing on a fork-locked prod that has a dev workspace, the base still preselects the locked root and the backend rejects the create. `findDefaultForkBase` is a pure hierarchy walk with no access to protection-rule state, and steering the root's own default into the dev would change behavior for admins who can legitimately fork prod. Left as-is deliberately — it predates this change and needs the rule state at the call site to fix properly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fork creation so that when you fork from inside a dev workspace (or its descendants), the default base is that dev workspace instead of the family root. This prevents dropping dev changes and avoids failures when prod is fork-locked; only the preselected base changes.

- **Bug Fixes**
  - Added `findDefaultForkBase(...)` to pick the nearest enabled dev workspace, falling back to the family root.
  - Used it to seed the default base in the global fork modal and the sidebar’s inline create; preserves a staged base on re-entry.
  - Carried `is_dev_workspace` and `dev_workspace_label` on superadmin-synthesized entries in `useForkableWorkspaces` so defaults and badges remain accurate.
  - Added tests for dev-subtree, outside-subtree, and disabled-dev cases.

<sup>Written for commit e2a241481a18afe9660aab66356e7b5b41620f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

