### PR TITLE
fix: keep the mermaid fullscreen dialog in its pane and its emoji vector

### DIFF
--- a/frontend/src/lib/components/common/modal/Modal.svelte
+++ b/frontend/src/lib/components/common/modal/Modal.svelte
@@ -20,6 +20,11 @@
 		style?: string
 		cancelText?: string | undefined
 		kind?: 'button' | 'X'
+		/** Make the dialog fill the height it is anchored to and lay its body out as a flex
+		 * column, so content can size itself with `h-full` / `flex-1 min-h-0`. Off by default:
+		 * the dialog otherwise hugs its content, and percentage heights inside it do not
+		 * resolve (the centering wrapper is `min-h-full`, i.e. height:auto). */
+		fillHeight?: boolean
 		/** Force a minimum z-index base. Defaults to elevating above the AI chat
 		 * side panel when it is open. Pass an explicit value to stack above other
 		 * surfaces (e.g. a modal opened over the /sessions preview-pane editor). */
@@ -36,6 +41,7 @@
 		style = '',
 		cancelText = undefined,
 		kind = 'button',
+		fillHeight = false,
 		minZIndex: minZIndexProp = undefined,
 		settings,
 		children: children_render,
@@ -119,12 +125,17 @@
 					></div>
 
 					<div class="{posClass} inset-0 z-10 overflow-y-auto">
