### PR TITLE
fix: require an explicit user for azure workload identity on postgres

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -2642,7 +2642,7 @@ pub(crate) async fn pg_dump_database(
 
     let host = &pg_db.host;
     let port = pg_db.port.unwrap_or(5432).to_string();
-    let user = pg_db.user.as_deref().unwrap_or("postgres");
+    let user = pg_db.login_name();
     let dbname = &pg_db.dbname;
 
     let mut cmd = tokio::process::Command::new("pg_dump");
@@ -2686,7 +2686,7 @@ pub(crate) async fn pg_dump_database(
 async fn pg_import_dump(target_db: &PgDatabase, dump_file: &DumpFile) -> Result<()> {
     let host = &target_db.host;
     let port = target_db.port.unwrap_or(5432).to_string();
-    let user = target_db.user.as_deref().unwrap_or("postgres");
+    let user = target_db.login_name();
     let dbname = &target_db.dbname;
 
     let mut cmd = tokio::process::Command::new("psql");

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -794,6 +794,23 @@ ta9ELulniZau8zUAtwqwecxodzl+KO8NYj0a9PGgAM64dMqkRtRA8P4UP350Nag3\n\
         assert!(pg(Some("allow"), None).to_uri().contains("sslmode=prefer"));
         assert!(pg(None, None).to_uri().contains("sslmode=prefer"));
     }
+
+    /// The other paths default a missing login to `postgres`; Entra must not, or the
+    /// server rejects a role the resource never named.
+    #[test]
+    fn entra_login_rejects_a_missing_user() {
+        let mut db = pg(None, None);
+        assert_eq!(db.entra_login().unwrap(), "u");
+        assert_eq!(db.login_name(), "u");
+
+        db.user = None;
+        assert_eq!(db.login_name(), "postgres");
+
+        for blank in [None, Some(""), Some("  ")] {
+            db.user = blank.map(|u: &str| u.to_string());
+            assert!(db.entra_login().is_err(), "{blank:?} is not a login");
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -1079,22 +1096,45 @@ impl PgDatabase {
                 error::Error::InternalErr(format!("IAM token generation failed: {e:#}"))
             })?;
 
-        self.connect_with_token("IAM RDS", &token).await
+        self.connect_with_token("IAM RDS", user, &token).await
+    }
+
+    /// The role an Entra-authenticated connection logs in as. Azure maps each Entra
+    /// principal to a role of its own (`pgaadauth_create_principal`), so unlike the
+    /// other paths this one has no sensible default: `postgres` would send the server a
+    /// role name the resource never mentions, and the rejection then names a value the
+    /// user never configured.
+    pub fn entra_login(&self) -> error::Result<&str> {
+        self.user
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .ok_or_else(|| {
+                error::Error::BadRequest(
+                    "Azure workload identity authentication requires `user` on the resource. \
+                     Set it to the Postgres role the worker's Entra principal is mapped to, \
+                     as created by pgaadauth_create_principal."
+                        .to_string(),
+                )
+            })
     }
 
     /// Connect to Azure Database for PostgreSQL as the worker's federated identity.
-    /// The Entra ID access token replaces the password; `user` must be the Entra
-    /// principal name the server knows the identity by.
+    /// The Entra ID access token replaces the password.
     #[cfg(feature = "enterprise")]
     pub async fn connect_with_workload_identity(
         &self,
     ) -> Result<(tokio_postgres::Client, TokioPgConnection), error::Error> {
+        // Before the token exchange: a missing login is worth reporting without first
+        // spending a round trip to Entra ID on it.
+        let user = self.entra_login()?;
+
         let workload_identity = azure_workload_identity::WorkloadIdentityConfig::resolve()?;
         let token = workload_identity
             .access_token(azure_workload_identity::AZURE_OSSRDBMS_SCOPE)
             .await?;
 
-        self.connect_with_token("Azure workload identity", &token)
+        self.connect_with_token("Azure workload identity", user, &token)
             .await
     }
 
@@ -1106,13 +1146,13 @@ impl PgDatabase {
     async fn connect_with_token(
         &self,
         auth_kind: &str,
+        user: &str,
         token: &str,
     ) -> Result<(tokio_postgres::Client, TokioPgConnection), error::Error> {
         use native_tls::TlsConnector;
         use postgres_native_tls::MakeTlsConnector;
 
         let port = self.port.unwrap_or(5432);
-        let user = self.login_name();
 
         let mut connector = TlsConnector::builder();
         let verified = Self::configure_pg_tls_verification(

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -860,6 +860,11 @@ impl Future for TokioPgConnection {
 }
 
 impl PgDatabase {
+    /// The role the connection logs in as, whichever way it authenticates.
+    pub fn login_name(&self) -> &str {
+        self.user.as_deref().unwrap_or("postgres")
+    }
+
     pub fn to_uri(&self) -> String {
         let sslmode = match self.sslmode.as_deref() {
             Some("allow") => "prefer".to_string(),
@@ -878,7 +883,7 @@ impl PgDatabase {
         };
         format!(
             "postgres://{user}:{password}@{host}:{port}/{dbname}?sslmode={sslmode}",
-            user = urlencoding::encode(&self.user.as_deref().unwrap_or("postgres")),
+            user = urlencoding::encode(self.login_name()),
             password = urlencoding::encode(&self.password.as_deref().unwrap_or("")),
             host = host,
             port = self.port.unwrap_or(5432),
@@ -1066,7 +1071,7 @@ impl PgDatabase {
         };
 
         let port = self.port.unwrap_or(5432);
-        let user = self.user.as_deref().unwrap_or("postgres");
+        let user = self.login_name();
 
         let token = db_iam_ee::generate_auth_token(&region, &self.host, port as u64, user)
             .await
@@ -1107,7 +1112,7 @@ impl PgDatabase {
         use postgres_native_tls::MakeTlsConnector;
 
         let port = self.port.unwrap_or(5432);
-        let user = self.user.as_deref().unwrap_or("postgres");
+        let user = self.login_name();
 
         let mut connector = TlsConnector::builder();
         let verified = Self::configure_pg_tls_verification(

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -2617,7 +2617,7 @@ fn pg_secret_attach_statements(db_resource: Value, alias_name: &str) -> Result<V
             esc(&res.host),
             res.port.unwrap_or(5432),
             esc(&res.dbname),
-            esc(res.user.as_deref().unwrap_or("postgres")),
+            esc(res.login_name()),
             esc(res.password.as_deref().unwrap_or("")),
         ),
         format!("ATTACH 'sslmode={sslmode}' AS {alias_name} (TYPE postgres, SECRET {secret_name});"),

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -94,11 +94,17 @@ impl PgAuthMode {
     }
 
     /// What to announce in the job log. Password auth is the default and stays silent.
-    fn log_name(&self) -> Option<&'static str> {
+    /// The token modes name the login they present: the token itself says nothing about
+    /// which role the server is asked for, so a rejection is otherwise indistinguishable
+    /// from an ordinary bad password.
+    fn log_name(&self, database: &PgDatabase) -> Option<String> {
+        let login = database.login_name();
         match self {
             PgAuthMode::Password => None,
-            PgAuthMode::Iam => Some("IAM RDS authentication"),
-            PgAuthMode::WorkloadIdentity => Some("Azure Workload Identity"),
+            PgAuthMode::Iam => Some(format!("IAM RDS authentication (login {login})")),
+            PgAuthMode::WorkloadIdentity => {
+                Some(format!("Azure Workload Identity (login {login})"))
+            }
         }
     }
 
@@ -707,7 +713,7 @@ pub async fn do_postgresql(
 
     let auth_mode = PgAuthMode::of(&database)?;
 
-    if let Some(mode) = auth_mode.log_name() {
+    if let Some(mode) = auth_mode.log_name(&database) {
         windmill_queue::append_logs(&job.id, &job.workspace_id, format!("Using {mode}\n"), conn)
             .await;
     }

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -94,17 +94,20 @@ impl PgAuthMode {
     }
 
     /// What to announce in the job log. Password auth is the default and stays silent.
-    /// The token modes name the login they present: the token itself says nothing about
-    /// which role the server is asked for, so a rejection is otherwise indistinguishable
-    /// from an ordinary bad password.
+    /// The token modes name the login they present, which is the one thing the token
+    /// itself does not carry.
     fn log_name(&self, database: &PgDatabase) -> Option<String> {
-        let login = database.login_name();
         match self {
             PgAuthMode::Password => None,
-            PgAuthMode::Iam => Some(format!("IAM RDS authentication (login {login})")),
-            PgAuthMode::WorkloadIdentity => {
-                Some(format!("Azure Workload Identity (login {login})"))
-            }
+            PgAuthMode::Iam => Some(format!(
+                "IAM RDS authentication (login {})",
+                database.login_name()
+            )),
+            PgAuthMode::WorkloadIdentity => Some(match database.entra_login() {
+                Ok(login) => format!("Azure Workload Identity (login {login})"),
+                // Connecting rejects a missing login; do not invent one here.
+                Err(_) => "Azure Workload Identity".to_string(),
+            }),
         }
     }
 
@@ -2152,6 +2155,36 @@ mod tests {
         assert_eq!(
             PgAuthMode::of(&db("%20ms_entraid%0A")).unwrap(),
             PgAuthMode::WorkloadIdentity
+        );
+    }
+
+    /// The job log is the only place the presented login is visible, and the two token
+    /// modes differ on whether a missing one has a default at all.
+    #[test]
+    fn test_log_name_reports_the_presented_login() {
+        let db = |user: &str| {
+            PgDatabase::parse_uri(&format!("postgres://{user}:pw@host:5432/db")).unwrap()
+        };
+
+        assert_eq!(PgAuthMode::Password.log_name(&db("someuser")), None);
+        assert_eq!(
+            PgAuthMode::Iam.log_name(&db("someuser")).unwrap(),
+            "IAM RDS authentication (login someuser)"
+        );
+        assert_eq!(
+            PgAuthMode::Iam.log_name(&db("")).unwrap(),
+            "IAM RDS authentication (login postgres)"
+        );
+        assert_eq!(
+            PgAuthMode::WorkloadIdentity
+                .log_name(&db("someuser"))
+                .unwrap(),
+            "Azure Workload Identity (login someuser)"
+        );
+        // Entra has no default login, so none is named rather than implying `postgres`.
+        assert_eq!(
+            PgAuthMode::WorkloadIdentity.log_name(&db("")).unwrap(),
+            "Azure Workload Identity"
         );
     }
 


### PR DESCRIPTION
## Summary

A Postgres resource that selects Azure workload identity (password = `ms_entraid`) but leaves `user` unset silently logged in as `postgres`. Azure maps each Entra principal to a role of its own, created with `pgaadauth_create_principal('<identity_name>', …)`, so `postgres` is never that role — the connection fails with a server error naming a role the user never configured, which is a confusing place to start debugging from.

That mode now requires an explicit `user`, and says what to set it to:

> Azure workload identity authentication requires `user` on the resource. Set it to the Postgres role the worker's Entra principal is mapped to, as created by pgaadauth_create_principal.

The check runs before the token exchange, so a misconfigured resource fails immediately rather than after a round trip to Entra ID.

**Scoped to workload identity only.** IAM RDS keeps its `postgres` default: that path is older and a deployment may depend on it, whereas `ms_entraid` shipped in v1.778.0 and nothing can yet rely on its fallback.

This does *not* apply to MSSQL, where the same sentinel ignores `user` entirely — the fedauth token is the whole identity assertion there and no username is sent. Postgres still needs a role name in the startup packet.

## Changes

- `PgDatabase::entra_login()` — resolves the Entra login or returns an actionable `BadRequest`. Treats a blank or whitespace-only `user` as unset, so a resource created through the API or git-sync can't slip an empty string through.
- `connect_with_workload_identity()` validates the login before minting a token; `connect_with_token()` now takes the login explicitly so the two token modes can differ on whether a default exists.
- `PgDatabase::login_name()` — the single definition of the implicit `postgres` default used by the non-Entra paths. Replaces six copies of `user.as_deref().unwrap_or("postgres")` across `to_uri()`, `connect_with_iam()`, `pg_dump_database()`, `pg_import_dump()` and the DuckDB `CREATE SECRET … USER` builder.
- Both token modes name the presented login in the job log, which is the one thing the token itself doesn't carry:
  ```
  Using Azure Workload Identity (login <role>)
  Using IAM RDS authentication (login <role>)
  ```
  Password auth stays silent, as before.

## Test plan

- [x] `cargo test -p windmill-common --lib entra_login` — blank/whitespace/absent `user` is rejected; the non-Entra default stays `postgres`
- [x] `cargo test -p windmill-worker --lib log_name` — explicit login, the `postgres` default on IAM, no invented login for Entra, and silence for password auth
- [x] `cargo check --features enterprise,private` (both token modes are EE-gated)
- [x] `cargo check -p windmill-worker --features duckdb` (`duckdb_executor.rs` only compiles behind this flag)
- [ ] On an EE build, run a Postgres script against an `ms_entraid` resource with no `user` and confirm it fails with the message above instead of a server error about `postgres`
- [ ] Same resource with `user` set to the pgaadauth role: connects, and the log reads `Using Azure Workload Identity (login <role>)`
- [ ] A resource with `use_iam_auth: true` still connects and logs `Using IAM RDS authentication (login <role>)`

Not verified locally: the handshake itself. Both token modes need a real Azure/AWS-backed server, so only the guard, mode selection and log text were exercised here.