### PR TITLE
fix: serve getJob in the ai evals benchmark api catalog

### DIFF
--- a/.claude/hooks/format-frontend.sh
+++ b/.claude/hooks/format-frontend.sh
@@ -10,8 +10,12 @@ if [ -z "$FILE_PATH" ]; then
     exit 0
 fi
 
-# Check if the file is in the frontend directory
-if [[ "$FILE_PATH" == "$CLAUDE_PROJECT_DIR/frontend/"* ]]; then
+# Only the frontend app itself, i.e. a "frontend" directory sitting at a repo root.
+# A bare */frontend/* substring also matches ai_evals/adapters/frontend and the
+# ai_evals app fixtures, which no prettier config governs — prettier then falls back
+# to its defaults and rewrites the whole file. Anchoring to $CLAUDE_PROJECT_DIR
+# instead would skip worktrees edited from a session rooted elsewhere.
+if [[ "$FILE_PATH" == *"/frontend/"* ]] && [[ -e "${FILE_PATH%%/frontend/*}/.git" ]]; then
     # Check if it's a formattable file type
     if [[ "$FILE_PATH" =~ \.(ts|js|svelte|json|css|html|md)$ ]]; then
         cd "$CLAUDE_PROJECT_DIR/frontend" || exit 0

--- a/.claude/hooks/format-frontend.sh
+++ b/.claude/hooks/format-frontend.sh
@@ -11,7 +11,7 @@ if [ -z "$FILE_PATH" ]; then
 fi
 
 # Check if the file is in the frontend directory
-if [[ "$FILE_PATH" == *"/frontend/"* ]]; then
+if [[ "$FILE_PATH" == "$CLAUDE_PROJECT_DIR/frontend/"* ]]; then
     # Check if it's a formattable file type
     if [[ "$FILE_PATH" =~ \.(ts|js|svelte|json|css|html|md)$ ]]; then
         cd "$CLAUDE_PROJECT_DIR/frontend" || exit 0

--- a/.github/workflows/ai-evals-test.yml
+++ b/.github/workflows/ai-evals-test.yml
@@ -118,6 +118,12 @@ jobs:
           npm ci
           npm run generate-backend-client
 
+      - name: Run harness unit tests
+        working-directory: ./ai_evals
+        run: |
+          bun install
+          bun test adapters/
+
       - name: Run global AI evals
         timeout-minutes: 20
         working-directory: ./ai_evals

--- a/ai_evals/adapters/frontend/mockBackend.ts
+++ b/ai_evals/adapters/frontend/mockBackend.ts
@@ -748,6 +748,18 @@ const BENCHMARK_MCP_TOOLS: EndpointTool[] = [
 		}
 	},
 	{
+		name: 'getJob',
+		description: 'Get a job by id',
+		instructions: '',
+		path: '/w/{workspace}/jobs_u/get/{id}',
+		method: 'GET',
+		path_params_schema: {
+			type: 'object',
+			properties: { workspace: { type: 'string' }, id: { type: 'string', format: 'uuid' } },
+			required: ['workspace', 'id']
+		}
+	},
+	{
 		name: 'runScriptByPath',
 		description: 'Run the deployed version of a script by path',
 		instructions: '',
@@ -968,6 +980,8 @@ const BENCHMARK_WORKERS = [
 	}
 ]
 
+const BENCHMARK_JOB_GET_PATH = /^\/api\/w\/([^/]+)\/jobs_u\/get\/([^/]+)$/
+
 /** True when `handleBenchmarkApiFetch` has an answer for this `/api/...` url.
  * Any other relative fetch must keep its normal (non-benchmark) behavior —
  * intercepting it with a synthetic 404 sends the model into retry loops. */
