### PR TITLE
fix: refresh the dev-workspace pairing after attach and detach

### DIFF
--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -1398,7 +1398,10 @@
 									variant="accent"
 									unifiedSize="xs"
 									disabled={scanning}
-									startIcon={{ icon: scanning ? Loader2 : DiffIcon }}
+									startIcon={{
+										icon: scanning ? Loader2 : DiffIcon,
+										classes: scanning ? 'animate-spin' : undefined
+									}}
 									onClick={() => onScan?.()}
 								>
 									{scanning ? 'Computing diff…' : 'Compute diff'}

--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { workspaceStore, userWorkspaces, usersWorkspaceStore } from '$lib/stores'
-	import { WorkspaceService } from '$lib/gen'
+	import { WorkspaceService, type ProtectionRuleset } from '$lib/gen'
 	import { Badge, Button } from '$lib/components/common'
 	import Select from '$lib/components/select/Select.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
@@ -12,7 +12,7 @@
 	import { devBadgeText, devLabelKey, devLabelNoun } from '$lib/utils/devWorkspaceLabel'
 	import {
 		loadProtectionRules,
-		fetchProtectionRulesForWorkspace,
+		isRuleActiveInRulesets,
 		isRuleUnconditionallyActiveInRulesets
 	} from '$lib/workspaceProtectionRules.svelte'
 	import { GitFork, ExternalLink, Check, Minus } from 'lucide-svelte'
@@ -67,19 +67,27 @@
 		() => (!parentId ? $workspaceStore : undefined),
 		async (ws, _prev, { signal }) => {
 			if (!ws) return undefined
-			const rules = await fetchProtectionRulesForWorkspace(ws)
+			// `fetchProtectionRulesForWorkspace` fails open with an empty list, which the toggles below
+			// want but the status panel must not read as "nothing is enforced" — so keep the failure.
+			let rules: ProtectionRuleset[] | undefined
+			try {
+				rules = await WorkspaceService.listProtectionRules({ workspace: ws })
+			} catch (e) {
+				console.error(`Failed to fetch protection rules for workspace ${ws}:`, e)
+			}
 			// The generated client can't take an abort signal, so drop a superseded response here: a late
 			// result for a previously selected workspace must not overwrite the current one's rules.
 			if (signal.aborted) throw new DOMException('superseded', 'AbortError')
-			return { ws, rules }
+			return { ws, rules: rules ?? [], failed: rules === undefined }
 		}
 	)
 	// Only trust a result that belongs to the current workspace (guards the in-flight window and any
 	// out-of-order response); undefined means "not known yet" and is treated as locked below.
