### PR TITLE
fix: start python debug sessions whose script has third-party imports

### DIFF
--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -301,56 +301,16 @@ def _prepare_error_detail(response: dict) -> str:
     """
     Build the failure reason from a prepare-deps response.
 
-    `install_stderr` is the installer's raw output and is only present on newer workers;
-    `error` wraps the same text in a sentence, so take whichever is available rather than
-    both, which would print the installer's output twice.
+    `error` is the installer's own output prefixed with the step that failed, and
+    `install_stderr` is that same output unprefixed, so take one rather than both: joining
+    them prints the installer's output twice, and the prefix is what tells a reader whether
+    the venv or the install was what went wrong.
     """
-    for key in ("install_stderr", "error"):
+    for key in ("error", "install_stderr"):
         detail = str(response.get(key) or "").strip()
         if detail:
             return detail
     return "unknown error"
-
-
-# Prefixes uv uses for routine resolve/install progress, which it writes to stderr on a
-# perfectly successful run. `warning:` belongs here because uv's warnings are non-fatal by
-# construction (the hardlink fallback fires whenever the cache and the venv are on
-# different filesystems, which is the normal layout). The `+`/`-` forms are the
-# per-package change list.
-_INSTALLER_PROGRESS_PREFIXES = (
-    "resolved ",
-    "prepared ",
-    "installed ",
-    "uninstalled ",
-    "downloading ",
-    "downloaded ",
-    "building ",
-    "built ",
-    "updated ",
-    "audited ",
-    "using ",
-    "creating ",
-    "warning:",
-    "+ ",
-    "- ",
-)
-
-
-def _installer_diagnostics(stderr: str) -> str:
-    """
-    Strip an installer's routine progress from its stderr, keeping anything unexplained.
-
-    uv renders failures several ways (`error:`, `× No solution found` with tree glyphs), so
-    matching failure shapes misses some of them. Matching progress instead errs toward a
-    spurious warning rather than toward the silence this exists to prevent. All of this
-    goes away once the response carries an explicit failure flag to key on.
-    """
-    kept = [
-        line
-        for line in stderr.splitlines()
-        if line.strip() and not line.strip().lower().startswith(_INSTALLER_PROGRESS_PREFIXES)
-    ]
-    return "\n".join(kept).strip()
 
 
 def _first_line(detail: str, limit: int = 300) -> str:
@@ -469,14 +429,7 @@ class DebugSession:
             else:
                 logger.info("No external dependencies detected in code")
 
-            # `uv pip install` failing for individual packages does not fail the whole
-            # response, so a "successful" preparation can still carry the reason an import
-            # is about to fail.
-            installer_error = _installer_diagnostics(str(response.get("install_stderr") or ""))
-            if installer_error:
-                logger.warning(f"prepare-deps reported an installer error: {installer_error}")
-
-            return PrepareResult(venv_path=venv_path, error=installer_error or None)
+            return PrepareResult(venv_path=venv_path)
 
         except subprocess.TimeoutExpired:
             message = f"prepare-deps timed out after {PREPARE_DEPS_TIMEOUT_SECONDS}s"

--- a/debugger/dap_websocket_server.py
+++ b/debugger/dap_websocket_server.py
@@ -301,15 +301,15 @@ def _prepare_error_detail(response: dict) -> str:
     """
     Build the failure reason from a prepare-deps response.
 
-    `stderr` carries the installer's own output and is only present on newer workers, so
-    fall back to `error` alone when it is missing.
+    `install_stderr` is the installer's raw output and is only present on newer workers;
+    `error` wraps the same text in a sentence, so take whichever is available rather than
+    both, which would print the installer's output twice.
     """
-    parts = [
-        str(response[key]).strip()
-        for key in ("error", "stderr")
-        if response.get(key) and str(response[key]).strip()
-    ]
-    return "\n".join(parts) or "unknown error"
+    for key in ("install_stderr", "error"):
+        detail = str(response.get(key) or "").strip()
+        if detail:
+            return detail
+    return "unknown error"
 
 
 # Prefixes uv uses for routine resolve/install progress, which it writes to stderr on a
@@ -398,7 +398,7 @@ class DebugSession:
             # The debug service installs dependencies itself so that the registry credentials
             # the CLI needs never enter this interpreter, which executes the debugged script.
             logger.info(f"Using dependencies prepared by the debug service: {self._prepared_venv_path}")
-            return self._prepared_venv_path
+            return PrepareResult(venv_path=self._prepared_venv_path)
 
         if not self.windmill_path:
             logger.info("No windmill binary path configured, skipping dependency preparation")
@@ -472,7 +472,7 @@ class DebugSession:
             # `uv pip install` failing for individual packages does not fail the whole
             # response, so a "successful" preparation can still carry the reason an import
             # is about to fail.
-            installer_error = _installer_diagnostics(str(response.get("stderr") or ""))
+            installer_error = _installer_diagnostics(str(response.get("install_stderr") or ""))
             if installer_error:
                 logger.warning(f"prepare-deps reported an installer error: {installer_error}")
 


### PR DESCRIPTION
## Summary

#10531 and #10533 merged three minutes apart, both editing `prepare_dependencies()` in `debugger/dap_websocket_server.py`. They merged without a textual conflict into a type error:

- #10531 changed the function to return a `PrepareResult` dataclass.
- #10533 added a short-circuit returning `self._prepared_venv_path`, a bare `str`, for the case where the debug service already built the venv and passed `--venv-path`.

`handle_launch` then reads `prepared.error` on that `str` and raises `AttributeError`. The service never passes `--windmill` and always passes `--venv-path` once it has prepared a venv, so this is not an edge case: **every** Python debug session whose script imports a third-party package hits it. The session shows `Preparing dependencies...`, hangs, and dies three minutes later with

