### PR TITLE
fix: keep the same_worker pin across a flow module that spawns no job

### DIFF
--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -587,6 +587,69 @@ async fn test_deno_flow_same_worker(db: Pool<Postgres>) -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[cfg(feature = "deno_core")]
+#[sqlx::test(fixtures("base"))]
+async fn test_same_worker_survives_empty_branch(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server: ApiServer = ApiServer::start(db.clone()).await?;
+
+    // No branch matches and the default is empty, so `a` completes without spawning a job and
+    // hands the flow back over the UpdateFlow channel. `b` must still be pinned to the worker.
+    let flow: FlowValue = serde_json::from_value(json!({
+        "same_worker": true,
+        "modules": [
+            {
+                "id": "a",
+                "value": {
+                    "type": "branchone",
+                    "branches": [{
+                        "expr": "false",
+                        "modules": [{
+                            "id": "c",
+                            "value": {
+                                "type": "rawscript",
+                                "language": "deno",
+                                "content": "export function main(){ return 1 }",
+                            }
+                        }]
+                    }],
+                    "default": []
+                }
+            },
+            {
+                "id": "b",
+                "value": {
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": "export function main(){ return 42 }",
+                }
+            }
+        ]
+    }))
+    .unwrap();
+
+    let job = run_job_in_new_worker_until_complete(
+        &db,
+        false,
+        JobPayload::RawFlow { value: flow, path: None, restarted_from: None },
+        server.addr.port(),
+    )
+    .await;
+    assert_eq!(job.json_result().unwrap(), json!(42));
+
+    let same_worker: Option<bool> = sqlx::query_scalar(
+        "SELECT same_worker FROM v2_job WHERE parent_job = $1 AND flow_step_id = 'b'",
+    )
+    .bind(job.id)
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(same_worker, Some(true));
+
+    Ok(())
+}
+
 #[sqlx::test(fixtures("base"))]
 async fn test_flow_result_by_id(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;

--- a/backend/windmill-worker/src/result_processor.rs
+++ b/backend/windmill-worker/src/result_processor.rs
@@ -465,6 +465,7 @@ pub fn start_background_processor(
                             worker_dir,
                             stop_early_override,
                             token,
+                            unrecoverable,
                         }),
                     time,
                 }) => {
@@ -485,7 +486,7 @@ pub fn start_background_processor(
                         None,
                         Arc::new(result),
                         None,
-                        true,
+                        unrecoverable,
                         &same_worker_tx,
                         &worker_dir,
                         stop_early_override,

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -3617,6 +3617,10 @@ pub struct UpdateFlow {
     pub worker_dir: String,
     pub stop_early_override: Option<bool>,
     pub token: String,
+    /// Whether the flow must be resumed as if the previous step's worker had died: no retry,
+    /// straight to the failure module, and nothing pinned to this worker. Only true when the
+    /// flow is handed back from a state no live step can recover from.
+    pub unrecoverable: bool,
 }
 
 async fn do_nativets(

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3232,6 +3232,7 @@ async fn push_next_flow_job(
             w_id: flow_job.workspace_id.clone(),
             worker_dir: worker_dir.to_string(),
             token: client.token.clone(),
+            unrecoverable,
         })));
     }
 
@@ -3286,6 +3287,7 @@ async fn push_next_flow_job(
                             w_id: flow_job.workspace_id.clone(),
                             worker_dir: worker_dir.to_string(),
                             token: client.token.clone(),
+                            unrecoverable,
                         }
                     )));
                 }
@@ -3330,6 +3332,7 @@ async fn push_next_flow_job(
                     w_id: flow_job.workspace_id.clone(),
                     worker_dir: worker_dir.to_string(),
                     token: client.token.clone(),
+                    unrecoverable,
                 })));
             }
         }
@@ -3662,6 +3665,10 @@ async fn push_next_flow_job(
                     w_id: flow_job.workspace_id.clone(),
                     worker_dir: worker_dir.to_string(),
                     token: client.token.clone(),
+                    // A suspend that was disapproved or ran out its timeout cannot be
+                    // resumed by anything the flow does next, so the failure module is the
+                    // only way forward.
+                    unrecoverable: true,
                 })));
             }
         }


### PR DESCRIPTION
## Summary
In a `same_worker` flow, the step following a module that completed **without spawning a job** — an empty branch, an empty for-loop, or a module already marked `Success` — is pushed as an ordinary queued job instead of being pinned to the current worker. It is then routed by tag and can be picked up by any worker in the pool.

That breaks the `./shared` directory contract, and worse: if the step's tag resolves to a worker group that cannot execute its language, the step fails instantly and takes the flow down. A worker in native mode, for example, rejects any non-native job with `Worker is in native mode and cannot execute non-native job with language 'python3'` in ~2ms.

**Cause.** Such a module hands the flow back over the `UpdateFlow` channel (`worker_flow.rs:3211` → `PushNextFlowJob::Done(Some(UpdateFlow { .. }))`). The receiver in `result_processor.rs` resumed the flow with a hardcoded `unrecoverable = true` — the same value for all four producers of that message. That flag means "the previous step's worker crashed (OOM/zombie)" and is true for only one of them.

The hardcoded `true` dates from 2024-09 and was inert until #9662 (v1.731.0) made `unrecoverable` gate the pin:

```rust
let continue_on_same_worker = !unrecoverable
    && (flow.same_worker || job_same_worker)
```

Since v1.731.0 the flag reaches this path and silently drops the pin. `continue_with_runners` (dedicated flow-module runners) is disabled by the same flag on the same path.

**Observed failure.** A `same_worker` flow looping over records: `[b (python3) → f (python3) → g (branchone) → e (nativets hub script)]`. On the iteration where `f` returned null, no branch matched and the empty default made `g` complete without a job. `e` was then pushed unpinned, routed by its `nativets` tag to the native-mode worker group — the only group serving that tag. That worker's result processor then advanced the flow and pinned the *next* iteration to itself, so every python3 step in it, plus the failure module, died on the native-mode guard.

## Changes
The flag moves onto the message, so each producer states its own case instead of the shared receiver assuming the worst:

- `backend/windmill-worker/src/worker.rs`: add `unrecoverable` to `UpdateFlow`.
- `backend/windmill-worker/src/worker_flow.rs`: `false` for the three producers that hand back a live flow (module completed without a job, schedule-overlap stop-early, flow-level `skip_expr`); `true` for the suspend-timeout producer, which is the one case no live step can recover from.
- `backend/windmill-worker/src/result_processor.rs`: pass the message's flag through instead of a hardcoded `true`.
- `backend/tests/worker.rs`: regression test — a `same_worker` flow whose branchone matches no branch and has an empty default asserts that `v2_job.same_worker` is still true on the following step.

`unrecoverable` also suppresses retry evaluation and forces failure-module routing (`worker_flow.rs:3737`, `:3758`). Keeping it `true` for the suspend-timeout producer means that behaviour is unchanged: only the pin decision changes, and only for the producers where no worker died.

## Test plan
- [x] `cargo test --features deno_core,quickjs --test worker test_same_worker_survives_empty_branch` passes
- [x] Same test fails with the fix reverted (`left: Some(false), right: Some(true)`), confirming it pins the regression
- [x] `--test flow_engine_parity` — 32/32 pass
- [x] `--test worker flow` and `--test retry` show no new failures (`test_complex_flow_restart`, `retry::test_pass`, `retry::test_fail_step_one` fail identically on `main` in this environment — missing `go` binary)

Fixes WIN-2326