### PR TITLE
fix: stop offering to delete a dev workspace from the sidebar settings menu

### DIFF
--- a/frontend/src/lib/components/sidebar/SettingsMenu.svelte
+++ b/frontend/src/lib/components/sidebar/SettingsMenu.svelte
@@ -84,8 +84,13 @@
 	const canManageWorkspace = $derived(
 		$userStore?.is_admin || $superadmin || isForkOwner(settingsWs, $userStore?.email)
 	)
-	// Fork/dev workspaces are detected by their parent link, not the `wm-fork-` id prefix.
-	const currentWsIsFork = $derived(workspaceIsFork($workspaceStore, $userWorkspaces ?? []))
+	// Fork/dev workspaces are detected by their parent link, not the `wm-fork-` id prefix. A dev
+	// workspace is excluded: it is a standing environment its whole team works in, torn down by
+	// detaching it in the dev-workspace settings, so offering a one-click delete beside the account
+	// menu puts a destructive action on the wrong surface.
+	const currentWsIsThrowawayFork = $derived(
+		workspaceIsFork($workspaceStore, $userWorkspaces ?? []) && !currentWs?.is_dev_workspace
+	)
 
 	let leaveWorkspaceModal = $state(false)
 	let deleteForkModal = $state<DeleteForkedWorkspaceModal>()
@@ -160,7 +165,7 @@
 			: []),
 		// Fork deletion is a global-sidebar action on the active workspace, so keep it
 		// out of the session rail's per-target settings entry (`workspaceSettingsTarget`).
-		...(currentWsIsFork && !workspaceSettingsTarget
+		...(currentWsIsThrowawayFork && !workspaceSettingsTarget
 			? [
 					{
 						displayName: 'Delete forked workspace',


### PR DESCRIPTION
## Summary

The sidebar Settings menu offers "Delete forked workspace" on any workspace with a parent, which
includes **dev workspaces**. A dev workspace is not a throwaway: it is a standing environment the
whole team works in, paired with a prod workspace, and it is torn down by detaching it in the
dev-workspace settings (prod-admin gated). Offering a one-click delete beside the account menu puts
that destructive action on entirely the wrong surface — and deleting the dev workspace takes every
fork underneath it with it.

Throwaway forks keep the entry, which is what it was added for.

## Changes

- `SettingsMenu.svelte`: `currentWsIsFork` → `currentWsIsThrowawayFork`, which excludes
  `is_dev_workspace`. An orphaned `wm-fork-` workspace (parent FK set null) still counts as a
  throwaway fork and keeps the entry, as before.

## Test plan

- [x] `npm run check:fast` — no problems.
- [x] In the browser on a local chain `prod → prod-dev (dev) → stgws (staging) → wm-fork-leaf`:
      the Settings menu in `prod-dev` no longer lists "Delete forked workspace", while
      `wm-fork-leaf` (a throwaway fork) still does.

No visual change to capture beyond the menu entry disappearing on dev workspaces.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing "Delete forked workspace" in the sidebar for dev workspaces to prevent accidental teardown. The option still appears for throwaway forks as intended.

- **Bug Fixes**
  - Exclude dev workspaces (`is_dev_workspace`) from fork deletion logic in `SettingsMenu.svelte`.
  - Keep delete option for throwaway forks, including orphaned `wm-fork-*` workspaces.

<sup>Written for commit 5e424d112db89a78104ad3aaf3dd509aa71b7930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

