### PR TITLE
feat(ai): collapse thinking to a status row with a thought-for duration

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -149,7 +149,12 @@
 				{
 					role: 'assistant',
 					content: aiChatManager.currentReply,
-					...(aiChatManager.currentReasoning ? { reasoning: aiChatManager.currentReasoning } : {}),
+					...(aiChatManager.currentReasoning
+						? {
+								reasoning: aiChatManager.currentReasoning,
+								reasoningDurationMs: aiChatManager.currentReasoningDurationMs
+							}
+						: {}),
 					streaming: true,
 					contextElements: aiChatManager.contextManager
 						.getSelectedContext()

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -428,6 +428,38 @@ export class AIChatManager {
 	// a scalar: several workspace/provider pairs can be unavailable at once, and
 	// the chat loop only notifies on first detection per pair.
 	private reasoningSummaryUnavailableFor = $state<string[]>([])
+	// Timed off arrival, not off the typewriter: the reveal paces *display*, so
+	// reading the clock there would report how long the text took to paint.
+	private reasoningStartedAt: number | undefined
+	private reasoningEndedAt: number | undefined
+	/** Set the moment thinking ends, which is mid-turn — the answer is still
+	 * streaming. Reactive so the live message settles to "Thought for X" then,
+	 * rather than waiting for the turn to finalize. */
+	currentReasoningDurationMs = $state<number | undefined>(undefined)
+
+	private markReasoningStarted() {
+		if (this.reasoningStartedAt === undefined) {
+			this.reasoningStartedAt = Date.now()
+			this.currentReasoningDurationMs = undefined
+		}
+	}
+
+	/** Thinking ends at the first answer token; a turn that thinks straight into a
+	 * tool call ends it at the message boundary instead. */
+	private markReasoningEnded() {
+		if (this.reasoningStartedAt !== undefined && this.reasoningEndedAt === undefined) {
+			this.reasoningEndedAt = Date.now()
+			this.currentReasoningDurationMs = this.reasoningEndedAt - this.reasoningStartedAt
+		}
+	}
+
+	private takeReasoningDuration(): number | undefined {
+		const duration = this.currentReasoningDurationMs
+		this.reasoningStartedAt = undefined
+		this.reasoningEndedAt = undefined
+		this.currentReasoningDurationMs = undefined
+		return duration
+	}
 
 	private reasoningSummaryKey(provider: string): string {
 		return `${this.operatingWorkspace ?? ''}:${provider}`
@@ -2931,6 +2963,7 @@ export class AIChatManager {
 			this.currentReply = ''
 			this.currentReasoning = ''
 			this.currentReasoningActive = false
+			this.takeReasoningDuration()
 
 			// Compaction trigger. Without a known context window there is no limit
 			// to enforce, so compaction stays off rather than guessing one.
@@ -2996,9 +3029,19 @@ export class AIChatManager {
 				messages: [...this.messages],
 				abortController: this.abortController,
 				callbacks: {
-					onNewToken: (token) => this.replyReveal.push(token),
-					onReasoningDelta: (token) => this.reasoningReveal.push(token),
-					onReasoningStart: () => (this.currentReasoningActive = true),
+					onNewToken: (token) => {
+						this.markReasoningEnded()
+						this.replyReveal.push(token)
+					},
+					// Not every provider fires onReasoningStart, so deltas start the clock too.
+					onReasoningDelta: (token) => {
+						this.markReasoningStarted()
+						this.reasoningReveal.push(token)
+					},
+					onReasoningStart: () => {
+						this.markReasoningStarted()
+						this.currentReasoningActive = true
+					},
 					onMessageEnd: () => {
 						// Drain any un-revealed backlog into currentReply first, so the reads
 						// below see the full text. This funnel covers clean completion, tool
@@ -3006,6 +3049,10 @@ export class AIChatManager {
 						// keeps text from being lost or duplicated on any exit path.
 						this.replyReveal.flush()
 						this.reasoningReveal.flush()
+						// A turn that reasoned straight into a tool call never saw an answer
+						// token, so this is where its thinking stops.
+						this.markReasoningEnded()
+						const reasoningDurationMs = this.takeReasoningDuration()
 						// Keep the streamed text for the abort/error paths. Non-empty only:
 						// parsers flush (and reset) when a tool call starts after text, and
 						// the catch's later empty call would wipe it — stale keeps are
@@ -3019,7 +3066,9 @@ export class AIChatManager {
 								{
 									role: 'assistant',
 									content: this.currentReply,
-									...(this.currentReasoning ? { reasoning: this.currentReasoning } : {}),
+									...(this.currentReasoning
+										? { reasoning: this.currentReasoning, reasoningDurationMs }
+										: {}),
 									contextElements:
 										this.mode === AIMode.SCRIPT
 											? oldSelectedContext.filter((c) => c.type === 'code')

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -453,11 +453,17 @@ export class AIChatManager {
 		}
 	}
 
-	private takeReasoningDuration(): number | undefined {
-		const duration = this.currentReasoningDurationMs
+	private resetReasoningTiming() {
 		this.reasoningStartedAt = undefined
 		this.reasoningEndedAt = undefined
 		this.currentReasoningDurationMs = undefined
+	}
+
+	/** Reads the duration and clears it, so the next reasoning pass of the same
+	 * turn (after a tool call) times itself from scratch. */
+	private takeReasoningDuration(): number | undefined {
+		const duration = this.currentReasoningDurationMs
+		this.resetReasoningTiming()
 		return duration
 	}
 
@@ -2963,7 +2969,7 @@ export class AIChatManager {
 			this.currentReply = ''
 			this.currentReasoning = ''
 			this.currentReasoningActive = false
-			this.takeReasoningDuration()
+			this.resetReasoningTiming()
 
 			// Compaction trigger. Without a known context window there is no limit
 			// to enforce, so compaction stays off rather than guessing one.

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FlowAIChatHelpers } from './flow/core'
 import type { PipelineAIChatHelpers } from './pipeline/core'
 import type { CurrentEditor } from '$lib/components/flows/types'
@@ -3010,6 +3010,15 @@ describe('AIChatManager reasoning duration', () => {
 		mocks.getCurrentModel.mockReturnValue({ model: 'test-model', provider: 'openai' })
 	})
 
+	// The file-level hook only clears call records, so the clock spy below would
+	// stay installed and freeze time for anything that runs after it.
+	afterEach(() => {
+		nowSpy?.mockRestore()
+		nowSpy = undefined
+	})
+
+	let nowSpy: ReturnType<typeof vi.spyOn> | undefined
+
 	function assistantDurations(manager: AIChatManager): (number | undefined)[] {
 		return manager.displayMessages
 			.filter((m) => m.role === 'assistant')
@@ -3022,7 +3031,7 @@ describe('AIChatManager reasoning duration', () => {
 		manager.setAiChatInput({ restoreInstructions: vi.fn(), focusInput: vi.fn() } as any)
 
 		let now = 1_000
-		vi.spyOn(Date, 'now').mockImplementation(() => now)
+		nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
 
 		vi.mocked(runChatLoop).mockImplementation(async (config) => {
 			config.callbacks.onReasoningStart?.()
@@ -3053,7 +3062,7 @@ describe('AIChatManager reasoning duration', () => {
 		manager.setAiChatInput({ restoreInstructions: vi.fn(), focusInput: vi.fn() } as any)
 
 		let now = 1_000
-		vi.spyOn(Date, 'now').mockImplementation(() => now)
+		nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
 
 		vi.mocked(runChatLoop).mockImplementation(async (config) => {
 			// First pass reasons straight into a tool call — no answer token, so the

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -3003,3 +3003,81 @@ describe('AIChatManager.waitForPipelineHelpers', () => {
 		await expect(manager.waitForPipelineHelpers(10)).resolves.toBe(false)
 	})
 })
+
+describe('AIChatManager reasoning duration', () => {
+	beforeEach(() => {
+		localStorage.clear()
+		mocks.getCurrentModel.mockReturnValue({ model: 'test-model', provider: 'openai' })
+	})
+
+	function assistantDurations(manager: AIChatManager): (number | undefined)[] {
+		return manager.displayMessages
+			.filter((m) => m.role === 'assistant')
+			.map((m) => (m as { reasoningDurationMs?: number }).reasoningDurationMs)
+	}
+
+	it('stops the clock at the first answer token, not at the end of the turn', async () => {
+		const manager = new AIChatManager()
+		manager.changeMode(AIMode.ASK)
+		manager.setAiChatInput({ restoreInstructions: vi.fn(), focusInput: vi.fn() } as any)
+
+		let now = 1_000
+		vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+		vi.mocked(runChatLoop).mockImplementation(async (config) => {
+			config.callbacks.onReasoningStart?.()
+			config.callbacks.onReasoningDelta?.('weighing the options')
+			now += 4_000
+			config.callbacks.onNewToken('here is the answer')
+			// The answer keeps streaming well past the end of thinking; none of it
+			// may land in the duration.
+			now += 9_000
+			config.callbacks.onMessageEnd()
+			return {
+				addedMessages: [],
+				tokenUsage: {} as any,
+				lastIterationUsage: null,
+				hitMaxIterations: false
+			}
+		})
+
+		manager.instructions = 'do a thing'
+		await manager.sendRequest()
+
+		expect(assistantDurations(manager)).toEqual([4_000])
+	})
+
+	it('times each reasoning pass of a tool-using turn independently', async () => {
+		const manager = new AIChatManager()
+		manager.changeMode(AIMode.ASK)
+		manager.setAiChatInput({ restoreInstructions: vi.fn(), focusInput: vi.fn() } as any)
+
+		let now = 1_000
+		vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+		vi.mocked(runChatLoop).mockImplementation(async (config) => {
+			// First pass reasons straight into a tool call — no answer token, so the
+			// message boundary is where its thinking stops.
+			config.callbacks.onReasoningDelta?.('which tool do I need')
+			now += 3_000
+			config.callbacks.onMessageEnd()
+			// Tool execution must not be billed to either pass.
+			now += 20_000
+			config.callbacks.onReasoningDelta?.('now what does that result mean')
+			now += 7_000
+			config.callbacks.onNewToken('here is the answer')
+			config.callbacks.onMessageEnd()
+			return {
+				addedMessages: [],
+				tokenUsage: {} as any,
+				lastIterationUsage: null,
+				hitMaxIterations: false
+			}
+		})
+
+		manager.instructions = 'do a thing'
+		await manager.sendRequest()
+
+		expect(assistantDurations(manager)).toEqual([3_000, 7_000])
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/AIChatModelSettings.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatModelSettings.svelte
@@ -25,6 +25,7 @@
 	import { base } from '$lib/base'
 	import AIPromptsModal from '$lib/components/settings/AIPromptsModal.svelte'
 	import { getAiChatManager } from './aiChatManagerContext'
+	import { thinkingPreferences } from './thinkingPreferences.svelte'
 	import {
 		getReasoningCapability,
 		resolveEffectiveReasoning,
@@ -377,6 +378,19 @@
 					<div class="text-2xs text-tertiary mt-0.5">Not supported by this model</div>
 				</div>
 			{/if}
+
+			<!-- A reading preference rather than a model parameter: it applies to every
+			     chat in this browser, including thinking already in the transcript. -->
+			<MenuItem
+				{item}
+				class="w-full flex items-center gap-2 px-3 py-1.5 text-left font-normal hover:bg-surface-hover data-[highlighted]:bg-surface-hover rounded-sm transition-colors cursor-pointer"
+				onClick={() => (thinkingPreferences.expandByDefault = !thinkingPreferences.expandByDefault)}
+			>
+				<span class="truncate grow min-w-0 text-2xs text-secondary">Always expand thinking</span>
+				{#if thinkingPreferences.expandByDefault}
+					<Check size={14} class="shrink-0 text-primary" />
+				{/if}
+			</MenuItem>
 		</div>
 	{/snippet}
 </DropdownV2>

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import Markdown from 'svelte-exmarkdown'
 	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
-	import { Brain, Loader2 } from 'lucide-svelte'
 	import type { DisplayMessage } from './shared'
 	import ChatCollapsibleCard from './ChatCollapsibleCard.svelte'
 	import { thinkingPreferences } from './thinkingPreferences.svelte'
@@ -29,7 +28,7 @@
 	const reasoningDurationMs = $derived(
 		message.role === 'assistant' ? message.reasoningDurationMs : undefined
 	)
-	// Spinner while the reasoning text streams before the answer. Only the live
+	// Shimmer while the reasoning text streams before the answer. Only the live
 	// synthetic message carries `streaming` — a finalized reasoning-only message
 	// (thinking that led straight to a tool call) must not look in-progress.
 	const reasoningStreaming = $derived(
@@ -103,17 +102,11 @@
 		label={reasoningLabel}
 		expanded={reasoningExpanded}
 		onToggle={() => (reasoningToggled = !reasoningExpanded)}
+		shimmer={reasoningStreaming}
 		class="mb-2"
 		labelClass="truncate"
 		contentClass="font-main text-secondary {markdownProse.xs}"
 	>
-		{#snippet icon()}
-			{#if reasoningStreaming}
-				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500 shrink-0" />
-			{:else}
-				<Brain class="w-3 h-3 text-secondary shrink-0" />
-			{/if}
-		{/snippet}
 		<Markdown md={reasoning} plugins={[gfmPlugin()]} />
 	</ChatCollapsibleCard>
 {/if}

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import Markdown from 'svelte-exmarkdown'
 	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
-	import { twMerge } from 'tailwind-merge'
-	import { Brain, ChevronDown, ChevronRight, Loader2 } from 'lucide-svelte'
-	import { slide } from 'svelte/transition'
+	import { Brain, Loader2 } from 'lucide-svelte'
 	import type { DisplayMessage } from './shared'
+	import ChatCollapsibleCard from './ChatCollapsibleCard.svelte'
 	import CodeDisplay from './script/CodeDisplay.svelte'
 	import LinkRenderer from './LinkRenderer.svelte'
 	import { workspaceStore } from '$lib/stores'
@@ -74,36 +73,22 @@
 </script>
 
 {#if reasoning}
-	<div class="mb-2 bg-surface border border-border-light rounded-md overflow-hidden text-xs">
-		<button
-			class={twMerge(
-				'w-full p-2 bg-surface-secondary/30 hover:bg-surface-hover transition-colors flex items-center gap-2 text-left',
-				reasoningExpanded ? 'border-b border-border-light' : ''
-			)}
-			onclick={() => (reasoningToggled = !reasoningExpanded)}
-		>
-			{#if reasoningExpanded}
-				<ChevronDown class="w-3 h-3 text-secondary" />
-			{:else}
-				<ChevronRight class="w-3 h-3 text-secondary" />
-			{/if}
+	<ChatCollapsibleCard
+		label="Thinking"
+		expanded={reasoningExpanded}
+		onToggle={() => (reasoningToggled = !reasoningExpanded)}
+		class="mb-2"
+		contentClass="font-sans text-secondary {markdownProse.xs}"
+	>
+		{#snippet icon()}
 			{#if reasoningStreaming}
-				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500" />
+				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500 shrink-0" />
 			{:else}
-				<Brain class="w-3.5 h-3.5 text-secondary" />
+				<Brain class="w-3 h-3 text-secondary shrink-0" />
 			{/if}
-			<span class="text-primary font-medium text-2xs">Thinking</span>
-		</button>
-
-		{#if reasoningExpanded}
-			<div
-				transition:slide={{ duration: 150 }}
-				class="p-2 bg-surface text-secondary {markdownProse.xs}"
-			>
-				<Markdown md={reasoning} plugins={[gfmPlugin()]} />
-			</div>
-		{/if}
-	</div>
+		{/snippet}
+		<Markdown md={reasoning} plugins={[gfmPlugin()]} />
+	</ChatCollapsibleCard>
 {/if}
 
 {#if message.content}

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -4,6 +4,7 @@
 	import { Brain, Loader2 } from 'lucide-svelte'
 	import type { DisplayMessage } from './shared'
 	import ChatCollapsibleCard from './ChatCollapsibleCard.svelte'
+	import { thinkingPreferences } from './thinkingPreferences.svelte'
 	import CodeDisplay from './script/CodeDisplay.svelte'
 	import LinkRenderer from './LinkRenderer.svelte'
 	import { workspaceStore } from '$lib/stores'
@@ -23,15 +24,40 @@
 	const reasoning = $derived(
 		message.role === 'assistant' ? message.reasoning?.trim() || undefined : undefined
 	)
+	// Set the moment thinking ends, which is mid-turn on the live message — the
+	// answer streams on afterwards.
+	const reasoningDurationMs = $derived(
+		message.role === 'assistant' ? message.reasoningDurationMs : undefined
+	)
 	// Spinner while the reasoning text streams before the answer. Only the live
 	// synthetic message carries `streaming` — a finalized reasoning-only message
 	// (thinking that led straight to a tool call) must not look in-progress.
 	const reasoningStreaming = $derived(
-		!!reasoning && message.role === 'assistant' && !!message.streaming && !message.content
+		!!reasoning &&
+			message.role === 'assistant' &&
+			!!message.streaming &&
+			!message.content &&
+			reasoningDurationMs === undefined
 	)
-	// Expand while still thinking, collapse once the answer begins — unless toggled.
+	// Undefined until this block is toggled by hand, so flipping the preference
+	// reaches every block the reader hasn't already made a decision about.
 	let reasoningToggled = $state<boolean | undefined>(undefined)
-	const reasoningExpanded = $derived(reasoningToggled ?? reasoningStreaming)
+	const reasoningExpanded = $derived(reasoningToggled ?? thinkingPreferences.expandByDefault)
+	const reasoningLabel = $derived(
+		reasoningDurationMs !== undefined
+			? `Thought for ${formatThinkingDuration(reasoningDurationMs)}`
+			: reasoningStreaming
+				? 'Thinking...'
+				: 'Thinking'
+	)
+
+	function formatThinkingDuration(ms: number): string {
+		const seconds = Math.max(1, Math.round(ms / 1000))
+		if (seconds < 60) return `${seconds}s`
+		const minutes = Math.floor(seconds / 60)
+		const rest = seconds % 60
+		return rest === 0 ? `${minutes}m` : `${minutes}m ${rest}s`
+	}
 
 	const candidatePaths = $derived(extractCandidatePaths(message.content))
 	const rendererPlugin = {
@@ -74,10 +100,11 @@
 
 {#if reasoning}
 	<ChatCollapsibleCard
-		label="Thinking"
+		label={reasoningLabel}
 		expanded={reasoningExpanded}
 		onToggle={() => (reasoningToggled = !reasoningExpanded)}
 		class="mb-2"
+		labelClass="truncate"
 		contentClass="font-sans text-secondary {markdownProse.xs}"
 	>
 		{#snippet icon()}

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -105,7 +105,7 @@
 		onToggle={() => (reasoningToggled = !reasoningExpanded)}
 		class="mb-2"
 		labelClass="truncate"
-		contentClass="font-sans text-secondary {markdownProse.xs}"
+		contentClass="font-main text-secondary {markdownProse.xs}"
 	>
 		{#snippet icon()}
 			{#if reasoningStreaming}

--- a/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
@@ -43,26 +43,24 @@
 	{#snippet headerButton()}
 		<button
 			class={twMerge(
-				'min-w-0 py-0.5 my-0.5 rounded-md hover:bg-surface-hover transition-colors inline-flex items-center text-left',
+				'min-w-0 py-0.5 my-0.5 rounded-md hover:bg-surface-hover transition-colors inline-flex items-center gap-2 text-left',
 				headerClass
 			)}
 			onclick={onToggle}
 			disabled={!toggleable}
 		>
-			<div class="flex items-center gap-2 min-w-0">
-				{@render icon?.()}
-				<span class={twMerge('text-primary font-medium text-2xs', labelClass)}>
-					{label}
-				</span>
-				{#if toggleable}
-					<ChevronRight
-						class={twMerge(
-							'w-3 h-3 text-secondary transition-transform duration-150 shrink-0',
-							expanded ? 'rotate-90' : ''
-						)}
-					/>
-				{/if}
-			</div>
+			{@render icon?.()}
+			<span class={twMerge('text-primary font-medium text-2xs', labelClass)}>
+				{label}
+			</span>
+			{#if toggleable}
+				<ChevronRight
+					class={twMerge(
+						'w-3 h-3 text-secondary transition-transform duration-150 shrink-0',
+						expanded ? 'rotate-90' : ''
+					)}
+				/>
+			{/if}
 		</button>
 	{/snippet}
 

--- a/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
@@ -11,7 +11,8 @@
 		// A card with nothing to reveal keeps the header inert (no chevron, no
 		// hover affordance implying a toggle).
 		toggleable?: boolean
-		icon?: Snippet
+		// Sweeps a highlight across the label while the row is in progress.
+		shimmer?: boolean
 		// Pinned to the right of the header row, outside the toggle button.
 		headerRight?: Snippet
 		// Always-visible content between the header and the expandable body.
@@ -28,7 +29,7 @@
 		expanded,
 		onToggle,
 		toggleable = true,
-		icon,
+		shimmer = false,
 		headerRight,
 		belowHeader,
 		children,
@@ -40,6 +41,12 @@
 </script>
 
 <div class={twMerge('font-mono text-xs', className)}>
+	{#snippet labelText()}
+		<span class={twMerge('text-secondary font-medium text-2xs', labelClass)}>
+			{label}
+		</span>
+	{/snippet}
+
 	{#snippet headerButton()}
 		<button
 			class={twMerge(
@@ -49,10 +56,16 @@
 			onclick={onToggle}
 			disabled={!toggleable}
 		>
-			{@render icon?.()}
-			<span class={twMerge('text-primary font-medium text-2xs', labelClass)}>
-				{label}
-			</span>
+			{#if shimmer}
+				<span class="shimmer inline-flex items-center min-w-0">
+					{@render labelText()}
+					<span class="shimmer-band inline-flex items-center min-w-0" aria-hidden="true">
+						{@render labelText()}
+					</span>
+				</span>
+			{:else}
+				{@render labelText()}
+			{/if}
 			{#if toggleable}
 				<ChevronRight
 					class={twMerge(
@@ -84,3 +97,53 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	/* A white copy of the label sits on top of the coloured one and is revealed
+	   through a travelling band, so the highlight is a colour change rather than
+	   an opacity change and the row keeps its own colour underneath. */
+	.shimmer {
+		position: relative;
+	}
+	.shimmer-band {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		/* Forces the copy white whatever colour the caller gives the label, without
+		   having to out-specify its utility classes. */
+		filter: brightness(0) invert(1);
+		--wm-shimmer-band: linear-gradient(
+			100deg,
+			rgba(0, 0, 0, 0.2) 40%,
+			rgba(0, 0, 0, 1) 50%,
+			rgba(0, 0, 0, 0.2) 60%
+		);
+		-webkit-mask-image: var(--wm-shimmer-band);
+		mask-image: var(--wm-shimmer-band);
+		-webkit-mask-size: 250% 100%;
+		mask-size: 250% 100%;
+		-webkit-mask-repeat: no-repeat;
+		mask-repeat: no-repeat;
+		animation: wm-shimmer-sweep 2.6s linear infinite;
+	}
+	/* The travel itself takes 1.5s — the rest of the period holds the band
+	   off-screen, so sweeps are spaced out instead of running back to back.
+	   250% wide is what puts it off-screen at both ends rather than popping at
+	   the edges; the row rests at the gradient's floor in between. */
+	@keyframes wm-shimmer-sweep {
+		0% {
+			-webkit-mask-position: 100% 0;
+			mask-position: 100% 0;
+		}
+		58%,
+		100% {
+			-webkit-mask-position: 0 0;
+			mask-position: 0 0;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.shimmer-band {
+			display: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
@@ -141,9 +141,15 @@
 			mask-position: 0 0;
 		}
 	}
+	/* The sweep is the only thing marking a row as running, so it degrades to a
+	   flat wash rather than disappearing — otherwise a running tool row would be
+	   indistinguishable from a settled one here. */
 	@media (prefers-reduced-motion: reduce) {
 		.shimmer-band {
-			display: none;
+			animation: none;
+			-webkit-mask-image: none;
+			mask-image: none;
+			opacity: 0.35;
 		}
 	}
 </style>

--- a/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import { ChevronRight } from 'lucide-svelte'
+	import { twMerge } from 'tailwind-merge'
+	import { slide } from 'svelte/transition'
+	import type { Snippet } from 'svelte'
+
+	interface Props {
+		label: string
+		expanded: boolean
+		onToggle: () => void
+		// A card with nothing to reveal keeps the header inert (no chevron, no
+		// hover affordance implying a toggle).
+		toggleable?: boolean
+		icon?: Snippet
+		// Pinned to the right of the header row, outside the toggle button.
+		headerRight?: Snippet
+		// Always-visible content between the header and the expandable body.
+		belowHeader?: Snippet
+		children?: Snippet
+		class?: string
+		headerClass?: string
+		labelClass?: string
+		contentClass?: string
+	}
+
+	let {
+		label,
+		expanded,
+		onToggle,
+		toggleable = true,
+		icon,
+		headerRight,
+		belowHeader,
+		children,
+		class: className,
+		headerClass,
+		labelClass,
+		contentClass
+	}: Props = $props()
+</script>
+
+<div class={twMerge('font-mono text-xs', className)}>
+	{#snippet headerButton()}
+		<button
+			class={twMerge(
+				'min-w-0 py-0.5 my-0.5 rounded-md hover:bg-surface-hover transition-colors inline-flex items-center text-left',
+				headerClass
+			)}
+			onclick={onToggle}
+			disabled={!toggleable}
+		>
+			<div class="flex items-center gap-2 min-w-0">
+				{@render icon?.()}
+				<span class={twMerge('text-primary font-medium text-2xs', labelClass)}>
+					{label}
+				</span>
+				{#if toggleable}
+					<ChevronRight
+						class={twMerge(
+							'w-3 h-3 text-secondary transition-transform duration-150 shrink-0',
+							expanded ? 'rotate-90' : ''
+						)}
+					/>
+				{/if}
+			</div>
+		</button>
+	{/snippet}
+
+	{#if headerRight}
+		<div class="flex items-center justify-between gap-2">
+			{@render headerButton()}
+			{@render headerRight()}
+		</div>
+	{:else}
+		{@render headerButton()}
+	{/if}
+
+	{@render belowHeader?.()}
+
+	{#if expanded && children}
+		<div
+			transition:slide={{ duration: 150 }}
+			class={twMerge('border border-border-light rounded-md bg-surface p-3', contentClass)}
+		>
+			{@render children()}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import { Loader2, ChevronRight, XCircle, Play } from 'lucide-svelte'
+	import { Loader2, XCircle, Play } from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
 	import { getAiChatManager } from './aiChatManagerContext'
 
 	const aiChatManager = getAiChatManager()
 	import { isActiveUserQuestion, type ToolDisplayMessage } from './shared'
-	import { twMerge } from 'tailwind-merge'
-	import { slide } from 'svelte/transition'
+	import ChatCollapsibleCard from './ChatCollapsibleCard.svelte'
 	import ToolContentDisplay from './ToolContentDisplay.svelte'
 	import ToolMessageActions from './ToolMessageActions.svelte'
 	import ToolPreviewCard from './ToolPreviewCard.svelte'
@@ -38,9 +37,11 @@
 	const detailsAvailable = $derived(message.showDetails === true || message.error !== undefined)
 
 	let isExpanded = $derived(
-		(detailsAvailable && (!isSuccessful || !autoCollapseDetails)) ||
-			(message.isStreamingArguments && hasParameters) ||
-			(message.isLoading && message.needsConfirmation)
+		Boolean(
+			(detailsAvailable && (!isSuccessful || !autoCollapseDetails)) ||
+				(message.isStreamingArguments && hasParameters) ||
+				(message.isLoading && message.needsConfirmation)
+		)
 	)
 
 	const visibleActions = $derived(
@@ -65,141 +66,113 @@
 {#if activeUserQuestion}
 	<AskUserQuestionDisplay toolCallId={message.tool_call_id} userQuestion={activeUserQuestion} />
 {:else}
+	<!-- Discrete preview chip for an item a tool created/updated, pinned to the
+	     right of the header row. Rendered inline (not gated on expand) so it stays
+	     visible after the tool collapses. -->
+	{#snippet previewChip()}
+		{#if message.previewCard}
+			<ToolPreviewCard card={message.previewCard} />
+		{/if}
+	{/snippet}
+
 	<!-- Queued calls (waiting their turn behind the executing tool) are faded: the
 	     reduced weight is what says "not started" — no icon, no spinner. -->
-	<div
-		class={twMerge(
-			'font-mono text-xs',
-			message.isQueued && !message.error ? 'opacity-60 hover:opacity-100 transition-opacity' : ''
-		)}
+	<ChatCollapsibleCard
+		label={message.content}
+		expanded={isExpanded}
+		onToggle={() => (isExpanded = !isExpanded)}
+		toggleable={detailsAvailable || message.isStreamingArguments === true}
+		class={message.isQueued && !message.error
+			? 'opacity-60 hover:opacity-100 transition-opacity'
+			: ''}
+		headerClass={message.needsConfirmation ? 'opacity-80' : ''}
+		labelClass={showPreviewChip ? 'truncate' : ''}
+		contentClass="space-y-3"
+		headerRight={showPreviewChip ? previewChip : undefined}
 	>
-		<!-- Collapsible Header -->
-		{#snippet headerButton()}
-			<button
-				class={twMerge(
-					'min-w-0 py-0.5 my-0.5 rounded-md hover:bg-surface-hover transition-colors inline-flex items-center text-left',
-					message.needsConfirmation ? 'opacity-80' : ''
-				)}
-				onclick={() => (isExpanded = !isExpanded)}
-				disabled={!detailsAvailable && !message.isStreamingArguments}
-			>
-				<div class="flex items-center gap-2 min-w-0">
-					{#if message.isLoading && !message.needsConfirmation}
-						<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500 shrink-0" />
-					{/if}
-					<span
-						class={twMerge('text-primary font-medium text-2xs', showPreviewChip ? 'truncate' : '')}
-					>
-						{message.content}
-					</span>
-
-					{#if detailsAvailable || message.isStreamingArguments}
-						<ChevronRight
-							class={twMerge(
-								'w-3 h-3 text-secondary transition-transform duration-150 shrink-0',
-								isExpanded ? 'rotate-90' : ''
-							)}
-						/>
-					{/if}
-				</div>
-			</button>
+		{#snippet icon()}
+			{#if message.isLoading && !message.needsConfirmation}
+				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500 shrink-0" />
+			{/if}
 		{/snippet}
 
-		<!-- Discrete preview chip for an item a tool created/updated, pinned to
-		     the right of the header row. Rendered inline (not gated on expand) so it
-		     stays visible after the tool collapses. -->
-		{#if showPreviewChip && message.previewCard}
-			<div class="flex items-center justify-between gap-2">
-				{@render headerButton()}
-				<ToolPreviewCard card={message.previewCard} />
-			</div>
-		{:else}
-			{@render headerButton()}
-		{/if}
-
 		<!-- Image a tool produced (e.g. take_screenshot) — shown inline, not gated on expand. -->
-		{#if message.imageUrl}
-			<div class="my-1">
-				<ExpandableImage
-					src={message.imageUrl}
-					alt="App preview screenshot"
-					class="max-h-48 max-w-full rounded border border-border-light"
+		{#snippet belowHeader()}
+			{#if message.imageUrl}
+				<div class="my-1">
+					<ExpandableImage
+						src={message.imageUrl}
+						alt="App preview screenshot"
+						class="max-h-48 max-w-full rounded border border-border-light"
+					/>
+				</div>
+			{/if}
+		{/snippet}
+
+		<!-- Parameters Section - show if we have parameters, or if confirmation is needed (even with empty params) -->
+		{#if hasParameters || message.needsConfirmation}
+			<div class={message.needsConfirmation ? 'opacity-80' : ''}>
+				<ToolContentDisplay
+					title="Parameters"
+					content={message.parameters}
+					streaming={message.isStreamingArguments}
+					toolName={message.toolName}
+					showFade={message.showFade}
 				/>
 			</div>
 		{/if}
 
-		<!-- Expanded Content -->
-		{#if isExpanded}
-			<div
-				transition:slide={{ duration: 150 }}
-				class="border border-border-light rounded-md bg-surface p-3 space-y-3"
-			>
-				<!-- Parameters Section - show if we have parameters, or if confirmation is needed (even with empty params) -->
-				{#if hasParameters || message.needsConfirmation}
-					<div class={message.needsConfirmation ? 'opacity-80' : ''}>
-						<ToolContentDisplay
-							title="Parameters"
-							content={message.parameters}
-							streaming={message.isStreamingArguments}
-							toolName={message.toolName}
-							showFade={message.showFade}
-						/>
-					</div>
-				{/if}
-
-				<!-- Confirmation Footer -->
-				{#if message.needsConfirmation}
-					<div class="flex flex-row items-center justify-end gap-2">
-						<Button
-							variant="default"
-							size="xs"
-							on:click={() => {
-								if (message.tool_call_id) {
-									aiChatManager.handleToolConfirmation(message.tool_call_id, false)
-								}
-							}}
-							startIcon={{ icon: XCircle }}
-							destructive
-						></Button>
-						<Button
-							variant="accent"
-							size="xs"
-							on:click={() => {
-								if (message.tool_call_id) {
-									aiChatManager.handleToolConfirmation(message.tool_call_id, true)
-								}
-							}}
-							startIcon={{ icon: Play }}
-						>
-							Run
-						</Button>
-					</div>
-
-					<!-- Logs and Result - hide while streaming -->
-				{:else if !message.isStreamingArguments}
-					<ToolContentDisplay
-						title="Logs"
-						content={message.logs}
-						loading={message.isLoading}
-						showWhileLoading={false}
-						showFade={message.showFade}
-					/>
-
-					{#if visibleActions.length > 0}
-						<ToolMessageActions actions={visibleActions} />
-					{:else if message.webSearchSources?.length && !message.error}
-						<WebSearchSourcesDisplay sources={message.webSearchSources} />
-					{:else}
-						<ToolContentDisplay
-							title="Result"
-							content={message.result}
-							error={message.error}
-							loading={message.isLoading}
-							showFade={message.showFade}
-						/>
-					{/if}
-				{/if}
+		<!-- Confirmation Footer -->
+		{#if message.needsConfirmation}
+			<div class="flex flex-row items-center justify-end gap-2">
+				<Button
+					variant="default"
+					size="xs"
+					on:click={() => {
+						if (message.tool_call_id) {
+							aiChatManager.handleToolConfirmation(message.tool_call_id, false)
+						}
+					}}
+					startIcon={{ icon: XCircle }}
+					destructive
+				></Button>
+				<Button
+					variant="accent"
+					size="xs"
+					on:click={() => {
+						if (message.tool_call_id) {
+							aiChatManager.handleToolConfirmation(message.tool_call_id, true)
+						}
+					}}
+					startIcon={{ icon: Play }}
+				>
+					Run
+				</Button>
 			</div>
+
+			<!-- Logs and Result - hide while streaming -->
+		{:else if !message.isStreamingArguments}
+			<ToolContentDisplay
+				title="Logs"
+				content={message.logs}
+				loading={message.isLoading}
+				showWhileLoading={false}
+				showFade={message.showFade}
+			/>
+
+			{#if visibleActions.length > 0}
+				<ToolMessageActions actions={visibleActions} />
+			{:else if message.webSearchSources?.length && !message.error}
+				<WebSearchSourcesDisplay sources={message.webSearchSources} />
+			{:else}
+				<ToolContentDisplay
+					title="Result"
+					content={message.result}
+					error={message.error}
+					loading={message.isLoading}
+					showFade={message.showFade}
+				/>
+			{/if}
 		{/if}
-	</div>
+	</ChatCollapsibleCard>
 {/if}

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Loader2, XCircle, Play } from 'lucide-svelte'
+	import { XCircle, Play } from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
 	import { getAiChatManager } from './aiChatManagerContext'
 
@@ -31,6 +31,10 @@
 			!message.isStreamingArguments
 	)
 	const autoCollapseDetails = $derived(message.autoCollapseDetails !== false)
+
+	// Executing right now, as opposed to queued behind another tool or waiting on
+	// the user — the only state that gets the shimmer.
+	const isRunning = $derived(Boolean(message.isLoading && !message.needsConfirmation))
 
 	// An errored tool must be expandable even if it never opted into details,
 	// otherwise the error set on its status would be invisible.
@@ -75,13 +79,15 @@
 		{/if}
 	{/snippet}
 
-	<!-- Queued calls (waiting their turn behind the executing tool) are faded: the
-	     reduced weight is what says "not started" — no icon, no spinner. -->
+	<!-- The shimmer is the only running indicator, so the states have to read off
+	     weight alone: queued calls (waiting their turn behind the executing tool)
+	     are faded, the running one sweeps, a settled one is plain. -->
 	<ChatCollapsibleCard
 		label={message.content}
 		expanded={isExpanded}
 		onToggle={() => (isExpanded = !isExpanded)}
 		toggleable={detailsAvailable || message.isStreamingArguments === true}
+		shimmer={isRunning}
 		class={message.isQueued && !message.error
 			? 'opacity-60 hover:opacity-100 transition-opacity'
 			: ''}
@@ -90,12 +96,6 @@
 		contentClass="space-y-3"
 		headerRight={showPreviewChip ? previewChip : undefined}
 	>
-		{#snippet icon()}
-			{#if message.isLoading && !message.needsConfirmation}
-				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500 shrink-0" />
-			{/if}
-		{/snippet}
-
 		<!-- Image a tool produced (e.g. take_screenshot) — shown inline, not gated on expand. -->
 		{#snippet belowHeader()}
 			{#if message.imageUrl}

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -601,6 +601,9 @@ export type AssistantDisplayMessage = BaseDisplayMessage & {
 	role: 'assistant'
 	/** Summarized reasoning/thinking text streamed before the answer (Anthropic + compat providers). */
 	reasoning?: string
+	/** Wall time the model spent reasoning, from the first thinking token to the
+	 * first answer token. Absent on messages finalized before it was recorded. */
+	reasoningDurationMs?: number
 	/**
 	 * True only on the synthetic live message appended while tokens stream
 	 * (see AIChat.svelte). Finalized messages never set it — without the flag,

--- a/frontend/src/lib/components/copilot/chat/thinkingPreferences.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/thinkingPreferences.svelte.ts
@@ -1,0 +1,19 @@
+import { BROWSER } from 'esm-env'
+import { getLocalSetting, storeLocalSetting } from '$lib/utils'
+
+const EXPAND_THINKING_SETTING = 'ai-chat-expand-thinking'
+
+// How the reader wants to read, not anything about the conversation — so it
+// lives per browser rather than in chat history or workspace settings, and
+// applies to every chat at once.
+let expandByDefault = $state(BROWSER && getLocalSetting(EXPAND_THINKING_SETTING) === 'true')
+
+export const thinkingPreferences = {
+	get expandByDefault() {
+		return expandByDefault
+	},
+	set expandByDefault(value: boolean) {
+		expandByDefault = value
+		storeLocalSetting(EXPAND_THINKING_SETTING, value ? 'true' : undefined)
+	}
+}


### PR DESCRIPTION
## Summary

Thinking blocks were their own bordered card with a header strip, they auto-expanded while streaming, and they never said how long the model actually thought. They now read as one quiet status row in the same visual language as tool calls: `Thinking...` while the model reasons, `Thought for 12s` once it stops, expandable either way.

The row settles the moment thinking ends — at the first answer token — not when the turn finalizes, so the duration appears while the answer is still streaming.

In-progress rows are marked by a shimmer sweep instead of a spinner, and that applies to tool calls too: a white copy of the label rides over the coloured one, revealed through a travelling band. Both spinners and the brain icon are gone, so a chat transcript is now a column of plain hint-weight labels where only the live one moves.

A user-scoped **Always expand thinking** preference (localStorage, all chats) is available for readers who want the reasoning open by default.

## Changes

- **New `ChatCollapsibleCard.svelte`**: the collapsible-row shape both thinking and tool calls render — inline header button, rotating chevron, detached `border … bg-surface p-3` body, `text-secondary` label. `ToolExecutionDisplay` passes its preview chip as `headerRight` and its screenshot as `belowHeader`.
- **`shimmer` prop marks work in progress**: `AssistantMessage` sets it while reasoning streams, `ToolExecutionDisplay` while a tool is executing (not when queued behind another tool, and not while awaiting confirmation). A mask can only subtract alpha, so a *white* band needs a second copy of the label stacked on the first; it is forced white with `filter: brightness(0) invert(1)` rather than colour overrides, so it doesn't matter what classes the caller gives the label. `aria-hidden`, `pointer-events: none`, and dropped entirely under `prefers-reduced-motion`.
- **No icons on either row**: the spinner on running tools and the `Brain` on thinking are both removed — the shimmer is the only in-progress signal, and weight alone separates queued (faded), running (sweeping) and settled (plain).
- **`reasoningDurationMs` on `AssistantDisplayMessage`**, timed off token *arrival* rather than the typewriter (which paces display and would report paint time). Starts at the first thinking token, stops at the first answer token, or at the message boundary for a turn that reasons straight into a tool call. Exposed live via `AIChatManager.currentReasoningDurationMs` so the streaming message settles mid-turn; persisted with the message, so a reload still shows `Thought for 10s`.
- **`thinkingPreferences.svelte.ts`**: `ai-chat-expand-thinking` via the existing `getLocalSetting`/`storeLocalSetting` helpers, surfaced as *Always expand thinking* in the model/thinking dropdown. Each block tracks manual toggles separately, so flipping the preference reaches every block the reader hasn't already decided about.
- **Fix**: the expanded reasoning body was rendering monospace — `font-sans` is a dead class in this repo (`tailwind.config.cjs:452` replaces `fontFamily` with `main`/`mono`). It uses `font-main` now.

## Screenshots

The sweep, on a running tool call (one full 2.6s cycle: 1.5s of travel, then the band waits off-screen):

![shimmer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/guilhem/win-2283-improve-thinking-ui/1785922308-shimmer.gif)

Live `Thinking...` — the still catches one frame, with the band over the middle of the label:

![thinking](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/guilhem/win-2283-improve-thinking-ui/1785922310-shot-thinking.png)

A settled transcript — `Thought for Xs` and finished tool calls, collapsed by default, nothing moving:

![settled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/guilhem/win-2283-improve-thinking-ui/1785922315-shot-settled.png)

Expanded reasoning (body font, after the fix above):

![expanded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/guilhem/win-2283-improve-thinking-ui/1785922318-shot-expanded.png)

The preference, in the model/thinking dropdown:

![settings](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/guilhem/win-2283-improve-thinking-ui/1785858500-shot-settings.png)

## Test plan

- [x] Reasoning model shows a shimmering `Thinking...` while reasoning, then `Thought for Xs` once the answer starts streaming
- [x] A tool call shimmers while executing, and stops the moment it settles
- [x] A tool awaiting confirmation does not shimmer; a queued tool stays faded
- [x] Expanding shows the full summary, rendered as prose in the body font
- [x] Duration survives a reload (persisted on the display message)
- [x] *Always expand thinking* persists across reload and opens blocks by default
- [ ] A tool-using turn records an independent duration per reasoning pass, and tool cards (confirmation, results, images, preview chips) are unchanged
- [ ] A provider with hidden reasoning summaries still shows its existing indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
