### PR TITLE
feat: make createApp and updateApp the full-code app tools over MCP

### DIFF
--- a/backend/.sqlx/query-b6f0ebbe674e1290afda7b5bed3b463f1d73d66b5924734274272509c98573db.json
+++ b/backend/.sqlx/query-b6f0ebbe674e1290afda7b5bed3b463f1d73d66b5924734274272509c98573db.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO app (workspace_id, path, summary, policy, versions)\n         VALUES ($1, $2, '', '{}'::jsonb, '{}') RETURNING 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b6f0ebbe674e1290afda7b5bed3b463f1d73d66b5924734274272509c98573db"
+}

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -426,7 +426,11 @@ def find_mcp_tools(spec: Dict[str, Any]) -> List[Dict[str, Any]]:
             if isinstance(operation, dict) and operation.get('x-mcp-tool') is True:
                 # Extract tool information
                 tool = {
-                    'name': operation.get('operationId', f"{method}_{path.replace('/', '_').replace('{', '').replace('}', '')}"),
+                    # The name an agent sees. Defaults to the operationId, which
+                    # every generated client is keyed on, so an endpoint whose
+                    # tool should read differently overrides it here rather than
+                    # by renaming the operation.
+                    'name': operation.get('x-mcp-tool-name') or operation.get('operationId', f"{method}_{path.replace('/', '_').replace('{', '').replace('}', '')}"),
                     'description': build_tool_description(operation, method, path),
                     'instructions': operation.get('x-mcp-instructions', ''),
                     'path': path,

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -443,7 +443,16 @@ def find_mcp_tools(spec: Dict[str, Any]) -> List[Dict[str, Any]]:
                     'include_query_params': operation.get('x-mcp-tool-include-query-params'),
                 }
                 tools.append(tool)
-    
+
+    # A tool name used to be an operationId, which OpenAPI already keeps unique.
+    # `x-mcp-tool-name` gives that up, and a duplicate would be silent: a token's
+    # `mcp:endpoints:<name>` resolves by first match, so which endpoint it reaches
+    # would depend on the order of this file.
+    names = [t['name'] for t in tools]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate MCP tool name(s): {', '.join(duplicates)}")
+
     return tools
 
 def generate_typescript_code(tools: List[Dict[str, Any]], spec: Dict[str, Any], base_path: str = "") -> str:

--- a/backend/windmill-api-integration-tests/tests/apps.rs
+++ b/backend/windmill-api-integration-tests/tests/apps.rs
@@ -411,6 +411,24 @@ async fn test_raw_app_kind_is_not_flipped_by_update(db: Pool<Postgres>) -> anyho
         "expected the raw update of a low-code app to be refused"
     );
 
+    // Nor may the source endpoints compile a value that isn't a raw app's: both
+    // refuse up front, without queueing a bundle job no worker would pick up here.
+    let resp = authed(client().post(format!("{base}/create_raw_source")))
+        .json(&json!({
+            "path": "u/test-user/from_source",
+            "summary": "",
+            "value": { "grid": [] },
+            "policy": { "execution_mode": "publisher" }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    assert!(
+        resp.text().await?.contains("no `files` to bundle"),
+        "expected a low-code value to be refused before bundling"
+    );
+
     // The source endpoint refuses the same mismatch up front — it must not queue
     // a bundle job (which no worker would pick up here) to find that out.
     let resp = authed(client().post(format!("{base}/update_raw_source/{low_code_path}")))

--- a/backend/windmill-api-integration-tests/tests/apps.rs
+++ b/backend/windmill-api-integration-tests/tests/apps.rs
@@ -474,3 +474,53 @@ async fn test_raw_app_kind_is_not_flipped_by_update(db: Pool<Postgres>) -> anyho
 
     Ok(())
 }
+
+/// Who may create at a path is the app table's answer, not a rule restated in the
+/// handler: a non-admin member of `g/<group>` writes there, and nowhere a
+/// non-member does. Both are decided before the sources are compiled, so an empty
+/// `files` is enough to say which side of that check the request reached.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_create_raw_source_write_check_follows_app_rls(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    sqlx::query(
+        "INSERT INTO usr_to_group (workspace_id, usr, group_) VALUES
+         ('test-workspace', 'test-user-2', 'all')",
+    )
+    .execute(&db)
+    .await?;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace/apps");
+    let create_as_member = |path: &'static str| {
+        client()
+            .post(format!("{base}/create_raw_source"))
+            .header("Authorization", "Bearer SECRET_TOKEN_2")
+            .json(&json!({
+                "path": path,
+                "summary": "",
+                "value": { "files": {} },
+                "policy": { "execution_mode": "publisher" }
+            }))
+            .send()
+    };
+
+    let resp = create_as_member("g/all/from_source").await.unwrap();
+    assert_eq!(
+        resp.status(),
+        400,
+        "a group member must reach the compile: {}",
+        resp.text().await?
+    );
+
+    let resp = create_as_member("u/test-user/from_source").await.unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "expected another user's path to be refused"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11795,6 +11795,9 @@ paths:
     get:
       summary: list all apps
       operationId: listApps
+      x-mcp-tool: true
+      x-mcp-instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateAppRawSource deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."
+      x-mcp-tool-include-query-params: [path_start]
       tags:
         - app
       parameters:
@@ -11854,16 +11857,6 @@ paths:
     post:
       summary: create app
       operationId: createApp
-      x-mcp-tool: true
-      x-mcp-tool-include-fields:
-        - path
-        - value
-        - summary
-        - policy
-        - deployment_message
-      x-mcp-tool-opaque-fields:
-        - value
-        - policy
       tags:
         - app
       parameters:
@@ -11988,6 +11981,9 @@ paths:
     get:
       summary: get app by path
       operationId: getAppByPath
+      x-mcp-tool: true
+      x-mcp-instructions: "Returns the app's whole `value`, which is what updateAppRawSource needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."
+      x-mcp-tool-include-query-params: []
       tags:
         - app
       parameters:
@@ -12298,17 +12294,6 @@ paths:
     post:
       summary: update app
       operationId: updateApp
