### PR TITLE
fix: locate coursier artifacts by coordinate so private maven registries work

### DIFF
--- a/backend/windmill-worker/src/java_executor.rs
+++ b/backend/windmill-worker/src/java_executor.rs
@@ -525,16 +525,19 @@ async fn move_to_repository(
         let (mut subdirs, mut holds_artifact) = (vec![], false);
         let mut entries = tokio::fs::read_dir(dir).await?;
         while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name().to_string_lossy().into_owned();
             if entry.file_type().await?.is_dir() {
-                subdirs.push(entry);
+                subdirs.push((name, entry));
             } else {
-                holds_artifact = true;
+                // coursier's own bookkeeping (`.<name>.checked`, `.<name>.error`, checksums) is
+                // dot-prefixed; only a downloaded artifact is not
+                holds_artifact |= !name.starts_with('.');
             }
         }
-        // every repository coursier probed and got a 404 from is left with an empty directory at
-        // the coordinate, so the match only counts where the artifact itself landed: the first
-        // repository tried is a default one, and claiming its leftover would cache an empty
-        // directory as the installed artifact
+        // a repository coursier probed and did not get the artifact from keeps a directory at the
+        // coordinate holding nothing but that bookkeeping, and default repositories are probed
+        // before the configured ones, so claiming the first match would cache an empty directory
+        // as the installed artifact
         if holds_artifact {
             if let Some(w) = wanted
                 .iter_mut()
@@ -545,8 +548,8 @@ async fn move_to_repository(
                 return Ok(());
             }
         }
-        for entry in subdirs {
-            below.push(entry.file_name().to_string_lossy().into_owned());
+        for (name, entry) in subdirs {
+            below.push(name);
             find_and_copy(&entry.path(), below, wanted).await?;
             below.pop();
         }
@@ -1194,13 +1197,15 @@ mod tests {
         let central = format!("{fetch_dir}/https/repo1.maven.org/maven2");
         let nexus = format!("{fetch_dir}/https/nexus.local/repository/maven-public");
         touch(&format!("{central}/com/corp/public/1.0/public-1.0.jar")).await;
-        create_dir_all(format!("{nexus}/com/corp/public/1.0"))
-            .await
-            .unwrap();
+        touch(&format!(
+            "{nexus}/com/corp/public/1.0/.public-1.0.jar.error"
+        ))
+        .await;
         touch(&format!("{nexus}/com/corp/internal/1.0/internal-1.0.jar")).await;
-        create_dir_all(format!("{central}/com/corp/internal/1.0"))
-            .await
-            .unwrap();
+        touch(&format!(
+            "{central}/com/corp/internal/1.0/.internal-1.0.jar.error"
+        ))
+        .await;
 
         let deps = vec![
             dep(&repository_dir, "com/corp", "public", "1.0"),

--- a/backend/windmill-worker/src/java_executor.rs
+++ b/backend/windmill-worker/src/java_executor.rs
@@ -27,8 +27,8 @@ use windmill_queue::{append_logs, CanceledBy, MiniPulledJob};
 use crate::{
     common::{
         build_command_with_isolation, create_args_and_out_file, get_reserved_variables,
-        read_result, resolve_nsjail_timeout, resolve_nsjail_tmp_mount_block, start_child_process,
-        OccupancyMetrics,
+        read_result, resolve_job_timeout, resolve_nsjail_timeout, resolve_nsjail_tmp_mount_block,
+        start_child_process, OccupancyMetrics,
     },
     handle_child, is_sandboxing_enabled, read_ee_registry_bool_with_workspace_override,
     read_ee_registry_with_workspace_override,
@@ -299,11 +299,21 @@ pub async fn resolve<'a>(
                     std::env::var("TMP").unwrap_or_else(|_| String::from("/tmp")),
                 );
         }
-        // Resolution against a distant or slow registry can run for minutes, and the lockfile has to
-        // be read from a clean stdout, so it cannot go through handle_child's polling loop: without
-        // a ping of its own the job is reaped as a zombie and restarted mid-resolution.
+        // The lockfile has to be read from a clean stdout, so this cannot go through handle_child's
+        // polling loop. That leaves resolution with neither a ping nor a time bound of its own: it
+        // needs the heartbeat not to be reaped as a zombie mid-resolution, and the timeout so a
+        // wedged registry connection cannot park the job in `running` forever.
+        cmd.kill_on_drop(true);
+        let (timeout, ..) = resolve_job_timeout(conn, w_id, *job_id, None).await;
         let _heartbeat = JobPingHeartbeat::start(conn, *job_id, "java lockfile resolution");
-        let output = cmd.output().await?;
+        let output = tokio::time::timeout(timeout, cmd.output())
+            .await
+            .map_err(|_| {
+                Error::ExecutionErr(format!(
+                    "resolving the java lockfile timed out after {}s",
+                    timeout.as_secs()
+                ))
+            })??;
         // Check if the command was successful
         if output.status.success() {
             String::from_utf8(output.stdout).expect("Failed to convert output to String")
@@ -380,8 +390,8 @@ async fn install<'a>(
     );
     let job_dir = job_dir.to_owned();
     let fetch_dir = format!("{}/tmp-fetch-{}", *JAVA_CACHE_DIR, Uuid::new_v4());
-    let fetch_dir2 = fetch_dir.clone();
-    par_install_language_dependencies_all_at_once(
+    let (cmd_fetch_dir, postinstall_fetch_dir) = (fetch_dir.clone(), fetch_dir.clone());
+    let installed = par_install_language_dependencies_all_at_once(
         deps,
         "java",
         "java",
@@ -440,7 +450,7 @@ async fn install<'a>(
                 "--parallel",
                 &format!("{}", *JAVA_CONCURRENT_DOWNLOADS),
                 "--cache",
-                &fetch_dir,
+                &cmd_fetch_dir,
             ])
             .args(&repos)
             .arg("--intransitive")
@@ -460,11 +470,10 @@ async fn install<'a>(
             Ok(cmd)
         },
         async move |dependencies| {
-            let res = move_to_repository(&fetch_dir2, &*JAVA_REPOSITORY_DIR, &dependencies).await;
-            if let Err(e) = remove_dir_all(&fetch_dir2).await {
-                tracing::warn!("could not remove java fetch dir {fetch_dir2}: {e}");
-            }
-            Ok(res?)
+            Ok(
+                move_to_repository(&postinstall_fetch_dir, &*JAVA_REPOSITORY_DIR, &dependencies)
+                    .await?,
+            )
         },
         &job.id,
         &job.workspace_id,
@@ -472,19 +481,24 @@ async fn install<'a>(
         is_sandboxing_enabled(),
         conn,
     )
