### PR TITLE
feat: register mounted CA certificates in windmill_extra at startup

### DIFF
--- a/debugger/README.md
+++ b/debugger/README.md
@@ -119,8 +119,8 @@ not enough on its own, since `requests` carries its own bundle and Node reads on
 only the service needs them.
 
 Registering that CA in the container's system store happens on its own: mount it into
-`/usr/local/share/ca-certificates/` and `windmill_extra` runs `update-ca-certificates` before
-starting any service. `RUN_UPDATE_CA_CERTIFICATE_AT_START=true` forces the same thing whether or not
+`/usr/local/share/ca-certificates/` **named `*.crt`**, the only extension `update-ca-certificates`
+reads, and `windmill_extra` runs it before starting any service. `RUN_UPDATE_CA_CERTIFICATE_AT_START=true` forces the same thing whether or not
 certificates are mounted there, and `RUN_UPDATE_CA_CERTIFICATE_PATH` overrides the tool, matching
 the server and worker. Both are best-effort: a UID that cannot write `/etc/ssl/certs` logs a warning
 and the container still boots. `INIT_SCRIPT` remains the hook for anything more involved, and unlike

--- a/debugger/README.md
+++ b/debugger/README.md
@@ -118,9 +118,18 @@ not enough on its own, since `requests` carries its own bundle and Node reads on
 `NODE_EXTRA_CA_CERTS`. Registry settings are deliberately not forwarded: they carry credentials and
 only the service needs them.
 
-To install that CA into the container's system store in the first place, set `INIT_SCRIPT` on the
-`windmill_extra` container (e.g. `INIT_SCRIPT=update-ca-certificates`). It runs before any service
-starts and aborts startup if it fails, the same hook a worker offers.
+Registering that CA in the container's system store happens on its own: mount it into
+`/usr/local/share/ca-certificates/` and `windmill_extra` runs `update-ca-certificates` before
+starting any service. `RUN_UPDATE_CA_CERTIFICATE_AT_START=true` forces the same thing whether or not
+certificates are mounted there, and `RUN_UPDATE_CA_CERTIFICATE_PATH` overrides the tool, matching
+the server and worker. Both are best-effort: a UID that cannot write `/etc/ssl/certs` logs a warning
+and the container still boots. `INIT_SCRIPT` remains the hook for anything more involved, and unlike
+the CA update it aborts startup when it fails.
+
+Note what the system store does *not* cover, which is most of what a debug session installs with:
+uv trusts its own bundled roots unless `PY_NATIVE_CERT`/`UV_NATIVE_TLS` is `true`, Bun and Node read
+only `NODE_EXTRA_CA_CERTS`, and `requests` carries certifi. Registering the CA fixes Python's stdlib
+`ssl`, `curl` and `git`; the rest still needs the variables above.
 
 Keeping the settings out of the session's environment only bounds what the debugged script can read
 from itself. An unsandboxed session runs under the same user as the service and can still read the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,9 +187,9 @@ services:
       # - DEBUG_ALLOWED_ORIGINS=https://your-windmill-host # Optional CSWSH hardening: comma-separated allowlist of browser Origins permitted to open debug WebSockets
     volumes:
       - lsp_cache:/pyls/.cache
-      # Behind a TLS-intercepting proxy, mount its CA here and it is registered in the system trust
-      # store before any service starts. uv, Bun and requests read their own roots, so also set
-      # PY_NATIVE_CERT / NODE_EXTRA_CA_CERTS / REQUESTS_CA_BUNDLE — see debugger/README.md
+      # Behind a TLS-intercepting proxy, mount its CA here (as .crt) and it is registered in the
+      # system trust store before any service starts. That alone does not cover dependency
+      # installation — see debugger/README.md for the variables it also needs
       # - ./corp-ca.crt:/usr/local/share/ca-certificates/corp-ca.crt:ro
     logging: *default-logging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,10 @@ services:
       # - DEBUG_ALLOWED_ORIGINS=https://your-windmill-host # Optional CSWSH hardening: comma-separated allowlist of browser Origins permitted to open debug WebSockets
     volumes:
       - lsp_cache:/pyls/.cache
