### PR TITLE
fix: reflect custom tag add/remove in the manage-tags drawer immediately

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -57,18 +57,23 @@ use windmill_common::{
     get_database_url,
     global_settings::{
         AI_CONFIG_SETTING, APP_WORKSPACED_ROUTE_SETTING, AUTOMATE_USERNAME_CREATION_SETTING,
-        CRITICAL_ALERT_MUTE_UI_SETTING, DEFAULT_TAGS_WORKSPACES_SETTING, DISABLE_HUB_SETTING,
-        EMAIL_DOMAIN_SETTING, ENV_SETTINGS, GITHUB_APP_WEBHOOK_BASE_URL_SETTING,
-        HTTP_ROUTE_WORKSPACED_ROUTE_SETTING, HUB_ACCESSIBLE_URL_SETTING, HUB_BASE_URL_SETTING,
-        MAX_RETENTION_OVERRIDE_WORKSPACES, RETENTION_PERIOD_SECS_OVERRIDES_SETTING,
-        RUFF_CONFIG_SETTING, WORKSPACE_FAIRNESS_DURATION_SECS_SETTING,
-        WORKSPACE_FAIRNESS_ENABLED_SETTING, WORKSPACE_FAIRNESS_MAX_PERCENT_SETTING,
-        WORKSPACE_FAIRNESS_MIN_TOTAL_SETTING, WS_BASE_URL_SETTING,
+        CRITICAL_ALERT_MUTE_UI_SETTING, CUSTOM_TAGS_SETTING, DEFAULT_TAGS_WORKSPACES_SETTING,
+        DISABLE_HUB_SETTING, EMAIL_DOMAIN_SETTING, ENV_SETTINGS,
+        GITHUB_APP_WEBHOOK_BASE_URL_SETTING, HTTP_ROUTE_WORKSPACED_ROUTE_SETTING,
+        HUB_ACCESSIBLE_URL_SETTING, HUB_BASE_URL_SETTING, MAX_RETENTION_OVERRIDE_WORKSPACES,
+        RETENTION_PERIOD_SECS_OVERRIDES_SETTING, RUFF_CONFIG_SETTING,
+        WORKSPACE_FAIRNESS_DURATION_SECS_SETTING, WORKSPACE_FAIRNESS_ENABLED_SETTING,
+        WORKSPACE_FAIRNESS_MAX_PERCENT_SETTING, WORKSPACE_FAIRNESS_MIN_TOTAL_SETTING,
+        WS_BASE_URL_SETTING,
     },
     instance_config::{self, ApplyMode, InstanceConfig},
     server::Smtp,
 };
-use windmill_common::{error::to_anyhow, worker::CLOUD_HOSTED, PgDatabase};
+use windmill_common::{
+    error::to_anyhow,
+    worker::{reload_custom_tags_setting, CLOUD_HOSTED},
+    PgDatabase,
+};
 
 /// Unauthenticated settings routes.
 ///
@@ -115,10 +120,7 @@ pub fn global_service() -> Router {
             post(set_global_setting).get(get_global_setting),
         )
         .route("/list_global", get(list_global_settings))
-        .route(
-            "/github_app_stale_webhooks",
-            get(github_app_stale_webhooks),
-        )
+        .route("/github_app_stale_webhooks", get(github_app_stale_webhooks))
         .route(
             "/instance_config",
             get(get_instance_config).put(set_instance_config),
@@ -787,7 +789,6 @@ pub async fn set_global_setting_internal(
         value
     };
 
-
     // EE gate for workspace-fairness settings. Workspace fairness only matters
     // on multi-tenant clusters; it is licensed as an Enterprise feature so the
     // setter rejects writes from non-EE builds. Disabling/clearing writes are
@@ -852,6 +853,12 @@ pub async fn set_global_setting_internal(
         bump_instance_ai_config_revision();
     }
 
+    // Tag reads are served from an in-memory cache that this process otherwise only
+    // refreshes on the next global-settings poll, so without this a refetch right after
+    // the write still returns the pre-write list.
+    if key == CUSTOM_TAGS_SETTING {
+        reload_custom_tags_setting(db).await?;
+    }
 
     Ok(())
 }
@@ -1198,7 +1205,6 @@ async fn set_instance_config(
         if ai_config_changed {
             bump_instance_ai_config_revision();
         }
-
     }
 
     if !desired.worker_configs.is_empty() {

--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -855,9 +855,13 @@ pub async fn set_global_setting_internal(
 
     // Tag reads are served from an in-memory cache that this process otherwise only
     // refreshes on the next global-settings poll, so without this a refetch right after
-    // the write still returns the pre-write list.
+    // the write still returns the pre-write list. The setting is already persisted at
+    // this point, so a failed refresh must not be reported as a failed write — the
+    // poller retries it.
     if key == CUSTOM_TAGS_SETTING {
-        reload_custom_tags_setting(db).await?;
+        if let Err(e) = reload_custom_tags_setting(db).await {
+            tracing::error!(error = %e, "Could not reload custom tags setting after write");
+        }
     }
 
     Ok(())

--- a/frontend/src/lib/components/AssignableTagsInner.svelte
+++ b/frontend/src/lib/components/AssignableTagsInner.svelte
@@ -82,20 +82,43 @@
 		}
 	}
 
