### PR TITLE
feat: signpost the dbt migration path on the pipelines page

### DIFF
--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { base } from '$lib/base'
-	import { userStore } from '$lib/stores'
 	import Alert from '$lib/components/common/alert/Alert.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import DbtIcon from '$lib/components/icons/DbtIcon.svelte'
@@ -16,18 +15,16 @@
 			runs here unchanged as its own kind of script, with dbt still owning its models, refs and
 			tests. All it needs is a warehouse configured under
 			<a class="underline" href="{base}/workspace_settings?tab=dbt">Settings → dbt</a>. Its models
-			do surface in the asset graph, so the two can sit side by side and you can adopt pipelines
-			later, or never.
+			show up in the asset graph as <span class="font-mono">dbt://</span> nodes, visible next to whatever
+			pipelines you do build, so you can adopt pipelines later, or never.
 		</p>
 		<div class="flex flex-row flex-wrap items-center gap-2">
-			{#if !$userStore?.operator}
-				<!-- The dbt mark goes in as a child rather than `startIcon`: that slot
-				     sizes its icon with lucide's `size`, which DbtIcon has no prop for. -->
-				<Button variant="default" unifiedSize="sm" href="{base}/scripts/add?lang=dbt">
-					<DbtIcon width={14} height={14} />
-					New dbt script
-				</Button>
-			{/if}
+			<!-- The dbt mark goes in as a child rather than `startIcon`: that slot
+			     sizes its icon with lucide's `size`, which DbtIcon has no prop for. -->
+			<Button variant="default" unifiedSize="sm" href="{base}/scripts/add?lang=dbt">
+				<DbtIcon width={14} height={14} />
+				New dbt script
+			</Button>
 			<Button
 				variant="subtle"
 				unifiedSize="sm"

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { base } from '$lib/base'
+	import { userStore } from '$lib/stores'
+	import Alert from '$lib/components/common/alert/Alert.svelte'
+	import Button from '$lib/components/common/button/Button.svelte'
+	import DbtIcon from '$lib/components/icons/DbtIcon.svelte'
+	import { BookOpen } from 'lucide-svelte'
+
+	const DBT_DOCS = 'https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt'
+</script>
+
+<Alert type="info" title="Already using dbt? Bring the project as it is" size="xs">
+	<div class="flex flex-col gap-2">
+		<p>
+			An unmodified dbt project runs here as a script of its own, and its models land on this graph
+			as <span class="font-mono">dbt://</span> assets that native pipeline steps read and write like
+			any other, so you can move one model at a time instead of rewriting the project. All it needs
+			is a warehouse configured under
+			<a class="underline" href="{base}/workspace_settings?tab=dbt">Settings → dbt</a>, which the
+			project names by name.
+		</p>
+		<div class="flex flex-row flex-wrap items-center gap-2">
+			{#if !$userStore?.operator}
+				<!-- The dbt mark goes in as a child rather than `startIcon`: that slot
+				     sizes its icon with lucide's `size`, which DbtIcon has no prop for. -->
+				<Button variant="default" unifiedSize="sm" href="{base}/scripts/add?lang=dbt">
+					<DbtIcon width={14} height={14} />
+					New dbt script
+				</Button>
+			{/if}
+			<Button
+				variant="subtle"
+				unifiedSize="sm"
+				href={DBT_DOCS}
+				target="_blank"
+				rel="noreferrer"
+				startIcon={{ icon: BookOpen }}
+			>
+				dbt documentation
+			</Button>
+		</div>
+	</div>
+</Alert>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
@@ -8,7 +8,7 @@
 	const DBT_DOCS = 'https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt'
 </script>
 
-<Alert type="info" title="Windmill also runs dbt, and a dbt project is not a pipeline" size="xs">
+<Alert type="info" title="Prefer using dbt? Windmill also runs dbt" size="xs">
 	<div class="flex flex-col gap-2">
 		<p>
 			A pipeline is Windmill's own abstraction; an existing dbt project stays a dbt project, and

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte
@@ -9,15 +9,15 @@
 	const DBT_DOCS = 'https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt'
 </script>
 
-<Alert type="info" title="Already using dbt? Bring the project as it is" size="xs">
+<Alert type="info" title="Windmill also runs dbt, and a dbt project is not a pipeline" size="xs">
 	<div class="flex flex-col gap-2">
 		<p>
-			An unmodified dbt project runs here as a script of its own, and its models land on this graph
-			as <span class="font-mono">dbt://</span> assets that native pipeline steps read and write like
-			any other, so you can move one model at a time instead of rewriting the project. All it needs
-			is a warehouse configured under
-			<a class="underline" href="{base}/workspace_settings?tab=dbt">Settings → dbt</a>, which the
-			project names by name.
+			A pipeline is Windmill's own abstraction; an existing dbt project stays a dbt project, and
+			runs here unchanged as its own kind of script, with dbt still owning its models, refs and
+			tests. All it needs is a warehouse configured under
+			<a class="underline" href="{base}/workspace_settings?tab=dbt">Settings → dbt</a>. Its models
+			do surface in the asset graph, so the two can sit side by side and you can adopt pipelines
+			later, or never.
 		</p>
 		<div class="flex flex-row flex-wrap items-center gap-2">
 			{#if !$userStore?.operator}

--- a/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
@@ -84,7 +84,9 @@
 			<!-- Below the pipeline content on purpose: dbt is a separate runtime, not a
 			     way of building a pipeline, and reads as one when it sits in the flow
 			     that defines what a pipeline is. -->
-			<PipelineDbtSignpost />
+			{#if !$userStore?.operator}
+				<PipelineDbtSignpost />
+			{/if}
 		</div>
 	</div>
 </div>

--- a/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
@@ -3,6 +3,7 @@
 	import PipelineFolderList from '$lib/components/assets/AssetGraph/PipelineFolderList.svelte'
 	import PipelineSetupSignpost from '$lib/components/assets/AssetGraph/PipelineSetupSignpost.svelte'
 	import PipelineAlphaAckModal from '$lib/components/assets/AssetGraph/PipelineAlphaAckModal.svelte'
+	import PipelineDbtSignpost from '$lib/components/assets/AssetGraph/PipelineDbtSignpost.svelte'
 	import { BookOpen, NetworkIcon } from 'lucide-svelte'
 	import { onMount } from 'svelte'
 
@@ -73,6 +74,8 @@
 					Pipelines documentation
 				</a>
 			</div>
+
+			<PipelineDbtSignpost />
 
 			{#if !$userStore?.operator && $workspaceStore}
 				<PipelineSetupSignpost workspace={$workspaceStore} />

--- a/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
@@ -75,13 +75,16 @@
 				</a>
 			</div>
 
-			<PipelineDbtSignpost />
-
 			{#if !$userStore?.operator && $workspaceStore}
 				<PipelineSetupSignpost workspace={$workspaceStore} />
 			{/if}
 
 			<PipelineFolderList />
+
+			<!-- Below the pipeline content on purpose: dbt is a separate runtime, not a
+			     way of building a pipeline, and reads as one when it sits in the flow
+			     that defines what a pipeline is. -->
+			<PipelineDbtSignpost />
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge prerequisite:** the dbt docs page is not published yet — `https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt` returns 404. That is the canonical URL (already shipped on `main` by `workspaceSettings/DbtSettings.svelte:90`) and is kept deliberately so it self-heals on publish, but this PR puts it on a prominent button. Publish the page before merging.

## Summary

A dbt user landing on `/pipeline` had no signal that Windmill runs their existing project as-is: the page described native pipeline steps only, so the implied cost of adopting Windmill here was "rewrite the project as a pipeline". This adds an info alert stating that dbt is separately supported, with the links that make it actionable.

The alert is deliberately framed so dbt does **not** read as a flavour of data pipelines: a pipeline is Windmill's own abstraction, a dbt project stays a dbt project (dbt keeps owning its models, refs and tests), and the only overlap claimed is graph *visibility*. That claim is bounded on purpose — nothing native can write a `dbt://` relation (`// materialize` takes DuckLake targets only) and `AssetKind::Dbt` is excluded from `is_auto_trigger_kind`, so a `dbt://` read wires no cascade. It sits below the pipeline content for the same reason, so it isn't parsed as part of the definition of a pipeline.

## Changes

- New `PipelineDbtSignpost.svelte` under `frontend/src/lib/components/assets/AssetGraph/`: an info `Alert` titled "Prefer using dbt? Windmill also runs dbt".
- Three links out of it: **New dbt script** (`/scripts/add?lang=dbt`, which seeds the full dbt project scaffold), **dbt documentation** (external), and an inline link to `Settings → dbt` where the warehouse is configured.
- Rendered on `/pipeline` after the existing setup checklist and folder list, and hidden for operators — every affordance in it (create a script, configure a warehouse) is one an operator cannot act on, matching how the sibling `PipelineSetupSignpost` and the folder-create section are already gated.

## Screenshots

![dbt-alert-light](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipelines-dbt-alert/1785845602-dbt-alert-light.png)

![dbt-alert-dark](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipelines-dbt-alert/1785843663-dbt-alert-dark.png)

(dark shot predates the final copy tweaks; layout and placement are unchanged)

## Test plan

- [x] `npm run check` passes with 0 errors (warning count unchanged from main)
- [x] `/pipeline` renders the alert in both light and dark themes
- [x] **New dbt script** lands on a fresh dbt draft with the `wm_dbt.yaml` / `dbt_project.yml` / `models/example.sql` scaffold
- [x] `Settings → dbt` resolves to `/workspace_settings?tab=dbt`
- [x] **dbt documentation** button resolves to the canonical docs URL with `target="_blank"` / `rel="noreferrer"` — the URL itself 404s until the docs page ships (see the note above)
- [ ] As an operator, the whole alert is hidden (gate mirrors the two existing ones on the page; not exercised with an operator account)