### PR TITLE
chore: log the resolved worker tags at startup and on config reload

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -2100,7 +2100,11 @@ pub async fn load_worker_config(
         // if no priority is used, push all tags with a priority to 0
         priority_tags_sorted.push(PriorityTags { priority: 0, tags: worker_tags.clone() });
     }
-    tracing::debug!("Custom tags priority set: {:?}", priority_tags_sorted);
+    if priority_tags_map.is_empty() {
+        tracing::info!("Worker tags: {:?}", worker_tags);
+    } else {
+        tracing::info!("Worker tags, by priority desc: {:?}", priority_tags_sorted);
+    }
 
     let env_vars_static = config.env_vars_static.unwrap_or_default().clone();
     let resolved_env_vars: HashMap<String, String> = load_env_vars(


### PR DESCRIPTION
## Summary
The tags a worker actually ends up pulling were reachable at INFO only as one field of the full `WorkerConfig` Debug dump on the `listening for jobs, WORKER_GROUP: …, config: …` line (`windmill-worker/src/worker.rs`). That line is printed once, when the worker enters its loop, so a tag change applied through a worker-group config reload swapped what the worker pulls with no log at all — the only trace was a `debug!` that is off in normal deployments.

This gives the resolved tags their own INFO line in `load_worker_config`, which runs both at startup and on every config reload.

Note that `Loaded setting custom_tags, common: [...]` — the line that looks like it reports this — is the instance-wide *available* custom tags setting, unrelated to what a given worker pulls.

## Changes
- `backend/windmill-common/src/worker.rs`: replace the `debug!("Custom tags priority set: …")` at the end of `load_worker_config` with an INFO line — `Worker tags: [...]`, or `Worker tags, by priority desc: [...]` when the group has priority tags configured, so the priority ordering that governs pull order is visible without re-deriving it.

## Test plan
- [ ] Start a worker with a plain worker group: `Worker tags: ["bash", "deno", …]` appears at INFO, alongside the existing `Loading config from WORKER_GROUP: …`
- [ ] Set priority tags on the group in the UI: the line becomes `Worker tags, by priority desc: [PriorityTags { priority: 2, tags: [...] }, …]`
- [ ] Edit the group's tags while the worker is running: the reload logs the new tags (previously silent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs the resolved worker tags at INFO on startup and on each config reload, making tag changes visible without DEBUG. When priority tags are set, the log shows the priority-sorted view.

- **Bug Fixes**
  - Print "Worker tags: [...]" or "Worker tags, by priority desc: [...]" from `load_worker_config`.
  - Previously, tags appeared only once in the initial config dump; reloads produced no tag log.

<sup>Written for commit c44e422cbc90a1c438d2c45120dbf666a81fa49d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

