### PR TITLE
fix: filter the AI Sandbox entry by the flow insert search

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
@@ -200,12 +200,7 @@
 
 	let scrollable: HTMLElement | undefined = $state()
 	function onKeyDown(e: KeyboardEvent) {
-		let length =
-			topLevelNodes?.length +
-			inlineScripts.length +
-			aiLength +
-			filteredWorkspaceItems.length +
-			hubCompletions.length
+		let length = hubOffset + (hubCompletions?.length ?? 0)
 		if (e.key === 'ArrowDown') {
 			selectedByKeyboard = (selectedByKeyboard + 1) % length
 			scrollable?.scrollTo({ top: selectedByKeyboard * 32, behavior: 'smooth' })
@@ -266,12 +261,36 @@
 	)
 	let aiLength = $derived(showAiRows ? 2 : 0)
 
+	// Must match the heading and label rendered for the AI Sandbox section
+	const aiSandboxHeading = 'AI Sandbox'
+	const aiSandboxLabel = 'Claude Code'
+	let matchesAiSandbox = $derived.by(() => {
+		const query = funcDesc?.trim().toLowerCase() ?? ''
+		if (query.length == 0) {
+			return true
+		}
+		return [aiSandboxHeading, aiSandboxLabel].some((term) => {
+			const lowered = term.toLowerCase()
+			return lowered.startsWith(query) || lowered.split(' ').some((w) => w.startsWith(query))
+		})
+	})
+	// Gates the AI Sandbox row and its slot in the index space; both must agree or arrow keys land
+	// on an index that renders nothing.
+	let showAiSandbox = $derived(
+		selectedKind === 'script' &&
+			preFilter === 'all' &&
+			!selected &&
+			customUi?.aiSandbox != false &&
+			matchesAiSandbox
+	)
+
 	// Every result row lives in one keyboard index space, and hovering a row moves that index, so
 	// mouse and keyboard can never highlight two different rows. Offsets follow the render order.
 	let inlineOffset = $derived(topLevelNodes.length)
 	let aiOffset = $derived(inlineOffset + (inlineScripts?.length ?? 0))
 	let workspaceOffset = $derived(aiOffset + aiLength)
-	let hubOffset = $derived(workspaceOffset + (filteredWorkspaceItems?.length ?? 0))
+	let aiSandboxOffset = $derived(workspaceOffset + (filteredWorkspaceItems?.length ?? 0))
+	let hubOffset = $derived(aiSandboxOffset + (showAiSandbox ? 1 : 0))
 </script>
 
 <svelte:window onkeydown={onKeyDown} />
@@ -500,13 +519,14 @@
 			{/await}
 			<div class="pb-1"></div>
 		{/if}
-		{#if selectedKind === 'script' && preFilter === 'all' && !selected && customUi?.aiSandbox != false}
-			<div class="pb-0 text-2xs font-normal text-secondary ml-2">AI Sandbox</div>
+		{#if showAiSandbox}
+			<div class="pb-0 text-2xs font-normal text-secondary ml-2">{aiSandboxHeading}</div>
 			<FlowScriptPickerQuick
 				eeRestricted={false}
-				selected={false}
+				selected={selectedByKeyboard === aiSandboxOffset}
+				onHover={() => hover(aiSandboxOffset)}
 				enterpriseLangs={[]}
-				label="Claude Code"
+				label={aiSandboxLabel}
 				lang="claudesandbox"
 				on:click={() => {
 					dispatch('new', {

--- a/frontend/src/lib/components/flows/pickers/FlowScriptPicker.svelte
+++ b/frontend/src/lib/components/flows/pickers/FlowScriptPicker.svelte
@@ -32,9 +32,6 @@
 				<LanguageIcon {lang} />
 			{/if}
 			<span class="text-xs">{label}</span>
-			{#if lang === 'claudesandbox'}
-				<span class="text-primary !text-xs">(new)</span>
-			{/if}
 		</div>
 	</Button>
 	{#snippet text()}

--- a/frontend/src/lib/components/flows/pickers/FlowScriptPickerQuick.svelte
+++ b/frontend/src/lib/components/flows/pickers/FlowScriptPickerQuick.svelte
@@ -58,9 +58,6 @@
 	{/if}
 	<span class="grow truncate text-left {eeRestricted ? 'text-disabled' : ''}">
 		{label}{#if eeRestricted}&nbsp;(EE){/if}
-		{#if lang === 'claudesandbox'}
-			<span class="text-primary !text-xs">(new)</span>
-		{/if}
 	</span>
 	{#if selected}
 		<kbd class="!text-xs">&crarr;</kbd>


### PR DESCRIPTION
## Summary

In the flow editor insert menu, the `AI Sandbox` → `Claude Code` entry was rendered unconditionally: its `{#if}` checked `selectedKind`, `preFilter`, the folder/integration selection and the whitelabel flag, but never the search query. So it stayed on screen no matter what you typed, alongside results that had nothing to do with it.

It is now matched against the search like the other entries in that panel, and the `(new)` badge on the Claude Code picker is removed.

Fixes WIN-2323

## Changes

- `FlowInputsQuick.svelte`: gate the AI Sandbox section on a `matchesAiSandbox` derived — empty search shows it, otherwise the query (trimmed, case-insensitive) must prefix-match `AI Sandbox` or `Claude Code`, or one of their words. Word-prefix rather than plain `startsWith` so `code` still finds `Claude Code`; rather than substring-anywhere so single letters like `e` don't match everything. The heading and label are held in constants shared with the markup so the filter can't drift from what is rendered.
- `FlowScriptPickerQuick.svelte` / `FlowScriptPicker.svelte`: drop the `(new)` badge shown for `lang === 'claudesandbox'`. This covers both the quick insert menu and the legacy full-page insert panel that `FlowInputs.svelte` uses.

The `AI Sandbox` item in the insert menu's left-hand column is a category button (like `Trigger`, `Flow`, `For loop`) and is intentionally left unfiltered.

## Screenshots

Searching `slack` — AI Sandbox section no longer shown:

![search-slack](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2323-regardless-of-what-you-search-in-the-insert-menu-of-the-flow/1785915795-win2323-search-slack.png)

Searching `claude` — shown, without the `(new)` badge:

![search-claude](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2323-regardless-of-what-you-search-in-the-insert-menu-of-the-flow/1785915795-win2323-search-claude.png)

Searching `ai sandbox ` (trailing space) — still shown:

![search-trailing-space](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2323-regardless-of-what-you-search-in-the-insert-menu-of-the-flow/1785915795-win2323-search-aisandbox-trailing-space.png)

Empty search — default listing unchanged:

![no-search](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2323-regardless-of-what-you-search-in-the-insert-menu-of-the-flow/1785915795-win2323-no-search.png)

## Test plan

- [x] `npm run check:fast` passes
- [x] Flow editor insert menu, All tab: empty search still lists `AI Sandbox` / `Claude Code`
- [x] Searching `slack` and `e` hides the section (heading and item together)
- [x] Searching `claude`, `code`, `ai sandbox` and `ai sandbox ` (trailing space) shows it
- [x] `(new)` badge gone from the Claude Code entry

No test added: this is a two-line `$derived` inline in a Svelte component, and the repo does not test Svelte components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2323 by filtering the AI Sandbox → Claude Code entry in the flow insert menu by the search query, wiring it into hover/arrow-key selection, and removing the stale “(new)” badge.

- **Bug Fixes**
  - Show the section only when the trimmed, case-insensitive query word-prefix matches “AI Sandbox” or “Claude Code” (empty search still shows it). Adjust keyboard index/count so arrows never land on an empty slot.
  - Remove the “(new)” badge for `claudesandbox` in both quick and full script pickers.

<sup>Written for commit 4309283c04d18d28d95ebe5c6a25573962a6190c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

