### PR TITLE
fix: show which MCP endpoint tools a token scope will actually expose

### DIFF
--- a/backend/windmill-mcp/src/server/runner.rs
+++ b/backend/windmill-mcp/src/server/runner.rs
@@ -127,7 +127,9 @@ impl<B: McpBackend> Runner<B> {
 }
 
 /// How an endpoint tool interacts with the token's `mcp:scripts:` / `mcp:flows:`
-/// path scopes.
+/// path scopes. Mirrored in
+/// `frontend/src/lib/components/mcp/endpointScopePolicy.ts` so the scope picker
+/// only advertises tools this policy will actually list — keep the two in sync.
 enum EndpointPathPolicy {
     /// Executes the script/flow named by the `path` argument. Gated by the
     /// script/flow scope alone (an endpoint scope is not enough to run things):

--- a/frontend/src/lib/components/mcp/McpScopeSelector.svelte
+++ b/frontend/src/lib/components/mcp/McpScopeSelector.svelte
@@ -461,8 +461,6 @@
 	let exposedScriptCount = $state<number | undefined>(undefined)
 	let exposedFlowCount = $state<number | undefined>(undefined)
 
-	// Mirror the backend's is_resource_allowed: `*`, an exact path, or an `x/*`
-	// subtree (matching the folder itself or anything beneath it).
 	// Custom-mode counts are computed synchronously from the already-loaded
 	// allScripts/allFlows plus the current selections/patterns — no extra fetch.
 	$effect(() => {
@@ -670,8 +668,8 @@
 					<Alert type="warning" size="xs" title="Some selected endpoints will not be exposed">
 						<span class="text-xs">
 							Endpoints that cannot be limited to specific script paths are withheld from a token
-							restricted to a script selection: {withheldEndpoints.join(', ')}. Clear the Scripts
-							selection and patterns to expose them.
+							restricted to a script selection: {withheldEndpoints.join(', ')}. Widening the script
+							wildcard pattern to <code>*</code> exposes them, and keeps the run tools below available.
 						</span>
 					</Alert>
 				{/if}

--- a/frontend/src/lib/components/mcp/McpScopeSelector.svelte
+++ b/frontend/src/lib/components/mcp/McpScopeSelector.svelte
@@ -11,7 +11,9 @@
 	import {
 		endpointPathPolicy,
 		isEndpointExposed,
-		parseMcpScopeState
+		matchesAnyPattern,
+		parseMcpScopeState,
+		pruneEndpointSelection
 	} from '$lib/components/mcp/endpointScopePolicy'
 	import InfoIcon from 'lucide-svelte/icons/info'
 	import { SvelteMap } from 'svelte/reactivity'
@@ -44,13 +46,9 @@
 		visibleEndpointTools.filter((e) => endpointPathPolicy(e.name)?.kind !== 'runByPath')
 	)
 
-	// Drop selections the list doesn't offer (non-GET endpoints once read-only
-	// flips on, run-by-path names carried over from an older scope string) so the
-	// scope doesn't keep references the server ignores or rejects.
 	$effect(() => {
 		if (selectedEndpoints.length === 0) return
-		const allowed = new Set(selectableEndpointTools.map((e) => e.name))
-		const filtered = selectedEndpoints.filter((n) => allowed.has(n))
+		const filtered = pruneEndpointSelection(selectedEndpoints, readOnly)
 		if (filtered.length !== selectedEndpoints.length) {
 			selectedEndpoints = filtered
 		}
@@ -465,19 +463,6 @@
 
 	// Mirror the backend's is_resource_allowed: `*`, an exact path, or an `x/*`
 	// subtree (matching the folder itself or anything beneath it).
-	function matchesAnyPattern(path: string, patterns: string[]): boolean {
-		for (const p of patterns) {
-			if (p === '*' || p === path) return true
-			if (p.endsWith('/*')) {
-				const prefix = p.slice(0, -2)
-				if (path === prefix || (path.startsWith(prefix) && path[prefix.length] === '/')) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
 	// Custom-mode counts are computed synchronously from the already-loaded
 	// allScripts/allFlows plus the current selections/patterns — no extra fetch.
 	$effect(() => {

--- a/frontend/src/lib/components/mcp/McpScopeSelector.svelte
+++ b/frontend/src/lib/components/mcp/McpScopeSelector.svelte
@@ -8,6 +8,11 @@
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { FlowService, FolderService, IntegrationService, ScriptService } from '$lib/gen'
 	import { mcpEndpointTools } from '$lib/mcpEndpointTools'
+	import {
+		endpointPathPolicy,
+		isEndpointExposed,
+		parseMcpScopeState
+	} from '$lib/components/mcp/endpointScopePolicy'
 	import InfoIcon from 'lucide-svelte/icons/info'
 	import { SvelteMap } from 'svelte/reactivity'
 
@@ -32,11 +37,19 @@
 		readOnly ? mcpEndpointTools.filter((e) => e.method === 'GET') : mcpEndpointTools
 	)
 
-	// When read-only flips on, prune already-selected non-GET endpoints so the
-	// scope string doesn't keep references to tools the server will reject.
+	// Endpoints the "API Endpoints" list actually governs. The run-by-path tools
+	// are gated by the script/flow selection instead, so listing them here would
+	// offer a checkbox the server ignores; they get their own section.
+	const selectableEndpointTools = $derived(
+		visibleEndpointTools.filter((e) => endpointPathPolicy(e.name)?.kind !== 'runByPath')
+	)
+
+	// Drop selections the list doesn't offer (non-GET endpoints once read-only
+	// flips on, run-by-path names carried over from an older scope string) so the
+	// scope doesn't keep references the server ignores or rejects.
 	$effect(() => {
-		if (!readOnly || selectedEndpoints.length === 0) return
-		const allowed = new Set(visibleEndpointTools.map((e) => e.name))
+		if (selectedEndpoints.length === 0) return
+		const allowed = new Set(selectableEndpointTools.map((e) => e.name))
 		const filtered = selectedEndpoints.filter((n) => allowed.has(n))
 		if (filtered.length !== selectedEndpoints.length) {
 			selectedEndpoints = filtered
@@ -169,8 +182,10 @@
 		}
 	}
 
-	// Compute scope string from selections
-	$effect(() => {
+	// Compute scope string from selections. Derived rather than assigned straight
+	// to `scope` so the exposure previews below can read it in the same pass as
+	// the selection that changed it.
+	const computedScope = $derived.by(() => {
 		let scopeParts: string[] = []
 
 		if (selectedMode === 'custom') {
@@ -206,7 +221,11 @@
 			scopeParts.push(`mcp:hub:${newMcpApps.join(',')}`)
 		}
 
-		scope = scopeParts.join(' ')
+		return scopeParts.join(' ')
+	})
+
+	$effect(() => {
+		scope = computedScope
 	})
 
 	// Clear pattern inputs when not in custom scope
@@ -485,6 +504,39 @@
 		return `This scope matches ${parts.join(' and ')}. Only the ${MCP_TOOL_FETCH_LIMIT} most recent of each type are exposed as MCP tools; the rest are omitted. Narrow the scope to avoid overloading the assistant's context.`
 	})
 
+	// Parsed from the emitted scope string rather than from the selections, so the
+	// previews below answer "what will the server expose for this token" with the
+	// same input the server gets.
+	const scopeState = $derived(
+		parseMcpScopeState(computedScope.split(/\s+/).filter((s) => s.length > 0))
+	)
+
+	const exposedEndpointTools = $derived(
+		visibleEndpointTools.filter((e) => isEndpointExposed(scopeState, e.name))
+	)
+
+	const runByPathTools = $derived(
+		visibleEndpointTools.flatMap((e) => {
+			const policy = endpointPathPolicy(e.name)
+			return policy?.kind === 'runByPath'
+				? [
+						{
+							name: e.name,
+							resource: policy.resource,
+							exposed: isEndpointExposed(scopeState, e.name)
+						}
+					]
+				: []
+		})
+	)
+
+	// Endpoints the user picked that the server will still withhold: the ones
+	// that cannot be confined to a path (run-preview, delete-by-hash) once the
+	// token is limited to specific script paths.
+	const withheldEndpoints = $derived(
+		selectedEndpoints.filter((name) => !isEndpointExposed(scopeState, name))
+	)
+
 	function selectAllScripts() {
 		selectedScripts = [...allScripts]
 	}
@@ -498,7 +550,7 @@
 		selectedFlows = []
 	}
 	function selectAllEndpoints() {
-		selectedEndpoints = [...visibleEndpointTools.map((e) => e.name)]
+		selectedEndpoints = [...selectableEndpointTools.map((e) => e.name)]
 	}
 	function clearAllEndpoints() {
 		selectedEndpoints = []
@@ -623,11 +675,46 @@
 				<div class="flex flex-col gap-2 mt-2">
 					{@render sectionHeader('API Endpoints', selectAllEndpoints, clearAllEndpoints)}
 					<MultiSelect
-						items={safeSelectItems(visibleEndpointTools.map((e) => e.name))}
+						items={safeSelectItems(selectableEndpointTools.map((e) => e.name))}
 						placeholder="Select endpoints"
 						bind:value={selectedEndpoints}
 					/>
 				</div>
+
+				{#if withheldEndpoints.length > 0}
+					<Alert type="warning" size="xs" title="Some selected endpoints will not be exposed">
+						<span class="text-xs">
+							Endpoints that cannot be limited to specific script paths are withheld from a token
+							restricted to a script selection: {withheldEndpoints.join(', ')}. Clear the Scripts
+							selection and patterns to expose them.
+						</span>
+					</Alert>
+				{/if}
+
+				{#if runByPathTools.length > 0}
+					<div class="flex flex-col gap-2 mt-2">
+						<span class="block text-xs font-semibold">Run tools</span>
+						<p class="text-xs text-tertiary">
+							Running a script or flow by path is granted by the Scripts and Flows selections above,
+							not by the endpoint list, so a token can never run something outside its scope.
+						</p>
+						<div class="flex flex-col gap-1">
+							{#each runByPathTools as tool (tool.name)}
+								<div class="flex items-center gap-2">
+									<Badge rounded small color={tool.exposed ? 'green' : 'gray'}>{tool.name}</Badge>
+									<span class="text-xs text-tertiary">
+										{#if tool.exposed}
+											exposed
+										{:else}
+											not exposed — select at least one {tool.resource} above, or add a {tool.resource}
+											wildcard pattern
+										{/if}
+									</span>
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
 
 				<div class="text-xs text-primary mt-2">
 					Selected: {selectedScripts.length} scripts, {selectedFlows.length} flows, {selectedEndpoints.length}
@@ -716,7 +803,7 @@
 
 				<span class="block text-xs mt-2">API endpoint tools that will be available via MCP</span>
 				<div class="flex flex-wrap gap-1">
-					{#each visibleEndpointTools as endpoint (endpoint.name)}
+					{#each exposedEndpointTools as endpoint (endpoint.name)}
 						<Popover notClickable>
 							{#snippet text()}
 								<div class="flex flex-col gap-1">

--- a/frontend/src/lib/components/mcp/endpointScopePolicy.test.ts
+++ b/frontend/src/lib/components/mcp/endpointScopePolicy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isEndpointExposed, parseMcpScopeState } from './endpointScopePolicy'
+import {
+	isEndpointExposed,
+	parseMcpScopeState,
+	pruneEndpointSelection
+} from './endpointScopePolicy'
 
 const state = (...scopes: string[]) => parseMcpScopeState(scopes)
 
@@ -28,5 +32,24 @@ describe('isEndpointExposed', () => {
 		expect(
 			isEndpointExposed(state('mcp:scripts:*', 'mcp:endpoints:*'), 'runScriptPreviewAndWaitResult')
 		).toBe(true)
+	})
+})
+
+describe('pruneEndpointSelection', () => {
+	it('keeps a `*` endpoint scope, which would otherwise revoke every endpoint tool', () => {
+		expect(pruneEndpointSelection(['*'], false)).toEqual(['*'])
+		expect(pruneEndpointSelection(['*'], true)).toEqual(['*'])
+	})
+
+	it('drops only names the endpoint scope cannot honor', () => {
+		expect(pruneEndpointSelection(['runScriptByPath', 'listScripts'], false)).toEqual([
+			'listScripts'
+		])
+		// Non-GET endpoints go only when the token is read-only.
+		expect(pruneEndpointSelection(['createScript', 'listScripts'], false)).toEqual([
+			'createScript',
+			'listScripts'
+		])
+		expect(pruneEndpointSelection(['createScript', 'listScripts'], true)).toEqual(['listScripts'])
 	})
 })

--- a/frontend/src/lib/components/mcp/endpointScopePolicy.test.ts
+++ b/frontend/src/lib/components/mcp/endpointScopePolicy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isEndpointExposed, parseMcpScopeState } from './endpointScopePolicy'
+
+const state = (...scopes: string[]) => parseMcpScopeState(scopes)
+
+describe('isEndpointExposed', () => {
+	it('gates run-by-path tools on the script/flow scope, not the endpoint scope', () => {
+		// Selecting the endpoint without any script path exposes nothing...
+		const endpointsOnly = state('mcp:endpoints:runScriptByPath,listScripts')
+		expect(isEndpointExposed(endpointsOnly, 'runScriptByPath')).toBe(false)
+		expect(isEndpointExposed(endpointsOnly, 'listScripts')).toBe(true)
+
+		// ...while a script path exposes it without any endpoint scope.
+		expect(isEndpointExposed(state('mcp:scripts:f/team/*'), 'runScriptByPath')).toBe(true)
+		expect(isEndpointExposed(state('mcp:scripts:f/team/*'), 'runFlowByPath')).toBe(false)
+
+		// Favorites reach their runnables through per-item tools only.
+		expect(isEndpointExposed(state('mcp:favorites'), 'runScriptByPath')).toBe(false)
+		expect(isEndpointExposed(state('mcp:all'), 'runScriptByPath')).toBe(true)
+	})
+
+	it('withholds unconfinable tools from path-confined tokens', () => {
+		const confined = state('mcp:scripts:f/team/*', 'mcp:endpoints:*')
+		expect(isEndpointExposed(confined, 'runScriptPreviewAndWaitResult')).toBe(false)
+		expect(isEndpointExposed(confined, 'getScriptByPath')).toBe(true)
+
+		// A `*` script pattern is not a confinement.
+		expect(
+			isEndpointExposed(state('mcp:scripts:*', 'mcp:endpoints:*'), 'runScriptPreviewAndWaitResult')
+		).toBe(true)
+	})
+})

--- a/frontend/src/lib/components/mcp/endpointScopePolicy.ts
+++ b/frontend/src/lib/components/mcp/endpointScopePolicy.ts
@@ -6,6 +6,8 @@
  * picker advertises tools the server will never list.
  */
 
+import { mcpEndpointTools } from '$lib/mcpEndpointTools'
+
 export type McpResourceKind = 'script' | 'flow'
 
 export type EndpointPathPolicy =
@@ -61,7 +63,9 @@ function parseResourceList(resources: string): string[] {
 }
 
 /** Mirrors `parse_mcp_scopes` so the picker can preview exactly what the server
- *  will make of the scope string it is about to emit. */
+ *  will make of the scope string it is about to emit. `mcp:hub:` is deliberately
+ *  ignored: hub apps select which hub scripts become tools and never affect
+ *  endpoint-tool exposure. */
 export function parseMcpScopeState(scopes: string[]): McpScopeState {
 	const state: McpScopeState = {
 		all: false,
@@ -119,16 +123,34 @@ function matchesPattern(name: string, pattern: string): boolean {
 	return name.length === prefix.length || name[prefix.length] === '/'
 }
 
-function isAllowed(name: string, allowed: string[]): boolean {
-	if (allowed.length === 0) return false
-	if (allowed.includes('*')) return true
-	return allowed.some((pattern) => matchesPattern(name, pattern))
+/** Mirrors `is_resource_allowed`: whether a path (or endpoint name) is granted by
+ *  any of these patterns, where a pattern is `*`, an exact path, or `<prefix>/*`. */
+export function matchesAnyPattern(path: string, patterns: string[]): boolean {
+	if (patterns.length === 0) return false
+	if (patterns.includes('*')) return true
+	return patterns.some((pattern) => matchesPattern(path, pattern))
+}
+
+const nonGetEndpoints = new Set(
+	mcpEndpointTools.filter((e) => e.method !== 'GET').map((e) => e.name)
+)
+
+/** Strip from an `mcp:endpoints:` selection only the names that scope cannot
+ *  honor: run-by-path tools, which `isEndpointExposed` gates on the script/flow
+ *  scope instead, and — for a read-only token — the non-GET endpoints the server
+ *  refuses. Every other entry is preserved, notably a `*` wildcard, which is a
+ *  valid endpoint scope that dropping would silently revoke every endpoint tool. */
+export function pruneEndpointSelection(selected: string[], readOnly: boolean): string[] {
+	return selected.filter(
+		(name) =>
+			endpointPathPolicy(name)?.kind !== 'runByPath' && !(readOnly && nonGetEndpoints.has(name))
+	)
 }
 
 /** Whether the server will list this endpoint tool for a token with these scopes. */
 export function isEndpointExposed(state: McpScopeState, name: string): boolean {
 	const granular = !state.all && !state.favorites
-	const endpointAllowed = !granular || isAllowed(name, state.endpoints)
+	const endpointAllowed = !granular || matchesAnyPattern(name, state.endpoints)
 	const policy = endpointPathPolicy(name)
 	switch (policy?.kind) {
 		case 'runByPath':

--- a/frontend/src/lib/components/mcp/endpointScopePolicy.ts
+++ b/frontend/src/lib/components/mcp/endpointScopePolicy.ts
@@ -1,0 +1,141 @@
+/**
+ * Mirrors `endpoint_path_policy` / `endpoint_tool_in_scope` in
+ * backend/windmill-mcp/src/server/runner.rs. Two endpoint tools are not governed
+ * by the `mcp:endpoints:` scope at all, and two more are hidden from tokens
+ * confined to specific script paths — without mirroring that here, the scope
+ * picker advertises tools the server will never list.
+ */
+
+export type McpResourceKind = 'script' | 'flow'
+
+export type EndpointPathPolicy =
+	/** Runs the script/flow named by the `path` argument. Listed when the token
+	 *  grants at least one path of that kind; the endpoint scope is ignored. */
+	| { kind: 'runByPath'; resource: McpResourceKind }
+	/** Reads/writes a script/flow named by a path argument, itself confined to
+	 *  the token's path patterns. Listed by the endpoint scope. */
+	| { kind: 'pathArgs'; resource: McpResourceKind }
+	/** Takes no checkable path (delete-by-hash) or runs arbitrary code
+	 *  (preview); hidden from tokens confined to specific paths. */
+	| { kind: 'unconfinable'; resource: McpResourceKind }
+
+export function endpointPathPolicy(name: string): EndpointPathPolicy | undefined {
+	switch (name) {
+		case 'runScriptByPath':
+			return { kind: 'runByPath', resource: 'script' }
+		case 'runFlowByPath':
+			return { kind: 'runByPath', resource: 'flow' }
+		case 'getScriptByPath':
+		case 'deleteScriptByPath':
+		case 'createScript':
+			return { kind: 'pathArgs', resource: 'script' }
+		case 'getFlowByPath':
+		case 'deleteFlowByPath':
+		case 'createFlow':
+		case 'updateFlow':
+			return { kind: 'pathArgs', resource: 'flow' }
+		case 'deleteScriptByHash':
+		case 'runScriptPreviewAndWaitResult':
+			return { kind: 'unconfinable', resource: 'script' }
+		default:
+			return undefined
+	}
+}
+
+/** The parsed shape of an MCP token's scopes, as `McpScopeConfig` on the backend. */
+export type McpScopeState = {
+	/** Legacy `mcp:all` — grants every path and endpoint. */
+	all: boolean
+	/** Legacy `mcp:favorites` — reaches favorites through per-item tools only. */
+	favorites: boolean
+	scripts: string[]
+	flows: string[]
+	endpoints: string[]
+}
+
+function parseResourceList(resources: string): string[] {
+	return resources
+		.split(',')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0)
+}
+
+/** Mirrors `parse_mcp_scopes` so the picker can preview exactly what the server
+ *  will make of the scope string it is about to emit. */
+export function parseMcpScopeState(scopes: string[]): McpScopeState {
+	const state: McpScopeState = {
+		all: false,
+		favorites: false,
+		scripts: [],
+		flows: [],
+		endpoints: []
+	}
+	for (const scope of scopes) {
+		if (scope === 'mcp:all') {
+			state.all = true
+			state.scripts.push('*')
+			state.flows.push('*')
+			state.endpoints.push('*')
+		} else if (scope === 'mcp:favorites') {
+			state.favorites = true
+		} else if (scope.startsWith('mcp:all:')) {
+			const folder = scope.slice('mcp:all:'.length)
+			state.scripts.push(folder)
+			state.flows.push(folder)
+			state.endpoints.push('*')
+		} else if (scope.startsWith('mcp:scripts:')) {
+			state.scripts.push(...parseResourceList(scope.slice('mcp:scripts:'.length)))
+		} else if (scope.startsWith('mcp:flows:')) {
+			state.flows.push(...parseResourceList(scope.slice('mcp:flows:'.length)))
+		} else if (scope.startsWith('mcp:endpoints:')) {
+			state.endpoints.push(...parseResourceList(scope.slice('mcp:endpoints:'.length)))
+		}
+	}
+	return state
+}
+
+function patterns(state: McpScopeState, resource: McpResourceKind): string[] {
+	return resource === 'script' ? state.scripts : state.flows
+}
+
+/** Whether the token grants access to any concrete path of this kind. */
+function hasAnyResource(state: McpScopeState, resource: McpResourceKind): boolean {
+	return state.all || patterns(state, resource).length > 0
+}
+
+/** Whether the token restricts this kind to specific paths. A `*` pattern grants
+ *  every path, so it is not a confinement. */
+function isPathConfined(state: McpScopeState, resource: McpResourceKind): boolean {
+	if (state.all) return false
+	const list = patterns(state, resource)
+	return list.length > 0 && !list.includes('*')
+}
+
+function matchesPattern(name: string, pattern: string): boolean {
+	if (pattern === name) return true
+	if (!pattern.endsWith('/*')) return false
+	const prefix = pattern.slice(0, -2)
+	if (!name.startsWith(prefix)) return false
+	return name.length === prefix.length || name[prefix.length] === '/'
+}
+
+function isAllowed(name: string, allowed: string[]): boolean {
+	if (allowed.length === 0) return false
+	if (allowed.includes('*')) return true
+	return allowed.some((pattern) => matchesPattern(name, pattern))
+}
+
+/** Whether the server will list this endpoint tool for a token with these scopes. */
+export function isEndpointExposed(state: McpScopeState, name: string): boolean {
+	const granular = !state.all && !state.favorites
+	const endpointAllowed = !granular || isAllowed(name, state.endpoints)
+	const policy = endpointPathPolicy(name)
+	switch (policy?.kind) {
+		case 'runByPath':
+			return hasAnyResource(state, policy.resource)
+		case 'unconfinable':
+			return endpointAllowed && !isPathConfined(state, policy.resource)
+		default:
+			return endpointAllowed
+	}
+}


### PR DESCRIPTION
## Summary

The MCP token scope picker offered endpoint tools that the server then refused to list, with nothing in the UI explaining why. Two gaps, both reported from the field:

- **`runScriptByPath` / `runFlowByPath` are not governed by `mcp:endpoints:` at all.** The runner gates them on whether the token grants *any* script/flow path (`has_any`), so a token scoped `mcp:endpoints:getScriptByPath,runScriptByPath,listScripts` never gets `runScriptByPath` — while a token that happens to carry `mcp:flows:` gets `runFlowByPath` it never asked for. The picker listed both in the "API Endpoints" multiselect, so selecting one looked like it should work.
- **`runScriptPreviewAndWaitResult` / `deleteScriptByHash` are withheld from path-confined tokens.** They take no checkable path, so `endpoint_tool_in_scope` hides them once the token is limited to specific script paths. The picker let you select them anyway, and the Folders-mode preview listed them as available.

The gating is deliberate (an endpoint scope must not authorize running an arbitrary path), so this PR fixes the UI rather than the policy: the picker now mirrors the runner's listing rules and shows exactly what the token will expose.

## Changes

- New `frontend/src/lib/components/mcp/endpointScopePolicy.ts` — a TypeScript mirror of `endpoint_path_policy`, `endpoint_tool_in_scope`, `path_confined` (`backend/windmill-mcp/src/server/runner.rs`) and `parse_mcp_scopes` / `is_resource_allowed` / `has_any` (`backend/windmill-mcp/src/common/scope.rs`).
- `McpScopeSelector.svelte`:
  - The "API Endpoints" list no longer offers the run-by-path tools, since selecting them there does nothing. They get a dedicated **Run tools** section that reports `exposed` / `not exposed — select at least one script above, or add a script wildcard pattern`, driven live by the Scripts/Flows selections.
  - A warning when a selected endpoint will still be withheld because the token is confined to specific script paths.
  - The Favorites / All / Folders preview now lists only the endpoint tools that scope will actually expose (previously it listed every tool unconditionally — including run-by-path under Favorites, and the unconfinable pair under Folders).
  - The scope string became a `$derived` so the previews recompute in the same pass as the selection that changed them.
- Comment on the Rust `EndpointPathPolicy` enum pointing at the TS mirror, so the two stay in sync.

## Picked vs exposed

Every row below was walked through in the running app and read back off the rendered picker (39 endpoint tools total in this build).

| # | Scope | Picked | `runScriptByPath` | `runFlowByPath` | Unconfinable pair | Endpoint tools listed |
|---|---|---|---|---|---|---|
| 1 | Favorites only | — | not exposed | not exposed | exposed | 37 |
| 2 | All scripts/flows | — | exposed | exposed | exposed | 39 |
| 3 | Folders (`app_custom`) | — | exposed | exposed | **withheld** (path-confined) | 37 |
| 4 | Custom | nothing | not exposed | not exposed | n/a | — |
| 5 | Custom | script pattern `u/admin/*` | **exposed** | not exposed | n/a | — |
| 6 | Custom | script + flow patterns | exposed | exposed | n/a | — |
| 7 | Custom | flow pattern only | not exposed | **exposed** | n/a | — |
| 8 | Custom | script pattern + `runScriptPreviewAndWaitResult` | exposed | exposed | **withheld** + warning | — |
| 9 | Custom | same, pattern widened to `*` | exposed | exposed | exposed, warning clears | — |
| 10 | Custom + **read-only** | script pattern + `runScriptPreviewAndWaitResult` | section hidden | section hidden | pruned from selection | GET only |

Rows 1–3 are the preview-badge modes; rows 4–10 are the custom picker. Row 3 is the case the old UI got wrong in both directions at once: it advertised the unconfinable pair a folder token can never call. Row 10 drops the whole Run tools section because both run tools are POST.

## Screenshots

**Custom, nothing picked** — both run tools state what would enable them, instead of sitting silently in the endpoint list:

![mcp-custom-empty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/improve-mcp-token-ux/1785861294-mcp-custom-empty.png)

**Custom, `u/admin/*` script pattern + `runScriptPreviewAndWaitResult` picked** (rows 5 and 8) — `runScriptByPath` flips to exposed, `runFlowByPath` stays off, and the withheld endpoint is called out with the remedy that satisfies both gates:

![mcp-custom-scope](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/improve-mcp-token-ux/1785859000-mcp-custom-scope.png)

**Favorites preview** (row 1) — 37 badges, no `runScriptByPath` / `runFlowByPath`. Before this PR all 39 were listed, including two the server would never hand out:

![mcp-favorites-preview](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/improve-mcp-token-ux/1785861296-mcp-favorites-preview.png)

## Test plan

- [ ] `frontend/src/lib/components/mcp/endpointScopePolicy.test.ts` pins the mirror against the two confusing cases (run-by-path gated on the script/flow scope, unconfinable tools withheld from path-confined tokens).
- [ ] Open Account settings → Generate MCP URL → **Custom**: with nothing selected both run tools read "not exposed"; typing `u/admin/*` into *Script wildcard patterns* flips `runScriptByPath` to "exposed" and leaves `runFlowByPath` alone; typing a flow pattern flips `runFlowByPath`.
- [ ] Select `runScriptPreviewAndWaitResult` while a script pattern is set — the withheld-endpoints warning appears.
- [ ] Switch to **Favorites only** — the endpoint preview no longer lists `runScriptByPath` / `runFlowByPath`; switch to **Folders** — it no longer lists `runScriptPreviewAndWaitResult` / `deleteScriptByHash`.
- [ ] Edit an existing MCP token whose scope contains `mcp:endpoints:runScriptByPath` — the no-op name is dropped from the endpoint list and the Run tools section explains the real gate.
- [ ] Regression guard for the endpoint-selection prune: a `*` endpoint scope must survive, since dropping it would emit a scope with no `mcp:endpoints:` part and silently revoke every endpoint tool. Verified by opening a `mcp:scripts:* mcp:flows:* mcp:endpoints:*` token in the edit modal and saving untouched — the scope round-trips intact.
