### PR TITLE
fix: report python debugger dependency install failures instead of timing out

### DIFF
--- a/debugger/dap_debug_service.ts
+++ b/debugger/dap_debug_service.ts
@@ -805,6 +805,13 @@ class PythonDebugSession extends BaseDebugSession {
 			this.debugpyWs.onclose = () => {
 				logger.info('Debugpy WebSocket closed')
 				this.debugpyWs = null
+				// A Python server that dies mid-request must fail it now; otherwise the caller
+				// waits out the command timeout, which for `launch` is minutes.
+				const aborted = Array.from(this.pendingDebugpyRequests.values())
+				this.pendingDebugpyRequests.clear()
+				for (const pending of aborted) {
+					pending.reject(new Error('Debugpy connection closed'))
+				}
 			}
 		})
 	}

--- a/debugger/dap_debug_service.ts
+++ b/debugger/dap_debug_service.ts
@@ -489,6 +489,15 @@ abstract class BaseDebugSession {
 // Python Debug Session
 // ============================================================================
 
+const DEFAULT_DEBUGPY_TIMEOUT_MS = 10_000
+
+// `launch` waits on dependency preparation in the Python server, which allows `windmill
+// prepare-deps` up to 120s; anything shorter here reports a timeout while the install is
+// still legitimately running.
+const DEBUGPY_TIMEOUT_MS_BY_COMMAND: Record<string, number> = {
+	launch: 180_000
+}
+
 class PythonDebugSession extends BaseDebugSession {
 	private debugpyWs: WebSocket | null = null
 	private debugpySeq = 1
@@ -531,11 +540,13 @@ class PythonDebugSession extends BaseDebugSession {
 			arguments: args
 		}
 
+		const timeoutMs = DEBUGPY_TIMEOUT_MS_BY_COMMAND[command] ?? DEFAULT_DEBUGPY_TIMEOUT_MS
+
 		return new Promise((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				this.pendingDebugpyRequests.delete(seq)
-				reject(new Error(`Debugpy command timeout: ${command}`))
-			}, 10000)
+				reject(new Error(`Debugpy command timeout: ${command} (after ${timeoutMs}ms)`))
+			}, timeoutMs)
 
 			this.pendingDebugpyRequests.set(seq, {
 				resolve: (value) => {

--- a/debugger/dap_debug_service.ts
+++ b/debugger/dap_debug_service.ts
@@ -1030,7 +1030,13 @@ sys.stdout.flush()
 			})
 		} catch (error) {
 			this.sendEvent('output', { category: 'stderr', output: `Failed to start Python: ${error}\n` })
+			// Claim the terminated event before cleanup kills the process, otherwise the
+			// `exited` handler sends a second one whose empty body erases this error.
+			this.terminatedSent = true
 			this.sendEvent('terminated', { error: String(error) })
+			// A Python server that refused the launch stays in its connection loop, so
+			// nothing else ever reaps it, its websocket or the temp dir.
+			await this.cleanup()
 		}
 	}
 

--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -312,6 +312,21 @@ def _prepare_error_detail(response: dict) -> str:
     return "\n".join(parts) or "unknown error"
 
 
+def _installer_error_detail(stderr: str) -> str:
+    """
+    Extract an installer's error report from its stderr.
+
+    uv writes routine resolve/install progress to stderr as well, so output alone does not
+    mean the install failed; only an `error:` line does, along with the `Caused by:` lines
+    that follow it. Anything less selective warns on every successful install.
+    """
+    lines = stderr.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.strip().lower().startswith("error")), None
+    )
+    return "\n".join(lines[start:]).strip() if start is not None else ""
+
+
 def _first_line(detail: str, limit: int = 300) -> str:
     """Condense a multi-line failure into the single line a DAP response message allows."""
     line = next((s.strip() for s in detail.splitlines() if s.strip()), detail.strip())
@@ -423,12 +438,12 @@ class DebugSession:
 
             # `uv pip install` failing for individual packages does not fail the whole
             # response, so a "successful" preparation can still carry the reason an import
