### PR TITLE
fix(frontend): draw the tab strip's scroll bar instead of the native one

### DIFF
--- a/frontend/src/lib/assets/app.css
+++ b/frontend/src/lib/assets/app.css
@@ -280,8 +280,9 @@
 	}
 
 	/* Subtle scrollbar: a thin, rounded thumb that only appears on hover, on both
-	   axes. Shared by ScrollableX (tab strips, code blocks) and the AI chat. Size
-	   via the `--wm-scrollbar-size` var (default 6px). Higher specificity than the
+	   axes. Shared by ScrollableX (code blocks, tab headers) and the AI chat. Size
+	   via the `--wm-scrollbar-size` var (default 6px) — WebKit only; Firefox sizes
+	   `thin` itself and spends ~11px of the box on it. Higher specificity than the
 	   app-wide `*::-webkit-scrollbar`, so it overrides it. */
 	.scrollbar-subtle {
 		scrollbar-width: thin;

--- a/frontend/src/lib/components/common/ScrollableX.svelte
+++ b/frontend/src/lib/components/common/ScrollableX.svelte
@@ -4,7 +4,9 @@
 	// Subtle horizontal scroll: native overflow (so wheel/trackpad/drag always
 	// work) with the shared `.scrollbar-subtle` thumb (thin, hover-revealed). Bar
 	// thickness is tunable via the `--wm-scrollbar-size` CSS var (pass through
-	// `style`), so denser callers (e.g. the tab strip) can shrink it.
+	// `style`) — WebKit only, so Firefox spends its own ~11px of the box on the
+	// bar whatever this says. Not for a height-constrained row: draw the thumb
+	// yourself there, the way the tab strip does.
 	let {
 		class: c = '',
 		style = '',

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -105,11 +105,15 @@
 	const thumbWidth = $derived(
 		overflowing ? Math.min(viewport, Math.max(MIN_THUMB, (viewport / content) * viewport)) : 0
 	)
-	// `scrollLeft` is fractional on HiDPI while the two widths are rounded, so the
-	// ratio can tip past 1 and poke the thumb out of the track — clamp it.
+	// Clamped at both ends: `scrollLeft` is fractional on HiDPI while the widths
+	// are rounded, so the ratio can tip past 1, and WebKit's elastic overscroll
+	// drives it negative — either way the thumb would leave the track.
 	const thumbLeft = $derived(
 		scrollable > 0
-			? Math.min(viewport - thumbWidth, (scrollLeft / scrollable) * (viewport - thumbWidth))
+			? Math.max(
+					0,
+					Math.min(viewport - thumbWidth, (scrollLeft / scrollable) * (viewport - thumbWidth))
+				)
 			: 0
 	)
 
@@ -136,8 +140,8 @@
 	// Drag the thumb: pointer capture keeps the gesture alive past the strip's
 	// edges, and the ratio maps thumb travel back onto scroll travel. Recomputing
 	// from the anchor each move (rather than accumulating) means clamping at
-	// either end doesn't drift, and reading the travel live keeps the thumb under
-	// the cursor when a tab opens mid-drag.
+	// either end doesn't drift, and reading the travel live keeps a tab opening
+	// mid-drag from scaling every later move against a stale track.
 	function handleThumbPointerDown(e: PointerEvent) {
 		const el = scrollEl
 		// Primary button only: a right-click would open the context menu without

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -29,7 +29,6 @@
 	import { X } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import { untrack } from 'svelte'
-	import ScrollableX from '../ScrollableX.svelte'
 
 	interface Props {
 		tabs: TabItem[]
@@ -41,7 +40,9 @@
 		 * activated via Enter/Space — lets the active tab host a secondary affordance
 		 * (e.g. toggling the breadcrumb picker rendered in `tabAccessory`). */
 		onActiveClick?: (id: string) => void
-		/** Extra classes for the outer tab strip. */
+		/** Extra classes for the outer tab strip. It is 32px tall unless `trailing`
+		 * content is taller; a fixed height here overrides that, and going taller
+		 * pulls the tabs away from the scroll bar, which stays on the bottom edge. */
 		class?: string
 		/** Render inside the scroll row, right after the last tab (e.g. a "+" new-tab
 		 * button) — scrolls with the tabs, unlike `trailing`. */
@@ -88,6 +89,81 @@
 		if (!isDragging) dndMiddle = next
 	})
 
+	// Scroll bar. The native one is hidden (`no-scrollbar`) and redrawn here: its
+	// height is a WebKit-only setting, so Firefox spends 11px of the strip on a
+	// bar there is no room for and clips the tabs. Ours is 4px in every engine and
+	// costs no layout height at all.
+	const MIN_THUMB = 24
+	let scrollEl = $state<HTMLElement | undefined>(undefined)
+	let scrollLeft = $state(0)
+	let viewport = $state(0)
+	let content = $state(0)
+	const scrollable = $derived(Math.max(0, content - viewport))
+	const overflowing = $derived(scrollable > 1)
+	// Clamped to the viewport: a pane dragged shut leaves a few pixels of strip,
+	// and an unclamped minimum-width thumb would hang out of it.
+	const thumbWidth = $derived(
+		overflowing ? Math.min(viewport, Math.max(MIN_THUMB, (viewport / content) * viewport)) : 0
+	)
+	// `scrollLeft` is fractional on HiDPI while the two widths are rounded, so the
+	// ratio can tip past 1 and poke the thumb out of the track — clamp it.
+	const thumbLeft = $derived(
+		scrollable > 0
+			? Math.min(viewport - thumbWidth, (scrollLeft / scrollable) * (viewport - thumbWidth))
+			: 0
+	)
+
+	function measure() {
+		const el = scrollEl
+		if (!el) return
+		scrollLeft = el.scrollLeft
+		viewport = el.clientWidth
+		content = el.scrollWidth
+	}
+
+	// Both ends move independently: the viewport on a pane resize, the content as
+	// tabs open, close and get renamed.
+	$effect(() => {
+		const el = scrollEl
+		if (!el) return
+		measure()
+		const ro = new ResizeObserver(measure)
+		ro.observe(el)
+		if (el.firstElementChild) ro.observe(el.firstElementChild)
+		return () => ro.disconnect()
+	})
+
+	// Drag the thumb: pointer capture keeps the gesture alive past the strip's
+	// edges, and the ratio maps thumb travel back onto scroll travel. Recomputing
+	// from the anchor each move (rather than accumulating) means clamping at
+	// either end doesn't drift, and reading the travel live keeps the thumb under
+	// the cursor when a tab opens mid-drag.
+	function handleThumbPointerDown(e: PointerEvent) {
+		const el = scrollEl
+		// Primary button only: a right-click would open the context menu without
+		// delivering the pointerup that ends the drag.
+		if (!el || e.button !== 0) return
+		e.preventDefault()
+		const target = e.currentTarget as HTMLElement
+		const startX = e.clientX
+		const startScroll = el.scrollLeft
+		target.setPointerCapture(e.pointerId)
+		const onMove = (ev: PointerEvent) => {
+			const travel = viewport - thumbWidth
+			if (travel <= 0) return
+			el.scrollLeft = startScroll + ((ev.clientX - startX) / travel) * scrollable
+		}
+		const onUp = (ev: PointerEvent) => {
+			target.releasePointerCapture(ev.pointerId)
+			target.removeEventListener('pointermove', onMove)
+			target.removeEventListener('pointerup', onUp)
+			target.removeEventListener('pointercancel', onUp)
+		}
+		target.addEventListener('pointermove', onMove)
+		target.addEventListener('pointerup', onUp)
+		target.addEventListener('pointercancel', onUp)
+	}
+
 	function handleConsider(e: CustomEvent<DndEvent<TabItem>>) {
 		isDragging = true
 		dndMiddle = e.detail.items
@@ -100,7 +176,7 @@
 
 	function tabClasses(isActive: boolean) {
 		return twMerge(
-			'group relative inline-flex items-center gap-1.5 px-2.5 h-7 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
+			'group relative inline-flex items-center gap-1.5 px-2.5 h-6 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
 			isActive
 				? 'bg-surface-tertiary text-emphasis'
 				: 'bg-transparent text-hint hover:text-secondary'
@@ -189,41 +265,69 @@
 	</div>
 {/snippet}
 
-<div bind:this={stripEl} class={twMerge('flex items-center bg-surface', c)}>
-	<!-- 4px bar to match the strip's `pb-1` reserve. -->
-	<ScrollableX class="flex-1 min-w-0 pt-1 pl-1 pb-1" style="--wm-scrollbar-size: 4px;">
-		<div class="flex items-center" role="tablist">
-			{#each pinnedLeft as tab (tab.id)}
-				{@render tabButton(tab)}
-			{/each}
-
-			<div
-				class="flex items-center"
-				use:dndzone={{
-					items: dndMiddle,
-					flipDurationMs: 150,
-					type: dndType,
-					dropTargetStyle: {}
-				}}
-				onconsider={handleConsider}
-				onfinalize={handleFinalize}
-			>
-				{#each dndMiddle as tab (tab.id)}
-					<div>
-						{@render tabButton(tab)}
-					</div>
+<div bind:this={stripEl} class={twMerge('flex items-center bg-surface min-h-8', c)}>
+	<!-- The tabs centre in the full strip and the bar overlays the air under them,
+	     flush with the strip's bottom edge — it takes no height of its own, so the
+	     strip never resizes and the tabs sit at the same place whether or not they
+	     overflow. -->
+	<div class="group/scroll relative flex-1 min-w-0 self-stretch">
+		<div
+			bind:this={scrollEl}
+			onscroll={() => scrollEl && (scrollLeft = scrollEl.scrollLeft)}
+			class="h-full overflow-x-auto overflow-y-hidden no-scrollbar pl-1"
+		>
+			<!-- `w-max`: without it the row is pinned to the viewport width and the tabs
+			     overflow *out* of it, so the ResizeObserver below never sees a tab open
+			     or a label change and the scroll bar goes stale. -->
+			<div class="flex items-center h-full w-max" role="tablist">
+				{#each pinnedLeft as tab (tab.id)}
+					{@render tabButton(tab)}
 				{/each}
+
+				<div
+					class="flex items-center"
+					use:dndzone={{
+						items: dndMiddle,
+						flipDurationMs: 150,
+						type: dndType,
+						dropTargetStyle: {}
+					}}
+					onconsider={handleConsider}
+					onfinalize={handleFinalize}
+				>
+					{#each dndMiddle as tab (tab.id)}
+						<!-- `flex`, not the default block: an inline-flex tab in a block wrapper
+					     sits on a text baseline and rides ~1.5px off the row's centre. -->
+						<div class="flex">
+							{@render tabButton(tab)}
+						</div>
+					{/each}
+				</div>
+
+				{#each pinnedRight as tab (tab.id)}
+					{@render tabButton(tab)}
+				{/each}
+
+				{#if afterTabs}
+					{@render afterTabs()}
+				{/if}
 			</div>
-
-			{#each pinnedRight as tab (tab.id)}
-				{@render tabButton(tab)}
-			{/each}
-
-			{#if afterTabs}
-				{@render afterTabs()}
-			{/if}
 		</div>
-	</ScrollableX>
+
+		{#if overflowing}
+			<!-- Decorative: it mirrors the scroll position and can be dragged, but the
+			     strip is scrollable without it (wheel, trackpad, and the arrow keys that
+			     scroll the focused tab into view), so it stays out of the a11y tree
+			     rather than posing as a control at a 4px hit target. -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				aria-hidden="true"
+				class="absolute bottom-0 left-0 h-1 rounded-full touch-none bg-hint/0 group-hover/scroll:bg-hint/40 hover:!bg-secondary/60 transition-colors"
+				style="width: {thumbWidth}px; transform: translateX({thumbLeft}px);"
+				onpointerdown={handleThumbPointerDown}
+			></div>
+		{/if}
+	</div>
 
 	{#if trailing}
 		<div class="ml-1 pr-1 flex items-center shrink-0">

--- a/frontend/src/routes/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/+page.svelte
@@ -12,8 +12,8 @@
 
 	let tab = $state('button')
 
-	// Enough tabs to overflow a narrow strip so the shared ScrollableX hover
-	// scrollbar is exercised: drag to reorder, hover to reveal the 4px thumb.
+	// Enough tabs to overflow a narrow strip so the strip's own hover scrollbar is
+	// exercised: drag to reorder, hover to reveal the 4px thumb.
 	let draggableTabs = $state<TabItem[]>(
 		Array.from({ length: 14 }, (_, i) => ({ id: `t${i}`, label: `Preview tab ${i + 1}` }))
 	)
@@ -200,8 +200,8 @@ That's the full round-trip.`
 		</TabContent>
 		<TabContent value="scrollbar" class="p-4">
 			<div class="text-xs text-tertiary mb-3">
-				DraggableTabs (uses the shared <code>ScrollableX</code>, 4px bar): hover to reveal the
-				thumb, drag to reorder.
+				DraggableTabs (draws its own 4px bar on the strip's bottom edge): hover to reveal the thumb,
+				drag to reorder.
 			</div>
 			<div class="border border-border-light rounded-md" style="max-width: 420px;">
 				<DraggableTabs


### PR DESCRIPTION
## Summary

The AI-sessions preview tab strip clipped its tabs at the top and left a wide gutter under them once the tabs overflowed. The strip is a fixed 32px (`h-8`), and `DraggableTabs` sized its scroll row to fit tabs + a 4px scrollbar reserve — but a *native* horizontal scrollbar claims layout height on top of that reserve, and how much is engine-specific:

| | scrollbar cost | tab clipped at top | gap under tab |
|---|---|---|---|
| Firefox 153 (`scrollbar-width: thin`) | **11px** | **3.5px** | **11.5px** |
| Chrome / Safari, overlay scrollbars | 0px | none | 5.5px |

`--wm-scrollbar-size: 4px` is a WebKit-only knob, so Firefox ignores it and spends 11px; 24px of tab plus an 11px bar cannot fit in a 32px strip under any padding arrangement. This is a regression from #10003, which replaced the melt scroll-area — whose 4px bar was *absolutely positioned "so toggling it never shifts layout"* — with a native `overflow-x: auto` row.

The fix hides the native bar and draws the thumb, so it costs no layout height and is 4px in every engine.

## Changes

- `DraggableTabs`: hide the native scrollbar (`no-scrollbar`) and render a 4px thumb positioned from `scrollLeft`/`scrollWidth`. Hover-revealed like the bar it replaces, draggable via pointer capture, and only rendered while the tabs overflow. `aria-hidden` — it mirrors scroll position rather than posing as a control at a 4px hit target, and the strip stays scrollable by wheel, trackpad and the existing arrow-key tab navigation.
- Tabs and thumb share one line: the tabs centre in the strip and the thumb sits on the strip's bottom edge, flush under them. The tabs land in the same place whether or not the strip overflows.
- Tab height `h-7` → `h-6` (28px → 24px) so the tabs clear the bar in a 32px strip.
- Strip default height `h-9` → `min-h-8`, matching the height the sessions caller already forced, so every strip has the same geometry; `min-h` rather than `h` so a taller `trailing` control can still grow it.
- `w-max` on the tab row: without it the row's box is pinned to the viewport and the tabs overflow *out* of it, so the `ResizeObserver` never sees a tab open and the thumb goes stale.
- Each dnd item wrapper is `flex`: an `inline-flex` tab in a block wrapper sits on a text baseline and rides ~1.5px off the row's centre.
- Comment fixes for the surfaces that no longer use `ScrollableX` for this (kitchen sink caption, `ScrollableX`, `app.css`), including the Firefox cost so the next caller doesn't repeat it.

`ScrollableX` itself is unchanged and still used by `Tabs`/`TabsV2` headers, code blocks and the chat — none of them are height-constrained, so nothing is clipped there.

## Screenshots

Sessions preview strip, 7 tabs overflowing, mid-scroll (Chromium, 4×).

**Before** — the native thumb sits below the strip's bottom border, over the previewed page:

![pr-sessions-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-sessions-tabs-overflow/1785946762-pr-sessions-before.png)

**After** — the thumb is inside the strip, flush under the tabs:

![pr-sessions-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-sessions-tabs-overflow/1785946764-pr-sessions-after.png)

Raw-app editor strip, now 32px and sharing the same geometry:

![pr-rawapp-wide](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-sessions-tabs-overflow/1785946767-pr-rawapp-wide.png)

Measured in the running app, sessions strip: `3.5 air · 24 tab · 0 · 4 bar · 1 border = 32`, identical with the tabs fitting (only the thumb stops rendering).

## Test plan

- [ ] **Firefox** (where the bug is visible): open a session, open enough preview tabs to overflow the strip — tabs are not clipped at the top, the thumb appears on hover, drags, and tracks the cursor
- [ ] Chrome: same strip, confirm the WebKit path did not regress
- [ ] Tabs land at the same height whether or not the strip overflows (widen the panel until they fit)
- [ ] Raw-app editor, split with preview: both strips are 32px, the split/rebuild buttons still sit clear of the pane border
- [ ] Drag-reorder still works, and dragging the thumb while a tab opens keeps the thumb under the cursor
- [ ] Drag a pane nearly shut: the thumb stays inside the strip instead of hanging out of it