-    .await?;
+    .await;
+
+    // coursier failing against the registry bails before the postinstall step ever runs, so the
+    // cache it was writing into has to be reclaimed on every path out
+    match remove_dir_all(&fetch_dir).await {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => {
+            tracing::warn!("could not remove java fetch dir {fetch_dir}: {e}")
+        }
+        _ => {}
+    }
+    installed?;
     Ok(classpath)
 }
 
-/// Copies every fetched artifact out of coursier's cache and into the shared repository, at the
-/// `<group as path>/<artifact>/<version>` location the classpath is built from.
-///
-/// Coursier lays its cache out as `<scheme>/<host>/<registry url path>/<group as path>/...`, so how
-/// deep the maven layout starts depends on the configured registry: one segment for Maven Central
-/// (`maven2`), two for a Nexus or Artifactory repository (`repository/maven-public`), none for a
-/// root-hosted mirror. Matching on the coordinate suffix rather than on a fixed depth is what keeps
-/// private registries working: copy the artifacts one level off and every classpath entry silently
-/// points at a directory that does not exist, since javac ignores missing entries without a word.
+/// Copies every fetched artifact out of coursier's cache into the `<group as path>/<artifact>/
+/// <version>` location the classpath is built from. Coursier's cache is laid out as
+/// `<scheme>/<host>/<registry url path>/<group as path>/...`, so the depth at which the maven
+/// layout starts varies with the registry url and only the coordinate can be matched on.
 async fn move_to_repository(
     fetch_dir: &str,
     repository_dir: &str,
@@ -494,6 +508,7 @@ async fn move_to_repository(
         coordinate: Vec<String>,
         destination: String,
         display_name: String,
+        found: bool,
     }
 
     #[async_recursion]
@@ -504,19 +519,33 @@ async fn move_to_repository(
         below: &mut Vec<String>,
         wanted: &mut Vec<Wanted>,
     ) -> anyhow::Result<()> {
-        if wanted.is_empty() {
+        if wanted.iter().all(|w| w.found) {
             return Ok(());
         }
-        if let Some(i) = wanted.iter().position(|w| below.ends_with(&w.coordinate)) {
-            let Wanted { destination, .. } = wanted.remove(i);
-            copy_dir_recursively(dir, &PathBuf::from(destination))?;
-            return Ok(());
-        }
+        let (mut subdirs, mut holds_artifact) = (vec![], false);
         let mut entries = tokio::fs::read_dir(dir).await?;
         while let Some(entry) = entries.next_entry().await? {
-            if !entry.file_type().await?.is_dir() {
-                continue;
+            if entry.file_type().await?.is_dir() {
+                subdirs.push(entry);
+            } else {
+                holds_artifact = true;
             }
+        }
+        // every repository coursier probed and got a 404 from is left with an empty directory at
+        // the coordinate, so the match only counts where the artifact itself landed: the first
+        // repository tried is a default one, and claiming its leftover would cache an empty
+        // directory as the installed artifact
+        if holds_artifact {
+            if let Some(w) = wanted
+                .iter_mut()
+                .find(|w| !w.found && below.ends_with(&w.coordinate))
+            {
+                copy_dir_recursively(dir, &PathBuf::from(&w.destination))?;
+                w.found = true;
+                return Ok(());
+            }
+        }
+        for entry in subdirs {
             below.push(entry.file_name().to_string_lossy().into_owned());
             find_and_copy(&entry.path(), below, wanted).await?;
             below.pop();
@@ -539,6 +568,7 @@ async fn move_to_repository(
                     .collect(),
                 destination: path.clone(),
                 display_name: display_name.clone(),
+                found: false,
             })
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -548,15 +578,17 @@ async fn move_to_repository(
 
     find_and_copy(&PathBuf::from(fetch_dir), &mut vec![], &mut wanted).await?;
 
-    if !wanted.is_empty() {
+    let missing = wanted
+        .iter()
+        .filter(|w| !w.found)
+        .map(|w| w.display_name.as_str())
+        .sorted()
+        .collect_vec();
+    if !missing.is_empty() {
         bail!(
             "the configured maven repositories did not serve: {}. \
             Coursier reported success but no artifact for them was found in its cache.",
-            wanted
-                .iter()
-                .map(|w| w.display_name.as_str())
-                .sorted()
-                .join(", ")
+            missing.join(", ")
         );
     }
     Ok(())
@@ -1141,6 +1173,45 @@ mod tests {
             "gson-2.8.9.jar",
             "commons-lang3-3.8.1.jar",
         ]) {
+            assert!(
+                metadata(format!("{}/{jar}", dep.path)).await.is_ok(),
+                "{} was not copied to {}",
+                dep.display_name,
+                dep.path
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn the_empty_directory_a_404_leaves_behind_does_not_claim_the_coordinate() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetch_dir = tmp.path().join("fetch").to_str().unwrap().to_owned();
+        let repository_dir = tmp.path().join("repository").to_str().unwrap().to_owned();
+
+        // a repository that 404s is left with an empty directory at the coordinate. Each artifact
+        // is served by one of the two repositories and left empty under the other, so whichever
+        // one the walk reaches first, an empty directory precedes an artifact.
+        let central = format!("{fetch_dir}/https/repo1.maven.org/maven2");
+        let nexus = format!("{fetch_dir}/https/nexus.local/repository/maven-public");
+        touch(&format!("{central}/com/corp/public/1.0/public-1.0.jar")).await;
+        create_dir_all(format!("{nexus}/com/corp/public/1.0"))
+            .await
+            .unwrap();
+        touch(&format!("{nexus}/com/corp/internal/1.0/internal-1.0.jar")).await;
+        create_dir_all(format!("{central}/com/corp/internal/1.0"))
+            .await
+            .unwrap();
+
+        let deps = vec![
+            dep(&repository_dir, "com/corp", "public", "1.0"),
+            dep(&repository_dir, "com/corp", "internal", "1.0"),
+        ];
+
+        move_to_repository(&fetch_dir, &repository_dir, &deps)
+            .await
+            .unwrap();
+
+        for (dep, jar) in deps.iter().zip(["public-1.0.jar", "internal-1.0.jar"]) {
             assert!(
                 metadata(format!("{}/{jar}", dep.path)).await.is_ok(),
                 "{} was not copied to {}",

--- a/backend/windmill-worker/src/java_executor.rs
+++ b/backend/windmill-worker/src/java_executor.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::PathBuf, process::Stdio};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 
 use crate::global_cache::save_cache;
 use anyhow::{anyhow, bail};
@@ -486,17 +490,26 @@ async fn move_to_repository(
     repository_dir: &str,
     deps: &[RequiredDependency<()>],
 ) -> anyhow::Result<()> {
+    struct Wanted {
+        coordinate: Vec<String>,
+        destination: String,
+        display_name: String,
+    }
+
     #[async_recursion]
     async fn find_and_copy(
-        dir: &str,
-        wanted: &mut HashMap<String, (String, String)>,
+        dir: &Path,
+        // components walked past below the fetch dir, compared against coordinates one component
+        // at a time so that windows' native separator cannot defeat the match
+        below: &mut Vec<String>,
+        wanted: &mut Vec<Wanted>,
     ) -> anyhow::Result<()> {
         if wanted.is_empty() {
             return Ok(());
         }
-        if let Some(suffix) = wanted.keys().find(|s| dir.ends_with(s.as_str())).cloned() {
-            let (destination, _) = wanted.remove(&suffix).expect("key was just found");
-            copy_dir_recursively(&PathBuf::from(dir), &PathBuf::from(&destination))?;
+        if let Some(i) = wanted.iter().position(|w| below.ends_with(&w.coordinate)) {
+            let Wanted { destination, .. } = wanted.remove(i);
+            copy_dir_recursively(dir, &PathBuf::from(destination))?;
             return Ok(());
         }
         let mut entries = tokio::fs::read_dir(dir).await?;
@@ -504,34 +517,44 @@ async fn move_to_repository(
             if !entry.file_type().await?.is_dir() {
                 continue;
             }
-            let path = entry
-                .path()
-                .to_str()
-                .ok_or(anyhow!("Internal Error: Cannot convert Path to Str"))?
-                .to_owned();
-            find_and_copy(&path, wanted).await?;
+            below.push(entry.file_name().to_string_lossy().into_owned());
+            find_and_copy(&entry.path(), below, wanted).await?;
+            below.pop();
         }
         Ok(())
     }
 
-    let mut wanted = HashMap::new();
-    for RequiredDependency { path, display_name, .. } in deps {
-        let suffix = path
-            .strip_prefix(repository_dir)
-            .filter(|suffix| suffix.starts_with('/'))
-            .ok_or_else(|| anyhow!("Internal Error: {path} is not under {repository_dir}"))?;
-        wanted.insert(suffix.to_owned(), (path.clone(), display_name.clone()));
-    }
+    let mut wanted = deps
+        .iter()
+        .map(|RequiredDependency { path, display_name, .. }| {
+            let suffix = path
+                .strip_prefix(repository_dir)
+                .filter(|suffix| suffix.starts_with('/'))
+                .ok_or_else(|| anyhow!("Internal Error: {path} is not under {repository_dir}"))?;
+            Ok(Wanted {
+                coordinate: suffix
+                    .split('/')
+                    .filter(|component| !component.is_empty())
+                    .map(str::to_owned)
+                    .collect(),
+                destination: path.clone(),
+                display_name: display_name.clone(),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    // longest coordinate first: a group id ending in another one's coordinates (com.org.foo:bar
+    // over org.foo:bar) would otherwise be free to claim the shorter one's directory
+    wanted.sort_by_key(|w| std::cmp::Reverse(w.coordinate.len()));
 
-    find_and_copy(fetch_dir, &mut wanted).await?;
+    find_and_copy(&PathBuf::from(fetch_dir), &mut vec![], &mut wanted).await?;
 
     if !wanted.is_empty() {
         bail!(
             "the configured maven repositories did not serve: {}. \
             Coursier reported success but no artifact for them was found in its cache.",
             wanted
-                .values()
-                .map(|(_, display_name)| display_name.as_str())
+                .iter()
+                .map(|w| w.display_name.as_str())
                 .sorted()
                 .join(", ")
         );
@@ -1120,6 +1143,35 @@ mod tests {
         ]) {
             assert!(
                 metadata(format!("{}/{jar}", dep.path)).await.is_ok(),
+                "{} was not copied to {}",
+                dep.display_name,
+                dep.path
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_group_id_ending_in_another_coordinate_does_not_claim_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetch_dir = tmp.path().join("fetch").to_str().unwrap().to_owned();
+        let repository_dir = tmp.path().join("repository").to_str().unwrap().to_owned();
+        let root = format!("{fetch_dir}/https/nexus.local/repository/maven-public");
+
+        touch(&format!("{root}/org/foo/bar/1/bar-1.jar")).await;
+        touch(&format!("{root}/com/org/foo/bar/1/bar-1.jar")).await;
+
+        let deps = vec![
+            dep(&repository_dir, "org/foo", "bar", "1"),
+            dep(&repository_dir, "com/org/foo", "bar", "1"),
+        ];
+
+        move_to_repository(&fetch_dir, &repository_dir, &deps)
+            .await
+            .unwrap();
+
+        for dep in &deps {
+            assert!(
+                metadata(format!("{}/bar-1.jar", dep.path)).await.is_ok(),
                 "{} was not copied to {}",
                 dep.display_name,
                 dep.path

--- a/backend/windmill-worker/src/java_executor.rs
+++ b/backend/windmill-worker/src/java_executor.rs
@@ -29,6 +29,7 @@ use crate::{
     handle_child, is_sandboxing_enabled, read_ee_registry_bool_with_workspace_override,
     read_ee_registry_with_workspace_override,
     universal_pkg_installer::{par_install_language_dependencies_all_at_once, RequiredDependency},
+    worker_utils::JobPingHeartbeat,
     COURSIER_CACHE_DIR, DISABLE_NUSER, JAVA_CACHE_DIR, JAVA_HOME_DIR, JAVA_REPOSITORY_DIR,
     MAVEN_REPOS, NO_DEFAULT_MAVEN, NSJAIL_PATH, PATH_ENV, PROXY_ENVS,
 };
@@ -294,6 +295,10 @@ pub async fn resolve<'a>(
                     std::env::var("TMP").unwrap_or_else(|_| String::from("/tmp")),
                 );
         }
+        // Resolution against a distant or slow registry can run for minutes, and the lockfile has to
+        // be read from a clean stdout, so it cannot go through handle_child's polling loop: without
+        // a ping of its own the job is reaped as a zombie and restarted mid-resolution.
+        let _heartbeat = JobPingHeartbeat::start(conn, *job_id, "java lockfile resolution");
         let output = cmd.output().await?;
         // Check if the command was successful
         if output.status.success() {
@@ -450,35 +455,12 @@ async fn install<'a>(
 
             Ok(cmd)
         },
-        async move |_| {
-            move_to_repository(&fetch_dir2, 0).await?;
-            remove_dir_all(&fetch_dir2).await?;
-            #[async_recursion]
-            async fn move_to_repository(path: &str, depth: u8) -> anyhow::Result<()> {
-                if depth == 3 {
-                    copy_dir_recursively(
-                        &PathBuf::from(path),
-                        &PathBuf::from(&*JAVA_REPOSITORY_DIR),
-                    )?;
-
-                    return Ok(());
-                }
-                let mut entries = tokio::fs::read_dir(path).await?;
-                loop {
-                    let Some(entry) = entries.next_entry().await? else {
-                        break Ok(());
-                    };
-
-                    let path = entry
-                        .path()
-                        .to_str()
-                        .ok_or(anyhow!("Internal Error: Cannot convert Path to Str"))?
-                        .to_owned();
-
-                    move_to_repository(&path, depth + 1).await?;
-                }
+        async move |dependencies| {
+            let res = move_to_repository(&fetch_dir2, &*JAVA_REPOSITORY_DIR, &dependencies).await;
+            if let Err(e) = remove_dir_all(&fetch_dir2).await {
+                tracing::warn!("could not remove java fetch dir {fetch_dir2}: {e}");
             }
-            Ok(())
+            Ok(res?)
         },
         &job.id,
         &job.workspace_id,
@@ -488,6 +470,73 @@ async fn install<'a>(
     )
     .await?;
     Ok(classpath)
+}
+
+/// Copies every fetched artifact out of coursier's cache and into the shared repository, at the
+/// `<group as path>/<artifact>/<version>` location the classpath is built from.
+///
+/// Coursier lays its cache out as `<scheme>/<host>/<registry url path>/<group as path>/...`, so how
+/// deep the maven layout starts depends on the configured registry: one segment for Maven Central
+/// (`maven2`), two for a Nexus or Artifactory repository (`repository/maven-public`), none for a
+/// root-hosted mirror. Matching on the coordinate suffix rather than on a fixed depth is what keeps
+/// private registries working: copy the artifacts one level off and every classpath entry silently
+/// points at a directory that does not exist, since javac ignores missing entries without a word.
+async fn move_to_repository(
+    fetch_dir: &str,
+    repository_dir: &str,
+    deps: &[RequiredDependency<()>],
+) -> anyhow::Result<()> {
+    #[async_recursion]
+    async fn find_and_copy(
+        dir: &str,
+        wanted: &mut HashMap<String, (String, String)>,
+    ) -> anyhow::Result<()> {
+        if wanted.is_empty() {
+            return Ok(());
+        }
+        if let Some(suffix) = wanted.keys().find(|s| dir.ends_with(s.as_str())).cloned() {
+            let (destination, _) = wanted.remove(&suffix).expect("key was just found");
+            copy_dir_recursively(&PathBuf::from(dir), &PathBuf::from(&destination))?;
+            return Ok(());
+        }
+        let mut entries = tokio::fs::read_dir(dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if !entry.file_type().await?.is_dir() {
+                continue;
+            }
+            let path = entry
+                .path()
+                .to_str()
+                .ok_or(anyhow!("Internal Error: Cannot convert Path to Str"))?
+                .to_owned();
+            find_and_copy(&path, wanted).await?;
+        }
+        Ok(())
+    }
+
+    let mut wanted = HashMap::new();
+    for RequiredDependency { path, display_name, .. } in deps {
+        let suffix = path
+            .strip_prefix(repository_dir)
+            .filter(|suffix| suffix.starts_with('/'))
+            .ok_or_else(|| anyhow!("Internal Error: {path} is not under {repository_dir}"))?;
+        wanted.insert(suffix.to_owned(), (path.clone(), display_name.clone()));
+    }
+
+    find_and_copy(fetch_dir, &mut wanted).await?;
+
+    if !wanted.is_empty() {
+        bail!(
+            "the configured maven repositories did not serve: {}. \
+            Coursier reported success but no artifact for them was found in its cache.",
+            wanted
+                .values()
+                .map(|(_, display_name)| display_name.as_str())
+                .sorted()
+                .join(", ")
+        );
+    }
+    Ok(())
 }
 
 async fn compile<'a>(
@@ -1012,3 +1061,91 @@ class Wmill {
     }
 }
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dep(
+        repository_dir: &str,
+        group_path: &str,
+        artifact: &str,
+        version: &str,
+    ) -> RequiredDependency<()> {
+        RequiredDependency {
+            path: format!("{repository_dir}/{group_path}/{artifact}/{version}"),
+            _s3_handle: format!("{}:{artifact}:{version}", group_path.replace("/", ".")),
+            display_name: format!("{artifact}:{version}"),
+            custom_payload: (),
+        }
+    }
+
+    async fn touch(path: &str) {
+        let path = PathBuf::from(path);
+        create_dir_all(path.parent().unwrap()).await.unwrap();
+        File::create(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn artifacts_are_found_whatever_the_registry_url_path_is() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetch_dir = tmp.path().join("fetch").to_str().unwrap().to_owned();
+        let repository_dir = tmp.path().join("repository").to_str().unwrap().to_owned();
+
+        // maven central has a single url segment before the maven layout, a nexus repository two,
+        // and a root-hosted mirror none at all
+        touch(&format!("{fetch_dir}/https/repo1.maven.org/maven2/commons-cli/commons-cli/1.4/commons-cli-1.4.jar")).await;
+        touch(&format!("{fetch_dir}/https/nexus.local/repository/maven-public/com/google/code/gson/gson/2.8.9/gson-2.8.9.jar")).await;
+        touch(&format!("{fetch_dir}/https/maven.local/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar")).await;
+
+        let deps = vec![
+            dep(&repository_dir, "commons-cli", "commons-cli", "1.4"),
+            dep(&repository_dir, "com/google/code/gson", "gson", "2.8.9"),
+            dep(
+                &repository_dir,
+                "org/apache/commons",
+                "commons-lang3",
+                "3.8.1",
+            ),
+        ];
+
+        move_to_repository(&fetch_dir, &repository_dir, &deps)
+            .await
+            .unwrap();
+
+        for (dep, jar) in deps.iter().zip([
+            "commons-cli-1.4.jar",
+            "gson-2.8.9.jar",
+            "commons-lang3-3.8.1.jar",
+        ]) {
+            assert!(
+                metadata(format!("{}/{jar}", dep.path)).await.is_ok(),
+                "{} was not copied to {}",
+                dep.display_name,
+                dep.path
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn artifact_missing_from_the_cache_is_named_in_the_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let fetch_dir = tmp.path().join("fetch").to_str().unwrap().to_owned();
+        let repository_dir = tmp.path().join("repository").to_str().unwrap().to_owned();
+
+        touch(&format!("{fetch_dir}/https/nexus.local/repository/maven-public/commons-cli/commons-cli/1.4/commons-cli-1.4.jar")).await;
+
+        let deps = vec![
+            dep(&repository_dir, "commons-cli", "commons-cli", "1.4"),
+            dep(&repository_dir, "com/google/code/gson", "gson", "2.8.9"),
+        ];
+
+        let err = move_to_repository(&fetch_dir, &repository_dir, &deps)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("gson:2.8.9"), "unexpected error: {err}");
+        assert!(!err.contains("commons-cli:1.4"), "unexpected error: {err}");
+    }
+}

--- a/backend/windmill-worker/src/universal_pkg_installer.rs
+++ b/backend/windmill-worker/src/universal_pkg_installer.rs
@@ -291,6 +291,11 @@ pub async fn par_install_language_dependencies_all_at_once<
         let child = start_child_process(cmd, &installer_executable_name, false).await?;
         let mut buf = "".to_owned();
         let pipe_stdout = if stdout_on_err { Some(&mut buf) } else { None };
+        // handle_child only pings the job id it is handed, and that one is nil while output is
+        // buffered, so nothing would refresh this job's ping for the length of the batch install.
+        let _heartbeat = stdout_on_err.then(|| {
+            crate::worker_utils::JobPingHeartbeat::start(conn, *job_id, "dependency installation")
+        });
 
         if let Err(e) = crate::handle_child::handle_child(
             &(if pipe_stdout.is_some() {


### PR DESCRIPTION
## Summary

Java jobs failed to compile on any worker configured with a private maven registry, with a
`package … does not exist` error for every dependency even though the install phase reported
success.

`install()` fetched artifacts into a throwaway coursier cache and then moved them into the
shared repository by walking to a **hardcoded depth of 3**. Coursier lays its cache out as
`<scheme>/<host>/<registry url path…>/<group as path>/<artifact>/<version>/`, so depth 3 only
lands on the maven root when the registry URL has exactly one path segment — which is true of
Maven Central (`maven2`) and of almost nothing else:

| registry URL | depth 3 lands on | jars end up at | classpath expects |
|---|---|---|---|
| `…/maven2` | `maven2` | `repository/com/google/…` | ✅ |
| Nexus `…/repository/maven-public` | `repository` | `repository/maven-public/com/google/…` | ❌ |
| Artifactory `…/artifactory/libs-release` | `artifactory` | `repository/libs-release/com/google/…` | ❌ |
| root-hosted `https://maven.intra/` | `com` | `repository/google/code/…` | ❌ |

The classpath is built separately as `repository/<group as path>/<artifact>/<version>/*`, so
every entry pointed at a directory that did not exist — and `javac` ignores missing classpath
entries without a word. The failure surfaced only as a wall of compiler errors well after a
green "Fetching 19 packages… Done".

Verified on a real coursier tree fetched from a 3-segment registry: the old walk copies
`repositories/` to the repository root while the classpath looks for `com/google/…`.

The same jobs were also being restarted mid-resolution as false zombies, which this fixes too.

## Changes

**Locating the artifacts**

- Locate each artifact by its `<group as path>/<artifact>/<version>` coordinate instead of a
  fixed depth, so the number of path segments in the registry URL no longer matters.
- Match on path components rather than raw strings, so Windows' native separator cannot defeat
  the comparison.
- Try the longest coordinate first, so a group id ending in another one's coordinates
  (`com.org.foo:bar` over `org.foo:bar`) cannot claim the shorter one's directory.
- Only accept a coordinate directory that actually holds the artifact. Coursier leaves an
  **empty** directory at the coordinate under every repository it probed and 404'd on, and the
  default repositories are probed before the configured ones — so with a private registry and
  `no_default_maven` off, an internal artifact has an empty directory under Maven Central and
  the real one under the private registry, and which is walked first is `read_dir` order.
  Claiming the leftover would have cached an empty directory as the installed artifact, written
  its `.valid.windmill` marker, and (on EE) pushed it to S3 as the canonical tar for the fleet.
  Coursier's own bookkeeping next to a cached artifact (`.<name>.checked`, `.<name>.error`,
  checksums) is dot-prefixed, so only a non-hidden entry counts as the artifact having landed —
  a plain 404 leaves the directory truly empty, but a failed or partial download leaves those.

**Surfacing failures**

- Fail the job naming the artifacts when coursier reports success but an expected coordinate is
  absent from its cache. Previously `mark_success` wrote validity markers for artifacts that
  were never copied; the marker write then failed into `tracing::error!` only, invisible to the
  user, and every subsequent run silently re-fetched the whole dependency set.
- Reclaim the temporary fetch dir on every path out of `install()`, not just the success path —
  coursier failing against the registry is the likely case here and it bails before the
  postinstall step runs.

**False zombie restarts**

- Keep the job's ping fresh during java lockfile resolution: `resolve()` runs coursier through a
  raw `cmd.output()` (the lockfile has to be read from a clean stdout, so it cannot go through
  `handle_child`'s polling loop), so nothing refreshed `last_ping` and a resolution against a
  slow or distant registry was reaped as a zombie and restarted.
- Bound that same call with `resolve_job_timeout` and `kill_on_drop`, since the zombie reaper
  was incidentally the only thing turning a wedged resolution into a terminal state.
- Same heartbeat for the batch dependency install: `handle_child` only pings the job id it is
  handed, and that one is nil whenever output is buffered to a string, so nothing refreshed the
  ping for the whole install.

## Test plan

- [x] `cargo test -p windmill-worker --features java java_executor` — 4 unit tests over real
      coursier directory shapes: registry URLs with 0, 1 and 3 path segments; the empty
      404-leftover directory (constructed symmetrically so it fails regardless of `read_dir`
      order — confirmed it does fail without the guard); overlapping coordinates; and the
      missing-artifact error naming the right artifact.
- [x] Real java job (the default cowsay/gson/jackson template) run end to end on an EE build
      (`--features java,quickjs,enterprise,private`) against a **multi-segment private registry**
      (`maven_repos` = a 3-path-segment URL, `no_default_maven` on, zero "requires Enterprise"
      warnings in the job log, so the registry was genuinely used):

      | | repository root | job |
      |---|---|---|
      | before | `repositories` (a stray URL segment) | 8 javac errors, `cannot find symbol ObjectMapper` / `Cowsay` |
      | after | `com commons-cli javax org` | success, and `com/google/code/gson/gson/2.8.9/` holds `gson-2.8.9.jar` |

- [x] Same EE setup with a repository that 404s everything probed *before* the one that serves:
      the real jar lands (not the empty leftover) and all 19 `.valid.windmill` markers are written
      against populated directories.
- [x] Also run on a CE build against Maven Central — no regression on the default path, no
      leftover `tmp-fetch-*` dirs on either the success or the failure path, no worker errors.
- [x] `cargo check -p windmill-worker --features java --all-targets`