```
Debugpy command timeout: launch (after 180000ms)
```

which is verbatim the error #10531 was written to eliminate, now at 180s instead of 10s. Stdlib-only scripts and the whole TypeScript/Bun path are unaffected, which is why it wasn't obvious.

Two smaller defects from the same sibling-branch split are in the blast radius. The Python consumer reads a `stderr` key; the field the CLI serializes is `install_stderr` (`PrepareResponse`, `skip_serializing_if = "Option::is_none"`), which is what the service's own consumer in `dap_debug_service.ts` already reads. And the installer-diagnostics pass over a `success: true` response is unreachable: every `success: true` site in `prepare_deps.rs` sets `install_stderr: None`. It existed to work around a producer that warned and returned success on a failed `uv pip install`; #10533 made that producer return `success: false`, so the workaround is obsolete rather than merely inert.

## Changes

- `prepare_dependencies()` returns `PrepareResult(venv_path=...)` from the service-prepared short-circuit, so it satisfies its own annotation on every path.
- `_prepare_error_detail` reads `install_stderr` rather than the nonexistent `stderr`, and takes one field rather than joining two: `error` is the same installer output prefixed with the step that failed, so joining printed it twice. `error` is preferred because `_first_line` feeds this into the DAP response message, and the raw stderr begins with uv's `Using Python ... environment at:` progress line, which reads like success on a refused launch.
- Dropped the unreachable installer-diagnostics pass on the success branch, along with `_installer_diagnostics` and `_INSTALLER_PROGRESS_PREFIXES`, which had no other callers. Its comment also asserted the opposite of what `prepare_deps.rs` documents about atomic installs.

## Not in scope

Moving the install into the service left two behaviours reachable only in the server's standalone mode, both worth a follow-up and neither a regression this PR introduces:

- No progress is emitted during the real install. The service installs before spawning the Python server and sends no events, so a cold cache is a silent console for up to `DAP_PREPARE_DEPS_TIMEOUT_MS`; the `Preparing dependencies...` line the user sees arrives afterwards, from the server.
- A known install failure no longer refuses the launch on the service path. The service emits an `output` event and starts the session anyway, so the user gets the installer's reason *and* a `ModuleNotFoundError`, and the two events arrive out of order. That reporting site (`dap_debug_service.ts`, `response.install_stderr || response.error`) also prefers the unprefixed installer output, so it wants the same `error`-first ordering this PR applies on the Python side.

## Test plan

Driven against a real `dap_debug_service.ts`, a real `windmill prepare-deps` built from this tree, and the real Python DAP server.

- [x] **Service path, third-party import** (`import tabulate`): completes in ~0.6s, `tabulate 0.10.0` imported from the service-built venv, result returned. Against the unfixed tree the identical run hangs and fails at 180.4s with `Debugpy command timeout: launch` — the reported symptom, reproduced and fixed.
- [x] **Breakpoints and inspection on that path**: paused at `main:7`, stack `main:7 / <module>:15`, locals populated, `evaluate("tabulate.__version__")` → `'0.10.0'`, step and continue to completion.
- [x] **Through the editor** with the real signed-token flow (`ws_base_url` pointed at a local service, backend JWKS): breakpoint hit, variables and call stack populated, resume prints `PY: tabulate 0.10.0` and returns the result. Reverting the one-line fix reproduces the hang in the same UI.
- [x] **Standalone, unresolvable package**: launch refused with `success: false` at 0.28s, message `Failed to prepare dependencies: uv pip install failed: Using Python 3.12.13 environment at: venv`, and uv's full `No solution found` diagnostic in the console once, not twice. Without the `error`-first ordering the message instead began `Using Python 3.12.13 environment at: venv`.
- [x] **Standalone, successful install**: unchanged after removing the dead branch.
- [x] **Stdlib-only script**: unchanged (no venv produced, no `--venv-path`).
- [x] **TypeScript/Bun session** (`import lodash`): unaffected, completes in ~0.3s.
- [x] `python -m py_compile` clean; no remaining references to the removed helpers.

## Screenshots

Same script and breakpoint in both, through the script editor's debug console.

Before, on `main` — the session never starts and nothing else ever appears:

![hung-session](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/debugger-prepared-venv-result/1785937133-hung-session.png)

After — paused at the breakpoint, with `rows`, `table` and the imported `tabulate` module in the variables panel:

![paused-at-breakpoint](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/debugger-prepared-venv-result/1785937172-paused-at-breakpoint.png)

## Note on tests

Nothing under `debugger/` runs in CI — no workflow references the directory, and `test_dap_server.py` / `test_debug_service.ts` are manual clients needing a running server. A `str` returned from a `-> PrepareResult` function is what a type checker catches, not a test; standing up a pytest harness for a one-line return-type fix is more scaffolding than the fix warrants, so none is shipped. The Rust side already pins the wire shape this branch renames to (`test_install_stderr_is_additive`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python debug sessions that use third-party imports by ensuring dependency prep always returns a `PrepareResult`, preventing the 180s launch timeout and hung sessions. Error handling now reads the correct fields for clearer failure messages.

- **Bug Fixes**
  - Always return `PrepareResult(venv_path=...)` when the service provides `--venv-path`, fixing the `AttributeError` and timeout.
  - Read `error` or `install_stderr` (not `stderr`) for failure detail, preferring `error` to keep the failing step.
  - Removed unreachable installer-diagnostics path and related helpers.

<sup>Written for commit 1f003bd15757019c3822b3af22f13e4b85d2a9a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


