### PR TITLE
fix: keep AI settings editor in sync with the config it just saved

### DIFF
--- a/frontend/src/lib/components/instanceSettings/InstanceAISettings.svelte
+++ b/frontend/src/lib/components/instanceSettings/InstanceAISettings.svelte
@@ -145,5 +145,8 @@
 		link="https://www.windmill.dev/docs/core_concepts/ai_generation"
 		promptScope="instance"
 		customSave={handleCustomSave}
+		onSave={(savedConfig) => {
+			initialConfig = savedConfig
+		}}
 	/>
 {/if}

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -57,7 +57,7 @@
 		usesInstanceAiConfig?: boolean
 		instanceAiSummary?: InstanceAISummary
 		customSave?: (config: AIConfig) => Promise<void>
-		onSave?: (info?: GetCopilotSettingsStateResponse) => void | Promise<void>
+		onSave?: (savedConfig: AIConfig, info?: GetCopilotSettingsStateResponse) => void | Promise<void>
 		title?: string
 		description?: string
 		link?: string
@@ -332,7 +332,10 @@
 			sendUserToast('AI settings updated')
 		}
 		storeInitialState()
-		await onSave?.(settingsState)
+		// The parent owns `initialConfig`, so it must learn what was persisted: this component is
+		// destroyed when the settings tab changes, and a stale `initialConfig` would come back as the
+		// editor state on remount and overwrite the saved config on the next save.
+		await onSave?.(clone(config), settingsState)
 	}
 
 	async function onAiProviderChange(provider: AIProvider) {

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -332,10 +332,14 @@
 			sendUserToast('AI settings updated')
 		}
 		storeInitialState()
-		// The parent owns `initialConfig`, so it must learn what was persisted: this component is
-		// destroyed when the settings tab changes, and a stale `initialConfig` would come back as the
-		// editor state on remount and overwrite the saved config on the next save.
-		await onSave?.(clone(config), settingsState)
+		// Hand the parent what was persisted: it owns `initialConfig`, and this component is
+		// destroyed on a settings tab switch, so a stale prop returns as editor state on remount
+		// and is written back by the next save. Clone it, since `providers` aliases our `$state`
+		// and the `lastLoadedConfigKey` guard would then track our own edits; pre-arm that guard
+		// so the prop update does not re-apply the config over what the editor now shows.
+		const savedConfig = clone(config)
+		lastLoadedConfigKey = JSON.stringify(savedConfig)
+		await onSave?.(savedConfig, settingsState)
 	}
 
 	async function onAiProviderChange(provider: AIProvider) {

--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -2029,7 +2029,8 @@ export async function main(
 								{hasInstanceAiConfig}
 								{usesInstanceAiConfig}
 								{instanceAiSummary}
-								onSave={(copilotSettingsState) => {
+								onSave={(savedConfig, copilotSettingsState) => {
+									aiInitialConfig = savedConfig
 									if (!copilotSettingsState) {
 										return
 									}


### PR DESCRIPTION
## Summary

On `/workspace_settings`, each tab is rendered inside an `{#if tab == ...}` chain, so switching tabs destroys and recreates the tab's component while the page component survives. `AISettings` is initialized from `aiInitialConfig`, which the page loads once per workspace and never refreshed after a save.

Saving AI settings therefore left the page holding the pre-save config. Coming back to the AI tab remounted the editor from that stale value: the provider toggle showed up deselected even though the provider was persisted (a real page reload showed it correctly, which is why this reads as "the toggle resets after refresh" and does not reproduce on reload). Worse, the next save wrote that stale editor state back, dropping the provider from `workspace_settings.ai_config` for real.

`AISettings` now hands the config it persisted back through `onSave`, and both parents assign it to their `initialConfig`. The config is deep-cloned on the way out: passing the live `$state` proxy would make the parent's prop alias the editor's own state, and the component's `JSON.stringify(initialConfig)` reload guard would then track its own mutations.

## Changes

- `AISettings.svelte`: `onSave` now receives the persisted config as its first argument (a deep clone), with the copilot settings state moving to the second.
- `workspace_settings/+page.svelte`: assign that config to `aiInitialConfig` on save.
- `InstanceAISettings.svelte`: same, for the instance-level editor.

## Test plan

Reproduced and verified against the dev server with a scripted browser run (workspace with an `anthropic` and an `openai` resource):

- [x] Enable Anthropic, save -> persisted as `{"providers":{"anthropic":...}}`
- [x] Switch to another settings tab and back without reloading -> toggle stays on (was off before the fix)
- [x] Enable OpenAI from that state and save -> both providers persist (before the fix, `["openai"]` only: Anthropic silently dropped)
- [x] Full page reload -> both toggles on
- [x] `npm run check` -> 0 errors

## Screenshots

Settings tab round-trip after saving Anthropic.

Before -- editor remounts from the stale config, provider looks unconfigured:

![before-fix-tab-roundtrip](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ai-settings-toggle-persistence/1785840343-before-fix-tab-roundtrip.png)

After -- editor reflects what was saved:

![after-tab-roundtrip](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ai-settings-toggle-persistence/1785840345-after-tab-roundtrip.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the provider settings editor in sync with the saved config. Switching tabs no longer resets toggles or drops providers, and the post-save reload is skipped.

- **Bug Fixes**
  - The editor now emits the persisted config via `onSave`, and parents update their `initialConfig` (workspace and instance).
  - The emitted config is deep-cloned and the reload guard is pre-armed to avoid state aliasing and skip the post-save reload.

<sup>Written for commit 8f78508352505001c1a9c20ee73938618086d790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

