### PR TITLE
feat: show far more items per node in the home tree view

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -371,6 +371,10 @@
 		// node's own children count undercounts because rows nest into subfolders.
 		count: number
 	}
+	// The endpoint's maximum. Expanding an owner is one deliberate click on one scoped
+	// prefix, and the tree renders every row it gets back, so paging it in browse-sized
+	// chunks would only bury the folder's contents behind "Load more".
+	const OWNER_PAGE_SIZE = 1000
 	let ownerLoad = $state<Record<string, OwnerLoadState>>({})
 	let treeOwnerItems = $state<ItemType[]>([])
 	let treeGen = 0
@@ -426,7 +430,7 @@
 				kinds: itemKind !== 'all' ? itemKind : undefined,
 				pathStart: `${owner}/`,
 				includeDraftOnly: true,
-				perPage: 100,
+				perPage: OWNER_PAGE_SIZE,
 				cursor: more ? st?.cursor : undefined
 			})
 		} catch (e: any) {
@@ -1673,7 +1677,6 @@
 			{#key treeKey}
 				<TreeViewRoot
 					items={treeSource}
-					{nbDisplayed}
 					{collapseAll}
 					sortCompare={compareItems}
 					groupDesc={sortOrder === 'name_desc'}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -843,9 +843,9 @@
 	// folder rows the tree ignores (folders come from the store and are all injected
 	// already) — so surfacing it there is confusing. Restrict it to scoped mode, where
 	// it pages within the selected owner. In lazy mode the footer instead reveals more
-	// root nodes purely client-side (nbDisplayed) when there are more than are shown,
-	// and each folder paginates within itself; users past the window are reached via
-	// their owner chip.
+	// root nodes purely client-side (the tree owns that window) when there are more than
+	// are shown, and each folder paginates within itself; users past the window are
+	// reached via their owner chip.
 	let treeGlobalHasMore = $derived(ownerFilter != undefined && !searching ? hasMoreServer : false)
 	$effect(() => {
 		if ($userStore && $workspaceStore) {

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -48,8 +48,9 @@
 	}: Props = $props()
 
 	// Bounds the request burst from "expand all": however many root owners are rendered
-	// (nbDisplayed can grow via "load 30 more"), it fetches at most this many. Lazy
-	// owners past the cap stay collapsed and load on a single click (see the effect).
+	// (the tree's root window grows via its own "load more"), it fetches at most this
+	// many. Lazy owners past the cap stay collapsed and load on a single click (see the
+	// effect).
 	const EXPAND_ALL_LOAD_LIMIT = 20
 
 	const isFolderItem = (i: typeof item): i is FolderItem => i && 'folderName' in i

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -93,19 +93,20 @@
 		return (ownerCounts[ownerKey] ?? 0) + (hasPipeline ? 1 : 0)
 	})
 
-	let showMax = $state(15)
-	// A lazy owner paginates server-side ("Load more"), so when opened on its own it
-	// shows all its already-loaded rows (no second, confusing client "Show more").
-	// EXCEPT under "expand all" (collapseAll=false), which opens every visible owner at
-	// once — rendering all of each would be thousands of rows and freeze the tab — so
-	// there we cap to the client slice and let "Show more" reveal the rest per owner.
-	let effectiveMax = $derived(
-		isLazyOwner && ownerState != undefined && (isFolder(item) || isUser(item))
-			? collapseAll
-				? item.items.length
-				: Math.min(item.items.length, showMax)
-			: showMax
-	)
+	// Cap on how many of a node's already-loaded children render at once, and how many
+	// more each "Show more" reveals.
+	const SHOW_MAX = 100
+	let showMax = $state(SHOW_MAX)
+	// Opening a node by hand is a request to see what it holds, so it renders every row
+	// already loaded for it; pagination is server-side ("Load more"), not a second
+	// client cap stacked on top of it. "Expand all" and search instead open every node
+	// at once — rendering all of each would be thousands of rows and freeze the tab —
+	// so those cap to `showMax` and let "Show more" reveal the rest node by node.
+	let effectiveMax = $derived.by(() => {
+		// A leaf has no children to slice; it renders through <Item>.
+		if (!isFolder(item) && !isUser(item)) return 0
+		return collapseAll && !isSearching ? item.items.length : Math.min(item.items.length, showMax)
+	})
 
 	$effect(() => {
 		const expandAll = !collapseAll
@@ -247,7 +248,7 @@
 					<div
 						class="text-center text-xs py-2 text-secondary cursor-pointer hover:text-primary"
 						onclick={() => {
-							showMax += Math.min(30, item.items.length - showMax)
+							showMax += Math.min(SHOW_MAX, item.items.length - showMax)
 						}}
 					>
 						Show more ({showMax}/{item.items.length})

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -6,7 +6,6 @@
 	interface Props {
 		collapseAll: boolean
 		showCode: (path: string, summary: string) => void
-		nbDisplayed: number
 		items: ItemType[] | undefined
 		isSearching?: boolean
 		pipelineFolders?: Set<string>
@@ -42,7 +41,6 @@
 	let {
 		collapseAll,
 		showCode,
-		nbDisplayed = $bindable(),
 		items,
 		isSearching = false,
 		pipelineFolders,
@@ -58,6 +56,12 @@
 		onExpandOwner,
 		onCollapseOwner
 	}: Props = $props()
+
+	// A root node is a collapsed one-line header until it is expanded, so rendering many
+	// costs almost nothing — unlike the list view, whose window counts actual rows. This
+	// is also how many more each click reveals.
+	const ROOT_MAX = 100
+	let rootDisplayed = $state(ROOT_MAX)
 
 	let groupedItems: ReturnType<typeof groupItems> | 'loading' = $state('loading')
 	$effect(() => {
@@ -153,7 +157,7 @@
 	</div>
 {:else}
 	<div class="border rounded-md bg-surface-tertiary">
-		{#each groupedItems.slice(0, nbDisplayed) as item, rootIndex ('folderName' in item ? `f__${item.folderName}` : 'username' in item ? `u__${item.username}` : `i__${item.type}__${item.path}`)}
+		{#each groupedItems.slice(0, rootDisplayed) as item, rootIndex ('folderName' in item ? `f__${item.folderName}` : 'username' in item ? `u__${item.username}` : `i__${item.type}__${item.path}`)}
 			{#if item}
 				<TreeView
 					{rootIndex}
@@ -175,17 +179,17 @@
 			{/if}
 		{/each}
 	</div>
-	{#if nbDisplayed < groupedItems.length || hasMoreServer}
+	{#if rootDisplayed < groupedItems.length || hasMoreServer}
 		<span class="text-xs font-normal text-secondary"
-			>{Math.min(nbDisplayed, groupedItems.length)} root nodes{hasMoreServer
+			>{Math.min(rootDisplayed, groupedItems.length)} root nodes{hasMoreServer
 				? ''
 				: ` out of ${groupedItems.length}`}
 			<button
 				class="ml-4 text-xs font-normal text-primary hover:text-emphasis"
 				onclick={() => {
-					if (nbDisplayed < groupedItems.length) nbDisplayed += 30
+					if (rootDisplayed < groupedItems.length) rootDisplayed += ROOT_MAX
 					else onLoadMore?.()
-				}}>load 30 more</button
+				}}>load {ROOT_MAX} more</button
 			></span
 		>
 	{/if}


### PR DESCRIPTION
## Summary

Fixes WIN-2317. Closes #10502.

The home page tree view already loads each `f/<folder>` / `u/<user>` on demand, but every
cap around that lazy load was sized for the flat list rather than for a tree: 15 root
nodes, 15 children per node, 100 rows per owner request. In a workspace of any size that
means a folder you just expanded shows a slice of itself, and the only hint that the rest
exists is a small "load 30 more" link at the very bottom of the page — below the fold, as
the issue reports.

Nothing about the caps was load-bearing for a manual expand: a collapsed root node is one
header row, and a node you clicked open is a request to see what it holds. So they are
raised, and the client cap is dropped entirely for a node the user opened by hand.

## Changes

- `ItemsList.svelte`: a lazy owner's page size 100 → 1000 (`OWNER_PAGE_SIZE`, the
  endpoint's max — `list_runnables` clamps there, and the search pass already uses it).
  One click now loads a 400-item folder whole instead of leaving 300 behind "Load more".
- `TreeView.svelte`: a node opened by hand renders **every** row already loaded for it, not
  just the first slice. This rule already applied to top-level lazy owners; it now covers
  nested subfolders too, which were the ones stuck at 15. "Expand all" and search still
  open every node at once, so those keep a client cap — raised 15 → 100 (`SHOW_MAX`), with
  "Show more" stepping by the same amount instead of 30.
- `TreeViewRoot.svelte`: root nodes 15 → 100 (`ROOT_MAX`), stepping by 100. The tree now
  owns this window instead of sharing the flat list's `nbDisplayed`, which counted actual
  rows and so had no reason to bound collapsed folder headers.

## Screenshots

Seeded workspace: 42 top-level folders, one (`f/bigfolder`) holding 400 runnables — 150
directly, 120 in `sub_a`, 130 in `sub_b`.

**Root nodes — the tree stopped at 15 of 42, with the "load 30 more" link at the page bottom (the issue's complaint). Now all 42 render and the footer is gone.**

| Before | After |
|---|---|
| ![before-root-bottom](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2317-show-more-items-in-lazy-loaded-subflow-tree-view/1785863478-before-root-bottom.png) | ![after-root-bottom](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2317-show-more-items-in-lazy-loaded-subflow-tree-view/1785863478-after-root-bottom.png) |

**Expanding `f/bigfolder` (400 items) — one click used to stop at 100 with "Load more in f/bigfolder"; it now returns the whole folder, so the rows run straight through.**

| Before | After |
|---|---|
| ![before-folder-loadmore](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2317-show-more-items-in-lazy-loaded-subflow-tree-view/1785863478-before-folder-loadmore.png) | ![after-folder-continuous](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2317-show-more-items-in-lazy-loaded-subflow-tree-view/1785863478-after-folder-continuous.png) |

**Nested subfolder `sub_a` (120 items) — capped at 15 with "Show more (15/120)"; now fully rendered on expand.**

| Before | After |
|---|---|
| ![before-subfolder-showmore](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2317-show-more-items-in-lazy-loaded-subflow-tree-view/1785863478-before-subfolder-showmore.png) | ![after-subfolder-full](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2317-show-more-items-in-lazy-loaded-subflow-tree-view/1785863478-after-subfolder-full.png) |

## Test plan

Verified against the seeded workspace above (Playwright, headless Chromium):

- [x] Tree view root renders all 42 owners; no "root nodes / load more" footer.
- [x] One click on `f/bigfolder` (400 items) loads and renders all of it — 150 direct rows
      plus the `sub_a` / `sub_b` nodes, no "Load more in f/bigfolder".
- [x] Expanding `sub_a` renders all 120 rows, no "Show more".
- [x] "Expand all" still caps: `Show more (100/120)`, `(100/130)`, `(100/152)`, and only
      the first 20 owners issue a request (`EXPAND_ALL_LOAD_LIMIT`, unchanged).
- [x] Tree view under an active search stays capped the same way (100 per node) rather
      than rendering every merged match at once.
- [x] `npm run check` — 0 errors, no new warnings in `components/home`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show far more items per node in the home tree so expanded folders render fully and nothing gets hidden below the fold. Fixes WIN-2317 by removing client caps on manual expand, raising sensible limits, and aligning expand-all with the tree’s own root window.

- **New Features**
  - Manual expand now renders all already-loaded rows for a node; no extra client cap. "Expand all" and search keep a 100-per-node cap with 100-step "Show more", measured against the tree’s root window.
  - Owner fetch page size increased to 1000 in `ItemsList.svelte` so one click loads large folders.
  - Root nodes show up to 100 by default in `TreeViewRoot.svelte`, with "load 100 more"; decoupled from the flat list’s count.

<sup>Written for commit 0cb591e283d9d90a9e331cb76d9f6366ea59f7b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

