### PR TITLE
feat: let the database manager run its jobs on a custom worker tag

### DIFF
--- a/frontend/src/lib/components/DBManagerContent.svelte
+++ b/frontend/src/lib/components/DBManagerContent.svelte
@@ -9,6 +9,7 @@
 		getLanguageByResourceType
 	} from './apps/components/display/dbtable/utils'
 	import DbManager from './DBManager.svelte'
+	import DbWorkerTagPicker from './DbWorkerTagPicker.svelte'
 	import MissingWorkerTagAlert from './jobs/MissingWorkerTagAlert.svelte'
 	import {
 		dbSchemaOpsWithPreviewScripts,
@@ -49,6 +50,9 @@
 		 *  navigation `$workspaceStore`; pass the acting workspace when embedded in
 		 *  a session preview whose workspace differs from the top nav. */
 		workspace?: string
+		/** Worker tag every job of this manager runs on, overriding the database
+		 *  language's native tag. Bound so the hints below can offer to set it. */
+		workerTag?: string
 	}
 
 	let {
@@ -62,7 +66,8 @@
 		selectedTables = $bindable([]),
 		disabledTables = [],
 		onImport,
-		workspace = undefined
+		workspace = undefined,
+		workerTag = $bindable()
 	}: Props = $props()
 
 	let ws = $derived(workspace ?? $workspaceStore)
