### PR TITLE
fix: load the workspace AI config even when the docked chat is disabled

### DIFF
--- a/frontend/src/lib/components/FlowWrapper.svelte
+++ b/frontend/src/lib/components/FlowWrapper.svelte
@@ -77,7 +77,7 @@
 </script>
 
 {#if trialRender}
-	<AiChatLayout noPadding={true} {disableAi}>
+	<AiChatLayout noPadding={true} {disableAi} loadAiConfig={!disableAi}>
 		{#if light}<div class="bg-red-500 absolute z-10">Trial version</div>{/if}
 		<!-- Gate on a resolved workspace: the draft handle is detached (local-only)
 		     until one exists, so editing before then would be lost on the re-key. -->

--- a/frontend/src/lib/components/ScriptWrapper.svelte
+++ b/frontend/src/lib/components/ScriptWrapper.svelte
@@ -38,7 +38,7 @@
 	})
 </script>
 
-<AiChatLayout noPadding {disableAi}>
+<AiChatLayout noPadding {disableAi} loadAiConfig={!disableAi}>
 	{#if $workspaceStore && draftSync.draft}
 		<ScriptBuilder
 			bind:script={draftSync.draft}

--- a/frontend/src/lib/components/copilot/FlowInlineScriptAIButton.svelte
+++ b/frontend/src/lib/components/copilot/FlowInlineScriptAIButton.svelte
@@ -6,6 +6,7 @@
 	import { base } from '$lib/base'
 	import { twMerge } from 'tailwind-merge'
 	import { aiChatManager, AIMode } from './chat/AIChatManager.svelte'
+	import { chatState } from './chat/sharedChatState.svelte'
 	import { copilotInfo } from '$lib/aiStore'
 	import type { ComponentProps } from 'svelte'
 
@@ -36,37 +37,49 @@
 	/>
 {/snippet}
 
-{#if $copilotInfo.enabled}
-	{@render button(() => {
-		aiChatManager.openChat()
-		const availableContext = aiChatManager.contextManager.getAvailableContext()
-		aiChatManager.contextManager.setSelectedModuleContext(moduleId, availableContext)
-	})}
-{:else}
-	<Popover
-		floatingConfig={{
-			middleware: [
-				autoPlacement({
-					allowedPlacements: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'top', 'bottom']
-				})
-			]
-		}}
-	>
-		{#snippet trigger()}
-			{@render button()}
-		{/snippet}
-		{#snippet content({ close })}
-			<div class="p-4">
-				<p class="text-sm">
-					Enable Windmill AI in the <a
-						href="{base}/workspace_settings?tab=ai"
-						target="_blank"
-						class="inline-flex flex-row items-center gap-1"
-					>
-						workspace settings <ExternalLink size={16} />
-					</a>
-				</p>
-			</div>
-		{/snippet}
-	</Popover>
+<!-- This button only opens the docked chat pane. Without one there is nothing to
+     open, so it hides rather than rendering a dead click — the flow and raw-app
+     toolbars carry the "open in AI session" entry point in that mode. -->
+{#if chatState.dockedChatAvailable}
+	{#if $copilotInfo.enabled}
+		{@render button(() => {
+			aiChatManager.openChat()
+			const availableContext = aiChatManager.contextManager.getAvailableContext()
+			aiChatManager.contextManager.setSelectedModuleContext(moduleId, availableContext)
+		})}
+	{:else}
+		<Popover
+			floatingConfig={{
+				middleware: [
+					autoPlacement({
+						allowedPlacements: [
+							'bottom-start',
+							'bottom-end',
+							'top-start',
+							'top-end',
+							'top',
+							'bottom'
+						]
+					})
+				]
+			}}
+		>
+			{#snippet trigger()}
+				{@render button()}
+			{/snippet}
+			{#snippet content({ close })}
+				<div class="p-4">
+					<p class="text-sm">
+						Enable Windmill AI in the <a
+							href="{base}/workspace_settings?tab=ai"
+							target="_blank"
+							class="inline-flex flex-row items-center gap-1"
+						>
+							workspace settings <ExternalLink size={16} />
+						</a>
+					</p>
+				</div>
+			{/snippet}
+		</Popover>
+	{/if}
 {/if}

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -51,8 +51,12 @@
 	let contentPadLeft = $derived(noBorder || $userStore?.operator || isMobile ? 0 : sidebarWidth)
 
 	$effect(() => {
+		chatState.dockedChatAvailable = !disableAi
 		if (disableAi) {
 			chatState.size = 0
+		}
+		return () => {
+			chatState.dockedChatAvailable = false
 		}
 	})
 

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -22,6 +22,13 @@
 		children: any
 		onMenuOpen?: () => void
 		disableAi?: boolean
+		// Whether this layout loads the workspace AI config. It gates far more than
+		// the docked pane (code completion, metadata generation, the "open in AI
+		// session" buttons), so it must not be tied to `disableAi`. Pass false where
+		// another component owns the load for a different workspace — on the sessions
+		// route SessionWrapper loads the session's acting workspace, and both writing
+		// the global store would race.
+		loadAiConfig?: boolean
 		// Only the root layout's docked chat is the "legacy" counterpart of AI
 		// Sessions — SDK wrappers reuse this layout for script/flow chats where
 		// the sessions beta banner would make no sense.
@@ -35,6 +42,7 @@
 		children,
 		onMenuOpen,
 		disableAi,
+		loadAiConfig = true,
 		showSessionsBetaBanner = false
 	}: Props = $props()
 
@@ -49,7 +57,7 @@
 	})
 
 	$effect(() => {
-		if ($workspaceStore && !disableAi) {
+		if ($workspaceStore && loadAiConfig) {
 			loadCopilot($workspaceStore)
 		}
 	})

--- a/frontend/src/lib/components/copilot/chat/sharedChatState.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/sharedChatState.svelte.ts
@@ -13,9 +13,15 @@ export const DEFAULT_SIZE = 22
 
 type ChatState = {
 	size: number
+	// Whether a docked chat pane is mounted (set by AiChatLayout). False in AI
+	// Sessions mode, where the root layout renders no pane: aiChatManager.openChat()
+	// only writes `size`, so a button that opens the pane without checking this is a
+	// silent no-op. Entry points that can't fall back to a session must hide instead.
+	dockedChatAvailable: boolean
 }
 
 // we first check BROWSER before localStorage to avoid SSR issues when using Drawer in a SvelteKit app (chatState is imported in Drawer.svelte)
 export const chatState = $state<ChatState>({
-	size: BROWSER && localStorage.getItem('ai-chat-open') === 'true' ? DEFAULT_SIZE : 0
+	size: BROWSER && localStorage.getItem('ai-chat-open') === 'true' ? DEFAULT_SIZE : 0,
+	dockedChatAvailable: false
 })

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -1375,6 +1375,7 @@
 				{children}
 				noPadding={devOnly || menuHidden}
 				disableAi={globalAiEnabled && !$userStore?.operator ? true : sessionMode}
+				loadAiConfig={!sessionMode}
 				showSessionsBetaBanner={!$userStore?.operator}
 				sidebarWidth={railWidth}
 				transitionClass={sidebarTransitionClass}


### PR DESCRIPTION
## Summary

Fixes WIN-2290. AI buttons across the app told users to "Enable Windmill AI in the workspace settings" even when AI was configured, because the workspace AI config was never fetched.

`AiChatLayout` was the only thing that loaded it (`loadCopilot`), and it did so only when its own docked chat pane was enabled:

```svelte
if ($workspaceStore && !disableAi) loadCopilot($workspaceStore)
```

Since AI Sessions shipped default-on (#10242), the root layout passes `disableAi={globalAiEnabled && !operator ? true : sessionMode}` — i.e. **always true** for a non-operator on the sessions beta. So on every workspace page the config was never fetched, `copilotInfo.enabled` stayed at its `false` default, and everything gated on it fell back to the "not enabled" branch: the "open in AI session" buttons, the inline-script AI button, code completion, metadata generation, step-input filling, script/cron/regex generation.

It looked intermittent because a few side paths do populate the store: opening an AI session (`SessionWrapper`), or saving the AI settings page. Visit one of those first and the buttons behave for the rest of that page-session; hard-reload and they are wrong again. That also explains why it is more consistently wrong with an **instance-level** AI config: nobody ever opens the workspace AI settings page to configure it, so the one incidental path that populated the store never runs.

`disableAi` means "don't render the docked chat pane", not "AI is off" — the AI config gates far more than that pane, so this decouples the two.

## Changes

- `AiChatLayout`: new `loadAiConfig` prop (default `true`) gates the `loadCopilot` effect, replacing the `!disableAi` condition.
- Root `(logged)/+layout.svelte`: passes `loadAiConfig={!sessionMode}`. The config now loads on every workspace page regardless of the docked pane; on `/sessions` it stays off because `SessionWrapper` owns the load there — it loads the session's *acting* workspace, and two writers of the global `copilotInfo`/`copilotWorkspace` store would race.
- `ScriptWrapper` / `FlowWrapper` (SDK): pass `loadAiConfig={!disableAi}` to keep their existing behaviour exactly (an embed with AI disabled still issues no request).

No behaviour change for operators, for users opted out of the sessions beta, or on the sessions route.

## Screenshots

Flow editor, workspace with AI configured. Before, the inline-script AI button opens the bogus "Enable Windmill AI in the workspace settings" popover:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2290-ai-button-shows-incorrect-enable-tooltip-when-already/1785826330-before-fix-tooltip.png)

After, the same button no longer claims AI is disabled:

![after-inline](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2290-ai-button-shows-incorrect-enable-tooltip-when-already/1785826332-after-inline-wand.png)

And the flow's AI button hovers with its real label instead of the enable-AI popover:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2290-ai-button-shows-incorrect-enable-tooltip-when-already/1785826334-after-fix-tooltip.png)

## Test plan

- [x] Workspace-level AI config: flow editor AI buttons render the enabled branch and hover shows "Open in AI session" (was the enable-AI popover).
- [x] Instance-level AI config only (workspace `ai_config` NULL): same result, confirming the `get_copilot_info` instance fallback reaches the UI.
- [x] `/sessions` still resolves its model from the session's acting workspace (composer shows `gpt-4o`); the layout does not double-load there.
- [x] `npm run check` — 0 errors.
- [x] `vitest run src/lib/aiStore.test.ts` — passing.

## Known adjacent gap (not fixed here)

With the config now loaded, the flow's *inline-script* AI button (`FlowInlineScriptAIButton`, and the raw-app equivalent) takes its enabled branch and calls `aiChatManager.openChat()` — but in AI Sessions mode the docked pane it opens is not mounted, so the click does nothing. That pre-existed this PR (it already happened whenever the store had been populated by a side path); `ScriptEditor` already solved it by routing through `OpenInSessionButton` with the legacy button as a fallback, and the inline-script buttons still need the same treatment. Filed separately rather than widened into this fix.

No test added: the bug is prop wiring in a layout, and there is no component-test harness here that would pin it without disproportionate fixtures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2290 by loading the workspace AI config even when the docked chat is disabled. Also hides the inline-script AI button when no docked chat exists to avoid dead clicks.

- **Bug Fixes**
  - Added `loadAiConfig` prop to `AiChatLayout` and load the config when true, independent of `disableAi`.
  - Root `(logged)/+layout.svelte` sets `loadAiConfig={!sessionMode}` to load on all workspace pages and avoid double-loading on `/sessions`.
  - `ScriptWrapper` and `FlowWrapper` pass `loadAiConfig={!disableAi}` to keep embeds with AI disabled from issuing requests.
  - `FlowInlineScriptAIButton` hides when no docked chat pane is mounted; `AiChatLayout` sets `chatState.dockedChatAvailable` accordingly.

<sup>Written for commit cf21e59f130dd03b2229670fcb1d2a0d9c85fd47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

