### PR TITLE
feat: preview and edit steps inside expanded subflows

### DIFF
--- a/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
+++ b/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
@@ -56,7 +56,10 @@
 			let modules = modulesCache.get(key)
 			if (!modules) {
 				modules = (await FlowService.getFlowByPath({ workspace: ws!, path })).value.modules
-				modulesCache.set(key, modules)
+				// A response from before the last deploy must not repopulate the cache it cleared.
+				if (gen === cachedGeneration) {
+					modulesCache.set(key, modules)
+				}
 			}
 			return modules
 		})

--- a/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
+++ b/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { getContext, untrack } from 'svelte'
+	import { resource } from 'runed'
+	import { FlowService, type FlowModule } from '$lib/gen'
+	import { workspaceStore } from '$lib/stores'
+	import Badge from '$lib/components/common/badge/Badge.svelte'
+	import Button from '$lib/components/common/button/Button.svelte'
+	import Skeleton from '$lib/components/common/skeleton/Skeleton.svelte'
+	import FlowGraphViewerStep from '$lib/components/FlowGraphViewerStep.svelte'
+	import { ChevronRight, ExternalLink, Pen } from 'lucide-svelte'
+	import { sendUserToast } from '$lib/utils'
+	import type { FlowEditorContext } from '../types'
+	import { resolveExpandedSubflowStep } from '../expandedSubflowStep'
+	import { parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
+
+	interface Props {
+		/** Graph node id of the selected step, of the form `subflow:<step>[:<step>...]:<leaf>`. */
+		selectedId: string
+		/** Called once the subflow was deployed from the drawer, to refresh the inlined graph. */
+		onSubflowUpdated?: () => void
+	}
+
+	let { selectedId, onSubflowUpdated }: Props = $props()
+
+	const { flowStore, flowEditorDrawer, opWorkspace } =
+		getContext<FlowEditorContext>('FlowEditorContext')
+	let opWs = $derived(opWorkspace?.() ?? $workspaceStore)
+
+	let leafId = $derived(parseExpandedSubflowId(selectedId)?.leaf ?? selectedId)
+
+	let step = resource([() => selectedId, () => opWs], async ([id, ws]) =>
+		resolveExpandedSubflowStep(
+			id,
+			untrack(() => $state.snapshot(flowStore.val.value.modules) as FlowModule[]),
+			async (path) => (await FlowService.getFlowByPath({ workspace: ws!, path })).value.modules
+		)
+	)
+
+	// While a new selection resolves, `step.current` still holds the previous step: hide the
+	// breadcrumb and the actions rather than pointing them at the step the user just left.
+	let resolved = $derived(step.loading ? undefined : step.current)
+
+	function editSubflow(path: string, stepId: string | undefined) {
+		$flowEditorDrawer?.openDrawer(
+			path,
+			() => {
+				sendUserToast('Subflow has been updated')
+				step.refetch()
+				onSubflowUpdated?.()
+			},
+			stepId
+		)
+	}
+</script>
+
+<div class="flex flex-col h-full bg-surface">
+	<div class="flex items-center justify-between gap-2 px-4 py-2 border-b shrink-0">
+		<div class="flex items-center gap-1 min-w-0 text-xs text-secondary">
+			<Badge color="indigo">{leafId}</Badge>
+			{#if resolved}
+				<span class="shrink-0">in</span>
+				{#each resolved.pathChain as path, i (i)}
+					{#if i > 0}
+						<ChevronRight size={12} class="shrink-0" />
+					{/if}
+					<span class="truncate text-primary font-medium" title={path}>{path}</span>
+				{/each}
+			{/if}
+		</div>
+		{#if resolved}
+			{@const { containingFlowPath, module } = resolved}
+			<div class="flex items-center gap-1 shrink-0">
+				<Button
+					unifiedSize="sm"
+					variant="subtle"
+					startIcon={{ icon: Pen }}
+					on:click={() => editSubflow(containingFlowPath, module ? leafId : undefined)}
+				>
+					Edit
+				</Button>
+				<Button
+					unifiedSize="sm"
+					variant="subtle"
+					title="Open the subflow in a new tab"
+					startIcon={{ icon: ExternalLink }}
+					iconOnly
+					href={`/flows/edit/${containingFlowPath}?workspace=${opWs}${
+						module ? `&selected=${encodeURIComponent(leafId)}` : ''
+					}`}
+					target="_blank"
+				/>
+			</div>
+		{/if}
+	</div>
+	<div class="min-h-0 grow overflow-auto">
+		{#if step.loading}
+			<div class="p-4">
+				<Skeleton layout={[[2], 1, [8]]} />
+			</div>
+		{:else if step.error}
+			<div class="p-4 text-xs text-secondary">
+				Could not load the subflow this step belongs to: {step.error.message}
+			</div>
+		{:else if resolved?.module}
+			<FlowGraphViewerStep stepDetail={resolved.module} workspace={opWs} />
+		{:else}
+			<div class="p-4 text-xs text-secondary">
+				This step is part of an expanded subflow and is not editable from this flow.
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
+++ b/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
@@ -14,6 +14,7 @@
 		type ResolvedExpandedSubflowStep
 	} from '../expandedSubflowStep'
 	import { parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
+	import { base } from '$app/paths'
 
 	interface Props {
 		/** Graph node id of the selected step, of the form `subflow:<step>[:<step>...]:<leaf>`. */
@@ -32,8 +33,9 @@
 
 	// Modules of the subflows crossed so far: the panel stays mounted while the user clicks
 	// through the expansion, so without this every click refetches the whole chain. Deploying
-	// a subflow bumps the generation, which is part of the key, rather than invalidating it.
+	// a subflow bumps the generation, which drops what the cache holds.
 	let modulesCache = new Map<string, FlowModule[]>()
+	let cachedGeneration = 0
 	let generation = $state(0)
 	// `undefined` while resolving. A resolution is only applied when it is still the one the
 	// current selection asked for, so a slower deep chain can't overwrite a newer selection.
@@ -42,11 +44,15 @@
 
 	$effect(() => {
 		const [id, ws, gen] = [selectedId, opWs, generation]
+		if (gen !== cachedGeneration) {
+			modulesCache.clear()
+			cachedGeneration = gen
+		}
 		const request = ++latestRequest
 		loaded = undefined
 		const rootModules = untrack(() => $state.snapshot(flowStore.val.value.modules) as FlowModule[])
 		resolveExpandedSubflowStep(id, rootModules, async (path) => {
-			const key = `${gen}:${ws}:${path}`
+			const key = `${ws}:${path}`
 			let modules = modulesCache.get(key)
 			if (!modules) {
 				modules = (await FlowService.getFlowByPath({ workspace: ws!, path })).value.modules
@@ -110,7 +116,7 @@
 					title="Open the subflow in a new tab"
 					startIcon={{ icon: ExternalLink }}
 					iconOnly
-					href={`/flows/edit/${containingFlowPath}?workspace=${opWs}${
+					href={`${base}/flows/edit/${containingFlowPath}?workspace=${opWs}${
 						module ? `&selected=${encodeURIComponent(leafId)}` : ''
 					}`}
 					target="_blank"

--- a/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
+++ b/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
@@ -119,9 +119,9 @@
 					title="Open the subflow in a new tab"
 					startIcon={{ icon: ExternalLink }}
 					iconOnly
-					href={`${base}/flows/edit/${containingFlowPath}?workspace=${opWs}${
-						module ? `&selected=${encodeURIComponent(leafId)}` : ''
-					}`}
+					href={`${base}/flows/edit/${containingFlowPath}?workspace=${encodeURIComponent(
+						opWs ?? ''
+					)}${module ? `&selected=${encodeURIComponent(leafId)}` : ''}`}
 					target="_blank"
 				/>
 			</div>

--- a/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
+++ b/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { getContext, untrack } from 'svelte'
-	import { resource } from 'runed'
 	import { FlowService, type FlowModule } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import Badge from '$lib/components/common/badge/Badge.svelte'
@@ -10,7 +9,10 @@
 	import { ChevronRight, ExternalLink, Pen } from 'lucide-svelte'
 	import { sendUserToast } from '$lib/utils'
 	import type { FlowEditorContext } from '../types'
-	import { resolveExpandedSubflowStep } from '../expandedSubflowStep'
+	import {
+		resolveExpandedSubflowStep,
+		type ResolvedExpandedSubflowStep
+	} from '../expandedSubflowStep'
 	import { parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
 
 	interface Props {
@@ -28,24 +30,46 @@
 
 	let leafId = $derived(parseExpandedSubflowId(selectedId)?.leaf ?? selectedId)
 
-	let step = resource([() => selectedId, () => opWs], async ([id, ws]) =>
-		resolveExpandedSubflowStep(
-			id,
-			untrack(() => $state.snapshot(flowStore.val.value.modules) as FlowModule[]),
-			async (path) => (await FlowService.getFlowByPath({ workspace: ws!, path })).value.modules
-		)
-	)
+	// Modules of the subflows crossed so far: the panel stays mounted while the user clicks
+	// through the expansion, so without this every click refetches the whole chain. Deploying
+	// a subflow bumps the generation, which is part of the key, rather than invalidating it.
+	let modulesCache = new Map<string, FlowModule[]>()
+	let generation = $state(0)
+	// `undefined` while resolving. A resolution is only applied when it is still the one the
+	// current selection asked for, so a slower deep chain can't overwrite a newer selection.
+	let loaded = $state<{ step?: ResolvedExpandedSubflowStep; error?: Error } | undefined>(undefined)
+	let latestRequest = 0
 
-	// While a new selection resolves, `step.current` still holds the previous step: hide the
-	// breadcrumb and the actions rather than pointing them at the step the user just left.
-	let resolved = $derived(step.loading ? undefined : step.current)
+	$effect(() => {
+		const [id, ws, gen] = [selectedId, opWs, generation]
+		const request = ++latestRequest
+		loaded = undefined
+		const rootModules = untrack(() => $state.snapshot(flowStore.val.value.modules) as FlowModule[])
+		resolveExpandedSubflowStep(id, rootModules, async (path) => {
+			const key = `${gen}:${ws}:${path}`
+			let modules = modulesCache.get(key)
+			if (!modules) {
+				modules = (await FlowService.getFlowByPath({ workspace: ws!, path })).value.modules
+				modulesCache.set(key, modules)
+			}
+			return modules
+		})
+			.then((step) => {
+				if (request === latestRequest) loaded = { step }
+			})
+			.catch((error) => {
+				if (request === latestRequest) loaded = { error }
+			})
+	})
+
+	let resolved = $derived(loaded?.step)
 
 	function editSubflow(path: string, stepId: string | undefined) {
 		$flowEditorDrawer?.openDrawer(
 			path,
 			() => {
 				sendUserToast('Subflow has been updated')
-				step.refetch()
+				generation++
 				onSubflowUpdated?.()
 			},
 			stepId
@@ -95,13 +119,13 @@
 		{/if}
 	</div>
 	<div class="min-h-0 grow overflow-auto">
-		{#if step.loading}
+		{#if loaded == undefined}
 			<div class="p-4">
 				<Skeleton layout={[[2], 1, [8]]} />
 			</div>
-		{:else if step.error}
+		{:else if loaded.error}
 			<div class="p-4 text-xs text-secondary">
-				Could not load the subflow this step belongs to: {step.error.message}
+				Could not load the subflow this step belongs to: {loaded.error.message}
 			</div>
 		{:else if resolved?.module}
 			<FlowGraphViewerStep stepDetail={resolved.module} workspace={opWs} />

--- a/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
+++ b/frontend/src/lib/components/flows/content/ExpandedSubflowStep.svelte
@@ -70,14 +70,16 @@
 		{#if resolved}
 			{@const { containingFlowPath, module } = resolved}
 			<div class="flex items-center gap-1 shrink-0">
-				<Button
-					unifiedSize="sm"
-					variant="subtle"
-					startIcon={{ icon: Pen }}
-					on:click={() => editSubflow(containingFlowPath, module ? leafId : undefined)}
-				>
-					Edit
-				</Button>
+				{#if $flowEditorDrawer}
+					<Button
+						unifiedSize="sm"
+						variant="subtle"
+						startIcon={{ icon: Pen }}
+						on:click={() => editSubflow(containingFlowPath, module ? leafId : undefined)}
+					>
+						Edit
+					</Button>
+				{/if}
 				<Button
 					unifiedSize="sm"
 					variant="subtle"

--- a/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
@@ -20,11 +20,12 @@
 	const flowEditorContext = getContext<FlowEditorContext>('FlowEditorContext')
 	let opWs = $derived(flowEditorContext?.opWorkspace?.() ?? $workspaceStore)
 
-	export async function openDrawer(path: string, cb: () => void): Promise<void> {
+	export async function openDrawer(path: string, cb: () => void, stepId?: string): Promise<void> {
 		flowPath = path
 		flow = undefined
 		loading = true
 		callback = cb
+		selectedStepId = stepId
 		flowEditorDrawer?.openDrawer?.()
 
 		try {
@@ -47,6 +48,7 @@
 
 	let callback: (() => void) | undefined = undefined
 	let flowPath: string = $state('')
+	let selectedStepId: string | undefined = $state(undefined)
 	let flow: Flow | undefined = $state(undefined)
 	let savedFlow: Flow | undefined = $state(undefined)
 	let loading = $state(true)
@@ -92,7 +94,7 @@
 				initialPath={flowPath}
 				autosaveWorkspace={opWs}
 				newFlow={false}
-				selectedId="settings-metadata"
+				selectedId={selectedStepId ?? 'settings-metadata'}
 				loading={false}
 				bind:savedFlow
 				{diffDrawer}
@@ -117,7 +119,8 @@
 			<Button
 				variant="default"
 				on:click={() => {
-					window.open(`/flows/edit/${flowPath}`, '_blank', 'noopener,noreferrer')
+					const selected = selectedStepId ? `?selected=${encodeURIComponent(selectedStepId)}` : ''
+					window.open(`/flows/edit/${flowPath}${selected}`, '_blank', 'noopener,noreferrer')
 					flowEditorDrawer?.closeDrawer()
 				}}
 				startIcon={{ icon: ExternalLink }}

--- a/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
@@ -68,6 +68,7 @@
 	const flowStateStore: StateStore<FlowState> = $state({ val: {} })
 
 	let diffDrawer: DiffDrawer | undefined = $state()
+	let flowBuilder: FlowBuilder | undefined = $state(undefined)
 </script>
 
 <Drawer bind:this={flowEditorDrawer} size="100%">
@@ -89,6 +90,7 @@
 			</div>
 		{:else if flow}
 			<FlowBuilder
+				bind:this={flowBuilder}
 				{flowStore}
 				{flowStateStore}
 				initialPath={flowPath}
@@ -119,7 +121,9 @@
 			<Button
 				variant="default"
 				on:click={() => {
-					const selected = selectedStepId ? `?selected=${encodeURIComponent(selectedStepId)}` : ''
+					// Follow the drawer's own selection, which the user may have moved since it opened.
+					const stepId = flowBuilder?.getSelectedId() ?? selectedStepId
+					const selected = stepId ? `?selected=${encodeURIComponent(stepId)}` : ''
 					window.open(`/flows/edit/${flowPath}${selected}`, '_blank', 'noopener,noreferrer')
 					flowEditorDrawer?.closeDrawer()
 				}}

--- a/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
@@ -12,6 +12,7 @@
 	import { initFlow } from '$lib/components/flows/flowStore.svelte'
 	import type { FlowState } from '$lib/components/flows/flowState'
 	import type { FlowEditorContext } from '../types'
+	import { base } from '$app/paths'
 
 	let flowEditorDrawer: Drawer | undefined = $state()
 
@@ -124,7 +125,7 @@
 					// Follow the drawer's own selection, which the user may have moved since it opened.
 					const stepId = flowBuilder?.getSelectedId() ?? selectedStepId
 					const selected = stepId ? `?selected=${encodeURIComponent(stepId)}` : ''
-					window.open(`/flows/edit/${flowPath}${selected}`, '_blank', 'noopener,noreferrer')
+					window.open(`${base}/flows/edit/${flowPath}${selected}`, '_blank', 'noopener,noreferrer')
 					flowEditorDrawer?.closeDrawer()
 				}}
 				startIcon={{ icon: ExternalLink }}

--- a/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
@@ -14,6 +14,7 @@
 	import { handleSelectTriggerFromKind, type Trigger } from '$lib/components/triggers/utils'
 	import { computeMissingInputWarnings } from '../missingInputWarnings'
 	import FlowResult from './FlowResult.svelte'
+	import ExpandedSubflowStep from './ExpandedSubflowStep.svelte'
 	import type { StateStore } from '$lib/utils'
 	import FlowSelectionPanel from './FlowSelectionPanel.svelte'
 	import {
@@ -176,9 +177,10 @@
 		{onDeployTrigger}
 	/>
 {:else if selectedId?.startsWith('subflow:')}
-	<div class="p-4"
-		>Selected step is witin an expanded subflow and is not directly editable in the flow editor</div
-	>
+	<ExpandedSubflowStep
+		{selectedId}
+		onSubflowUpdated={() => flowModuleSchemaMap?.reloadExpandedSubflows()}
+	/>
 {:else}
 	{@const dup = checkDup(flowStore.val.value.modules)}
 	{#if dup}

--- a/frontend/src/lib/components/flows/expandedSubflowStep.test.ts
+++ b/frontend/src/lib/components/flows/expandedSubflowStep.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import type { FlowModule } from '$lib/gen'
+import { resolveExpandedSubflowStep } from './expandedSubflowStep'
+
+const script = (id: string): FlowModule =>
+	({ id, value: { type: 'rawscript', language: 'bun', content: '', input_transforms: {} } }) as any
+const subflow = (id: string, path: string): FlowModule =>
+	({ id, value: { type: 'flow', path } }) as any
+const forloop = (id: string, modules: FlowModule[]): FlowModule =>
+	({ id, value: { type: 'forloopflow', modules, iterator: { type: 'static', value: [] } } }) as any
+
+// `outer` inlines `f/inner`, which inlines `f/innermost`; each subflow step also sits
+// inside a for loop, which the graph node id does not record.
+const flows: Record<string, FlowModule[]> = {
+	'f/inner': [forloop('l', [subflow('b', 'f/innermost')])],
+	'f/innermost': [forloop('m', [script('leaf')])]
+}
+const rootModules = [forloop('k', [subflow('a', 'f/inner')])]
+const loadFlowModules = async (path: string) => flows[path]
+
+describe('resolveExpandedSubflowStep', () => {
+	it('follows every subflow boundary down to the selected step', async () => {
+		const resolved = await resolveExpandedSubflowStep(
+			'subflow:a:b:leaf',
+			rootModules,
+			loadFlowModules
+		)
+		expect(resolved?.pathChain).toEqual(['f/inner', 'f/innermost'])
+		expect(resolved?.containingFlowPath).toBe('f/innermost')
+		expect(resolved?.module?.id).toBe('leaf')
+	})
+
+	it('still reports the containing flow when the step is not one of its modules', async () => {
+		const resolved = await resolveExpandedSubflowStep(
+			'subflow:a:b:leaf-tool-0',
+			rootModules,
+			loadFlowModules
+		)
+		expect(resolved?.containingFlowPath).toBe('f/innermost')
+		expect(resolved?.module).toBeUndefined()
+	})
+})

--- a/frontend/src/lib/components/flows/expandedSubflowStep.test.ts
+++ b/frontend/src/lib/components/flows/expandedSubflowStep.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { FlowModule } from '$lib/gen'
-import { resolveExpandedSubflowStep } from './expandedSubflowStep'
+import { expandedSubflowParentId, resolveExpandedSubflowStep } from './expandedSubflowStep'
 
 const script = (id: string): FlowModule =>
 	({ id, value: { type: 'rawscript', language: 'bun', content: '', input_transforms: {} } }) as any
@@ -17,6 +17,16 @@ const flows: Record<string, FlowModule[]> = {
 }
 const rootModules = [forloop('k', [subflow('a', 'f/inner')])]
 const loadFlowModules = async (path: string) => flows[path]
+
+describe('expandedSubflowParentId', () => {
+	// The last segment of `subflowSteps` is the parent's own step, so it belongs to the
+	// parent key: `subflow:a:b` sits in expansion `a`, not in itself.
+	it('is the enclosing expansion, not the expansion itself', () => {
+		expect(expandedSubflowParentId('subflow:a:b')).toBe('a')
+		expect(expandedSubflowParentId('subflow:a:b:c')).toBe('subflow:a:b')
+		expect(expandedSubflowParentId('a')).toBeUndefined()
+	})
+})
 
 describe('resolveExpandedSubflowStep', () => {
 	it('follows every subflow boundary down to the selected step', async () => {

--- a/frontend/src/lib/components/flows/expandedSubflowStep.ts
+++ b/frontend/src/lib/components/flows/expandedSubflowStep.ts
@@ -1,0 +1,47 @@
+import type { FlowModule } from '$lib/gen'
+import { findStepPath, parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
+
+export type ResolvedExpandedSubflowStep = {
+	/** The flow the selected step lives in, i.e. the innermost subflow crossed. */
+	containingFlowPath: string
+	/** Path of each subflow crossed from the edited flow down to the containing one. */
+	pathChain: string[]
+	/** The selected step, or `undefined` when the id points at something that isn't a
+	 * module of the containing flow (an AI agent tool node, a stale selection...). */
+	module: FlowModule | undefined
+}
+
+/**
+ * Resolves a `subflow:A:B:leaf` graph node id (an inline-expanded subflow step) to the
+ * step it stands for, following each `Flow{path}` boundary through the flows it points
+ * at. `loadFlowModules` fetches a flow's modules by path.
+ *
+ * Returns `undefined` when `id` is not an expanded-subflow node or a boundary can't be
+ * followed; a resolution whose `module` is undefined still carries the containing flow,
+ * which is enough to open it in the editor.
+ */
+export async function resolveExpandedSubflowStep(
+	id: string,
+	rootModules: FlowModule[],
+	loadFlowModules: (path: string) => Promise<FlowModule[]>
+): Promise<ResolvedExpandedSubflowStep | undefined> {
+	const parsed = parseExpandedSubflowId(id)
+	if (!parsed) {
+		return undefined
+	}
+	let modules = rootModules
+	const pathChain: string[] = []
+	for (const stepId of parsed.subflowSteps) {
+		const value = findStepPath(modules, stepId)?.target.value
+		if (value?.type !== 'flow') {
+			return undefined
+		}
+		pathChain.push(value.path)
+		modules = await loadFlowModules(value.path)
+	}
+	return {
+		containingFlowPath: pathChain[pathChain.length - 1],
+		pathChain,
+		module: findStepPath(modules, parsed.leaf)?.target
+	}
+}

--- a/frontend/src/lib/components/flows/expandedSubflowStep.ts
+++ b/frontend/src/lib/components/flows/expandedSubflowStep.ts
@@ -12,6 +12,21 @@ export type ResolvedExpandedSubflowStep = {
 }
 
 /**
+ * Graph node id of the expansion an inline-expanded subflow node sits in, i.e. the key
+ * whose modules hold the step it stands for: `subflow:a:b` → `a`, `subflow:a:b:c` →
+ * `subflow:a:b`. `undefined` for a top-level expansion, whose step belongs to the edited
+ * flow itself. Note that the last segment of `subflowSteps` is the parent's own step, so
+ * every segment stays in the parent key.
+ */
+export function expandedSubflowParentId(nodeId: string): string | undefined {
+	const steps = parseExpandedSubflowId(nodeId)?.subflowSteps
+	if (!steps) {
+		return undefined
+	}
+	return steps.length > 1 ? 'subflow:' + steps.join(':') : steps[0]
+}
+
+/**
  * Resolves a `subflow:A:B:leaf` graph node id (an inline-expanded subflow step) to the
  * step it stands for, following each `Flow{path}` boundary through the flows it points
  * at. `loadFlowModules` fetches a flow's modules by path.

--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -351,6 +351,10 @@
 		graph?.enableNotes?.()
 	}
 
+	export function reloadExpandedSubflows(): void {
+		graph?.reloadExpandedSubflows?.()
+	}
+
 	function toggleNoteMode() {
 		noteMode = !noteMode
 	}

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1118,10 +1118,10 @@
 				(parseExpandedSubflowId(b)?.subflowSteps.length ?? 0)
 		)
 		for (const id of ids) {
-			// A later reload owns the state from here on, and an expansion the user collapsed
-			// while its request was in flight must not come back.
+			// A later reload owns the state from here on.
 			if (reload !== latestReload) return
-			if (expandedSubflows[id] == undefined) continue
+			const expansion = expandedSubflows[id]
+			if (expansion == undefined) continue
 			const path = expandedSubflowPath(id)
 			if (path == undefined) {
 				delete expandedSubflows[id]
@@ -1130,7 +1130,10 @@
 			try {
 				const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
 				if (reload !== latestReload) return
-				if (expandedSubflows[id] == undefined) continue
+				// While this request was in flight the user may have collapsed the expansion, or
+				// collapsed it and re-expanded onto another flow: only commit onto the very
+				// expansion this response was fetched for.
+				if (expandedSubflows[id] !== expansion) continue
 				expandedSubflows[id] = { modules: flow.value.modules, groups: flow.value.groups }
 			} catch (err) {
 				sendUserToast(`Could not reload expanded subflow ${path}: ${err.body ?? err}`, true)

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -466,6 +466,10 @@
 		return newNodes
 	}
 
+	// Flow path each expanded subflow was loaded from, so its inlined steps can be refetched
+	// after the subflow is edited elsewhere. Keyed like `expandedSubflows`, by graph node id.
+	let expandedSubflowPaths: Record<string, string> = {}
+
 	let eventHandler = {
 		deleteBranch: (detail, label) => {
 			selectionManager.selectId(label)
@@ -508,10 +512,12 @@
 			const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
 			expandedSubflows[id] = { modules: flow.value.modules, groups: flow.value.groups }
 			expandedSubflows = expandedSubflows
+			expandedSubflowPaths[id] = path
 		},
 		minimizeSubflow: (id: string) => {
 			delete expandedSubflows[id]
 			expandedSubflows = expandedSubflows
+			delete expandedSubflowPaths[id]
 		},
 		expandGroup: (groupId: string) => {
 			groupDisplayState.expandGroup(groupId)
@@ -1089,6 +1095,21 @@
 		if (!showNotes) {
 			showNotes = true
 		}
+	}
+
+	export async function reloadExpandedSubflows() {
+		const reloaded = await Promise.all(
+			Object.entries(expandedSubflowPaths).map(async ([id, path]) => {
+				const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
+				return [id, { modules: flow.value.modules, groups: flow.value.groups }] as const
+			})
+		)
+		for (const [id, data] of reloaded) {
+			if (expandedSubflows[id] != undefined) {
+				expandedSubflows[id] = data
+			}
+		}
+		expandedSubflows = expandedSubflows
 	}
 
 	export function createGroupFromSelection(ids: string[]) {

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1094,6 +1094,8 @@
 		}
 	}
 
+	let latestReload = 0
+
 	/** Flow an expanded subflow node stands for, read from the step it inlines: the edited
 	 * flow for a top-level expansion, the enclosing expansion's modules otherwise. */
 	function expandedSubflowPath(nodeId: string): string | undefined {
@@ -1109,12 +1111,17 @@
 	 * its refreshed parent: a step now pointing at another flow must not keep rendering the
 	 * one it pointed at when it was expanded. */
 	export async function reloadExpandedSubflows() {
+		const reload = ++latestReload
 		const ids = Object.keys(expandedSubflows).sort(
 			(a, b) =>
 				(parseExpandedSubflowId(a)?.subflowSteps.length ?? 0) -
 				(parseExpandedSubflowId(b)?.subflowSteps.length ?? 0)
 		)
 		for (const id of ids) {
+			// A later reload owns the state from here on, and an expansion the user collapsed
+			// while its request was in flight must not come back.
+			if (reload !== latestReload) return
+			if (expandedSubflows[id] == undefined) continue
 			const path = expandedSubflowPath(id)
 			if (path == undefined) {
 				delete expandedSubflows[id]
@@ -1122,6 +1129,8 @@
 			}
 			try {
 				const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
+				if (reload !== latestReload) return
+				if (expandedSubflows[id] == undefined) continue
 				expandedSubflows[id] = { modules: flow.value.modules, groups: flow.value.groups }
 			} catch (err) {
 				sendUserToast(`Could not reload expanded subflow ${path}: ${err.body ?? err}`, true)

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { FlowService, type FlowModule, type FlowNote, type Job, type OpenFlow } from '../../gen'
+	import { findStepPath, parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
 	import { AI_OR_ASSET_NODE_TYPES, NODE, type GraphModuleState } from '.'
 	import { getContext, onDestroy, onMount, tick, untrack, type Snippet } from 'svelte'
 	import { createFlowDiffManager } from '../flows/flowDiffManager.svelte'
@@ -466,10 +467,6 @@
 		return newNodes
 	}
 
-	// Flow path each expanded subflow was loaded from, so its inlined steps can be refetched
-	// after the subflow is edited elsewhere. Keyed like `expandedSubflows`, by graph node id.
-	let expandedSubflowPaths: Record<string, string> = {}
-
 	let eventHandler = {
 		deleteBranch: (detail, label) => {
 			selectionManager.selectId(label)
@@ -512,12 +509,10 @@
 			const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
 			expandedSubflows[id] = { modules: flow.value.modules, groups: flow.value.groups }
 			expandedSubflows = expandedSubflows
-			expandedSubflowPaths[id] = path
 		},
 		minimizeSubflow: (id: string) => {
 			delete expandedSubflows[id]
 			expandedSubflows = expandedSubflows
-			delete expandedSubflowPaths[id]
 		},
 		expandGroup: (groupId: string) => {
 			groupDisplayState.expandGroup(groupId)
@@ -1097,16 +1092,39 @@
 		}
 	}
 
+	/** Flow an expanded subflow node stands for, read from the step it inlines: the edited
+	 * flow for a top-level expansion, the enclosing expansion's modules otherwise. */
+	function expandedSubflowPath(nodeId: string): string | undefined {
+		const parsed = parseExpandedSubflowId(nodeId)
+		const steps = parsed?.subflowSteps
+		const parentModules = steps
+			? expandedSubflows[steps.length > 1 ? 'subflow:' + steps.join(':') : steps[0]]?.modules
+			: modules
+		const value = parentModules && findStepPath(parentModules, parsed?.leaf ?? nodeId)?.target.value
+		return value && value.type === 'flow' ? value.path : undefined
+	}
+
+	/** Refetch the steps inlined by every expanded subflow, e.g. after one was deployed from
+	 * the flow editor drawer. Outermost first, so a nested expansion resolves its path from
+	 * its refreshed parent: a step now pointing at another flow must not keep rendering the
+	 * one it pointed at when it was expanded. */
 	export async function reloadExpandedSubflows() {
-		const reloaded = await Promise.all(
-			Object.entries(expandedSubflowPaths).map(async ([id, path]) => {
-				const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
-				return [id, { modules: flow.value.modules, groups: flow.value.groups }] as const
-			})
+		const ids = Object.keys(expandedSubflows).sort(
+			(a, b) =>
+				(parseExpandedSubflowId(a)?.subflowSteps.length ?? 0) -
+				(parseExpandedSubflowId(b)?.subflowSteps.length ?? 0)
 		)
-		for (const [id, data] of reloaded) {
-			if (expandedSubflows[id] != undefined) {
-				expandedSubflows[id] = data
+		for (const id of ids) {
+			const path = expandedSubflowPath(id)
+			if (path == undefined) {
+				delete expandedSubflows[id]
+				continue
+			}
+			try {
+				const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
+				expandedSubflows[id] = { modules: flow.value.modules, groups: flow.value.groups }
+			} catch (err) {
+				console.error(`Could not reload expanded subflow ${path}`, err)
 			}
 		}
 		expandedSubflows = expandedSubflows

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { FlowService, type FlowModule, type FlowNote, type Job, type OpenFlow } from '../../gen'
 	import { findStepPath, parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
+	import { expandedSubflowParentId } from '../flows/expandedSubflowStep'
+	import { sendUserToast } from '$lib/utils'
 	import { AI_OR_ASSET_NODE_TYPES, NODE, type GraphModuleState } from '.'
 	import { getContext, onDestroy, onMount, tick, untrack, type Snippet } from 'svelte'
 	import { createFlowDiffManager } from '../flows/flowDiffManager.svelte'
@@ -1095,12 +1097,10 @@
 	/** Flow an expanded subflow node stands for, read from the step it inlines: the edited
 	 * flow for a top-level expansion, the enclosing expansion's modules otherwise. */
 	function expandedSubflowPath(nodeId: string): string | undefined {
-		const parsed = parseExpandedSubflowId(nodeId)
-		const steps = parsed?.subflowSteps
-		const parentModules = steps
-			? expandedSubflows[steps.length > 1 ? 'subflow:' + steps.join(':') : steps[0]]?.modules
-			: modules
-		const value = parentModules && findStepPath(parentModules, parsed?.leaf ?? nodeId)?.target.value
+		const parentId = expandedSubflowParentId(nodeId)
+		const parentModules = parentId == undefined ? modules : expandedSubflows[parentId]?.modules
+		const stepId = parseExpandedSubflowId(nodeId)?.leaf ?? nodeId
+		const value = parentModules && findStepPath(parentModules, stepId)?.target.value
 		return value && value.type === 'flow' ? value.path : undefined
 	}
 
@@ -1124,7 +1124,7 @@
 				const flow = await FlowService.getFlowByPath({ workspace: workspace, path })
 				expandedSubflows[id] = { modules: flow.value.modules, groups: flow.value.groups }
 			} catch (err) {
-				console.error(`Could not reload expanded subflow ${path}`, err)
+				sendUserToast(`Could not reload expanded subflow ${path}: ${err.body ?? err}`, true)
 			}
 		}
 		expandedSubflows = expandedSubflows


### PR DESCRIPTION
## Summary

In the flow editor, expanding a subflow inlines its steps in the graph — but selecting one of those steps showed only *"Selected step is witin an expanded subflow and is not directly editable in the flow editor"*: no preview of the step, and no way to reach the flow that owns it.

Selecting such a step now shows a read-only preview of it (the same step viewer the flow graph viewer uses: step inputs, code, lockfile, iterator expression, branch predicates, nested flow graph) plus a breadcrumb of the subflow chain it lives in, an **Edit** button that opens that subflow in the flow editor drawer *with the step already selected*, and an open-in-new-tab link to `/flows/edit/<subflow>?selected=<step>`.

Fixes WIN-2316

## Changes

- `expandedSubflowStep.ts` — resolver for a `subflow:A:B:leaf` graph node id: follows each `Flow{path}` boundary through the flow it points at, level by level. Each boundary may itself sit inside a for-loop or branch (the node id only records subflow boundaries), so every level is walked with `findStepPath`. When the id points at something that isn't a module of the containing flow (an AI agent tool node, a stale selection) it still reports the containing flow, so the Edit action stays useful.
- `ExpandedSubflowStep.svelte` — the new panel, replacing the placeholder text. Resolutions are request-token guarded so a slower deep chain can't overwrite a newer selection, and the subflow modules it fetches are memoised for as long as the panel stays mounted (clicking through an expansion no longer refetches the chain per click).
- `FlowEditorDrawer.openDrawer` takes an optional step id to select on open; its "Edit in new tab & close drawer" action now follows the drawer's live selection.
- `FlowGraphV2.reloadExpandedSubflows()` refetches the steps inlined by every expanded subflow after one is deployed from the drawer, outermost first. Each expansion's path is re-derived from the current tree (the edited flow, or its refreshed parent expansion) rather than remembered from expand time, so a step that now points at a different flow stops rendering the old one; expansions whose step is gone are dropped, and one failing fetch no longer aborts the rest.

## Test plan

- [x] `npm run check` — 0 errors, no new warnings
- [x] `expandedSubflowStep.test.ts` — multi-level descent through boundaries nested in containers, plus the unresolvable-leaf fallback
- [x] Expand a subflow in the flow editor, select a step inside it → preview + breadcrumb + Edit
- [x] Two-level expansion → breadcrumb lists both flows, Edit opens the innermost one
- [x] Step inside a for-loop of an expanded subflow resolves; loop container itself previews its iterator
- [x] Edit → drawer opens the subflow at that step; deploy → toast, panel refreshes, inlined graph picks up the change without a reload
- [x] Repoint an intermediate subflow step at another flow and deploy → the nested expansion re-resolves to the new flow instead of keeping the old one

## Screenshots

Before — selecting a step inside an expanded subflow:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2316-show-preview-and-edit-button-for-subflow-steps/1785861896-before-message.png)

After — preview, breadcrumb, Edit and open-in-new-tab:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2316-show-preview-and-edit-button-for-subflow-steps/1785861898-after-preview.png)

Two-level expansion (`f/test/inner › f/test/other`):

![after-nested](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2316-show-preview-and-edit-button-for-subflow-steps/1785862933-after-nested-v2.png)

Edit opens the owning subflow in the drawer, already on that step:

![after-drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2316-show-preview-and-edit-button-for-subflow-steps/1785861903-after-drawer.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a read-only preview and quick edit path for steps inside expanded subflows in the flow editor. Delivers WIN-2316 by letting users inspect a step and jump straight to the owning subflow.

- New Features
  - Selecting a step in an expanded subflow shows a read-only preview (inputs, code, lockfile, iterator, branch predicates, nested graph) with a breadcrumb of the subflow chain.
  - Edit opens the owning subflow in the drawer with that step selected, plus an open-in-new-tab link that preserves the selection.
  - Resolver walks nested subflow boundaries (across loops/branches) to the selected step; falls back to the containing flow if the leaf isn’t a direct module.
  - After deploying from the drawer, inlined steps are reloaded with paths re-derived; stale expansions are dropped and one failing fetch doesn’t stop others. Exposes reloadExpandedSubflows() for the panel to trigger.

- Bug Fixes
  - Hide the Edit button when no flow editor drawer is available.
  - “Open in new tab” links are base-prefixed, encode the workspace, and from the drawer follow the drawer’s current selection.
  - Prevent a pre-deploy response from repopulating the subflow module cache after it’s invalidated; slower resolutions can’t overwrite newer selections.
  - Expanded-subflow reloads are guarded: collapsing during reload won’t revive it, newer reloads supersede older ones, and a reload response applies only to the exact expansion it was fetched for.

<sup>Written for commit db0b25b50d74c1fedb94643adeacd1d7ffecbb7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