+      # Behind a TLS-intercepting proxy, mount its CA here and it is registered in the system trust
+      # store before any service starts. uv, Bun and requests read their own roots, so also set
+      # PY_NATIVE_CERT / NODE_EXTRA_CA_CERTS / REQUESTS_CA_BUNDLE — see debugger/README.md
+      # - ./corp-ca.crt:/usr/local/share/ca-certificates/corp-ca.crt:ro
     logging: *default-logging
 
   caddy:

--- a/docker/entrypoint-extra.sh
+++ b/docker/entrypoint-extra.sh
@@ -36,32 +36,39 @@ export HOME
 # Register CA certificates mounted into the image before anything opens a TLS connection.
 # Best-effort on purpose, unlike INIT_SCRIPT below: a non-root UID cannot write /etc/ssl/certs, and
 # a deployment that never needed a custom CA must still boot. Env var names and the default-off
-# behavior match the server/worker binary, so one setting covers every container.
-#
-# This only reaches what reads the system trust store: Python's stdlib ssl, curl, git. uv verifies
-# against its own bundled roots unless PY_NATIVE_CERT/UV_NATIVE_TLS is true, Bun and Node read only
-# NODE_EXTRA_CA_CERTS, and requests carries certifi — see debugger/README.md.
+# behavior match the server/worker binary, so one setting covers every container. What the system
+# trust store does and does not reach is documented in debugger/README.md.
+CA_CERT_DIR=/usr/local/share/ca-certificates
+
 update_ca_certificates() {
     local reason="$1"
     local tool="${RUN_UPDATE_CA_CERTIFICATE_PATH:-/usr/sbin/update-ca-certificates}"
+    local output
     if [ ! -x "$tool" ]; then
         echo "[entrypoint] $reason but $tool is not executable, skipping CA update"
         return
     fi
     echo "[entrypoint] $reason, running $tool"
-    if "$tool" > /dev/null 2>&1; then
+    if output=$("$tool" 2>&1); then
         echo "[entrypoint] CA certificates updated"
     else
-        echo "[entrypoint] WARNING: $tool failed (UID $(id -u) may not own /etc/ssl/certs); continuing" >&2
+        # Carry the tool's own message: the usual cause is an unwritable /etc/ssl/certs under a
+        # non-root UID, but guessing that in place of the real error hides everything else.
+        echo "[entrypoint] WARNING: $tool failed (UID $(id -u)): ${output:-no output}; continuing" >&2
     fi
 }
 
 if [ "$(echo "${RUN_UPDATE_CA_CERTIFICATE_AT_START:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
     update_ca_certificates "RUN_UPDATE_CA_CERTIFICATE_AT_START=true"
-elif [ -n "$(ls -A /usr/local/share/ca-certificates 2>/dev/null)" ]; then
+elif [ -n "$(find -L "$CA_CERT_DIR" -maxdepth 1 -type f -name '*.crt' -print -quit 2>/dev/null)" ]; then
     # Certificates mounted there are unambiguous intent, and they do nothing until registered, so
     # take the same action without making the operator also find the env var.
-    update_ca_certificates "Found certificates in /usr/local/share/ca-certificates"
+    update_ca_certificates "Found certificates in $CA_CERT_DIR"
+elif [ -n "$(ls -A "$CA_CERT_DIR" 2>/dev/null)" ]; then
+    # Reporting success over a mount update-ca-certificates ignores would be worse than saying
+    # nothing: .pem is the spelling people reach for, and only .crt is read.
+    echo "[entrypoint] WARNING: $CA_CERT_DIR has files but none named *.crt, the only extension" \
+        "update-ca-certificates reads; they will be ignored" >&2
 fi
 
 # INIT_SCRIPT is the documented hook for preparing the host before anything reaches the network

--- a/docker/entrypoint-extra.sh
+++ b/docker/entrypoint-extra.sh
@@ -60,7 +60,7 @@ update_ca_certificates() {
 
 if [ "$(echo "${RUN_UPDATE_CA_CERTIFICATE_AT_START:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
     update_ca_certificates "RUN_UPDATE_CA_CERTIFICATE_AT_START=true"
-elif [ -n "$(find -L "$CA_CERT_DIR" -maxdepth 1 -type f -name '*.crt' -print -quit 2>/dev/null)" ]; then
+elif [ -n "$(find -L "$CA_CERT_DIR" -type f -name '*.crt' -print -quit 2>/dev/null)" ]; then
     # Certificates mounted there are unambiguous intent, and they do nothing until registered, so
     # take the same action without making the operator also find the env var.
     update_ca_certificates "Found certificates in $CA_CERT_DIR"

--- a/docker/entrypoint-extra.sh
+++ b/docker/entrypoint-extra.sh
@@ -33,6 +33,37 @@ if [ ! -w "$HOME" ]; then
 fi
 export HOME
 
+# Register CA certificates mounted into the image before anything opens a TLS connection.
+# Best-effort on purpose, unlike INIT_SCRIPT below: a non-root UID cannot write /etc/ssl/certs, and
+# a deployment that never needed a custom CA must still boot. Env var names and the default-off
+# behavior match the server/worker binary, so one setting covers every container.
+#
+# This only reaches what reads the system trust store: Python's stdlib ssl, curl, git. uv verifies
+# against its own bundled roots unless PY_NATIVE_CERT/UV_NATIVE_TLS is true, Bun and Node read only
+# NODE_EXTRA_CA_CERTS, and requests carries certifi — see debugger/README.md.
+update_ca_certificates() {
+    local reason="$1"
+    local tool="${RUN_UPDATE_CA_CERTIFICATE_PATH:-/usr/sbin/update-ca-certificates}"
+    if [ ! -x "$tool" ]; then
+        echo "[entrypoint] $reason but $tool is not executable, skipping CA update"
+        return
+    fi
+    echo "[entrypoint] $reason, running $tool"
+    if "$tool" > /dev/null 2>&1; then
+        echo "[entrypoint] CA certificates updated"
+    else
+        echo "[entrypoint] WARNING: $tool failed (UID $(id -u) may not own /etc/ssl/certs); continuing" >&2
+    fi
+}
+
+if [ "$(echo "${RUN_UPDATE_CA_CERTIFICATE_AT_START:-false}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+    update_ca_certificates "RUN_UPDATE_CA_CERTIFICATE_AT_START=true"
+elif [ -n "$(ls -A /usr/local/share/ca-certificates 2>/dev/null)" ]; then
+    # Certificates mounted there are unambiguous intent, and they do nothing until registered, so
+    # take the same action without making the operator also find the env var.
+    update_ca_certificates "Found certificates in /usr/local/share/ca-certificates"
+fi
+
 # INIT_SCRIPT is the documented hook for preparing the host before anything reaches the network
 # (CA certificates, proxies, mounts), matching the worker's INIT_SCRIPT. It must therefore complete
 # before any service starts, and a failure has to abort: services that come up with an unprepared


### PR DESCRIPTION
## Summary

`windmill_extra` ignored `RUN_UPDATE_CA_CERTIFICATE_AT_START`. The server and worker binary have honored it since forever (`backend/src/main.rs`, best-effort and default-off, with `RUN_UPDATE_CA_CERTIFICATE_PATH` to override the tool), so an operator who sets it across their deployment got it silently dropped on this one container — the same class of no-op as `INIT_SCRIPT` before #10532.

Follow-up to #10532, which left `INIT_SCRIPT=update-ca-certificates` as the only way to get a CA into this container's trust store.

## Changes

`docker/entrypoint-extra.sh` registers CA certificates before any service starts, by two routes:

- **`RUN_UPDATE_CA_CERTIFICATE_AT_START=true`**, with `RUN_UPDATE_CA_CERTIFICATE_PATH` overriding the tool. Same names, same default-off, same best-effort behavior as the server/worker, so one setting covers every container.
- **Certificates present in `/usr/local/share/ca-certificates/`** trigger the same action without the env var. Mounting a CA there is unambiguous intent and does nothing until registered, so requiring the operator to also discover a variable is what made this a support case in the first place.

Best-effort on purpose, unlike `INIT_SCRIPT`: a missing tool is skipped, a failing one warns and startup continues. The entrypoint explicitly supports arbitrary non-root UIDs, which cannot write `/etc/ssl/certs`, and a deployment that never needed a custom CA must still boot. `INIT_SCRIPT` keeps its abort-on-failure semantics and still runs after this, so it can do anything more involved.

The compose file gains a commented mount showing where the CA goes.

## What this does not fix, and why the docs say so

Registering the CA reaches only what reads the system trust store: Python's stdlib `ssl`, `curl`, `git`. It does **not** help the things a debug session actually installs with — uv verifies against its own bundled roots unless `PY_NATIVE_CERT`/`UV_NATIVE_TLS` is `true`, Bun and Node read only `NODE_EXTRA_CA_CERTS`, and `requests` carries certifi. All measured while doing #10532.

That is the trap worth avoiding: making the CA "just work" invites the conclusion that mounting it is sufficient, and then `pip` still fails with an untrusted certificate. `debugger/README.md` now states the split explicitly.

## Test plan

Exercised each path against the real entrypoint with a stub tool, services disabled:

- [x] `RUN_UPDATE_CA_CERTIFICATE_AT_START=true` runs the tool and logs success; `TRUE` is normalized too.
- [x] Tool exits non-zero → `WARNING: … may not own /etc/ssl/certs; continuing`, and the container proceeds to start services rather than dying on `set -e`.
- [x] Tool missing/not executable → logs `skipping CA update`, startup continues.
- [x] Certificates in the mount directory → runs without the env var; an **empty** directory stays completely silent.
- [x] Neither set → no CA output at all, behavior identical to today.
- [x] Ordering: CA update logs before `INIT_SCRIPT` runs, which logs before the service banner. `INIT_SCRIPT` still aborts with its own exit code (verified `exit 9` → container exit 9).
- [x] A `.pem` (or any non-`.crt`) in the mount directory warns that it will be ignored instead of reporting a bogus `CA certificates updated`; a `.crt` still auto-runs, including one nested in a subdirectory — the detection mirrors Debian's own `find -L "$LOCALCERTSDIR" -type f -name '*.crt'`, which is unbounded in depth.
- [x] A failing tool's own stderr reaches the log rather than a guessed cause.
- [x] `bash -n` on the entrypoint, compose file parses.

No test shipped: this is container startup wiring with no unit-testable surface, and the matrix above covers every branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable automatic registration of mounted CA certificates in the `windmill_extra` container at startup, matching server/worker behavior. Prevents silent no-op when operators set CA update env vars across all containers.

- **New Features**
  - `docker/entrypoint-extra.sh` updates the system trust store before services start when either:
    - `RUN_UPDATE_CA_CERTIFICATE_AT_START=true` (override via `RUN_UPDATE_CA_CERTIFICATE_PATH`), or
    - `*.crt` exists under `/usr/local/share/ca-certificates/` (recursive, follows symlinks like Debian).
  - Best-effort: skips if the tool is missing, warns on failure, never blocks boot; runs before `INIT_SCRIPT`, which still aborts on failure. `docker-compose.yml` adds a commented mount; `debugger/README.md` explains system trust store limits and notes vars for tool-specific roots (`PY_NATIVE_CERT`, `UV_NATIVE_TLS`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`).

- **Bug Fixes**
  - Avoid false success: only update when `*.crt` is present and the tool is executable; warn on non-`.crt` mounts. Detection mirrors Debian’s behavior (recursive, follows symlinks).

<sup>Written for commit 7d2d5c9eded8b78933837826ec99637215098931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

