### PR TITLE
fix: point re-opened previews at the tab already showing them

### DIFF
--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -143,8 +143,10 @@
 
 	let flashing = $state(false)
 	let flashTimer: ReturnType<typeof setTimeout> | undefined
-	// Guard against the effect's non-pulse reruns (tab/runtime changes) firing a flash.
-	let lastPulseNonce = -1
+	// Guard against the effect's non-pulse reruns (tab/runtime changes) firing a
+	// flash. Seeded from the current nonce: a pulse from before this host mounted
+	// is moot, the tab appearing is itself the change the flash would point at.
+	let lastPulseNonce = runtime?.previewTabs.focusPulse.nonce ?? -1
 	$effect(() => {
 		const pulse = runtime?.previewTabs.focusPulse
 		if (!pulse || pulse.nonce === lastPulseNonce) return
@@ -242,13 +244,6 @@
 		{:else if !runtime?.manager.artifacts.loading}
 			<div class="p-4 text-sm text-tertiary">This artifact is no longer available.</div>
 		{/if}
-		<!-- Overlay: the source editor's opaque bg would cover a ring on the container. -->
-		<div
-			class="pointer-events-none absolute inset-0 z-30 ring-2 ring-inset ring-border-accent transition-opacity duration-300 {flashing
-				? 'opacity-100'
-				: 'opacity-0'}"
-			aria-hidden="true"
-		></div>
 	</div>
 {:else if mounted}
 	<iframe
@@ -265,3 +260,15 @@
 		class="absolute inset-0 w-full h-full border-0 bg-surface {visibility}"
 	></iframe>
 {/if}
+
+<!-- Flash ring, a sibling of every tab body rather than a child of one: an
+     editor's own opaque background (or an iframe's document) would paint over a
+     ring drawn inside it. Sits above the active body's z-10, and stays
+     transparent while this tab is not the displayed one. -->
+<div
+	class="pointer-events-none absolute inset-0 z-30 ring-2 ring-inset ring-border-accent transition-opacity duration-300 {flashing &&
+	active
+		? 'opacity-100'
+		: 'opacity-0'}"
+	aria-hidden="true"
+></div>

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -263,8 +263,7 @@
 
 <!-- Flash ring, a sibling of every tab body rather than a child of one: an
      editor's own opaque background (or an iframe's document) would paint over a
-     ring drawn inside it. Sits above the active body's z-10, and stays
-     transparent while this tab is not the displayed one. -->
+     ring drawn inside it. -->
 <div
 	class="pointer-events-none absolute inset-0 z-30 ring-2 ring-inset ring-border-accent transition-opacity duration-300 {flashing &&
 	active

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -228,10 +228,40 @@ export class SessionPreviewTabs {
 		this.#schedulePersist()
 	}
 
+	// The tab the user is actually looking at, or undefined when the panel is
+	// collapsed and nothing is on screen.
+	#displayedTab(): SessionPreviewTab | undefined {
+		return this.#collapsed ? undefined : this.#tabs.find((t) => t.id === this.#activeId)
+	}
+
+	// Run a tab mutation, flashing the displayed tab's border when it left the
+	// panel showing exactly what it already showed. Re-opening a destination that
+	// is already on screen is otherwise indistinguishable from a dead click.
+	#pulsingIfUnchanged<T>(mutate: () => T): T {
+		const before = this.#displayedTab()
+		const shown = before && { id: before.id, url: before.url, loc: before.loc }
+		const result = mutate()
+		const after = this.#displayedTab()
+		if (
+			shown &&
+			after &&
+			after.id === shown.id &&
+			after.url === shown.url &&
+			after.loc === shown.loc
+		) {
+			this.pulseFocus(after.id)
+		}
+		return result
+	}
+
 	// Open — or focus, if already shown — a tab for a destination, and reveal the
 	// panel. An editable item dedupes against the tab already hosting that same
 	// (kind, path); anything else dedupes on the tab's observed location.
 	open(target: PreviewTarget): { status: 'opened' | 'focused' } {
+		return this.#pulsingIfUnchanged(() => this.#open(target))
+	}
+
+	#open(target: PreviewTarget): { status: 'opened' | 'focused' } {
 		const editorTarget = editorTargetFor(target)
 		// A fresh session starts collapsed, so without this the tab opens behind a
 		// collapsed panel and the user sees nothing change.
@@ -276,8 +306,12 @@ export class SessionPreviewTabs {
 		}
 		// Focus the tab currently *showing* this destination instead of opening a
 		// duplicate. Matched on the observed `loc`, not `url`: a tab that was
