### PR TITLE
fix(debugger): confine prepare-deps under nsjail in both language paths

### DIFF
--- a/debugger/README.md
+++ b/debugger/README.md
@@ -129,6 +129,14 @@ unsandboxed. Isolating sessions from the service takes `--nsjail --nsjail-config
 nsjail.debug.config.proto`: it is that config's PID namespace and `mount_proc` that put the service
 out of reach, not the flag on its own.
 
+The installer is jailed on the same terms, in both languages: `uv pip install` builds source
+distributions and `bun install` runs postinstall scripts, so a package's own code executes there
+too. It keeps the service's environment across that boundary — the config sets `keep_env`, which is
+how the settings above reach it — so replacing that with an allowlist would have to carry the
+registry and CA variables in explicitly. It also runs in its own process group, because `uv` and
+`bun` are grandchildren: signalling only the installer reparents them to init and they keep
+downloading, which would make the timeout and the cancel-on-disconnect half-measures.
+
 ### Frontend Integration
 
 ```svelte

--- a/debugger/dap_debug_service.ts
+++ b/debugger/dap_debug_service.ts
@@ -40,7 +40,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 // Import the working Bun debug session from the standalone server
-import { DebugSession as BunDebugSessionWorking, type NsjailConfig } from './dap_websocket_server_bun'
+import {
+	DebugSession as BunDebugSessionWorking,
+	killProcessTree,
+	nsjailWrap,
+	type NsjailConfig
+} from './dap_websocket_server_bun'
 import { sessionEnv } from './env_passthrough'
 
 // ============================================================================
@@ -349,6 +354,17 @@ interface SpawnOptions {
 	cmd: string[]
 	cwd?: string
 	env?: Record<string, string>
+	stdin?: Blob
+	/**
+	 * Hand the child this process's whole environment rather than the minimal set below. Only
+	 * the dependency installer wants it: the registry credentials and CA settings it reads are
+	 * precisely what the minimal set exists to keep away from a debugged script.
+	 */
+	inheritEnv?: boolean
+	/**
+	 * Start the child in its own process group, so killProcessTree can signal what it spawns.
+	 */
+	detached?: boolean
 	stdout?: 'pipe' | 'inherit'
 	stderr?: 'pipe' | 'inherit'
 }
@@ -364,30 +380,9 @@ const PREPARE_DEPS_TIMEOUT_MS = Number(process.env.DAP_PREPARE_DEPS_TIMEOUT_MS) 
  * This is the key function for sandboxed execution.
  */
 function spawnProcess(options: SpawnOptions): Subprocess {
-	let cmd = options.cmd
+	const cmd = nsjailWrap(options.cmd, config.nsjail, options.cwd)
 
 	if (config.nsjail.enabled) {
-		// Build nsjail command
-		const nsjailCmd = [config.nsjail.binaryPath]
-
-		// Add config file if specified
-		if (config.nsjail.configPath) {
-			nsjailCmd.push('--config', config.nsjail.configPath)
-		}
-
-		// Add any extra nsjail arguments
-		nsjailCmd.push(...config.nsjail.extraArgs)
-
-		// Add working directory if specified
-		if (options.cwd) {
-			nsjailCmd.push('--cwd', options.cwd)
-		}
-
-		// Separator and actual command
-		nsjailCmd.push('--')
-		nsjailCmd.push(...cmd)
-
-		cmd = nsjailCmd
 		logger.info(`Spawning with nsjail: ${cmd.join(' ')}`)
 	} else {
 		logger.info(`Spawning: ${cmd.join(' ')}`)
@@ -398,9 +393,12 @@ function spawnProcess(options: SpawnOptions): Subprocess {
 	return spawn({
 		cmd,
 		cwd: options.cwd || process.cwd(),
+		...(options.stdin ? { stdin: options.stdin } : {}),
+		...(options.detached ? { detached: true } : {}),
 		stdout: options.stdout || 'pipe',
 		stderr: options.stderr || 'pipe',
 		env: {
+			...(options.inheritEnv ? process.env : {}),
 			// Essential system vars
 			PATH: process.env.PATH || '/usr/bin:/bin',
 			HOME: process.env.HOME,
@@ -657,8 +655,10 @@ class PythonDebugSession extends BaseDebugSession {
 	 * server executes the submitted script inside its own interpreter: anything in that process is
 	 * recoverable by the script. The service never executes user code, so the credentials stop here.
 	 *
-	 * The trade-off is that the install itself is not jailed, so a source distribution's build
-	 * backend runs outside nsjail, as it already does for Bun sessions.
+	 * It still goes through spawnProcess so nsjail confines it on the same terms as the debuggee:
+	 * `uv pip install` builds source distributions, which executes their build backend's arbitrary
+	 * Python. Those same credentials are what `inheritEnv` is for — the jail config keeps the
+	 * environment across the boundary, so nothing else has to carry them in.
 	 */
 	private async prepareDependencies(code: string): Promise<string | null> {
 		if (!this.windmillPath) {
@@ -667,6 +667,12 @@ class PythonDebugSession extends BaseDebugSession {
 		}
 
 		const warn = (reason: string): null => {
+			// cleanup() kills the installer, which ends the read with nothing to parse. Reporting
+			// that as an install failure blames the user for their own disconnect, on a websocket
+			// that is being torn down anyway.
+			if (this.disposed) {
+				return null
+			}
 			logger.error(`prepare-deps failed: ${reason}`)
 			this.sendEvent('output', {
 				category: 'stderr',
@@ -676,7 +682,7 @@ class PythonDebugSession extends BaseDebugSession {
 		}
 
 		try {
-			const proc = spawn({
+			const proc = spawnProcess({
 				cmd: [this.windmillPath, 'prepare-deps'],
 				// The venv has to be built against the interpreter that will run the script: its
 				// site-packages goes on that interpreter's sys.path, and uv otherwise picks its
@@ -684,8 +690,8 @@ class PythonDebugSession extends BaseDebugSession {
 				stdin: new Blob([
 					JSON.stringify({ code, language: 'python3', python_path: config.pythonPath }) + '\n'
 				]),
-				stdout: 'pipe',
-				stderr: 'pipe'
+				inheritEnv: true,
+				detached: true
 			})
 			this.prepareDepsProcess = proc
 
@@ -694,9 +700,10 @@ class PythonDebugSession extends BaseDebugSession {
 			// races the read rather than only killing the child: a grandchild holding the pipe open
 			// keeps the read pending long after the child itself is gone.
 			let timer: ReturnType<typeof setTimeout> | undefined
+			// spawnProcess's return type does not carry the piped stdio through
 			const read = (async () => ({
-				output: await new Response(proc.stdout).text(),
-				stderr: await new Response(proc.stderr).text()
+				output: await new Response(proc.stdout as ReadableStream).text(),
+				stderr: await new Response(proc.stderr as ReadableStream).text()
 			}))()
 			const result = await Promise.race([
 				read,
@@ -708,9 +715,7 @@ class PythonDebugSession extends BaseDebugSession {
 			this.prepareDepsProcess = null
 
 			if (!result) {
-				// SIGKILL, not the default SIGTERM: prepare-deps does not act on SIGTERM while uv
-				// is running, so a polite signal leaves it running after the session gave up.
-				proc.kill('SIGKILL')
+				killProcessTree(proc)
 				return warn(
 					`dependency installation timed out after ${PREPARE_DEPS_TIMEOUT_MS / 1000}s`
 				)
@@ -1026,6 +1031,10 @@ class PythonDebugSession extends BaseDebugSession {
 	}
 
 	private async handleLaunch(request: DAPMessage): Promise<void> {
+		// Per launch, not per session: cleanup() also runs when a program finishes normally, and
+		// the flag must only mean "torn down while this launch was still preparing".
+		this.disposed = false
+
 		const args = request.arguments || {}
 		let code = args.code as string | undefined
 		this.scriptPath = args.program as string | undefined
@@ -1181,7 +1190,7 @@ sys.stdout.flush()
 
 		// A client that gives up mid-install must not leave the package manager running
 		if (this.prepareDepsProcess) {
-			this.prepareDepsProcess.kill('SIGKILL')
+			killProcessTree(this.prepareDepsProcess)
 			this.prepareDepsProcess = null
 		}
 

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -22,6 +22,7 @@
  */
 
 import { spawn, type Subprocess } from 'bun'
+import { readFileSync } from 'node:fs'
 import { mkdtemp, writeFile, unlink, rmdir, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -558,6 +559,63 @@ export interface NsjailConfig {
 }
 
 /**
+ * Wrap a command so nsjail runs it, or return it unchanged when sandboxing is off.
+ * The environment is not filtered here: the config sets `keep_env`, so the jailed process
+ * receives whatever the spawning call gives it.
+ */
+export function nsjailWrap(cmd: string[], nsjail: NsjailConfig | undefined, cwd?: string): string[] {
+	if (!nsjail?.enabled) {
+		return cmd
+	}
+	const wrapped = [nsjail.binaryPath]
+	if (nsjail.configPath) {
+		wrapped.push('--config', nsjail.configPath)
+	}
+	if (nsjail.extraArgs) {
+		wrapped.push(...nsjail.extraArgs)
+	}
+	if (cwd) {
+		wrapped.push('--cwd', cwd)
+	}
+	wrapped.push('--', ...cmd)
+	return wrapped
+}
+
+/**
+ * SIGKILL a subprocess along with everything it spawned.
+ *
+ * SIGKILL because `windmill prepare-deps` does not act on SIGTERM while uv is running. The
+ * whole group because uv is a grandchild: signalling the child alone reparents uv to init and
+ * it keeps downloading. The group id is read back from /proc instead of assumed, since a group
+ * kill aimed at this service's own group would take down every service in the container; a
+ * child spawned without `detached` therefore only gets the plain kill.
+ */
+export function killProcessTree(proc: Subprocess): void {
+	if (proc.exitCode !== null || proc.signalCode !== null) {
+		// Nothing left to signal, and the pid may already have been handed to someone else
+		return
+	}
+
+	let ownsGroup = false
+	try {
+		const stat = readFileSync(`/proc/${proc.pid}/stat`, 'utf8')
+		// The comm field can hold spaces and parentheses, so read the fields after its closing one
+		ownsGroup = Number(stat.slice(stat.lastIndexOf(')') + 2).split(' ')[2]) === proc.pid
+	} catch {
+		// Already reaped, or not Linux: fall back to killing the process alone
+	}
+	try {
+		if (ownsGroup) {
+			process.kill(-proc.pid, 'SIGKILL')
+		} else {
+			proc.kill('SIGKILL')
+		}
+	} catch (error) {
+		logger.error('Failed to kill process:', error)
+	}
+}
+
+/**
  * VLQ (Variable-Length Quantity) decoder for source maps.
  * Returns array of decoded integers from VLQ string.
  */
@@ -753,6 +811,11 @@ export class DebugSession {
 
 	// Path to installed node_modules (set after prepare-deps runs)
 	private nodeModulesPath?: string
+
+	// Running dependency installer, so a teardown mid-install can stop it
+	private prepareDepsProcess: Subprocess | null = null
+
+	private disposed = false
 
 	constructor(ws: WebSocket, options?: { nsjailConfig?: NsjailConfig; bunPath?: string; windmillPath?: string }) {
 		this.ws = ws
@@ -1438,6 +1501,10 @@ export class DebugSession {
 	 * Handle the 'launch' request.
 	 */
 	async handleLaunch(request: DAPMessage): Promise<void> {
+		// Per launch, not per session: cleanup() also runs when a program finishes normally, and
+		// the flag must only mean "torn down while this launch was still preparing".
+		this.disposed = false
+
 		const args = request.arguments || {}
 		let code = args.code as string | undefined
 		this.scriptPath = args.program as string | undefined
@@ -1491,6 +1558,16 @@ export class DebugSession {
 		// This analyzes imports and installs required npm packages
 		if (code) {
 			this.nodeModulesPath = await this.prepareDependencies(code) || undefined
+
+			// Installing takes long enough for the client to give up meanwhile, and cleanup() has
+			// then already run: starting the debuggee now would leak a process nothing owns.
+			// The response still goes out, since a client that terminated without closing the
+			// socket is otherwise left waiting out its own launch timeout.
+			if (this.disposed) {
+				logger.info('Session was torn down during dependency preparation, not starting Bun')
+				this.sendResponse(request, false, {}, 'Session terminated during dependency preparation')
+				return
+			}
 
 			// Remove version specifiers from imports (e.g., "lodash@4" -> "lodash")
 			// This must happen AFTER prepareDependencies (which needs the versions)
@@ -1573,6 +1650,11 @@ export class DebugSession {
 	 * Prepare dependencies by calling the windmill CLI's prepare-deps command.
 	 * This analyzes imports in the code and installs required npm packages.
 	 * Returns the path to node_modules if any were installed.
+	 *
+	 * Jailed on the same terms as the debuggee: `bun install` runs the packages' postinstall
+	 * scripts, which is user-supplied code executing next to the other services in the container.
+	 * Its environment is inherited rather than filtered, which is what carries the registry and
+	 * CA settings into the installer (the jail keeps the environment across the boundary).
 	 */
 	private async prepareDependencies(code: string, language: string = 'bun'): Promise<string | null> {
 		if (!this.windmillPath) {
@@ -1600,30 +1682,39 @@ export class DebugSession {
 			const input = JSON.stringify({ code, language }) + '\n'
 			logger.info(`prepare-deps input length: ${input.length}`)
 
-			// Spawn the windmill binary with prepare-deps command. This runs in the service
-			// process, so inheriting its environment is what gives prepare-deps the container's
-			// index and certificate settings; the allowlist above is what keeps them from the
-			// debugged script.
+			// Spawn the windmill binary with prepare-deps command. Its environment is inherited
+			// rather than filtered, which is what gives prepare-deps the container's index and
+			// certificate settings; the allowlist above is what keeps them from the debugged
+			// script, and the jail keeps them across its own boundary.
+			const cmd = nsjailWrap([this.windmillPath, 'prepare-deps'], this.nsjailConfig)
+			logger.info(`Spawning${this.nsjailConfig?.enabled ? ' with nsjail' : ''}: ${cmd.join(' ')}`)
 			const proc = spawn({
-				cmd: [this.windmillPath, 'prepare-deps'],
+				cmd,
 				stdin: new Blob([input]),  // Use Blob for complete stdin data
 				stdout: 'pipe',
-				stderr: 'pipe'
+				stderr: 'pipe',
+				// So the installer and the bun it spawns can be killed as one group
+				detached: true
 			})
+			this.prepareDepsProcess = proc
 
 			// Bound the wait: the only other ceiling is the DAP client's launch timeout,
 			// which is minutes, so a wedged installer would hang the session that long.
 			killTimer = setTimeout(() => {
 				timedOut = true
 				logger.error(`prepare-deps timed out after ${PREPARE_DEPS_TIMEOUT_MS}ms`)
-				// SIGKILL, not the default SIGTERM: prepare-deps does not act on SIGTERM while the
-				// package manager is running, so a polite signal leaves it going after the timeout.
-				proc.kill('SIGKILL')
+				killProcessTree(proc)
 			}, PREPARE_DEPS_TIMEOUT_MS)
 
 			// Wait for completion
 			const output = await new Response(proc.stdout).text()
 			const stderr = await new Response(proc.stderr).text()
+
+			// The read also ends when cleanup() kills the installer, which leaves no output to
+			// parse. Reporting that as an install failure blames the user for their own Stop.
+			if (this.disposed) {
+				return null
+			}
 
 			if (timedOut) {
 				const errorMsg = `prepare-deps timed out after ${PREPARE_DEPS_TIMEOUT_MS / 1000}s`
@@ -1682,6 +1773,9 @@ export class DebugSession {
 			logger.info('No external dependencies to install')
 			return null
 		} catch (error) {
+			if (this.disposed) {
+				return null
+			}
 			logger.error(`Failed to prepare dependencies: ${error}`)
 			this.sendEvent('output', {
 				category: 'console',
@@ -1691,6 +1785,7 @@ export class DebugSession {
 		} finally {
 			clearInterval(progress)
 			clearTimeout(killTimer)
+			this.prepareDepsProcess = null
 		}
 	}
 
@@ -1706,24 +1801,13 @@ export class DebugSession {
 		const inspectUrl = `127.0.0.1:${inspectPort}`
 
 		// Build the command - optionally wrapped with nsjail
-		let cmd: string[] = [this.bunPath, `--inspect-wait=${inspectUrl}`, this.scriptPath]
+		const cmd = nsjailWrap(
+			[this.bunPath, `--inspect-wait=${inspectUrl}`, this.scriptPath],
+			this.nsjailConfig,
+			cwd
+		)
 
 		if (this.nsjailConfig?.enabled) {
-			const nsjailCmd = [this.nsjailConfig.binaryPath]
-
-			if (this.nsjailConfig.configPath) {
-				nsjailCmd.push('--config', this.nsjailConfig.configPath)
-			}
-
-			if (this.nsjailConfig.extraArgs) {
-				nsjailCmd.push(...this.nsjailConfig.extraArgs)
-			}
-
-			nsjailCmd.push('--cwd', cwd)
-			nsjailCmd.push('--')
-			nsjailCmd.push(...cmd)
-
-			cmd = nsjailCmd
 			logger.info(`Starting Bun with nsjail: ${cmd.join(' ')}`)
 		} else {
 			logger.info(`Starting Bun with --inspect-wait=${inspectUrl}`)
@@ -2500,13 +2584,21 @@ export class DebugSession {
 	}
 
 	/**
-	 * Clean up resources.
+	 * Clean up resources. Public because both servers call it when a client goes away.
 	 */
-	private async cleanup(): Promise<void> {
+	async cleanup(): Promise<void> {
+		this.disposed = true
+
 		// Close inspector connection
 		if (this.inspectorWs) {
 			this.inspectorWs.close()
 			this.inspectorWs = null
+		}
+
+		// A disconnect during dependency installation must not leave bun install running
+		if (this.prepareDepsProcess) {
+			killProcessTree(this.prepareDepsProcess)
+			this.prepareDepsProcess = null
 		}
 
 		// Kill process
@@ -2648,9 +2740,14 @@ if (import.meta.main) {
 					logger.error('Error handling message:', error)
 				}
 			},
-			close(ws) {
+			async close(ws) {
 				logger.info('Client disconnected')
-				sessions.delete(ws)
+				const session = sessions.get(ws)
+				if (session) {
+					// Dropping the session without this leaves its installer and debuggee running
+					await session.cleanup()
+					sessions.delete(ws)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

`windmill prepare-deps` was spawned with Bun's raw `spawn` in both the Python and the TypeScript
session, bypassing the nsjail wrapping the debugged script itself gets. With `ENABLE_NSJAIL=true`,
`uv pip install` builds source distributions — running their build backend's arbitrary Python — and
`bun install` runs postinstall scripts, so a package's own code executed unconfined next to the LSP,
multiplayer and gateway services in the `windmill_extra` container. Before the install was hoisted
into the service (#10533) it was launched by the already-jailed Python DAP server, so this was a
regression in confinement.

Second defect, verified on the base: killing the installer did not reap the `uv` (or `bun`) it had
already spawned. The grandchild was reparented to init and kept downloading, so the timeout and the
cancel-on-disconnect only half-worked.

Rebased on #10532, which landed meanwhile; its `python_path` pin, `sessionEnv()` allowlist and
SIGKILL semantics are kept as they are and exercised together with the jail below.

## Changes

**The installer is jailed in both languages.** The service's Python installer now goes through
`spawnProcess()` (`stdin` and an environment passthrough added to `SpawnOptions` for it), and the
Bun session wraps its own installer the same way. The two inlined nsjail command builders — one in
each file — collapse into a shared `nsjailWrap()`.

The installer keeps the service's whole environment rather than the minimal set `spawnProcess()`
gives a debuggee; that is how the registry credentials and CA settings reach `uv`/`bun`, and the
jail config's `keep_env` carries them across the boundary. The debugged script's environment is
untouched and still holds neither — re-checked, including `/proc/self/environ`.

**The installer runs in its own process group** (`detached`) and is signalled as a group by a new
`killProcessTree()`. It reads the group id back from `/proc` rather than assuming it, because a
group kill aimed at the service's own group would take down every service in the container; a child
without `detached` degrades to the plain kill. SIGKILL, as on the base, since `prepare-deps` does
not act on SIGTERM while uv is running. With nsjail on, the PID namespace tears the tree down
anyway — the group is what covers the unjailed default.

**Cancellation is finished off.** A kill is no longer reported to the client as an install failure —
it ends the read with nothing to parse, which the parse path blamed on the installer, so pressing
Stop produced `Failed to prepare dependencies: windmill binary produced no response`. The Bun
session, which answers `launch` only after installing, now answers it on that path too. The
standalone Bun server's close handler only dropped the session from its map, so its installer,
debuggee and temp dir were never cleaned up; it calls `cleanup()` now, like the unified service
always has. The teardown flag is scoped to a launch rather than the session, since `cleanup()` also
runs when a program finishes normally.

`debugger/README.md` records the two constraints a future change would break: the installer needs
`keep_env` (or an explicit carry of the registry/CA variables), and it needs its own process group.

## Test plan

Driven against the real service with `--nsjail --nsjail-config`, with the config's `/debugger` mount
repointed at the worktree and the `windmill` binary under `/tmp`. Before/after runs use the base
branch's sources unchanged, in the same harness.

- [x] **Python session, jailed, end to end.** `import tinydb` installs and runs: log line `Spawning
      with nsjail: nsjail --config … -- <windmill> prepare-deps`, then `tinydb version: 4.8.2` and
      `hostname: debugger` (the jail's UTS name) from the debuggee.
- [x] **Cold cache, so the jailed install really goes to the index** (`WINDMILL_DIR` repointed;
      6.8 MB of uv cache written from inside the jail). #10532's interpreter pin holds through it:
      the venv is `python3.14` and the debuggee reports `interp: 3.14.6`.
- [x] **TypeScript session, jailed, end to end.** `import { camelCase } from "lodash-es"` installs
      through the jailed `bun install` and prints `camelCase: helloJailedWorld`.
- [x] **The installer is actually confined.** Sampled mid-install: its `pid`, `mnt`, `user` and
      `uts` namespaces all differ from the service's. On the base with `--nsjail` on, all four match
      the service — the gap this fixes.
- [x] **Registry settings still cross the jail.** The jailed installer's `/proc/<pid>/environ`
      carries `PY_INDEX_URL` and `UV_HTTP_TIMEOUT`; the install fails against a tarpit index exactly
      as configured, so they are in force and not merely present.
- [x] **No credential regression.** A Python session dumping `os.environ` and `/proc/self/environ`
      sees no registry variable and not a planted service-only secret; same for a TS session.
- [x] **Disconnect reaps the tree**, both languages, jailed and unjailed: hanging up mid-install
      leaves no `nsjail`, no installer and no `uv`/grandchild. On the base the installer and `uv`
      both survive — and outlive the service itself.
- [x] **Timeout reaps the tree.** With `DAP_PREPARE_DEPS_TIMEOUT_MS=8000` against a stalled index:
      nothing survives the deadline, the client gets `dependency installation timed out after 8s`,
      and the session still starts without the dependency, as before.
- [x] **Standalone Bun server**: same disconnect check against `dap_websocket_server_bun.ts` run
      directly. On the base the installer and its grandchild survive.
- [x] **Two launches on one socket** both run, in both languages — the case the per-launch teardown
      flag makes valid.
- [x] **Real failures still reported.** An unresolvable import still surfaces uv's own message
      (`No solution found when resolving dependencies`) rather than a bare `ModuleNotFoundError`.
- [x] Both entrypoints bundle (`bun build`); `tsc --strict` reports the same 13 pre-existing errors
      as the base and no new ones. No Rust or frontend code changed, so `docs/validation.md` adds
      nothing here.

No test ships: `debugger/` has no CI harness (its `test_*` files are manual scripts needing a live
service), and the only pure function added is a string builder — a unit test for it would be the
ceremonial kind AGENTS.md says not to ship. The substance is process lifecycle and sandbox wiring,
which only a real run exercises.