### PR TITLE
fix: translate folder principals when the compare page copies a folder

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -24471,7 +24471,7 @@ components:
         type: integer
     PerPage:
       name: per_page
-      description: number of items to return for a given page (default 30, max 100)
+      description: number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)
       in: query
       schema:
         type: integer

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -326,7 +326,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "label": {
                         "type": "string",
@@ -518,7 +518,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "resource_type": {
                         "type": "string",
@@ -591,7 +591,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "order_desc": {
                         "type": "boolean",
@@ -853,7 +853,7 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "order_desc": {
                         "type": "boolean",
@@ -1089,7 +1089,7 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "path_start": {
                         "type": "string",
@@ -1571,7 +1571,7 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "all_workspaces": {
                         "type": "boolean",
@@ -1705,7 +1705,7 @@ Creates a new version of an existing script when called with the same path and t
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "trigger_kind": {
                         "type": "string",
@@ -2313,7 +2313,7 @@ You should get the schema of the script or flow before updating the schedule to 
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "args": {
                         "type": "string",
@@ -2378,7 +2378,7 @@ You should get the schema of the script or flow before updating the schedule to 
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "ping_since": {
                         "type": "integer",

--- a/cli/src/commands/workspace/merge.ts
+++ b/cli/src/commands/workspace/merge.ts
@@ -65,6 +65,7 @@ const provider: DeployProvider = {
   // Users and groups
   listUsers: wmill.listUsers,
   listGroups: wmill.listGroups,
+  listGroupNames: wmill.listGroupNames,
   // Triggers — per-kind dispatch on the new TriggerDeployKind union.
   existsTriggerByKind: (kind, p) => triggerService(kind).exists(p),
   getTriggerForDeploy: async (kind, p) => {

--- a/cli/src/commands/workspace/merge.ts
+++ b/cli/src/commands/workspace/merge.ts
@@ -62,6 +62,9 @@ const provider: DeployProvider = {
   createFolder: wmill.createFolder,
   updateFolder: wmill.updateFolder,
   deleteFolder: wmill.deleteFolder,
+  // Users and groups
+  listUsers: wmill.listUsers,
+  listGroups: wmill.listGroups,
   // Triggers — per-kind dispatch on the new TriggerDeployKind union.
   existsTriggerByKind: (kind, p) => triggerService(kind).exists(p),
   getTriggerForDeploy: async (kind, p) => {
@@ -592,6 +595,13 @@ async function mergeWorkspaces(
 
     if (result.success) {
       log.info(colors.green(`  ✓ ${label}`));
+      if (result.droppedAccess?.length) {
+        log.info(
+          colors.yellow(
+            `    dropped access for ${result.droppedAccess.join(", ")} — no account in ${workspaceTo}`
+          )
+        );
+      }
       successCount++;
       if (
         !itemDeletedInSource &&

--- a/cli/test/deploy_folder_principals_unit.test.ts
+++ b/cli/test/deploy_folder_principals_unit.test.ts
@@ -21,8 +21,12 @@ function folderProvider(
     existsFolder: async () => alreadyExists,
     getFolder: async () => folder,
     listUsers: async (p: { workspace: string }) => users[p.workspace],
+    // `group_` rows only — what an identity rule resolves against.
     listGroups: async (p: { workspace: string; page?: number }) =>
       p.workspace === "dst" && p.page === 1 ? [{ name: "both" }] : [],
+    // `group_` unioned with instance groups — what an owner or ACL entry is matched against.
+    listGroupNames: async (p: { workspace: string }) =>
+      p.workspace === "dst" ? ["both", "igroup"] : [],
     createFolder: async (p: any) =>
       void captured.push(["createFolder", p.requestBody]),
     updateFolder: async (p: any) =>
@@ -33,8 +37,13 @@ function folderProvider(
 const translatable = {
   name: "x",
   summary: "s",
-  owners: ["u/alice_src", "u/bob", "g/both"],
-  extra_perms: { "u/alice_src": true, "u/bob": false, "g/only-src": true },
+  owners: ["u/alice_src", "u/bob", "g/both", "g/igroup"],
+  extra_perms: {
+    "u/alice_src": true,
+    "u/bob": false,
+    "g/only-src": true,
+    "g/igroup": true,
+  },
   default_permissioned_as: [{ path_glob: "**", permissioned_as: "u/alice_src" }],
   labels: ["l"],
 };
@@ -59,9 +68,10 @@ test("deployItem: folder principals are translated into the target's naming", as
     expect(captured.map(([name]) => name)).toEqual([fn]);
     const body = captured[0][1];
     // Alice resolves through her email; Bob and the source-only group are dropped, since
-    // narrowing a folder is safe where naming a stranger is not.
-    expect(body.owners).toEqual(["u/alice_dst", "g/both"]);
-    expect(body.extra_perms).toEqual({ "u/alice_dst": true });
+    // narrowing a folder is safe where naming a stranger is not. `g/igroup` is an instance
+    // group — instance-wide, so it grants access in the target and must survive.
+    expect(body.owners).toEqual(["u/alice_dst", "g/both", "g/igroup"]);
+    expect(body.extra_perms).toEqual({ "u/alice_dst": true, "g/igroup": true });
     expect(body.default_permissioned_as).toEqual([
       { path_glob: "**", permissioned_as: "u/alice_dst" },
     ]);
@@ -71,6 +81,52 @@ test("deployItem: folder principals are translated into the target's naming", as
     // Named once each, though Bob appears in both owners and the ACL.
     expect(result.droppedAccess).toEqual(["u/bob", "g/only-src"]);
   }
+});
+
+test("deployItem: an instance group is not accepted as an identity rule", async () => {
+  // `ensure_permissioned_as_exists` resolves a rule against `group_` alone, so carrying an
+  // instance group here would write a folder the server then rejects every item deploy into —
+  // the opposite of the owners/ACL case in the test above, which is why the two use different
+  // group sets rather than one.
+  const captured: [string, any][] = [];
+  const result = await deployItem(
+    folderProvider(captured, {
+      ...translatable,
+      default_permissioned_as: [
+        { path_glob: "**", permissioned_as: "g/igroup" },
+      ],
+    }),
+    "folder" as any,
+    "f/x",
+    "src",
+    "dst",
+  );
+
+  expect(result.success).toBe(false);
+  expect(captured).toEqual([]);
+  expect(result.error).toContain("g/igroup");
+});
+
+test("deployItem: an all-untranslatable owners list never blanks the target's", async () => {
+  // `update_folder` force-appends the caller only when they are not an admin, so writing `[]`
+  // over an existing list would leave an admin-deployed folder with no owners at all.
+  const captured: [string, any][] = [];
+  const result = await deployItem(
+    folderProvider(
+      captured,
+      { ...translatable, owners: ["u/bob"], extra_perms: {} },
+      true,
+    ),
+    "folder" as any,
+    "f/x",
+    "src",
+    "dst",
+  );
+
+  expect(result.success).toBe(true);
+  expect(captured[0][0]).toBe("updateFolder");
+  expect("owners" in JSON.parse(JSON.stringify(captured[0][1]))).toBe(false);
+  expect(result.droppedAccess).toEqual(["u/bob"]);
 });
 
 test("deployItem: an unresolvable identity rule writes nothing", async () => {

--- a/cli/test/deploy_folder_principals_unit.test.ts
+++ b/cli/test/deploy_folder_principals_unit.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { deployItem } from "../windmill-utils-internal/src/deploy.ts";
+
+// A folder's owners, ACL and identity rules name `u/<username>`, which is per-(workspace, email).
+// Copying one verbatim hands the folder — or an item's execution identity — to whoever happens to
+// hold that username in the target. Alice is the same person under two usernames, Bob exists only
+// in the source, and `g/only-src` is a source-only group.
+function folderProvider(
+  captured: [string, any][],
+  folder: Record<string, unknown>,
+  alreadyExists = false,
+) {
+  const users: Record<string, { email: string; username: string }[]> = {
+    src: [
+      { username: "alice_src", email: "alice@corp" },
+      { username: "bob", email: "bob@corp" },
+    ],
+    dst: [{ username: "alice_dst", email: "alice@corp" }],
+  };
+  return {
+    existsFolder: async () => alreadyExists,
+    getFolder: async () => folder,
+    listUsers: async (p: { workspace: string }) => users[p.workspace],
+    listGroups: async (p: { workspace: string; page?: number }) =>
+      p.workspace === "dst" && p.page === 1 ? [{ name: "both" }] : [],
+    createFolder: async (p: any) =>
+      void captured.push(["createFolder", p.requestBody]),
+    updateFolder: async (p: any) =>
+      void captured.push(["updateFolder", p.requestBody]),
+  } as any;
+}
+
+const translatable = {
+  name: "x",
+  summary: "s",
+  owners: ["u/alice_src", "u/bob", "g/both"],
+  extra_perms: { "u/alice_src": true, "u/bob": false, "g/only-src": true },
+  default_permissioned_as: [{ path_glob: "**", permissioned_as: "u/alice_src" }],
+  labels: ["l"],
+};
+
+test("deployItem: folder principals are translated into the target's naming", async () => {
+  // Create and update build the same body, and only one of them is exercised by any given
+  // deploy, so a translation dropped from one alone would go unnoticed.
+  for (const [alreadyExists, fn] of [
+    [false, "createFolder"],
+    [true, "updateFolder"],
+  ] as const) {
+    const captured: [string, any][] = [];
+    const result = await deployItem(
+      folderProvider(captured, translatable, alreadyExists),
+      "folder" as any,
+      "f/x",
+      "src",
+      "dst",
+    );
+
+    expect(result.success).toBe(true);
+    expect(captured.map(([name]) => name)).toEqual([fn]);
+    const body = captured[0][1];
+    // Alice resolves through her email; Bob and the source-only group are dropped, since
+    // narrowing a folder is safe where naming a stranger is not.
+    expect(body.owners).toEqual(["u/alice_dst", "g/both"]);
+    expect(body.extra_perms).toEqual({ "u/alice_dst": true });
+    expect(body.default_permissioned_as).toEqual([
+      { path_glob: "**", permissioned_as: "u/alice_dst" },
+    ]);
+    // Both were dropped entirely by the folder branch before this existed.
+    expect(body.labels).toEqual(["l"]);
+    expect(body.summary).toBe("s");
+    // Named once each, though Bob appears in both owners and the ACL.
+    expect(result.droppedAccess).toEqual(["u/bob", "g/only-src"]);
+  }
+});
+
+test("deployItem: an unresolvable identity rule writes nothing", async () => {
+  // Dropping the rule would run items landing in the folder as whoever deployed them, and
+  // carrying it verbatim would create a folder the server rejects every later item deploy into
+  // (`create_folder` checks a rule's shape, `ensure_permissioned_as_exists` its principal's
+  // existence). Refusing is the only option that leaves nothing broken behind.
+  const captured: [string, any][] = [];
+  const result = await deployItem(
+    folderProvider(captured, {
+      ...translatable,
+      default_permissioned_as: [{ path_glob: "**", permissioned_as: "u/bob" }],
+    }),
+    "folder" as any,
+    "f/x",
+    "src",
+    "dst",
+  );
+
+  expect(result.success).toBe(false);
+  expect(captured).toEqual([]);
+  expect(result.error).toContain("u/bob");
+  expect(result.error).toContain("has no account in dst");
+});
+
+test("deployItem: a rule whose user left the source says so", async () => {
+  // `u/ghost` has no source row to read an email from, so no change to the target can resolve
+  // it — telling the user to add them there would send them round a loop.
+  const captured: [string, any][] = [];
+  const result = await deployItem(
+    folderProvider(captured, {
+      ...translatable,
+      default_permissioned_as: [{ path_glob: "**", permissioned_as: "u/ghost" }],
+    }),
+    "folder" as any,
+    "f/x",
+    "src",
+    "dst",
+  );
+
+  expect(result.success).toBe(false);
+  expect(captured).toEqual([]);
+  expect(result.error).toContain("no longer has an account in src");
+});

--- a/cli/windmill-utils-internal/src/deploy.ts
+++ b/cli/windmill-utils-internal/src/deploy.ts
@@ -62,6 +62,11 @@ export function isTriggerOrScheduleKind(
 export interface DeployResult {
   success: boolean;
   error?: string;
+  /**
+   * Folder owners and ACL entries left behind because their principal has no account in the
+   * target workspace. The deploy still succeeded — see the folder branch of {@link deployItem}.
+   */
+  droppedAccess?: string[];
 }
 
 /**
@@ -162,6 +167,20 @@ export interface DeployProvider {
     requestBody: any;
   }): Promise<any>;
   deleteFolder(p: { workspace: string; name: string }): Promise<any>;
+  // Users and groups — read only to translate a folder's principals into the
+  // target workspace's own naming (see `principalTranslator`).
+  listUsers(p: {
+    workspace: string;
+  }): Promise<{ email: string; username: string }[]>;
+  /**
+   * The workspace's own groups. Must be the `group_` listing, not `listGroupNames`, which
+   * unions in instance groups that folder rules do not resolve against.
+   */
+  listGroups(p: {
+    workspace: string;
+    page?: number;
+    perPage?: number;
+  }): Promise<{ name: string }[]>;
   // Datatable migrations. In the diff, an item's `path` is
   // `<datatable>/<timestamp>_<name>` (see `parseDatatableMigrationDeployPath`).
   listDatatableMigrations(p: { workspace: string }): Promise<any>;
@@ -261,6 +280,89 @@ export function stripOperationalStateOnUpdate<T extends Record<string, any>>(
   if (!alreadyExists) return payload;
   const { mode: _mode, enabled: _enabled, ...rest } = payload;
   return rest as T;
+}
+
+/**
+ * Every workspace group, not just the first page.
+ *
+ * A group missed here reads as "no account in the target", which refuses a folder deploy outright,
+ * so the listing has to be exhaustive. `listGroups` paginates, and the stop condition is "this page
+ * added nothing new" rather than "this page was short": an instance whose `per_page` cap is below
+ * the `PER_PAGE` asked for would make every page short, and the same check also terminates against
+ * one that ignores `page` and keeps serving the first.
+ */
+async function workspaceGroupNames(
+  provider: DeployProvider,
+  workspace: string
+): Promise<Set<string>> {
+  const PER_PAGE = 1000;
+  const names = new Set<string>();
+  for (let page = 1; page <= 50; page++) {
+    const batch = await provider.listGroups({
+      workspace,
+      page,
+      perPage: PER_PAGE,
+    });
+    const before = names.size;
+    batch.forEach((g) => names.add(g.name));
+    if (names.size === before) break;
+  }
+  return names;
+}
+
+/**
+ * Resolve a source-workspace principal into the same person or group as the target names them.
+ *
+ * A `u/<username>` is workspace-local: the same username in the target can be a different account,
+ * so copying one verbatim can hand a folder — or an item's execution identity — to a namesake.
+ * Email is the only identifier stable across workspaces, so users go source username -> email ->
+ * target username, and anyone without an account there resolves to undefined for the caller to
+ * deal with. Groups match by name, which is what the server itself checks.
+ */
+async function principalTranslator(
+  provider: DeployProvider,
+  workspaceFrom: string,
+  workspaceTo: string
+): Promise<{
+  translate: (principal: string) => string | undefined;
+  danglesInSource: (principal: string) => boolean;
+}> {
+  const [fromUsers, toUsers, targetGroups] = await Promise.all([
+    // `list_users` is unpaginated, unlike the group listing above.
+    provider.listUsers({ workspace: workspaceFrom }),
+    provider.listUsers({ workspace: workspaceTo }),
+    workspaceGroupNames(provider, workspaceTo),
+  ]);
+  const emailOfSourceUsername = new Map(
+    fromUsers.map((u) => [u.username, u.email])
+  );
+  const targetUsernameOfEmail = new Map(
+    toUsers.map((u) => [u.email, u.username])
+  );
+
+  return {
+    /** The same principal as `workspaceTo` names it, or undefined when it has no account there. */
+    translate: (principal: string): string | undefined => {
+      if (principal.startsWith("u/")) {
+        const email = emailOfSourceUsername.get(principal.slice(2));
+        const username = email ? targetUsernameOfEmail.get(email) : undefined;
+        return username ? `u/${username}` : undefined;
+      }
+      if (principal.startsWith("g/")) {
+        return targetGroups.has(principal.slice(2)) ? principal : undefined;
+      }
+      // An email is already workspace-independent; it only has to name someone there.
+      return targetUsernameOfEmail.has(principal) ? principal : undefined;
+    },
+    /**
+     * The principal names a user the *source* no longer has, so it is untranslatable for want of
+     * an email to match on — adding that username to the target would not resolve it. Only `u/`
+     * can fail this way: a group name and an email are already what the target is searched by.
+     */
+    danglesInSource: (principal: string): boolean =>
+      principal.startsWith("u/") &&
+      !emailOfSourceUsername.has(principal.slice(2)),
+  };
 }
 
 function getSubModules(flowModule: any): any[][] {
@@ -429,6 +531,7 @@ export async function deployItem(
   onBehalfOf?: string
 ): Promise<DeployResult> {
   const preserveOnBehalfOf = onBehalfOf !== undefined;
+  let droppedAccess: string[] = [];
 
   try {
     const alreadyExists = await checkItemExists(
@@ -668,25 +771,67 @@ export async function deployItem(
         workspace: workspaceFrom,
         name,
       });
+      const rules: { path_glob: string; permissioned_as: string }[] =
+        folder.default_permissioned_as ?? [];
+      const owners: string[] = folder.owners ?? [];
+      const acl = Object.entries(
+        (folder.extra_perms ?? {}) as Record<string, boolean>
+      );
+      const { translate, danglesInSource } = await principalTranslator(
+        provider,
+        workspaceFrom,
+        workspaceTo
+      );
+
+      // An identity rule naming nobody in the target cannot be carried and cannot be dropped:
+      // dropping it runs items landing in the folder as whoever deployed them, and keeping it
+      // verbatim creates a folder the server then rejects every deploy into — `create_folder`
+      // validates a rule's shape, `ensure_permissioned_as_exists` its principal's existence at
+      // item-create time. So the whole folder deploy stops here instead.
+      const unresolvableRule = rules
+        .map((r) => r.permissioned_as)
+        .find((p) => !translate(p));
+      if (unresolvableRule) {
+        return {
+          success: false,
+          error: `f/${name} runs items on behalf of ${unresolvableRule}, ${
+            danglesInSource(unresolvableRule)
+              ? `who no longer has an account in ${workspaceFrom}. Point the folder's rule at someone who does`
+              : `who has no account in ${workspaceTo}. Add them there`
+          }, then deploy the folder again.`,
+        };
+      }
+
+      // An owner or ACL entry naming nobody there is dropped instead: that can only narrow the
+      // folder, and `create_folder` force-appends the caller to `owners`, so nobody is locked out.
+      droppedAccess = [
+        ...new Set([...owners, ...acl.map(([p]) => p)]),
+      ].filter((p) => !translate(p));
+      const requestBody = {
+        owners: owners.map(translate).filter((p): p is string => !!p),
+        extra_perms: Object.fromEntries(
+          acl.flatMap(([p, write]) => {
+            const t = translate(p);
+            return t ? [[t, write] as const] : [];
+          })
+        ),
+        summary: folder.summary ?? undefined,
+        default_permissioned_as: rules.map((r) => ({
+          ...r,
+          permissioned_as: translate(r.permissioned_as)!,
+        })),
+        labels: folder.labels ?? undefined,
+      };
       if (alreadyExists) {
         await provider.updateFolder({
           workspace: workspaceTo,
           name,
-          requestBody: {
-            owners: folder.owners,
-            extra_perms: folder.extra_perms,
-            summary: folder.summary ?? undefined,
-          },
+          requestBody,
         });
       } else {
         await provider.createFolder({
           workspace: workspaceTo,
-          requestBody: {
-            name,
-            owners: folder.owners,
-            extra_perms: folder.extra_perms,
-            summary: folder.summary ?? undefined,
-          },
+          requestBody: { name, ...requestBody },
         });
       }
     } else if (kind === "schedule") {
@@ -781,7 +926,10 @@ export async function deployItem(
       throw new Error(`Unknown kind: ${kind}`);
     }
 
-    return { success: true };
+    return {
+      success: true,
+      droppedAccess: droppedAccess.length ? droppedAccess : undefined,
+    };
   } catch (e: unknown) {
     return { success: false, error: toError(e) };
   }
@@ -903,6 +1051,8 @@ export async function getItemValue(
         owners: folder.owners,
         extra_perms: folder.extra_perms,
         summary: folder.summary,
+        default_permissioned_as: folder.default_permissioned_as,
+        labels: folder.labels,
       };
     } else if (kind === "schedule") {
       // Mirror the runtime-fields-ignore set used server-side so the diff drawer

--- a/cli/windmill-utils-internal/src/deploy.ts
+++ b/cli/windmill-utils-internal/src/deploy.ts
@@ -173,14 +173,20 @@ export interface DeployProvider {
     workspace: string;
   }): Promise<{ email: string; username: string }[]>;
   /**
-   * The workspace's own groups. Must be the `group_` listing, not `listGroupNames`, which
-   * unions in instance groups that folder rules do not resolve against.
+   * The workspace's own `group_` rows — the only groups an identity rule resolves against
+   * (`ensure_permissioned_as_exists`). Paginated.
    */
   listGroups(p: {
     workspace: string;
     page?: number;
     perPage?: number;
   }): Promise<{ name: string }[]>;
+  /**
+   * `group_` unioned with `instance_group`, which is what an owner or ACL entry is matched
+   * against — `get_groups_for_user` folds the caller's instance groups into `authed.groups`.
+   * Unpaginated server-side.
+   */
+  listGroupNames(p: { workspace: string }): Promise<string[]>;
   // Datatable migrations. In the diff, an item's `path` is
   // `<datatable>/<timestamp>_<name>` (see `parseDatatableMigrationDeployPath`).
   listDatatableMigrations(p: { workspace: string }): Promise<any>;
@@ -285,11 +291,11 @@ export function stripOperationalStateOnUpdate<T extends Record<string, any>>(
 /**
  * Every workspace group, not just the first page.
  *
- * A group missed here reads as "no account in the target", which refuses a folder deploy outright,
- * so the listing has to be exhaustive. `listGroups` paginates, and the stop condition is "this page
- * added nothing new" rather than "this page was short": an instance whose `per_page` cap is below
- * the `PER_PAGE` asked for would make every page short, and the same check also terminates against
- * one that ignores `page` and keeps serving the first.
+ * A group missed here reads as "has no account in the target", which refuses a folder deploy
+ * outright, so the listing has to be exhaustive. A short page ends it — `list_groups` runs through
+ * `paginate()`, which caps `per_page` at `MAX_PER_PAGE` (10000), so it can never return fewer than
+ * the 1000 asked for while more remain. The size check is the backstop for a server that ignores
+ * `page` and keeps serving the first one.
  */
 async function workspaceGroupNames(
   provider: DeployProvider,
@@ -305,7 +311,7 @@ async function workspaceGroupNames(
     });
     const before = names.size;
     batch.forEach((g) => names.add(g.name));
-    if (names.size === before) break;
+    if (batch.length < PER_PAGE || names.size === before) break;
   }
   return names;
 }
@@ -317,21 +323,26 @@ async function workspaceGroupNames(
  * so copying one verbatim can hand a folder — or an item's execution identity — to a namesake.
  * Email is the only identifier stable across workspaces, so users go source username -> email ->
  * target username, and anyone without an account there resolves to undefined for the caller to
- * deal with. Groups match by name, which is what the server itself checks.
+ * deal with. Groups match by name, but against *different* sets depending on where the principal
+ * sits — see `translateAccess` and `translateRule`.
  */
 async function principalTranslator(
   provider: DeployProvider,
   workspaceFrom: string,
   workspaceTo: string
 ): Promise<{
-  translate: (principal: string) => string | undefined;
+  translateAccess: (principal: string) => string | undefined;
+  translateRule: (principal: string) => string | undefined;
   danglesInSource: (principal: string) => boolean;
 }> {
-  const [fromUsers, toUsers, targetGroups] = await Promise.all([
-    // `list_users` is unpaginated, unlike the group listing above.
+  const [fromUsers, toUsers, ruleGroups, accessGroups] = await Promise.all([
+    // `list_users` is unpaginated, unlike the `listGroups` listing above.
     provider.listUsers({ workspace: workspaceFrom }),
     provider.listUsers({ workspace: workspaceTo }),
     workspaceGroupNames(provider, workspaceTo),
+    provider
+      .listGroupNames({ workspace: workspaceTo })
+      .then((names) => new Set(names)),
   ]);
   const emailOfSourceUsername = new Map(
     fromUsers.map((u) => [u.username, u.email])
@@ -340,20 +351,35 @@ async function principalTranslator(
     toUsers.map((u) => [u.email, u.username])
   );
 
+  const resolve = (
+    principal: string,
+    groups: Set<string>
+  ): string | undefined => {
+    if (principal.startsWith("u/")) {
+      const email = emailOfSourceUsername.get(principal.slice(2));
+      const username = email ? targetUsernameOfEmail.get(email) : undefined;
+      return username ? `u/${username}` : undefined;
+    }
+    if (principal.startsWith("g/")) {
+      return groups.has(principal.slice(2)) ? principal : undefined;
+    }
+    // An email is already workspace-independent; it only has to name someone there.
+    return targetUsernameOfEmail.has(principal) ? principal : undefined;
+  };
+
   return {
-    /** The same principal as `workspaceTo` names it, or undefined when it has no account there. */
-    translate: (principal: string): string | undefined => {
-      if (principal.startsWith("u/")) {
-        const email = emailOfSourceUsername.get(principal.slice(2));
-        const username = email ? targetUsernameOfEmail.get(email) : undefined;
-        return username ? `u/${username}` : undefined;
-      }
-      if (principal.startsWith("g/")) {
-        return targetGroups.has(principal.slice(2)) ? principal : undefined;
-      }
-      // An email is already workspace-independent; it only has to name someone there.
-      return targetUsernameOfEmail.has(principal) ? principal : undefined;
-    },
+    /**
+     * For an owner or an ACL entry. Instance groups count: they are instance-wide, and
+     * `get_groups_for_user` folds them into the `authed.groups` that `extra_perms` is matched
+     * against, so `g/<instance group>` grants access in the target exactly as it did in the source.
+     */
+    translateAccess: (principal: string) => resolve(principal, accessGroups),
+    /**
+     * For an identity rule, which resolves only against the workspace's own `group_` rows —
+     * `ensure_permissioned_as_exists` rejects an instance group, so accepting one here would
+     * write a folder the server then refuses every item deploy into.
+     */
+    translateRule: (principal: string) => resolve(principal, ruleGroups),
     /**
      * The principal names a user the *source* no longer has, so it is untranslatable for want of
      * an email to match on — adding that username to the target would not resolve it. Only `u/`
@@ -777,11 +803,8 @@ export async function deployItem(
       const acl = Object.entries(
         (folder.extra_perms ?? {}) as Record<string, boolean>
       );
-      const { translate, danglesInSource } = await principalTranslator(
-        provider,
-        workspaceFrom,
-        workspaceTo
-      );
+      const { translateAccess, translateRule, danglesInSource } =
+        await principalTranslator(provider, workspaceFrom, workspaceTo);
 
       // An identity rule naming nobody in the target cannot be carried and cannot be dropped:
       // dropping it runs items landing in the folder as whoever deployed them, and keeping it
@@ -790,7 +813,7 @@ export async function deployItem(
       // item-create time. So the whole folder deploy stops here instead.
       const unresolvableRule = rules
         .map((r) => r.permissioned_as)
-        .find((p) => !translate(p));
+        .find((p) => !translateRule(p));
       if (unresolvableRule) {
         return {
           success: false,
@@ -803,24 +826,33 @@ export async function deployItem(
       }
 
       // An owner or ACL entry naming nobody there is dropped instead: that can only narrow the
-      // folder, and `create_folder` force-appends the caller to `owners`, so nobody is locked out.
-      droppedAccess = [
-        ...new Set([...owners, ...acl.map(([p]) => p)]),
-      ].filter((p) => !translate(p));
+      // folder, never widen it.
+      droppedAccess = [...new Set([...owners, ...acl.map(([p]) => p)])].filter(
+        (p) => !translateAccess(p)
+      );
+      const translatedOwners = owners
+        .map(translateAccess)
+        .filter((p): p is string => !!p);
       const requestBody = {
-        owners: owners.map(translate).filter((p): p is string => !!p),
+        // Sending `[]` would blank the target's owners, and `update_folder` only force-appends the
+        // caller when they are not an admin — so an admin deploying a folder whose every owner is
+        // untranslatable would leave an owner-less folder behind. Omitting the key keeps whatever
+        // the target had; on create the server appends the caller regardless.
+        owners: translatedOwners.length ? translatedOwners : undefined,
         extra_perms: Object.fromEntries(
           acl.flatMap(([p, write]) => {
-            const t = translate(p);
+            const t = translateAccess(p);
             return t ? [[t, write] as const] : [];
           })
         ),
         summary: folder.summary ?? undefined,
+        // Both mirror the source rather than preserving the target: a rule or label cleared at the
+        // source has to clear here too, or the copy keeps applying an identity nobody asked for.
         default_permissioned_as: rules.map((r) => ({
           ...r,
-          permissioned_as: translate(r.permissioned_as)!,
+          permissioned_as: translateRule(r.permissioned_as)!,
         })),
-        labels: folder.labels ?? undefined,
+        labels: folder.labels ?? [],
       };
       if (alreadyExists) {
         await provider.updateFolder({

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -708,7 +708,7 @@
 		const diff = comparison?.diffs.find((d) => getItemKey(d) === statusKey)
 		const removes = diff ? removesInTarget(diff) : false
 
-		let result: DeployResult
+		let result: DeployResult & { droppedAccess?: string[] }
 		if (removes) {
 			result = await deleteItemInWorkspace(kind, path, workspaceToDeployTo)
 		} else {
@@ -724,6 +724,17 @@
 
 		if (result.success) {
 			deploymentStatus[statusKey] = { status: 'deployed' }
+			// The folder landed with less access than its source, which is not something to discover
+			// later from someone who can no longer open it.
+			if (result.droppedAccess?.length) {
+				sendUserToast(
+					`${statusKey}: dropped access for ${result.droppedAccess.join(', ')} — no account in ${workspaceToDeployTo}`,
+					'warning',
+					undefined,
+					undefined,
+					10000
+				)
+			}
 		} else {
 			deploymentStatus[statusKey] = { status: 'failed', error: result.error }
 			sendUserToast(`Failed to deploy ${statusKey}: ${result.error}`, 'error')

--- a/frontend/src/lib/components/DeployWorkspace.svelte
+++ b/frontend/src/lib/components/DeployWorkspace.svelte
@@ -38,6 +38,7 @@
 	import { isRunnableByPath } from './apps/inputType'
 	import type { Runnable } from './raw_apps/utils'
 	import WorkspaceDeployLayout from './WorkspaceDeployLayout.svelte'
+	import { sendUserToast } from '$lib/toast'
 	import OnBehalfOfSelector, {
 		needsOnBehalfOfSelection,
 		type OnBehalfOfChoice,
@@ -344,6 +345,17 @@
 		if (result.success) {
 			allAlreadyExists[statusPath] = true
 			deploymentStatus[statusPath] = { status: 'deployed' }
+			// The folder landed with less access than its source, which is not something to discover
+			// later from someone who can no longer open it.
+			if (result.droppedAccess?.length) {
+				sendUserToast(
+					`${statusPath}: dropped access for ${result.droppedAccess.join(', ')} — no account in ${workspaceToDeployTo}`,
+					'warning',
+					undefined,
+					undefined,
+					10000
+				)
+			}
 		} else {
 			deploymentStatus[statusPath] = { status: 'failed', error: result.error }
 		}

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -335,7 +335,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "label": {
                         "type": "string",
@@ -527,7 +527,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "resource_type": {
                         "type": "string",
@@ -600,7 +600,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "order_desc": {
                         "type": "boolean",
@@ -861,7 +861,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "order_desc": {
                         "type": "boolean",
@@ -1097,7 +1097,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "path_start": {
                         "type": "string",
@@ -1579,7 +1579,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "all_workspaces": {
                         "type": "boolean",
@@ -1713,7 +1713,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "trigger_kind": {
                         "type": "string",
@@ -2315,7 +2315,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "args": {
                         "type": "string",
@@ -2380,7 +2380,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                 },
                 "per_page": {
                         "type": "integer",
-                        "description": "number of items to return for a given page (default 30, max 100)"
+                        "description": "number of items to return for a given page (default 1000, max 10000; the script and job listings default to 10000 and apply no maximum)"
                 },
                 "ping_since": {
                         "type": "integer",

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -41,6 +41,7 @@ import {
 	checkItemExists as sharedCheckItemExists,
 	getOnBehalfOf as sharedGetOnBehalfOf,
 	getItemValue as sharedGetItemValue,
+	folderName,
 	type DeployProvider,
 	type DeployKind,
 	type DeployResult,
@@ -352,7 +353,7 @@ export interface DeployItemParams {
  */
 export async function deployItem(
 	params: DeployItemParams
-): Promise<DeployResult & { conflict?: boolean }> {
+): Promise<DeployResult & { conflict?: boolean; droppedAccess?: string[] }> {
 	const {
 		kind,
 		path,
@@ -398,6 +399,10 @@ export async function deployItem(
 		} catch (e: any) {
 			return { success: false, error: e.body || e.message || String(e) }
 		}
+	}
+
+	if (kind === 'folder') {
+		return deployFolder(folderName(path), workspaceFrom, workspaceTo, !!createOnly)
 	}
 
 	const appIdentity =
@@ -528,6 +533,24 @@ export async function getItemValue(
 			return {}
 		}
 	}
+	if (kind === 'folder') {
+		// The published shared value omits the two fields `deployFolder` carries, so the diff a
+		// reviewer reads would not mention the identity rules the deploy is about to rewrite.
+		// Delete with `deployFolder`.
+		try {
+			const folder = await FolderService.getFolder({ workspace, name: folderName(path) })
+			return {
+				name: folder.name,
+				owners: folder.owners,
+				extra_perms: folder.extra_perms,
+				summary: folder.summary,
+				default_permissioned_as: folder.default_permissioned_as,
+				labels: folder.labels
+			}
+		} catch {
+			return {}
+		}
+	}
 	return sharedGetItemValue(makeProvider(), kind as DeployKind, path, workspace)
 }
 
@@ -578,12 +601,14 @@ export async function getOnBehalfOfOrThrow(
 async function workspaceGroupNames(workspace: string): Promise<Set<string>> {
 	const PER_PAGE = 1000
 	const names = new Set<string>()
-	// Stops on a short page; the size check is the backstop for a server that ignores `page`.
+	// The stop condition is "this page added nothing new" rather than "this page was short": an
+	// instance whose `per_page` cap is below the one asked for would make every page short, and the
+	// same check terminates against one that ignores `page` and keeps serving the first.
 	for (let page = 1; page <= 50; page++) {
 		const batch = await GroupService.listGroups({ workspace, page, perPage: PER_PAGE })
 		const before = names.size
 		batch.forEach((g) => names.add(g.name))
-		if (batch.length < PER_PAGE || names.size === before) break
+		if (names.size === before) break
 	}
 	return names
 }
@@ -606,18 +631,82 @@ async function principalTranslator(workspaceFrom: string, workspaceTo: string) {
 	const emailOfSourceUsername = new Map(fromUsers.map((u) => [u.username, u.email]))
 	const targetUsernameOfEmail = new Map(toUsers.map((u) => [u.email, u.username]))
 
-	/** The same principal as `workspaceTo` names it, or undefined when it has no account there. */
-	return (principal: string): string | undefined => {
-		if (principal.startsWith('u/')) {
-			const email = emailOfSourceUsername.get(principal.slice(2))
-			const username = email ? targetUsernameOfEmail.get(email) : undefined
-			return username ? `u/${username}` : undefined
+	return {
+		/** The same principal as `workspaceTo` names it, or undefined when it has no account there. */
+		translate: (principal: string): string | undefined => {
+			if (principal.startsWith('u/')) {
+				const email = emailOfSourceUsername.get(principal.slice(2))
+				const username = email ? targetUsernameOfEmail.get(email) : undefined
+				return username ? `u/${username}` : undefined
+			}
+			if (principal.startsWith('g/')) {
+				return targetGroups.has(principal.slice(2)) ? principal : undefined
+			}
+			// An email is already workspace-independent; it only has to name someone there.
+			return targetUsernameOfEmail.has(principal) ? principal : undefined
+		},
+		/**
+		 * The principal names a user the *source* no longer has, so it is untranslatable for want of
+		 * an email to match on — adding that username to the target would not resolve it. Only `u/`
+		 * can fail this way: a group name and an email are already what the target is searched by.
+		 */
+		danglesInSource: (principal: string): boolean =>
+			principal.startsWith('u/') && !emailOfSourceUsername.has(principal.slice(2))
+	}
+}
+
+/**
+ * `f/<name>` as `workspaceTo` would have to store it, or the identity rule that stops it being
+ * copied there at all.
+ *
+ * Every principal is translated into the target's own naming (see `principalTranslator`), and the
+ * two kinds of unresolvable principal are separated because they fail differently:
+ *
+ *  - an **owner or ACL entry** with no account in the target is dropped, and named in `dropped`.
+ *    The folder ends up more restrictive than its source, never less, and `create_folder` makes
+ *    the caller an owner, so nobody is locked out of what they just created.
+ *  - an **identity rule** with no account in the target stops the copy, whichever caller asked for
+ *    it. Dropping it would leave the folder applying no rule where the source applied one, so an
+ *    item landing inside runs as whoever deployed it; carrying it verbatim is worse still, since
+ *    the server validates a rule's shape at folder-create time but its principal's existence at
+ *    item-create time, so the folder would be written and then reject every deploy into it.
+ */
+async function translatedFolderBody(
+	name: string,
+	workspaceFrom: string,
+	workspaceTo: string
+): Promise<
+	| { unresolvableRule: string; danglesInSource: boolean }
+	| { requestBody: Record<string, unknown>; dropped: string[] }
+> {
+	const folder = await FolderService.getFolder({ workspace: workspaceFrom, name })
+	const rules = folder.default_permissioned_as ?? []
+	const owners = folder.owners ?? []
+	const acl = Object.entries((folder.extra_perms ?? {}) as Record<string, boolean>)
+	const { translate, danglesInSource } = await principalTranslator(workspaceFrom, workspaceTo)
+
+	const unresolvableRule = rules.map((r) => r.permissioned_as).find((p) => !translate(p))
+	if (unresolvableRule) {
+		return { unresolvableRule, danglesInSource: danglesInSource(unresolvableRule) }
+	}
+
+	return {
+		dropped: [...new Set([...owners, ...acl.map(([p]) => p)])].filter((p) => !translate(p)),
+		requestBody: {
+			owners: owners.map(translate).filter((p): p is string => !!p),
+			extra_perms: Object.fromEntries(
+				acl.flatMap(([p, write]) => {
+					const t = translate(p)
+					return t ? [[t, write] as const] : []
+				})
+			),
+			summary: folder.summary ?? undefined,
+			default_permissioned_as: rules.map((r) => ({
+				...r,
+				permissioned_as: translate(r.permissioned_as)!
+			})),
+			labels: folder.labels ?? undefined
 		}
-		if (principal.startsWith('g/')) {
-			return targetGroups.has(principal.slice(2)) ? principal : undefined
-		}
-		// An email is already workspace-independent; it only has to name someone there.
-		return targetUsernameOfEmail.has(principal) ? principal : undefined
 	}
 }
 
@@ -629,26 +718,10 @@ export type CreateFolderResult = DeployResult & {
 /**
  * Copy a folder into `workspaceTo`, creating it and never updating it.
  *
- * `deployItem` re-probes and switches to `updateFolder` when the folder turns out to exist, which
- * would replace its owners and ACL with the source's. For a folder the user asked to deploy that is
- * the point; for one created on their behalf to give an item somewhere to land it would silently
- * rewrite the permissions of a folder someone else just created. Losing that race is success here —
- * the folder exists, which is all the caller needed.
- *
- * Every principal is translated into the target's own naming (see `principalTranslator`), and the
- * two kinds of unresolvable principal are treated differently because they fail differently:
- *
- *  - an **owner or ACL entry** with no account in the target is dropped. The folder ends up more
- *    restrictive than its source, never less, and `create_folder` makes the caller an owner, so
- *    nobody is locked out of what they just created.
- *  - an **identity rule** with no account in the target refuses the whole copy. Dropping it would
- *    leave the folder applying no rule where the source applied one, so an item landing inside runs
- *    as whoever deployed it — the silent substitution this prompt exists to prevent — and carrying
- *    it verbatim is worse still: the server validates a rule's shape at folder-create time but its
- *    principal's existence at item-create time, so the folder would be created and then reject
- *    every deploy into it, including the retry.
- *
- * `default_permissioned_as` and `labels` are carried at all, which the shared folder deploy drops.
+ * `deployItem` writes the folder the user selected, so it updates an existing one. This creates the
+ * folder nobody asked to deploy — the one an item needs somewhere to land — so an update would
+ * silently rewrite the permissions of a folder someone else just created. Losing that race is
+ * success: the folder exists, which is all the caller needed.
  */
 export async function createFolderIfAbsent(
 	name: string,
@@ -656,43 +729,22 @@ export async function createFolderIfAbsent(
 	workspaceTo: string
 ): Promise<CreateFolderResult> {
 	try {
-		const folder = await FolderService.getFolder({ workspace: workspaceFrom, name })
-		const rules = folder.default_permissioned_as ?? []
-		const owners = folder.owners ?? []
-		const acl = Object.entries((folder.extra_perms ?? {}) as Record<string, boolean>)
-		const translate = await principalTranslator(workspaceFrom, workspaceTo)
-
-		const unresolvableRule = rules.map((r) => r.permissioned_as).find((p) => !translate(p))
-		if (unresolvableRule) {
+		const copy = await translatedFolderBody(name, workspaceFrom, workspaceTo)
+		if ('unresolvableRule' in copy) {
 			return {
 				success: false,
 				error:
-					`f/${name} runs items on behalf of ${unresolvableRule}, which has no account in ` +
-					`the target workspace. Bring the folder across from the compare page first.`
+					`f/${name} runs items on behalf of ${copy.unresolvableRule}, who ` +
+					(copy.danglesInSource
+						? `no longer has an account in ${workspaceFrom}. Point the folder's rule at someone who does first.`
+						: `has no account in ${workspaceTo}. Bring the folder across from the compare page first.`)
 			}
 		}
-
-		const droppedAccess = [...owners, ...acl.map(([p]) => p)].filter((p) => !translate(p))
 		await FolderService.createFolder({
 			workspace: workspaceTo,
-			requestBody: {
-				name,
-				owners: owners.map(translate).filter((p): p is string => !!p),
-				extra_perms: Object.fromEntries(
-					acl.flatMap(([p, write]) => {
-						const t = translate(p)
-						return t ? [[t, write] as const] : []
-					})
-				),
-				summary: folder.summary ?? undefined,
-				default_permissioned_as: rules.map((r) => ({
-					...r,
-					permissioned_as: translate(r.permissioned_as)!
-				})),
-				labels: folder.labels
-			}
+			requestBody: { name, ...copy.requestBody }
 		})
-		return { success: true, droppedAccess: droppedAccess.length ? droppedAccess : undefined }
+		return { success: true, droppedAccess: copy.dropped.length ? copy.dropped : undefined }
 	} catch (e) {
 		// The name conflict a concurrent create produces is not part of the API contract, so ask
 		// again rather than matching its message.
@@ -700,6 +752,59 @@ export async function createFolderIfAbsent(
 			if (await checkItemExists('folder', `f/${name}`, workspaceTo)) return { success: true }
 		} catch {}
 		return { success: false, error: `${e}` }
+	}
+}
+
+/**
+ * The folder half of `deployItem`, kept here rather than taken from the shared package.
+ *
+ * This app consumes the published `windmill-utils-internal`, whose folder branch builds both bodies
+ * from `owners`/`extra_perms`/`summary` alone: it drops the folder's identity rules and labels, and
+ * copies workspace-local `u/<username>` principals verbatim into a workspace where the same
+ * username can be a different account. The shared branch is fixed in this repo — delete this once
+ * that version ships and the dependency is bumped.
+ */
+async function deployFolder(
+	name: string,
+	workspaceFrom: string,
+	workspaceTo: string,
+	createOnly: boolean
+): Promise<DeployResult & { conflict?: boolean; droppedAccess?: string[] }> {
+	try {
+		const copy = await translatedFolderBody(name, workspaceFrom, workspaceTo)
+		if ('unresolvableRule' in copy) {
+			return {
+				success: false,
+				error:
+					`f/${name} runs items on behalf of ${copy.unresolvableRule}, who ` +
+					(copy.danglesInSource
+						? `no longer has an account in ${workspaceFrom}. Point the folder's rule at someone who does`
+						: `has no account in ${workspaceTo}. Add them there`) +
+					`, then deploy the folder again.`
+			}
+		}
+		if (await FolderService.existsFolder({ workspace: workspaceTo, name })) {
+			if (createOnly) {
+				return {
+					success: false,
+					conflict: true,
+					error: `f/${name} already exists in ${workspaceTo}`
+				}
+			}
+			await FolderService.updateFolder({
+				workspace: workspaceTo,
+				name,
+				requestBody: copy.requestBody
+			})
+		} else {
+			await FolderService.createFolder({
+				workspace: workspaceTo,
+				requestBody: { name, ...copy.requestBody }
+			})
+		}
+		return { success: true, droppedAccess: copy.dropped.length ? copy.dropped : undefined }
+	} catch (e: any) {
+		return { success: false, error: e.body || e.message || String(e) }
 	}
 }
 

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -591,24 +591,23 @@ export async function getOnBehalfOfOrThrow(
 }
 
 /**
- * Every workspace group, not just the first page.
+ * Every workspace `group_` row, not just the first page — the only groups an identity rule resolves
+ * against (`ensure_permissioned_as_exists`). `listGroupNames` is the wrong call here: it unions in
+ * instance groups, and a same-named one would let a rule through that the server then rejects.
  *
- * `listGroupNames` would be the obvious call but unions in instance groups, which folder rules do
- * not resolve against — a same-named instance group would let an unusable rule through. `listGroups`
- * reads the workspace's own `group_` rows, which is what the server checks, but it paginates: a
- * group missed here reads as "no account in the target", which now refuses a folder copy outright.
+ * A group missed here reads as "has no account in the target", which refuses a folder copy
+ * outright, so the listing has to be exhaustive. A short page ends it — `list_groups` runs through
+ * `paginate()`, which caps `per_page` at `MAX_PER_PAGE` (10000), so it can never return fewer than
+ * the 1000 asked for while more remain. The size check backstops a server that ignores `page`.
  */
 async function workspaceGroupNames(workspace: string): Promise<Set<string>> {
 	const PER_PAGE = 1000
 	const names = new Set<string>()
-	// The stop condition is "this page added nothing new" rather than "this page was short": an
-	// instance whose `per_page` cap is below the one asked for would make every page short, and the
-	// same check terminates against one that ignores `page` and keeps serving the first.
 	for (let page = 1; page <= 50; page++) {
 		const batch = await GroupService.listGroups({ workspace, page, perPage: PER_PAGE })
 		const before = names.size
 		batch.forEach((g) => names.add(g.name))
-		if (names.size === before) break
+		if (batch.length < PER_PAGE || names.size === before) break
 	}
 	return names
 }
@@ -620,31 +619,46 @@ async function workspaceGroupNames(workspace: string): Promise<Set<string>> {
  * so copying one verbatim can hand a folder — or an item's execution identity — to a namesake. Email
  * is the only identifier stable across workspaces, so users go source username -> email -> target
  * username, and anyone without an account there resolves to undefined for the caller to deal with.
+ * Groups match by name, but against *different* sets depending on where the principal sits — see
+ * `translateAccess` and `translateRule`.
  */
 async function principalTranslator(workspaceFrom: string, workspaceTo: string) {
-	const [fromUsers, toUsers, targetGroups] = await Promise.all([
-		// `list_users` is unpaginated, unlike the group listing below.
+	const [fromUsers, toUsers, ruleGroups, accessGroups] = await Promise.all([
+		// `list_users` is unpaginated, unlike the `listGroups` listing above.
 		UserService.listUsers({ workspace: workspaceFrom }),
 		UserService.listUsers({ workspace: workspaceTo }),
-		workspaceGroupNames(workspaceTo)
+		workspaceGroupNames(workspaceTo),
+		GroupService.listGroupNames({ workspace: workspaceTo }).then((names) => new Set(names))
 	])
 	const emailOfSourceUsername = new Map(fromUsers.map((u) => [u.username, u.email]))
 	const targetUsernameOfEmail = new Map(toUsers.map((u) => [u.email, u.username]))
 
+	const resolve = (principal: string, groups: Set<string>): string | undefined => {
+		if (principal.startsWith('u/')) {
+			const email = emailOfSourceUsername.get(principal.slice(2))
+			const username = email ? targetUsernameOfEmail.get(email) : undefined
+			return username ? `u/${username}` : undefined
+		}
+		if (principal.startsWith('g/')) {
+			return groups.has(principal.slice(2)) ? principal : undefined
+		}
+		// An email is already workspace-independent; it only has to name someone there.
+		return targetUsernameOfEmail.has(principal) ? principal : undefined
+	}
+
 	return {
-		/** The same principal as `workspaceTo` names it, or undefined when it has no account there. */
-		translate: (principal: string): string | undefined => {
-			if (principal.startsWith('u/')) {
-				const email = emailOfSourceUsername.get(principal.slice(2))
-				const username = email ? targetUsernameOfEmail.get(email) : undefined
-				return username ? `u/${username}` : undefined
-			}
-			if (principal.startsWith('g/')) {
-				return targetGroups.has(principal.slice(2)) ? principal : undefined
-			}
-			// An email is already workspace-independent; it only has to name someone there.
-			return targetUsernameOfEmail.has(principal) ? principal : undefined
-		},
+		/**
+		 * For an owner or an ACL entry. Instance groups count: they are instance-wide, and
+		 * `get_groups_for_user` folds them into the `authed.groups` that `extra_perms` is matched
+		 * against, so `g/<instance group>` grants access in the target exactly as it did in the source.
+		 */
+		translateAccess: (principal: string) => resolve(principal, accessGroups),
+		/**
+		 * For an identity rule, which resolves only against the workspace's own `group_` rows —
+		 * `ensure_permissioned_as_exists` rejects an instance group, so accepting one here would write
+		 * a folder the server then refuses every item deploy into.
+		 */
+		translateRule: (principal: string) => resolve(principal, ruleGroups),
 		/**
 		 * The principal names a user the *source* no longer has, so it is untranslatable for want of
 		 * an email to match on — adding that username to the target would not resolve it. Only `u/`
@@ -683,29 +697,39 @@ async function translatedFolderBody(
 	const rules = folder.default_permissioned_as ?? []
 	const owners = folder.owners ?? []
 	const acl = Object.entries((folder.extra_perms ?? {}) as Record<string, boolean>)
-	const { translate, danglesInSource } = await principalTranslator(workspaceFrom, workspaceTo)
+	const { translateAccess, translateRule, danglesInSource } = await principalTranslator(
+		workspaceFrom,
+		workspaceTo
+	)
 
-	const unresolvableRule = rules.map((r) => r.permissioned_as).find((p) => !translate(p))
+	const unresolvableRule = rules.map((r) => r.permissioned_as).find((p) => !translateRule(p))
 	if (unresolvableRule) {
 		return { unresolvableRule, danglesInSource: danglesInSource(unresolvableRule) }
 	}
 
+	const translatedOwners = owners.map(translateAccess).filter((p): p is string => !!p)
 	return {
-		dropped: [...new Set([...owners, ...acl.map(([p]) => p)])].filter((p) => !translate(p)),
+		dropped: [...new Set([...owners, ...acl.map(([p]) => p)])].filter((p) => !translateAccess(p)),
 		requestBody: {
-			owners: owners.map(translate).filter((p): p is string => !!p),
+			// Sending `[]` would blank the target's owners, and `update_folder` only force-appends the
+			// caller when they are not an admin — so an admin deploying a folder whose every owner is
+			// untranslatable would leave an owner-less folder behind. Omitting the key keeps whatever
+			// the target had; on create the server appends the caller regardless.
+			owners: translatedOwners.length ? translatedOwners : undefined,
 			extra_perms: Object.fromEntries(
 				acl.flatMap(([p, write]) => {
-					const t = translate(p)
+					const t = translateAccess(p)
 					return t ? [[t, write] as const] : []
 				})
 			),
 			summary: folder.summary ?? undefined,
+			// Both mirror the source rather than preserving the target: a rule or label cleared at the
+			// source has to clear here too, or the copy keeps applying an identity nobody asked for.
 			default_permissioned_as: rules.map((r) => ({
 				...r,
-				permissioned_as: translate(r.permissioned_as)!
+				permissioned_as: translateRule(r.permissioned_as)!
 			})),
-			labels: folder.labels ?? undefined
+			labels: folder.labels ?? []
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #10354, which fixed how a folder is copied between workspaces on the one path it touched (`createFolderIfAbsent`). The **compare page** copies folders through the shared `deployItem`, whose folder branch built both the create and the update body from `owners`, `extra_perms` and `summary` alone — so it still had every defect that PR fixed.

Two consequences:

1. **`default_permissioned_as` and `labels` never crossed.** A copied folder applies no create-time identity rules, so an item deployed into it carrying no `on_behalf_of` of its own runs as whoever deployed it rather than as the principal the source folder would have chosen.
2. **`u/<username>` principals crossed verbatim**, and a username is per-(workspace, email). The same username in the target can be a different account, which then receives folder ownership or ACL access and can be selected by an identity rule. A CI reviewer rated this P1 when the identical code appeared in #10354.

Principals now resolve **source username → email → target username**, email being the only identifier stable across workspaces. Groups match by name, against two different sets depending on where the principal sits:

- an **identity rule** resolves against the workspace's own `group_` rows (`listGroups`), which is all `ensure_permissioned_as_exists` accepts;
- an **owner or ACL entry** resolves against `group_ ∪ instance_group` (`listGroupNames`), because `get_groups_for_user` folds instance groups into the `authed.groups` that `extra_perms` is matched against — an instance group is instance-wide and grants access in the target exactly as it did in the source.

Collapsing those two into one set (the first round of this PR did) either drops an instance-group owner on every deploy or writes a folder whose rule the server then refuses every item deploy into. Both halves are verified below.

The two kinds of unresolvable principal are separated because they fail differently:

- an **owner or ACL entry** is dropped and reported — that can only narrow the folder, and `create_folder` force-appends the caller to `owners`, so nobody is locked out;
- an **identity rule** refuses the copy. Dropping it runs items as the deployer; carrying it verbatim creates a folder the server then rejects every deploy into, because `create_folder` validates a rule's *shape* while `ensure_permissioned_as_exists` validates its principal's *existence* at item-create time.

### Why the fix lands twice

The shared package is the real home and fixing it also fixes `wmill workspace merge`. But the frontend consumes the **published** `windmill-utils-internal` (1.8.2), so the compare page cannot benefit until that version ships and the dependency is bumped. Until then it needs the mirror in `utils_workspace_deploy.ts` — the same arrangement #10354 used for `makeProvider`. **Follow-up for someone with npm credentials: publish the package, bump `frontend/package.json`, and delete `deployFolder` / `translatedFolderBody` / the folder branch of `getItemValue` from the frontend.** There is no publish workflow for this package (`npm_on_release.yml` only publishes the CLI and typescript-client), so it is a manual step.

### `perPage` documentation

Every paginated endpoint documented "default 30, max 100" while `paginate()` uses `DEFAULT_PER_PAGE = 1000` / `MAX_PER_PAGE = 10000`. That wrong comment is exactly what made the merged PR read groups a page at a time and miss them (a P1 there). Corrected on the shared `PerPage` parameter, including the caveat that the script and job listings use `paginate_without_limits` (default 10000, no maximum), and the two tracked artifacts derived from the spec regenerated with `backend/generate_mcp_endpoints_tools/generate_mcp_tools.py`.

## Changes

- `cli/windmill-utils-internal/src/deploy.ts` — folder branch translates every principal and carries `default_permissioned_as` + `labels`; new `principalTranslator` / `workspaceGroupNames` helpers; `listUsers` / `listGroups` added to `DeployProvider`; `droppedAccess` added to `DeployResult`; folder `getItemValue` surfaces the two new fields so the diff drawer shows what the deploy rewrites
- `cli/src/commands/workspace/merge.ts` — provider wiring, and dropped access reported per item
- `frontend/src/lib/utils_workspace_deploy.ts` — `deployFolder` mirror behind `deployItem`; `translatedFolderBody` extracted so `createFolderIfAbsent` and the new path cannot drift; folder `getItemValue` mirrored
- `frontend/src/lib/components/CompareWorkspaces.svelte`, `DeployWorkspace.svelte` — warn when a folder lands with less access than its source
- `backend/windmill-api/openapi.yaml` + regenerated `mcpEndpointTools.ts` / `auto_generated_endpoints.rs` — correct `perPage` description
- `cli/test/deploy_folder_principals_unit.test.ts` — pins the translation, the drop-and-report, and that an unresolvable rule writes nothing

## Verification

Verified against a real EE backend and Postgres, not by reading code. Scratch workspaces `scratchfoldersrc` → fork `wm-fork-scratchfolderdev`, with `alice@…` in both under **different** usernames (`alice_src` / `alice_dev`), `bob_src` source-only, group `scratchboth` in both and `scratchonlysrc` source-only. All fixtures deleted afterwards.

**Pre-change code** (fix stashed, same deploy replayed) — every defect reproduced:

```
owners  {u/alice_src,u/bob_src,g/scratchboth,u/admin}
extra_perms  {"u/bob_src": true, "u/alice_src": true, "g/scratchonlysrc": true, ...}
default_permissioned_as  []
labels  NULL
```

**Post-change, create path:**

```
owners  {u/alice_dev,g/scratchboth,u/admin}
extra_perms  {"u/alice_dev": true, "g/scratchboth": true, "u/admin": true}
default_permissioned_as  [{"path_glob":"jobs/**","permissioned_as":"u/alice_dev"},
                          {"path_glob":"**","permissioned_as":"g/scratchboth"}]
labels  {scratch,translated}
```

- **Update path**: re-deploying an existing folder translates identically, and *repaired* the folder the pre-change code had mis-copied.
- **Refusal**: a folder whose rule names `u/bob_src` was refused on both the create and the update path and never written to the target.
- **`wmill workspace merge`** produced byte-identical results, exercising the shared package directly rather than the mirror.
- **Instance groups** (second round): a folder owned by `g/<instance group>` keeps that owner and ACL entry across a deploy, while a folder whose *rule* names one is refused. The asymmetry is real, not theoretical — creating a script in such a folder returns `Folder 'igrule' default_permissioned_as rule '**' resolves to group 'g/scratch_igroup' which does not exist in this workspace`.
- **Deploy drawer** (second round): folder dependency deployed from the staging/prod drawer warns on dropped access and fails without writing when its rule cannot be resolved.

Checks: `npm run check` 0 errors · CLI `tsc` no new errors (18 pre-existing, baseline-diffed) · `cargo check -p windmill-api --features mcp` clean · CLI unit tests 1050 pass · `utils_workspace_deploy.test.ts` 12 pass.

## Screenshots

Compare & Deploy — a folder deployed with unresolvable access warns rather than narrowing silently, and one whose identity rule cannot be resolved fails outright:

![folder-deploy-toasts](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/shared-folder-deploy-principals/1785939163-folder-deploy-toasts.png)

The folder diff drawer now shows `default_permissioned_as` and `labels` — previously it listed neither, so a reviewer could not see that the deploy was about to rewrite the folder's identity rules:

![folder-diff-drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/shared-folder-deploy-principals/1785939166-folder-diff-drawer.png)

_(Both captured before a reviewer-prompted wording tweak to the refusal message — it now distinguishes a principal absent from the target from one whose account has been removed from the source, since "add them to the target" is useless advice for the latter.)_

## Test plan

- [ ] Compare page, parent → fork: deploy a folder whose `default_permissioned_as` names a user present in both workspaces under different usernames; confirm the fork's row carries the target's username, plus `labels`
- [ ] Same folder with an owner and an ACL entry that have no account in the target: deploy succeeds, warning names each dropped principal once
- [ ] Folder whose identity rule names someone absent from the target: row fails, target folder unchanged (and not created)
- [ ] Re-deploy an existing folder to confirm the update path translates the same way
- [x] Deploy-to-staging/prod drawer (`DeployWorkspace.svelte`), which pulls folders in as dependencies and shares this path: dropped-access warning fires, and a folder whose identity rule cannot be resolved shows `Failed` with nothing written to the target
- [x] Folder owned by an **instance group**, deployed parent → fork: the owner and its ACL entry survive
- [x] Folder whose identity **rule** names an instance group: refused, since the server accepts it at folder-create and then rejects every item created in the folder (confirmed directly against the API)
- [ ] One pass with a non-admin, non-operator member as the deployer: every folder deploy now reads the user list of *both* workspaces, and the shared dev database has RLS stripped, so it would not surface a permission difference

## Known trade-off

`principalTranslator` is rebuilt per folder, and both bulk paths deploy sequentially, so a deploy touching N folders pays N × (2 × `listUsers` + the group pages). Memoizing it for the duration of a run would need the translator threaded through `deployItem`'s signature; deploy sets are typically a handful of folders, so this is left as-is deliberately rather than overlooked.