-            # is about to fail. Report it rather than let it become a bare ModuleNotFoundError.
-            installer_output = str(response.get("stderr") or "").strip()
-            if installer_output:
-                logger.warning(f"prepare-deps reported installer output: {installer_output}")
+            # is about to fail.
+            installer_error = _installer_error_detail(str(response.get("stderr") or ""))
+            if installer_error:
+                logger.warning(f"prepare-deps reported an installer error: {installer_error}")
 
-            return PrepareResult(venv_path=venv_path, error=installer_output or None)
+            return PrepareResult(venv_path=venv_path, error=installer_error or None)
 
         except subprocess.TimeoutExpired:
             message = f"prepare-deps timed out after {PREPARE_DEPS_TIMEOUT_SECONDS}s"
@@ -612,8 +627,6 @@ class DebugSession:
         if code:
             prepared = await self._prepare_dependencies_with_progress(code)
             if prepared.error:
-                # Reporting the reason is what keeps a failed install from reaching the user
-                # as nothing but a bare ModuleNotFoundError.
                 prefix = (
                     "Failed to prepare dependencies"
                     if prepared.fatal

--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -283,10 +283,18 @@ PREPARE_DEPS_PROGRESS_INTERVAL_SECONDS = 5
 
 @dataclass
 class PrepareResult:
-    """Outcome of dependency preparation: a venv path on success, a reason on failure."""
+    """
+    Outcome of dependency preparation.
+
+    `error` holds anything worth telling the user, including a problem reported by an
+    otherwise successful preparation. Only `fatal` means the packages are known to be
+    missing: failing to reach the CLI at all says nothing about the script's imports and
+    must not block a session that would otherwise run.
+    """
 
     venv_path: str | None = None
     error: str | None = None
+    fatal: bool = False
 
 
 def _prepare_error_detail(response: dict) -> str:
@@ -374,7 +382,8 @@ class DebugSession:
                 logger.error(f"prepare-deps failed (stdout): {result.stdout}")
                 detail = (result.stderr or "").strip() or (result.stdout or "").strip()
                 return PrepareResult(
-                    error=detail or f"windmill prepare-deps exited with code {result.returncode}"
+                    error=detail or f"windmill prepare-deps exited with code {result.returncode}",
+                    fatal=True,
                 )
 
             # Log raw output for debugging
@@ -399,7 +408,7 @@ class DebugSession:
             if not response.get("success"):
                 detail = _prepare_error_detail(response)
                 logger.error(f"prepare-deps error: {detail}")
-                return PrepareResult(error=detail)
+                return PrepareResult(error=detail, fatal=True)
 
             venv_path = response.get("venv_path")
             cached = response.get("cached", False)
@@ -412,12 +421,19 @@ class DebugSession:
             else:
                 logger.info("No external dependencies detected in code")
 
-            return PrepareResult(venv_path=venv_path)
+            # `uv pip install` failing for individual packages does not fail the whole
+            # response, so a "successful" preparation can still carry the reason an import
+            # is about to fail. Report it rather than let it become a bare ModuleNotFoundError.
+            installer_output = str(response.get("stderr") or "").strip()
+            if installer_output:
+                logger.warning(f"prepare-deps reported installer output: {installer_output}")
+
+            return PrepareResult(venv_path=venv_path, error=installer_output or None)
 
         except subprocess.TimeoutExpired:
             message = f"prepare-deps timed out after {PREPARE_DEPS_TIMEOUT_SECONDS}s"
             logger.error(message)
-            return PrepareResult(error=message)
+            return PrepareResult(error=message, fatal=True)
         except json.JSONDecodeError as e:
             raw = output[:500] if 'output' in dir() else '(not available)'
             logger.error(f"Failed to parse prepare-deps JSON output: {e}")
@@ -596,21 +612,24 @@ class DebugSession:
         if code:
             prepared = await self._prepare_dependencies_with_progress(code)
             if prepared.error:
-                # Running the script regardless would surface only a bare ModuleNotFoundError,
-                # hiding why the install actually failed.
+                # Reporting the reason is what keeps a failed install from reaching the user
+                # as nothing but a bare ModuleNotFoundError.
+                prefix = (
+                    "Failed to prepare dependencies"
+                    if prepared.fatal
+                    else "Warning: dependency preparation reported a problem, running anyway"
+                )
                 await self.send_event(
                     "output",
-                    {
-                        "category": "stderr",
-                        "output": f"Failed to prepare dependencies:\n{prepared.error}\n",
-                    },
+                    {"category": "stderr", "output": f"{prefix}:\n{prepared.error}\n"},
                 )
-                await self.send_response(
-                    request,
-                    success=False,
-                    message=f"Failed to prepare dependencies: {_first_line(prepared.error)}",
-                )
-                return
+                if prepared.fatal:
+                    await self.send_response(
+                        request,
+                        success=False,
+                        message=f"Failed to prepare dependencies: {_first_line(prepared.error)}",
+                    )
+                    return
             self._venv_path = prepared.venv_path
 
         # If callMain is True, append a call to main() with the provided args

--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -312,19 +312,36 @@ def _prepare_error_detail(response: dict) -> str:
     return "\n".join(parts) or "unknown error"
 
 
-def _installer_error_detail(stderr: str) -> str:
-    """
-    Extract an installer's error report from its stderr.
+# Prefixes uv uses for routine resolve/install progress, which it writes to stderr on a
+# perfectly successful run. The `+`/`-` forms are the per-package change list.
+_INSTALLER_PROGRESS_PREFIXES = (
+    "resolved ",
+    "prepared ",
+    "installed ",
+    "uninstalled ",
+    "downloaded ",
+    "audited ",
+    "using ",
+    "creating ",
+    "+ ",
+    "- ",
+)
 
-    uv writes routine resolve/install progress to stderr as well, so output alone does not
-    mean the install failed; only an `error:` line does, along with the `Caused by:` lines
-    that follow it. Anything less selective warns on every successful install.
+
+def _installer_diagnostics(stderr: str) -> str:
     """
-    lines = stderr.splitlines()
-    start = next(
-        (i for i, line in enumerate(lines) if line.strip().lower().startswith("error")), None
-    )
-    return "\n".join(lines[start:]).strip() if start is not None else ""
+    Strip an installer's routine progress from its stderr, keeping anything unexplained.
+
+    uv renders failures several ways (`error:`, `× No solution found` with tree glyphs), so
+    matching failure shapes misses some of them. Matching progress instead errs toward a
+    spurious warning rather than toward the silence this exists to prevent.
+    """
+    kept = [
+        line
+        for line in stderr.splitlines()
+        if line.strip() and not line.strip().lower().startswith(_INSTALLER_PROGRESS_PREFIXES)
+    ]
+    return "\n".join(kept).strip()
 
 
 def _first_line(detail: str, limit: int = 300) -> str:
@@ -439,7 +456,7 @@ class DebugSession:
             # `uv pip install` failing for individual packages does not fail the whole
             # response, so a "successful" preparation can still carry the reason an import
             # is about to fail.
-            installer_error = _installer_error_detail(str(response.get("stderr") or ""))
+            installer_error = _installer_diagnostics(str(response.get("stderr") or ""))
             if installer_error:
                 logger.warning(f"prepare-deps reported an installer error: {installer_error}")
 

--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -313,16 +313,24 @@ def _prepare_error_detail(response: dict) -> str:
 
 
 # Prefixes uv uses for routine resolve/install progress, which it writes to stderr on a
-# perfectly successful run. The `+`/`-` forms are the per-package change list.
+# perfectly successful run. `warning:` belongs here because uv's warnings are non-fatal by
+# construction (the hardlink fallback fires whenever the cache and the venv are on
+# different filesystems, which is the normal layout). The `+`/`-` forms are the
+# per-package change list.
 _INSTALLER_PROGRESS_PREFIXES = (
     "resolved ",
     "prepared ",
     "installed ",
     "uninstalled ",
+    "downloading ",
     "downloaded ",
+    "building ",
+    "built ",
+    "updated ",
     "audited ",
     "using ",
     "creating ",
+    "warning:",
     "+ ",
     "- ",
 )
@@ -334,7 +342,8 @@ def _installer_diagnostics(stderr: str) -> str:
 
     uv renders failures several ways (`error:`, `× No solution found` with tree glyphs), so
     matching failure shapes misses some of them. Matching progress instead errs toward a
-    spurious warning rather than toward the silence this exists to prevent.
+    spurious warning rather than toward the silence this exists to prevent. All of this
+    goes away once the response carries an explicit failure flag to key on.
     """
     kept = [
         line

--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -277,6 +277,39 @@ class WindmillDebugger(bdb.Bdb):
         return {}
 
 
+PREPARE_DEPS_TIMEOUT_SECONDS = 120
+PREPARE_DEPS_PROGRESS_INTERVAL_SECONDS = 5
+
+
+@dataclass
+class PrepareResult:
+    """Outcome of dependency preparation: a venv path on success, a reason on failure."""
+
+    venv_path: str | None = None
+    error: str | None = None
+
+
+def _prepare_error_detail(response: dict) -> str:
+    """
+    Build the failure reason from a prepare-deps response.
+
+    `stderr` carries the installer's own output and is only present on newer workers, so
+    fall back to `error` alone when it is missing.
+    """
+    parts = [
+        str(response[key]).strip()
+        for key in ("error", "stderr")
+        if response.get(key) and str(response[key]).strip()
+    ]
+    return "\n".join(parts) or "unknown error"
+
+
+def _first_line(detail: str, limit: int = 300) -> str:
+    """Condense a multi-line failure into the single line a DAP response message allows."""
+    line = next((s.strip() for s in detail.splitlines() if s.strip()), detail.strip())
+    return line[:limit]
+
+
 class DebugSession:
     """Manages a single debug session."""
 
@@ -304,14 +337,16 @@ class DebugSession:
         self.seq += 1
         return seq
 
-    def prepare_dependencies(self, code: str) -> str | None:
+    def prepare_dependencies(self, code: str) -> PrepareResult:
         """
         Prepare Python dependencies by calling the windmill CLI.
-        Returns the path to the venv's site-packages directory, or None if no dependencies needed.
+
+        Blocks for as long as the install takes, so it must run off the event loop; use
+        `_prepare_dependencies_with_progress` instead of calling this directly.
         """
         if not self.windmill_path:
             logger.info("No windmill binary path configured, skipping dependency preparation")
-            return None
+            return PrepareResult()
 
         logger.info(f"Preparing dependencies using {self.windmill_path}")
 
@@ -328,7 +363,7 @@ class DebugSession:
                 input=input_data,
                 capture_output=True,
                 text=True,
-                timeout=120,  # 2 minute timeout for dependency installation
+                timeout=PREPARE_DEPS_TIMEOUT_SECONDS,
             )
 
             elapsed = time.time() - start_time
@@ -337,7 +372,10 @@ class DebugSession:
             if result.returncode != 0:
                 logger.error(f"prepare-deps failed (stderr): {result.stderr}")
                 logger.error(f"prepare-deps failed (stdout): {result.stdout}")
-                return None
+                detail = (result.stderr or "").strip() or (result.stdout or "").strip()
+                return PrepareResult(
+                    error=detail or f"windmill prepare-deps exited with code {result.returncode}"
+                )
 
             # Log raw output for debugging
             logger.debug(f"prepare-deps stdout: {result.stdout[:500] if result.stdout else '(empty)'}")
@@ -350,15 +388,18 @@ class DebugSession:
             json_start = output.find('{')
             if json_start == -1:
                 logger.error(f"No JSON in prepare-deps output: {output}")
-                return None
+                return PrepareResult(
+                    error=f"No JSON in prepare-deps output: {output[:500] or '(empty)'}"
+                )
 
             json_str = output[json_start:]
             response = json.loads(json_str)
             logger.debug(f"prepare-deps response: {response}")
 
             if not response.get("success"):
-                logger.error(f"prepare-deps error: {response.get('error')}")
-                return None
+                detail = _prepare_error_detail(response)
+                logger.error(f"prepare-deps error: {detail}")
+                return PrepareResult(error=detail)
 
             venv_path = response.get("venv_path")
             cached = response.get("cached", False)
@@ -371,18 +412,50 @@ class DebugSession:
             else:
                 logger.info("No external dependencies detected in code")
 
-            return venv_path
+            return PrepareResult(venv_path=venv_path)
 
         except subprocess.TimeoutExpired:
-            logger.error("prepare-deps timed out after 120s")
-            return None
+            message = f"prepare-deps timed out after {PREPARE_DEPS_TIMEOUT_SECONDS}s"
+            logger.error(message)
+            return PrepareResult(error=message)
         except json.JSONDecodeError as e:
+            raw = output[:500] if 'output' in dir() else '(not available)'
             logger.error(f"Failed to parse prepare-deps JSON output: {e}")
-            logger.error(f"Raw output was: {output[:500] if 'output' in dir() else '(not available)'}")
-            return None
+            logger.error(f"Raw output was: {raw}")
+            return PrepareResult(error=f"Failed to parse prepare-deps output: {e}\n{raw}")
         except Exception as e:
             logger.exception(f"Error preparing dependencies: {e}")
-            return None
+            return PrepareResult(error=f"Error preparing dependencies: {e}")
+
+    async def _prepare_dependencies_with_progress(self, code: str) -> PrepareResult:
+        """
+        Run dependency preparation on a worker thread, reporting progress while it runs.
+
+        The install can take minutes on a cold cache; on the event loop it would stall
+        websocket keepalive until it returns and block the progress events below.
+        """
+        await self.send_event(
+            "output", {"category": "stdout", "output": "Preparing dependencies...\n"}
+        )
+
+        task = asyncio.create_task(asyncio.to_thread(self.prepare_dependencies, code))
+        waited = 0
+        while True:
+            done, _ = await asyncio.wait(
+                {task}, timeout=PREPARE_DEPS_PROGRESS_INTERVAL_SECONDS
+            )
+            if done:
+                break
+            waited += PREPARE_DEPS_PROGRESS_INTERVAL_SECONDS
+            await self.send_event(
+                "output",
+                {
+                    "category": "stdout",
+                    "output": f"Still preparing dependencies... ({waited}s)\n",
+                },
+            )
+
+        return task.result()
 
     def _next_var_ref(self) -> int:
         ref = self._variables_ref_counter
@@ -521,7 +594,24 @@ class DebugSession:
 
         # Prepare dependencies before modifying the code
         if code:
-            self._venv_path = self.prepare_dependencies(code)
+            prepared = await self._prepare_dependencies_with_progress(code)
+            if prepared.error:
+                # Running the script regardless would surface only a bare ModuleNotFoundError,
+                # hiding why the install actually failed.
+                await self.send_event(
+                    "output",
+                    {
+                        "category": "stderr",
+                        "output": f"Failed to prepare dependencies:\n{prepared.error}\n",
+                    },
+                )
+                await self.send_response(
+                    request,
+                    success=False,
+                    message=f"Failed to prepare dependencies: {_first_line(prepared.error)}",
+                )
+                return
+            self._venv_path = prepared.venv_path
 
         # If callMain is True, append a call to main() with the provided args
         if self._call_main and code:

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -222,6 +222,8 @@ function generateMainCallArgs(code: string, args: Record<string, unknown>): stri
 const WINDMILL_BASE_URL = process.env.WINDMILL_BASE_URL || process.env.BASE_INTERNAL_URL // e.g., http://localhost:8000
 const REQUIRE_SIGNED_REQUESTS = process.env.REQUIRE_SIGNED_DEBUG_REQUESTS !== 'false'
 
+const PREPARE_DEPS_TIMEOUT_MS = 120_000
+
 // Opt-in cross-origin protection (CSWSH defense-in-depth); see
 // dap_debug_service.ts for the rationale. Only enforced for this file's
 // standalone Bun.serve entrypoint (the windmill-extra runtime imports the
@@ -1603,9 +1605,17 @@ export class DebugSession {
 				stderr: 'pipe'
 			})
 