+	async function setCustomTags(value: string[]) {
+		await SettingService.setGlobal({
+			key: CUSTOM_TAGS_SETTING,
+			requestBody: { value }
+		})
+		// Servers answer from an in-memory tag cache that replicas only refresh on the
+		// next global-settings poll, so refetching here can still return the pre-write
+		// list. The value just written is authoritative.
+		customTags = value
+		dispatch('refresh')
+	}
+
 	async function saveCustomTag(tag: string, restoreCustomTags: boolean = false) {
 		try {
-			await SettingService.setGlobal({
-				key: CUSTOM_TAGS_SETTING,
-				requestBody: { value: [...(customTags ?? []), tag.trim().replaceAll(' ', '_')] }
-			})
-			dispatch('refresh')
-			loadCustomTags()
+			await setCustomTags([...(customTags ?? []), tag.trim().replaceAll(' ', '_')])
 			sendUserToast(restoreCustomTags ? 'Tag restored' : 'Tag added')
 			if (!restoreCustomTags) {
 				newTag = ''
 			}
 		} catch (err) {
 			sendUserToast(`Could not ${restoreCustomTags ? 'restore' : 'save'} custom tag: ${err}`, true)
+		}
+	}
+
+	async function removeCustomTag(tag: string) {
+		try {
+			await setCustomTags((customTags ?? []).filter((x) => x != tag))
+			sendUserToast('Tag removed', false, [
+				{
+					label: 'Undo',
+					callback: () => {
+						saveCustomTag(tag, true)
+					}
+				}
+			])
+		} catch (err) {
+			sendUserToast(`Could not remove custom tag: ${err}`, true)
 		}
 	}
 </script>
@@ -119,24 +142,7 @@
 						<button
 							class="z-10 rounded-full p-1 duration-200 hover:bg-gray-200"
 							aria-label="Remove item"
-							onclick={stopPropagation(
-								preventDefault(async () => {
-									await SettingService.setGlobal({
-										key: CUSTOM_TAGS_SETTING,
-										requestBody: { value: customTags?.filter((x) => x != customTag) }
-									})
-									dispatch('refresh')
-									loadCustomTags()
-									sendUserToast('Tag removed', false, [
-										{
-											label: 'Undo',
-											callback: () => {
-												saveCustomTag(customTag, true)
-											}
-										}
-									])
-								})
-							)}
+							onclick={stopPropagation(preventDefault(() => removeCustomTag(customTag)))}
 						>
 							<X size={12} />
 						</button>


### PR DESCRIPTION
## Summary

Fixes WIN-2322. Adding or removing a custom tag in the **Manage tags** drawer (and in the *Custom tags* popover used by the script/flow tag pickers) did not update the badge list — you had to close and reopen the drawer to see the change.

Root cause: `GET /api/workers/custom_tags` is served from the process-local `CUSTOM_TAGS_PER_WORKSPACE` / `ALL_TAGS` caches, which are only refreshed when the `notify_global_setting_change` event is picked up by the settings poller. Since `20260203172950_polling_based_events`, that notification goes through the `notify_event` table, so the refresh lands ~1s after the write. The drawer wrote the setting and immediately refetched, so it consistently got the *pre-write* list back and re-rendered the old badges. Reopening the drawer remounts the component (the `Drawer` unmounts its children when closed), by which time the cache had caught up — hence the "close and reopen" workaround.

Measured before the fix on a local instance: the write is visible in `global_settings` instantly, but `GET /api/workers/custom_tags` kept returning the old list for **~1030 ms**.

## Changes

- `backend/windmill-api-settings`: `set_global_setting_internal` now calls `reload_custom_tags_setting` after writing `custom_tags`, so the process that served the write answers subsequent tag reads with the new value (read-your-writes). Other replicas still converge through the existing poller.
- `frontend/AssignableTagsInner.svelte`: add/remove/undo go through a single `setCustomTags` helper that applies the list it just wrote to local state instead of refetching. This keeps the drawer correct even when a follow-up `GET` is routed to a replica that has not polled yet, and drops a round-trip. The remove path also gained the `try/catch` + error toast the add path already had.

## Test plan

- [x] `npx svelte-check` — 0 errors
- [x] Backend rebuilt under `cargo watch`, no errors; API check: `POST /api/settings/global/custom_tags` followed immediately by `GET /api/workers/custom_tags` now returns the just-written list (previously stale for ~1s)
- [x] Manage tags drawer (Playwright, `/workers`): add a tag → badge appears immediately; remove a tag → badge disappears immediately; **Undo** on the remove toast → badge comes back immediately
- [x] Workspace-restricted tag `wstag(^admins)` added through the drawer renders identically to what the server round-trips back (`to_string_vec` reconstruction matches the optimistic value)

No test added: the behavior hinges on process-global tag caches (`ALL_TAGS`, `CUSTOM_TAGS_PER_WORKSPACE`), and a test mutating those would leak into other tests in the same process.

## Screenshots

Manage tags drawer, initial state:

![initial](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2322-fix-custom-tag-drawer-not-reflecting-changes/1785879626-wm2322-a-initial.png)

Right after clicking **Add custom tag** for `gpu_a100` (no reopen):

![after add](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2322-fix-custom-tag-drawer-not-reflecting-changes/1785879626-wm2322-b-after-add.png)

Right after removing `gpu_heavy` (no reopen):

![after remove](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2322-fix-custom-tag-drawer-not-reflecting-changes/1785879626-wm2322-c-after-remove.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2322 by making the Manage tags drawer and Custom tags popover update immediately after adding or removing a tag, without needing to close and reopen.

- **Bug Fixes**
  - Backend: when `CUSTOM_TAGS_SETTING` is written in `set_global_setting_internal`, call `reload_custom_tags_setting` to refresh the process-local cache for read-your-writes; do not fail the write if the refresh errors (log it and let the poller catch up).
  - Frontend: added `setCustomTags` to apply the just-written list to local state and dispatch a refresh instead of refetching, avoiding stale reads and a round-trip.
  - Frontend: remove now mirrors add with try/catch and error toast; Undo restores the tag immediately.

<sup>Written for commit eb266011e435f2aa4c227ca0c06b445cc89055d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

