### PR TITLE
feat: add multi-select and bulk actions to the Home page

### DIFF
--- a/frontend/src/lib/components/common/checkbox/Checkbox.svelte
+++ b/frontend/src/lib/components/common/checkbox/Checkbox.svelte
@@ -14,6 +14,10 @@
 		class?: string | undefined
 		/** Change handler (controlled — the parent owns `checked`). */
 		onChange?: (e: Event & { currentTarget: EventTarget & HTMLInputElement }) => void
+		/** Click handler, for the cases that need the modifier keys a `change`
+		 * event doesn't carry (e.g. shift-click to select a range). Fires before
+		 * `change`, so calling `preventDefault` here suppresses both. */
+		onClick?: (e: MouseEvent & { currentTarget: EventTarget & HTMLInputElement }) => void
 	}
 
 	let {
@@ -22,17 +26,35 @@
 		disabled = false,
 		title = undefined,
 		class: className = undefined,
-		onChange
+		onChange,
+		onClick
 	}: Props = $props()
+
+	let inputEl: HTMLInputElement | undefined = $state()
+	let clicks = $state(0)
+	// A click flips the box before any handler runs, and flips it back when the
+	// handler prevents the default — both outside Svelte's diff. So a controlled
+	// checkbox whose value did not change across a click keeps the browser's
+	// guess. Re-assert the controlled value after every click, not only when it
+	// differs from the last rendered one.
+	$effect(() => {
+		clicks
+		if (inputEl) inputEl.checked = checked
+	})
 </script>
 
 <input
+	bind:this={inputEl}
 	type="checkbox"
 	{checked}
 	{indeterminate}
 	{disabled}
 	{title}
 	onchange={onChange}
