### PR TITLE
fix(frontend): stop swallowing Ctrl/Cmd+Shift+S in the editors

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -10,7 +10,7 @@
 	import { buildWsUrl } from '$lib/wsUrl'
 	import { sendUserToast } from '$lib/toast'
 
-	import { createEventDispatcher, onDestroy, onMount, untrack } from 'svelte'
+	import { createEventDispatcher, onDestroy, onMount, tick, untrack } from 'svelte'
 
 	// import libStdContent from '$lib/es6.d.ts.txt?raw'
 	// import domContent from '$lib/dom.d.ts.txt?raw'
@@ -1670,9 +1670,11 @@
 				// Monaco swallows the keydown (addCommand prevents default and
 				// stops propagation), so page-level Ctrl/Cmd+S handlers never
 				// see it. Re-broadcast as a window event so editors that flush
-				// a draft on the shortcut (raw apps) can react regardless of
-				// which Monaco has focus.
-				window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut'))
+				// a draft on the shortcut can react regardless of which Monaco
+				// has focus. Only after `tick()`: the autosave payload is parked
+				// by a `$effect`, so dispatching synchronously would make every
+				// listener flush the state from before `updateCode()`.
+				void tick().then(() => window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut')))
 			})
 
 			editor?.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, function () {

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -901,7 +901,9 @@
 				}
 				break
 			case 's':
-				if (event.ctrlKey || event.metaKey) {
+				// Shift excluded: the switch lowercases so Ctrl+Shift+S lands here
+				// too, and swallowing it would steal the browser/OS shortcut.
+				if ((event.ctrlKey || event.metaKey) && !event.shiftKey) {
 					saveDraft()
 					event.preventDefault()
 				}

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -327,6 +327,15 @@
 		})
 	}
 
