### PR TITLE
feat: add a load all to the tree view's per-folder pager

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -483,11 +483,15 @@
 				// there. Left at where this run started, it would re-read every page already
 				// merged — and each of those dedups to nothing, so a "Load more" after a run
 				// that failed deep in the stream would spend its whole budget adding no rows.
+				// `loaded` moves with it: a node still marked unloaded is retried as a first
+				// load, which starts from no cursor and throws the saved one away.
 				const prev = ownerLoad[owner]
+				const advanced = nextCursor != undefined
 				ownerLoad[owner] = {
 					...prev,
 					cursor: nextCursor ?? prev?.cursor,
-					hasMore: nextCursor != undefined || (prev?.hasMore ?? false),
+					hasMore: advanced || (prev?.hasMore ?? false),
+					loaded: advanced || (prev?.loaded ?? false),
 					loading: false
 				}
 				sendUserToast(`Failed to load ${owner}: ${e?.body ?? e?.message ?? e}`, true)

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -480,11 +480,9 @@
 			} catch (e: any) {
 				if (gen !== treeGen) return
 				// Keep the cursor the pages that did land reached, so the next click resumes
-				// there. Left at where this run started, it would re-read every page already
-				// merged — and each of those dedups to nothing, so a "Load more" after a run
-				// that failed deep in the stream would spend its whole budget adding no rows.
-				// `loaded` moves with it: a node still marked unloaded is retried as a first
-				// load, which starts from no cursor and throws the saved one away.
+				// instead of re-reading pages that now dedup to nothing. `loaded` moves with
+				// it: a node still marked unloaded is retried as a first load, which starts
+				// from no cursor and throws the saved one away.
 				const prev = ownerLoad[owner]
 				const advanced = nextCursor != undefined
 				ownerLoad[owner] = {

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -371,6 +371,10 @@
 	// How far one "Load more" will page past rows it already has before giving up and
 	// leaving the rest to another click (see the catch-up loop in loadOwnerItems).
 	const OWNER_CATCH_UP_PAGES = 5
+	// Ceiling on the pages one "Load all" issues. It exists so a prefix that never stops
+	// handing back a cursor can't spin forever; hitting it leaves `hasMore` set, so the
+	// footer stays and another click resumes where this one stopped.
+	const OWNER_LOAD_ALL_PAGES = 100
 	let ownerLoad = $state<Record<string, OwnerLoadState>>({})
 	let treeOwnerItems = $state<ItemType[]>([])
 	let treeGen = 0
@@ -391,8 +395,15 @@
 
 	// `owner` is the full prefix a node covers: `f/<folder>`, `u/<username>`, or any
 	// folder under one. `force` re-fetches its first page even if already loaded (a
-	// re-sort / re-filter reload uses it to refresh the loaded rows in place).
-	async function loadOwnerItems(owner: string, more = false, force = false): Promise<void> {
+	// re-sort / re-filter reload uses it to refresh the loaded rows in place); `all`
+	// keeps paging until the prefix's stream is exhausted instead of stopping at a page.
+	async function loadOwnerItems(
+		owner: string,
+		more = false,
+		opts?: { force?: boolean; all?: boolean }
+	): Promise<void> {
+		const force = opts?.force ?? false
+		const all = opts?.all ?? false
 		const ws = $workspaceStore
 		if (!ws || !$userStore) return
 		// Track the prefix as open first — even a no-op call (re-expanding a cached node)
@@ -448,8 +459,10 @@
 		// A nested prefix's own stream restarts at its first row, which an ancestor's pages
 		// may already have brought in — that page then adds nothing and the click would read
 		// as broken. Keep paging until one adds something or the stream ends, bounded so a
-		// single click can't turn into an unbounded fetch loop.
-		for (let page = 0; page < OWNER_CATCH_UP_PAGES; page++) {
+		// single click can't turn into an unbounded fetch loop. "Load all" instead stops
+		// only at the end of the stream, so `loading` stays set for the whole run and the
+		// footer resolves to an exact count in one click.
+		for (let page = 0; page < (all ? OWNER_LOAD_ALL_PAGES : OWNER_CATCH_UP_PAGES); page++) {
 			let res: { items: RunnableItem[]; next_cursor?: string }
 			try {
 				res = await ScriptService.listRunnables({
@@ -477,7 +490,7 @@
 			const added = mergePage(res.items)
 			nextCursor = res.next_cursor
 			cursor = nextCursor
-			if (added > 0 || nextCursor == undefined) break
+			if (nextCursor == undefined || (!all && added > 0)) break
 		}
 		ownerLoad = Object.fromEntries([
 			// A replacing load dropped every row under this prefix, so a nested folder that
@@ -534,7 +547,9 @@
 			byDepth.set(d, [...(byDepth.get(d) ?? []), p])
 		}
 		for (const d of [...byDepth.keys()].sort((a, b) => a - b)) {
-			await Promise.all((byDepth.get(d) ?? []).map((p) => loadOwnerItems(p, false, true)))
+			await Promise.all(
+				(byDepth.get(d) ?? []).map((p) => loadOwnerItems(p, false, { force: true }))
+			)
 		}
 	}
 

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -479,7 +479,17 @@
 				})
 			} catch (e: any) {
 				if (gen !== treeGen) return
-				ownerLoad[owner] = { ...ownerLoad[owner], loading: false }
+				// Keep the cursor the pages that did land reached, so the next click resumes
+				// there. Left at where this run started, it would re-read every page already
+				// merged — and each of those dedups to nothing, so a "Load more" after a run
+				// that failed deep in the stream would spend its whole budget adding no rows.
+				const prev = ownerLoad[owner]
+				ownerLoad[owner] = {
+					...prev,
+					cursor: nextCursor ?? prev?.cursor,
+					hasMore: nextCursor != undefined || (prev?.hasMore ?? false),
+					loading: false
+				}
 				sendUserToast(`Failed to load ${owner}: ${e?.body ?? e?.message ?? e}`, true)
 				return
 			}
@@ -490,7 +500,10 @@
 			const added = mergePage(res.items)
 			nextCursor = res.next_cursor
 			cursor = nextCursor
-			if (nextCursor == undefined || (!all && added > 0)) break
+			// Collapsing the node is the only way to stop a run that spans many pages;
+			// without this it would keep paging a folder that is no longer on screen. What
+			// it reached is committed below, so its footer resumes from there.
+			if (nextCursor == undefined || !openOwners.has(owner) || (!all && added > 0)) break
 		}
 		ownerLoad = Object.fromEntries([
 			// A replacing load dropped every row under this prefix, so a nested folder that

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -145,6 +145,10 @@
 	// so a subfolder's contents don't look truncated, but bounded: under "expand all"
 	// this applies to every open owner at once (see effectiveMax).
 	let showMax = $state(30)
+	// Ceiling on what one node mounts at once. Comfortably past a server page, so the
+	// usual node still shows everything it loaded, but "Load all" can leave thousands of
+	// rows under one prefix and mounting all of them locks up the tab.
+	const LAZY_RENDER_MAX = 500
 	// A node that paginates server-side ("Load more") shows all its already-loaded rows
 	// when opened on its own, so there is one control to reach the rest and not a second,
 	// confusing client "Show more" in front of it. EXCEPT under "expand all"
@@ -152,12 +156,15 @@
 	// would be thousands of rows and freeze the tab — so there we cap to the client slice
 	// and let "Show more" reveal the rest per node.
 	let effectiveMax = $derived(
-		ownerLoad != undefined && nodePrefix != undefined && (isFolder(item) || isUser(item))
-			? collapseAll
-				? item.items.length
+		isFolder(item) || isUser(item)
+			? ownerLoad != undefined && nodePrefix != undefined && collapseAll
+				? Math.min(item.items.length, Math.max(showMax, LAZY_RENDER_MAX))
 				: Math.min(item.items.length, showMax)
 			: showMax
 	)
+	// One "Show more" reveals another slice the size of the one already on screen, so a
+	// node holding thousands of loaded rows doesn't take hundreds of clicks to unfold.
+	let showMoreStep = $derived(effectiveMax >= LAZY_RENDER_MAX ? LAZY_RENDER_MAX : 30)
 
 	$effect(() => {
 		const expandAll = !collapseAll
@@ -330,7 +337,10 @@
 							unifiedSize="sm"
 							variant="subtle"
 							on:click={() => {
-								showMax += Math.min(30, item.items.length - showMax)
+								// Grown from what is rendered, not from showMax: the lazy ceiling can
+								// already be showing more than showMax, and stepping that would take
+								// several clicks to change anything on screen.
+								showMax = Math.min(item.items.length, effectiveMax + showMoreStep)
 							}}
 						>
 							Show more
@@ -343,13 +353,15 @@
 						     re-sort/re-filter re-fetch keeps the old rows visible and swaps them
 						     in place, so flashing "Loading…" under them would just be noise. -->
 						<div class="text-center text-xs py-2 text-secondary">Loading…</div>
-					{:else if nodeHasMore && effectiveMax >= item.items.length}
+					{:else if nodeHasMore && (collapseAll || effectiveMax >= item.items.length)}
 						<!-- Every folder pages within its own prefix, so completing a subfolder
-						     doesn't mean paging everything its owner holds. Shown only once every
-						     already-loaded row is (in "expand all" the client "Show more" above
-						     reveals those first), and spelling out the counts is the point:
-						     without them this reads as an optional extra rather than as rows
-						     still missing. -->
+						     doesn't mean paging everything its owner holds. Under "expand all" it
+						     waits until the client "Show more" above has revealed every loaded row,
+						     so the two pagers don't stack under every open node at once; a node
+						     opened on its own shows both, one bounding what is rendered and the
+						     other what is fetched. Spelling out the counts is the point: without
+						     them this reads as an optional extra rather than as rows still
+						     missing. -->
 						<div
 							class="px-4 py-2 border-b flex flex-row items-center justify-between gap-4 bg-surface-secondary"
 							style="padding-left: {(depth + 1) * 16}px;"

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -162,9 +162,13 @@
 				: Math.min(item.items.length, showMax)
 			: showMax
 	)
-	// One "Show more" reveals another slice the size of the one already on screen, so a
-	// node holding thousands of loaded rows doesn't take hundreds of clicks to unfold.
-	let showMoreStep = $derived(effectiveMax >= LAZY_RENDER_MAX ? LAZY_RENDER_MAX : 30)
+	// One "Show more" reveals a slice the size of the ceiling once a node holds more than
+	// that, so thousands of loaded rows don't take hundreds of clicks to unfold. Keyed off
+	// what the node holds rather than what it renders: under "expand all" only the small
+	// client slice is on screen however many rows arrived.
+	let showMoreStep = $derived(
+		(isFolder(item) || isUser(item)) && item.items.length >= LAZY_RENDER_MAX ? LAZY_RENDER_MAX : 30
+	)
 
 	$effect(() => {
 		const expandAll = !collapseAll

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -162,6 +162,12 @@
 				: Math.min(item.items.length, showMax)
 			: showMax
 	)
+	// Which of the two footer buttons started the run in flight, so only that one spins: a
+	// "Load all" can take minutes where a "Load more" takes one request.
+	let loadingAll = $state(false)
+	$effect(() => {
+		if (!nodeState?.loading) loadingAll = false
+	})
 	// One "Show more" reveals a slice the size of the ceiling once a node holds more than
 	// that, so thousands of loaded rows don't take hundreds of clicks to unfold. Keyed off
 	// what the node holds rather than what it renders: under "expand all" only the small
@@ -357,15 +363,14 @@
 						     re-sort/re-filter re-fetch keeps the old rows visible and swaps them
 						     in place, so flashing "Loading…" under them would just be noise. -->
 						<div class="text-center text-xs py-2 text-secondary">Loading…</div>
-					{:else if nodeHasMore && (collapseAll || effectiveMax >= item.items.length)}
+					{:else if nodeHasMore && (collapseAll || nodeState?.loading || effectiveMax >= item.items.length)}
 						<!-- Every folder pages within its own prefix, so completing a subfolder
-						     doesn't mean paging everything its owner holds. Under "expand all" it
-						     waits until the client "Show more" above has revealed every loaded row,
-						     so the two pagers don't stack under every open node at once; a node
-						     opened on its own shows both, one bounding what is rendered and the
-						     other what is fetched. Spelling out the counts is the point: without
-						     them this reads as an optional extra rather than as rows still
-						     missing. -->
+						     doesn't mean paging everything its owner holds. Under "expand all" this
+						     waits for the client "Show more" above, so the two pagers don't stack
+						     under every open node at once — but never while loading, or a long run
+						     would unmount its own spinner on its first page. Spelling out the counts
+						     is the point: without them this reads as an optional extra rather than
+						     as rows still missing. -->
 						<div
 							class="px-4 py-2 border-b flex flex-row items-center justify-between gap-4 bg-surface-secondary"
 							style="padding-left: {(depth + 1) * 16}px;"
@@ -377,7 +382,8 @@
 								<Button
 									unifiedSize="sm"
 									variant="subtle"
-									loading={nodeState?.loading}
+									loading={nodeState?.loading && !loadingAll}
+									disabled={nodeState?.loading}
 									on:click={() =>
 										nodePrefix != undefined &&
 										onExpandOwner?.(nodePrefix, nodeState?.loaded ?? false)}
@@ -389,10 +395,13 @@
 								<Button
 									unifiedSize="sm"
 									variant="subtle"
-									loading={nodeState?.loading}
-									on:click={() =>
-										nodePrefix != undefined &&
-										onExpandOwner?.(nodePrefix, nodeState?.loaded ?? false, { all: true })}
+									loading={nodeState?.loading && loadingAll}
+									disabled={nodeState?.loading}
+									on:click={() => {
+										if (nodePrefix == undefined) return
+										loadingAll = true
+										onExpandOwner?.(nodePrefix, nodeState?.loaded ?? false, { all: true })
+									}}
 								>
 									Load all
 								</Button>

--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -28,7 +28,8 @@
 			string,
 			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
 		>
-		onExpandOwner?: (prefix: string, more?: boolean) => void
+		// `all` pages the prefix to the end in one call instead of fetching a single page.
+		onExpandOwner?: (prefix: string, more?: boolean, opts?: { all?: boolean }) => void
 		onCollapseOwner?: (prefix: string) => void
 		// Position of this node among the rendered root nodes; "expand all" only
 		// auto-loads the first EXPAND_ALL_LOAD_LIMIT of them (see the effect below).
@@ -356,16 +357,30 @@
 							<span class="text-xs text-secondary">
 								Showing {loadedHere}{ownerTotal != undefined ? ` of ${ownerTotal}` : ''} items in {nodePrefix}
 							</span>
-							<Button
-								unifiedSize="sm"
-								variant="subtle"
-								loading={nodeState?.loading}
-								on:click={() =>
-									nodePrefix != undefined &&
-									onExpandOwner?.(nodePrefix, nodeState?.loaded ?? false)}
-							>
-								Load more
-							</Button>
+							<div class="flex flex-row items-center gap-2 shrink-0">
+								<Button
+									unifiedSize="sm"
+									variant="subtle"
+									loading={nodeState?.loading}
+									on:click={() =>
+										nodePrefix != undefined &&
+										onExpandOwner?.(nodePrefix, nodeState?.loaded ?? false)}
+								>
+									Load more
+								</Button>
+								<!-- Same call, paged to the end: a folder several pages deep otherwise
+								     takes a click per page to reach an exact count. -->
+								<Button
+									unifiedSize="sm"
+									variant="subtle"
+									loading={nodeState?.loading}
+									on:click={() =>
+										nodePrefix != undefined &&
+										onExpandOwner?.(nodePrefix, nodeState?.loaded ?? false, { all: true })}
+								>
+									Load all
+								</Button>
+							</div>
 						</div>
 					{/if}
 				{/if}

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -35,7 +35,7 @@
 			string,
 			{ cursor?: string; hasMore: boolean; loading: boolean; loaded: boolean }
 		>
-		onExpandOwner?: (owner: string, more?: boolean) => void
+		onExpandOwner?: (owner: string, more?: boolean, opts?: { all?: boolean }) => void
 		onCollapseOwner?: (owner: string) => void
 		showEditButton?: boolean
 	}


### PR DESCRIPTION
## Summary

The home page tree view loads a folder's runnables one server page at a time; its footer reads
`Showing 300 of 750 items in f/foo` with a single **Load more** button, so reaching an exact
count on a folder several pages deep takes a click per page. This adds a **Load all** next to it
that pages the prefix to the end in one click.

Paging a folder to completion can leave thousands of rows under one node, and the tree used to
mount every loaded row when a node was opened on its own — 9000 rows locked up the tab. A node
now renders at most 500 rows and the existing client `Show more` pager reveals the rest, so both
pagers can be on screen at once: one bounds what is rendered, the other what is fetched.

## Changes

- `Load all` in the per-prefix footer, alongside `Load more`. It reuses the same
  `loadOwnerItems` path with an `all` flag, so `loading` stays set for the whole run and both
  buttons are disabled until it finishes.
- `loadOwnerItems`'s third positional `force` boolean became an options object
  (`{ force?, all? }`) — the only other caller is the reload path.
- The run is bounded by `OWNER_LOAD_ALL_PAGES` (100) and aborts as soon as the node is
  collapsed; whatever it reached is committed, so the footer resumes from there.
- A mid-run fetch failure now persists the cursor/`hasMore`/`loaded` the run reached. Without
  `loaded` moving with the cursor, the retry is treated as a first load, restarts from no cursor
  and re-reads every page already merged.
- A node renders at most `LAZY_RENDER_MAX` (500) rows, and the server pager now also shows for a
  node opened on its own so it stays reachable past that ceiling. One `Show more` reveals another
  500 when the node holds that many, instead of 30.

## Known limitation (pre-existing)

A reload — any row mutation, or an in-place sort/archive/kind change — re-fetches each open
prefix's first page only, so a folder paged to the end falls back to one page. That is how the
tree has always behaved after repeated `Load more` clicks; `Load all` just makes it easier to
notice. Restoring the full depth on reload would mean replaying every page on every star or
archive click, which is a separate change.

## Screenshots

Footer with the new button, on a folder holding 750 items across 3 server pages:

![shot-footer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/folder-load-all/1785949412-shot-footer.png)

After **Load all** — every row fetched, the server pager gone, rendering bounded by the client pager:

![shot-after-load-all](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/folder-load-all/1785949415-shot-after-load-all.png)

## Test plan

Exercised against a live dev server with seeded folders (750, 9000, and a 2000-item nested
subfolder):

- [x] 750-item folder: `Load all` issues 2 requests, footer disappears, badge reads `(750 items)`
- [x] 9000-item folder: 30 requests in ~2s, all rows fetched, tab stays responsive (rendering
      capped at 500), `Show more` steps by 500
- [x] Nested subfolder whose rows came from an ancestor's pages: fills in without duplicating
- [x] Mid-run request failure (page 3 aborted via route interception): one toast, rows kept, and
      the retry's first request carries the saved cursor instead of restarting
- [x] Partially paged node shows both pagers with distinct labels (`loaded rows` vs `items in f/big`)
- [x] `Load more` unchanged — still advances exactly one page
- [x] "Expand all" unaffected: 30 rows per node, 61 rendered in total
- [x] `npm run check` — 0 errors, no new warnings in the changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Load all button to the tree view folder pager to fetch all pages in one click. Caps per-node rendering to keep the UI responsive and makes long loads resumable; the pager stays visible during long runs.

- New Features
  - Added Load all next to Load more; fetches to the end in one run (max 100 pages), disables both buttons while loading (only the clicked one spins), keeps the pager visible mid-run, and stops if the node collapses. Footer resumes from the last cursor. Updated `loadOwnerItems` to use opts `{ force?, all? }` instead of a boolean.
  - Bounded rendering to 500 rows per node; client Show more reveals rows in 500-row steps and still respects the cap under “expand all”.

- Bug Fixes
  - On fetch failure, save cursor/hasMore/loaded so retries resume instead of restarting (including failed first loads).
  - Show more step now sizes by items held, not what’s rendered, so each click adds visible rows.

<sup>Written for commit 1269c095196bbfab4ae66a6b530728762cdf4042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

