### PR TITLE
fix: log the db auth mode used and hint at the ms_entraid sentinel

### DIFF
--- a/backend/windmill-common/src/azure_workload_identity.rs
+++ b/backend/windmill-common/src/azure_workload_identity.rs
@@ -27,6 +27,10 @@ pub const AZURE_OSSRDBMS_SCOPE: &str = "https://ossrdbms-aad.database.windows.ne
 /// worker's identity instead of failing to log in, which is why it is deliberately less
 /// password-shaped than the instance's `entraid`: that one is set by whoever runs the
 /// instance, this one sits where users keep their own secrets.
+///
+/// Compare it trimmed. A near-miss is otherwise forwarded to the server as a real
+/// password, and the resulting rejection is indistinguishable from an ordinary bad
+/// login, so the mode having been intended at all leaves no trace.
 pub const WORKLOAD_IDENTITY_PASSWORD: &str = "ms_entraid";
 
 /// Renew an access token this long before it expires.

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -64,6 +64,27 @@ lazy_static::lazy_static! {
     static ref RE_MSSQL_READONLY_INTENT: Regex = Regex::new(r#"(?mi)^-- ApplicationIntent=ReadOnly *(?:\r|\n|$)"#).unwrap();
 }
 
+/// A rejected login reports only the name it rejected, so a resource meant to reach the
+/// database as the worker's Azure identity, but whose password is not the sentinel, is
+/// indistinguishable from a wrong password. Point at the sentinel when the worker has an
+/// identity to offer, since that is the only case where the advice is actionable.
+fn login_error(e: tiberius::error::Error, sql_auth_user: Option<&str>) -> Error {
+    const LOGIN_FAILED: u32 = 18456;
+
+    let hint = sql_auth_user
+        .filter(|_| e.code() == Some(LOGIN_FAILED) && WorkloadIdentityConfig::resolve().is_ok())
+        .map(|user| {
+            format!(
+                "\n\nThis connected as SQL Server user `{user}`. This worker has an Azure workload \
+                 identity available: to authenticate as it instead, set the resource password to \
+                 `{WORKLOAD_IDENTITY_PASSWORD}` (`user` is then ignored)."
+            )
+        })
+        .unwrap_or_default();
+
+    Error::ExecutionErr(format!("{e}{hint}"))
+}
+
 pub async fn do_mssql(
     job: &MiniPulledJob,
     authed_client: &AuthedClient,
@@ -134,7 +155,10 @@ pub async fn do_mssql(
         append_logs(&job.id, &job.workspace_id, logs, conn).await;
     }
 
-    // Handle authentication based on available credentials
+    // Handle authentication based on available credentials. Every branch names the mode
+    // it picked: the server rejects a login the same way whichever mode produced it, so
+    // the job log is the only place the choice is visible.
+    let mut sql_auth_user = None;
     if database.integrated_auth.unwrap_or(false) {
         #[cfg(any(feature = "mssql-kerberos", feature = "mssql-winauth"))]
         {
@@ -151,7 +175,7 @@ pub async fn do_mssql(
                 "Integrated authentication is not available in this build. Requires mssql-kerberos (Linux) or mssql-winauth (Windows) feature.".to_string(),
             ));
         }
-    } else if database.password.as_deref() == Some(WORKLOAD_IDENTITY_PASSWORD) {
+    } else if database.password.as_deref().map(str::trim) == Some(WORKLOAD_IDENTITY_PASSWORD) {
         let workload_identity = WorkloadIdentityConfig::resolve()?;
         let logs = format!(
             "\nUsing Azure Workload Identity (client id {})",
@@ -162,6 +186,13 @@ pub async fn do_mssql(
         config.authentication(AuthMethod::aad_token(token));
     } else if let Some(token_value) = &database.aad_token {
         if let Some(token) = &token_value.token {
+            append_logs(
+                &job.id,
+                &job.workspace_id,
+                "\nUsing the AAD token set on the resource",
+                conn,
+            )
+            .await;
             config.authentication(AuthMethod::aad_token(token));
         } else {
             return Err(Error::BadRequest(
@@ -169,6 +200,9 @@ pub async fn do_mssql(
             ));
         }
     } else if let (Some(user), Some(password)) = (&database.user, &database.password) {
+        let logs = format!("\nUsing SQL Server authentication (user {user})");
+        append_logs(&job.id, &job.workspace_id, logs, conn).await;
+        sql_auth_user = Some(user.clone());
         config.authentication(AuthMethod::sql_server(user.clone(), password.clone()));
     } else {
         return Err(Error::BadRequest(
@@ -224,9 +258,9 @@ pub async fn do_mssql(
 
             Client::connect(config, tcp.compat_write())
                 .await
-                .map_err(to_anyhow)?
+                .map_err(|e| login_error(e, sql_auth_user.as_deref()))?
         }
-        Err(e) => return Err(to_anyhow(e).into()),
+        Err(e) => return Err(login_error(e, sql_auth_user.as_deref())),
     };
 
     let sig = parse_mssql_sig(&query)

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -64,20 +64,25 @@ lazy_static::lazy_static! {
     static ref RE_MSSQL_READONLY_INTENT: Regex = Regex::new(r#"(?mi)^-- ApplicationIntent=ReadOnly *(?:\r|\n|$)"#).unwrap();
 }
 
-/// A rejected login reports only the name it rejected, so a resource meant to reach the
-/// database as the worker's Azure identity, but whose password is not the sentinel, is
-/// indistinguishable from a wrong password. Point at the sentinel when the worker has an
-/// identity to offer, since that is the only case where the advice is actionable.
-fn login_error(e: tiberius::error::Error, sql_auth_user: Option<&str>) -> Error {
+/// Point a rejected login at the sentinel, but only where the advice is actionable: an
+/// Azure host, a worker that holds an identity, and a login the server rejected rather
+/// than a connection that never reached it.
+fn connect_error(e: tiberius::error::Error, host: &str, sql_auth_user: Option<&str>) -> Error {
     const LOGIN_FAILED: u32 = 18456;
+    // Matches the sovereign clouds as well as `.database.windows.net`.
+    let azure_host = host.to_ascii_lowercase().contains(".database.");
 
     let hint = sql_auth_user
-        .filter(|_| e.code() == Some(LOGIN_FAILED) && WorkloadIdentityConfig::resolve().is_ok())
+        .filter(|_| {
+            azure_host
+                && e.code() == Some(LOGIN_FAILED)
+                && WorkloadIdentityConfig::resolve().is_ok()
+        })
         .map(|user| {
             format!(
-                "\n\nThis connected as SQL Server user `{user}`. This worker has an Azure workload \
-                 identity available: to authenticate as it instead, set the resource password to \
-                 `{WORKLOAD_IDENTITY_PASSWORD}` (`user` is then ignored)."
+                "\n\nThis tried to authenticate as SQL Server user `{user}`. This worker has an \
+                 Azure workload identity available: to authenticate as it instead, set the \
+                 resource password to `{WORKLOAD_IDENTITY_PASSWORD}` (`user` is then ignored)."
             )
         })
         .unwrap_or_default();
@@ -155,9 +160,8 @@ pub async fn do_mssql(
         append_logs(&job.id, &job.workspace_id, logs, conn).await;
     }
 
-    // Handle authentication based on available credentials. Every branch names the mode
-    // it picked: the server rejects a login the same way whichever mode produced it, so
-    // the job log is the only place the choice is visible.
+    // Handle authentication based on available credentials. Every branch must name the
+    // mode it picked: the job log is the only place that choice is visible.
     let mut sql_auth_user = None;
     if database.integrated_auth.unwrap_or(false) {
         #[cfg(any(feature = "mssql-kerberos", feature = "mssql-winauth"))]
@@ -258,9 +262,9 @@ pub async fn do_mssql(
 
             Client::connect(config, tcp.compat_write())
                 .await
-                .map_err(|e| login_error(e, sql_auth_user.as_deref()))?
+                .map_err(|e| connect_error(e, host_ref, sql_auth_user.as_deref()))?
         }
-        Err(e) => return Err(login_error(e, sql_auth_user.as_deref())),
+        Err(e) => return Err(connect_error(e, host_ref, sql_auth_user.as_deref())),
     };
 
     let sig = parse_mssql_sig(&query)

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -80,7 +80,8 @@ enum PgAuthMode {
 
 impl PgAuthMode {
     fn of(database: &PgDatabase) -> error::Result<Self> {
-        let workload_identity = database.password.as_deref() == Some(WORKLOAD_IDENTITY_PASSWORD);
+        let workload_identity =
+            database.password.as_deref().map(str::trim) == Some(WORKLOAD_IDENTITY_PASSWORD);
         match (database.use_iam_auth == Some(true), workload_identity) {
             (true, true) => Err(Error::BadRequest(
                 "IAM RDS authentication cannot use the Azure workload identity password"
@@ -89,6 +90,17 @@ impl PgAuthMode {
             (true, false) => Ok(PgAuthMode::Iam),
             (false, true) => Ok(PgAuthMode::WorkloadIdentity),
             (false, false) => Ok(PgAuthMode::Password),
+        }
+    }
+
+    /// What to announce in the job log. Password auth is the unremarkable default and
+    /// stays silent; a token mode that was meant to be selected and was not is otherwise
+    /// indistinguishable from one that was.
+    fn log_name(&self) -> Option<&'static str> {
+        match self {
+            PgAuthMode::Password => None,
+            PgAuthMode::Iam => Some("IAM RDS authentication"),
+            PgAuthMode::WorkloadIdentity => Some("Azure Workload Identity"),
         }
     }
 
@@ -696,16 +708,11 @@ pub async fn do_postgresql(
 
     let auth_mode = PgAuthMode::of(&database)?;
 
-    // The sentinel password is easy to set by accident, so say in the job logs which
-    // identity the query actually ran as rather than only in the worker logs.
-    if matches!(auth_mode, PgAuthMode::WorkloadIdentity) {
-        windmill_queue::append_logs(
-            &job.id,
-            &job.workspace_id,
-            "Using Azure Workload Identity\n",
-            conn,
-        )
-        .await;
+    // Say in the job logs which identity the query actually ran as rather than only in
+    // the worker logs.
+    if let Some(mode) = auth_mode.log_name() {
+        windmill_queue::append_logs(&job.id, &job.workspace_id, format!("Using {mode}\n"), conn)
+            .await;
     }
 
     // Include the auth mode in the cache key to distinguish connections to the same host

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -93,9 +93,7 @@ impl PgAuthMode {
         }
     }
 
-    /// What to announce in the job log. Password auth is the unremarkable default and
-    /// stays silent; a token mode that was meant to be selected and was not is otherwise
-    /// indistinguishable from one that was.
+    /// What to announce in the job log. Password auth is the default and stays silent.
     fn log_name(&self) -> Option<&'static str> {
         match self {
             PgAuthMode::Password => None,
@@ -106,8 +104,9 @@ impl PgAuthMode {
 
     fn cache_key_segment(&self) -> &'static str {
         match self {
-            // Workload identity needs no segment of its own: what selects it, the
-            // sentinel password, is already part of to_uri().
+            // Workload identity needs no segment of its own: to_uri() carries the raw
+            // password and the mode is a pure function of it, so two modes can never
+            // share a key even though the mode is selected on the trimmed value.
             PgAuthMode::Password | PgAuthMode::WorkloadIdentity => "",
             PgAuthMode::Iam => "&iam=true",
         }
@@ -708,8 +707,6 @@ pub async fn do_postgresql(
 
     let auth_mode = PgAuthMode::of(&database)?;
 
-    // Say in the job logs which identity the query actually ran as rather than only in
-    // the worker logs.
     if let Some(mode) = auth_mode.log_name() {
         windmill_queue::append_logs(&job.id, &job.workspace_id, format!("Using {mode}\n"), conn)
             .await;
@@ -2143,6 +2140,12 @@ mod tests {
         assert_eq!(
             PgAuthMode::of(&db("hunter2")).unwrap(),
             PgAuthMode::Password
+        );
+        // A pasted sentinel keeps its surrounding whitespace, and an unrecognized one is
+        // forwarded to the server as a real password instead of selecting the mode.
+        assert_eq!(
+            PgAuthMode::of(&db("%20ms_entraid%0A")).unwrap(),
+            PgAuthMode::WorkloadIdentity
         );
     }
 


### PR DESCRIPTION
## Summary

Azure workload identity for `mssql` / `postgres` resources (#10470, released in v1.778.0) is selected by setting the resource password to the sentinel `ms_entraid`. When that string does not match, the code silently falls through to plain SQL Server authentication and sends the resource's `user` as a login name.

A report of "Entra ID auth does not work" turned out to be exactly that: the resource had the managed identity's client ID in `user` and something else in `password`, so the connection authenticated as SQL user `ee8f5073-…` and Azure rejected it with `18456`. Nothing in the job log said which auth mode had been chosen, so establishing that the Entra branch had never run took a full session of reading Azure SQL audit rows and hand-checking tiberius' LOGIN7 encoding against MS-TDS.

This does not change how workload identity authenticates. It makes the choice visible, and makes the near-miss recoverable.

**This does not fix that customer's connection** — their resource config was wrong and only they can fix it. What it fixes is that the next occurrence explains itself instead of costing a support round-trip. The underlying discoverability problem remains: `ms_entraid` is documented nowhere outside two Rust files, and that fix belongs in the docs repo.

## Changes

- `mssql_executor.rs`: every auth branch now names the mode it selected. Previously only `integrated_auth` and the `ms_entraid` branch logged; the `aad_token` and user/password branches were silent, so the absence of a line was ambiguous between "fell through to SQL auth" and "this code never logs here". The SQL-auth line includes the user, which is the field that was wrong in the report.
- `mssql_executor.rs`: new `login_error` appends a hint naming the sentinel when a login fails with `18456`, the connection used SQL auth, **and** the worker actually has Azure workload identity env vars. Gated on that last condition so the advice only appears where it is actionable. Replaces `to_anyhow(e).into()` on the two `Client::connect` error paths, which deliberately drops the `@file:line:col` suffix from those errors.
- `pg_executor.rs`: `PgAuthMode::log_name()` announces every non-default mode. Password auth stays silent, so ordinary Postgres jobs gain no log line. **Visible change for existing EE users: IAM RDS Postgres jobs now log `Using IAM RDS authentication` where they previously logged nothing.**
- Both paths compare the sentinel **trimmed**. A pasted value keeping its trailing newline previously went to the server as a literal password and failed as an ordinary bad login.
- The trim rationale lives on the `WORKLOAD_IDENTITY_PASSWORD` const, one place, rather than repeated at both call sites.

## Test plan

- [x] `cargo check -p windmill-worker --features mssql,enterprise` clean. Note `mod mssql_executor` is gated `#[cfg(all(feature = "enterprise", feature = "mssql"))]`, so `--features mssql` alone does **not** compile that file; only the combined set covers it. The CE build was checked for `pg_executor.rs`, which is not EE-gated.
- [x] `azure_workload_identity` unit tests pass, and `test_workload_identity_password_selects_the_auth_mode` was extended to pin the trim (`%20ms_entraid%0A`, which `parse_uri` percent-decodes to `" ms_entraid\n"`)
- [x] Real Postgres job, password auth: returns `[{"ok": 1}]`, no log line added
- [x] Real Postgres job with password `"  ms_entraid\n"`: selects workload identity and logs `Using Azure Workload Identity`, instead of sending the padded value as a password
- [ ] **Not exercised: the MSSQL path end-to-end.** No Azure SQL instance reachable from dev and `mssql` is not compiled into the dev backend. The MSSQL edits are the same trim logic proven on the Postgres path, two `append_logs` calls matching the two already in that function, and an error-formatting helper. Everything touched on that path is an error path or a log line except the trim, so it cannot break a connection that currently succeeds — but it is untested against a real server.

No frontend changes, so no screenshots. No `*_ee.rs` files modified.