-		// opened here but navigated away no longer counts as showing it.
-		const shown = this.#tabs.find((t) => t.loc === url)
+		// opened here but navigated away no longer counts as showing it. Both sides
+		// are canonicalized because a caller may bake `?workspace=` into the href
+		// (the frame re-injects it from the session anyway) while the observed loc
+		// has had it stripped — comparing raw would reopen the page as a duplicate.
+		const canonicalUrl = canonicalizeObservedLoc(url)
+		const shown = this.#tabs.find((t) => canonicalizeObservedLoc(t.loc) === canonicalUrl)
 		if (shown) {
 			this.#activeId = shown.id
 			this.#flush()
@@ -294,6 +328,10 @@ export class SessionPreviewTabs {
 	// Re-point the active tab at a destination (breadcrumb pick / in-editor link /
 	// iframe-posted editor navigation).
 	navigate(target: PreviewTarget): void {
+		this.#pulsingIfUnchanged(() => this.#navigate(target))
+	}
+
+	#navigate(target: PreviewTarget): void {
 		const t = this.#tabs.find((x) => x.id === this.#activeId)
 		if (!t) return
 		const editorTarget = editorTargetFor(target)

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -172,6 +172,11 @@ export class SessionPreviewTabs {
 	#reloadPulse = $state({ id: '', nonce: 0 })
 	// Set while a mutation sequence is being judged as a whole (see asOneChange).
 	#pulsing = false
+	// Fullscreen overrides the collapsed layout, so the panel can be on screen
+	// while `#collapsed` still says otherwise. Page-level state (it outlives a
+	// session switch, unlike the persisted per-session flag), pushed in here so
+	// the flash decision reads what the user can actually see.
+	#fullscreen = false
 	readonly #adapter: PreviewTabsAdapter
 	readonly #flushDelay: number
 	#flushHandle: ReturnType<typeof setTimeout> | undefined
@@ -234,16 +239,22 @@ export class SessionPreviewTabs {
 		this.#schedulePersist()
 	}
 
-	// The tab the user is actually looking at, or undefined when the panel is
-	// collapsed and nothing is on screen.
+	// Whether the panel is on screen at all — fullscreen wins over collapsed.
+	setFullscreen(fullscreen: boolean): void {
+		this.#fullscreen = fullscreen
+	}
+
+	// The tab the user is actually looking at, or undefined when nothing is on screen.
 	#displayedTab(): SessionPreviewTab | undefined {
-		return this.#collapsed ? undefined : this.#tabs.find((t) => t.id === this.#activeId)
+		if (this.#collapsed && !this.#fullscreen) return undefined
+		return this.#tabs.find((t) => t.id === this.#activeId)
 	}
 
 	// Run a caller's own multi-call sequence (select + navigate + reveal) as a
 	// single change for the flash decision. Judging each call separately would
 	// flash a tab the sequence had just switched to, since the step that made it
-	// visible is not the step that finds nothing left to change.
+	// visible is not the step that finds nothing left to change. `mutate` must be
+	// synchronous: the verdict is read the moment it returns.
 	asOneChange<T>(mutate: () => T): T {
 		return this.#pulsingIfUnchanged(mutate)
 	}

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -59,13 +59,17 @@ function targetUrl(target: PreviewTarget): string {
 // Point a tab at a new destination. Clears `friendlyLabel`/`friendlyPath`
 // (bound to the previous editor's item): a new editor re-stamps them, and
 // navigating to a plain page must drop the stale name so the tab falls back
-// to the location label.
+// to the location label. Only on an actual change of destination, though —
+// nothing re-stamps a tab that stays on the item it already hosts, so wiping
+// there would strand its label at the storage path (`…/draft_<uuid>`).
 function retargetTab(tab: SessionPreviewTab, url: string): void {
+	if (tab.url !== url) {
+		tab.friendlyLabel = undefined
+		tab.friendlyPath = undefined
+		tab.editorNamed = undefined
+	}
 	tab.url = url
 	tab.loc = url
-	tab.friendlyLabel = undefined
-	tab.friendlyPath = undefined
-	tab.editorNamed = undefined
 }
 
 // Strip the query params the sessions preview injects into iframe URLs
@@ -166,6 +170,8 @@ export class SessionPreviewTabs {
 	// Ephemeral UI signals — not part of the persisted snapshot.
 	#focusPulse = $state({ id: '', nonce: 0 })
 	#reloadPulse = $state({ id: '', nonce: 0 })
+	// Set while a mutation sequence is being judged as a whole (see asOneChange).
+	#pulsing = false
 	readonly #adapter: PreviewTabsAdapter
 	readonly #flushDelay: number
 	#flushHandle: ReturnType<typeof setTimeout> | undefined
@@ -234,10 +240,30 @@ export class SessionPreviewTabs {
 		return this.#collapsed ? undefined : this.#tabs.find((t) => t.id === this.#activeId)
 	}
 
+	// Run a caller's own multi-call sequence (select + navigate + reveal) as a
+	// single change for the flash decision. Judging each call separately would
+	// flash a tab the sequence had just switched to, since the step that made it
+	// visible is not the step that finds nothing left to change.
+	asOneChange<T>(mutate: () => T): T {
+		return this.#pulsingIfUnchanged(mutate)
+	}
+
 	// Run a tab mutation, flashing the displayed tab's border when it left the
 	// panel showing exactly what it already showed. Re-opening a destination that
 	// is already on screen is otherwise indistinguishable from a dead click.
 	#pulsingIfUnchanged<T>(mutate: () => T): T {
+		// Already inside a sequence: that outer call owns the decision, and an
+		// inner open()/navigate() must not rule on its own slice of it.
+		if (this.#pulsing) return mutate()
+		this.#pulsing = true
+		try {
+			return this.#pulseIfSameDestination(mutate)
+		} finally {
+			this.#pulsing = false
+		}
+	}
+
+	#pulseIfSameDestination<T>(mutate: () => T): T {
 		const before = this.#displayedTab()
 		const shown = before && { id: before.id, url: before.url, loc: before.loc }
 		const result = mutate()

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -700,6 +700,39 @@ describe('SessionPreviewTabs.pulseFocus', () => {
 		expect(o.focusPulse.nonce).toBe(3)
 	})
 
+	it('judges a composed select+navigate as one change', () => {
+		const o = owner()
+		o.open(pageTarget)
+		const runs = o.tabs[0].id
+		o.open(rawAppTarget)
+		expect(o.focusPulse.nonce).toBe(0)
+		// open_page reusing a *background* page tab: the switch is the visible change.
+		o.asOneChange(() => {
+			o.select(runs)
+			o.navigate(pageTarget)
+		})
+		expect(o.focusPulse.nonce).toBe(0)
+		// Same sequence once that tab is already displayed: nothing changes, so flash.
+		o.asOneChange(() => {
+			o.select(runs)
+			o.navigate(pageTarget)
+		})
+		expect(o.focusPulse).toEqual({ id: runs, nonce: 1 })
+	})
+
+	it('keeps the editor-stamped label when re-pointed at the same item', () => {
+		const o = owner()
+		o.open(scriptTarget)
+		o.setEditorFriendlyLabel({ kind: 'script', path: 'u/me/foo' }, 'My script', 'u/me/staged')
+		// Nothing re-stamps a tab that never changed item, so a wipe here would be
+		// permanent — and would make the "nothing changed" flash a lie.
+		o.navigate(scriptTarget)
+		expect(o.tabs[0].friendlyLabel).toBe('My script')
+		expect(o.tabs[0].friendlyPath).toBe('u/me/staged')
+		o.navigate(flowTarget)
+		expect(o.tabs[0].friendlyLabel).toBeUndefined()
+	})
+
 	it('focuses (and flashes) a run tab whose href carries ?workspace=', () => {
 		const o = owner()
 		const run: PreviewTarget = {

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -700,6 +700,17 @@ describe('SessionPreviewTabs.pulseFocus', () => {
 		expect(o.focusPulse.nonce).toBe(3)
 	})
 
+	it('still flashes a collapsed-but-fullscreen panel', () => {
+		const o = owner()
+		o.open(rawAppTarget)
+		o.setCollapsed(true)
+		// Fullscreen carries over from the previous session and overrides collapse,
+		// so the tab is on screen and a re-open of it changes nothing visible.
+		o.setFullscreen(true)
+		o.open(rawAppTarget)
+		expect(o.focusPulse.nonce).toBe(1)
+	})
+
 	it('judges a composed select+navigate as one change', () => {
 		const o = owner()
 		o.open(pageTarget)

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -681,4 +681,51 @@ describe('SessionPreviewTabs.pulseFocus', () => {
 		o.pulseFocus('tab-b')
 		expect(o.focusPulse).toEqual({ id: 'tab-b', nonce: 3 })
 	})
+
+	it('fires on re-opening whatever the panel already displays, for any tab kind', () => {
+		const o = owner()
+		o.open(rawAppTarget)
+		expect(o.focusPulse.nonce).toBe(0)
+		o.open(rawAppTarget)
+		expect(o.focusPulse).toEqual({ id: o.activeId, nonce: 1 })
+		// A second tab taking over is its own visible change.
+		o.open(pageTarget)
+		expect(o.focusPulse.nonce).toBe(1)
+		o.open(pageTarget)
+		expect(o.focusPulse).toEqual({ id: o.activeId, nonce: 2 })
+		// Re-pointing the displayed tab elsewhere changes what is on screen.
+		o.navigate(scriptTarget)
+		expect(o.focusPulse.nonce).toBe(2)
+		o.navigate(scriptTarget)
+		expect(o.focusPulse.nonce).toBe(3)
+	})
+
+	it('focuses (and flashes) a run tab whose href carries ?workspace=', () => {
+		const o = owner()
+		const run: PreviewTarget = {
+			type: 'page',
+			href: `${base}/run/job-1?workspace=fork`,
+			label: 'Run'
+		}
+		o.open(run)
+		// What the frame reports back has the injected params stripped.
+		o.observeLocation(o.activeId, `${base}/run/job-1?workspace=fork&nomenubar=true`)
+		expect(o.tabs.length).toBe(1)
+		expect(o.open(run).status).toBe('focused')
+		expect(o.tabs.length).toBe(1)
+		expect(o.focusPulse.nonce).toBe(1)
+	})
+
+	it('stays quiet when the re-open is what reveals the tab', () => {
+		const o = owner()
+		o.open(rawAppTarget)
+		o.setCollapsed(true)
+		// Un-collapsing onto the same tab is already visible.
+		o.open(rawAppTarget)
+		expect(o.focusPulse.nonce).toBe(0)
+		// Switching back to a background tab is too.
+		o.open(pageTarget)
+		o.open(rawAppTarget)
+		expect(o.focusPulse.nonce).toBe(0)
+	})
 })

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -482,14 +482,7 @@ function createRuntime(session: Session): SessionRuntime {
 	}
 
 	manager.openArtifact = (id, name) => {
-		// Capture before open() un-collapses / re-activates: flash only when the tab
-		// was already the displayed one (nothing else visibly changes).
-		const wasDisplayed = !previewTabs.collapsed
-		const prevActive = previewTabs.activeId
-		const { status } = previewTabs.open({ type: 'artifact', id, name })
-		if (status === 'focused' && wasDisplayed && previewTabs.activeId === prevActive) {
-			previewTabs.pulseFocus(previewTabs.activeId)
-		}
+		previewTabs.open({ type: 'artifact', id, name })
 	}
 	manager.closeArtifact = (id) => previewTabs.closeArtifact(id)
 	// Key the store before any configureGlobalMode runs, so a new session's first create shows at once.

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -1047,9 +1047,13 @@ setOpenPagePreviewHandler(({ sessionId: callerSessionId, href, label, newTab }) 
 			// would silently not re-fire — force a load. Hashless targets need no
 			// reload: focusing the already-correct view is enough.
 			const unchanged = href.includes('#') && (existing.loc || existing.url) === href
-			owner.select(existing.id)
-			owner.navigate({ type: 'page', href, label })
-			owner.setCollapsed(false)
+			// One change, not three: switching to a background tab is already visible,
+			// so the navigate that follows must not read as "nothing happened".
+			owner.asOneChange(() => {
+				owner.select(existing.id)
+				owner.navigate({ type: 'page', href, label })
+				owner.setCollapsed(false)
+			})
 			if (unchanged) {
 				owner.pulseReload(existing.id)
 				return `Re-opened the ${label} preview tab on the requested view.`

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -318,6 +318,12 @@
 	let emptyStateNewTabOpen = $state(false)
 
 	let fullscreen = $state(false)
+	// Fullscreen is page state, not per-session, so it outlives a session switch —
+	// tell the incoming session's model, whose own collapsed flag it overrides, or
+	// re-opening the item plainly on screen would be judged invisible and not flash.
+	$effect(() => {
+		owner?.setFullscreen(fullscreen)
+	})
 	// Collapse the preview panel to give the chat the full width. Per-session and
 	// owned by the runtime's previewTabs (restored on switch, written back on
 	// toggle) so it survives session switches with the rest of the tab model.

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -477,8 +477,7 @@
 	// (or focus, if already shown) the item's preview in the active session's panel —
 	// the visible chat is always the active session, so `owner` is its panel. Read
 	// `owner` lazily inside the handler (not in the effect body) so this registers
-	// once, not on every session switch. A 'focused' open leaves the tab where it is,
-	// so pulse it to make the click visibly land.
+	// once, not on every session switch.
 	$effect(() => {
 		return registerToolDisplayActionHandler('open_item_preview', (action) => {
 			if (action.type !== 'open_item_preview') return
@@ -486,8 +485,7 @@
 			if (!o) return
 			const target = previewTargetForSessionTarget(action.previewKind, action.path)
 			if (!target) return
-			const { status } = o.open(target)
-			if (status === 'focused') o.pulseFocus(o.activeId)
+			o.open(target)
 		})
 	})
 


### PR DESCRIPTION
## Summary

In AI sessions, re-opening something that is already in the preview panel gave no feedback. Clicking an artifact chip flashed the preview border to say "it's already here, look" — but clicking the Preview chip for an app, script, flow or page did nothing visible at all, so the click read as dead.

The pulse itself was firing for those cases. The flash ring simply did not exist for them: it was markup nested **inside** the `artifact` branch of `PreviewTabHost`, so an editor or iframe tab had nothing to light up.

Working on that surfaced a second, related bug: a run re-opened from the jobs tray spawned a duplicate tab instead of focusing the one already showing it.

## Changes

- **Render the flash ring for every tab kind.** Hoisted it out of the artifact branch to a sibling of every tab body. It has to be a sibling rather than a child — an editor's opaque background (or an iframe's document) paints over a ring drawn inside it.
- **Move the "should this flash?" decision into the model.** `SessionPreviewTabs` now snapshots the displayed tab around `open()` and `navigate()` and pulses only when the mutation left the panel showing exactly what it already showed. Two hand-rolled copies of that rule (artifacts in `sessionRuntime`, the tool-chip handler in `+page.svelte`) are gone, so every re-open path is covered: artifact chips, the chat's Preview chip, the `open_preview` / `open_page` tools, the jobs tray, the tab picker, breadcrumb picks and in-editor links.
- **`asOneChange(fn)`** for callers that reach a destination through their own sequence. `open_page`'s reuse branch does `select` → `navigate` → reveal; judged per call, the switch to a background tab would be followed by a `navigate` that finds nothing left to change and flashes a tab the user had just been moved to.
- **Fix duplicate run tabs.** Callers bake `?workspace=` into a run href, while a tab's observed `loc` has it stripped by `canonicalizeObservedLoc` — so the dedupe compared `/run/<id>?workspace=x` against `/run/<id>` and never matched. Both sides are now canonicalized in `open()`. Both trigger paths (jobs tray, in-iframe run click) bake the param in, which is why this belongs at the comparison rather than the call sites.
- **`retargetTab` no longer wipes a tab's editor-stamped label when the destination is unchanged.** Nothing re-stamps a tab that never left its item, so the wipe was permanent — a draft's label fell back to its `…/draft_<uuid>` storage path.

## Screenshots

Re-opening an app preview that is **already displayed**, via the tab-strip picker. `open()` returns `focused`, nothing about the panel changes, so the border flashes to say "it's already here". This is the case that could not flash at all before: the ring lived inside the `artifact` branch, so an app tab had nothing to light up.

| before / after the flash | mid-flash |
|---|---|
| ![32-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ah-artifact-preview-pulse/1785938528-32-after.png) | ![31-flash](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ah-artifact-preview-pulse/1785938531-31-flash.png) |

Captured from a real pulse (the ring's class was observed flipping `opacity-100` → `opacity-0`), not a forced style.

## Test plan

- [ ] With a script, flow or app displayed in the preview, re-open that same item (chat Preview chip, `open_preview`, or the tab picker): the tab stays put and its border flashes once, with no second tab.
- [ ] Same for an artifact and for a plain page tab (Runs/Schedules).
- [ ] Open a run from the jobs tray twice: one tab, flashing on the second click, and the run page inside it scoped to the session's workspace.
- [ ] With two tabs open, re-open the one sitting in the background: it becomes active **without** flashing — the switch is itself the visible change.
- [ ] Collapse the panel, then re-open the tab it was showing: it reveals without flashing.
- [ ] Re-open via `open_page` a Runs tab that is open but not focused: switches to it, does not flash.
- [ ] Rename an unsaved draft, then re-pick it in the breadcrumb picker: the tab keeps its name instead of reverting to `…/draft_<uuid>`.