-      x-mcp-tool: true
-      x-mcp-instructions: "Low-code apps only. An app whose `raw_app` field (from getAppByPath) is true is a raw (full-code) app and is refused here; use updateAppRawSource for those."
-      x-mcp-tool-include-fields:
-        - path
-        - value
-        - summary
-        - policy
-        - deployment_message
-      x-mcp-tool-opaque-fields:
-        - value
-        - policy
       tags:
         - app
       parameters:
@@ -12349,6 +12334,67 @@ paths:
       responses:
         "200":
           description: app updated
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /w/{workspace}/apps/create_raw_source:
+    post:
+      # The summary is what the MCP token picker shows next to the tool, so it has
+      # to carry the consequence of granting it, not just what it does.
+      summary: create a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)
+      operationId: createAppRawSource
+      x-mcp-tool: true
+      x-mcp-instructions: "Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. There is no MCP tool for creating a low-code app — those are built in their editor."
+      x-mcp-tool-include-fields:
+        - path
+        - value
+        - summary
+        - policy
+      tags:
+        - app
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+      requestBody:
+        description: raw app sources to bundle and deploy
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+                summary:
+                  type: string
+                value:
+                  type: object
+                  description: "The raw app's value. `files` maps each source path to its content and must contain an entry point; `runnables` and `data` are carried through unchanged."
+                  properties:
+                    files:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    runnables:
+                      type: object
+                    data:
+                      type: object
+                  required: [files]
+                policy:
+                  $ref: "#/components/schemas/Policy"
+                deployment_message:
+                  type: string
+                custom_path:
+                  type: string
+                labels:
+                  type: array
+                  items:
+                    type: string
+              required: [path, value, summary, policy]
+      responses:
+        "201":
+          description: app created
           content:
             text/plain:
               schema:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11797,7 +11797,7 @@ paths:
       operationId: listApps
       x-mcp-tool: true
       x-mcp-instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."
-      x-mcp-tool-include-query-params: [path_start]
+      x-mcp-tool-include-query-params: [path_start, page, per_page]
       tags:
         - app
       parameters:
@@ -11982,7 +11982,7 @@ paths:
       summary: get app by path
       operationId: getAppByPath
       x-mcp-tool: true
-      x-mcp-instructions: "Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."
+      x-mcp-instructions: "Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. A big enough app is truncated by the tool-result limit; sending that back fails the build rather than deploying something partial, so edit those in the app editor or with the CLI. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."
       x-mcp-tool-include-query-params: []
       tags:
         - app

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11796,7 +11796,7 @@ paths:
       summary: list all apps
       operationId: listApps
       x-mcp-tool: true
-      x-mcp-instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."
+      x-mcp-instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. An app with no `raw_app` field is low-code — the field is omitted rather than sent as false. A low-code app can only be read here — editing one is a job for its editor in the UI."
       x-mcp-tool-include-query-params: [path_start, page, per_page]
       tags:
         - app
@@ -12390,10 +12390,16 @@ paths:
                   type: string
                 custom_path:
                   type: string
+                preserve_on_behalf_of:
+                  type: boolean
+                  description: "When true and the caller is a member of the 'wm_deployers' group, preserves the original on_behalf_of value in the policy instead of overwriting it."
                 labels:
                   type: array
                   items:
                     type: string
+                skip_draft_deletion:
+                  type: boolean
+                  description: "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
               required: [path, value, summary, policy]
       responses:
         "201":

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11796,7 +11796,7 @@ paths:
       summary: list all apps
       operationId: listApps
       x-mcp-tool: true
-      x-mcp-instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateAppRawSource deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."
+      x-mcp-instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."
       x-mcp-tool-include-query-params: [path_start]
       tags:
         - app
@@ -11982,7 +11982,7 @@ paths:
       summary: get app by path
       operationId: getAppByPath
       x-mcp-tool: true
-      x-mcp-instructions: "Returns the app's whole `value`, which is what updateAppRawSource needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."
+      x-mcp-instructions: "Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."
       x-mcp-tool-include-query-params: []
       tags:
         - app
@@ -12346,7 +12346,10 @@ paths:
       summary: create a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)
       operationId: createAppRawSource
       x-mcp-tool: true
-      x-mcp-instructions: "Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. There is no MCP tool for creating a low-code app — those are built in their editor."
+      # Creating an app through MCP means creating a full-code one; low-code apps
+      # are legacy and aren't exposed there at all.
+      x-mcp-tool-name: createApp
+      x-mcp-instructions: "Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps are legacy and have no MCP tool at all — they are built in their editor."
       x-mcp-tool-include-fields:
         - path
         - value
@@ -12407,7 +12410,8 @@ paths:
       summary: update a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)
       operationId: updateAppRawSource
       x-mcp-tool: true