+			// Bound the wait: the only other ceiling is the DAP client's launch timeout,
+			// which is minutes, so a wedged installer would hang the session that long.
+			const killTimer = setTimeout(() => {
+				logger.error(`prepare-deps timed out after ${PREPARE_DEPS_TIMEOUT_MS}ms`)
+				proc.kill()
+			}, PREPARE_DEPS_TIMEOUT_MS)
+
 			// Wait for completion
 			const output = await new Response(proc.stdout).text()
 			const stderr = await new Response(proc.stderr).text()
+			clearTimeout(killTimer)
 			logger.info(`prepare-deps output: ${output.substring(0, 200)}`)
 			logger.info(`prepare-deps stderr: ${stderr.substring(0, 200)}`)
 

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -1579,6 +1579,18 @@ export class DebugSession {
 
 		logger.info(`Preparing dependencies using ${this.windmillPath}`)
 
+		// The launch response is only sent once this returns, so without progress a cold
+		// cache looks like a frozen debugger for as long as the install takes.
+		this.sendEvent('output', { category: 'console', output: 'Preparing dependencies...\n' })
+		let waited = 0
+		const progress = setInterval(() => {
+			waited += 5
+			this.sendEvent('output', {
+				category: 'console',
+				output: `Still preparing dependencies... (${waited}s)\n`
+			})
+		}, 5000)
+
 		try {
 			const input = JSON.stringify({ code, language }) + '\n'
 			logger.info(`prepare-deps input length: ${input.length}`)
@@ -1648,6 +1660,8 @@ export class DebugSession {
 				output: `Warning: Failed to prepare dependencies: ${error}\n`
 			})
 			return null
+		} finally {
+			clearInterval(progress)
 		}
 	}
 

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -1592,6 +1592,8 @@ export class DebugSession {
 				output: `Still preparing dependencies... (${waited}s)\n`
 			})
 		}, 5000)
