### PR TITLE
fix(triggers): stop one failing trigger count from zeroing the rest

### DIFF
--- a/backend/windmill-api/src/triggers/handler.rs
+++ b/backend/windmill-api/src/triggers/handler.rs
@@ -187,14 +187,18 @@ pub async fn get_triggers_count_internal(
     .await?
     .unwrap_or(0);
 
+    // These counts are independent reads: they share a connection to avoid one acquire
+    // per trigger kind, but must not share a transaction. A single failing count would
+    // abort it and, since `trigger_count` falls back to 0 on error, silently zero every
+    // count after it.
     #[allow(unused)]
-    let mut tx = db.begin().await?;
+    let mut conn = db.acquire().await?;
 
     #[cfg(feature = "http_trigger")]
     let http_routes_count = {
         use crate::triggers::http::HttpTrigger;
         let count = HttpTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -205,7 +209,7 @@ pub async fn get_triggers_count_internal(
     let websocket_count = {
         use crate::triggers::websocket::WebsocketTrigger;
         let count = WebsocketTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -216,7 +220,7 @@ pub async fn get_triggers_count_internal(
     let kafka_count = {
         use crate::triggers::kafka::KafkaTrigger;
         let count = KafkaTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -227,7 +231,7 @@ pub async fn get_triggers_count_internal(
     let nats_count = {
         use crate::triggers::nats::NatsTrigger;
         let count = NatsTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -238,7 +242,7 @@ pub async fn get_triggers_count_internal(
     let postgres_count = {
         use crate::triggers::postgres::PostgresTrigger;
         let count = PostgresTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -249,7 +253,7 @@ pub async fn get_triggers_count_internal(
     let mqtt_count = {
         use crate::triggers::mqtt::MqttTrigger;
         let count = MqttTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -260,7 +264,7 @@ pub async fn get_triggers_count_internal(
     let amqp_count = {
         use crate::triggers::amqp::AmqpTrigger;
         let count = AmqpTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -270,7 +274,9 @@ pub async fn get_triggers_count_internal(
     #[cfg(all(feature = "sqs_trigger", feature = "enterprise", feature = "private"))]
     let sqs_count = {
         use crate::triggers::sqs::SqsTrigger;
-        let count = SqsTrigger.trigger_count(&mut tx, w_id, is_flow, path).await;
+        let count = SqsTrigger
+            .trigger_count(&mut conn, w_id, is_flow, path)
+            .await;
         count
     };
     #[cfg(not(all(feature = "sqs_trigger", feature = "enterprise", feature = "private")))]
@@ -279,7 +285,9 @@ pub async fn get_triggers_count_internal(
     #[cfg(all(feature = "gcp_trigger", feature = "enterprise", feature = "private"))]
     let gcp_count = {
         use crate::triggers::gcp::GcpTrigger;
-        let count = GcpTrigger.trigger_count(&mut tx, w_id, is_flow, path).await;
+        let count = GcpTrigger
+            .trigger_count(&mut conn, w_id, is_flow, path)
+            .await;
         count
     };
     #[cfg(not(all(feature = "gcp_trigger", feature = "enterprise", feature = "private")))]
@@ -289,7 +297,7 @@ pub async fn get_triggers_count_internal(
     let azure_count = {
         use crate::triggers::azure::AzureTrigger;
         let count = AzureTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
@@ -300,14 +308,14 @@ pub async fn get_triggers_count_internal(
     let email_count = {
         use crate::triggers::email::EmailTrigger;
         let count = EmailTrigger
-            .trigger_count(&mut tx, w_id, is_flow, path)
+            .trigger_count(&mut conn, w_id, is_flow, path)
             .await;
         count
     };
     #[cfg(not(all(feature = "smtp", feature = "enterprise", feature = "private")))]
     let email_count = 0;
 
-    tx.commit().await?;
+    drop(conn);
 
     let webhook_count = (if is_flow {
         sqlx::query_scalar!(

--- a/backend/windmill-trigger/src/handler.rs
+++ b/backend/windmill-trigger/src/handler.rs
@@ -361,7 +361,17 @@ pub trait TriggerCrud: Send + Sync + 'static {
         .bind(script_path)
         .fetch_one(&mut *tx)
         .await
-        .unwrap_or(0);
+        // Falling back to 0 keeps one unreadable table from failing the whole count
+        // endpoint, but the cause must still reach the logs: a silent 0 is
+        // indistinguishable from "no triggers" in the UI.
+        .unwrap_or_else(|err| {
+            tracing::error!(
+                "failed to count {} triggers of {} {script_path} in {workspace_id}: {err:#}",
+                Self::TABLE_NAME,
+                if is_flow { "flow" } else { "script" }
+            );
+            0
+        });
 
         count
     }


### PR DESCRIPTION
## Summary

`get_triggers_count_internal` ran every per-kind trigger count inside a single
transaction, and `TriggerCrud::trigger_count` falls back to `0` on any error without
logging it. If one count fails (unreadable table, statement timeout, ...), that
transaction is aborted, every subsequent count fails with `current transaction is
aborted, commands ignored until end of transaction block`, and each of those errors is
swallowed to `0` as well. The endpoint returns 200 with fabricated zeros, so the
triggers panel reads "no triggers", and nothing about the original failure reaches the
logs.

Reproduced with the same shape (shared tx, `format!`-built `COUNT(*)`s bound through the
extended protocol, `unwrap_or(0)`):

```
before (shared transaction):          after (pooled connection):
  count(pg_class)     = 1302            count(pg_class)     = 1302
  count(bad_table)    = 0               count(bad_table)    = 0
  count(pg_class)     = 0   <- wrong    count(pg_class)     = 1302
  count(pg_namespace) = 0   <- wrong    count(pg_namespace) = 25
```

## Changes

- `get_triggers_count_internal` takes a pooled connection (`db.acquire()`) instead of
  opening a transaction. These are independent read-only `COUNT(*)`s, so each is now its
  own implicit transaction and one failure no longer poisons the counts after it. It
  also drops a `BEGIN`/`COMMIT` round trip from a path the flow editor hits on every
  subflow node click (`FlowPathViewer.svelte`).
- `TriggerCrud::trigger_count` logs the error before falling back to 0, so a silent 0
  is no longer indistinguishable from "no triggers".

## Not covered here

A pooled connection that is handed back to the pool while its session is still inside a
failed transaction (`idle in transaction (aborted)`) will still break every `db.begin()`
that draws it, for up to `max_lifetime`. sqlx's on-release health check is a bare `Sync`,
which succeeds in that state, and `Rollback::drop` no-ops because the client-side
transaction depth is 0, so such a connection never self-heals. That is a separate fix
(an `after_release` `ROLLBACK` guard on the pool) with a per-release round-trip cost to
weigh first.

Note what that means for this endpoint specifically: `db.acquire()` succeeds on a
poisoned connection (the acquire-time health check is the same blind `Sync`), so where
`db.begin()` used to surface a 500, the per-kind counts now each fail, get logged, and
fall back to 0. The response can be a 200 reading "no triggers" rather than an error.
The counts after it are still correct once the connection is healthy, which is the case
this PR is about, and the failure is now in the logs instead of nowhere. Making a
poisoned connection loud again belongs with the pool guard above, not here.

## Test plan

- [x] `cargo check -p windmill-api -p windmill-trigger --features http_trigger,websocket,postgres_trigger,mqtt_trigger,amqp_trigger`
- [x] `cargo check -p windmill-api --features enterprise,private,kafka,nats,sqs_trigger,gcp_trigger,azure_trigger,smtp,http_trigger,websocket`
- [x] standalone sqlx harness against Postgres producing the before/after table above
- [ ] not exercised against a running backend: the local dev backend builds with
      `--features quickjs`, which compiles out every trigger kind, so all counts are 0
      there regardless. To verify manually, build with trigger features, make one
      trigger table unreadable for the API role, then confirm the other kinds keep their
      real counts and the failure shows up in the backend logs.

No regression test: pinning this needs a table the API role cannot read, which is more
fixture than the assertion is worth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes trigger count endpoint so one failing count no longer zeros the rest. Each count now runs independently and errors are logged instead of silently returning 0.

- **Bug Fixes**
  - Use a pooled connection per count (no shared transaction) to avoid poisoning later counts after a failure.
  - Log errors in `TriggerCrud::trigger_count` before falling back to 0, making failures visible in logs.
  - Removes an extra `BEGIN`/`COMMIT` round trip on a hot path.

<sup>Written for commit 179ad5fd990ba4b3498ddc4a18ac58a22da8118d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


