### PR TITLE
fix: keep the token scope builder inside its panel when scopes get long

### DIFF
--- a/frontend/src/lib/components/common/modal/Modal.svelte
+++ b/frontend/src/lib/components/common/modal/Modal.svelte
@@ -138,7 +138,9 @@
 									>
 								{/if}
 								<div class="flex">
-									<div class="text-left flex-1">
+									<!-- min-w-0: without it this flex item takes its content's min-content width and
+									     stretches the modal past its max-width instead of letting content shrink. -->
+									<div class="text-left flex-1 min-w-0">
 										<div class="flex flex-row items-center justify-between">
 											<h3 class="text-emphasis text-lg font-semibold">{title}</h3>
 											{@render settings?.()}

--- a/frontend/src/lib/components/settings/CreateToken.svelte
+++ b/frontend/src/lib/components/settings/CreateToken.svelte
@@ -173,7 +173,9 @@
 </script>
 
 <div>
-	<div class="p-4 rounded-md mb-6 min-w-min bg-surface-tertiary">
+	<!-- Stays bounded by the panel width: a content-driven width (min-w-min) would let a long
+	     scope chip stretch this card and push the rest of the form out of view. -->
+	<div class="p-4 rounded-md mb-6 bg-surface-tertiary">
 		<h3 class="pb-2 font-semibold text-emphasis text-sm">{title}</h3>
 
 		{#if showMcpMode && !mcpOnly}

--- a/frontend/src/lib/components/settings/ScopeSelector.svelte
+++ b/frontend/src/lib/components/settings/ScopeSelector.svelte
@@ -490,6 +490,25 @@
 	fetchScopeDomains()
 </script>
 
+<!-- The label can be a long comma-joined path list: it has to truncate rather than widen its
+     container, which would push the per-scope "Restrict paths" buttons out of the panel. -->
+{#snippet scopeChip(label: string, removeTitle: string, onRemove: (e: MouseEvent) => void)}
+	<span
+		class="inline-flex items-center gap-1 min-w-0 max-w-full px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded font-mono"
+	>
+		<span class="truncate" title={label}>{label}</span>
+		<button
+			type="button"
+			onclick={onRemove}
+			class="text-blue-600 hover:text-blue-800 flex-shrink-0"
+			title={removeTitle}
+			{disabled}
+		>
+			<X size={10} />
+		</button>
+	</span>
+{/snippet}
+
 <div class="w-full {className} p-2">
 	{#if loading}
 		<div class="flex items-center justify-center py-12">
@@ -518,20 +537,7 @@
 			{:else}
 				<div class="flex flex-wrap gap-2">
 					{#each selectedScopes.slice(0, 10) as scope}
-						<span
-							class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded font-mono"
-						>
-							{scope}
-							<button
-								type="button"
-								onclick={() => removeSelectedScope(scope)}
-								class="text-blue-600 hover:text-blue-800 flex-shrink-0"
-								title="Remove scope"
-								{disabled}
-							>
-								<X size={10} />
-							</button>
-						</span>
+						{@render scopeChip(scope, 'Remove scope', () => removeSelectedScope(scope))}
 					{/each}
 					{#if selectedScopes.length > 10}
 						<span
@@ -597,23 +603,10 @@
 										{domain.name}
 									</label>
 									{#each selectedScopes as scope}
-										<span
-											class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded font-mono"
-										>
-											{scope}
-											<button
-												type="button"
-												onclick={(e) => {
-													e.stopPropagation()
-													removeSelectedScope(scope)
-												}}
-												class="text-blue-600 hover:text-blue-800 flex-shrink-0"
-												title="Remove scope"
-												{disabled}
-											>
-												<X size={10} />
-											</button>
-										</span>
+										{@render scopeChip(scope, 'Remove scope', (e) => {
+											e.stopPropagation()
+											removeSelectedScope(scope)
+										})}
 									{/each}
 								</div>
 								{#if domain.description}
@@ -724,19 +717,9 @@
 										{#if scope.requires_resource_path && resourcePathArray.length > 0}
 											<div class="flex flex-wrap gap-1 mt-2">
 												{#each resourcePathArray as path}
-													<span
-														class="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded font-mono"
-													>
-														{path}
-														<button
-															type="button"
-															onclick={() => removeResourcePath(scope.value, path)}
-															class="text-blue-600 hover:text-blue-800 flex-shrink-0"
-															title="Remove path"
-														>
-															<X size={10} />
-														</button>
-													</span>
+													{@render scopeChip(path, 'Remove path', () =>
+														removeResourcePath(scope.value, path)
+													)}
 												{/each}
 											</div>
 										{/if}

--- a/frontend/src/lib/components/settings/ScopeSelector.svelte
+++ b/frontend/src/lib/components/settings/ScopeSelector.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { type ScopeDomain, type ScopeDefinition, TokenService } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
-	import { ChevronRight, Loader2, X } from 'lucide-svelte'
+	import { ChevronRight, Loader2, Plus, X } from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
 	import Popover from '../meltComponents/Popover.svelte'
 	import Tooltip from '../Tooltip.svelte'
@@ -665,8 +665,15 @@
 														contentClasses="p-3"
 													>
 														{#snippet trigger()}
-															<Button size="xs" disabled={isDisabled} variant="default">
-																Restrict paths
+															<Button
+																size="xs"
+																disabled={isDisabled}
+																variant="default"
+																startIcon={resourcePathArray.length > 0
+																	? { icon: Plus }
+																	: undefined}
+															>
+																{resourcePathArray.length > 0 ? 'Add path' : 'Restrict paths'}
 																<Tooltip light>
 																	Restrict this scope to specific resource paths. If no paths are
 																	specified, the scope gives full access.


### PR DESCRIPTION
## Summary

In the token scope builder, restricting `jobs:run:scripts` to a handful of script paths
made the per-scope **Restrict paths** buttons disappear.

The selected-scope chip renders the whole comma-joined path list as one unbreakable
string (`jobs:run:scripts:f/a/b,f/c/d,u/e/f`). Nothing capped its width, and two ancestors
propagated that width outwards instead of constraining it:

- `CreateToken`'s card carried `min-w-min`, so it sized itself to that chip and pushed the
  rest of the form past the right edge of the user-settings panel — the second grid column
  ("Write", "Run flows" and their "Restrict paths" buttons) ended up off-screen.
- `Modal`'s body wrapper is a `flex-1` item without `min-w-0`, so the same content
  stretched the "Edit token" modal past its `max-w`, with the same result.

## Changes

- `ScopeSelector.svelte`: factor the three copies of the scope chip into one `scopeChip`
  snippet that truncates its label (`min-w-0 max-w-full` + inner `truncate`) and exposes
  the full value via `title`.
- `CreateToken.svelte`: drop `min-w-min` from the token card so it stays bounded by the
  panel and its content shrinks instead.
- `Modal.svelte`: add `min-w-0` to the modal body wrapper so wide content can shrink
  rather than stretch the modal past its max width.
- `ScopeSelector.svelte`: the popover trigger reads "Restrict paths" only while a scope has
  no paths; once it has some it becomes "+ Add path", which is the action you actually want
  at that point (and what the report was looking for).

The scope strings sent to the API are untouched. One incidental unification: the snippet
applies the component's `disabled` prop to all three remove buttons, where the resource-path
chip previously had none — unreachable today (no consumer passes `disabled`) and the more
correct of the two behaviors.

## Screenshots

**Before** — 3 script paths on `jobs:run:scripts`; the right column and its "Restrict
paths" button are pushed out of the panel:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-acaff89d/1785861956-repro-before.png)

**After** — same state, chip truncates, both "Restrict paths" buttons stay reachable:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-acaff89d/1785861958-final-after.png)

**Edit token modal, before** — same content stretched the modal past `max-w-3xl`:

![edit-modal-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-acaff89d/1785861960-edit-modal.png)

**Edit token modal, after**:

![edit-modal-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-acaff89d/1785861962-edit-modal-expanded.png)

**Button label** — "Restrict paths" while empty (Run flows), "+ Add path" once a scope has
paths (Run scripts):

![add-path-label](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-acaff89d/1785863507-add-path-label.png)

**Narrow viewport (820px)** — still contained:

![narrow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-acaff89d/1785861964-narrow.png)

## Test plan

- [x] User settings → Tokens → "Limit token permissions" → Jobs → "Run scripts" →
      "Restrict paths": add several `f/…`/`u/…` paths and confirm nothing overflows and
      both "Restrict paths" buttons stay visible (measured `scrollWidth == clientWidth` at
      every level of the panel).
- [x] Same check in the "Edit token" modal on an already-scoped token.
- [x] Repeated at 820px and 420px viewport widths.
- [x] `npm run check` — 0 errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow in the token scope builder and Edit token modal when long scope/path lists are selected, keeping buttons visible and the modal within its max width.

- **Bug Fixes**
  - `ScopeSelector.svelte`: added a reusable `scopeChip` that truncates long labels and shows the full value in `title`.
  - `ScopeSelector.svelte`: the path popover now shows "+ Add path" with a plus icon once paths exist; otherwise "Restrict paths".
  - `CreateToken.svelte`: removed `min-w-min` from the token card so content doesn’t push the panel wider.
  - `Modal.svelte`: added `min-w-0` to the body flex item so wide content shrinks instead of stretching the modal.

<sup>Written for commit e51cacfcc49b15b0fef025f806765727750d0912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