-      x-mcp-instructions: "Use this to change a raw (full-code) app — an app whose `raw_app` field is true. Send the whole `value` (`files`, `runnables`, `data`), not a patch: read the current one with getAppByPath first and edit it. The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps use updateApp instead."
+      x-mcp-tool-name: updateApp
+      x-mcp-instructions: "Use this to change a raw (full-code) app — an app whose `raw_app` field is true. Send the whole `value` (`files`, `runnables`, `data`), not a patch: read the current one with getAppByPath first and edit it. The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps are legacy and have no MCP tool at all — they are edited in their editor."
       x-mcp-tool-include-fields:
         - path
         - value

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -17,9 +17,7 @@ use crate::{
     auth::{get_end_user_email, AuthCache, OptTokened},
     db::{ApiAuthed, DB},
     jobs::RunJobQuery,
-    users::{
-        require_is_writer, require_owner_of_path, require_path_read_access_for_preview, OptAuthed,
-    },
+    users::{require_owner_of_path, require_path_read_access_for_preview, OptAuthed},
     utils::{build_scope_path_predicate, check_scopes},
     webhook_util::{WebhookMessage, WebhookShared},
     HTTP_CLIENT,
@@ -2719,6 +2717,41 @@ async fn update_app_raw_source(
     Ok(format!("app {} updated (npath: {:?})", opath, npath))
 }
 
+/// Whether the caller may create an app at `path` — asked of the database rather
+/// than restated here, like `can_write_app`: the app's RLS grants group members
+/// write on a `g/<group>/…` path, which a hand-written check misses. The probe is
+/// the insert itself, rolled back; `app` has no insert trigger, so the only trace
+/// is a consumed sequence value.
+async fn can_create_app(
+    user_db: &UserDB,
+    authed: &ApiAuthed,
+    w_id: &str,
+    path: &str,
+) -> Result<bool> {
+    let mut tx = user_db.clone().begin(authed).await?;
+    let allowed = sqlx::query_scalar!(
+        "INSERT INTO app (workspace_id, path, summary, policy, versions)
+         VALUES ($1, $2, '', '{}'::jsonb, '{}') RETURNING 1",
+        w_id,
+        path
+    )
+    .fetch_optional(&mut *tx)
+    .await;
+    tx.rollback().await?;
+    match allowed {
+        Ok(row) => Ok(row.is_some()),
+        Err(sqlx::Error::Database(e)) => match e.code().as_deref() {
+            // RLS refuses an insert outright rather than filtering it out.
+            Some("42501") => Ok(false),
+            // The path was taken between the existence check and this probe.
+            // Permission is not what is wrong, so let the real insert say so.
+            Some("23505") => Ok(true),
+            _ => Err(sqlx::Error::Database(e).into()),
+        },
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// Whether a deployed app already occupies `path`. Through the privileged pool
 /// on purpose: a path taken by an app the caller can't see is still taken, and
 /// `create_app_internal` would fail on the unique index either way.
@@ -2777,21 +2810,17 @@ async fn create_app_raw_source(
     if app_exists(&db, &w_id, &path).await? {
         return Err(Error::BadRequest(format!("App {path} already exists")));
     }
-    require_is_writer(
-        &authed,
-        &path,
-        &w_id,
-        db.clone(),
-        "SELECT extra_perms FROM app WHERE path = $1 AND workspace_id = $2",
-        "app",
-    )
-    .await?;
+    if !can_create_app(&user_db, &authed, &w_id, &path).await? {
+        return Err(Error::PermissionDenied(format!(
+            "You do not have permission to create app {path}"
+        )));
+    }
 
     let (js, css) =
-        apps_raw_bundle::bundle_raw_app_sources(&db, &user_db, &authed, &w_id, &files.files).await?;
+        apps_raw_bundle::bundle_raw_app_sources(&db, &user_db, &authed, &w_id, &files.files)
+            .await?;
 
-    let (mut tx, npath, v_id) =
-        create_app_internal(authed, db, user_db, &w_id, true, app).await?;
+    let (mut tx, npath, v_id) = create_app_internal(authed, db, user_db, &w_id, true, app).await?;
     store_raw_app_file(&w_id, &v_id, "js", bytes::Bytes::from(js), &mut tx).await?;
     if !css.is_empty() {
         store_raw_app_file(&w_id, &v_id, "css", bytes::Bytes::from(css), &mut tx).await?;

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -119,6 +119,11 @@ pub fn workspaced_service(raw_app_body_limit: usize) -> Router {
             post(update_app_raw).layer(axum::extract::DefaultBodyLimit::max(raw_app_body_limit)),
         )
         .route(
+            "/create_raw_source",
+            post(create_app_raw_source)
+                .layer(axum::extract::DefaultBodyLimit::max(raw_app_body_limit)),
+        )
+        .route(
             "/update_raw_source/{*path}",
             post(update_app_raw_source)
                 .layer(axum::extract::DefaultBodyLimit::max(raw_app_body_limit)),
@@ -2710,6 +2715,62 @@ async fn update_app_raw_source(
     );
 
     Ok(format!("app {} updated (npath: {:?})", opath, npath))
+}
+
+/// Create a raw app from its sources, compiling them on a worker. The counterpart
+/// of `update_app_raw_source`: `create_raw` takes a bundle the caller already
+/// built, which an API client has no way to produce.
+async fn create_app_raw_source(
+    authed: ApiAuthed,
+    Extension(user_db): Extension<UserDB>,
+    Extension(db): Extension<DB>,
+    Extension(webhook): Extension<WebhookShared>,
+    Path(w_id): Path<String>,
+    Json(app): Json<CreateApp>,
+) -> Result<(StatusCode, String)> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot create apps for security reasons".to_string(),
+        ));
+    }
+
+    let path = app.path.clone();
+    check_scopes(&authed, || format!("apps:write:{}", path))?;
+    // See update_app_raw_source: the compile runs caller-supplied sources on a
+    // worker, so writing an app must not be a way to gain that.
+    check_scopes(&authed, || "jobs:run".to_string())?;
+
+    if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
+        &w_id,
+        AuditAuthorable::username(&authed),
+        &authed.groups,
+        authed.is_admin,
+        &db,
+    )
+    .await?
+    {
+        return Err(Error::PermissionDenied(msg));
+    }
+
+    let files: RawAppSourceFiles = serde_json::from_str(app.value.0.get())
+        .map_err(|e| Error::BadRequest(format!("app value is not a raw app source: {e}")))?;
+    let (js, css) =
+        apps_raw_bundle::bundle_raw_app_sources(&db, &user_db, &authed, &w_id, &files.files).await?;
+
+    let (mut tx, npath, v_id) =
+        create_app_internal(authed, db, user_db, &w_id, true, app).await?;
+    store_raw_app_file(&w_id, &v_id, "js", bytes::Bytes::from(js), &mut tx).await?;
+    if !css.is_empty() {
+        store_raw_app_file(&w_id, &v_id, "css", bytes::Bytes::from(css), &mut tx).await?;
+    }
+    tx.commit().await?;
+
+    webhook.send_message(
+        w_id.clone(),
+        WebhookMessage::CreateApp { workspace: w_id, path: npath.clone() },
+    );
+
+    Ok((StatusCode::CREATED, npath))
 }
 
 /// The part of a raw app's value the bundler needs.

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -17,7 +17,9 @@ use crate::{
     auth::{get_end_user_email, AuthCache, OptTokened},
     db::{ApiAuthed, DB},
     jobs::RunJobQuery,
-    users::{require_owner_of_path, require_path_read_access_for_preview, OptAuthed},
+    users::{
+        require_is_writer, require_owner_of_path, require_path_read_access_for_preview, OptAuthed,
+    },
     utils::{build_scope_path_predicate, check_scopes},
     webhook_util::{WebhookMessage, WebhookShared},
     HTTP_CLIENT,
@@ -2717,6 +2719,20 @@ async fn update_app_raw_source(
     Ok(format!("app {} updated (npath: {:?})", opath, npath))
 }
 
+/// Whether a deployed app already occupies `path`. Through the privileged pool
+/// on purpose: a path taken by an app the caller can't see is still taken, and
+/// `create_app_internal` would fail on the unique index either way.
+async fn app_exists(db: &DB, w_id: &str, path: &str) -> Result<bool> {
+    Ok(sqlx::query_scalar!(
+        "SELECT EXISTS(SELECT 1 FROM app WHERE path = $1 AND workspace_id = $2)",
+        path,
+        w_id
+    )
+    .fetch_one(db)
+    .await?
+    .unwrap_or(false))
+}
+
 /// Create a raw app from its sources, compiling them on a worker. The counterpart
 /// of `update_app_raw_source`: `create_raw` takes a bundle the caller already
 /// built, which an API client has no way to produce.
@@ -2754,6 +2770,23 @@ async fn create_app_raw_source(
 
     let files: RawAppSourceFiles = serde_json::from_str(app.value.0.get())
         .map_err(|e| Error::BadRequest(format!("app value is not a raw app source: {e}")))?;
+
+    // Before the compile, which costs a job on a worker: it must not run for a
+    // path already taken, nor for one the caller can't write. `create_app_internal`
+    // rejects both, but only after the sources have been built.
+    if app_exists(&db, &w_id, &path).await? {
+        return Err(Error::BadRequest(format!("App {path} already exists")));
+    }
+    require_is_writer(
+        &authed,
+        &path,
+        &w_id,
+        db.clone(),
+        "SELECT extra_perms FROM app WHERE path = $1 AND workspace_id = $2",
+        "app",
+    )
+    .await?;
+
     let (js, css) =
         apps_raw_bundle::bundle_raw_app_sources(&db, &user_db, &authed, &w_id, &files.files).await?;
 

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -1076,7 +1076,7 @@ Creates a new version of an existing script when called with the same path and t
     EndpointTool {
         name: Cow::Borrowed("listApps"),
         description: Cow::Borrowed("list all apps"),
-        instructions: Cow::Borrowed("Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateAppRawSource deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."),
+        instructions: Cow::Borrowed("Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."),
         path: Cow::Borrowed("/w/{workspace}/apps/list"),
         method: Cow::Borrowed("GET"),
         path_params_schema: None,
@@ -1097,7 +1097,7 @@ Creates a new version of an existing script when called with the same path and t
     EndpointTool {
         name: Cow::Borrowed("getAppByPath"),
         description: Cow::Borrowed("get app by path"),
-        instructions: Cow::Borrowed("Returns the app's whole `value`, which is what updateAppRawSource needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."),
+        instructions: Cow::Borrowed("Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."),
         path: Cow::Borrowed("/w/{workspace}/apps/get/p/{path}"),
         method: Cow::Borrowed("GET"),
         path_params_schema: Some(serde_json::json!({
@@ -1117,9 +1117,9 @@ Creates a new version of an existing script when called with the same path and t
         body_field_renames: None,
     },
     EndpointTool {
-        name: Cow::Borrowed("createAppRawSource"),
+        name: Cow::Borrowed("createApp"),
         description: Cow::Borrowed("create a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)"),
-        instructions: Cow::Borrowed("Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. There is no MCP tool for creating a low-code app — those are built in their editor."),
+        instructions: Cow::Borrowed("Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps are legacy and have no MCP tool at all — they are built in their editor."),
         path: Cow::Borrowed("/w/{workspace}/apps/create_raw_source"),
         method: Cow::Borrowed("POST"),
         path_params_schema: None,
@@ -1224,9 +1224,9 @@ Creates a new version of an existing script when called with the same path and t
         body_field_renames: None,
     },
     EndpointTool {
-        name: Cow::Borrowed("updateAppRawSource"),
+        name: Cow::Borrowed("updateApp"),
         description: Cow::Borrowed("update a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)"),
-        instructions: Cow::Borrowed("Use this to change a raw (full-code) app — an app whose `raw_app` field is true. Send the whole `value` (`files`, `runnables`, `data`), not a patch: read the current one with getAppByPath first and edit it. The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps use updateApp instead."),
+        instructions: Cow::Borrowed("Use this to change a raw (full-code) app — an app whose `raw_app` field is true. Send the whole `value` (`files`, `runnables`, `data`), not a patch: read the current one with getAppByPath first and edit it. The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps are legacy and have no MCP tool at all — they are edited in their editor."),
         path: Cow::Borrowed("/w/{workspace}/apps/update_raw_source/{path}"),
         method: Cow::Borrowed("POST"),
         path_params_schema: Some(serde_json::json!({

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -1083,6 +1083,14 @@ Creates a new version of an existing script when called with the same path and t
         query_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
+                "page": {
+                        "type": "integer",
+                        "description": "which page to return (start at 1, default 1)"
+                },
+                "per_page": {
+                        "type": "integer",
+                        "description": "number of items to return for a given page (default 30, max 100)"
+                },
                 "path_start": {
                         "type": "string",
                         "description": "mask to filter matching starting path"
@@ -1097,7 +1105,7 @@ Creates a new version of an existing script when called with the same path and t
     EndpointTool {
         name: Cow::Borrowed("getAppByPath"),
         description: Cow::Borrowed("get app by path"),
-        instructions: Cow::Borrowed("Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."),
+        instructions: Cow::Borrowed("Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. A big enough app is truncated by the tool-result limit; sending that back fails the build rather than deploying something partial, so edit those in the app editor or with the CLI. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."),
         path: Cow::Borrowed("/w/{workspace}/apps/get/p/{path}"),
         method: Cow::Borrowed("GET"),
         path_params_schema: Some(serde_json::json!({

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -1076,7 +1076,7 @@ Creates a new version of an existing script when called with the same path and t
     EndpointTool {
         name: Cow::Borrowed("listApps"),
         description: Cow::Borrowed("list all apps"),
-        instructions: Cow::Borrowed("Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."),
+        instructions: Cow::Borrowed("Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. An app with no `raw_app` field is low-code — the field is omitted rather than sent as false. A low-code app can only be read here — editing one is a job for its editor in the UI."),
         path: Cow::Borrowed("/w/{workspace}/apps/list"),
         method: Cow::Borrowed("GET"),
         path_params_schema: None,

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -1074,48 +1074,32 @@ Creates a new version of an existing script when called with the same path and t
         body_field_renames: None,
     },
     EndpointTool {
-        name: Cow::Borrowed("createApp"),
-        description: Cow::Borrowed("create app"),
-        instructions: Cow::Borrowed(""),
-        path: Cow::Borrowed("/w/{workspace}/apps/create"),
-        method: Cow::Borrowed("POST"),
+        name: Cow::Borrowed("listApps"),
+        description: Cow::Borrowed("list all apps"),
+        instructions: Cow::Borrowed("Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateAppRawSource deploys. A low-code app can only be read here — editing one is a job for its editor in the UI."),
+        path: Cow::Borrowed("/w/{workspace}/apps/list"),
+        method: Cow::Borrowed("GET"),
         path_params_schema: None,
-        query_params_schema: None,
-        body_schema: Some(serde_json::json!({
+        query_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
-                "path": {
-                        "type": "string"
-                },
-                "value": {
-                        "type": "object"
-                },
-                "summary": {
-                        "type": "string"
-                },
-                "policy": {
-                        "type": "object"
-                },
-                "deployment_message": {
-                        "type": "string"
+                "path_start": {
+                        "type": "string",
+                        "description": "mask to filter matching starting path"
                 }
         },
-        "required": [
-                "path",
-                "value",
-                "summary",
-                "policy"
-        ]
+        "required": []
 })),
+        body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
     },
     EndpointTool {
-        name: Cow::Borrowed("updateApp"),
-        description: Cow::Borrowed("update app"),
-        instructions: Cow::Borrowed("Low-code apps only. An app whose `raw_app` field (from getAppByPath) is true is a raw (full-code) app and is refused here; use updateAppRawSource for those."),
-        path: Cow::Borrowed("/w/{workspace}/apps/update/{path}"),
-        method: Cow::Borrowed("POST"),
+        name: Cow::Borrowed("getAppByPath"),
+        description: Cow::Borrowed("get app by path"),
+        instructions: Cow::Borrowed("Returns the app's whole `value`, which is what updateAppRawSource needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP."),
+        path: Cow::Borrowed("/w/{workspace}/apps/get/p/{path}"),
+        method: Cow::Borrowed("GET"),
         path_params_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
@@ -1128,31 +1112,116 @@ Creates a new version of an existing script when called with the same path and t
         ]
 })),
         query_params_schema: None,
+        body_schema: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
+        name: Cow::Borrowed("createAppRawSource"),
+        description: Cow::Borrowed("create a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)"),
+        instructions: Cow::Borrowed("Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. There is no MCP tool for creating a low-code app — those are built in their editor."),
+        path: Cow::Borrowed("/w/{workspace}/apps/create_raw_source"),
+        method: Cow::Borrowed("POST"),
+        path_params_schema: None,
+        query_params_schema: None,
         body_schema: Some(serde_json::json!({
         "type": "object",
         "properties": {
+                "path": {
+                        "type": "string"
+                },
                 "summary": {
                         "type": "string"
                 },
                 "value": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "The raw app's value. `files` maps each source path to its content and must contain an entry point; `runnables` and `data` are carried through unchanged.",
+                        "properties": {
+                                "files": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                                "type": "string"
+                                        }
+                                },
+                                "runnables": {
+                                        "type": "object"
+                                },
+                                "data": {
+                                        "type": "object"
+                                }
+                        },
+                        "required": [
+                                "files"
+                        ]
                 },
                 "policy": {
-                        "type": "object"
-                },
-                "deployment_message": {
-                        "type": "string"
-                },
-                "path__body": {
-                        "type": "string",
-                        "description": "(body parameter). Defaults to `path` when omitted; set it only to change the path."
+                        "type": "object",
+                        "properties": {
+                                "triggerables": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                                "type": "object"
+                                        }
+                                },
+                                "triggerables_v2": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                                "type": "object"
+                                        }
+                                },
+                                "s3_inputs": {
+                                        "type": "array",
+                                        "items": {
+                                                "type": "object"
+                                        }
+                                },
+                                "allowed_s3_keys": {
+                                        "type": "array",
+                                        "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                        "s3_path": {
+                                                                "type": "string"
+                                                        },
+                                                        "resource": {
+                                                                "type": "string"
+                                                        }
+                                                }
+                                        }
+                                },
+                                "execution_mode": {
+                                        "type": "string",
+                                        "description": "Possible values: viewer, publisher, anonymous"
+                                },
+                                "on_behalf_of": {
+                                        "type": "string"
+                                },
+                                "on_behalf_of_email": {
+                                        "type": "string"
+                                },
+                                "sandbox": {
+                                        "type": "boolean",
+                                        "description": "Publisher opt-in to app sandbox isolation (alpha). When true the app is isolated from each viewer's Windmill session. When false/absent the app runs same-origin with the viewer's full session (the default, pre-isolation behavior).\n"
+                                },
+                                "frontend_sdk_scopes": {
+                                        "type": "array",
+                                        "items": {
+                                                "type": "string"
+                                        },
+                                        "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true — an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
+                                }
+                        }
                 }
-        }
+        },
+        "required": [
+                "path",
+                "value",
+                "summary",
+                "policy"
+        ]
 })),
         query_field_renames: None,
-        body_field_renames: Some(serde_json::json!({
-        "path__body": "path"
-})),
+        body_field_renames: None,
     },
     EndpointTool {
         name: Cow::Borrowed("updateAppRawSource"),

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -579,10 +579,17 @@ fn extra_scopes_for_route(route_path: &str) -> Option<(&'static str, &'static [&
     // what its own request is minted.
     let mut segments = route_path.split('/').skip_while(|s| *s != "w");
     let (_, _ws) = (segments.next()?, segments.next()?);
-    // Compiling an app's sources runs the app's own dependencies on a worker, so
-    // a token reaches that capability only by naming this tool.
-    (segments.next() == Some("apps") && segments.next() == Some("update_raw_source"))
-        .then_some(("updateAppRawSource", &["jobs:run"]))
+    if segments.next() != Some("apps") {
+        return None;
+    }
+    // Both deploy an app by compiling its sources, which runs the app's own
+    // dependencies on a worker — a token reaches that only by naming the tool.
+    // The names are the ones agents see (`x-mcp-tool-name`), not the operation ids.
+    match segments.next() {
+        Some("create_raw_source") => Some(("createApp", &["jobs:run"])),
+        Some("update_raw_source") => Some(("updateApp", &["jobs:run"])),
+        _ => None,
+    }
 }
 
 /// Whether the token names `tool` rather than reaching it through a blanket
@@ -708,6 +715,22 @@ mod tests {
     }
 
     #[test]
+    fn proxy_jwt_raw_app_create_needs_the_tool_named() {
+        // Same as the update route: creating an app compiles its sources too.
+        let route = "/api/w/ws/apps/create_raw_source";
+        let named = scopes(&["mcp:endpoints:createApp"]);
+        assert_eq!(
+            jwt_scopes_for_proxied_route(Some(&named), "POST", route).unwrap(),
+            Some(scopes(&["apps:write", "jobs:run"]))
+        );
+        let implicit = scopes(&["mcp:all"]);
+        assert_eq!(
+            jwt_scopes_for_proxied_route(Some(&implicit), "POST", route).unwrap(),
+            Some(scopes(&["apps:write"]))
+        );
+    }
+
+    #[test]
     fn proxy_jwt_raw_app_source_deploy_needs_the_tool_named() {
         // The handler requires jobs:run as well: compiling an app's sources runs
         // its dependencies on a worker. It goes in the per-request JWT, not on the
@@ -716,7 +739,7 @@ mod tests {
         // on create, mcp:all through OAuth) reach every endpoint without naming
         // one, and must not carry a capability their consent screen never showed.
         let route = "/api/w/ws/apps/update_raw_source/u/admin/app";
-        let named = scopes(&["mcp:endpoints:listScripts,updateAppRawSource"]);
+        let named = scopes(&["mcp:endpoints:listScripts,updateApp"]);
         assert_eq!(
             jwt_scopes_for_proxied_route(Some(&named), "POST", route).unwrap(),
             Some(scopes(&["apps:write", "jobs:run"]))

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -585,6 +585,10 @@ fn extra_scopes_for_route(route_path: &str) -> Option<(&'static str, &'static [&
     // Both deploy an app by compiling its sources, which runs the app's own
     // dependencies on a worker — a token reaches that only by naming the tool.
     // The names are the ones agents see (`x-mcp-tool-name`), not the operation ids.
+    //
+    // They are deliberately the names the retired low-code tools used, so a token
+    // issued before that switch reaches these instead — an accepted upgrade, not
+    // an oversight: MCP has one pair of app-write tools and they are these.
     match segments.next() {
         Some("create_raw_source") => Some(("createApp", &["jobs:run"])),
         Some("update_raw_source") => Some(("updateApp", &["jobs:run"])),

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -1082,48 +1082,32 @@ export const mcpEndpointTools: EndpointTool[] = [
         bodyFieldRenames: undefined
     },
     {
-        name: "createApp",
-        description: "create app",
-        instructions: "",
-        path: "/w/{workspace}/apps/create",
-        method: "POST",
+        name: "listApps",
+        description: "list all apps",
+        instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateAppRawSource deploys. A low-code app can only be read here — editing one is a job for its editor in the UI.",
+        path: "/w/{workspace}/apps/list",
+        method: "GET",
         pathParamsSchema: undefined,
-        queryParamsSchema: undefined,
-        bodySchema: {
+        queryParamsSchema: {
         "type": "object",
         "properties": {
-                "path": {
-                        "type": "string"
-                },
-                "value": {
-                        "type": "object"
-                },
-                "summary": {
-                        "type": "string"
-                },
-                "policy": {
-                        "type": "object"
-                },
-                "deployment_message": {
-                        "type": "string"
+                "path_start": {
+                        "type": "string",
+                        "description": "mask to filter matching starting path"
                 }
         },
-        "required": [
-                "path",
-                "value",
-                "summary",
-                "policy"
-        ]
+        "required": []
 },
+        bodySchema: undefined,
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
     },
     {
-        name: "updateApp",
-        description: "update app",
-        instructions: "Low-code apps only. An app whose `raw_app` field (from getAppByPath) is true is a raw (full-code) app and is refused here; use updateAppRawSource for those.",
-        path: "/w/{workspace}/apps/update/{path}",
-        method: "POST",
+        name: "getAppByPath",
+        description: "get app by path",
+        instructions: "Returns the app's whole `value`, which is what updateAppRawSource needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP.",
+        path: "/w/{workspace}/apps/get/p/{path}",
+        method: "GET",
         pathParamsSchema: {
         "type": "object",
         "properties": {
@@ -1136,31 +1120,116 @@ export const mcpEndpointTools: EndpointTool[] = [
         ]
 },
         queryParamsSchema: undefined,
+        bodySchema: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
+        name: "createAppRawSource",
+        description: "create a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)",
+        instructions: "Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. There is no MCP tool for creating a low-code app — those are built in their editor.",
+        path: "/w/{workspace}/apps/create_raw_source",
+        method: "POST",
+        pathParamsSchema: undefined,
+        queryParamsSchema: undefined,
         bodySchema: {
         "type": "object",
         "properties": {
+                "path": {
+                        "type": "string"
+                },
                 "summary": {
                         "type": "string"
                 },
                 "value": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "The raw app's value. `files` maps each source path to its content and must contain an entry point; `runnables` and `data` are carried through unchanged.",
+                        "properties": {
+                                "files": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                                "type": "string"
+                                        }
+                                },
+                                "runnables": {
+                                        "type": "object"
+                                },
+                                "data": {
+                                        "type": "object"
+                                }
+                        },
+                        "required": [
+                                "files"
+                        ]
                 },
                 "policy": {
-                        "type": "object"
-                },
-                "deployment_message": {
-                        "type": "string"
-                },
-                "path__body": {
-                        "type": "string",
-                        "description": "(body parameter). Defaults to `path` when omitted; set it only to change the path."
+                        "type": "object",
+                        "properties": {
+                                "triggerables": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                                "type": "object"
+                                        }
+                                },
+                                "triggerables_v2": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                                "type": "object"
+                                        }
+                                },
+                                "s3_inputs": {
+                                        "type": "array",
+                                        "items": {
+                                                "type": "object"
+                                        }
+                                },
+                                "allowed_s3_keys": {
+                                        "type": "array",
+                                        "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                        "s3_path": {
+                                                                "type": "string"
+                                                        },
+                                                        "resource": {
+                                                                "type": "string"
+                                                        }
+                                                }
+                                        }
+                                },
+                                "execution_mode": {
+                                        "type": "string",
+                                        "description": "Possible values: viewer, publisher, anonymous"
+                                },
+                                "on_behalf_of": {
+                                        "type": "string"
+                                },
+                                "on_behalf_of_email": {
+                                        "type": "string"
+                                },
+                                "sandbox": {
+                                        "type": "boolean",
+                                        "description": "Publisher opt-in to app sandbox isolation (alpha). When true the app is isolated from each viewer's Windmill session. When false/absent the app runs same-origin with the viewer's full session (the default, pre-isolation behavior).\n"
+                                },
+                                "frontend_sdk_scopes": {
+                                        "type": "array",
+                                        "items": {
+                                                "type": "string"
+                                        },
+                                        "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true \u2014 an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
+                                }
+                        }
                 }
-        }
+        },
+        "required": [
+                "path",
+                "value",
+                "summary",
+                "policy"
+        ]
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: {
-        "path__body": "path"
-}
+        bodyFieldRenames: undefined
     },
     {
         name: "updateAppRawSource",

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -1084,7 +1084,7 @@ export const mcpEndpointTools: EndpointTool[] = [
     {
         name: "listApps",
         description: "list all apps",
-        instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI.",
+        instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. An app with no `raw_app` field is low-code — the field is omitted rather than sent as false. A low-code app can only be read here — editing one is a job for its editor in the UI.",
         path: "/w/{workspace}/apps/list",
         method: "GET",
         pathParamsSchema: undefined,

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -1091,6 +1091,14 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: {
         "type": "object",
         "properties": {
+                "page": {
+                        "type": "integer",
+                        "description": "which page to return (start at 1, default 1)"
+                },
+                "per_page": {
+                        "type": "integer",
+                        "description": "number of items to return for a given page (default 30, max 100)"
+                },
                 "path_start": {
                         "type": "string",
                         "description": "mask to filter matching starting path"
@@ -1105,7 +1113,7 @@ export const mcpEndpointTools: EndpointTool[] = [
     {
         name: "getAppByPath",
         description: "get app by path",
-        instructions: "Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP.",
+        instructions: "Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. A big enough app is truncated by the tool-result limit; sending that back fails the build rather than deploying something partial, so edit those in the app editor or with the CLI. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP.",
         path: "/w/{workspace}/apps/get/p/{path}",
         method: "GET",
         pathParamsSchema: {

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -1084,7 +1084,7 @@ export const mcpEndpointTools: EndpointTool[] = [
     {
         name: "listApps",
         description: "list all apps",
-        instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateAppRawSource deploys. A low-code app can only be read here — editing one is a job for its editor in the UI.",
+        instructions: "Lists every app, low-code and full-code alike. `raw_app` tells them apart: true is a full-code app, which getAppByPath then reads and updateApp deploys. A low-code app can only be read here — editing one is a job for its editor in the UI.",
         path: "/w/{workspace}/apps/list",
         method: "GET",
         pathParamsSchema: undefined,
@@ -1105,7 +1105,7 @@ export const mcpEndpointTools: EndpointTool[] = [
     {
         name: "getAppByPath",
         description: "get app by path",
-        instructions: "Returns the app's whole `value`, which is what updateAppRawSource needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP.",
+        instructions: "Returns the app's whole `value`, which is what updateApp needs: it takes the whole thing, not a patch. `raw_app` says whether this is a full-code app (its value holds `files`/`runnables`) or a low-code one (a `grid`), and only a full-code app can be deployed through MCP.",
         path: "/w/{workspace}/apps/get/p/{path}",
         method: "GET",
         pathParamsSchema: {
@@ -1125,9 +1125,9 @@ export const mcpEndpointTools: EndpointTool[] = [
         bodyFieldRenames: undefined
     },
     {
-        name: "createAppRawSource",
+        name: "createApp",
         description: "create a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)",
-        instructions: "Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. There is no MCP tool for creating a low-code app — those are built in their editor.",
+        instructions: "Creates a raw (full-code) app: `value.files` holds its sources, keyed by path (`/index.tsx`, `/App.tsx`, `/package.json`), and needs an entry point (`/index.tsx`, `/index.ts` or `/index.js`). The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps are legacy and have no MCP tool at all — they are built in their editor.",
         path: "/w/{workspace}/apps/create_raw_source",
         method: "POST",
         pathParamsSchema: undefined,
@@ -1232,9 +1232,9 @@ export const mcpEndpointTools: EndpointTool[] = [
         bodyFieldRenames: undefined
     },
     {
-        name: "updateAppRawSource",
+        name: "updateApp",
         description: "update a raw app from its sources, compiling them on a worker (which runs the app's own dependencies to do so)",
-        instructions: "Use this to change a raw (full-code) app — an app whose `raw_app` field is true. Send the whole `value` (`files`, `runnables`, `data`), not a patch: read the current one with getAppByPath first and edit it. The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps use updateApp instead.",
+        instructions: "Use this to change a raw (full-code) app — an app whose `raw_app` field is true. Send the whole `value` (`files`, `runnables`, `data`), not a patch: read the current one with getAppByPath first and edit it. The sources are compiled on a worker by the same build the editor and the CLI run, so a compile error comes back as the error of this call. Compiling runs the app's own dependencies on a worker, so this tool can execute code there. Low-code apps are legacy and have no MCP tool at all — they are edited in their editor.",
         path: "/w/{workspace}/apps/update_raw_source/{path}",
         method: "POST",
         pathParamsSchema: {


### PR DESCRIPTION
## Summary

Low-code apps are legacy, so `createApp` and `updateApp` — the app tools an agent gets over MCP — should be the full-code ones. Today they're the low-code ones, and an agent can't read an app at all.

The MCP app surface after this:

| tool | endpoint | |
|---|---|---|
| `listApps` | `/apps/list` | every app; `raw_app` tells the kinds apart |
| `getAppByPath` | `/apps/get/p/{path}` | the app's whole value, which a deploy needs |
| `createApp` | `/apps/create_raw_source` | **new endpoint** — create a full-code app from its sources |
| `updateApp` | `/apps/update_raw_source/{path}` | update one (#10500) |

The low-code `/apps/create` and `/apps/update/{path}` are no longer MCP tools. The endpoints are untouched — the editor, the CLI and git-sync still use them.

## How the names work

`createApp` and `updateApp` stay the operationIds of the low-code endpoints, because the frontend, the CLI and the published client are all keyed on them; renaming those would ripple through every caller for no gain. What changes is the name the *tool* carries: a new `x-mcp-tool-name` on the raw-source endpoints, which the generator uses in place of the operationId. So an agent sees `createApp`/`updateApp` and they are the full-code ones, while `AppService.updateApp` keeps meaning what it means.

## Changes

- **`POST /w/{workspace}/apps/create_raw_source`** — the create counterpart of `update_raw_source`: sources as JSON, compiled on a worker through `wmill app bundle`, then the app is created and the bundle stored. Same guards as the update path (non-operator, `apps:write:<path>`, `jobs:run` because the compile runs the app's own dependencies, deploy rules).
- **`listApps` and `getAppByPath` become tools.** Without a read tool the deploy tools aren't usable: `updateApp` takes the *whole* value, so an agent has to read it first — its own instructions said "read the current one with getAppByPath", which wasn't exposed. `listApps` carries no `value`, so listing stays cheap.
- **`x-mcp-tool-name`** in the generator, defaulting to the operationId.
- **The `jobs:run` gate covers both deploy routes** and matches on the names agents see. That gate is keyed on the tool name the token grants, so it had to follow the rename or `updateApp` would 403 for every token that named it.
- Each tool's instructions say which kind it is for: the read tools explain that `raw_app` distinguishes them and only a full-code app deploys through MCP; the write tools say low-code apps are legacy and have no MCP tool at all.

## Upgrade note — existing MCP tokens

The tool names are reused deliberately, and that has a consequence worth stating before merge: a token issued **before** this change whose scope names `mcp:endpoints:updateApp` (or `createApp`) selected the *low-code* tool, which couldn't run anything on a worker. After this it names the full-code deploy tool, so it gets `jobs:run` minted for that call and can have a worker compile app sources — i.e. run the app's own dependencies. Nobody re-consents; the picker's warning only reaches newly-issued tokens.

That was a deliberate call (MCP has one pair of app-write tools and these are them), not an oversight — the mint site says so, so nobody "fixes" it later. **Existing MCP tokens are worth reviewing when this ships.** If you'd rather old grants not carry over, the alternative is names an old token can't hold (`updateFullCodeApp`, or the `updateAppRawSource` this branch started with) — say so and it's a one-line change plus a regen.

## Test plan

Verified against the dev backend (`WM_RAW_APP_BUNDLER_CLI` pointing at the local CLI, since `app bundle` ships in the release that just merged and isn't on npm yet).

- [x] `POST /apps/create_raw_source` with a React app's sources → **201**, `raw_app = true`, 187,124-byte bundle stored — byte-identical to `wmill app bundle` on the same sources
- [x] a low-code value (`{grid: []}`) → 400 `no \`files\` to bundle`, before any job is queued (integration case, needs no worker)
- [x] a **non-admin member of `g/all`** creating at `g/all/…` reaches the compile, and gets 403 at another user's `u/…` path (integration case, needs no worker)
- [x] the same two outcomes straight from the `app` policies in psql: the group member's insert succeeds, the outsider's raises `42501`
- [x] generated tool list is exactly `listApps, getAppByPath, createApp, updateApp`, and `createApp`/`updateApp` point at the raw-source endpoints
- [x] the scope gate mints `jobs:run` for a token naming `createApp` or `updateApp`, and not for `mcp:all` — 6 scope tests pass under `--features mcp`
- [x] `cargo test -p windmill-api-integration-tests --test apps` — 2 passed; 6 scope tests; `cargo check -p windmill-api --features mcp`, `npm run check:fast` — clean

## Review findings addressed

- **create compiled before the checks that reject it** (claude, pi) — the path-already-taken and writer checks now run before the bundle job, matching what `update_raw_source` does and what its comment claims.
- **create refused `g/<group>/…` for a non-admin group member** (codex, claude) — that check was a hand-written restatement of the app RLS, and it missed the `see_member` policy that grants a group member write on their group's paths. It now probes the insert itself through `user_db` and rolls it back, the way the update path asks `can_write_app`, and a denial answers 403 like the update path rather than 400.
- **`listApps` couldn't page past the 1000-row default** (codex) — `page` and `per_page` are in the tool schema now.
- **`getAppByPath` can truncate a large app's value** (codex) — the 87,500-byte tool-result cap is global to MCP and out of scope to change here. The instructions now say what happens: send a truncated value back and the build fails rather than deploying something partial, so large apps belong in the editor or the CLI. A chunked read is the real fix and is a separate change.
- **Reusing the tool names upgrades existing tokens** (all three) — see the upgrade note above; kept deliberately.

Follow-up to WIN-2291 / #10500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