@@ -103,12 +108,12 @@
 	)
 
 	let colDefs = resource(
-		() => [input, ws],
+		() => [input, ws, workerTag],
 		async () => {
 			colDefsError = undefined
 			if (!input) return
 			try {
-				return await loadAllTablesMetaData(ws, input)
+				return await loadAllTablesMetaData(ws, input, workerTag)
 			} catch (e) {
 				colDefsError = 'Error loading tables metadata: ' + ((e as Error)?.message || e)
 				return
@@ -117,7 +122,7 @@
 	)
 
 	let dbSchemasPromise = resource(
-		() => [input, ws],
+		() => [input, ws, workerTag],
 		async () => {
 			schemaError = undefined
 			if (!input) return
@@ -127,7 +132,8 @@
 					input.resourceType,
 					input.resourcePath,
 					ws,
-					(message: string) => (schemaError = message)
+					(message: string) => (schemaError = message),
+					{ customTag: workerTag }
 				)
 				if (!schema) {
 					schemaError ??= 'The schema query returned no schema'
@@ -138,7 +144,8 @@
 				try {
 					$dbSchemas[dbSchemasPath] = await getDucklakeSchema({
 						workspace: ws!,
-						ducklake: input.ducklake
+						ducklake: input.ducklake,
+						tag: workerTag
 					})
 				} catch (e) {
 					schemaError = 'Error fetching schema: ' + ((e as Error)?.message || e)
@@ -155,9 +162,10 @@
 	}
 
 	// Tag the schema/metadata jobs run on: for every DB the manager supports, the
-	// language name is the tag, which is what makes the missing-worker hint below
-	// possible without waiting for the poller to give up.
-	let jobTag = $derived(input ? getLanguageByResourceType(getDbType(input)) : undefined)
+	// language name is the tag unless overridden, which is what makes the
+	// missing-worker hint below possible without waiting for the poller to give up.
+	let defaultTag = $derived(input ? getLanguageByResourceType(getDbType(input)) : undefined)
+	let jobTag = $derived(workerTag ?? defaultTag)
 
 	// A job queued behind busy workers still loads eventually, so this is a hint
 	// rather than an error. The no-worker-at-all case fails outright instead.
@@ -214,6 +222,14 @@
 					Retry
 				</Button>
 			</div>
+			<!-- A database that no default worker can reach fails here rather than in the
+				missing-worker path below, so the same override is offered on any load error. -->
+			<DbWorkerTagPicker
+				bind:tag={workerTag}
+				{defaultTag}
+				workspace={ws}
+				class="border-t pt-3 max-w-md"
+			/>
 		</div>
 	</div>
 {:else if dbSchema && ws && input}
@@ -251,11 +267,13 @@
 						colDefs,
 						tableKey,
 						input: _input,
-						workspace: ws
+						workspace: ws,
+						tag: workerTag
 					})}
 				dbSchemaOps={dbSchemaOpsWithPreviewScripts({
 					input: _input,
 					workspace: ws,
+					tag: workerTag,
 					confirmRunOutOfOrder: (pending) =>
 						outOfOrderModal.ask({
 							title: 'Run migration out of order',
@@ -288,6 +306,7 @@
 				<SqlRepl
 					{input}
 					{workspace}
+					tag={workerTag}
 					onData={(data) => {
 						replResultData = data
 					}}
@@ -324,6 +343,12 @@
 						class="max-w-2xl w-full"
 					/>
 				{/if}
+				<DbWorkerTagPicker
+					bind:tag={workerTag}
+					{defaultTag}
+					workspace={ws}
+					class="max-w-md w-full"
+				/>
 			{/if}
 		</Pane>
 	</Splitpanes>

--- a/frontend/src/lib/components/DBManagerContent.svelte
+++ b/frontend/src/lib/components/DBManagerContent.svelte
@@ -4,10 +4,7 @@
 	import { Loader2, RefreshCcw } from 'lucide-svelte'
 	import Alert from './common/alert/Alert.svelte'
 	import Button from './common/button/Button.svelte'
-	import {
-		dbSupportsSchemas,
-		getLanguageByResourceType
-	} from './apps/components/display/dbtable/utils'
+	import { dbSupportsSchemas } from './apps/components/display/dbtable/utils'
 	import DbManager from './DBManager.svelte'
 	import DbWorkerTagPicker from './DbWorkerTagPicker.svelte'
 	import MissingWorkerTagAlert from './jobs/MissingWorkerTagAlert.svelte'
@@ -15,6 +12,7 @@
 		dbSchemaOpsWithPreviewScripts,
 		dbTableOpsWithPreviewScripts,
 		getDbType,
+		getDefaultDbTag,
 		getDucklakeSchema
 	} from './dbOps'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
@@ -107,14 +105,25 @@
 				: undefined
 	)
 
+	// A query already handed to the queue cannot be taken back: `resource` aborts its
+	// controller, but the poller behind these queries doesn't watch the signal, and a
+	// job left on a tag no worker serves only fails ~90s later. Stamp each run so a
+	// superseded one can neither report its failure nor overwrite what replaced it —
+	// picking a working tag from the hints below is exactly that race.
+	let colDefsRun = 0
+	let schemaRun = 0
+
 	let colDefs = resource(
 		() => [input, ws, workerTag],
 		async () => {
+			const run = ++colDefsRun
 			colDefsError = undefined
 			if (!input) return
 			try {
-				return await loadAllTablesMetaData(ws, input, workerTag)
+				const metadata = await loadAllTablesMetaData(ws, input, workerTag)
+				return run === colDefsRun ? metadata : colDefs.current
 			} catch (e) {
+				if (run !== colDefsRun) return colDefs.current
 				colDefsError = 'Error loading tables metadata: ' + ((e as Error)?.message || e)
 				return
 			}
@@ -124,30 +133,37 @@
 	let dbSchemasPromise = resource(
 		() => [input, ws, workerTag],
 		async () => {
+			const run = ++schemaRun
 			schemaError = undefined
 			if (!input) return
 			const dbSchemasPath = schemaCacheKey(input)
 			if (input.type == 'database') {
+				// Reported through a local, not `schemaError` directly, so a superseded
+				// run's callback can't fail a load that already succeeded.
+				let queryError: string | undefined
 				const schema = await getDbSchemas(
 					input.resourceType,
 					input.resourcePath,
 					ws,
-					(message: string) => (schemaError = message),
+					(message: string) => (queryError = message),
 					{ customTag: workerTag }
 				)
+				if (run !== schemaRun) return
 				if (!schema) {
-					schemaError ??= 'The schema query returned no schema'
+					schemaError = queryError ?? 'The schema query returned no schema'
 					return
 				}
 				$dbSchemas[dbSchemasPath] = schema
 			} else if (input.type == 'ducklake') {
 				try {
-					$dbSchemas[dbSchemasPath] = await getDucklakeSchema({
+					const schema = await getDucklakeSchema({
 						workspace: ws!,
 						ducklake: input.ducklake,
 						tag: workerTag
 					})
+					if (run === schemaRun) $dbSchemas[dbSchemasPath] = schema
 				} catch (e) {
+					if (run !== schemaRun) return
 					schemaError = 'Error fetching schema: ' + ((e as Error)?.message || e)
 				}
 			}
@@ -161,10 +177,9 @@
 		return colDefs.loading || dbSchemasPromise.loading
 	}
 
-	// Tag the schema/metadata jobs run on: for every DB the manager supports, the
-	// language name is the tag unless overridden, which is what makes the
-	// missing-worker hint below possible without waiting for the poller to give up.
-	let defaultTag = $derived(input ? getLanguageByResourceType(getDbType(input)) : undefined)
+	// Knowing the tag up front is what makes the missing-worker hint below possible
+	// without waiting for the poller to give up.
+	let defaultTag = $derived(input ? getDefaultDbTag(input) : undefined)
 	let jobTag = $derived(workerTag ?? defaultTag)
 
 	// A job queued behind busy workers still loads eventually, so this is a hint

--- a/frontend/src/lib/components/DBManagerDrawer.svelte
+++ b/frontend/src/lib/components/DBManagerDrawer.svelte
@@ -13,6 +13,7 @@
 		LoaderCircle,
 		Minimize,
 		RefreshCcw,
+		Tag,
 		Upload
 	} from 'lucide-svelte'
 	import DBManagerContent from './DBManagerContent.svelte'
@@ -24,6 +25,11 @@
 	import Alert from './common/alert/Alert.svelte'
 	import { sendUserToast } from '$lib/toast'
 	import { isCloudHosted } from '$lib/cloud'
+	import { useDbManagerTag } from './dbManagerTag.svelte'
+	import DbWorkerTagPicker from './DbWorkerTagPicker.svelte'
+	import Popover from './meltComponents/Popover.svelte'
+	import { getLanguageByResourceType } from './apps/components/display/dbtable/utils'
+	import { getDbType } from './dbOps'
 
 	interface Props {
 		uriState: DbManagerUriState
@@ -80,6 +86,17 @@
 	})
 
 	let dbManagerContent: DBManagerContent | undefined = $state()
+
+	// Per-database worker tag override, remembered across drawer opens.
+	const workerTag = useDbManagerTag(
+		() => ws,
+		() => uriState.effectiveInput
+	)
+	let defaultTag = $derived(
+		uriState.effectiveInput
+			? getLanguageByResourceType(getDbType(uriState.effectiveInput))
+			: undefined
+	)
 
 	let hasReplResult = $state(false)
 
@@ -181,6 +198,7 @@
 					bind:this={dbManagerContent}
 					input={uriState.effectiveInput}
 					workspace={uriState.workspace}
+					bind:workerTag={() => workerTag.tag, (v) => (workerTag.tag = v)}
 					bind:hasReplResult
 					bind:selectedSchemaKey={uriState.selectedSchema}
 					bind:selectedTableKey={uriState.selectedTable}
@@ -223,6 +241,29 @@
 					Import
 				</Button>
 			{/if}
+			<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
+				{#snippet trigger()}
+					<Button
+						size="xs"
+						color="light"
+						startIcon={{ icon: Tag }}
+						nonCaptureEvent
+						title="Worker tag the database jobs run on"
+					>
+						{workerTag.tag ?? 'Worker tag'}
+					</Button>
+				{/snippet}
+				{#snippet content()}
+					<div class="p-4 w-96">
+						<DbWorkerTagPicker
+							bind:tag={() => workerTag.tag, (v) => (workerTag.tag = v)}
+							{defaultTag}
+							workspace={ws}
+						/>
+					</div>
+				{/snippet}
+			</Popover>
+
 			<Button
 				loading={dbManagerContent?.isLoading() ?? false}
 				on:click={refreshManager}

--- a/frontend/src/lib/components/DBManagerDrawer.svelte
+++ b/frontend/src/lib/components/DBManagerDrawer.svelte
@@ -13,7 +13,6 @@
 		LoaderCircle,
 		Minimize,
 		RefreshCcw,
-		Tag,
 		Upload
 	} from 'lucide-svelte'
 	import DBManagerContent from './DBManagerContent.svelte'
@@ -26,10 +25,7 @@
 	import { sendUserToast } from '$lib/toast'
 	import { isCloudHosted } from '$lib/cloud'
 	import { useDbManagerTag } from './dbManagerTag.svelte'
-	import DbWorkerTagPicker from './DbWorkerTagPicker.svelte'
-	import Popover from './meltComponents/Popover.svelte'
-	import { getLanguageByResourceType } from './apps/components/display/dbtable/utils'
-	import { getDbType } from './dbOps'
+	import DbWorkerTagButton from './DbWorkerTagButton.svelte'
 
 	interface Props {
 		uriState: DbManagerUriState
@@ -91,11 +87,6 @@
 	const workerTag = useDbManagerTag(
 		() => ws,
 		() => uriState.effectiveInput
-	)
-	let defaultTag = $derived(
-		uriState.effectiveInput
-			? getLanguageByResourceType(getDbType(uriState.effectiveInput))
-			: undefined
 	)
 
 	let hasReplResult = $state(false)
@@ -241,28 +232,13 @@
 					Import
 				</Button>
 			{/if}
-			<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
-				{#snippet trigger()}
-					<Button
-						size="xs"
-						color="light"
-						startIcon={{ icon: Tag }}
-						nonCaptureEvent
-						title="Worker tag the database jobs run on"
-					>
-						{workerTag.tag ?? 'Worker tag'}
-					</Button>
-				{/snippet}
-				{#snippet content()}
-					<div class="p-4 w-96">
-						<DbWorkerTagPicker
-							bind:tag={() => workerTag.tag, (v) => (workerTag.tag = v)}
-							{defaultTag}
-							workspace={ws}
-						/>
-					</div>
-				{/snippet}
-			</Popover>
+			{#if uriState.effectiveInput && ws}
+				<DbWorkerTagButton
+					bind:tag={() => workerTag.tag, (v) => (workerTag.tag = v)}
+					input={uriState.effectiveInput}
+					workspace={ws}
+				/>
+			{/if}
 
 			<Button
 				loading={dbManagerContent?.isLoading() ?? false}

--- a/frontend/src/lib/components/DbWorkerTagButton.svelte
+++ b/frontend/src/lib/components/DbWorkerTagButton.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Tag } from 'lucide-svelte'
+	import Button from './common/button/Button.svelte'
+	import Popover from './meltComponents/Popover.svelte'
+	import DbWorkerTagPicker from './DbWorkerTagPicker.svelte'
+	import { getDefaultDbTag } from './dbOps'
+	import type { DbInput } from './dbTypes'
+
+	interface Props {
+		/** Tag override; undefined runs the database's jobs on their native tag. */
+		tag: string | undefined
+		input: DbInput
+		/** Workspace the custom tags are read from; defaults to the navigation one. */
+		workspace?: string
+	}
+
+	let { tag = $bindable(), input, workspace = undefined }: Props = $props()
+
+	let defaultTag = $derived(getDefaultDbTag(input))
+</script>
+
+<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
+	{#snippet trigger()}
+		<Button
+			size="xs"
+			color="light"
+			startIcon={{ icon: Tag }}
+			nonCaptureEvent
+			title="Worker tag the database jobs run on"
+		>
+			{tag ?? 'Worker tag'}
+		</Button>
+	{/snippet}
+	{#snippet content()}
+		<div class="p-4 w-96">
+			<DbWorkerTagPicker bind:tag {defaultTag} {workspace} />
+		</div>
+	{/snippet}
+</Popover>

--- a/frontend/src/lib/components/DbWorkerTagPicker.svelte
+++ b/frontend/src/lib/components/DbWorkerTagPicker.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import WorkerTagSelect from './WorkerTagSelect.svelte'
+
+	interface Props {
+		/** Tag override; undefined runs the jobs on `defaultTag`. */
+		tag: string | undefined
+		/** Tag the jobs carry with no override, i.e. the database language's native one. */
+		defaultTag: string | undefined
+		/** Workspace the custom tags are read from; defaults to the navigation one. */
+		workspace?: string
+		class?: string
+	}
+
+	let {
+		tag = $bindable(),
+		defaultTag,
+		workspace = undefined,
+		class: className = ''
+	}: Props = $props()
+</script>
+
+<div class={'flex flex-col gap-1 ' + className}>
+	<span class="text-xs font-semibold text-secondary">Worker tag</span>
+	<WorkerTagSelect bind:tag noLabel nullTag={defaultTag} workspaceId={workspace} size="sm" />
+	<span class="text-xs text-tertiary">
+		Queries of this database run as jobs tagged <b>{defaultTag}</b>. Pick a custom tag to run them
+		on a specific worker group instead, e.g. the only one that can reach this database.
+	</span>
+</div>

--- a/frontend/src/lib/components/SqlRepl.svelte
+++ b/frontend/src/lib/components/SqlRepl.svelte
@@ -28,13 +28,16 @@
 		/** Workspace the REPL queries and DDL migrations run against; defaults to
 		 * the nav workspace. */
 		workspace?: string | undefined
+		/** Worker tag the queries run on instead of the language's native one. */
+		tag?: string | undefined
 	}
 	let {
 		input,
 		onData,
 		placeholderTableName,
 		onSchemaChange,
-		workspace = undefined
+		workspace = undefined,
+		tag = undefined
 	}: Props = $props()
 	let ws = $derived(workspace ?? $workspaceStore)
 	let dbType = $derived(getDbType(input))
@@ -121,7 +124,8 @@
 					requestBody: {
 						language: getLanguageByResourceType(dbType),
 						content: transformedCode,
-						args: dbArg
+						args: dbArg,
+						tag
 					}
 				},
 				// The user types arbitrary SQL here, so treat every run as a write.

--- a/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
@@ -70,7 +70,10 @@ export async function loadTableMetaData(
  * own pane, so toasting here would double-report it. */
 export async function loadAllTablesMetaData(
 	workspace: string | undefined,
-	input: DbInput
+	input: DbInput,
+	// Worker tag to run the introspection job on instead of the language's native
+	// one, for a database only reachable from a specific worker group.
+	tag?: string
 ): Promise<Record<string, TableMetadata> | undefined> {
 	if (!input || !workspace) return undefined
 
@@ -86,7 +89,7 @@ export async function loadAllTablesMetaData(
 
 		let result = (await runScriptAndPollResult({
 			workspace,
-			requestBody: { language, content, args: dbArg }
+			requestBody: { language, content, args: dbArg, tag }
 		})) as ({ table_name: string; schema_name?: string } & object)[]
 		const map: Record<string, TableMetadata> = {}
 
@@ -97,7 +100,7 @@ export async function loadAllTablesMetaData(
 			map[tableKey].push(col)
 		}
 
-		await fetchAndAddSnowflakePrimaryKeysInMap(map, input, workspace)
+		await fetchAndAddSnowflakePrimaryKeysInMap(map, input, workspace, undefined, tag)
 
 		return map
 	} catch (e) {
@@ -118,13 +121,14 @@ async function fetchAndAddSnowflakePrimaryKeysInMap(
 	map: Record<string, TableMetadata>,
 	input: DbInput,
 	workspace: string,
-	tableKey?: string
+	tableKey?: string,
+	tag?: string
 ) {
 	if (
 		input.type == 'database' &&
 		(input.resourceType === 'snowflake' || (input.resourceType as any) === 'snowflake_oauth')
 	) {
-		let pkResult = await fetchSnowflakePrimaryKeys(workspace, getDatabaseArg(input), tableKey)
+		let pkResult = await fetchSnowflakePrimaryKeys(workspace, getDatabaseArg(input), tableKey, tag)
 		for (const pk of pkResult) {
 			const pkTableKey = `${pk.schema_name}.${pk.table_name}`.toUpperCase()
 			// Also check the original casing and the provided tableKey
@@ -147,7 +151,8 @@ async function fetchAndAddSnowflakePrimaryKeysInMap(
 async function fetchSnowflakePrimaryKeys(
 	workspace: string,
 	dbArg: any,
-	tableKey?: string
+	tableKey?: string,
+	tag?: string
 ): Promise<SnowflakeShowPrimaryKeysResult[]> {
 	const payload: Record<string, unknown> = {}
 	if (tableKey) payload.table = tableKey
@@ -157,7 +162,8 @@ async function fetchSnowflakePrimaryKeys(
 		requestBody: {
 			language: 'snowflake',
 			args: dbArg,
-			content
+			content,
+			tag
 		}
 	})) as SnowflakeShowPrimaryKeysResult[]
 }

--- a/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
@@ -71,8 +71,7 @@ export async function loadTableMetaData(
 export async function loadAllTablesMetaData(
 	workspace: string | undefined,
 	input: DbInput,
-	// Worker tag to run the introspection job on instead of the language's native
-	// one, for a database only reachable from a specific worker group.
+	// Overrides the language's native worker tag.
 	tag?: string
 ): Promise<Record<string, TableMetadata> | undefined> {
 	if (!input || !workspace) return undefined

--- a/frontend/src/lib/components/dbManagerTag.svelte.ts
+++ b/frontend/src/lib/components/dbManagerTag.svelte.ts
@@ -1,0 +1,45 @@
+import { getLocalSetting, storeLocalSetting } from '$lib/utils'
+import type { DbInput } from './dbTypes'
+
+/**
+ * Every database manager operation runs as a job on the language's native tag
+ * (`postgresql`, `duckdb`, …). A database reachable only from one worker group
+ * (private network, VPC) needs those jobs on that group's tag instead, and it
+ * needs it on every visit — hence local storage rather than component state.
+ */
+function tagKey(workspace: string | undefined, input: DbInput | undefined): string | undefined {
+	if (!workspace || !input) return undefined
+	const path = input.type === 'ducklake' ? `ducklake://${input.ducklake}` : input.resourcePath
+	return `dbManagerWorkerTag:${workspace}:${path}`
+}
+
+export interface DbManagerTagState {
+	/** Tag override for this database's jobs; undefined runs them on the language default. */
+	tag: string | undefined
+}
+
+export function useDbManagerTag(
+	getWorkspace: () => string | undefined,
+	getInput: () => DbInput | undefined
+): DbManagerTagState {
+	let key = $derived(tagKey(getWorkspace(), getInput()))
+	// Local storage is not reactive, so a tag set here is remembered separately to
+	// re-run the readers that depend on it.
+	let written = $state<Record<string, string | undefined>>({})
+	let tag = $derived.by(() => {
+		if (!key) return undefined
+		return (key in written ? written[key] : getLocalSetting(key)) ?? undefined
+	})
+	return {
+		get tag() {
+			return tag
+		},
+		set tag(v: string | undefined) {
+			const k = key
+			if (!k) return
+			const value = v ? v : undefined
+			written = { ...written, [k]: value }
+			storeLocalSetting(k, value)
+		}
+	}
+}

--- a/frontend/src/lib/components/dbManagerTag.svelte.ts
+++ b/frontend/src/lib/components/dbManagerTag.svelte.ts
@@ -13,6 +13,12 @@ function tagKey(workspace: string | undefined, input: DbInput | undefined): stri
 	return `dbManagerWorkerTag:${workspace}:${path}`
 }
 
+/** Tags set this session, shared by every caller: local storage is not reactive, so a
+ * per-instance cache would leave a second drawer open on the same database deriving —
+ * and running its jobs on — the tag the first one just replaced. `null` is an explicit
+ * clear, absent means "not set here, read local storage". */
+const overrides = $state<Record<string, string | null>>({})
+
 export interface DbManagerTagState {
 	/** Tag override for this database's jobs; undefined runs them on the language default. */
 	tag: string | undefined
@@ -23,12 +29,10 @@ export function useDbManagerTag(
 	getInput: () => DbInput | undefined
 ): DbManagerTagState {
 	let key = $derived(tagKey(getWorkspace(), getInput()))
-	// Local storage is not reactive, so a tag set here is remembered separately to
-	// re-run the readers that depend on it.
-	let written = $state<Record<string, string | undefined>>({})
 	let tag = $derived.by(() => {
 		if (!key) return undefined
-		return (key in written ? written[key] : getLocalSetting(key)) ?? undefined
+		const set = overrides[key]
+		return (set === undefined ? getLocalSetting(key) : set) ?? undefined
 	})
 	return {
 		get tag() {
@@ -38,7 +42,7 @@ export function useDbManagerTag(
 			const k = key
 			if (!k) return
 			const value = v ? v : undefined
-			written = { ...written, [k]: value }
+			overrides[k] = value ?? null
 			storeLocalSetting(k, value)
 		}
 	}

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -51,7 +51,8 @@ export function dbTableOpsWithPreviewScripts({
 	colDefs,
 	workspace,
 	whereClause,
-	version
+	version,
+	tag
 }: {
 	input: DbInput
 	tableKey: string
@@ -63,6 +64,9 @@ export function dbTableOpsWithPreviewScripts({
 	// DuckLake time-travel: when set, reads are pinned to this catalog snapshot
 	// via `AT (VERSION => n)` (DuckDB/ducklake only). Read-only by nature.
 	version?: number
+	// Worker tag to run the jobs on instead of the language's native one, for a
+	// database only reachable from a specific worker group.
+	tag?: string
 }): IDbTableOps {
 	const dbType = getDbType(input)
 	const language = getLanguageByResourceType(dbType)
@@ -87,7 +91,7 @@ export function dbTableOpsWithPreviewScripts({
 			})
 			const result = await runScriptAndPollResult({
 				workspace,
-				requestBody: { args: { ...dbArg, quicksearch }, language, content }
+				requestBody: { args: { ...dbArg, quicksearch }, language, content, tag }
 			})
 			const count = result?.[0].count as number
 			return count
@@ -102,7 +106,7 @@ export function dbTableOpsWithPreviewScripts({
 			})
 			let items = (await runScriptAndPollResult({
 				workspace,
-				requestBody: { args: { ...dbArg, ...params }, language, content }
+				requestBody: { args: { ...dbArg, ...params }, language, content, tag }
 			})) as unknown[]
 			if (!items || !Array.isArray(items)) {
 				throw 'items is not an array'
@@ -121,7 +125,8 @@ export function dbTableOpsWithPreviewScripts({
 					requestBody: {
 						args: { ...dbArg, value_to_update: newValue, ...values },
 						language,
-						content
+						content,
+						tag
 					}
 				},
 				writingJobOptions
@@ -130,14 +135,14 @@ export function dbTableOpsWithPreviewScripts({
 		onDelete: async ({ values }) => {
 			const content = makeMarker('DELETE', { table: tableKey, columns: colDefs })
 			await runScriptAndPollResult(
-				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content } },
+				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content, tag } },
 				writingJobOptions
 			)
 		},
 		onInsert: async ({ values }) => {
 			const content = makeMarker('INSERT', { table: tableKey, columns: colDefs })
 			await runScriptAndPollResult(
-				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content } },
+				{ workspace, requestBody: { args: { ...dbArg, ...values }, language, content, tag } },
 				writingJobOptions
 			)
 		}
@@ -260,13 +265,18 @@ export class MigrationRunCancelled extends Error {
 export function dbSchemaOpsWithPreviewScripts({
 	workspace,
 	input,
-	confirmRunOutOfOrder
+	confirmRunOutOfOrder,
+	tag
 }: {
 	workspace: string
 	input: DbInput
 	/** Asked before running a just-created migration ahead of `pendingCount`
 	 * still-pending earlier ones. Return false to abort (throws MigrationRunCancelled). */
 	confirmRunOutOfOrder?: (pendingCount: number) => Promise<boolean>
+	// Worker tag to run the jobs on instead of the language's native one, for a
+	// database only reachable from a specific worker group. Data table migrations
+	// are run by the server and keep their own tag.
+	tag?: string
 }): IDbSchemaOps {
 	const dbType = getDbType(input)
 	const dbArg = getDatabaseArg(input)
@@ -345,7 +355,7 @@ export function dbSchemaOpsWithPreviewScripts({
 			: undefined
 		if (!datatableName || !status?.enabled) {
 			await runScriptAndPollResult(
-				{ workspace, requestBody: { args: dbArg, content, language } },
+				{ workspace, requestBody: { args: dbArg, content, language, tag } },
 				writingJobOptions
 			)
 			return
@@ -456,7 +466,7 @@ export function dbSchemaOpsWithPreviewScripts({
 					const fkContent = makeMarker('FOREIGN_KEYS', { table, schema })
 					const fkResult = await runScriptAndPollResult({
 						workspace,
-						requestBody: { args: dbArg, content: fkContent, language }
+						requestBody: { args: dbArg, content: fkContent, language, tag }
 					})
 
 					let rawForeignKeys: RawForeignKey[]
@@ -489,7 +499,7 @@ export function dbSchemaOpsWithPreviewScripts({
 					const pkContent = makeMarker('PRIMARY_KEY_CONSTRAINT', { table, schema })
 					const pkResult = (await runScriptAndPollResult({
 						workspace,
-						requestBody: { args: dbArg, content: pkContent, language }
+						requestBody: { args: dbArg, content: pkContent, language, tag }
 					})) as { constraint_name?: string; CONSTRAINT_NAME?: string }[]
 
 					if (pkResult && Array.isArray(pkResult) && pkResult.length > 0) {
@@ -513,17 +523,20 @@ export function dbSchemaOpsWithPreviewScripts({
 
 export async function getDucklakeSchema({
 	workspace,
-	ducklake
+	ducklake,
+	tag
 }: {
 	workspace: string
 	ducklake: string
+	tag?: string
 }): Promise<DBSchema> {
 	let result = await runScriptAndPollResult({
 		workspace,
 		requestBody: {
 			language: 'duckdb',
 			content: `ATTACH 'ducklake://${ducklake}' AS __ducklake__; ${DUCKLAKE_GET_SCHEMA_QUERY}`,
-			args: {}
+			args: {},
+			tag
 		}
 	})
 	let schemas = Array.isArray(result) && result.length && (result?.[0]?.['result'] ?? {})

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -64,8 +64,7 @@ export function dbTableOpsWithPreviewScripts({
 	// DuckLake time-travel: when set, reads are pinned to this catalog snapshot
 	// via `AT (VERSION => n)` (DuckDB/ducklake only). Read-only by nature.
 	version?: number
-	// Worker tag to run the jobs on instead of the language's native one, for a
-	// database only reachable from a specific worker group.
+	// Overrides the language's native worker tag.
 	tag?: string
 }): IDbTableOps {
 	const dbType = getDbType(input)
@@ -273,9 +272,9 @@ export function dbSchemaOpsWithPreviewScripts({
 	/** Asked before running a just-created migration ahead of `pendingCount`
 	 * still-pending earlier ones. Return false to abort (throws MigrationRunCancelled). */
 	confirmRunOutOfOrder?: (pendingCount: number) => Promise<boolean>
-	// Worker tag to run the jobs on instead of the language's native one, for a
-	// database only reachable from a specific worker group. Data table migrations
-	// are run by the server and keep their own tag.
+	// Overrides the language's native worker tag, for a database only reachable from
+	// a specific worker group. Data table migrations are run by the server, which
+	// picks their tag itself, so they are unaffected.
 	tag?: string
 }): IDbSchemaOps {
 	const dbType = getDbType(input)
@@ -587,6 +586,12 @@ export function getDbType(input: DbInput): DbType {
 		case 'ducklake':
 			return 'duckdb'
 	}
+}
+
+/** Tag the database's jobs carry with no override: for every DB the manager
+ * supports, the language of its queries is also the name of its native tag. */
+export function getDefaultDbTag(input: DbInput): string {
+	return getLanguageByResourceType(getDbType(input))
 }
 
 export function getDatabaseArg(input: DbInput | undefined) {

--- a/frontend/src/lib/components/raw_apps/RawAppDataTableDrawer.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppDataTableDrawer.svelte
@@ -13,6 +13,7 @@
 	import type { DbInput } from '../dbTypes'
 	import type { SelectedTable } from '../DBManager.svelte'
 	import { getRawAppOperatingWorkspace } from './rawAppWorkspace'
+	import { useDbManagerTag } from '../dbManagerTag.svelte'
 
 	const getOpWs = getRawAppOperatingWorkspace()
 	let opWs = $derived(getOpWs?.() ?? $workspaceStore)
@@ -148,6 +149,13 @@
 
 	// Can add: has tables selected
 	const canAdd = $derived(selectedDatatable && selectedTables.length > 0)
+
+	// Shares the drawer-set override with the Database Manager: same data table,
+	// same worker group needed to reach it.
+	const workerTag = useDbManagerTag(
+		() => opWs,
+		() => dbInput
+	)
 </script>
 
 <svelte:window bind:innerWidth={windowWidth} />
@@ -171,6 +179,7 @@
 					bind:this={dbManagerContent}
 					input={dbInput}
 					workspace={opWs}
+					bind:workerTag={() => workerTag.tag, (v) => (workerTag.tag = v)}
 					bind:hasReplResult
 					bind:selectedSchemaKey
 					bind:selectedTableKey

--- a/frontend/src/lib/components/raw_apps/RawAppDataTableDrawer.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppDataTableDrawer.svelte
@@ -14,6 +14,7 @@
 	import type { SelectedTable } from '../DBManager.svelte'
 	import { getRawAppOperatingWorkspace } from './rawAppWorkspace'
 	import { useDbManagerTag } from '../dbManagerTag.svelte'
+	import DbWorkerTagButton from '../DbWorkerTagButton.svelte'
 
 	const getOpWs = getRawAppOperatingWorkspace()
 	let opWs = $derived(getOpWs?.() ?? $workspaceStore)
@@ -226,6 +227,14 @@
 					Add to app
 				{/if}
 			</Button>
+
+			{#if dbInput && opWs}
+				<DbWorkerTagButton
+					bind:tag={() => workerTag.tag, (v) => (workerTag.tag = v)}
+					input={dbInput}
+					workspace={opWs}
+				/>
+			{/if}
 
 			<Button
 				loading={dbManagerContent?.isLoading() ?? false}


### PR DESCRIPTION
## Summary

Fixes WIN-2315.

Every Database Manager operation — schema introspection, table metadata, row reads and
writes, DDL, the SQL REPL — runs as a Windmill preview job tagged with the database
language (`postgresql`, `mysql`, `duckdb`, …). That tag decides which worker group picks
the job up, and the default groups are not always the right ones: a database on a private
network is often reachable only from one group, and #10456 already surfaced the case where
no worker serves the native tag at all. Until now the drawer had no way to say "run these
on that group instead" — the only fix was to widen a worker group's tags instance-wide.

This adds a per-database worker tag override to the drawer, and offers it exactly where
the failure shows up.

## Changes

**Setting the tag**
- New `DbWorkerTagPicker` wraps the existing `WorkerTagSelect` (custom tags + live
  worker-availability dots), with the language's native tag as the placeholder so it is
  clear what the jobs run on without an override.
- Both database drawers (the Database Manager and the raw-app `Data` drawer) get a
  `Worker tag` popover in their action bar; the button label shows the active override.
- `useDbManagerTag` (`dbManagerTag.svelte.ts`) keeps the override in local storage under
  `dbManagerWorkerTag:<workspace>:<db path>`. A database that needs a specific group needs
  it on every visit, not just the one where it was set. Tags set this session are held in
  one module-level map rather than per caller: local storage is not reactive, so a
  per-instance cache would leave a second drawer open on the same database running its
  jobs on the tag the first one just replaced.

**Hinting at it when the default tag doesn't work**
- The picker is rendered under the existing missing-worker warning (shown after 10s of a
  still-queued job) and in the load-error panel. A database no default worker can *reach*
  fails as an error rather than as a missing tag, so both paths offer the override.
- `MissingWorkerTagAlert` now probes the tag actually in use, so picking a tag no worker
  serves is reported against that tag.

**Plumbing**
- `tag` threaded through `dbTableOpsWithPreviewScripts` (count/select/insert/update/delete),
  `dbSchemaOpsWithPreviewScripts` (DDL + foreign-key/primary-key lookups),
  `getDucklakeSchema`, `loadAllTablesMetaData` (+ the Snowflake primary-key follow-up),
  `getDbSchemas` (`customTag`, already supported) and `SqlRepl`. All optional — every
  other caller is unchanged and keeps the native tag.
- Changing the tag is a dependency of the schema/metadata resources, so the manager
  refetches on the new tag immediately. Each load is stamped so a superseded one can
  neither report its failure nor overwrite what replaced it: a job already queued cannot
  be recalled (`resource` aborts a controller the poller behind these queries doesn't
  watch), and one left on an unserved tag only fails ~90s later — which is precisely the
  window in which the user picks a working tag from the hint.
- Data table migrations are run by the server on its own tag and are deliberately left
  alone.

## Screenshots

Local instance whose worker group does not serve `postgresql`, on a `postgresql` resource.

Queued too long — the missing-worker warning, now with the override right under it:

![slowload-hint](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2315-add-custom-tags-with-worker-fallback-hints/1785861846-slowload-hint.png)

The poller gives up — same override on the error panel:

![error-hint](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2315-add-custom-tags-with-worker-fallback-hints/1785861933-error-hint.png)

Picking a custom tag (availability dots come from `WorkerTagSelect`):

![tag-dropdown](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2315-add-custom-tags-with-worker-fallback-hints/1785861794-tag-dropdown2.png)

Same database, now loading on a tag a worker actually serves:

![loaded-with-custom-tag](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2315-add-custom-tags-with-worker-fallback-hints/1785861796-loaded-with-custom-tag.png)

The action-bar popover, reachable whether or not anything is failing:

![actionbar-popover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2315-add-custom-tags-with-worker-fallback-hints/1785861798-actionbar-popover.png)

## Test plan

Exercised end to end against a local instance whose only worker serves the default tags
(not `postgresql`), on a `postgresql` resource, with `duckdb` declared as an assignable
custom tag so a real worker would pick the jobs up:

- [x] With no override, the drawer shows the missing-worker warning and then the error
      panel, both offering the picker.
- [x] Selecting the custom tag refetches immediately: schema, table list and 622 rows load.
      Every job in `v2_job` for that window carries the override
      (`LOAD_TABLE_METADATA`, the introspection query, `COUNT`, `SELECT`).
- [x] SQL REPL run (`SELECT * FROM _sqlx_migrations`) queued on the override.
- [x] DDL through the manager (`New table` → `wm_tag_probe`) queued on the override and
      the table was created.
- [x] The override survives a full page reload (local storage) and the action-bar button
      shows it; clearing it removes the entry and returns the jobs to `postgresql`.
- [x] Picking a working tag from the slow-load hint while the native-tag job is still
      queued: the manager stays loaded 140s later, past that job's no-worker verdict
      (regression test for the staleness guard — it flipped back to the error panel
      before the fix).
- [x] `npm run check` — 0 errors (65 pre-existing warnings, none in the changed files);
      prettier clean.

No unit test ships with this: the one logic module is rune-based, and this repo has no
vitest project that runs runes — `*.svelte.test.ts` is excluded from both the `server` and
`dom` projects, so the single existing rune test never runs. Adding a project for it would
pull that unrelated dormant file into CI, which is out of scope here.

- [x] Raw-app `Data` drawer, against a data table: same missing-worker hint and error
      panel, the picker there loads the schema on the override, and it is stored under its
      own key (`…:datatable://main` alongside `…:u/admin/local_pg`, neither leaking into
      the other).

Not exercised in a browser: two drawers open on the *same* database at once. Session
writes now live in a single module-level `$state` map that every instance derives from,
so there is no per-instance cache left to go stale; each drawer's write→derive→refetch
path was verified on its own.