@@ -975,6 +989,7 @@ export function hasBenchmarkApiHandler(url: string): boolean {
 	const path = url.split('?')[0]
 	return (
 		path === '/api/workers/list' ||
+		BENCHMARK_JOB_GET_PATH.test(path) ||
 		/^\/api\/w\/[^/]+\/jobs\/queue\/list$/.test(path) ||
 		path === '/api/embeddings/query_hub_scripts' ||
 		path.startsWith('/api/scripts/hub/get_full/')
@@ -990,6 +1005,17 @@ export function handleBenchmarkApiFetch(url: string): Response {
 	}
 	if (/^\/api\/w\/[^/]+\/jobs\/queue\/list$/.test(path)) {
 		return Response.json([])
+	}
+	const jobGet = BENCHMARK_JOB_GET_PATH.exec(path)
+	if (jobGet) {
+		const job = getBenchmarkCompletedJob(
+			decodeURIComponent(jobGet[1]),
+			decodeURIComponent(jobGet[2])
+		)
+		if (!job) {
+			return Response.json({ error: `Job not found for "${jobGet[2]}"` }, { status: 404 })
+		}
+		return Response.json(job)
 	}
 	if (path === '/api/embeddings/query_hub_scripts') {
 		const text = new URLSearchParams(url.split('?')[1] ?? '').get('text') ?? ''

--- a/ai_evals/adapters/frontend/mockBackend.ts
+++ b/ai_evals/adapters/frontend/mockBackend.ts
@@ -561,6 +561,35 @@ export function runBenchmarkScriptPreview(input: {
 	})
 }
 
+export function runBenchmarkScriptByPath(input: {
+	workspace: string
+	path: string
+	args?: Record<string, unknown>
+}): string {
+	const script = getBenchmarkScriptByPath(input.workspace, input.path)
+	return createBenchmarkCompletedJob({
+		workspace: input.workspace,
+		jobKind: 'script',
+		success: script !== null,
+		scriptPath: input.path,
+		args: input.args,
+		result:
+			script !== null
+				? {
+						path: input.path,
+						args: input.args ?? {},
+						mocked: true
+					}
+				: {
+						error: `Script "${input.path}" not found in benchmark workspace`
+					},
+		logs:
+			script !== null
+				? 'Mock benchmark script run completed successfully.'
+				: `Script "${input.path}" not found in benchmark workspace.`
+	})
+}
+
 export function runBenchmarkFlowByPath(input: {
 	workspace: string
 	path: string
@@ -749,7 +778,7 @@ const BENCHMARK_MCP_TOOLS: EndpointTool[] = [
 	},
 	{
 		name: 'getJob',
-		description: 'Get a job by id',
+		description: 'get job',
 		instructions: '',
 		path: '/w/{workspace}/jobs_u/get/{id}',
 		method: 'GET',
@@ -757,6 +786,15 @@ const BENCHMARK_MCP_TOOLS: EndpointTool[] = [
 			type: 'object',
 			properties: { workspace: { type: 'string' }, id: { type: 'string', format: 'uuid' } },
 			required: ['workspace', 'id']
+		},
+		query_params_schema: {
+			type: 'object',
+			properties: {
+				no_logs: { type: 'boolean' },
+				no_code: { type: 'boolean' },
+				approval_token: { type: 'string' }
+			},
+			required: []
 		}
 	},
 	{
@@ -981,6 +1019,24 @@ const BENCHMARK_WORKERS = [
 ]
 
 const BENCHMARK_JOB_GET_PATH = /^\/api\/w\/([^/]+)\/jobs_u\/get\/([^/]+)$/
+const BENCHMARK_RUN_BY_PATH = /^\/api\/w\/([^/]+)\/jobs\/run\/(p|f)\/([^/]+)$/
+
+/** `executeEndpoint` sends a JSON string; anything else means no args were supplied. */
+function parseBenchmarkRequestBody(
+	body: BodyInit | null | undefined
+): Record<string, unknown> | undefined {
+	if (typeof body !== 'string') {
+		return undefined
+	}
+	try {
+		const parsed = JSON.parse(body)
+		return typeof parsed === 'object' && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: undefined
+	} catch {
+		return undefined
+	}
+}
 
 /** True when `handleBenchmarkApiFetch` has an answer for this `/api/...` url.
  * Any other relative fetch must keep its normal (non-benchmark) behavior —
@@ -990,6 +1046,7 @@ export function hasBenchmarkApiHandler(url: string): boolean {
 	return (
 		path === '/api/workers/list' ||
 		BENCHMARK_JOB_GET_PATH.test(path) ||
+		BENCHMARK_RUN_BY_PATH.test(path) ||
 		/^\/api\/w\/[^/]+\/jobs\/queue\/list$/.test(path) ||
 		path === '/api/embeddings/query_hub_scripts' ||
 		path.startsWith('/api/scripts/hub/get_full/')
@@ -998,7 +1055,7 @@ export function hasBenchmarkApiHandler(url: string): boolean {
 
 /** Answer a relative `/api/...` fetch — from the API catalog executor, or from the
  * chat's hub tools. */
-export function handleBenchmarkApiFetch(url: string): Response {
+export function handleBenchmarkApiFetch(url: string, init?: RequestInit): Response {
 	const path = url.split('?')[0]
 	if (path === '/api/workers/list') {
 		return Response.json(BENCHMARK_WORKERS)
@@ -1008,14 +1065,33 @@ export function handleBenchmarkApiFetch(url: string): Response {
 	}
 	const jobGet = BENCHMARK_JOB_GET_PATH.exec(path)
 	if (jobGet) {
-		const job = getBenchmarkCompletedJob(
-			decodeURIComponent(jobGet[1]),
-			decodeURIComponent(jobGet[2])
-		)
+		const id = decodeURIComponent(jobGet[2])
+		const job = getBenchmarkCompletedJob(decodeURIComponent(jobGet[1]), id)
 		if (!job) {
-			return Response.json({ error: `Job not found for "${jobGet[2]}"` }, { status: 404 })
+			return Response.json({ error: `Job not found for "${id}"` }, { status: 404 })
+		}
+		// The real endpoint lets a caller drop the bulky fields. Ignoring that here would
+		// size the model's context off a payload it explicitly asked to shrink.
+		const query = new URLSearchParams(url.split('?')[1] ?? '')
+		if (query.get('no_logs') === 'true') {
+			delete job.logs
+		}
+		if (query.get('no_code') === 'true') {
+			delete job.raw_code
 		}
 		return Response.json(job)
+	}
+	const runByPath = BENCHMARK_RUN_BY_PATH.exec(path)
+	if (runByPath) {
+		const workspace = decodeURIComponent(runByPath[1])
+		const runnablePath = decodeURIComponent(runByPath[3])
+		const args = parseBenchmarkRequestBody(init?.body)
+		// The real endpoint answers with the bare job id as text, not JSON.
+		return new Response(
+			runByPath[2] === 'f'
+				? runBenchmarkFlowByPath({ workspace, path: runnablePath, args })
+				: runBenchmarkScriptByPath({ workspace, path: runnablePath, args })
+		)
 	}
 	if (path === '/api/embeddings/query_hub_scripts') {
 		const text = new URLSearchParams(url.split('?')[1] ?? '').get('text') ?? ''

--- a/ai_evals/adapters/frontend/mockBackendApi.test.ts
+++ b/ai_evals/adapters/frontend/mockBackendApi.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+	createBenchmarkCompletedJob,
+	handleBenchmarkApiFetch,
+	hasBenchmarkApiHandler,
+	listBenchmarkMcpTools,
+	resetBenchmarkMockBackend
+} from './mockBackend'
+
+const WORKSPACE = 'benchmark-api-ws'
+
+// A catalog entry with no fetch handler is a dead end: `call_api_get` builds a
+// relative `/api/...` url, the stub declines it, and node's fetch throws on the
+// relative url instead of returning a result the model can act on. The model then
+// burns its remaining turns searching for an endpoint that will never answer.
+describe('benchmark API catalog', () => {
+	beforeEach(() => resetBenchmarkMockBackend())
+	afterEach(() => resetBenchmarkMockBackend())
+
+	it('answers every GET endpoint it advertises', () => {
+		const unanswered = listBenchmarkMcpTools()
+			.filter((tool) => tool.method.toUpperCase() === 'GET')
+			.map((tool) =>
+				`/api${tool.path.replace('{workspace}', WORKSPACE)}`.replace(/\{[^}]+\}/g, 'x')
+			)
+			.filter((url) => !hasBenchmarkApiHandler(url))
+
+		// The draft-covered reads are refused by name before any fetch, so they are
+		// advertised without a handler on purpose.
+		expect(unanswered).toEqual([
+			`/api/w/${WORKSPACE}/scripts/get/p/x`,
+			`/api/w/${WORKSPACE}/variables/get/x`
+		])
+	})
+
+	it('serves a recorded job so a model can check the run it just started', async () => {
+		const id = createBenchmarkCompletedJob({
+			workspace: WORKSPACE,
+			jobKind: 'preview',
+			result: 'Hello, World!'
+		})
+
+		const res = handleBenchmarkApiFetch(`/api/w/${WORKSPACE}/jobs_u/get/${id}`)
+
+		expect(res.status).toBe(200)
+		expect(await res.json()).toMatchObject({
+			id,
+			success: true,
+			result: 'Hello, World!'
+		})
+	})
+
+	it('404s an unknown job id instead of letting the fetch fall through', () => {
+		expect(hasBenchmarkApiHandler(`/api/w/${WORKSPACE}/jobs_u/get/missing`)).toBe(true)
+		expect(handleBenchmarkApiFetch(`/api/w/${WORKSPACE}/jobs_u/get/missing`).status).toBe(404)
+	})
+})

--- a/ai_evals/adapters/frontend/mockBackendApi.test.ts
+++ b/ai_evals/adapters/frontend/mockBackendApi.test.ts
@@ -1,36 +1,62 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import {
 	createBenchmarkCompletedJob,
+	getBenchmarkCompletedJob,
 	handleBenchmarkApiFetch,
 	hasBenchmarkApiHandler,
 	listBenchmarkMcpTools,
-	resetBenchmarkMockBackend
+	resetBenchmarkMockBackend,
+	registerBenchmarkWorkspaceRunnables
 } from './mockBackend'
 
 const WORKSPACE = 'benchmark-api-ws'
 
-// A catalog entry with no fetch handler is a dead end: `call_api_get` builds a
-// relative `/api/...` url, the stub declines it, and node's fetch throws on the
-// relative url instead of returning a result the model can act on. The model then
-// burns its remaining turns searching for an endpoint that will never answer.
+// A catalog entry with no fetch handler is a dead end: the catalog executor builds a
+// relative `/api/...` url, the stub declines it, and node's fetch throws on the relative
+// url instead of returning a result the model can act on. Mutating entries are reachable
+// too — the eval runners define no `requestConfirmation`, so `call_api_endpoint` executes
+// unconfirmed.
 describe('benchmark API catalog', () => {
 	beforeEach(() => resetBenchmarkMockBackend())
 	afterEach(() => resetBenchmarkMockBackend())
 
-	it('answers every GET endpoint it advertises', () => {
+	it('answers every endpoint it advertises', () => {
 		const unanswered = listBenchmarkMcpTools()
-			.filter((tool) => tool.method.toUpperCase() === 'GET')
 			.map((tool) =>
 				`/api${tool.path.replace('{workspace}', WORKSPACE)}`.replace(/\{[^}]+\}/g, 'x')
 			)
 			.filter((url) => !hasBenchmarkApiHandler(url))
 
-		// The draft-covered reads are refused by name before any fetch, so they are
+		// The draft-covered entries are refused by name before any fetch, so they are
 		// advertised without a handler on purpose.
 		expect(unanswered).toEqual([
 			`/api/w/${WORKSPACE}/scripts/get/p/x`,
+			`/api/w/${WORKSPACE}/flows/create`,
+			`/api/w/${WORKSPACE}/schedules/delete/x`,
 			`/api/w/${WORKSPACE}/variables/get/x`
 		])
+	})
+
+	it('runs a deployed script by path, the way call_api_endpoint reaches it', async () => {
+		registerBenchmarkWorkspaceRunnables(WORKSPACE, {
+			scripts: [
+				{
+					path: 'f/evals/greet',
+					summary: 'Greet',
+					language: 'bun',
+					content: 'export async function main() {}'
+				}
+			]
+		})
+
+		const res = handleBenchmarkApiFetch(
+			`/api/w/${WORKSPACE}/jobs/run/p/${encodeURIComponent('f/evals/greet')}`,
+			{ method: 'POST', body: JSON.stringify({ name: 'ada' }) }
+		)
+
+		expect(res.status).toBe(200)
+		const job = getBenchmarkCompletedJob(WORKSPACE, (await res.text()).trim())
+		expect(job).toMatchObject({ success: true, args: { name: 'ada' } })
 	})
 
 	it('serves a recorded job so a model can check the run it just started', async () => {

--- a/ai_evals/adapters/frontend/vitestAdapter.test.ts
+++ b/ai_evals/adapters/frontend/vitestAdapter.test.ts
@@ -13,7 +13,7 @@ const ORIGINAL_FETCH = globalThis.fetch
 globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
 	const url = typeof input === 'string' ? input : ((input as Request | URL | null)?.url ?? '')
 	if (typeof url === 'string' && hasBenchmarkApiHandler(url)) {
-		return handleBenchmarkApiFetch(url)
+		return handleBenchmarkApiFetch(url, init)
 	}
 	return ORIGINAL_FETCH(input as Parameters<typeof fetch>[0], init)
 }) as typeof fetch


### PR DESCRIPTION
## Summary

The `AI Evals (global mode)` job gates on all four models passing a single case, and it went red when `gemini-3-flash-preview` hit its 10-turn cap ([run 30909232069](https://github.com/windmill-labs/windmill/actions/runs/30909232069/job/91991538251)). The model had already produced the correct draft on turn 2; it then tried to verify its own test run and could not, because the harness offered no way to look a job up.

The eval harness serves its own catalog slice (`BENCHMARK_MCP_TOOLS`) in place of the backend's MCP endpoint catalog, and that slice had **no** job-lookup endpoint, while the real catalog does expose `getJob`. So the model's follow-up searches (`get job result`, `get run`, `job`, `result`) were unsatisfiable by construction, and it spent every remaining turn hunting for an endpoint that could never answer. Any model that tries to check its own run can fall into this; gemini just happened to be the one that did.

The second commit is unrelated and small: the repo's prettier hook was reformatting files it does not own.

## Changes

- Add a `getJob` entry to `BENCHMARK_MCP_TOOLS`, mirroring the real catalog entry in `backend/windmill-api/src/mcp/auto_generated_endpoints.rs` (`GET /w/{workspace}/jobs_u/get/{id}`). Its description deliberately avoids "result"/"run" tokens so search ranking does not become easier than production.
- Serve that path from `hasBenchmarkApiHandler` / `handleBenchmarkApiFetch` out of the existing in-memory `benchmarkJobs` store, returning 404 for an unknown id rather than falling through to node's relative-URL `TypeError`.
- Add `mockBackendApi.test.ts`, pinning the invariant that broke: every GET the harness advertises must have a fetch handler.
- `chore`: `.claude/hooks/format-frontend.sh` gated on a bare `*"/frontend/"*` substring, so it also matched `ai_evals/adapters/frontend/*.ts` and rewrote them with default prettier settings (nothing above `ai_evals/` provides a config). One edit produced a 777-insertion / 682-deletion diff of pure style churn. Now anchored to `"$CLAUDE_PROJECT_DIR/frontend/"*`.

`getCompletedJobResultMaybe` is deliberately **not** wired up: it carries no `x-mcp-tool`, so it is absent from the product catalog, and adding it to the harness would let evals validate a call the real chat cannot make. `getJob` returns `result` and `success`, answering the same question through the path production actually exposes.

## Test plan

- [x] `bun test adapters/frontend/` in `ai_evals/` — 66 pass, 1 skip, 0 fail. The two new job tests fail without the fix and pass with it.
- [x] `bun run typecheck` in `ai_evals/` — unchanged at 248 pre-existing errors.
- [x] End to end against a live backend: `global-test1-script-create` still passes, and a throwaway probe case drove the production `call_api_get` into the new handler and got a 200. That confirmed the workspace arrives percent-encoded (`%2Ftmp%2Fwmill-frontend-global-benchmark-…`), so the `decodeURIComponent` is load-bearing — without it the lookup 404s. Probe case and instrumentation removed.
- [x] Hook exercised directly: `ai_evals/adapters/frontend/*.ts` now no-ops, a real `frontend/src/lib/` file still formats in repo style, and the EE repo has no `frontend/` so nothing legitimate was dropped.

No `frontend/` files are touched, so no screenshots apply.

This makes the harness stop manufacturing the loop; it does not make the gate tolerant, so a model that wanders for other reasons can still redden the job on a 10-turn budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve `getJob` and run-by-path endpoints in the evals benchmark API so models can start runs and look them up without stalling. Also tighten the frontend format hook and run harness unit tests in CI.

- **Bug Fixes**
  - Added `getJob` to the catalog and served `GET /w/{workspace}/jobs_u/get/{id}` with decoded params, `no_logs`/`no_code` support, and 404 for unknown ids.
  - Handled `POST /w/{workspace}/jobs/run/p/{path}` and `/f/{path}` to execute by path, accept JSON args, and return the job id as text; wired the adapter to pass `init` so request bodies are read.
  - Added `mockBackendApi.test.ts` to ensure every advertised GET has a handler and to validate run-by-path and job retrieval; CI now runs `bun test adapters/` before evals.
  - Format hook now only targets a repo-root `frontend/` app (checks for a `.git` root) to avoid rewriting files under `ai_evals/`.

<sup>Written for commit f05e42feae550ef406be76e252be0901e77575dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