+		let killTimer: ReturnType<typeof setTimeout> | undefined
+		let timedOut = false
 
 		try {
 			const input = JSON.stringify({ code, language }) + '\n'
@@ -1607,7 +1609,8 @@ export class DebugSession {
 
 			// Bound the wait: the only other ceiling is the DAP client's launch timeout,
 			// which is minutes, so a wedged installer would hang the session that long.
-			const killTimer = setTimeout(() => {
+			killTimer = setTimeout(() => {
+				timedOut = true
 				logger.error(`prepare-deps timed out after ${PREPARE_DEPS_TIMEOUT_MS}ms`)
 				proc.kill()
 			}, PREPARE_DEPS_TIMEOUT_MS)
@@ -1615,7 +1618,16 @@ export class DebugSession {
 			// Wait for completion
 			const output = await new Response(proc.stdout).text()
 			const stderr = await new Response(proc.stderr).text()
-			clearTimeout(killTimer)
+
+			if (timedOut) {
+				const errorMsg = `prepare-deps timed out after ${PREPARE_DEPS_TIMEOUT_MS / 1000}s`
+				this.sendEvent('output', {
+					category: 'console',
+					output: `Warning: Failed to prepare dependencies: ${errorMsg}\n`
+				})
+				return null
+			}
+
 			logger.info(`prepare-deps output: ${output.substring(0, 200)}`)
 			logger.info(`prepare-deps stderr: ${stderr.substring(0, 200)}`)
 
@@ -1672,6 +1684,7 @@ export class DebugSession {
 			return null
 		} finally {
 			clearInterval(progress)
+			clearTimeout(killTimer)
 		}
 	}
 

--- a/debugger/test_dap_server.py
+++ b/debugger/test_dap_server.py
@@ -45,6 +45,10 @@ def main(x: str, count: int = 1):
 # Breakpoints for the main() test: lines 3 and 4 (inside main function)
 MAIN_BREAKPOINT_LINES = [3, 4]
 
+# `launch` waits on dependency installation, so the import test below needs far more than
+# the default budget on a cold cache.
+REQUEST_TIMEOUTS = {"launch": 180.0}
+
 
 class DAPTestClient:
     def __init__(self, url: str = "ws://localhost:5679"):
@@ -103,7 +107,7 @@ class DAPTestClient:
 
         # Wait for response with timeout
         try:
-            response = await asyncio.wait_for(future, timeout=10.0)
+            response = await asyncio.wait_for(future, timeout=REQUEST_TIMEOUTS.get(command, 10.0))
             return response
         except asyncio.TimeoutError:
             print(f"Timeout waiting for response to {command}")

--- a/frontend/src/lib/components/debug/dapClient.ts
+++ b/frontend/src/lib/components/debug/dapClient.ts
@@ -128,7 +128,13 @@ export class DAPClient {
 						logs: s.logs,
 						output: s.output
 					}))
+					// Reject rather than drop: a dropped `launch` leaves its caller awaiting
+					// until the timeout below fires, which is minutes rather than seconds.
+					const aborted = Array.from(this.pendingRequests.values())
 					this.pendingRequests.clear()
+					for (const pending of aborted) {
+						pending.reject(new Error('DAP connection closed'))
+					}
 				}
 
 				this.ws.onerror = (error) => {

--- a/frontend/src/lib/components/debug/dapClient.ts
+++ b/frontend/src/lib/components/debug/dapClient.ts
@@ -82,6 +82,14 @@ const initialState: DebugState = {
 
 export const debugState = writable<DebugState>({ ...initialState })
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000
+
+// `launch` waits on dependency installation in the debug server, which can take minutes on a
+// cold cache; anything shorter here reports a timeout while the install is still running.
+const REQUEST_TIMEOUT_MS_BY_COMMAND: Record<string, number> = {
+	launch: 180_000
+}
+
 export class DAPClient {
 	private ws: WebSocket | null = null
 	private seq = 1
@@ -164,11 +172,13 @@ export class DAPClient {
 			arguments: args
 		}
 
+		const timeoutMs = REQUEST_TIMEOUT_MS_BY_COMMAND[command] ?? DEFAULT_REQUEST_TIMEOUT_MS
+
 		return new Promise((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				this.pendingRequests.delete(seq)
-				reject(new Error(`Request timeout: ${command}`))
-			}, 10000)
+				reject(new Error(`Request timeout: ${command} (after ${timeoutMs}ms)`))
+			}, timeoutMs)
 
 			this.pendingRequests.set(seq, {
 				resolve: (value) => {


### PR DESCRIPTION
## Summary

Starting a Python debug session on a cold dependency cache failed with `Debugpy command timeout: launch`, followed by a bare `ModuleNotFoundError`. Those are one bug, not two: the launch waits on `windmill prepare-deps` (up to 120s), every client above it gave up after 10s, and when preparation failed the script was run anyway so the only thing the user ever saw was the missing import.

Three linked defects:

1. `prepare_dependencies()` was a blocking `subprocess.run` called from an async DAP handler. It stalled the event loop for the whole install, which also stalls websocket keepalive.
2. Both `dap_debug_service.ts` and `dapClient.ts` capped every command at 10s, including `launch`. 10s < 120s, so a slow install always lost.
3. Preparation failures returned `None` and the script ran regardless, so the real reason never reached the user.

## Changes

- **Off the event loop**: `prepare_dependencies` now runs via `asyncio.to_thread`, and `handle_launch` awaits it while streaming `Preparing dependencies...` / `Still preparing dependencies... (Ns)` output events every 5s, so a slow launch is visibly working rather than frozen.
- **Per-command timeouts** instead of raising the global 10s: `launch` gets 180s in `dap_debug_service.ts` and in `dapClient.ts`; every other command keeps the 10s default. The timeout value is now in the error message.
- **Failures are reported**, with the distinction that matters:
  - the installer reporting failure (non-zero exit, `success: false`, or a 120s timeout) fails the launch with the reason, instead of running into a `ModuleNotFoundError`;
  - failing to reach the CLI at all (no JSON, unparseable output, missing binary) warns and still runs, because it says nothing about whether the script's imports are satisfied and must not brick a session that would otherwise work.
- **Consumes `PrepareResponse.stderr` if present, degrades if absent** so it can land in either order relative to the sibling branch adding that field. It is read both on failure and on a `success: true` response, because `prepare_python_deps_standalone` currently swallows a non-zero `uv pip install` into `tracing::warn!` and still returns success (`prepare_deps.rs:246`) — which is exactly the unreachable-index case. Until that producer change lands, this surfaces the installer's own error as a warning before the import fails, rather than saying nothing.
- **Connection close now rejects in-flight requests** in both clients. With `launch` at 180s, a debug server dying mid-launch would otherwise leave the caller awaiting for three minutes instead of ten seconds.
- **Bun/TypeScript sessions emit the same progress**, since `dapClient.ts` is shared across languages and that path also blocks the launch response on `prepare-deps` — without this it would sit silent for up to 180s where it used to error at 10s.
- `test_dap_server.py` had the identical 10s cap, which is why its `run_import_test()` could never reproduce this on a cold cache.

## Merge notes

Scoped to stay clear of the sibling branch editing `spawnProcess()` in `dap_debug_service.ts` — the edits here are at lines 492-560 and 805-815 and do not touch it.

## Test plan

Verified with a stub `windmill prepare-deps` driving a real DAP server and the real debug service over websockets:

- [x] **Slow success (12s install)** completes end-to-end, progress streams at 5s/10s, script output arrives. Against the pre-fix service the same run fails at 10.2s with `Debugpy command timeout: launch` — the reported error, reproduced and fixed.
- [x] **Event loop stays free**: websocket ping round-trips in 0.001s during preparation; pre-fix it took 4.0s (the remainder of the blocking call).
- [x] **`success: false` with `stderr`** fails the launch and shows the installer error; **without `stderr`** shows the `error` field alone (both sibling orderings).
- [x] **Non-zero exit / no JSON** reports the stderr rather than a generic failure.
- [x] **`success: true` carrying installer stderr** warns, then still runs the script.
- [x] **Missing `--windmill` binary** warns and still runs a stdlib-only script (no regression for working sessions).
- [x] **Python server killed mid-launch** surfaces `Debugpy connection closed` at 8.8s instead of hanging to 180s.
- [x] **Bun/TypeScript session** streams the same progress and completes a 12s launch.
- [x] `npm run check:fast` clean; `bun build` clean; `python -m py_compile` clean.

### Screenshots

None: the `frontend/` diff is a timeout map plus a promise-rejection on socket close in `dapClient.ts`, with no visual surface of its own. The user-visible strings this PR adds (progress lines, failure reasons) originate in the debugger servers and were exercised end-to-end over the real DAP protocol as above, but not in a browser — no backend or dev server is running for this worktree, and reaching the debug console needs both plus a configured debug-service URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python debugger launches that timed out on cold caches by moving dependency install off the event loop, streaming progress, and surfacing real `uv`/installer errors. `launch` now has a longer per-command timeout so slow installs don’t fail early, and failed launches are cleaned up.

- **Bug Fixes**
  - Run dependency preparation in a worker thread and keep websockets responsive; emit “Preparing dependencies…” and progress every 5s.
  - Use per-command timeouts: `launch` is 180s; others stay 10s. Include the timeout value in error messages.
  - Report installer failures (non‑zero exit, `success: false`, or 120s timeout) and stop the launch with the reason, instead of falling into `ModuleNotFoundError`.
  - If the CLI can’t be reached or output is unparseable/missing, warn and run anyway to avoid blocking valid sessions.
  - Read `stderr` from prepare responses even on success; strip routine `uv` progress lines (including build, download, and warning lines) and surface only meaningful installer errors.
  - Reject pending requests when the DAP or `debugpy` connection closes; on launch failure, send `terminated` immediately and clean up to reap the server and temp dir.
  - Bun/TypeScript sessions stream the same preparation progress and bound prepare‑deps at 120s to prevent indefinite hangs.
  - Test client increases `launch` timeout to 180s to cover cold-cache installs.

<sup>Written for commit 92774211bb7083d86b5a12bbbfe2114029a847c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