+	onclick={(e) => {
+		onClick?.(e)
+		clicks++
+	}}
 	class={twMerge(
 		'rounded max-w-4 w-full',
 		// When disabled, grey it and let hover fall through to a wrapping trigger

--- a/frontend/src/lib/components/common/checkbox/Checkbox.svelte
+++ b/frontend/src/lib/components/common/checkbox/Checkbox.svelte
@@ -32,11 +32,9 @@
 
 	let inputEl: HTMLInputElement | undefined = $state()
 	let clicks = $state(0)
-	// A click flips the box before any handler runs, and flips it back when the
-	// handler prevents the default — both outside Svelte's diff. So a controlled
-	// checkbox whose value did not change across a click keeps the browser's
-	// guess. Re-assert the controlled value after every click, not only when it
-	// differs from the last rendered one.
+	// A click flips the box before any handler runs, outside Svelte's diff — so a
+	// controlled checkbox whose value does NOT change across a click would keep
+	// the browser's guess. Re-assert after every click, not only on a change.
 	$effect(() => {
 		clicks
 		if (inputEl) inputEl.checked = checked

--- a/frontend/src/lib/components/common/table/AppRow.svelte
+++ b/frontend/src/lib/components/common/table/AppRow.svelte
@@ -11,6 +11,7 @@
 	import { createEventDispatcher } from 'svelte'
 	import Button from '../button/Button.svelte'
 	import Row from './Row.svelte'
+	import type { RowSelection } from './rowSelection'
 	import InheritedLabels from '$lib/components/InheritedLabels.svelte'
 	import Badge from '../badge/Badge.svelte'
 	import {
@@ -48,6 +49,7 @@
 		menuOpen?: boolean
 		showEditButton?: boolean
 		keyboardSelected?: boolean
+		rowSelection?: RowSelection
 	}
 
 	let {
@@ -60,7 +62,8 @@
 		depth = 0,
 		menuOpen = $bindable(false),
 		showEditButton = $bindable(true),
-		keyboardSelected = false
+		keyboardSelected = false,
+		rowSelection = undefined
 	}: Props = $props()
 
 	const dispatch = createEventDispatcher()
@@ -112,6 +115,7 @@
 	canFavorite={!app.draft_only}
 	{depth}
 	{keyboardSelected}
+	{rowSelection}
 >
 	{#snippet badges()}
 		{#if app.execution_mode == 'anonymous'}

--- a/frontend/src/lib/components/common/table/FlowRow.svelte
+++ b/frontend/src/lib/components/common/table/FlowRow.svelte
@@ -14,6 +14,7 @@
 	import Badge from '../badge/Badge.svelte'
 	import Button from '../button/Button.svelte'
 	import Row from './Row.svelte'
+	import type { RowSelection } from './rowSelection'
 	import { sendUserToast } from '$lib/toast'
 	import { copyToClipboard, isOwner } from '$lib/utils'
 	import { isDeployable } from '$lib/utils_deployable'
@@ -57,6 +58,7 @@
 		menuOpen?: boolean
 		showEditButton?: boolean
 		keyboardSelected?: boolean
+		rowSelection?: RowSelection
 	}
 
 	let {
@@ -70,7 +72,8 @@
 		depth = 0,
 		menuOpen = $bindable(false),
 		showEditButton = $bindable(true),
-		keyboardSelected = false
+		keyboardSelected = false,
+		rowSelection = undefined
 	}: Props = $props()
 
 	const dispatch = createEventDispatcher()
@@ -135,6 +138,7 @@
 	canFavorite={!flow.draft_only}
 	{depth}
 	{keyboardSelected}
+	{rowSelection}
 >
 	{#snippet badges()}
 		{#if flow.archived}

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -170,7 +170,7 @@
      with its sibling folder at the same depth. -->
 <div
 	bind:this={rowEl}
-	data-home-row-key={rowSelection?.key}
+	data-row-selection-key={rowSelection?.key}
 	data-row-keyboard-selected={keyboardSelected ? 'true' : undefined}
 	class={twMerge(
 		'group/row w-full inline-flex items-center gap-4 first-of-type:!border-t-0 first-of-type:rounded-t-md last-of-type:rounded-b-md [*:not(:last-child)]:border-b px-4 py-3 border-b last:border-b-0',

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -8,6 +8,7 @@
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
 	import Tooltip from '../../meltComponents/Tooltip.svelte'
 	import Checkbox from '../checkbox/Checkbox.svelte'
+	import type { RowSelection } from './rowSelection'
 
 	interface Props {
 		marked: string | undefined
@@ -24,6 +25,9 @@
 		 * children — checkbox, buttons, links) toggles selection. Opt-in so
 		 * existing tables that don't want it are unaffected. */
 		selectOnRowClick?: boolean
+		/** Home-style multi-select: the kind icon doubles as the checkbox instead
+		 * of adding a column, so an unused selection costs the row nothing. */
+		rowSelection?: RowSelection
 		alignWithSelectable?: boolean
 		errorHandlerMuted?: boolean
 		aiId?: string | undefined
@@ -80,6 +84,7 @@
 		isSelectable = false,
 		selectDisabledReason = undefined,
 		selectOnRowClick = false,
+		rowSelection = undefined,
 		alignWithSelectable = false,
 		errorHandlerMuted = false,
 		aiId = undefined,
@@ -113,6 +118,9 @@
 	})
 
 	const clickToSelect = $derived(selectOnRowClick && isSelectable && !disabled)
+	// Once selection mode is on the whole card toggles, and the title stops being
+	// a link so a stray click can't navigate out of the selection.
+	const inSelectionMode = $derived(!!rowSelection?.active)
 
 	// Interactive children that handle their own activation — selecting the row on
 	// top of them would double-fire (mouse) or hijack their keyboard activation.
@@ -121,6 +129,11 @@
 	}
 
 	function handleRowClick(e: MouseEvent) {
+		if (inSelectionMode) {
+			if (fromInteractiveChild(e)) return
+			rowSelection?.onToggle(e)
+			return
+		}
 		if (!clickToSelect) return
 		// Don't double-toggle when the click originated from an interactive child
 		// (the checkbox itself, action buttons, or the title link).
@@ -157,12 +170,17 @@
      with its sibling folder at the same depth. -->
 <div
 	bind:this={rowEl}
+	data-home-row-key={rowSelection?.key}
 	class={twMerge(
-		'w-full inline-flex items-center gap-4 first-of-type:!border-t-0 first-of-type:rounded-t-md last-of-type:rounded-b-md [*:not(:last-child)]:border-b px-4 py-3 border-b last:border-b-0',
+		'group/row w-full inline-flex items-center gap-4 first-of-type:!border-t-0 first-of-type:rounded-t-md last-of-type:rounded-b-md [*:not(:last-child)]:border-b px-4 py-3 border-b last:border-b-0',
 		depth > 0 ? '!rounded-none' : '',
 		disabled ? 'opacity-25' : 'hover:bg-surface-hover',
-		clickToSelect ? 'cursor-pointer select-none' : '',
-		selected ? 'bg-surface-accent-selected' : keyboardSelected ? 'bg-gray-200 dark:bg-gray-700' : ''
+		clickToSelect || inSelectionMode ? 'cursor-pointer select-none' : '',
+		selected || rowSelection?.selected
+			? 'bg-surface-accent-selected'
+			: keyboardSelected
+				? 'bg-gray-200 dark:bg-gray-700'
+				: ''
 	)}
 	style={depth > 0 ? `padding-left: ${(depth + 1) * 16}px;` : ''}
 	role={clickToSelect ? 'button' : undefined}
@@ -181,16 +199,48 @@
 		<div class="rounded max-w-4 w-full"></div>
 	{/if}
 
-	{#if href}
+	{#if rowSelection}
+		<!-- The icon slot itself: the kind icon until the row is hovered (or
+		     selection mode is on), the checkbox from then on. Both are stacked in a
+		     fixed 16px box and swapped with visibility so nothing shifts. -->
+		<div class="shrink relative w-4 h-4">
+			<div
+				class={twMerge(
+					'absolute inset-0',
+					rowSelection.active ? 'invisible' : 'group-hover/row:invisible'
+				)}
+			>
+				<RowIcon {kind} {triggerKind} />
+			</div>
+			<Checkbox
+				class={twMerge(
+					'absolute inset-0 w-4 h-4',
+					rowSelection.active ? '' : 'invisible group-hover/row:visible'
+				)}
+				checked={rowSelection.selected}
+				title={rowSelection.selected ? 'Deselect' : 'Select (shift-click to select a range)'}
+				onClick={(e) => {
+					// Left unprevented on purpose: the browser's own toggle already lands
+					// on the value we are about to compute, except on a range re-select,
+					// which Checkbox re-asserts. Preventing it would revert the box AFTER
+					// the update and leave every clicked row visually unticked.
+					e.stopPropagation()
+					rowSelection?.onToggle(e)
+				}}
+			/>
+		</div>
+	{/if}
+
+	{#if href && !inSelectionMode}
 		<a
 			{href}
 			data-row-keyboard-selected={keyboardSelected ? 'true' : undefined}
 			class="min-w-0 grow hover:underline decoration-gray-400 inline-flex items-center gap-4"
 		>
-			{@render rowContent()}
+			{@render rowContent(!rowSelection)}
 		</a>
 	{:else}
-		{@render rowContent()}
+		{@render rowContent(!rowSelection)}
 	{/if}
 
 	{#if errorHandlerMuted}
@@ -216,11 +266,13 @@
 	</div>
 </div>
 
-{#snippet rowContent()}
-	<div class="shrink">
-		<RowIcon {kind} {triggerKind} />
-	</div>
-	<div class="grow">
+{#snippet rowContent(withIcon: boolean)}
+	{#if withIcon}
+		<div class="shrink">
+			<RowIcon {kind} {triggerKind} />
+		</div>
+	{/if}
+	<div class="grow min-w-0">
 		<div class="text-emphasis flex-wrap text-left text-xs font-semibold">
 			{#if customSummary}
 				{@render customSummary?.()}

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -171,6 +171,7 @@
 <div
 	bind:this={rowEl}
 	data-home-row-key={rowSelection?.key}
+	data-row-keyboard-selected={keyboardSelected ? 'true' : undefined}
 	class={twMerge(
 		'group/row w-full inline-flex items-center gap-4 first-of-type:!border-t-0 first-of-type:rounded-t-md last-of-type:rounded-b-md [*:not(:last-child)]:border-b px-4 py-3 border-b last:border-b-0',
 		depth > 0 ? '!rounded-none' : '',
@@ -234,7 +235,6 @@
 	{#if href && !inSelectionMode}
 		<a
 			{href}
-			data-row-keyboard-selected={keyboardSelected ? 'true' : undefined}
 			class="min-w-0 grow hover:underline decoration-gray-400 inline-flex items-center gap-4"
 		>
 			{@render rowContent(!rowSelection)}

--- a/frontend/src/lib/components/common/table/ScriptRow.svelte
+++ b/frontend/src/lib/components/common/table/ScriptRow.svelte
@@ -16,6 +16,7 @@
 	import Badge from '../badge/Badge.svelte'
 	import Button from '../button/Button.svelte'
 	import Row from './Row.svelte'
+	import type { RowSelection } from './rowSelection'
 	import { sendUserToast } from '$lib/toast'
 	import { capitalize, copyToClipboard, isOwner } from '$lib/utils'
 	import { isDeployable } from '$lib/utils_deployable'
@@ -68,6 +69,7 @@
 		menuOpen?: boolean
 		showEditButton?: boolean
 		keyboardSelected?: boolean
+		rowSelection?: RowSelection
 	}
 
 	let {
@@ -82,7 +84,8 @@
 		depth = 0,
 		menuOpen = $bindable(false),
 		showEditButton = $bindable(true),
-		keyboardSelected = false
+		keyboardSelected = false,
+		rowSelection = undefined
 	}: Props = $props()
 
 	const dispatch = createEventDispatcher()
@@ -153,6 +156,7 @@
 	canFavorite={!script.draft_only}
 	{depth}
 	{keyboardSelected}
+	{rowSelection}
 >
 	{#snippet badges()}
 		{#if script.lock_error_logs}

--- a/frontend/src/lib/components/common/table/rowSelection.ts
+++ b/frontend/src/lib/components/common/table/rowSelection.ts
@@ -5,8 +5,8 @@
  * column — this variant leaves the default row untouched until it is used.
  */
 export type RowSelection = {
-	/** Stable row identity; also emitted as `data-home-row-key` so a shift-click
-	 * range can read the rendered order back from the DOM. */
+	/** Stable row identity; also emitted as `data-row-selection-key` so a caller
+	 * can read the rendered order back from the DOM (for a shift-click range). */
 	key: string
 	selected: boolean
 	/** Selection mode is on: every row shows its checkbox, and clicking the row

--- a/frontend/src/lib/components/common/table/rowSelection.ts
+++ b/frontend/src/lib/components/common/table/rowSelection.ts
@@ -1,0 +1,16 @@
+/**
+ * Wiring for a row whose kind icon doubles as a selection control: the icon
+ * swaps to a checkbox on hover, and stays one while a selection is active.
+ * Distinct from `Row`'s `isSelectable`, which adds a permanent leading checkbox
+ * column — this variant leaves the default row untouched until it is used.
+ */
+export type RowSelection = {
+	/** Stable row identity; also emitted as `data-home-row-key` so a shift-click
+	 * range can read the rendered order back from the DOM. */
+	key: string
+	selected: boolean
+	/** Selection mode is on: every row shows its checkbox, and clicking the row
+	 * toggles it instead of opening the item. */
+	active: boolean
+	onToggle: (e: MouseEvent | KeyboardEvent) => void
+}

--- a/frontend/src/lib/components/home/BulkActionsBar.svelte
+++ b/frontend/src/lib/components/home/BulkActionsBar.svelte
@@ -124,18 +124,20 @@
 		if (action === 'discard') invalidateWorkspaceDrafts(workspace)
 		const failed = res.filter((o) => o.error != undefined)
 		await onDone()
+		// Only what the batch actually changed leaves the selection. The rows it
+		// skipped as ineligible stay ticked so the next action can still address
+		// them — a partial failure must not drop them along with the successes.
+		const untouched = items.filter((i) => !batch.some((b) => b.key === i.key)).map((i) => i.key)
 		if (failed.length === 0) {
-			sendUserToast(`${ACTION_LABEL[action]}: ${res.length} item${res.length === 1 ? '' : 's'}`)
-			// Only the acted-on items leave the selection: a filtered batch keeps the
-			// rest ticked so the next action can still address them.
-			selection.keepOnly(items.filter((i) => !batch.some((b) => b.key === i.key)).map((i) => i.key))
+			sendUserToast(`${ACTION_LABEL[action]}: ${res.length} item${plural(res.length)}`)
+			selection.keepOnly(untouched)
 			close()
 			return
 		}
-		// Keep the failures ticked (and the modal open, listing them) so they can be
-		// retried without rebuilding the selection.
+		// Keep the failures ticked too (and the modal open, listing them) so they can
+		// be retried without rebuilding the selection.
 		outcomes = res
-		selection.keepOnly(failed.map((o) => o.item.key))
+		selection.keepOnly([...untouched, ...failed.map((o) => o.item.key)])
 	}
 </script>
 

--- a/frontend/src/lib/components/home/BulkActionsBar.svelte
+++ b/frontend/src/lib/components/home/BulkActionsBar.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+	/**
+	 * Contextual bar for the Home page's multi-selection: what can be done to the
+	 * current selection, why the rest can't, and the confirmation + per-item
+	 * outcome of the run.
+	 */
+	import { Alert, Button } from '$lib/components/common'
+	import ConfirmationModal from '$lib/components/common/confirmationModal/ConfirmationModal.svelte'
+	import DropdownV2 from '$lib/components/DropdownV2.svelte'
+	import Select from '$lib/components/select/Select.svelte'
+	import Label from '$lib/components/Label.svelte'
+	import { sendUserToast } from '$lib/toast'
+	import { invalidateWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
+	import { Archive, ArchiveRestore, FolderInput, MoreHorizontal, Trash, X } from 'lucide-svelte'
+	import {
+		blockedReason,
+		eligible,
+		movedPath,
+		runBulk,
+		type BulkAction,
+		type BulkContext,
+		type BulkOutcome
+	} from './bulkActions'
+	import type { BulkItem, HomeSelection } from './homeSelection.svelte'
+
+	interface Props {
+		selection: HomeSelection
+		workspace: string
+		isAdmin: boolean
+		/** Owner prefixes (`f/<folder>` / `u/<user>`) the user may move items into. */
+		moveTargets: string[]
+		/** Refresh the list and its counts once the batch is done. */
+		onDone: () => Promise<void> | void
+	}
+
+	let { selection, workspace, isAdmin, moveTargets, onDone }: Props = $props()
+
+	let ctx: BulkContext = $derived({ workspace, isAdmin })
+	let items = $derived(selection.items)
+
+	const plural = (n: number) => (n === 1 ? '' : 's')
+	const ACTION_LABEL: Record<BulkAction, string> = {
+		move: 'Move',
+		archive: 'Archive',
+		unarchive: 'Unarchive',
+		delete: 'Delete',
+		discard: 'Discard drafts'
+	}
+	const MODAL_TITLE: Record<BulkAction, (n: number) => string> = {
+		move: (n) => `Move ${n} item${plural(n)}`,
+		archive: (n) => `Archive ${n} item${plural(n)}`,
+		unarchive: (n) => `Unarchive ${n} item${plural(n)}`,
+		delete: (n) => `Delete ${n} item${plural(n)}`,
+		discard: (n) => `Discard ${n} draft${plural(n)}`
+	}
+
+	function targets(action: BulkAction): BulkItem[] {
+		return eligible(action, items, ctx)
+	}
+
+	/** Every distinct reason the ineligible rows are out, so both the disabled
+	 * action and the modal can say whether the limit comes from permissions, the
+	 * item's kind, or its state. Empty when the whole selection is eligible. */
+	function blockedSummary(action: BulkAction): string {
+		return [
+			...new Set(
+				items.map((i) => blockedReason(action, i, ctx)).filter((r): r is string => r != undefined)
+			)
+		].join('; ')
+	}
+
+	function actionTitle(action: BulkAction): string {
+		const n = targets(action).length
+		if (n === 0) return `Cannot ${ACTION_LABEL[action].toLowerCase()}: ${blockedSummary(action)}`
+		if (n < items.length) return `${ACTION_LABEL[action]} ${n} of the ${items.length} selected`
+		return `${ACTION_LABEL[action]} ${n} item${plural(n)}`
+	}
+
+	function countSuffix(action: BulkAction): string {
+		const n = targets(action).length
+		return n > 0 && n < items.length ? ` (${n})` : ''
+	}
+
+	let pending = $state<BulkAction | undefined>(undefined)
+	let moveTarget = $state<string | undefined>(undefined)
+	let running = $state(false)
+	let progress = $state(0)
+	let outcomes = $state<BulkOutcome[] | undefined>(undefined)
+
+	let pendingItems = $derived(pending ? targets(pending) : [])
+	let failures = $derived(outcomes?.filter((o) => o.error != undefined) ?? [])
+	// A discard removes a draft-only item outright but only the draft of a
+	// deployed one — the modal has to name which paths go for good.
+	let discardDeletes = $derived(pendingItems.filter((i) => i.draftOnly))
+	let discardReverts = $derived(pendingItems.filter((i) => !i.draftOnly))
+
+	function open(action: BulkAction) {
+		if (targets(action).length === 0) return
+		pending = action
+		outcomes = undefined
+		progress = 0
+		moveTarget = action === 'move' ? moveTargets[0] : undefined
+	}
+
+	function close() {
+		pending = undefined
+		outcomes = undefined
+		running = false
+	}
+
+	async function confirm() {
+		const action = pending
+		if (!action || running) return
+		if (action === 'move' && !moveTarget) return
+		running = true
+		progress = 0
+		outcomes = undefined
+		const batch = pendingItems
+		const res = await runBulk(action, batch, ctx, {
+			target: moveTarget,
+			onProgress: (done) => (progress = done)
+		})
+		running = false
+		if (action === 'discard') invalidateWorkspaceDrafts(workspace)
+		const failed = res.filter((o) => o.error != undefined)
+		await onDone()
+		if (failed.length === 0) {
+			sendUserToast(`${ACTION_LABEL[action]}: ${res.length} item${res.length === 1 ? '' : 's'}`)
+			// Only the acted-on items leave the selection: a filtered batch keeps the
+			// rest ticked so the next action can still address them.
+			selection.keepOnly(items.filter((i) => !batch.some((b) => b.key === i.key)).map((i) => i.key))
+			close()
+			return
+		}
+		// Keep the failures ticked (and the modal open, listing them) so they can be
+		// retried without rebuilding the selection.
+		outcomes = res
+		selection.keepOnly(failed.map((o) => o.item.key))
+	}
+</script>
+
+<div
+	class="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-2 rounded-md border bg-surface px-3 py-2 shadow-lg"
+>
+	<span class="text-xs font-semibold text-emphasis whitespace-nowrap">
+		{selection.size} selected
+	</span>
+	<div class="h-4 border-l"></div>
+	<Button
+		variant="subtle"
+		unifiedSize="sm"
+		startIcon={{ icon: FolderInput }}
+		disabled={targets('move').length === 0}
+		title={actionTitle('move')}
+		on:click={() => open('move')}
+	>
+		Move{countSuffix('move')}
+	</Button>
+	{#if targets('unarchive').length > targets('archive').length}
+		<Button
+			variant="subtle"
+			unifiedSize="sm"
+			startIcon={{ icon: ArchiveRestore }}
+			disabled={targets('unarchive').length === 0}
+			title={actionTitle('unarchive')}
+			on:click={() => open('unarchive')}
+		>
+			Unarchive{countSuffix('unarchive')}
+		</Button>
+	{:else}
+		<Button
+			variant="subtle"
+			unifiedSize="sm"
+			startIcon={{ icon: Archive }}
+			disabled={targets('archive').length === 0}
+			title={actionTitle('archive')}
+			on:click={() => open('archive')}
+		>
+			Archive{countSuffix('archive')}
+		</Button>
+	{/if}
+	<DropdownV2
+		placement="top-end"
+		items={[
+			{
+				displayName: `Discard drafts${countSuffix('discard')}`,
+				icon: Trash,
+				action: () => open('discard'),
+				disabled: targets('discard').length === 0
+			},
+			{
+				displayName: `Delete${countSuffix('delete')}`,
+				icon: Trash,
+				type: 'delete' as const,
+				action: () => open('delete'),
+				disabled: targets('delete').length === 0
+			}
+		]}
+	>
+		{#snippet buttonReplacement()}
+			<Button
+				nonCaptureEvent
+				variant="subtle"
+				unifiedSize="sm"
+				startIcon={{ icon: MoreHorizontal }}
+				title="More actions"
+			>
+				More
+			</Button>
+		{/snippet}
+	</DropdownV2>
+	<div class="h-4 border-l"></div>
+	<Button
+		variant="subtle"
+		unifiedSize="sm"
+		iconOnly
+		startIcon={{ icon: X }}
+		title="Cancel selection (Esc)"
+		on:click={() => selection.exit()}
+	/>
+</div>
+
+<ConfirmationModal
+	open={pending != undefined}
+	title={pending ? MODAL_TITLE[pending](pendingItems.length) : ''}
+	confirmationText={failures.length > 0 ? 'Retry' : pending ? ACTION_LABEL[pending] : ''}
+	type={pending === 'delete' || pending === 'discard' ? 'danger' : 'info'}
+	loading={running}
+	onCanceled={close}
+	onConfirmed={confirm}
+>
+	<div class="flex flex-col w-full gap-4 text-sm">
+		{#if pending === 'move'}
+			<Label label="Destination folder">
+				<Select
+					items={moveTargets.map((t) => ({ label: t, value: t }))}
+					bind:value={moveTarget}
+					placeholder="Select a folder"
+				/>
+			</Label>
+			{#if moveTarget}
+				{@const target = moveTarget}
+				{@render pathList(
+					'Will be moved to',
+					pendingItems.map((i) => `${i.path} → ${movedPath(i, target)}`)
+				)}
+			{/if}
+		{:else if pending === 'discard'}
+			{#if discardDeletes.length > 0}
+				<Alert type="warning" title="Permanently removed">
+					These exist only as your draft, so discarding deletes them outright.
+				</Alert>
+				{@render pathList(
+					'',
+					discardDeletes.map((i) => i.displayPath)
+				)}
+			{/if}
+			{#if discardReverts.length > 0}
+				{@render pathList(
+					'Draft removed, deployed version kept',
+					discardReverts.map((i) => i.displayPath)
+				)}
+			{/if}
+		{:else if pending === 'delete'}
+			<Alert type="warning" title="Permanently deleted">
+				Deleted items are gone from the workspace; only a workspace admin can recover them from the
+				trash bin.
+			</Alert>
+			{@render pathList(
+				'',
+				pendingItems.map((i) => i.displayPath)
+			)}
+		{:else if pending != undefined}
+			{@render pathList(
+				'',
+				pendingItems.map((i) => i.displayPath)
+			)}
+		{/if}
+
+		{#if pending && pendingItems.length < items.length}
+			{@const skipped = items.length - pendingItems.length}
+			<div class="text-xs text-hint">
+				{skipped} selected item{plural(skipped)} left untouched: {blockedSummary(pending)}
+			</div>
+		{/if}
+
+		{#if running}
+			<div class="text-xs text-secondary">{progress} / {pendingItems.length} done…</div>
+		{/if}
+
+		{#if failures.length > 0}
+			<Alert type="error" title="{failures.length} failed">
+				<div class="flex flex-col gap-1 mt-1 max-h-48 overflow-y-auto">
+					{#each failures as f (f.item.key)}
+						<div class="text-2xs">
+							<span class="font-mono">{f.item.displayPath}</span>: {f.error}
+						</div>
+					{/each}
+				</div>
+			</Alert>
+		{/if}
+	</div>
+</ConfirmationModal>
+
+{#snippet pathList(title: string, paths: string[])}
+	<div class="flex flex-col gap-1">
+		{#if title}
+			<span class="text-xs font-semibold text-secondary">{title}</span>
+		{/if}
+		<div class="flex flex-col gap-0.5 max-h-48 overflow-y-auto border rounded-md p-2">
+			{#each paths as p, i (i)}
+				<span class="text-2xs font-mono text-primary truncate" title={p}>{p}</span>
+			{/each}
+		</div>
+	</div>
+{/snippet}

--- a/frontend/src/lib/components/home/BulkActionsBar.svelte
+++ b/frontend/src/lib/components/home/BulkActionsBar.svelte
@@ -71,6 +71,9 @@
 
 	function actionTitle(action: BulkAction): string {
 		const n = targets(action).length
+		// Selection mode is entered from the toolbar with nothing picked yet, so this
+		// is the state the primary entry point lands on — it has no blocked reason.
+		if (items.length === 0) return `Select items to ${ACTION_LABEL[action].toLowerCase()}`
 		if (n === 0) return `Cannot ${ACTION_LABEL[action].toLowerCase()}: ${blockedSummary(action)}`
 		if (n < items.length) return `${ACTION_LABEL[action]} ${n} of the ${items.length} selected`
 		return `${ACTION_LABEL[action]} ${n} item${plural(n)}`
@@ -119,28 +122,37 @@
 		progress = 0
 		outcomes = undefined
 		const batch = pendingItems
-		const res = await runBulk(action, batch, ctx, {
-			target: moveTarget,
-			onProgress: (done) => (progress = done)
-		})
-		running = false
-		if (action === 'discard') invalidateWorkspaceDrafts(workspace)
-		const failed = res.filter((o) => o.error != undefined)
-		await onDone()
-		// Only what the batch actually changed leaves the selection. The rows it
-		// skipped as ineligible stay ticked so the next action can still address
-		// them — a partial failure must not drop them along with the successes.
-		const untouched = items.filter((i) => !batch.some((b) => b.key === i.key)).map((i) => i.key)
-		if (failed.length === 0) {
-			sendUserToast(`${ACTION_LABEL[action]}: ${res.length} item${plural(res.length)}`)
-			selection.keepOnly(untouched)
-			close()
-			return
+		let finished = false
+		try {
+			const res = await runBulk(action, batch, ctx, {
+				target: moveTarget,
+				onProgress: (done) => (progress = done)
+			})
+			if (action === 'discard') invalidateWorkspaceDrafts(workspace)
+			const failed = res.filter((o) => o.error != undefined)
+			// `running` is still set across the refetch: it is what keeps the dialog's
+			// Enter from starting the same batch again over an untrimmed selection.
+			await onDone()
+			// Only what the batch actually changed leaves the selection. The rows it
+			// skipped as ineligible stay ticked so the next action can still address
+			// them — a partial failure must not drop them along with the successes.
+			const untouched = items.filter((i) => !batch.some((b) => b.key === i.key)).map((i) => i.key)
+			if (failed.length === 0) {
+				sendUserToast(`${ACTION_LABEL[action]}: ${res.length} item${plural(res.length)}`)
+				selection.keepOnly(untouched)
+				finished = true
+				return
+			}
+			// Keep the failures ticked too (and the modal open, listing them) so they
+			// can be retried without rebuilding the selection.
+			outcomes = res
+			selection.keepOnly([...untouched, ...failed.map((o) => o.item.key)])
+		} finally {
+			// Released here and nowhere else: while it is set, Escape can't dismiss the
+			// dialog and both its buttons are disabled, so a throw would wedge it shut.
+			running = false
+			if (finished) close()
 		}
-		// Keep the failures ticked too (and the modal open, listing them) so they can
-		// be retried without rebuilding the selection.
-		outcomes = res
-		selection.keepOnly([...untouched, ...failed.map((o) => o.item.key)])
 	}
 </script>
 
@@ -194,14 +206,18 @@
 				displayName: `Discard drafts${countSuffix('discard')}`,
 				icon: Trash,
 				action: () => open('discard'),
-				disabled: targets('discard').length === 0
+				disabled: targets('discard').length === 0,
+				// Only while blocked: a disabled entry can't open its modal, so the reason
+				// has to live here — and an enabled one would render a pointless ⓘ.
+				tooltip: targets('discard').length === 0 ? actionTitle('discard') : undefined
 			},
 			{
 				displayName: `Delete${countSuffix('delete')}`,
 				icon: Trash,
 				type: 'delete' as const,
 				action: () => open('delete'),
-				disabled: targets('delete').length === 0
+				disabled: targets('delete').length === 0,
+				tooltip: targets('delete').length === 0 ? actionTitle('delete') : undefined
 			}
 		]}
 	>

--- a/frontend/src/lib/components/home/BulkActionsBar.svelte
+++ b/frontend/src/lib/components/home/BulkActionsBar.svelte
@@ -102,10 +102,13 @@
 		moveTarget = action === 'move' ? moveTargets[0] : undefined
 	}
 
+	// The dialog's Escape fires this even while its Cancel button is disabled by
+	// `loading`. A batch in flight cannot be called off, and closing over it would
+	// hide the progress and drop the per-item failures it is about to report.
 	function close() {
+		if (running) return
 		pending = undefined
 		outcomes = undefined
-		running = false
 	}
 
 	async function confirm() {
@@ -158,18 +161,10 @@
 	>
 		Move{countSuffix('move')}
 	</Button>
-	{#if targets('unarchive').length > targets('archive').length}
-		<Button
-			variant="subtle"
-			unifiedSize="sm"
-			startIcon={{ icon: ArchiveRestore }}
-			disabled={targets('unarchive').length === 0}
-			title={actionTitle('unarchive')}
-			on:click={() => open('unarchive')}
-		>
-			Unarchive{countSuffix('unarchive')}
-		</Button>
-	{:else}
+	<!-- Both render when both have targets: a selection mixing archived and active
+	     rows would otherwise be a dead end for whichever action lost the toss. With
+	     no targets either way, Archive stands alone and disabled, explaining why. -->
+	{#if targets('archive').length > 0 || targets('unarchive').length === 0}
 		<Button
 			variant="subtle"
 			unifiedSize="sm"
@@ -179,6 +174,17 @@
 			on:click={() => open('archive')}
 		>
 			Archive{countSuffix('archive')}
+		</Button>
+	{/if}
+	{#if targets('unarchive').length > 0}
+		<Button
+			variant="subtle"
+			unifiedSize="sm"
+			startIcon={{ icon: ArchiveRestore }}
+			title={actionTitle('unarchive')}
+			on:click={() => open('unarchive')}
+		>
+			Unarchive{countSuffix('unarchive')}
 		</Button>
 	{/if}
 	<DropdownV2

--- a/frontend/src/lib/components/home/Item.svelte
+++ b/frontend/src/lib/components/home/Item.svelte
@@ -10,6 +10,9 @@
 	import ShareModal from '../ShareModal.svelte'
 	import { createEventDispatcher } from 'svelte'
 	import { ArrowBigUp } from 'lucide-svelte'
+	import { userStore, workspaceStore } from '$lib/stores'
+	import { getHomeSelection, toBulkItem } from './homeSelection.svelte'
+	import type { RowSelection } from '../common/table/rowSelection'
 
 	const dispatch = createEventDispatcher()
 
@@ -34,6 +37,33 @@
 		showEditButton = true,
 		keyboardSelected = false
 	}: Props = $props()
+
+	// Read from context rather than threaded down: the tree renders items through
+	// several nested levels that have no other reason to know about selection.
+	const homeSelection = getHomeSelection()
+	// Raw apps are not selectable: none of the bulk actions can address one (they
+	// have no draft, archive or move route from Home).
+	let bulkItem = $derived(
+		homeSelection?.available && item.type !== 'raw_app'
+			? toBulkItem(item, $userStore, $workspaceStore)
+			: undefined
+	)
+	$effect(() => {
+		const b = bulkItem
+		if (!b || !homeSelection) return
+		homeSelection.register(b)
+		return () => homeSelection.unregister(b.key)
+	})
+	let rowSelection: RowSelection | undefined = $derived(
+		bulkItem && homeSelection
+			? {
+					key: bulkItem.key,
+					selected: homeSelection.has(bulkItem.key),
+					active: homeSelection.active,
+					onToggle: (e) => bulkItem && homeSelection.toggle(bulkItem, 'shiftKey' in e && e.shiftKey)
+				}
+			: undefined
+	)
 </script>
 
 {#if item.type == 'script'}
@@ -54,6 +84,7 @@
 		{showCode}
 		{showEditButton}
 		{keyboardSelected}
+		{rowSelection}
 	/>
 {:else if item.type == 'flow'}
 	<FlowRow
@@ -72,6 +103,7 @@
 		bind:menuOpen
 		{showEditButton}
 		{keyboardSelected}
+		{rowSelection}
 	/>
 {:else if item.type == 'app'}
 	<AppRow
@@ -86,6 +118,7 @@
 		bind:menuOpen
 		{showEditButton}
 		{keyboardSelected}
+		{rowSelection}
 	/>
 {:else if item.type == 'raw_app'}
 	<RawAppRow

--- a/frontend/src/lib/components/home/Item.svelte
+++ b/frontend/src/lib/components/home/Item.svelte
@@ -41,8 +41,10 @@
 	// Read from context rather than threaded down: the tree renders items through
 	// several nested levels that have no other reason to know about selection.
 	const homeSelection = getHomeSelection()
-	// Raw apps are not selectable: none of the bulk actions can address one (they
-	// have no draft, archive or move route from Home).
+	// A raw app the listing returns is an `app` row carrying `raw_app`, and is
+	// selectable like any other app. The separate `raw_app` type is the legacy
+	// listing shape, which renders through RawAppRow — no selection control there,
+	// so it must not enter the selection either.
 	let bulkItem = $derived(
 		homeSelection?.available && item.type !== 'raw_app'
 			? toBulkItem(item, $userStore, $workspaceStore)

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -19,6 +19,7 @@
 	import type uFuzzy from '@leeoniya/ufuzzy'
 	import {
 		ArrowDownUp,
+		CheckSquare,
 		ChevronsDownUp,
 		ChevronsUpDown,
 		Code2,
@@ -38,7 +39,7 @@
 	import ToggleButtonGroup from '../common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '../common/toggleButton-v2/ToggleButton.svelte'
 	import FlowIcon from './FlowIcon.svelte'
-	import { canWrite, getLocalSetting, storeLocalSetting } from '$lib/utils'
+	import { canWrite, getLocalSetting, isOwner, storeLocalSetting } from '$lib/utils'
 	import { sendUserToast } from '$lib/toast'
 	import { page } from '$app/state'
 	import { setQuery } from '$lib/navigation'
@@ -54,6 +55,8 @@
 	import TextInput from '../text_input/TextInput.svelte'
 	import { NetworkIcon } from 'lucide-svelte'
 	import { base } from '$lib/base'
+	import BulkActionsBar from './BulkActionsBar.svelte'
+	import { HomeSelection, setHomeSelection, toBulkItem } from './homeSelection.svelte'
 	interface Props {
 		filter?: string
 		subtab?: 'flow' | 'script' | 'app'
@@ -1135,6 +1138,11 @@
 		selectedIndex = previousNbDisplayed
 	}
 
+	// Elements that own the keyboard themselves (menus, dialogs, comboboxes): the
+	// list's own shortcuts stand down while one of them has focus.
+	const SKIP_SELECTOR =
+		'[role="menu"], [role="menuitem"], [role="dialog"], [role="listbox"], [role="combobox"], [aria-expanded="true"], [data-menu], [data-chat-keyboard-scope]'
+
 	function getSelectedRowActionButtons(): HTMLElement[] {
 		const anchor = document.querySelector<HTMLElement>('a[data-row-keyboard-selected="true"]')
 		const actions = anchor?.parentElement?.querySelector<HTMLElement>('[data-row-actions]')
@@ -1142,8 +1150,19 @@
 	}
 
 	function handleGlobalKeydown(e: KeyboardEvent) {
-		if (treeView) return
 		const target = e.target as HTMLElement | null
+
+		// Escape leaves selection mode from either view (everything below is flat-list
+		// navigation) — unless a menu or dialog owns the key, which closes itself first.
+		if (e.key === 'Escape' && homeSelection.active) {
+			const active = document.activeElement as HTMLElement | null
+			if (!target?.closest(SKIP_SELECTOR) && !active?.closest(SKIP_SELECTOR)) {
+				e.preventDefault()
+				homeSelection.exit()
+				return
+			}
+		}
+		if (treeView) return
 
 		// When focus is inside a row's action buttons, handle arrow keys ourselves:
 		//  - Left/Right cycle between buttons (Left from the first returns to search).
@@ -1223,8 +1242,7 @@
 			return
 		}
 
-		const skipSelector =
-			'[role="menu"], [role="menuitem"], [role="dialog"], [role="listbox"], [role="combobox"], [aria-expanded="true"], [data-menu], [data-chat-keyboard-scope]'
+		const skipSelector = SKIP_SELECTOR
 		if (target) {
 			const tag = target.tagName
 			const isEditable =
@@ -1285,7 +1303,15 @@
 				selectedIndex = selectedIndex - 1
 			}
 		} else if (e.key === 'Enter') {
-			if (selectedIndex === loadMoreIndex && hasMore) {
+			// In selection mode the rows carry no link, so Enter ticks the highlighted
+			// row instead of opening it.
+			if (homeSelection.active && selectedIndex >= 0 && selectedIndex < displayedItems.length) {
+				const item = displayedItems[selectedIndex]
+				if (item.type !== 'raw_app') {
+					e.preventDefault()
+					homeSelection.toggle(toBulkItem(item, $userStore, $workspaceStore), e.shiftKey)
+				}
+			} else if (selectedIndex === loadMoreIndex && hasMore) {
 				e.preventDefault()
 				loadMoreAndPreselectFirstNew()
 			} else if (selectedIndex >= 0 && selectedIndex < displayedItems.length) {
@@ -1313,6 +1339,29 @@
 	$effect(() => {
 		storeLocalSetting(INCLUDE_WITHOUT_MAIN_SETTING_NAME, includeWithoutMain ? 'true' : undefined)
 	})
+
+	// Multi-selection + bulk actions. Published through context so the tree's
+	// nested levels don't have to carry it; `Item` is the only reader.
+	const homeSelection = new HomeSelection()
+	setHomeSelection(homeSelection)
+	$effect(() => {
+		homeSelection.available = showEditButtons && !!$userStore && !$userStore.operator
+	})
+	// A selected path means nothing in another workspace. Narrowing the view
+	// within one (kind, owner, label, search) keeps the selection instead, so
+	// items can be gathered across several filters; every action lists the paths
+	// it will touch, so nothing acts invisibly.
+	$effect(() => {
+		$workspaceStore
+		untrack(() => homeSelection.exit())
+	})
+	// Only folders/user spaces the user owns: a move into any other lands as a
+	// per-item permission error the user could have been spared.
+	let moveTargets = $derived(
+		[...allFolderOwners, ...($userStore?.username ? [`u/${$userStore.username}`] : [])].filter(
+			(o) => isOwner(`${o}/x`, $userStore, $workspaceStore)
+		)
+	)
 </script>
 
 <SearchItems
@@ -1547,6 +1596,17 @@
 						{/if}
 					</Button>
 				{/if}
+				{#if homeSelection.available && !homeSelection.active}
+					<Button
+						unifiedSize="sm"
+						variant="subtle"
+						startIcon={{ icon: CheckSquare }}
+						title="Select several items to move, archive, delete or discard them at once"
+						on:click={() => homeSelection.enter()}
+					>
+						Select items
+					</Button>
+				{/if}
 			</div>
 		{/if}
 	</div>
@@ -1660,5 +1720,20 @@
 				{/if}
 			</div>
 		{/if}
+		{#if homeSelection.active}
+			<!-- The bar floats over the page bottom; without this the last rows sit
+			     under it with no way to scroll them clear. -->
+			<div class="h-20"></div>
+		{/if}
 	</div>
 </CenteredPage>
+
+{#if homeSelection.active && $workspaceStore}
+	<BulkActionsBar
+		selection={homeSelection}
+		workspace={$workspaceStore}
+		isAdmin={!!($userStore?.is_admin || $userStore?.is_super_admin)}
+		{moveTargets}
+		onDone={reloadItemsAndCounts}
+	/>
+{/if}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1143,17 +1143,29 @@
 	const SKIP_SELECTOR =
 		'[role="menu"], [role="menuitem"], [role="dialog"], [role="listbox"], [role="combobox"], [aria-expanded="true"], [data-menu], [data-chat-keyboard-scope]'
 
+	// The marker sits on the row itself, not on its title link — selection mode
+	// drops the link, and the action buttons must stay keyboard-reachable there too.
 	function getSelectedRowActionButtons(): HTMLElement[] {
-		const anchor = document.querySelector<HTMLElement>('a[data-row-keyboard-selected="true"]')
-		const actions = anchor?.parentElement?.querySelector<HTMLElement>('[data-row-actions]')
+		const actions = document.querySelector<HTMLElement>(
+			'[data-row-keyboard-selected="true"] [data-row-actions]'
+		)
 		return actions ? Array.from(actions.querySelectorAll<HTMLElement>('button, a[href]')) : []
 	}
 
 	function handleGlobalKeydown(e: KeyboardEvent) {
+		// An open dialog owns the keyboard, even when focus is still on the control
+		// that opened it (a modal opened from a button doesn't move focus). Checking
+		// only the focused element is not enough: this listener is registered on
+		// window in the capture phase before the dialog's own, so without this the
+		// list acts first — Enter would tick the highlighted row INTO the batch the
+		// dialog is confirming, and Escape would clear the whole selection instead of
+		// just dismissing the dialog. Dialogs are only in the DOM while open.
+		if (document.querySelector('[role="dialog"]')) return
+
 		const target = e.target as HTMLElement | null
 
-		// Escape leaves selection mode from either view (everything below is flat-list
-		// navigation) — unless a menu or dialog owns the key, which closes itself first.
+		// Escape leaves selection mode from either view; everything below is flat-list
+		// navigation. A menu that owns the key closes itself first.
 		if (e.key === 'Escape' && homeSelection.active) {
 			const active = document.activeElement as HTMLElement | null
 			if (!target?.closest(SKIP_SELECTOR) && !active?.closest(SKIP_SELECTOR)) {
@@ -1315,8 +1327,9 @@
 				e.preventDefault()
 				loadMoreAndPreselectFirstNew()
 			} else if (selectedIndex >= 0 && selectedIndex < displayedItems.length) {
+				// The row's title link is its first anchor (the action buttons follow it).
 				const anchor = document.querySelector<HTMLAnchorElement>(
-					'a[data-row-keyboard-selected="true"]'
+					'[data-row-keyboard-selected="true"] a[href]'
 				)
 				if (anchor) {
 					e.preventDefault()

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -499,20 +499,21 @@
 		// force: the owners are still marked loaded, so re-fetch their first page and
 		// swap it in place (loadOwnerItems replaces each owner's rows atomically — the
 		// old rows stay visible until the new ones arrive, so nothing blanks mid-reorder).
-		for (const o of toReload) loadOwnerItems(o, false, true)
+		// Awaited so a caller reconciling against the rendered rows sees the reloaded
+		// tree rather than the pre-reload ones; the per-owner swap stays atomic either way.
+		await Promise.all(toReload.map((o) => loadOwnerItems(o, false, true)))
 	}
 
 	// For row mutations (create/delete/move/archive), which also change how many
 	// runnables an owner holds. A scope change (sort/archive/kind/…) doesn't go
 	// through here: the counts resource keys on those itself.
 	async function reloadItemsAndCounts(): Promise<void> {
-		// A row mutated from its own menu (or by a bulk action) can be gone or sit at
-		// a new path afterwards; snapshot what was on screen so the selection can drop
-		// what this reload removes rather than keep pointing at a dead path.
+		// A mutated row can be gone, or sit at a new path, afterwards: snapshot what
+		// was on screen so the selection can drop what this reload removes instead of
+		// keeping a dead path. `tick` lets the reloaded rows re-register first.
 		const renderedBefore = homeSelection.renderedKeys
 		void ownerCountsRes.refetch()
 		await reloadItems()
-		// Let the rows re-render so the registry reflects the reloaded list.
 		await tick()
 		homeSelection.dropVanished(renderedBefore)
 	}
@@ -1160,11 +1161,10 @@
 	}
 
 	function handleGlobalKeydown(e: KeyboardEvent) {
-		// An open dialog owns the keyboard. Testing only the focused element misses
-		// it — a modal opened from a button leaves focus on that button — and this
-		// capture listener is registered before the dialog's, so the list would act
-		// first: Enter would tick a row into the batch being confirmed. Dialogs are
-		// in the DOM only while open.
+		// An open dialog owns the keyboard. Testing the focused element alone misses it
+		// (a modal opened from a button leaves focus on that button), and this capture
+		// listener runs before the dialog's, so Enter would tick a row into the batch
+		// being confirmed. Dialogs are in the DOM only while open.
 		if (document.querySelector('[role="dialog"]')) return
 
 		const target = e.target as HTMLElement | null

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1610,15 +1610,19 @@
 					</Button>
 				{/if}
 				{#if homeSelection.available && !homeSelection.active}
+					<!-- Last child of a flex-row-reverse row, so `mr-auto` absorbs the free
+					     space and pins it to the far left, away from the view/sort controls. -->
 					<Button
-						unifiedSize="sm"
-						variant="subtle"
+						wrapperClasses="mr-auto"
 						startIcon={{ icon: CheckSquare }}
-						title="Select several items to move, archive, delete or discard them at once"
+						iconOnly
+						size="xs"
+						color="light"
+						variant="default"
+						spacingSize="xs2"
+						title="Select items — move, archive, delete or discard several at once"
 						on:click={() => homeSelection.enter()}
-					>
-						Select items
-					</Button>
+					/>
 				{/if}
 			</div>
 		{/if}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -506,8 +506,15 @@
 	// runnables an owner holds. A scope change (sort/archive/kind/…) doesn't go
 	// through here: the counts resource keys on those itself.
 	async function reloadItemsAndCounts(): Promise<void> {
+		// A row mutated from its own menu (or by a bulk action) can be gone or sit at
+		// a new path afterwards; snapshot what was on screen so the selection can drop
+		// what this reload removes rather than keep pointing at a dead path.
+		const renderedBefore = homeSelection.renderedKeys
 		void ownerCountsRes.refetch()
 		await reloadItems()
+		// Let the rows re-render so the registry reflects the reloaded list.
+		await tick()
+		homeSelection.dropVanished(renderedBefore)
 	}
 
 	function filterItemsPathsBaseOnUserFilters(
@@ -1153,13 +1160,11 @@
 	}
 
 	function handleGlobalKeydown(e: KeyboardEvent) {
-		// An open dialog owns the keyboard, even when focus is still on the control
-		// that opened it (a modal opened from a button doesn't move focus). Checking
-		// only the focused element is not enough: this listener is registered on
-		// window in the capture phase before the dialog's own, so without this the
-		// list acts first — Enter would tick the highlighted row INTO the batch the
-		// dialog is confirming, and Escape would clear the whole selection instead of
-		// just dismissing the dialog. Dialogs are only in the DOM while open.
+		// An open dialog owns the keyboard. Testing only the focused element misses
+		// it — a modal opened from a button leaves focus on that button — and this
+		// capture listener is registered before the dialog's, so the list would act
+		// first: Enter would tick a row into the batch being confirmed. Dialogs are
+		// in the DOM only while open.
 		if (document.querySelector('[role="dialog"]')) return
 
 		const target = e.target as HTMLElement | null
@@ -1315,21 +1320,32 @@
 				selectedIndex = selectedIndex - 1
 			}
 		} else if (e.key === 'Enter') {
+			// Enter belongs to whatever control has focus — the action bar's buttons,
+			// a row's own actions, a link. Claiming it there would both suppress that
+			// control and act on the highlighted row instead.
+			if (target?.closest('button, a[href], [role="button"]')) return
 			// In selection mode the rows carry no link, so Enter ticks the highlighted
-			// row instead of opening it.
-			if (homeSelection.active && selectedIndex >= 0 && selectedIndex < displayedItems.length) {
-				const item = displayedItems[selectedIndex]
-				if (item.type !== 'raw_app') {
-					e.preventDefault()
-					homeSelection.toggle(toBulkItem(item, $userStore, $workspaceStore), e.shiftKey)
-				}
+			// row instead of opening it. Never for a legacy raw-app row, which carries
+			// no selection control — that falls through to opening it below.
+			if (
+				homeSelection.active &&
+				selectedIndex >= 0 &&
+				selectedIndex < displayedItems.length &&
+				displayedItems[selectedIndex].type !== 'raw_app'
+			) {
+				e.preventDefault()
+				homeSelection.toggle(
+					toBulkItem(displayedItems[selectedIndex], $userStore, $workspaceStore),
+					e.shiftKey
+				)
 			} else if (selectedIndex === loadMoreIndex && hasMore) {
 				e.preventDefault()
 				loadMoreAndPreselectFirstNew()
 			} else if (selectedIndex >= 0 && selectedIndex < displayedItems.length) {
-				// The row's title link is its first anchor (the action buttons follow it).
+				// Direct child only: that is the title link. Selection mode drops it, and
+				// a descendant match would find the row's Edit link and open the editor.
 				const anchor = document.querySelector<HTMLAnchorElement>(
-					'[data-row-keyboard-selected="true"] a[href]'
+					'[data-row-keyboard-selected="true"] > a[href]'
 				)
 				if (anchor) {
 					e.preventDefault()

--- a/frontend/src/lib/components/home/bulkActions.test.ts
+++ b/frontend/src/lib/components/home/bulkActions.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { blockedReason, movedPath, type BulkContext } from './bulkActions'
+import type { BulkItem } from './homeSelection.svelte'
+
+/** A fully-permitted, deployed row; each case overrides only what it is about. */
+function item(over: Partial<BulkItem> = {}): BulkItem {
+	return {
+		key: 'script/f/alpha/x',
+		kind: 'script',
+		path: 'f/alpha/x',
+		displayPath: 'f/alpha/x',
+		summary: '',
+		canWrite: true,
+		owner: true,
+		archived: false,
+		draftOnly: false,
+		isDraft: false,
+		rawApp: false,
+		...over
+	}
+}
+
+const admin: BulkContext = { workspace: 'w', isAdmin: true }
+const member: BulkContext = { workspace: 'w', isAdmin: false }
+
+// Each action's gate has to keep matching what the equivalent per-row menu entry
+// allows (common/table/{Script,Flow,App}Row.svelte, MoveDrawer.svelte) — a bulk
+// action that drifts looser than the single-row one is a permission hole.
+describe('blockedReason', () => {
+	it('lets a fully-permitted deployed row through every action it applies to', () => {
+		expect(blockedReason('move', item(), admin)).toBeUndefined()
+		expect(blockedReason('archive', item(), admin)).toBeUndefined()
+		expect(blockedReason('delete', item(), admin)).toBeUndefined()
+		expect(blockedReason('unarchive', item({ archived: true }), admin)).toBeUndefined()
+		expect(blockedReason('discard', item({ isDraft: true }), admin)).toBeUndefined()
+	})
+
+	it('gates delete per kind: script needs admin, flow needs owner, app needs write', () => {
+		expect(blockedReason('delete', item({ kind: 'script' }), member)).toBeDefined()
+		expect(blockedReason('delete', item({ kind: 'flow', owner: false }), member)).toBeDefined()
+		expect(blockedReason('delete', item({ kind: 'flow' }), member)).toBeUndefined()
+		// An app is deletable without ownership, matching AppRow's `disabled: !canEdit`.
+		expect(blockedReason('delete', item({ kind: 'app', owner: false }), member)).toBeUndefined()
+		expect(blockedReason('delete', item({ kind: 'app', canWrite: false }), member)).toBeDefined()
+	})
+
+	it('requires ownership to move, and refuses archived rows', () => {
+		expect(blockedReason('move', item({ owner: false }), admin)).toBeDefined()
+		expect(blockedReason('move', item({ canWrite: false }), admin)).toBeDefined()
+		expect(blockedReason('move', item({ archived: true }), admin)).toBeDefined()
+	})
+
+	it('archives only scripts and flows, and only in the matching state', () => {
+		expect(blockedReason('archive', item({ kind: 'app' }), admin)).toBeDefined()
+		expect(blockedReason('archive', item({ archived: true }), admin)).toBeDefined()
+		expect(blockedReason('unarchive', item({ archived: false }), admin)).toBeDefined()
+	})
+
+	it('routes a draft-only row to discard, never to move/archive/delete', () => {
+		const draftOnly = item({ draftOnly: true, isDraft: true })
+		expect(blockedReason('discard', draftOnly, admin)).toBeUndefined()
+		expect(blockedReason('move', draftOnly, admin)).toBeDefined()
+		expect(blockedReason('archive', draftOnly, admin)).toBeDefined()
+		expect(blockedReason('delete', draftOnly, admin)).toBeDefined()
+	})
+
+	it('has nothing to discard on a row with no draft of yours', () => {
+		expect(blockedReason('discard', item(), admin)).toBeDefined()
+	})
+})
+
+describe('movedPath', () => {
+	it('keeps everything below the owner prefix, so nested paths keep their shape', () => {
+		expect(movedPath(item({ path: 'f/alpha/x' }), 'f/beta')).toBe('f/beta/x')
+		expect(movedPath(item({ path: 'f/alpha/sub/x' }), 'f/beta')).toBe('f/beta/sub/x')
+		expect(movedPath(item({ path: 'u/ana/x' }), 'f/beta')).toBe('f/beta/x')
+	})
+})

--- a/frontend/src/lib/components/home/bulkActions.ts
+++ b/frontend/src/lib/components/home/bulkActions.ts
@@ -77,7 +77,7 @@ async function moveItem(ctx: BulkContext, item: BulkItem, target: string): Promi
 	if (newPath === item.path) return
 	await updateItemPathAndSummary({
 		workspace: ctx.workspace,
-		kind: item.kind === 'flow' ? 'flow' : item.kind === 'script' ? 'script' : 'app',
+		kind: item.kind,
 		initialPath: item.path,
 		newPath,
 		newSummary: item.summary
@@ -117,14 +117,8 @@ async function deleteItem(ctx: BulkContext, item: BulkItem): Promise<void> {
 }
 
 async function discardItemDraft(ctx: BulkContext, item: BulkItem): Promise<void> {
-	const kind =
-		item.kind === 'script'
-			? 'script'
-			: item.kind === 'flow'
-				? 'flow'
-				: item.rawApp
-					? 'raw_app'
-					: 'app'
+	// The draft overlay is the one place a raw app is its own kind.
+	const kind = item.kind === 'app' && item.rawApp ? 'raw_app' : item.kind
 	// invalidate=false: the caller refreshes the draft list once for the batch.
 	const res = await discardDraft(kind, item.path, ctx.workspace, item.draftOnly, false, false)
 	if (!res.success) throw new Error(res.error ?? 'discard failed')

--- a/frontend/src/lib/components/home/bulkActions.ts
+++ b/frontend/src/lib/components/home/bulkActions.ts
@@ -1,0 +1,174 @@
+/**
+ * Bulk operations behind the Home page's selection bar. Each runner performs
+ * exactly what the matching per-row menu entry does, once per selected item, so
+ * a batch can never take a path the single-row action wouldn't.
+ *
+ * Delete and discard stay distinct: discarding a draft on a deployed item only
+ * removes the draft, discarding a draft-only item removes the item, and deleting
+ * addresses the deployed row. A draft-only item is therefore not deletable —
+ * there is nothing deployed at its path.
+ */
+import { AppService, FlowService, ScriptService } from '$lib/gen'
+import { updateItemPathAndSummary } from '$lib/components/moveRenameManager'
+import { discardDraft } from '$lib/utils_draft_deploy'
+import type { BulkItem } from './homeSelection.svelte'
+
+export type BulkAction = 'move' | 'archive' | 'unarchive' | 'delete' | 'discard'
+
+export type BulkContext = {
+	workspace: string
+	/** Deleting a script is admin-only, mirroring the row menu. */
+	isAdmin: boolean
+}
+
+/** Why `action` cannot be applied to `item`; `undefined` means it can. The
+ * string is surfaced verbatim, so it has to say whether the limit comes from
+ * permissions, the item's kind, or its state. */
+export function blockedReason(
+	action: BulkAction,
+	item: BulkItem,
+	ctx: BulkContext
+): string | undefined {
+	const notOwner = 'you are not an owner of this path'
+	switch (action) {
+		case 'move':
+			if (item.draftOnly) return 'a draft-only item has no deployed path to move'
+			if (item.archived) return 'archived items cannot be moved'
+			if (!item.owner) return notOwner
+			if (!item.canWrite) return 'you do not have write permission on this path'
+			return undefined
+		case 'archive':
+		case 'unarchive':
+			if (item.kind !== 'script' && item.kind !== 'flow')
+				return 'only scripts and flows can be archived'
+			if (item.draftOnly) return 'a draft-only item has nothing deployed to archive'
+			if (!item.owner) return notOwner
+			if (!item.canWrite) return 'you do not have write permission on this path'
+			if (action === 'archive' && item.archived) return 'already archived'
+			if (action === 'unarchive' && !item.archived) return 'not archived'
+			return undefined
+		case 'delete':
+			if (item.draftOnly) return 'a draft-only item is removed by discarding its draft'
+			if (item.kind === 'script' && !ctx.isAdmin)
+				return 'deleting a script requires being a workspace admin'
+			if (item.kind === 'flow' && !item.owner) return notOwner
+			if (!item.canWrite) return 'you do not have write permission on this path'
+			return undefined
+		case 'discard':
+			if (!item.isDraft && !item.draftOnly) return 'no draft of yours on this item'
+			return undefined
+	}
+}
+
+export function eligible(action: BulkAction, items: BulkItem[], ctx: BulkContext): BulkItem[] {
+	return items.filter((i) => blockedReason(action, i, ctx) == undefined)
+}
+
+/** Where an item lands under `target` (`f/<folder>` or `u/<user>`): everything
+ * below its own owner prefix is preserved, so nested paths keep their shape. */
+export function movedPath(item: BulkItem, target: string): string {
+	const rest = item.path.split('/').slice(2).join('/')
+	return `${target}/${rest}`
+}
+
+async function moveItem(ctx: BulkContext, item: BulkItem, target: string): Promise<void> {
+	const newPath = movedPath(item, target)
+	// Re-saving a script at its current path would mint a pointless new version.
+	if (newPath === item.path) return
+	await updateItemPathAndSummary({
+		workspace: ctx.workspace,
+		kind: item.kind === 'flow' ? 'flow' : item.kind === 'script' ? 'script' : 'app',
+		initialPath: item.path,
+		newPath,
+		newSummary: item.summary
+	})
+}
+
+async function setArchived(ctx: BulkContext, item: BulkItem, archived: boolean): Promise<void> {
+	if (item.kind === 'flow') {
+		await FlowService.archiveFlowByPath({
+			workspace: ctx.workspace,
+			path: item.path,
+			requestBody: { archived }
+		})
+		return
+	}
+	if (archived) {
+		await ScriptService.archiveScriptByPath({ workspace: ctx.workspace, path: item.path })
+		return
+	}
+	// Scripts have no unarchive route: redeploying the current version as its own
+	// child clears the flag, exactly as the row menu does.
+	const r = await ScriptService.getScriptByPath({ workspace: ctx.workspace, path: item.path })
+	await ScriptService.createScript({
+		workspace: ctx.workspace,
+		requestBody: { ...r, parent_hash: r.hash, lock: r.lock }
+	})
+}
+
+async function deleteItem(ctx: BulkContext, item: BulkItem): Promise<void> {
+	if (item.kind === 'script') {
+		await ScriptService.deleteScriptByPath({ workspace: ctx.workspace, path: item.path })
+	} else if (item.kind === 'flow') {
+		await FlowService.deleteFlowByPath({ workspace: ctx.workspace, path: item.path })
+	} else {
+		await AppService.deleteApp({ workspace: ctx.workspace, path: item.path })
+	}
+}
+
+async function discardItemDraft(ctx: BulkContext, item: BulkItem): Promise<void> {
+	const kind =
+		item.kind === 'script'
+			? 'script'
+			: item.kind === 'flow'
+				? 'flow'
+				: item.rawApp
+					? 'raw_app'
+					: 'app'
+	// invalidate=false: the caller refreshes the draft list once for the batch.
+	const res = await discardDraft(kind, item.path, ctx.workspace, item.draftOnly, false, false)
+	if (!res.success) throw new Error(res.error ?? 'discard failed')
+}
+
+export type BulkOutcome = { item: BulkItem; error?: string }
+
+/**
+ * Apply `action` to each item in turn, never aborting the batch on a failure —
+ * every item gets its own outcome so partial success is reported rather than
+ * hidden. `onProgress` is called after each item with the number completed.
+ */
+export async function runBulk(
+	action: BulkAction,
+	items: BulkItem[],
+	ctx: BulkContext,
+	opts: { target?: string; onProgress?: (done: number) => void } = {}
+): Promise<BulkOutcome[]> {
+	const outcomes: BulkOutcome[] = []
+	for (const item of items) {
+		try {
+			switch (action) {
+				case 'move':
+					if (!opts.target) throw new Error('no target folder')
+					await moveItem(ctx, item, opts.target)
+					break
+				case 'archive':
+					await setArchived(ctx, item, true)
+					break
+				case 'unarchive':
+					await setArchived(ctx, item, false)
+					break
+				case 'delete':
+					await deleteItem(ctx, item)
+					break
+				case 'discard':
+					await discardItemDraft(ctx, item)
+					break
+			}
+			outcomes.push({ item })
+		} catch (e: any) {
+			outcomes.push({ item, error: e?.body ?? e?.message ?? String(e) })
+		}
+		opts.onProgress?.(outcomes.length)
+	}
+	return outcomes
+}

--- a/frontend/src/lib/components/home/homeSelection.svelte.ts
+++ b/frontend/src/lib/components/home/homeSelection.svelte.ts
@@ -10,7 +10,10 @@ import { isOwner } from '$lib/utils'
 import { effectivePath } from './treeViewUtils'
 import type { UserExt } from '$lib/stores'
 
-export type BulkKind = 'script' | 'flow' | 'app' | 'raw_app'
+/** A raw app is not a kind of its own here: the listing returns it as an `app`
+ * row carrying `raw_app`, which every action addresses through `BulkItem.rawApp`
+ * (only the draft overlay distinguishes the two). */
+export type BulkKind = 'script' | 'flow' | 'app'
 
 /** The flattened row facts every bulk action needs, snapshotted at selection
  * time so an action still knows what it is acting on after the list reloads. */
@@ -101,6 +104,11 @@ export class HomeSelection {
 
 	register(item: BulkItem): void {
 		this.registry.set(item.key, item)
+		// Refresh the snapshot of an already-selected row too: the per-row menu stays
+		// usable during a selection and every action reloads the list, so a row that
+		// was archived or lost write access meanwhile must not keep passing the
+		// eligibility gates on its stale copy.
+		if (this.selected.has(item.key)) this.selected.set(item.key, item)
 	}
 
 	unregister(key: string): void {

--- a/frontend/src/lib/components/home/homeSelection.svelte.ts
+++ b/frontend/src/lib/components/home/homeSelection.svelte.ts
@@ -1,0 +1,169 @@
+/**
+ * Multi-selection state for the Home page, shared by the flat list and the tree
+ * view. `ItemsList` owns the instance and publishes it through context; each
+ * `Item` reads it to render its row's selection affordance, so the state doesn't
+ * have to be threaded through `TreeViewRoot`/`TreeView`.
+ */
+import { getContext, setContext } from 'svelte'
+import { SvelteMap } from 'svelte/reactivity'
+import { isOwner } from '$lib/utils'
+import { effectivePath } from './treeViewUtils'
+import type { UserExt } from '$lib/stores'
+
+export type BulkKind = 'script' | 'flow' | 'app' | 'raw_app'
+
+/** The flattened row facts every bulk action needs, snapshotted at selection
+ * time so an action still knows what it is acting on after the list reloads. */
+export type BulkItem = {
+	key: string
+	kind: BulkKind
+	/** Storage path — what every API call addresses. */
+	path: string
+	/** What the row shows: a draft-only item is parked at a generated path but
+	 * named by the path typed in the editor. */
+	displayPath: string
+	summary: string
+	canWrite: boolean
+	owner: boolean
+	archived: boolean
+	draftOnly: boolean
+	/** The authed user has a draft at this path (the listing only flags their own). */
+	isDraft: boolean
+	rawApp: boolean
+}
+
+type RawItem = {
+	type?: string
+	path: string
+	summary?: string
+	canWrite?: boolean
+	archived?: boolean
+	draft_only?: boolean | null
+	draft_path?: string | null
+	is_draft?: boolean
+	raw_app?: boolean
+}
+
+/** Row identity for selection. Deliberately hash-free: archiving or renaming
+ * mints a new script hash, and a key that moved would orphan the selection. */
+export function bulkKey(item: { type?: string; path: string }): string {
+	return `${item.type}/${item.path}`
+}
+
+export function toBulkItem(
+	item: RawItem,
+	user: UserExt | undefined,
+	workspace: string | undefined
+): BulkItem {
+	return {
+		key: bulkKey(item),
+		kind: (item.type ?? 'script') as BulkKind,
+		path: item.path,
+		displayPath: effectivePath(item),
+		summary: item.summary ?? '',
+		canWrite: item.canWrite ?? false,
+		owner: isOwner(item.path, user, workspace),
+		archived: item.archived ?? false,
+		draftOnly: !!item.draft_only,
+		isDraft: !!item.is_draft,
+		rawApp: !!item.raw_app
+	}
+}
+
+export class HomeSelection {
+	/** The page offers multi-selection at all (never to an operator, and not on
+	 * the embedded read-only variants of the list). */
+	available = $state(false)
+	/** Selection mode is on even with nothing selected yet — entered from the
+	 * toolbar, so every row reveals its checkbox before the first pick. */
+	private explicit = $state(false)
+	private selected = new SvelteMap<string, BulkItem>()
+	/** Every rendered selectable row, so a shift-click range can resolve the keys
+	 * between the anchor and the clicked row back to items. */
+	private registry = new SvelteMap<string, BulkItem>()
+	private anchor: string | undefined = undefined
+
+	get active(): boolean {
+		return this.available && (this.explicit || this.selected.size > 0)
+	}
+
+	get size(): number {
+		return this.selected.size
+	}
+
+	get items(): BulkItem[] {
+		return [...this.selected.values()]
+	}
+
+	has(key: string): boolean {
+		return this.selected.has(key)
+	}
+
+	register(item: BulkItem): void {
+		this.registry.set(item.key, item)
+	}
+
+	unregister(key: string): void {
+		this.registry.delete(key)
+	}
+
+	enter(): void {
+		this.explicit = true
+	}
+
+	exit(): void {
+		this.explicit = false
+		this.selected.clear()
+		this.anchor = undefined
+	}
+
+	/** Keep only these keys selected (a bulk run leaves its failures ticked so
+	 * they can be retried); an empty result leaves selection mode entirely. */
+	keepOnly(keys: string[]): void {
+		const keep = new Set(keys)
+		for (const key of [...this.selected.keys()]) {
+			if (!keep.has(key)) this.selected.delete(key)
+		}
+		if (this.selected.size === 0) this.exit()
+		else this.anchor = undefined
+	}
+
+	toggle(item: BulkItem, range = false): void {
+		this.explicit = true
+		if (range && this.anchor != undefined && this.anchor !== item.key) {
+			if (this.selectRange(this.anchor, item.key)) return
+		}
+		if (this.selected.has(item.key)) this.selected.delete(item.key)
+		else this.selected.set(item.key, item)
+		this.anchor = item.key
+	}
+
+	/** Visual order is read back from the DOM: the tree nests rows and pages them
+	 * in lazily, so no single array holds the rendered order of both views.
+	 * Returns false when either end is off-screen, so the caller falls back to a
+	 * plain toggle rather than selecting an arbitrary span. */
+	private selectRange(from: string, to: string): boolean {
+		const keys = Array.from(document.querySelectorAll<HTMLElement>('[data-home-row-key]')).map(
+			(el) => el.dataset.homeRowKey ?? ''
+		)
+		const a = keys.indexOf(from)
+		const b = keys.indexOf(to)
+		if (a < 0 || b < 0) return false
+		for (const key of keys.slice(Math.min(a, b), Math.max(a, b) + 1)) {
+			const it = this.registry.get(key)
+			if (it) this.selected.set(key, it)
+		}
+		this.anchor = to
+		return true
+	}
+}
+
+const HOME_SELECTION_KEY = 'homeSelection'
+
+export function setHomeSelection(selection: HomeSelection): void {
+	setContext(HOME_SELECTION_KEY, selection)
+}
+
+export function getHomeSelection(): HomeSelection | undefined {
+	return getContext<HomeSelection | undefined>(HOME_SELECTION_KEY)
+}

--- a/frontend/src/lib/components/home/homeSelection.svelte.ts
+++ b/frontend/src/lib/components/home/homeSelection.svelte.ts
@@ -102,6 +102,25 @@ export class HomeSelection {
 		return this.selected.has(key)
 	}
 
+	/** Keys of the rows currently on screen. */
+	get renderedKeys(): Set<string> {
+		return new Set(this.registry.keys())
+	}
+
+	/**
+	 * Drop selections whose row was on screen before a reload and is gone after it:
+	 * the row was deleted or moved (a move changes its path, hence its key) from its
+	 * own menu, so its path is dead and a bulk action would address a stale one. A
+	 * row that was never on screen is left alone — a selection deliberately survives
+	 * narrowing the view, so absence alone doesn't mean the item is gone.
+	 */
+	dropVanished(renderedBefore: Set<string>): void {
+		for (const key of [...this.selected.keys()]) {
+			if (renderedBefore.has(key) && !this.registry.has(key)) this.selected.delete(key)
+		}
+		if (this.selected.size === 0) this.anchor = undefined
+	}
+
 	register(item: BulkItem): void {
 		this.registry.set(item.key, item)
 		// Refresh the snapshot of an already-selected row too: the per-row menu stays
@@ -151,8 +170,8 @@ export class HomeSelection {
 	 * Returns false when either end is off-screen, so the caller falls back to a
 	 * plain toggle rather than selecting an arbitrary span. */
 	private selectRange(from: string, to: string): boolean {
-		const keys = Array.from(document.querySelectorAll<HTMLElement>('[data-home-row-key]')).map(
-			(el) => el.dataset.homeRowKey ?? ''
+		const keys = Array.from(document.querySelectorAll<HTMLElement>('[data-row-selection-key]')).map(
+			(el) => el.dataset.rowSelectionKey ?? ''
 		)
 		const a = keys.indexOf(from)
 		const b = keys.indexOf(to)

--- a/frontend/src/lib/components/home/homeSelection.svelte.ts
+++ b/frontend/src/lib/components/home/homeSelection.svelte.ts
@@ -108,11 +108,10 @@ export class HomeSelection {
 	}
 
 	/**
-	 * Drop selections whose row was on screen before a reload and is gone after it:
-	 * the row was deleted or moved (a move changes its path, hence its key) from its
-	 * own menu, so its path is dead and a bulk action would address a stale one. A
-	 * row that was never on screen is left alone — a selection deliberately survives
-	 * narrowing the view, so absence alone doesn't mean the item is gone.
+	 * Drop selections whose row was on screen before a reload and is gone after it —
+	 * deleted, or moved to a new path and so a new key. A row that was never on
+	 * screen is left alone: a selection deliberately survives narrowing the view, so
+	 * absence there is not evidence the item is gone.
 	 */
 	dropVanished(renderedBefore: Set<string>): void {
 		for (const key of [...this.selected.keys()]) {

--- a/frontend/src/lib/components/home/homeSelection.test.ts
+++ b/frontend/src/lib/components/home/homeSelection.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { HomeSelection, type BulkItem } from './homeSelection.svelte'
+
+function bulk(key: string, over: Partial<BulkItem> = {}): BulkItem {
+	return {
+		key,
+		kind: 'script',
+		path: key.split('/').slice(1).join('/'),
+		displayPath: key.split('/').slice(1).join('/'),
+		summary: '',
+		canWrite: true,
+		owner: true,
+		archived: false,
+		draftOnly: false,
+		isDraft: false,
+		rawApp: false,
+		...over
+	}
+}
+
+function selectionOf(...items: BulkItem[]): HomeSelection {
+	const s = new HomeSelection()
+	s.available = true
+	for (const i of items) {
+		s.register(i)
+		s.toggle(i)
+	}
+	return s
+}
+
+// A row can be moved or deleted from its own menu while a selection is active,
+// and a bulk action addressing the dead path afterwards is the failure mode.
+describe('HomeSelection.dropVanished', () => {
+	it('drops a selected row that was on screen before the reload and is gone after', () => {
+		const a = bulk('script/f/a/one')
+		const b = bulk('script/f/a/two')
+		const s = selectionOf(a, b)
+		const before = s.renderedKeys
+
+		// `b` was deleted: its row unmounts and does not come back.
+		s.unregister(b.key)
+		s.dropVanished(before)
+
+		expect(s.items.map((i) => i.key)).toEqual([a.key])
+	})
+
+	it('re-keys a moved row: the old key goes, the new one is a fresh selection', () => {
+		const a = bulk('script/f/a/one')
+		const s = selectionOf(a)
+		const before = s.renderedKeys
+
+		// A move changes the path, hence the key — the row comes back as a new one.
+		s.unregister(a.key)
+		s.register(bulk('script/f/b/one'))
+		s.dropVanished(before)
+
+		expect(s.items).toEqual([])
+	})
+
+	it('keeps a selected row that was never on screen', () => {
+		// Selections survive narrowing the view, so a row absent from the reload is
+		// not evidence that it is gone.
+		const offScreen = bulk('script/f/other/one')
+		const s = selectionOf(offScreen)
+		s.unregister(offScreen.key)
+
+		s.dropVanished(new Set())
+
+		expect(s.items.map((i) => i.key)).toEqual([offScreen.key])
+	})
+})
+
+describe('HomeSelection.register', () => {
+	it('refreshes the snapshot of an already-selected row', () => {
+		const item = bulk('script/f/a/one')
+		const s = selectionOf(item)
+
+		// The row was archived from its own menu and re-rendered.
+		s.register(bulk('script/f/a/one', { archived: true }))
+
+		expect(s.items[0].archived).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

Closes #10449.

The Home page is where workspace scripts, flows and apps are browsed, but every management
action had to be performed one item at a time. This adds a multi-selection mode with a
contextual action bar, in both the flat list and the tree view.

Selection stays out of the way until it is used: the default row is visually unchanged, and a
row's kind icon swaps to a checkbox on hover. Clicking that checkbox enters selection mode
without opening the item; from then on every row shows its checkbox and clicking a row card
toggles it. Shift-click selects a range, Escape or the bar's Cancel leaves.

Covers stages 1 and 2 of the issue's plan (selection foundation + move / archive / discard /
delete). Stages 3 (duplicate/fork) and 4 (batch rename) are not included.

## Changes

**Selection**
- `home/homeSelection.svelte.ts` — a `HomeSelection` class published through context, so the
  tree's nested levels don't have to carry it; `home/Item.svelte` is its only reader, which
  covers the flat list and the tree at once.
- Shift-click ranges resolve visual order by reading `data-home-row-key` back out of the DOM —
  the tree nests rows and pages them in lazily, so no single array holds the rendered order of
  both views. Either end being off-screen falls back to a plain toggle.
- `common/table/Row.svelte` gains an opt-in `rowSelection` prop: the kind icon and the checkbox
  are stacked in a fixed 16px box and swapped with `visibility`, so nothing shifts. The row's
  title link is suppressed while a selection is active. Rows without the prop (the compare &
  deploy layout, `Dev.svelte`) are unaffected.
- A "Select items" toolbar button enters selection mode before the first pick.

**Bulk actions** (`home/bulkActions.ts`, `home/BulkActionsBar.svelte`)
- Move to folder, Archive / Unarchive, Delete, Discard drafts. Each runner performs exactly
  what the matching per-row menu entry does, once per item, so a batch can never take a path
  the single-row action wouldn't.
- Delete and discard stay distinct, per the issue: discarding a deployed item's draft only
  removes the draft, discarding a draft-only item removes the item, and a draft-only item is
  therefore not deletable — there is nothing deployed at its path.
- Only actions compatible with the selection are enabled, and the reason the rest are out is
  surfaced on the disabled button and in the modal ("only scripts and flows can be archived",
  "you are not an owner of this path", …). The confirmation modal groups affected items by
  outcome and names every path that goes for good.
- Batches run item by item and never abort on a failure: each item gets its own outcome, and
  the modal stays open listing the failures with a Retry. Failures and rows the batch skipped
  as ineligible both stay ticked; only what actually changed leaves the selection.
- Move targets are limited to folders and user spaces the caller owns, so a move can't fail as
  a permission error that could have been prevented.

**Gating** — the feature is off for operators and wherever the list is rendered without edit
buttons (a protected workspace). Per-action gates mirror the row menus: script delete requires
workspace admin, flow delete/archive requires ownership, app delete requires write, move
requires ownership (what `MoveDrawer` enforces).

## Test plan

- [x] `frontend/src/lib/components/home/bulkActions.test.ts` — 7 cases pinning `blockedReason`
      per kind/state and `movedPath` preserving sub-path segments
- [x] `npm run check` — 0 errors (65 warnings, all pre-existing)
- [x] Flat list and tree view: hover affordance, click-to-enter, shift-click ranges (including
      across an expanded folder boundary in the tree), row-card click toggling instead of
      navigating, Escape to leave
- [x] Every action end-to-end against a seeded workspace, DB verified after each: archive +
      unarchive a script and a flow; move two scripts `f/alpha → f/beta`; delete two apps and a
      script; discard a draft-only script, a draft-only flow, and a draft on a deployed script
- [x] Mixed selections: an app in an Archive batch is counted out and the modal explains why
- [x] Partial failure (one delete forced to 500): the failed row and the skipped ineligible row
      both stay selected, the successful one leaves, and the modal lists the per-item error
- [x] Raw apps (an `app` row carrying `raw_app`): selectable, move and draft-discard both route
      through the right kind
- [x] Keyboard: Escape with a confirmation dialog open dismisses only the dialog; Enter confirms
      the dialog without ticking the highlighted row into the batch; ArrowRight still reaches a
      row's action buttons in both modes

## Screenshots

Hover reveals the selection control in place of the kind icon — the rest of the list is unchanged.
The toolbar entry is the icon on the left of the controls row:

![hover-affordance](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-7fc6678d/1785833161-v2-1-hover-affordance.png)

Move, with the resulting paths spelled out and the ineligible rows accounted for:

![move-modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-7fc6678d/1785833164-v2-3-move-modal.png)

Discard, grouped by outcome — what is removed for good vs. what keeps its deployed version:

![discard-modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-7fc6678d/1785833166-v2-5-discard-modal.png)

Tree view, same affordance and bar:

![tree-selection](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-7fc6678d/1785833169-v2-6-tree-selection.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-select to the Home list and tree with bulk Move, Archive/Unarchive, Delete, and Discard to manage items faster without changing the default row layout. Implements stages 1–2 of Linear #10449; duplicate/fork and batch rename are not included.

- **New Features**
  - Multi-select mode: checkbox replaces the kind icon on hover or via the “Select items” toolbar icon; row click toggles while active; Shift-click selects ranges across list and tree; Esc exits.
  - Bulk actions: Move, Archive/Unarchive, Delete, Discard drafts. Only eligible actions enable with clear reasons; the modal lists paths and per-item results with retry. Batches run item-by-item; failed/ineligible stay selected; move targets are limited to owned folders/spaces.
  - Keyboard: Enter toggles the highlighted row in selection mode; arrow keys still reach action buttons; the title link is suppressed while selecting.

- **Bug Fixes**
  - Keyboard safety: ignore Enter when a button/link has focus and let open dialogs own the keyboard; Esc exits selection without closing modals.
  - Selection robustness: selection survives filter changes and reloads; items that vanished or re-keyed are dropped; already-selected rows refresh their snapshot after list updates.
  - Checkbox reliability: added `onClick` to capture Shift for range select and re-assert checked state to avoid visual mismatch.

<sup>Written for commit 101c531ed679e0b10dff1deadafb73f4e3391eb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

