### PR TITLE
chore: write playwright screenshots under /tmp instead of the checkout

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,12 +7,12 @@
     "playwright": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium", "--headless"]
+      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium", "--headless", "--output-dir", "/tmp/playwright-mcp-${USER:-shared}"]
     },
     "playwright-headed": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium"]
+      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium", "--output-dir", "/tmp/playwright-mcp-${USER:-shared}"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,11 @@ Typical flow:
 5. `mcp__playwright__browser_take_screenshot` for visual confirmation
 6. `mcp__playwright__browser_console_messages` / `browser_network_requests` to surface errors
 
+Write screenshots to an absolute path under `/tmp` (the MCP servers already do; standalone
+Playwright scripts must be told): moving a PNG out of the checkout afterwards needs a `mv` the
+permission hooks always prompt on. Same reason to run `rm`/`mv`/`cp` as one plain command per Bash
+call: those hooks defer on `&&`, `;`, redirects, quotes and `$VAR`.
+
 **Attach the screenshots to the PR.** For any change under `frontend/`, embed screenshots of the affected UI in the PR body — the `pr` skill requires this and carries the upload recipe.
 
 If you cannot exercise a UI change (no dev server, etc.), say so explicitly rather than claiming success.


### PR DESCRIPTION
## Summary

Screenshots taken while verifying frontend changes were landing in the worktree, so every session ended with a `mv *.png <scratchpad>/` that the permission hooks prompt on. That prompt is deliberate: `allow-fileops-in-tmp.sh` requires *every* operand under `/tmp`, sources included, so a copy out of the checkout can't route around the `Read(**/.env)` / `Read(**/secrets/**)` deny rules via the allowed `Read(/tmp/**)`. The fix is to stop producing the files in the checkout rather than to widen any rule.

No permission rule is added, removed or relaxed here, and both hooks are unchanged.

## Changes

- `.mcp.json`: both Playwright MCP servers get `--output-dir /tmp/playwright-mcp-${USER:-shared}`, so `browser_take_screenshot` writes under `/tmp` (already covered by the existing `Read(/tmp/**)` allow). Per-user path so the directory can't collide on a shared machine.
- `AGENTS.md`: four lines in *Verifying Frontend Changes* telling agents to write screenshots to an absolute `/tmp` path (standalone Playwright scripts have to be told; the MCP servers now do it), and to issue `rm`/`mv`/`cp` as one plain command per Bash call. Both hooks whitelist every token on the line, so `&&`, `;`, redirects, quotes and `$VAR` make them defer to the `ask` rules, which turns an otherwise auto-allowed `rm` into a prompt when it is chained onto a `git status`.

No `frontend/` files are touched and there is no UI effect, so no screenshots apply.

## Test plan

- [ ] `jq -e . .mcp.json` parses
- [ ] After a session restart, `mcp__playwright__browser_take_screenshot` writes into `/tmp/playwright-mcp-$USER` and no `mv` out of the checkout is needed
- [ ] `mv /tmp/a.png /tmp/b/` still auto-allows and `mv <checkout>/a.png /tmp/b/` still prompts (guard unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Playwright screenshots to /tmp instead of the repo to prevent permission prompts and keep the worktree clean. Set `--output-dir /tmp/playwright-mcp-${USER:-shared}` for both `@playwright/mcp` servers in `.mcp.json`, and updated `AGENTS.md` to use absolute /tmp paths and run rm/mv/cp as single commands.

<sup>Written for commit 87da6f188103a257a45a37031c829ba1c537f8a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