-	let rootRules = $derived.by(() => {
+	let rootResult = $derived.by(() => {
 		const current = rootProtectionRules.current
-		return current && current.ws === $workspaceStore ? current.rules : undefined
+		return current && current.ws === $workspaceStore ? current : undefined
 	})
+	let rootRules = $derived(rootResult?.rules)
 	// Only a rule with no bypass users/groups matches the empty-bypass reserved lock we would create; a
 	// bypassable rule stays editable, otherwise forcing the lock on would revoke the bypassed users'
 	// direct-deploy / forking access.
@@ -100,6 +108,19 @@
 	// toggle's raw state, keeping the request consistent with what the locked toggle shows.
 	let effectiveLockProdDeploy = $derived(deployLocked || lockProdDeploy)
 	let effectiveLockProdForking = $derived(forkingLocked || lockProdForking)
+
+	// What the paired view reports. Unlike the toggles above, this asks whether the rule is enforced at
+	// all: a ruleset with bypass users still blocks everyone outside that list, so it is in force here
+	// even though the attach form leaves its toggle editable.
+	let enforcesDeployBlock = $derived(
+		isRuleActiveInRulesets(rootRules ?? [], 'DisableDirectDeployment')
+	)
+	let enforcesForkingBlock = $derived(
+		isRuleActiveInRulesets(rootRules ?? [], 'DisableWorkspaceForking')
+	)
+	// A failed read is not "nothing is enforced": report it as unknown rather than claiming allowed.
+	let enforcementReadFailed = $derived(rootResult?.failed ?? false)
+	let enforcementUnknown = $derived(rulesUnknown || enforcementReadFailed)
 
 	// A standalone root workspace, or an existing fork of this prod (same family), can be attached.
 	// A fork parented to a different workspace can't (the backend rejects a parent that isn't this
@@ -211,29 +232,35 @@
 		<div class="flex flex-col gap-1 rounded-md border bg-surface-secondary p-3">
 			<span class="text-xs font-semibold text-emphasis">Protections in force on this workspace</span
 			>
-			{#if rulesUnknown}
-				<span class="text-2xs text-secondary">Checking protection rules…</span>
+			{#if enforcementUnknown}
+				<span class="text-2xs text-secondary">
+					{enforcementReadFailed
+						? 'Could not read this workspace’s protection rules'
+						: 'Checking protection rules…'}
+				</span>
 			{:else}
 				<span class="text-2xs text-secondary flex items-center gap-1.5">
-					{#if alreadyBlocksDeploy}<Check size={12} class="text-green-600" />{:else}<Minus
+					{#if enforcesDeployBlock}<Check size={12} class="text-green-600" />{:else}<Minus
 							size={12}
 						/>{/if}
-					Direct edits {alreadyBlocksDeploy ? 'are blocked' : 'are allowed'}
+					Direct edits {enforcesDeployBlock ? 'are blocked' : 'are allowed'}
 				</span>
 				<span class="text-2xs text-secondary flex items-center gap-1.5">
-					{#if alreadyBlocksForking}<Check size={12} class="text-green-600" />{:else}<Minus
+					{#if enforcesForkingBlock}<Check size={12} class="text-green-600" />{:else}<Minus
 							size={12}
 						/>{/if}
-					Forking {alreadyBlocksForking ? 'is blocked' : 'is allowed'}
+					Forking {enforcesForkingBlock ? 'is blocked' : 'is allowed'}
 				</span>
 			{/if}
-			<button
-				type="button"
-				class="text-2xs text-secondary hover:text-primary hover:underline text-left w-fit"
-				onclick={() => goto(`${base}/workspace_settings?tab=rulesets`)}
-			>
-				Manage in Rulesets
-			</button>
+			<div>
+				<Button
+					variant="subtle"
+					unifiedSize="2xs"
+					onclick={() => goto(`${base}/workspace_settings?tab=rulesets`)}
+				>
+					Manage in Rulesets
+				</Button>
+			</div>
 		</div>
 		<div class="flex gap-2">
 			{#if pairedDev.isMember}

--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -15,7 +15,7 @@
 		fetchProtectionRulesForWorkspace,
 		isRuleUnconditionallyActiveInRulesets
 	} from '$lib/workspaceProtectionRules.svelte'
-	import { GitFork, ExternalLink } from 'lucide-svelte'
+	import { GitFork, ExternalLink, Check, Minus } from 'lucide-svelte'
 	import { resource } from 'runed'
 
 	let currentWs = $derived($userWorkspaces.find((w) => w.id === $workspaceStore))
@@ -60,10 +60,11 @@
 
 	// If this workspace already blocks direct deploy / forking through an existing protection rule, keep
 	// the matching lock toggle on but locked: attaching only manages its own reserved dev-workspace rule,
-	// so turning it "off" here couldn't lift a separately-defined block. Fetched only while the attach form
-	// is on screen; a failed fetch falls back to the editable default-on toggle (real rules still enforce).
+	// so turning it "off" here couldn't lift a separately-defined block. A failed fetch falls back to the
+	// editable default-on toggle (real rules still enforce). Once paired, the same rules report which
+	// locks are actually in force.
 	const rootProtectionRules = resource(
-		() => (!parentId && !pairedDev ? $workspaceStore : undefined),
+		() => (!parentId ? $workspaceStore : undefined),
 		async (ws, _prev, { signal }) => {
 			if (!ws) return undefined
 			const rules = await fetchProtectionRulesForWorkspace(ws)
@@ -122,10 +123,16 @@
 
 	async function refresh() {
 		usersWorkspaceStore.set(await WorkspaceService.listUserWorkspaces())
+		// Both lookups have to be refetched explicitly: neither resource's source value changes when
+		// this workspace gains or loses its dev workspace, so without this the caller who is not a
+		// member of the dev workspace (the one that reads the pairing from the server rather than
+		// from the workspace list) keeps seeing the pre-attach/detach state until the tab remounts.
+		devWorkspaceResource.refetch()
 		// Attach/detach changes this (root) workspace's protection rules; reload them so the
 		// direct-deploy / forking lock UI reflects the change without a workspace switch or reload.
 		if ($workspaceStore) {
 			await loadProtectionRules($workspaceStore)
+			rootProtectionRules.refetch()
 		}
 	}
 
@@ -199,6 +206,35 @@
 			This workspace's {devLabelNoun(pairedDev.label)} is <b>{pairedDev.name}</b> ({pairedDev.id}).
 			Edits to this workspace are redirected there.
 		</p>
+		<!-- The locks are protection rules, so being paired does not imply them: a pairing that came
+		     from the deploy_to migration rather than from an attach carries neither. -->
+		<div class="flex flex-col gap-1 rounded-md border bg-surface-secondary p-3">
+			<span class="text-xs font-semibold text-emphasis">Protections in force on this workspace</span
+			>
+			{#if rulesUnknown}
+				<span class="text-2xs text-secondary">Checking protection rules…</span>
+			{:else}
+				<span class="text-2xs text-secondary flex items-center gap-1.5">
+					{#if alreadyBlocksDeploy}<Check size={12} class="text-green-600" />{:else}<Minus
+							size={12}
+						/>{/if}
+					Direct edits {alreadyBlocksDeploy ? 'are blocked' : 'are allowed'}
+				</span>
+				<span class="text-2xs text-secondary flex items-center gap-1.5">
+					{#if alreadyBlocksForking}<Check size={12} class="text-green-600" />{:else}<Minus
+							size={12}
+						/>{/if}
+					Forking {alreadyBlocksForking ? 'is blocked' : 'is allowed'}
+				</span>
+			{/if}
+			<button
+				type="button"
+				class="text-2xs text-secondary hover:text-primary hover:underline text-left w-fit"
+				onclick={() => goto(`${base}/workspace_settings?tab=rulesets`)}
+			>
+				Manage in Rulesets
+			</button>
+		</div>
 		<div class="flex gap-2">
 			{#if pairedDev.isMember}
 				<Button
@@ -242,44 +278,53 @@
 				Change to {attachLabel === 'staging' ? 'dev' : 'staging'}
 			</button>
 		</div>
-		{#if deployLocked}
+		<div class="flex flex-col gap-2 rounded-md border bg-surface-secondary p-3">
 			<div class="flex flex-col gap-0.5">
+				<span class="text-xs font-semibold text-emphasis">Protect this workspace on attach</span>
+				<span class="text-2xs text-secondary">
+					Nothing is enforced until you attach: these add protection rules to this workspace so
+					changes are made in the dev workspace and promoted here.
+				</span>
+			</div>
+			{#if deployLocked}
+				<div class="flex flex-col gap-0.5">
+					<Toggle
+						checked
+						disabled
+						options={{
+							right: 'Block direct edits in this workspace (deploy via the dev workspace)'
+						}}
+					/>
+					{#if alreadyBlocksDeploy}
+						<span class="text-2xs text-secondary ml-11"
+							>Already enforced by an existing protection rule</span
+						>
+					{/if}
+				</div>
+			{:else}
 				<Toggle
-					checked
-					disabled
+					bind:checked={lockProdDeploy}
 					options={{
 						right: 'Block direct edits in this workspace (deploy via the dev workspace)'
 					}}
 				/>
-				{#if alreadyBlocksDeploy}
-					<span class="text-2xs text-secondary ml-11"
-						>Already enforced by an existing protection rule</span
-					>
-				{/if}
-			</div>
-		{:else}
-			<Toggle
-				bind:checked={lockProdDeploy}
-				options={{
-					right: 'Block direct edits in this workspace (deploy via the dev workspace)'
-				}}
-			/>
-		{/if}
-		{#if forkingLocked}
-			<div class="flex flex-col gap-0.5">
-				<Toggle checked disabled options={{ right: 'Prevent forking this workspace' }} />
-				{#if alreadyBlocksForking}
-					<span class="text-2xs text-secondary ml-11"
-						>Already enforced by an existing protection rule</span
-					>
-				{/if}
-			</div>
-		{:else}
-			<Toggle
-				bind:checked={lockProdForking}
-				options={{ right: 'Prevent forking this workspace' }}
-			/>
-		{/if}
+			{/if}
+			{#if forkingLocked}
+				<div class="flex flex-col gap-0.5">
+					<Toggle checked disabled options={{ right: 'Prevent forking this workspace' }} />
+					{#if alreadyBlocksForking}
+						<span class="text-2xs text-secondary ml-11"
+							>Already enforced by an existing protection rule</span
+						>
+					{/if}
+				</div>
+			{:else}
+				<Toggle
+					bind:checked={lockProdForking}
+					options={{ right: 'Prevent forking this workspace' }}
+				/>
+			{/if}
+		</div>
 		<div class="flex gap-2">
 			<Button variant="accent" disabled={busy || !selectedDevId} onclick={attach}>
 				Attach dev workspace
@@ -287,11 +332,10 @@
 			<Button
 				variant="default"
 				startIcon={{ icon: GitFork }}
-				onclick={() => goto(`${base}/user/fork_workspace`)}
+				onclick={() => goto(`${base}/user/fork_workspace?dev=true`)}
 			>
 				Create a new dev workspace
 			</Button>
 		</div>
 	</div>
 {/if}
-

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -89,6 +89,16 @@
 			createAsDevWorkspace = false
 		}
 	})
+	// "Create a new dev workspace" links here with ?dev=true, so the button creates what it names.
+	// Applied once eligibility is confirmed rather than at init, since the effect above would clear a
+	// toggle set while the server check is still in flight.
+	let devRequestedFromUrl = $state(page.url.searchParams.get('dev') === 'true')
+	$effect(() => {
+		if (devRequestedFromUrl && canDesignateDevWorkspace) {
+			devRequestedFromUrl = false
+			createAsDevWorkspace = true
+		}
+	})
 
 	// The base workspace to fork from. A fork's git branch is based on its parent's branch, so picking
 	// a fork here (rather than the root) yields a fork of a fork.


### PR DESCRIPTION
## Summary

Small fixes around the **Dev workspace** settings tab, found while investigating a report that a
paired workspace showed no deploy path rules and was not marked as a dev workspace.

**The reported symptom turned out not to be a UI bug.** On the affected instance the
`deploy_to` → lineage migration (`20260730080304`) ran fine but deliberately dropped that
customer's link: they had set `deploy_to` in **both** directions (`staging → prod` *and*
`prod → staging`), which the migration classifies as a cycle and preserves rather than converts:

```
 workspace_id | deploy_to  | reason
 de-prod      | de-staging | linking it would form a cycle in the workspace lineage
 de-staging   | de-prod    | linking it would form a cycle in the workspace lineage
```

Both sides stayed unrelated roots, so there was no lineage to hang a deploy target or a dev-workspace
label off. Their `deploy_ui` filters were never lost. Re-attaching from the prod workspace's Dev
workspace tab restores everything, with no code change — so this PR keeps only the defects that
stand on their own. I replayed the migration on a scratch DB seeded at the pre-migration schema with
every link shape (sole claimant, many-to-one, chain, dangling/archived target, fork-pointing-elsewhere,
target-already-has-a-dev, mutual): the ordinary `staging → prod` pair converts correctly to
`parent + is_dev_workspace` with its filters intact, and only the mutual pair is dropped.

## Changes

- **Refresh the pairing after attach/detach.** `devWorkspaceResource`'s source
  (`!isDev && !parentId && !canonicalDev`) does not change when the workspace gains or loses its dev
  workspace, so runed never re-runs it. For a prod admin who is *not* a member of the dev workspace —
  the path where the pairing is read from the server rather than from the workspace list — the tab
  kept showing the pre-detach state until it remounted, i.e. "you have to switch tab". Added an
  explicit `refetch()` for it and for the protection rules. Verified by A/B: with the refetch removed
  the stale pairing reproduces exactly.
- **Report which protections are in force on a paired root.** Pairing does not imply the locks — a
  pair that came from the migration rather than from an attach carries neither. Uses
  `isRuleActiveInRulesets` (a ruleset with bypass users is still enforced for everyone else), and a
  failed read is reported as unknown rather than as "allowed". The attach-form toggles keep the
  stricter `isRuleUnconditionallyActiveInRulesets` semantics, which are about whether the reserved
  empty-bypass lock can be forced on.
- **Scope the two attach-time lock toggles.** They rendered as bare toggles, already on, above the
  Attach button, reading as live settings that apparently did nothing. Now grouped under
  *"Protect this workspace on attach — nothing is enforced until you attach"*.
- **"Create a new dev workspace" now creates one.** It linked to `/user/fork_workspace` with the dev
  toggle defaulting off, so following it produced a plain fork. Links to `?dev=true`, which
  `CreateWorkspaceInner` applies once the server dev-existence check confirms eligibility (not at
  init, where the existing clearing effect would undo it).
- **Spin the Compute diff loader** — `Loader2` was passed as `startIcon` without `animate-spin`.

## Screenshots

Paired root — protections in force, and detach now re-renders straight into the attach form:

![paired-protections](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-workspace-path-rules/1785796546-paired-protections.png)

Attach form — toggles scoped to the attach action:

![attach-form](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-workspace-path-rules/1785796548-attach-form.png)

`?dev=true` — "Create a new dev workspace" lands with dev mode already on:

![fork-dev-preselected](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-workspace-path-rules/1785796550-fork-dev-preselected.png)

## Test plan

- [x] As a prod admin **not** a member of the paired dev workspace (delete the `usr` row), open
      Workspace settings → Dev workspace and Detach: the tab falls back to the attach form without a
      reload. Confirmed it reproduces when the `refetch()` is removed.
- [x] Attach again from the same screen: the pairing and the protections panel update in place.
- [x] Give the `dev_workspace_lock` ruleset a `bypass_users` entry: the panel still reports
      *blocked* (before the fix it claimed *allowed*).
- [x] Force the protection-rules request to fail: the panel reports *"Could not read this
      workspace's protection rules"* instead of claiming *allowed*.
- [x] From the attach form, "Create a new dev workspace" lands on `/user/fork_workspace?dev=true`
      with the Dev workspace toggle on.
- [x] `npm run check` — 0 errors.

No tests added: frontend-only, no new pure-logic utility, and the codebase does not unit-test Svelte
components.

## Follow-ups (not in this PR)

- Nothing in the product surfaces `workspace_deploy_to_unmigrated`; the only signal was a
  `RAISE WARNING` at migration time. A banner on the Dev workspace tab offering to attach the
  preserved link would make all five preserved reasons self-service.
- A migrated pair never gets the prod lock rules and has a NULL `dev_workspace_label`, unlike a real
  attach.
- The deploy path/type filters are only honoured by the per-item "Deploy to prod" menus; the
  Compare & Deploy page ignores `deploy_ui` entirely (pre-existing).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale dev-workspace pairing after attach/detach and shows which protections are actually enforced on paired roots. Also makes “Create a new dev workspace” create a dev workspace and adds a small UI polish.

- **Bug Fixes**
  - Refresh dev pairing and protection rules after attach/detach so the tab updates without switching views.
  - Paired view reports enforced protections (deploy and forking); failed reads show “unknown,” not “allowed.”
  - Scope attach-time lock toggles under a clear description; nothing is enforced until attach.
  - “Create a new dev workspace” links with `?dev=true`; `CreateWorkspaceInner` applies it after eligibility check.
  - Animate the Compute diff loader icon.

<sup>Written for commit 3bb3c64b7eceb04ab573a2fbbf958c0a919f672e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

