### PR TITLE
fix: match openrouter model ids by parsed vendor, not raw prefix

### DIFF
--- a/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
+++ b/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
@@ -259,25 +259,31 @@ describe('OpenRouter prompt caching', () => {
 		{ role: 'tool', tool_call_id: 't1', content: 'tool output' }
 	]
 
-	it('breaks on the system prompt and the newest user turn for Anthropic models', async () => {
-		const { getCompletion } = await import('./lib')
-		h.currentModel = { provider: 'openrouter', model: 'anthropic/claude-sonnet-5' }
+	// The `~` form is OpenRouter's own floating alias for the same vendor, so it has
+	// to reach the same gate — a prefix match on the raw id silently misses it and
+	// puts the chat back on full price every turn.
+	it.each(['anthropic/claude-sonnet-5', '~anthropic/claude-sonnet-latest'])(
+		'breaks on the system prompt and the newest user turn for %s',
+		async (model) => {
+			const { getCompletion } = await import('./lib')
+			h.currentModel = { provider: 'openrouter', model }
 
-		await getCompletion([...conversation], new AbortController(), undefined, {
-			promptCaching: true
-		})
+			await getCompletion([...conversation], new AbortController(), undefined, {
+				promptCaching: true
+			})
 
-		const sent = openaiCreate.mock.calls[0][0].messages
-		const ephemeral = { type: 'ephemeral' }
-		expect(sent[0].content).toEqual([
-			{ type: 'text', text: 'system prompt', cache_control: ephemeral }
-		])
-		expect(sent[1].content).toEqual([{ type: 'text', text: 'first', cache_control: ephemeral }])
-		expect(sent[3].content).toBe('tool output')
-		// The chat replays this same history through the Anthropic path, which rejects
-		// unknown fields on its own blocks, so the originals must come back untouched.
-		expect(conversation[0].content).toBe('system prompt')
-	})
+			const sent = openaiCreate.mock.calls[0][0].messages
+			const ephemeral = { type: 'ephemeral' }
+			expect(sent[0].content).toEqual([
+				{ type: 'text', text: 'system prompt', cache_control: ephemeral }
+			])
+			expect(sent[1].content).toEqual([{ type: 'text', text: 'first', cache_control: ephemeral }])
+			expect(sent[3].content).toBe('tool output')
+			// The chat replays this same history through the Anthropic path, which rejects
+			// unknown fields on its own blocks, so the originals must come back untouched.
+			expect(conversation[0].content).toBe('system prompt')
+		}
+	)
 
 	it('leaves other OpenRouter upstreams alone', async () => {
 		const { getCompletion } = await import('./lib')

--- a/frontend/src/lib/components/copilot/lib.test.ts
+++ b/frontend/src/lib/components/copilot/lib.test.ts
@@ -217,7 +217,12 @@ describe('model context windows', () => {
 		expect(getKnownModelContextWindow('claude-sonnet-4-6')).toBe(1000000)
 		expect(getKnownModelContextWindow('claude-opus-4-6')).toBe(1000000)
 		expect(getKnownModelContextWindow('claude-opus-4-8')).toBe(1000000)
+		expect(getKnownModelContextWindow('claude-opus-5')).toBe(1000000)
+		expect(getKnownModelContextWindow('claude-sonnet-5')).toBe(1000000)
 		expect(getKnownModelContextWindow('anthropic.claude-sonnet-4-6-v1:0')).toBe(1000000)
+		// OpenRouter dot-versions the same models; both spellings must resolve
+		expect(getKnownModelContextWindow('anthropic/claude-sonnet-4.6')).toBe(1000000)
+		expect(getKnownModelContextWindow('anthropic/claude-opus-4.8')).toBe(1000000)
 	})
 
 	it('keeps Haiku and older Claude models at 200K', () => {

--- a/frontend/src/lib/components/copilot/lib.test.ts
+++ b/frontend/src/lib/components/copilot/lib.test.ts
@@ -252,6 +252,10 @@ describe('model context windows', () => {
 		// latter is a 128K model and must stay unlisted
 		expect(getKnownModelContextWindow('gpt-4-1106-preview')).toBeUndefined()
 		expect(getKnownModelContextWindow('gpt-4.1-mini')).toBe(1000000)
+		// family fallbacks still catch a version welded onto the name (Ollama ids),
+		// which is what keeps compaction on for them
+		expect(getKnownModelContextWindow('llama3.1')).toBe(128000)
+		expect(getKnownModelContextWindow('llama3-70b-8192')).toBe(128000)
 	})
 
 	it('maps recent Gemini and DeepSeek models to the 1M window', () => {

--- a/frontend/src/lib/components/copilot/lib.test.ts
+++ b/frontend/src/lib/components/copilot/lib.test.ts
@@ -247,6 +247,13 @@ describe('model context windows', () => {
 		expect(getKnownModelContextWindow('gpt-5.5')).toBe(1000000)
 	})
 
+	it('does not let a version entry claim a longer version number', () => {
+		// `gpt-4.1` and `gpt-4-1106-preview` collapse to the same prefix, but the
+		// latter is a 128K model and must stay unlisted
+		expect(getKnownModelContextWindow('gpt-4-1106-preview')).toBeUndefined()
+		expect(getKnownModelContextWindow('gpt-4.1-mini')).toBe(1000000)
+	})
+
 	it('maps recent Gemini and DeepSeek models to the 1M window', () => {
 		expect(getKnownModelContextWindow('gemini-3.1-pro')).toBe(1000000)
 		expect(getKnownModelContextWindow('gemini-3-flash')).toBe(1000000)

--- a/frontend/src/lib/components/copilot/modelConfig.ts
+++ b/frontend/src/lib/components/copilot/modelConfig.ts
@@ -1,5 +1,33 @@
 import type { AIProvider } from '$lib/gen'
 
+export type ParsedModelId = {
+	/** Vendor namespace when the id carries one (`anthropic/claude-sonnet-5`). */
+	vendor: string | undefined
+	/** Bare model id: no vendor prefix, no variant suffix. */
+	base: string
+	/** Gateway variant suffix (`free`, `thinking`, ...) when present. */
+	variant: string | undefined
+}
+
+/**
+ * Split a model id into the parts the predicates below match on. Gateways decorate
+ * the vendor's id in ways a raw substring check misses: OpenRouter marks its own
+ * floating aliases with a `~` prefix (`~anthropic/claude-sonnet-latest`, distinct
+ * from the vendor-pinned `anthropic/claude-sonnet-5`) and appends `:variant`
+ * suffixes (`:free`, `:thinking`). Match on the parsed parts, never on the raw id.
+ */
+export function parseModelId(model: string): ParsedModelId {
+	const normalized = model.toLowerCase().replace(/^~/, '')
+	const slash = normalized.indexOf('/')
+	const rest = slash > 0 ? normalized.slice(slash + 1) : normalized
+	const colon = rest.indexOf(':')
+	return {
+		vendor: slash > 0 ? normalized.slice(0, slash) : undefined,
+		base: colon > 0 ? rest.slice(0, colon) : rest,
+		variant: colon > 0 ? rest.slice(colon + 1) : undefined
+	}
+}
+
 // Azure AI Foundry fronts multiple model families under one resource. Claude
 // deployments are served only through the Anthropic Messages API, so the chat must
 // route them like the native Anthropic provider (Anthropic SDK, message format)
@@ -19,18 +47,16 @@ export function usesAnthropicMessagesApi(provider: AIProvider, model: string): b
 // but only documents them for Anthropic-backed models, so the gate is on the routed
 // model rather than the provider alone.
 export function usesOpenRouterPromptCaching(provider: AIProvider, model: string): boolean {
-	return provider === 'openrouter' && model.toLowerCase().startsWith('anthropic/')
+	return provider === 'openrouter' && parseModelId(model).vendor === 'anthropic'
 }
 
 // gpt-5+ and o-series reasoning models reject the legacy `max_tokens` field on
 // the OpenAI/Azure Chat Completions API and require `max_completion_tokens`
-// instead. The check strips any provider prefix (e.g. OpenRouter's "openai/o3")
-// so it matches the bare model id, and the o-series match requires a digit after
-// the "o" (o1/o3/o4-mini) so it does not catch unrelated ids like Mistral's
-// "open-mistral-*" or "optimus-*".
+// instead. The check runs on the bare model id (so OpenRouter's "openai/o3"
+// matches), and the o-series match requires a digit after the "o" (o1/o3/o4-mini)
+// so it does not catch unrelated ids like Mistral's "open-mistral-*" or "optimus-*".
 export function requiresMaxCompletionTokens(model: string) {
-	const normalizedModel = model.toLowerCase()
-	const baseModel = normalizedModel.split('/').pop() ?? normalizedModel
+	const baseModel = parseModelId(model).base
 	return baseModel.startsWith('gpt-5') || /^o\d/.test(baseModel)
 }
 
@@ -45,6 +71,8 @@ const MODEL_CONTEXT_WINDOWS: [name: string, contextWindow: number][] = [
 	// Haiku, older Claude models (3.x, 4.0, 4.1, 4.5) and date-suffixed Claude 4
 	// base ids (claude-sonnet-4-20250514) fall through to 200K
 	['claude-fable-5', 1_000_000],
+	['claude-opus-5', 1_000_000],
+	['claude-sonnet-5', 1_000_000],
 	['claude-opus-4-8', 1_000_000],
 	['claude-opus-4-7', 1_000_000],
 	['claude-opus-4-6', 1_000_000],
@@ -74,8 +102,17 @@ const MODEL_CONTEXT_WINDOWS: [name: string, contextWindow: number][] = [
 	['codestral', 32_000]
 ]
 
+// Version separators differ by route to the same model: Anthropic writes
+// `claude-opus-4-8`, OpenRouter writes `anthropic/claude-opus-4.8`. Collapsing
+// dots to dashes on both sides keeps one table entry covering every route —
+// without it a dot-versioned id falls through to a coarser family entry.
+function normalizeVersionSeparators(model: string): string {
+	return model.replace(/\./g, '-')
+}
+
 export function getKnownModelContextWindow(model: string): number | undefined {
-	return MODEL_CONTEXT_WINDOWS.find(([name]) => model.includes(name))?.[1]
+	const id = normalizeVersionSeparators(parseModelId(model).base)
+	return MODEL_CONTEXT_WINDOWS.find(([name]) => id.includes(normalizeVersionSeparators(name)))?.[1]
 }
 
 export function getModelContextWindow(model: string) {

--- a/frontend/src/lib/components/copilot/modelConfig.ts
+++ b/frontend/src/lib/components/copilot/modelConfig.ts
@@ -110,15 +110,17 @@ function normalizeVersionSeparators(model: string): string {
 	return model.replace(/\./g, '-')
 }
 
-// `(?!\d)` stops a collapsed entry from running into a longer version number:
-// `gpt-4.1` becomes `gpt-4-1`, which would otherwise claim the 128K
+// An entry that ends on a version digit must not run into a longer version:
+// `gpt-4.1` collapses to `gpt-4-1`, which would otherwise claim the 128K
 // `gpt-4-1106-preview` as a 1M model. Suffixes that continue with a separator
 // (`claude-opus-4-8` in `...-4-8-v1`, `gpt-5` in `gpt-5-mini`) still match.
+// Family fallbacks ending on a letter get no such guard — a version welded
+// straight onto the name (`llama3.1`) is exactly what they exist to catch.
 const MODEL_CONTEXT_WINDOW_MATCHERS: [matcher: RegExp, contextWindow: number][] =
-	MODEL_CONTEXT_WINDOWS.map(([name, contextWindow]) => [
-		new RegExp(`${normalizeVersionSeparators(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!\\d)`),
-		contextWindow
-	])
+	MODEL_CONTEXT_WINDOWS.map(([name, contextWindow]) => {
+		const pattern = normalizeVersionSeparators(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+		return [new RegExp(/\d$/.test(pattern) ? `${pattern}(?!\\d)` : pattern), contextWindow]
+	})
 
 export function getKnownModelContextWindow(model: string): number | undefined {
 	const id = normalizeVersionSeparators(parseModelId(model).base)

--- a/frontend/src/lib/components/copilot/modelConfig.ts
+++ b/frontend/src/lib/components/copilot/modelConfig.ts
@@ -5,8 +5,6 @@ export type ParsedModelId = {
 	vendor: string | undefined
 	/** Bare model id: no vendor prefix, no variant suffix. */
 	base: string
-	/** Gateway variant suffix (`free`, `thinking`, ...) when present. */
-	variant: string | undefined
 }
 
 /**
@@ -15,16 +13,18 @@ export type ParsedModelId = {
  * floating aliases with a `~` prefix (`~anthropic/claude-sonnet-latest`, distinct
  * from the vendor-pinned `anthropic/claude-sonnet-5`) and appends `:variant`
  * suffixes (`:free`, `:thinking`). Match on the parsed parts, never on the raw id.
+ *
+ * `base` is the last `/` segment, so the deprecated `<model>/thinking` selection
+ * resolves the same way it did before this parser existed.
  */
 export function parseModelId(model: string): ParsedModelId {
 	const normalized = model.toLowerCase().replace(/^~/, '')
-	const slash = normalized.indexOf('/')
-	const rest = slash > 0 ? normalized.slice(slash + 1) : normalized
-	const colon = rest.indexOf(':')
+	const segments = normalized.split('/')
+	const last = segments[segments.length - 1]
+	const colon = last.indexOf(':')
 	return {
-		vendor: slash > 0 ? normalized.slice(0, slash) : undefined,
-		base: colon > 0 ? rest.slice(0, colon) : rest,
-		variant: colon > 0 ? rest.slice(colon + 1) : undefined
+		vendor: segments.length > 1 ? segments[0] : undefined,
+		base: colon > 0 ? last.slice(0, colon) : last
 	}
 }
 
@@ -61,7 +61,7 @@ export function requiresMaxCompletionTokens(model: string) {
 }
 
 // Context windows of the models we know, most specific entry first — the first
-// name included in the model id wins, so provider-prefixed and date-suffixed
+// name found in the bare model id wins, so vendor-namespaced and date-suffixed
 // ids (anthropic.claude-sonnet-4-6-...-v1:0, gpt-5.2-2026-01-01) still resolve.
 // Conservative family fallbacks sit below the explicit entries; models not
 // listed at all resolve to undefined, which disables auto-trimming and the
@@ -110,9 +110,19 @@ function normalizeVersionSeparators(model: string): string {
 	return model.replace(/\./g, '-')
 }
 
+// `(?!\d)` stops a collapsed entry from running into a longer version number:
+// `gpt-4.1` becomes `gpt-4-1`, which would otherwise claim the 128K
+// `gpt-4-1106-preview` as a 1M model. Suffixes that continue with a separator
+// (`claude-opus-4-8` in `...-4-8-v1`, `gpt-5` in `gpt-5-mini`) still match.
+const MODEL_CONTEXT_WINDOW_MATCHERS: [matcher: RegExp, contextWindow: number][] =
+	MODEL_CONTEXT_WINDOWS.map(([name, contextWindow]) => [
+		new RegExp(`${normalizeVersionSeparators(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!\\d)`),
+		contextWindow
+	])
+
 export function getKnownModelContextWindow(model: string): number | undefined {
 	const id = normalizeVersionSeparators(parseModelId(model).base)
-	return MODEL_CONTEXT_WINDOWS.find(([name]) => id.includes(normalizeVersionSeparators(name)))?.[1]
+	return MODEL_CONTEXT_WINDOW_MATCHERS.find(([matcher]) => matcher.test(id))?.[1]
 }
 
 export function getModelContextWindow(model: string) {

--- a/frontend/src/lib/components/copilot/modelConfig.ts
+++ b/frontend/src/lib/components/copilot/modelConfig.ts
@@ -14,8 +14,9 @@ export type ParsedModelId = {
  * from the vendor-pinned `anthropic/claude-sonnet-5`) and appends `:variant`
  * suffixes (`:free`, `:thinking`). Match on the parsed parts, never on the raw id.
  *
- * `base` is the last `/` segment, so the deprecated `<model>/thinking` selection
- * resolves the same way it did before this parser existed.
+ * `base` is the last `/` segment: the deprecated `<model>/thinking` selection puts
+ * its marker where a gateway puts the model, so callers that must resolve one of
+ * those ids first run it through `stripLegacyThinkingSuffix`.
  */
 export function parseModelId(model: string): ParsedModelId {
 	const normalized = model.toLowerCase().replace(/^~/, '')

--- a/frontend/src/lib/components/copilot/reasoningRegistry.ts
+++ b/frontend/src/lib/components/copilot/reasoningRegistry.ts
@@ -1,5 +1,5 @@
 import type { AIProvider, AIProviderModel } from '$lib/gen'
-import { usesAnthropicMessagesApi } from './modelConfig'
+import { parseModelId, usesAnthropicMessagesApi } from './modelConfig'
 
 /**
  * Reasoning effort is provider/model-specific. We never normalize a single
@@ -35,8 +35,7 @@ export function stripLegacyThinkingSuffix(model: string): string {
 
 /** Bare model id without any provider/gateway prefix (e.g. OpenRouter's `openai/o3`). */
 function baseModelId(model: string): string {
-	const normalized = model.toLowerCase()
-	return normalized.split('/').pop() ?? normalized
+	return parseModelId(model).base
 }
 
 /**


### PR DESCRIPTION
## Summary

Reported on #10471: OpenRouter publishes its own floating aliases with a `~` prefix
(`~anthropic/claude-sonnet-latest`) alongside the vendor-pinned ids
(`anthropic/claude-sonnet-5`). The model picker lists whatever `/models` returns, so
both forms are selectable — but `usesOpenRouterPromptCaching` gated on
`startsWith('anthropic/')`, so picking an alias silently dropped the `cache_control`
breakpoints added in #10481 and put the chat back on full input price every turn.

Verified against the live catalog: 11 of 338 OpenRouter models carry the prefix, 4 of
them Anthropic (`~anthropic/claude-{sonnet,opus,haiku,fable}-latest`).

The same class of mismatch reaches further than the alias: OpenRouter dot-versions its
ids (`anthropic/claude-sonnet-4.6`) while `MODEL_CONTEXT_WINDOWS` keys on dashes
(`claude-sonnet-4-6`), so every OpenRouter-routed Claude 4.6+ resolved to the 200K
`claude` fallback instead of 1M and the chat trimmed context five times earlier than
needed.

## Changes

- Add `parseModelId` to `modelConfig.ts`: one normalizer returning `{vendor, base, variant}`
  (strips a leading `~`, splits on the first `/`, drops a `:free`/`:thinking` suffix).
  The predicates now match on the parsed parts instead of raw substrings.
- `usesOpenRouterPromptCaching` gates on `vendor === 'anthropic'`, so aliases get
  cache breakpoints.
- `getKnownModelContextWindow` collapses `.` to `-` on both the query and the table
  keys, so one entry covers both spellings of a version.
- Add the missing `claude-opus-5` / `claude-sonnet-5` 1M entries (they were falling
  through to the 200K `claude` family entry).
- `requiresMaxCompletionTokens` and `reasoningRegistry`'s `baseModelId` use the shared
  parser instead of their own `split('/').pop()`.

Not fixed here: the `-latest` aliases carry no version, so version-keyed checks
(`/claude-(opus|sonnet)-4/` in the reasoning registry) can't match them and the effort
control stays hidden for those ids. That needs either an explicit alias-family map or
reading `supported_parameters` off the `/models` response we already fetch.

## Test plan
- [x] `npx vitest run src/lib/components/copilot/` — the two new guards
      (`~anthropic/claude-sonnet-latest` gets breakpoints; `anthropic/claude-sonnet-4.6`
      resolves to 1M) fail on the pre-fix code and pass after
- [x] `npm run check:fast` clean
- [ ] With an OpenRouter key: select `~anthropic/claude-sonnet-latest`, send two turns,
      confirm the second reports cached input tokens

## Screenshots

None. The only user-visible effect is the context-usage indicator's denominator for
OpenRouter-routed Claude models, which needs a configured OpenRouter provider + key to
render; this dev instance has no AI provider configured, so the change is verified at
the unit level only. No markup or styling changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch model matching to a parsed vendor approach and normalize version separators for OpenRouter IDs. Restores Anthropic prompt caching for `~` aliases and ensures 1M context windows for dot-versioned Claude 4.6+ and Claude 5, while anchoring version matches so shorter versions don’t swallow longer ones.

- **Bug Fixes**
  - Parse model IDs into `{ vendor, base }` and gate caching on `vendor === 'anthropic'` so `~anthropic/claude-sonnet-latest` gets breakpoints.
  - Normalize `.` to `-` for context-window lookups; add 1M entries for `claude-opus-5` and `claude-sonnet-5`.
  - Anchor context-window matches only for version-suffixed entries with `(?!\d)` so `gpt-4.1` doesn’t claim `gpt-4-1106-preview`; family fallbacks still catch welded versions like `llama3.1`.
  - Use the shared parser in `requiresMaxCompletionTokens` and the reasoning registry to correctly strip prefixes/suffixes.
  - Tests cover alias caching, dot-version context windows, and the scoped digit guard.

- **Refactors**
  - Document the legacy `/thinking` suffix invariant in `parseModelId` comments.

<sup>Written for commit 0ee63524485c2e8d804eb0a49750e57f8688f282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

