### PR TITLE
fix(ci): never let check-write-access fail the review chain

### DIFF
--- a/.github/workflows/check-write-access.yml
+++ b/.github/workflows/check-write-access.yml
@@ -30,8 +30,14 @@ jobs:
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
     steps:
+      # This check is purely additive: callers OR it with author_association, so it must
+      # never fail the job. Failing here would block every dependent reviewer job through
+      # `needs`, turning an unconfigured or misconfigured app into a total review outage
+      # rather than a fallback to the author_association path.
       - name: Mint internal app token
         id: app
+        if: vars.INTERNAL_APP_ID != ''
+        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.INTERNAL_APP_ID }}
@@ -41,7 +47,9 @@ jobs:
       - name: Resolve authorization
         id: check
         env:
-          GH_TOKEN: ${{ steps.app.outputs.token }}
+          # Without the app token, the default token still resolves public members and
+          # repo collaborators; private members simply fall through to author_association.
+          GH_TOKEN: ${{ steps.app.outputs.token || github.token }}
           USERNAME: ${{ inputs.username }}
           TRUSTED_BOT: ${{ inputs.trusted_bot }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

`check-write-access` is **additive** by design: every caller ORs its `authorized` output
with `github.event.comment.author_association`, so a failure should degrade to the
author_association path rather than block anything.

It does not. `claude`, `codex` and `pi` all declare `needs: [parse, check-access, plan]`, so
a failed `check-access` skips `plan` and with it all three reviewers. Any disruption to the
app credentials — an unset `INTERNAL_APP_ID`, a rotated `INTERNAL_APP_KEY`, the app
uninstalled from the org — turns a redundant authorization probe into a **total `/review`
outage**, and one that reads as "the reviewers are broken" rather than "the app is
misconfigured".

Latent here, since the app is configured. Found while porting these workflows to
windmill-labs/windmill-helm-charts#656, where the credentials are not guaranteed present
and this failure mode is reachable.

## Changes

- `check-write-access.yml`: guard the token-minting step with `if: vars.INTERNAL_APP_ID != ''`
  plus `continue-on-error`, and fall back to `${{ github.token }}` when no app token was
  produced.

The fallback token still resolves **public** org members and repo collaborators via
`/repos/{repo}/collaborators/{user}/permission`. Only **private** members lose resolution,
and they fall through to `author_association` exactly as they did before this workflow
existed — which is the pre-#9958 behaviour, not a new regression.

No behaviour change while the app is configured: the step runs as before and
`steps.app.outputs.token` is non-empty, so the `||` never takes the fallback.

## Test plan

- [x] Workflow parses; the guard and `continue-on-error` land on the token step only.
- [x] `Resolve authorization` is unguarded, so `authorized` is always produced and the job
      always succeeds.
- [ ] CI: `/review` on this PR still resolves the author and runs all three reviewers,
      confirming no regression on the configured path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `check-write-access` non-blocking so reviewer jobs still run when the internal app token can’t be minted. Falls back to `github.token`, keeping public/collaborator checks and degrading to author_association as needed.

- **Bug Fixes**
  - Guard “Mint internal app token” with `if: vars.INTERNAL_APP_ID != ''` and `continue-on-error` using `actions/create-github-app-token@v2`.
  - Set `GH_TOKEN` to `${{ steps.app.outputs.token || github.token }}` and keep “Resolve authorization” unguarded so `authorized` is always produced.

<sup>Written for commit d74968f689ec695dbe9df53a3baf07ad8c26e875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