+	// Monaco swallows the keydown, so an editor with focus never reaches the
+	// window handler; Editor/SimpleEditor/TemplateEditor re-broadcast it
+	// (untyped event, hence the manual listener). A step's code editor also
+	// flushes through its `formatAction`, and a redundant flush is a no-op.
+	$effect(() => {
+		window.addEventListener('wm-monaco-save-shortcut', saveDraft)
+		return () => window.removeEventListener('wm-monaco-save-shortcut', saveDraft)
+	})
+
 	// Materialize a brand-new flow's draft before the session preview loads it by
 	// path — an untouched new flow never autosaved, so forcePersist is the only
 	// thing that creates the row. Gated to never-deployed: forcePersist skips the

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -918,15 +918,25 @@
 	}
 
 	function onKeyDown(event: KeyboardEvent) {
-		switch (event.key) {
+		// Lowercased so Caps Lock (which yields `S`) still saves. Shift excluded:
+		// Ctrl+Shift+S must reach the browser/OS.
+		switch (event.key.length === 1 ? event.key.toLowerCase() : event.key) {
 			case 's':
-				if (event.ctrlKey || event.metaKey) {
+				if ((event.ctrlKey || event.metaKey) && !event.shiftKey) {
 					saveDraft()
 					event.preventDefault()
 				}
 				break
 		}
 	}
+
+	// Monaco swallows the keydown, so a code editor with focus never reaches the
+	// window handler above; Editor/SimpleEditor/TemplateEditor re-broadcast it
+	// (untyped event, hence the manual listener).
+	$effect(() => {
+		window.addEventListener('wm-monaco-save-shortcut', saveDraft)
+		return () => window.removeEventListener('wm-monaco-save-shortcut', saveDraft)
+	})
 
 	let path: Path | undefined = $state(undefined)
 	// Seed "path is already chosen" so the summary→path auto-slug (which only
@@ -1445,7 +1455,7 @@
 									<!-- Not for dbt: each kind tags a script for a role in a flow that a project
 										     bundle cannot fill (approval, trigger, preprocessor), and the runtime only
 										     ever runs it as an action. -->
-										{#if customUi?.settingsPanel?.metadata?.disableScriptKind !== true && !isDbt}
+									{#if customUi?.settingsPanel?.metadata?.disableScriptKind !== true && !isDbt}
 										<Section label="Script kind">
 											{#snippet header()}
 												<Tooltip
@@ -1904,8 +1914,7 @@
 																// Keep the saved pair. A script that has no recorded principal yet
 																// sends the email alone and the backend derives one from it.
 																script.on_behalf_of_email = originalOnBehalfOfEmail
-																script.on_behalf_of =
-																	originalOnBehalfOfPermissionedAs
+																script.on_behalf_of = originalOnBehalfOfPermissionedAs
 																customOnBehalfOfEmail = ''
 																preserveOnBehalfOf = true
 															} else if (choice === 'custom' && details) {

--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -29,7 +29,7 @@
 
 	import { allClasses } from './apps/editor/componentsPanel/cssUtils'
 
-	import { createEventDispatcher, onDestroy, onMount, untrack } from 'svelte'
+	import { createEventDispatcher, onDestroy, onMount, tick, untrack } from 'svelte'
 
 	import libStdContent from '$lib/es6.d.ts.txt?raw'
 	import domContent from '$lib/dom.d.ts.txt?raw'
@@ -458,8 +458,9 @@
 				updateCode()
 				shouldBindKey && format && format()
 				// See Editor.svelte — re-broadcast the swallowed shortcut for
-				// page-level draft-flush handlers.
-				window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut'))
+				// page-level draft-flush handlers, after `tick()` so they see
+				// the value `updateCode()` just materialized.
+				void tick().then(() => window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut')))
 			})
 
 			editor.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit7, function () {
@@ -490,8 +491,9 @@
 				updateCode()
 				shouldBindKey && format && format()
 				// See Editor.svelte — re-broadcast the swallowed shortcut for
-				// page-level draft-flush handlers.
-				window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut'))
+				// page-level draft-flush handlers, after `tick()` so they see
+				// the value `updateCode()` just materialized.
+				void tick().then(() => window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut')))
 			})
 
 			editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, function () {

--- a/frontend/src/lib/components/TemplateEditor.svelte
+++ b/frontend/src/lib/components/TemplateEditor.svelte
@@ -505,7 +505,12 @@
 		editor.onDidFocusEditorText(() => {
 			dispatch('focus')
 
-			editor?.addCommand(KeyMod.CtrlCmd | KeyCode.KeyS, function () {})
+			editor?.addCommand(KeyMod.CtrlCmd | KeyCode.KeyS, function () {
+				updateCode()
+				// See Editor.svelte — re-broadcast the swallowed shortcut for
+				// page-level draft-flush handlers.
+				window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut'))
+			})
 
 			editor?.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit7, function () {})
 		})

--- a/frontend/src/lib/components/TemplateEditor.svelte
+++ b/frontend/src/lib/components/TemplateEditor.svelte
@@ -21,7 +21,7 @@
 
 	import libStdContent from '$lib/es6.d.ts.txt?raw'
 	import { editor as meditor, Uri as mUri, languages, Range, KeyMod, KeyCode } from 'monaco-editor'
-	import { createEventDispatcher, getContext, onDestroy, onMount, untrack } from 'svelte'
+	import { createEventDispatcher, getContext, onDestroy, onMount, tick, untrack } from 'svelte'
 	import type { AppViewerContext } from './apps/types'
 	import { writable } from 'svelte/store'
 	// import '@codingame/monaco-vscode-standalone-languages'
@@ -508,8 +508,9 @@
 			editor?.addCommand(KeyMod.CtrlCmd | KeyCode.KeyS, function () {
 				updateCode()
 				// See Editor.svelte — re-broadcast the swallowed shortcut for
-				// page-level draft-flush handlers.
-				window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut'))
+				// page-level draft-flush handlers, after `tick()` so they see
+				// the value `updateCode()` just materialized.
+				void tick().then(() => window.dispatchEvent(new CustomEvent('wm-monaco-save-shortcut')))
 			})
 
 			editor?.addCommand(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit7, function () {})

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -465,6 +465,28 @@
 		}
 	}
 
+	/** Flush the pending autosave (also covers the toggle-off parked case).
+	 * Returns whether there was a draft to flush — false in the AI session pane,
+	 * which owns no handle. */
+	function flushDraft(): boolean {
+		if (inSessionPane || !$workspaceStore || !userDraftPath) return false
+		void UserDraftDbSyncer.flush({
+			workspace: $workspaceStore,
+			itemKind: 'app',
+			path: userDraftPath
+		})
+		return true
+	}
+
+	// Monaco swallows the keydown, so an inline script or template editor with
+	// focus never reaches the window handler below; Editor/SimpleEditor/
+	// TemplateEditor re-broadcast it (untyped event, hence the manual listener).
+	$effect(() => {
+		const onMonacoSave = () => void flushDraft()
+		window.addEventListener('wm-monaco-save-shortcut', onMonacoSave)
+		return () => window.removeEventListener('wm-monaco-save-shortcut', onMonacoSave)
+	})
+
 	let lock = false
 	function onKeyDown(event: KeyboardEvent) {
 		if (lock) return
@@ -494,17 +516,10 @@
 			case 's':
 				// Shift excluded: the switch lowercases so Ctrl+Shift+S lands here
 				// too, and swallowing it would steal the browser/OS shortcut.
-				if ((event.ctrlKey || event.metaKey) && !event.shiftKey) {
+				// Swallowed only when there is a draft to flush, so the contexts
+				// that can't act on it (AI session pane) leave the key alone.
+				if ((event.ctrlKey || event.metaKey) && !event.shiftKey && flushDraft()) {
 					event.preventDefault()
-					// Flush the pending autosave (also covers the toggle-off parked
-					// case); no-op in the AI session pane (no handle there).
-					if (!inSessionPane && $workspaceStore && userDraftPath) {
-						void UserDraftDbSyncer.flush({
-							workspace: $workspaceStore,
-							itemKind: 'app',
-							path: userDraftPath
-						})
-					}
 				}
 				break
 			// case 'ArrowDown': {

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -492,7 +492,9 @@
 				}
 				break
 			case 's':
-				if (event.ctrlKey || event.metaKey) {
+				// Shift excluded: the switch lowercases so Ctrl+Shift+S lands here
+				// too, and swallowing it would steal the browser/OS shortcut.
+				if ((event.ctrlKey || event.metaKey) && !event.shiftKey) {
 					event.preventDefault()
 					// Flush the pending autosave (also covers the toggle-off parked
 					// case); no-op in the AI session pane (no handle there).

--- a/frontend/src/lib/components/vscode.ts
+++ b/frontend/src/lib/components/vscode.ts
@@ -1,6 +1,6 @@
 import '@codingame/monaco-vscode-standalone-typescript-language-features'
 
-import { editor as meditor, Uri as mUri } from 'monaco-editor'
+import { editor as meditor, KeyCode, KeyMod, Uri as mUri } from 'monaco-editor'
 import { getAppliedDarkModeVariant } from '$lib/darkModeVariant'
 
 export let isInitialized = false
@@ -157,6 +157,15 @@ export async function initializeVscode(caller?: string, htmlContainer?: HTMLElem
 			await apiWrapper.start()
 
 			isInitialized = true
+
+			// vscode-api ships VS Code's keybindings, including Ctrl/Cmd+Shift+S
+			// (Save As) which has no meaning here. Left bound, every Monaco
+			// instance swallows the shortcut and the browser/OS one never fires.
+			meditor.addKeybindingRule({
+				keybinding: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyS,
+				command: null
+			})
+
 			meditor.defineTheme('nord', {
 				base: 'vs-dark',
 				inherit: true,


### PR DESCRIPTION
## Summary

Ctrl/Cmd+Shift+S was captured by Windmill and never reached the browser or OS, so whatever the user had bound to it (screenshot tool, devtools, extension) silently did nothing while an editor was open. Two independent layers were swallowing it.

**Page-level handlers.** `FlowBuilder` and `AppEditorHeader` normalize single-char keys with `event.key.toLowerCase()` in their keydown switch. That normalization exists so Ctrl+Shift+Z still reaches `case 'z'` for redo, but `case 's'` had no shift guard, so Ctrl+Shift+S fell into the save branch, flushed the draft and called `preventDefault()`.

**Monaco.** `monaco-editor` is aliased to `@codingame/monaco-vscode-editor-api`, which ships VS Code's keybinding set rather than the small standalone one. Ctrl+Shift+S resolved to `workbench.action.files.saveAs` and was swallowed inside every Monaco instance before the event could leave the editor. The command is meaningless here, so the binding is dropped at init. Probing neighbours confirms the shape: Ctrl+Shift+O and Ctrl+Shift+P are likewise taken (Go to Symbol, Command Palette) while unbound chords such as Ctrl+Shift+Q pass through untouched.

The second commit closes the sites that were taking Ctrl/Cmd+S without doing anything with it. Monaco stops propagation of the keydown, so a focused code editor never reaches the page-level handler; `Editor`/`SimpleEditor` already re-broadcast it as `wm-monaco-save-shortcut` for exactly this reason, but only `RawAppEditor` listened. In the app editor, Ctrl+S from an inline script or template editor was therefore a silent no-op — the draft only landed on the next autosave tick. The flow and script editors got there by accident, via the `formatAction` chain, which not every embedded editor wires up.

Ctrl/Cmd+S is unchanged in intent everywhere: flush the pending draft autosave (and format, in the script editor).

## Changes

- `FlowBuilder.svelte` / `AppEditorHeader.svelte`: require `!event.shiftKey` in the `case 's'` save branch
- `vscode.ts`: after vscode-api starts, `meditor.addKeybindingRule({ keybinding: CtrlCmd|Shift|KeyS, command: null })` to unbind Save As
- `ScriptBuilder.svelte`: lowercase the key in its switch, so Ctrl+S still saves with Caps Lock on (`event.key` is `S`), and exclude shift like the other two
- `FlowBuilder.svelte` / `ScriptBuilder.svelte` / `AppEditorHeader.svelte`: listen for `wm-monaco-save-shortcut` and flush, so Ctrl+S from any focused Monaco persists the draft and flashes the indicator. A redundant flush (script/flow, which also arrive via `formatAction`) is a no-op
- `TemplateEditor.svelte`: its Ctrl+S command was an empty function that swallowed the key and did nothing; it now materializes the code and re-broadcasts like the other editors
- `AppEditorHeader.svelte`: `preventDefault()` moved inside the guard, so the contexts that cannot act on the key (AI session pane, no draft path) leave it to the browser

The keybinding rule is scoped to the in-page Monaco instance shared by `Editor`, `SimpleEditor`, `TemplateEditor` and `DiffEditor`. The raw-app UI-builder iframe runs its own VS Code bundle and is deliberately untouched, so Ctrl+Shift+S still behaves like VS Code in there.

## Screenshots

No visible UI effect (keyboard shortcut routing only), so there is nothing to screenshot. Verified behaviourally instead, see below.

## Test plan

Verified in Chromium against a local dev server, reading `defaultPrevented` on a window capture listener after dispatch (capture is needed because Monaco stops propagation before the event reaches window):

| context | Ctrl+Shift+S before | Ctrl+Shift+S after | Ctrl+S after |
| --- | --- | --- | --- |
| flow editor | swallowed | passes through | saves |
| app editor | swallowed | passes through | saves |
| script editor, canvas focus | passes through | passes through | saves |
| script editor, code focus | swallowed | passes through | saves |

The "before" column is measured, not inferred: the fix was stashed, the page reloaded, and the swallow reproduced.

Second commit, measured the same way:

- App editor, edit then fire the Monaco re-broadcast: draft POST lands **0 ms after the event**, against **1516 ms** for the same edit left to the autosave debounce — the flush is real, not the debounce firing anyway.
- Script editor with the code editor focused: Ctrl+S emits exactly one `wm-monaco-save-shortcut`, and is still swallowed by Monaco (so the page-level handler could never have seen it).
- Caps Lock form of the shortcut (`key === 'S'`, no shift) now saves in all three editors; it was ignored in the script editor before.
- Ctrl+Shift+S still passes through in all three editors, with the canvas focused and with a code editor focused.

Manual checks worth repeating on review:

- [ ] Flow editor: Ctrl/Cmd+S saves the draft, Ctrl/Cmd+Shift+S reaches the browser/OS, Ctrl/Cmd+Shift+Z still redoes
- [ ] App editor: same three, plus Ctrl/Cmd+S from an inline script editor shows the autosave indicator
- [ ] Script editor with the caret inside the code editor: Ctrl/Cmd+S still saves and formats
- [ ] Raw app source editor: Ctrl/Cmd+Shift+S still handled by the embedded VS Code, unchanged

No test shipped: the diff is keydown guards, a keybinding-manager call and event wiring, none of which can be asserted without a full editor fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)