-						<div class="flex min-h-full items-center justify-center p-4">
+						<div
+							class="flex {fillHeight ? 'h-full' : 'min-h-full'} items-center justify-center p-4"
+						>
 							<!-- svelte-ignore a11y_no_static_element_interactions -->
 							<div
 								onclick={stopPropagation(bubble('click'))}
 								class={twMerge(
-									'relative transform overflow-hidden rounded-md bg-surface px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6',
+									'relative transform overflow-hidden rounded-md bg-surface px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:w-full sm:max-w-lg sm:p-6',
+									// The margins are what keeps a content-sized dialog off the viewport edges; a
+									// filling one takes its inset from the wrapper's padding instead.
+									fillHeight ? 'h-full flex flex-col' : 'sm:my-8',
 									c,
 									open
 										? 'ease-out duration-300 opacity-100 translate-y-0 sm:scale-100'
@@ -137,16 +148,16 @@
 										><CloseButton on:close={() => (open = false)} /></div
 									>
 								{/if}
-								<div class="flex">
+								<div class="flex {fillHeight ? 'flex-1 min-h-0' : ''}">
 									<!-- min-w-0: without it this flex item takes its content's min-content width and
 									     stretches the modal past its max-width instead of letting content shrink. -->
-									<div class="text-left flex-1 min-w-0">
+									<div class="text-left flex-1 min-w-0 {fillHeight ? 'flex flex-col min-h-0' : ''}">
 										<div class="flex flex-row items-center justify-between">
 											<h3 class="text-emphasis text-lg font-semibold">{title}</h3>
 											{@render settings?.()}
 										</div>
 
-										<div class="mt-4 text-sm text-primary">
+										<div class="mt-4 text-sm text-primary {fillHeight ? 'flex-1 min-h-0' : ''}">
 											{@render children_render?.()}
 										</div>
 									</div>

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -23,14 +23,13 @@
 
 	let expanded = $state(false)
 
-	// The dialog fills the enclosing pane when there is one (see overlayHost) and the viewport
-	// otherwise, so a viewport-relative canvas height overflows it in any pane shorter than the
-	// window. Size against whichever box it actually fills, less the chrome Modal.svelte wraps
-	// the canvas in — read off that component, and only correct while it stays in step:
-	// scroll wrapper p-4, box px-4/pt-5/pb-4 (sm:p-6) + sm:my-8, title row, and the body's mt-4.
-	const CHROME_PX = { belowSm: 112, fromSm: 188 }
+	// The dialog fills the enclosing pane when there is one (see overlayHost), the viewport
+	// otherwise. Size against that box less the chrome Modal.svelte wraps the canvas in — its
+	// scroll wrapper p-4, box px-4/pt-5/pb-4 (sm:p-6) + sm:my-8, title row and body mt-4. Held
+	// in rem, not px: those are all rem utilities and :root scales to 18px past 1760px.
+	const CHROME_REM = { belowSm: 7, fromSm: 11.75 }
 	const SM_BREAKPOINT_PX = 640
-	const MIN_CANVAS_PX = 240
+	const MIN_CANVAS_REM = 15
 	const overlayHost = getOverlayHost()
 	let windowWidth = $state(0)
 	let windowHeight = $state(0)
@@ -41,27 +40,24 @@
 	$effect(() => {
 		if (!expanded) return
 		const host = overlayHost?.el()
-		if (!host) return
+		// Reset here rather than in the teardown: `expanded` is tracked, so a teardown reset would
+		// resize the canvas mid fade-out, while the dialog is still on screen.
+		if (!host) {
+			hostHeight = undefined
+			return
+		}
 		// Seed synchronously so the first frame isn't sized off the window while the observer's
 		// initial callback is still pending.
 		hostHeight = host.clientHeight
 		const observer = new ResizeObserver(() => (hostHeight = host.clientHeight))
 		observer.observe(host)
-		return () => {
-			observer.disconnect()
-			hostHeight = undefined
-		}
+		return () => observer.disconnect()
 	})
 
 	// windowHeight covers the un-hosted case: documentElement's box is content-driven on a
 	// scrollable page, so observing it would miss a purely vertical window resize.
-	let canvasHeight = $derived(
-		Math.max(
-			MIN_CANVAS_PX,
-			(hostHeight ?? windowHeight) -
-				(windowWidth >= SM_BREAKPOINT_PX ? CHROME_PX.fromSm : CHROME_PX.belowSm)
-		)
-	)
+	let availableHeight = $derived(hostHeight ?? windowHeight)
+	let chromeRem = $derived(windowWidth >= SM_BREAKPOINT_PX ? CHROME_REM.fromSm : CHROME_REM.belowSm)
 
 	// Past this, render with whatever metrics are available rather than sit on the raw source.
 	const FONT_LOAD_TIMEOUT_MS = 2000
@@ -268,7 +264,7 @@
 		{/snippet}
 		<div
 			class="relative w-full overflow-hidden rounded border cursor-grab bg-surface-secondary"
-			style="height: {canvasHeight}px"
+			style="height: max({MIN_CANVAS_REM}rem, {availableHeight}px - {chromeRem}rem)"
 		>
 			{#if expanded}
 				<div use:panzoomAction class="w-full h-full flex items-center justify-center">

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -34,7 +34,9 @@
 	const overlayHost = getOverlayHost()
 	let windowWidth = $state(0)
 	let windowHeight = $state(0)
-	let hostHeight = $state(0)
+	// undefined means "no host to measure", which 0 does not: the panel is resized rather than
+	// unmounted, so a collapsed host measures 0 and must stay 0 rather than fall back to the window.
+	let hostHeight = $state<number | undefined>(undefined)
 
 	$effect(() => {
 		if (!expanded) return
@@ -47,7 +49,7 @@
 		observer.observe(host)
 		return () => {
 			observer.disconnect()
-			hostHeight = 0
+			hostHeight = undefined
 		}
 	})
 
@@ -56,34 +58,41 @@
 	let canvasHeight = $derived(
 		Math.max(
 			MIN_CANVAS_PX,
-			(hostHeight || windowHeight) -
+			(hostHeight ?? windowHeight) -
 				(windowWidth >= SM_BREAKPOINT_PX ? CHROME_PX.fromSm : CHROME_PX.belowSm)
 		)
 	)
 
-	// Emoji, including the keycap sequences whose base is an ASCII digit / # / * — those bases
-	// have to reach the font too, or a keycap is measured in the wrong family.
-	const EMOJI_IN_SOURCE = /[#*0-9]️?⃣|\p{Extended_Pictographic}[️‍]*/gu
 	// Past this, render with whatever metrics are available rather than sit on the raw source.
 	const FONT_LOAD_TIMEOUT_MS = 2000
 
 	/**
 	 * Mermaid sizes every node by measuring its rendered label, so the fonts that label will be
 	 * drawn in must be loaded first: measured against fallback metrics the boxes come out too
-	 * narrow and the labels overflow them once the real font swaps in. Only the emoji actually
-	 * present are requested — the emoji font's subsets cover digits, # and *, so passing the
-	 * whole source would fetch 64 KB for any diagram containing a number.
+	 * narrow and the labels overflow them once the real font swaps in.
+	 *
+	 * Only the non-ASCII of the source is offered to the emoji font. Its subsets cover digits,
+	 * `#` and `*`, so passing the whole source would pull 64 KB for any diagram carrying a
+	 * number. Keycaps still resolve: their U+20E3 is non-ASCII and shares a subset with the
+	 * digit bases, and every other emoji class — flags, skin tones, ZWJ sequences — is
+	 * non-ASCII by construction, so this needs no emoji grammar to keep up to date.
 	 */
 	async function loadLabelFonts(source: string): Promise<void> {
-		const emoji = source.match(EMOJI_IN_SOURCE)?.join('') ?? ''
-		const loads = [document.fonts.load('16px Inter', source)]
-		if (emoji) loads.push(document.fonts.load('16px "Noto Color Emoji"', emoji))
-		// Neither rejection nor a stalled fetch may reach the caller's catch, which reads any
-		// throw as a parse failure and drops the diagram to raw source.
-		await Promise.race([
-			Promise.all(loads).catch(() => {}),
-			new Promise((resolve) => setTimeout(resolve, FONT_LOAD_TIMEOUT_MS))
-		])
+		// eslint-disable-next-line no-control-regex
+		const nonAscii = source.replace(/[\x00-\x7F]/g, '')
+		const loads = [document.fonts?.load('16px Inter', source)]
+		if (nonAscii) loads.push(document.fonts?.load('16px "Noto Color Emoji"', nonAscii))
+		let timer: ReturnType<typeof setTimeout> | undefined
+		try {
+			// Neither a rejection nor a stalled fetch may reach the caller's catch, which reads any
+			// throw as a parse failure and drops the diagram to raw source.
+			await Promise.race([
+				Promise.all(loads).catch(() => {}),
+				new Promise((resolve) => (timer = setTimeout(resolve, FONT_LOAD_TIMEOUT_MS)))
+			])
+		} finally {
+			clearTimeout(timer)
+		}
 	}
 
 	async function render(source: string, dark: boolean) {
@@ -102,10 +111,10 @@
 				// Mermaid writes this stack into a <style> block inside the SVG, so the app's font
 				// never reaches a diagram: the bundled vector emoji font has to be named here or
 				// emoji fall back to the platform bitmap one, which ignores the zoom transform
-				// (app.css). Inter leads because that font also covers digits, # and * — without a
-				// preceding family that has them, a box lacking the MS core fonts renders those
-				// from the emoji font instead.
-				fontFamily: 'Inter, "trebuchet ms", verdana, arial, "Noto Color Emoji", sans-serif',
+				// (app.css). Inter sits last before it because the emoji font also covers digits,
+				// # and *; on a box without the MS core fonts those would otherwise render as its
+				// keycap glyphs. Keeping Inter behind them leaves diagram typography unchanged.
+				fontFamily: '"trebuchet ms", verdana, arial, Inter, "Noto Color Emoji", sans-serif',
 				// Throw on parse errors instead of injecting an orphan error diagram into the DOM.
 				suppressErrorRendering: true
 			})

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -62,12 +62,14 @@
 	// Past this, render with whatever metrics are available rather than sit on the raw source.
 	const FONT_LOAD_TIMEOUT_MS = 2000
 
-	// Mermaid draws `#NNN;` / `#xHHH;` as the character they name, so a label written that way is
-	// pure ASCII in source yet renders an emoji. Decode before sampling or those diagrams skip
-	// the preload below. Affects the font sample only — the source mermaid parses is untouched.
+	// Mermaid draws `#NNN;` as the character that code names (decimal only — its own test is
+	// /^\+?\d+$/), so a label written that way is pure ASCII in source yet renders an emoji.
+	// Decode before sampling or those diagrams skip the preload below. Feeds the font sample
+	// only, never the source mermaid parses, so over-matching a colour like `fill:#123;` costs
+	// at most one spurious subset and can never drop a character the sample needs.
 	function decodeEntityCodes(source: string): string {
-		return source.replace(/#(x[0-9a-f]+|\d+);/gi, (whole, code: string) => {
-			const point = code[0].toLowerCase() === 'x' ? parseInt(code.slice(1), 16) : Number(code)
+		return source.replace(/#(\+?\d+);/g, (whole, code: string) => {
+			const point = Number(code)
 			return point <= 0x10ffff ? String.fromCodePoint(point) : whole
 		})
 	}
@@ -84,9 +86,10 @@
 	 * non-ASCII by construction, so this needs no emoji grammar to keep up to date.
 	 */
 	async function loadLabelFonts(source: string): Promise<void> {
+		const decoded = decodeEntityCodes(source)
 		// eslint-disable-next-line no-control-regex
-		const nonAscii = decodeEntityCodes(source).replace(/[\x00-\x7F]/g, '')
-		const loads = [document.fonts?.load('16px Inter', source)]
+		const nonAscii = decoded.replace(/[\x00-\x7F]/g, '')
+		const loads = [document.fonts?.load('16px Inter', decoded)]
 		if (nonAscii) loads.push(document.fonts?.load('16px "Noto Color Emoji"', nonAscii))
 		let timer: ReturnType<typeof setTimeout> | undefined
 		try {

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -62,6 +62,16 @@
 	// Past this, render with whatever metrics are available rather than sit on the raw source.
 	const FONT_LOAD_TIMEOUT_MS = 2000
 
+	// Mermaid draws `#NNN;` / `#xHHH;` as the character they name, so a label written that way is
+	// pure ASCII in source yet renders an emoji. Decode before sampling or those diagrams skip
+	// the preload below. Affects the font sample only — the source mermaid parses is untouched.
+	function decodeEntityCodes(source: string): string {
+		return source.replace(/#(x[0-9a-f]+|\d+);/gi, (whole, code: string) => {
+			const point = code[0].toLowerCase() === 'x' ? parseInt(code.slice(1), 16) : Number(code)
+			return point <= 0x10ffff ? String.fromCodePoint(point) : whole
+		})
+	}
+
 	/**
 	 * Mermaid sizes every node by measuring its rendered label, so the fonts that label will be
 	 * drawn in must be loaded first: measured against fallback metrics the boxes come out too
@@ -75,7 +85,7 @@
 	 */
 	async function loadLabelFonts(source: string): Promise<void> {
 		// eslint-disable-next-line no-control-regex
-		const nonAscii = source.replace(/[\x00-\x7F]/g, '')
+		const nonAscii = decodeEntityCodes(source).replace(/[\x00-\x7F]/g, '')
 		const loads = [document.fonts?.load('16px Inter', source)]
 		if (nonAscii) loads.push(document.fonts?.load('16px "Noto Color Emoji"', nonAscii))
 		let timer: ReturnType<typeof setTimeout> | undefined

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -5,6 +5,7 @@
 	import Modal from '$lib/components/common/modal/Modal.svelte'
 	import { copyToClipboard, download } from '$lib/utils'
 	import { ClipboardCopy, Download, Maximize2, Minus, Plus, RotateCcw } from 'lucide-svelte'
+	import { getOverlayHost } from '$lib/components/common/overlayHost.svelte'
 	import type { PanZoom } from 'panzoom'
 
 	let { code }: { code: string } = $props()
@@ -22,6 +23,34 @@
 
 	let expanded = $state(false)
 
+	// The dialog fills the enclosing pane when there is one (see overlayHost) and the viewport
+	// otherwise, so a viewport-relative canvas height overflows it in any pane shorter than the
+	// window. Size against whichever box it actually fills, less the chrome Modal.svelte wraps
+	// it in: the scroll wrapper's p-4, plus the box's sm:my-8, sm:p-6, title row and mt-4.
+	const DIALOG_CHROME_PX = 188
+	const MIN_CANVAS_PX = 240
+	const overlayHost = getOverlayHost()
+	let windowHeight = $state(0)
+	let hostHeight = $state(0)
+
+	$effect(() => {
+		if (!expanded) return
+		const host = overlayHost?.el()
+		if (!host) return
+		const observer = new ResizeObserver(() => (hostHeight = host.clientHeight))
+		observer.observe(host)
+		return () => {
+			observer.disconnect()
+			hostHeight = 0
+		}
+	})
+
+	// windowHeight covers the un-hosted case: documentElement's box is content-driven on a
+	// scrollable page, so observing it would miss a purely vertical window resize.
+	let canvasHeight = $derived(
+		Math.max(MIN_CANVAS_PX, (hostHeight || windowHeight) - DIALOG_CHROME_PX)
+	)
+
 	async function render(source: string, dark: boolean) {
 		const seq = ++renderSeq
 		if (!source?.trim()) {
@@ -35,9 +64,23 @@
 				startOnLoad: false,
 				theme: dark ? 'dark' : 'default',
 				securityLevel: 'strict',
+				// Mermaid writes this stack into a <style> block inside the SVG, so the app's font
+				// never reaches a diagram: the bundled vector emoji font has to be named here or
+				// emoji fall back to the platform bitmap one, which ignores the zoom transform
+				// (app.css). Inter leads because that font also covers digits, # and * — without a
+				// preceding family that has them, a box lacking the MS core fonts renders those
+				// from the emoji font instead.
+				fontFamily: 'Inter, "trebuchet ms", verdana, arial, "Noto Color Emoji", sans-serif',
 				// Throw on parse errors instead of injecting an orphan error diagram into the DOM.
 				suppressErrorRendering: true
 			})
+			// Mermaid sizes every node by measuring its rendered label, so the emoji font has to be
+			// in memory first: measured against fallback metrics the boxes come out too narrow and
+			// the labels overflow them once the real font swaps in. The catch is load-bearing — a
+			// font failure reaching the outer catch would be read as a parse error and drop the
+			// whole diagram to raw source.
+			await document.fonts.load('16px "Noto Color Emoji"', source).catch(() => {})
+			if (seq !== renderSeq) return
 			// mermaid.render needs a fresh element id per attempt to avoid id collisions.
 			const result = await mermaid.render(`mermaid-${randomUUID()}`, source)
 			if (seq !== renderSeq) return
@@ -111,6 +154,8 @@
 	}
 </script>
 
+<svelte:window bind:innerHeight={windowHeight} />
+
 {#if showSvg}
 	<div class="relative">
 		<div class="absolute top-2 right-2 z-20 flex flex-row gap-1">
@@ -183,7 +228,8 @@
 			</div>
 		{/snippet}
 		<div
-			class="relative w-full h-[78vh] overflow-hidden rounded border cursor-grab bg-surface-secondary"
+			class="relative w-full overflow-hidden rounded border cursor-grab bg-surface-secondary"
+			style="height: {canvasHeight}px"
 		>
 			{#if expanded}
 				<div use:panzoomAction class="w-full h-full flex items-center justify-center">

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -57,7 +57,9 @@
 			if (document.fonts?.status === 'loading') {
 				await document.fonts.ready
 				if (seq !== renderSeq) return
-				svg = (await mermaid.render(`mermaid-${randomUUID()}`, source)).svg
+				const settled = await mermaid.render(`mermaid-${randomUUID()}`, source)
+				if (seq !== renderSeq) return
+				svg = settled.svg
 			}
 		} catch {
 			// Parse failure (often a partial block still streaming in): fall back to the

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -26,10 +26,13 @@
 	// The dialog fills the enclosing pane when there is one (see overlayHost) and the viewport
 	// otherwise, so a viewport-relative canvas height overflows it in any pane shorter than the
 	// window. Size against whichever box it actually fills, less the chrome Modal.svelte wraps
-	// it in: the scroll wrapper's p-4, plus the box's sm:my-8, sm:p-6, title row and mt-4.
-	const DIALOG_CHROME_PX = 188
+	// the canvas in — read off that component, and only correct while it stays in step:
+	// scroll wrapper p-4, box px-4/pt-5/pb-4 (sm:p-6) + sm:my-8, title row, and the body's mt-4.
+	const CHROME_PX = { belowSm: 112, fromSm: 188 }
+	const SM_BREAKPOINT_PX = 640
 	const MIN_CANVAS_PX = 240
 	const overlayHost = getOverlayHost()
+	let windowWidth = $state(0)
 	let windowHeight = $state(0)
 	let hostHeight = $state(0)
 
@@ -37,6 +40,9 @@
 		if (!expanded) return
 		const host = overlayHost?.el()
 		if (!host) return
+		// Seed synchronously so the first frame isn't sized off the window while the observer's
+		// initial callback is still pending.
+		hostHeight = host.clientHeight
 		const observer = new ResizeObserver(() => (hostHeight = host.clientHeight))
 		observer.observe(host)
 		return () => {
@@ -48,8 +54,37 @@
 	// windowHeight covers the un-hosted case: documentElement's box is content-driven on a
 	// scrollable page, so observing it would miss a purely vertical window resize.
 	let canvasHeight = $derived(
-		Math.max(MIN_CANVAS_PX, (hostHeight || windowHeight) - DIALOG_CHROME_PX)
+		Math.max(
+			MIN_CANVAS_PX,
+			(hostHeight || windowHeight) -
+				(windowWidth >= SM_BREAKPOINT_PX ? CHROME_PX.fromSm : CHROME_PX.belowSm)
+		)
 	)
+
+	// Emoji, including the keycap sequences whose base is an ASCII digit / # / * — those bases
+	// have to reach the font too, or a keycap is measured in the wrong family.
+	const EMOJI_IN_SOURCE = /[#*0-9]️?⃣|\p{Extended_Pictographic}[️‍]*/gu
+	// Past this, render with whatever metrics are available rather than sit on the raw source.
+	const FONT_LOAD_TIMEOUT_MS = 2000
+
+	/**
+	 * Mermaid sizes every node by measuring its rendered label, so the fonts that label will be
+	 * drawn in must be loaded first: measured against fallback metrics the boxes come out too
+	 * narrow and the labels overflow them once the real font swaps in. Only the emoji actually
+	 * present are requested — the emoji font's subsets cover digits, # and *, so passing the
+	 * whole source would fetch 64 KB for any diagram containing a number.
+	 */
+	async function loadLabelFonts(source: string): Promise<void> {
+		const emoji = source.match(EMOJI_IN_SOURCE)?.join('') ?? ''
+		const loads = [document.fonts.load('16px Inter', source)]
+		if (emoji) loads.push(document.fonts.load('16px "Noto Color Emoji"', emoji))
+		// Neither rejection nor a stalled fetch may reach the caller's catch, which reads any
+		// throw as a parse failure and drops the diagram to raw source.
+		await Promise.race([
+			Promise.all(loads).catch(() => {}),
+			new Promise((resolve) => setTimeout(resolve, FONT_LOAD_TIMEOUT_MS))
+		])
+	}
 
 	async function render(source: string, dark: boolean) {
 		const seq = ++renderSeq
@@ -74,12 +109,7 @@
 				// Throw on parse errors instead of injecting an orphan error diagram into the DOM.
 				suppressErrorRendering: true
 			})
-			// Mermaid sizes every node by measuring its rendered label, so the emoji font has to be
-			// in memory first: measured against fallback metrics the boxes come out too narrow and
-			// the labels overflow them once the real font swaps in. The catch is load-bearing — a
-			// font failure reaching the outer catch would be read as a parse error and drop the
-			// whole diagram to raw source.
-			await document.fonts.load('16px "Noto Color Emoji"', source).catch(() => {})
+			await loadLabelFonts(source)
 			if (seq !== renderSeq) return
 			// mermaid.render needs a fresh element id per attempt to avoid id collisions.
 			const result = await mermaid.render(`mermaid-${randomUUID()}`, source)
@@ -154,7 +184,7 @@
 	}
 </script>
 
-<svelte:window bind:innerHeight={windowHeight} />
+<svelte:window bind:innerHeight={windowHeight} bind:innerWidth={windowWidth} />
 
 {#if showSvg}
 	<div class="relative">

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -5,7 +5,6 @@
 	import Modal from '$lib/components/common/modal/Modal.svelte'
 	import { copyToClipboard, download } from '$lib/utils'
 	import { ClipboardCopy, Download, Maximize2, Minus, Plus, RotateCcw } from 'lucide-svelte'
-	import { getOverlayHost } from '$lib/components/common/overlayHost.svelte'
 	import type { PanZoom } from 'panzoom'
 
 	let { code }: { code: string } = $props()
@@ -22,42 +21,6 @@
 	let renderSeq = 0
 
 	let expanded = $state(false)
-
-	// The dialog fills the enclosing pane when there is one (see overlayHost), the viewport
-	// otherwise. Size against that box less the chrome Modal.svelte wraps the canvas in — its
-	// scroll wrapper p-4, box px-4/pt-5/pb-4 (sm:p-6) + sm:my-8, title row and body mt-4. Held
-	// in rem, not px: those are all rem utilities and :root scales to 18px past 1760px.
-	const CHROME_REM = { belowSm: 7, fromSm: 11.75 }
-	const SM_BREAKPOINT_PX = 640
-	const MIN_CANVAS_REM = 15
-	const overlayHost = getOverlayHost()
-	let windowWidth = $state(0)
-	let windowHeight = $state(0)
-	// undefined means "no host to measure", which 0 does not: the panel is resized rather than
-	// unmounted, so a collapsed host measures 0 and must stay 0 rather than fall back to the window.
-	let hostHeight = $state<number | undefined>(undefined)
-
-	$effect(() => {
-		if (!expanded) return
-		const host = overlayHost?.el()
-		// Reset here rather than in the teardown: `expanded` is tracked, so a teardown reset would
-		// resize the canvas mid fade-out, while the dialog is still on screen.
-		if (!host) {
-			hostHeight = undefined
-			return
-		}
-		// Seed synchronously so the first frame isn't sized off the window while the observer's
-		// initial callback is still pending.
-		hostHeight = host.clientHeight
-		const observer = new ResizeObserver(() => (hostHeight = host.clientHeight))
-		observer.observe(host)
-		return () => observer.disconnect()
-	})
-
-	// windowHeight covers the un-hosted case: documentElement's box is content-driven on a
-	// scrollable page, so observing it would miss a purely vertical window resize.
-	let availableHeight = $derived(hostHeight ?? windowHeight)
-	let chromeRem = $derived(windowWidth >= SM_BREAKPOINT_PX ? CHROME_REM.fromSm : CHROME_REM.belowSm)
 
 	async function render(source: string, dark: boolean) {
 		const seq = ++renderSeq
@@ -164,8 +127,6 @@
 	}
 </script>
 
-<svelte:window bind:innerHeight={windowHeight} bind:innerWidth={windowWidth} />
-
 {#if showSvg}
 	<div class="relative">
 		<div class="absolute top-2 right-2 z-20 flex flex-row gap-1">
@@ -200,7 +161,7 @@
 		</div>
 	</div>
 
-	<Modal bind:open={expanded} title="Diagram" kind="X" class="sm:max-w-none w-[92vw]">
+	<Modal bind:open={expanded} title="Diagram" kind="X" fillHeight class="sm:max-w-none w-[92vw]">
 		{#snippet settings()}
 			<div class="flex flex-row gap-1 mr-8">
 				<Button
@@ -238,8 +199,7 @@
 			</div>
 		{/snippet}
 		<div
-			class="relative w-full overflow-hidden rounded border cursor-grab bg-surface-secondary"
-			style="height: max({MIN_CANVAS_REM}rem, {availableHeight}px - {chromeRem}rem)"
+			class="relative w-full h-full overflow-hidden rounded border cursor-grab bg-surface-secondary"
 		>
 			{#if expanded}
 				<div use:panzoomAction class="w-full h-full flex items-center justify-center">

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -59,57 +59,6 @@
 	let availableHeight = $derived(hostHeight ?? windowHeight)
 	let chromeRem = $derived(windowWidth >= SM_BREAKPOINT_PX ? CHROME_REM.fromSm : CHROME_REM.belowSm)
 
-	// Past this, render with whatever metrics are available rather than sit on the raw source.
-	const FONT_LOAD_TIMEOUT_MS = 2000
-
-	// Variation selectors and the ZWJ carry no glyph yet repeat across up to nine of the ten
-	// emoji subsets, so sampling them makes one `❤️` start ~1.3 MB of downloads. The base
-	// characters alone select the right subset. Skin-tone modifiers and U+20E3 are deliberately
-	// kept: each is what selects the subset holding its ligature.
-	const EMOJI_FORMAT_CHARS = /[\uFE0E\uFE0F\u200D]/g
-
-	// Mermaid draws `#NNN;` as the character that code names (decimal only — its own test is
-	// /^\+?\d+$/), so a label written that way is pure ASCII in source yet renders an emoji.
-	// Decode before sampling or those diagrams skip the preload below. Feeds the font sample
-	// only, never the source mermaid parses, so over-matching a colour like `fill:#123;` costs
-	// at most one spurious subset and can never drop a character the sample needs.
-	function decodeEntityCodes(source: string): string {
-		return source.replace(/#(\+?\d+);/g, (whole, code: string) => {
-			const point = Number(code)
-			return point <= 0x10ffff ? String.fromCodePoint(point) : whole
-		})
-	}
-
-	/**
-	 * Mermaid sizes every node by measuring its rendered label, so the fonts that label will be
-	 * drawn in must be loaded first: measured against fallback metrics the boxes come out too
-	 * narrow and the labels overflow them once the real font swaps in.
-	 *
-	 * Only the non-ASCII of the source is offered to the emoji font. Its subsets cover digits,
-	 * `#` and `*`, so passing the whole source would pull 64 KB for any diagram carrying a
-	 * number. Keycaps still resolve: their U+20E3 is non-ASCII and shares a subset with the
-	 * digit bases, and every other emoji class — flags, skin tones, ZWJ sequences — is
-	 * non-ASCII by construction, so this needs no emoji grammar to keep up to date.
-	 */
-	async function loadLabelFonts(source: string): Promise<void> {
-		const decoded = decodeEntityCodes(source)
-		// eslint-disable-next-line no-control-regex
-		const nonAscii = decoded.replace(/[\x00-\x7F]/g, '').replace(EMOJI_FORMAT_CHARS, '')
-		const loads = [document.fonts?.load('16px Inter', decoded)]
-		if (nonAscii) loads.push(document.fonts?.load('16px "Noto Color Emoji"', nonAscii))
-		let timer: ReturnType<typeof setTimeout> | undefined
-		try {
-			// Neither a rejection nor a stalled fetch may reach the caller's catch, which reads any
-			// throw as a parse failure and drops the diagram to raw source.
-			await Promise.race([
-				Promise.all(loads).catch(() => {}),
-				new Promise((resolve) => (timer = setTimeout(resolve, FONT_LOAD_TIMEOUT_MS)))
-			])
-		} finally {
-			clearTimeout(timer)
-		}
-	}
-
 	async function render(source: string, dark: boolean) {
 		const seq = ++renderSeq
 		if (!source?.trim()) {
@@ -133,13 +82,20 @@
 				// Throw on parse errors instead of injecting an orphan error diagram into the DOM.
 				suppressErrorRendering: true
 			})
-			await loadLabelFonts(source)
-			if (seq !== renderSeq) return
 			// mermaid.render needs a fresh element id per attempt to avoid id collisions.
 			const result = await mermaid.render(`mermaid-${randomUUID()}`, source)
 			if (seq !== renderSeq) return
 			svg = result.svg
 			renderedCode = source
+			// Mermaid sizes each node by measuring its label, so a font still in flight yields
+			// boxes cut to fallback metrics that the real glyphs then overflow. Drawing the
+			// diagram is itself what asks for the fonts its glyphs need — including the emoji
+			// subsets — so let them settle and lay it out again against the true metrics.
+			if (document.fonts?.status === 'loading') {
+				await document.fonts.ready
+				if (seq !== renderSeq) return
+				svg = (await mermaid.render(`mermaid-${randomUUID()}`, source)).svg
+			}
 		} catch {
 			// Parse failure (often a partial block still streaming in): fall back to the
 			// raw source. `showSvg` already hides any previous diagram since `renderedCode`

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -62,10 +62,10 @@
 	// Past this, render with whatever metrics are available rather than sit on the raw source.
 	const FONT_LOAD_TIMEOUT_MS = 2000
 
-	// Variation selectors and the ZWJ carry no glyph but sit in nine of the ten emoji subsets,
-	// so sampling them makes one `❤️` start ~1.3 MB of downloads. The base characters on their
-	// own select the right subset. U+20E3 is deliberately not here: it lives in a single subset
-	// and is what makes a keycap resolve.
+	// Variation selectors and the ZWJ carry no glyph yet repeat across up to nine of the ten
+	// emoji subsets, so sampling them makes one `❤️` start ~1.3 MB of downloads. The base
+	// characters alone select the right subset. Skin-tone modifiers and U+20E3 are deliberately
+	// kept: each is what selects the subset holding its ligature.
 	const EMOJI_FORMAT_CHARS = /[\uFE0E\uFE0F\u200D]/g
 
 	// Mermaid draws `#NNN;` as the character that code names (decimal only — its own test is

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -62,6 +62,12 @@
 	// Past this, render with whatever metrics are available rather than sit on the raw source.
 	const FONT_LOAD_TIMEOUT_MS = 2000
 
+	// Variation selectors and the ZWJ carry no glyph but sit in nine of the ten emoji subsets,
+	// so sampling them makes one `❤️` start ~1.3 MB of downloads. The base characters on their
+	// own select the right subset. U+20E3 is deliberately not here: it lives in a single subset
+	// and is what makes a keycap resolve.
+	const EMOJI_FORMAT_CHARS = /[\uFE0E\uFE0F\u200D]/g
+
 	// Mermaid draws `#NNN;` as the character that code names (decimal only — its own test is
 	// /^\+?\d+$/), so a label written that way is pure ASCII in source yet renders an emoji.
 	// Decode before sampling or those diagrams skip the preload below. Feeds the font sample
@@ -88,7 +94,7 @@
 	async function loadLabelFonts(source: string): Promise<void> {
 		const decoded = decodeEntityCodes(source)
 		// eslint-disable-next-line no-control-regex
-		const nonAscii = decoded.replace(/[\x00-\x7F]/g, '')
+		const nonAscii = decoded.replace(/[\x00-\x7F]/g, '').replace(EMOJI_FORMAT_CHARS, '')
 		const loads = [document.fonts?.load('16px Inter', decoded)]
 		if (nonAscii) loads.push(document.fonts?.load('16px "Noto Color Emoji"', nonAscii))
 		let timer: ReturnType<typeof setTimeout> | undefined

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -127,14 +127,16 @@
 		active ? 'z-10 opacity-100 pointer-events-auto' : 'z-0 opacity-0 pointer-events-none'
 	)
 
-	// Overlays the editor opens (drawers, modals, popovers) anchor here rather than to the
+	// Overlays a tab opens (drawers, modals, popovers) anchor here rather than to the
 	// document, so they stay within this tab and hide with it when another tab takes over.
+	// Every branch that renders content in-realm must bind this — an unbound host makes the
+	// overlay fall back to viewport-`fixed`, spilling it across the whole app.
 	// The stack is per-tab for the same reason: this host stays mounted while hidden, and a
 	// shared stack would let its overlays arbitrate Escape for the tab the user is looking at.
-	let editorEl: HTMLDivElement | undefined = $state()
+	let overlayHostEl: HTMLDivElement | undefined = $state()
 	let hostDrawers = $state({ val: [] as string[] })
 	setOverlayHost({
-		el: () => editorEl,
+		el: () => overlayHostEl,
 		drawers: hostDrawers,
 		// The panel is resized rather than unmounted, so the active tab of a panel that
 		// is off screen is as invisible as a background tab.
@@ -178,7 +180,7 @@
 
 {#if slot.kind === 'editor' && mounted && runtime}
 	<div
-		bind:this={editorEl}
+		bind:this={overlayHostEl}
 		class="absolute inset-0 flex flex-col min-h-0 bg-surface {visibility}"
 		aria-hidden={!active}
 	>
@@ -236,7 +238,11 @@
 		{/if}
 	</div>
 {:else if slot.kind === 'artifact' && mounted}
-	<div class="absolute inset-0 flex flex-col min-h-0 bg-surface {visibility}" aria-hidden={!active}>
+	<div
+		bind:this={overlayHostEl}
+		class="absolute inset-0 flex flex-col min-h-0 bg-surface {visibility}"
+		aria-hidden={!active}
+	>
 		{#if artifact}
 			<ArtifactViewer {artifact} />
 		{:else if !runtime?.manager.artifacts.loading}


### PR DESCRIPTION
## Summary

Two defects in the mermaid diagram viewer, both visible when a diagram is opened fullscreen from a markdown artifact in an AI session.

**1. The fullscreen dialog escaped its pane.** `PreviewTabHost` provides an overlay host so a tab's modals anchor to the preview pane instead of the document, but only the *editor* branch bound the element — the artifact branch never did. `getOverlayHost().el()` therefore returned `undefined` and `Modal` fell back to viewport-`fixed`, so the dialog spanned the whole window and slid under the left nav rail, which paints over it (the dialog's z-index is trapped inside the tab container's `z-10` stacking context). The title rendered as "iagram".

**2. Emoji in a diagram ignored the bundled vector emoji font.** #10498 appended `'Noto Color Emoji'` to the app's *inherited* font stacks (`font-main` in the tailwind config, `.wrap` in `+layout.svelte`). Mermaid emits a `<style>` block **inside** the SVG it generates that hard-sets `font-family`, so nothing inherits into a diagram and emoji fell through to the platform font — Apple Color Emoji, the sbix bitmap font #10498 exists to avoid.

Measuring `🚀✅🔥` at 40px makes the fallback explicit:

| font stack | width |
| --- | --- |
| mermaid's stack, before | 120px |
| explicit `"Apple Color Emoji"` | 120px |
| explicit `"Noto Color Emoji"` | 149.41px |
| mermaid's stack, after | 149.41px |

## Changes

- `PreviewTabHost.svelte`: bind the overlay-host element on the artifact branch too, and rename `editorEl` → `overlayHostEl` since it is no longer editor-only. The third branch renders an `<iframe>`, whose overlays live in its own document, so it correctly needs no binding.
- `MermaidDisplay.svelte`: name `'Noto Color Emoji'` in `mermaid.initialize({ fontFamily })`. `Inter` sits after the MS core fonts — the emoji font's subsets cover digits, `#` and `*`, so on a box without Trebuchet/Verdana/Arial those would otherwise render as its keycap glyphs; keeping Inter behind them leaves diagram typography unchanged where the MS fonts exist.
- `MermaidDisplay.svelte`: re-render once `document.fonts.ready` settles. Mermaid sizes each node by measuring its label, so a font still in flight yields boxes cut to fallback metrics that the real glyphs then overflow. This is the [pattern mermaid recommends](https://github.com/mermaid-js/mermaid/issues/2651) for the same bug class (there, FontAwesome icons).
- `Modal.svelte`: add an opt-in `fillHeight` prop — wrapper `h-full`, box a flex column, body `flex-1 min-h-0` — so tall content can size itself with `h-full`. The centring wrapper is otherwise `min-h-full` (height:auto), which is why percentage heights inside a modal do not resolve. Defaults off; every existing caller renders an identical class set.
- `MermaidDisplay.svelte`: the fullscreen canvas is now plain `h-full` under that mode, replacing a viewport-relative `h-[78vh]` that overflowed the pane once the dialog was correctly anchored.

## Screenshots

Fullscreen diagram opened from an artifact tab, before — the dialog spans the whole window and is clipped by the nav rail (the title reads "iagram"):

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/mermaid-artifacts/1785940890-before.png)

After — contained in the preview pane, filling it, no backdrop scrollbar:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/mermaid-artifacts/1785941381-after-final.png)

## Notes on the approach

The first draft of this PR predicted which font subsets a diagram would need and preloaded them before rendering. That required the code to know about `unicode-range` layout, mermaid's `#NNN;` entity codes, and emoji format characters — and review rounds kept finding classes it had missed (flags and skin-tone modifiers, entity-coded emoji, and U+FE0F sitting in 9 of 10 subsets, which made one `❤️` start 1.3 MB of downloads). Re-rendering after `document.fonts.ready` needs none of that: the browser already knows exactly which subsets the glyphs require. Verified across entity codes, VS16, flags, skin tones, keycaps and ZWJ sequences — all correct — while a digits-only diagram fetches no emoji font at all.

Likewise, the canvas height was originally measured with a `ResizeObserver` and a constant duplicating `Modal`'s padding. Two review rounds found bugs in that constant. Giving `Modal` a fill-height mode removes the arithmetic entirely.

## Test plan

- [ ] In an AI session, have the chat create a markdown artifact containing a ```mermaid fenced block, then click the expand icon on the diagram. The dialog stays inside the preview pane — no part of it under the left nav rail — and fills it without a backdrop scrollbar.
- [ ] Do the same for a mermaid block in a chat *message* (no overlay host): the dialog is viewport-anchored and centred, with no clipping.
- [ ] Resize the window with the dialog open, including past 1760px wide where `:root` scales to 18px: the canvas tracks the available height.
- [ ] Put emoji in node labels (`A["🚀 Deploy"]`, `A["❤️ VS16"]`, `A["🇫🇷 Flag"]`, `A["1️⃣ Keycap"]`). Boxes are wide enough for the label — no clipped trailing characters — and the emoji are Noto's designs, not the platform's.
- [ ] Confirm a few unrelated modals still look right (`fillHeight` defaults off, but `Modal` is shared).
- [ ] **Firefox specifically**: zoom into a diagram with emoji using the fullscreen pan/zoom. The emoji scale with the diagram rather than staying at their unzoomed size — the symptom #10498 targets. *(Not verified here: both local Playwright servers are Chromium, where the platform emoji font scales fine, so this case went unexercised.)*

No test added: this is Svelte component layout and font wiring, which per AGENTS.md the codebase does not unit-test, and the behaviour is geometry that only reproduces in a real browser.
