### PR TITLE
chore(ci): drop the now-live dbt quickstart docs-link exemption

### DIFF
--- a/.github/scripts/check-docs-links.mjs
+++ b/.github/scripts/check-docs-links.mjs
@@ -18,12 +18,7 @@ const RETRIES = 2
 // Links whose target page is written but not yet deployed on windmill.dev: the app
 // link is already the final slug, so a 404 is expected until the docs side ships.
 // The value is why the entry exists, for whoever has to judge whether it still should.
-const PENDING_DEPLOY = new Map([
-	[
-		'https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt',
-		'windmilldocs#1625 (dbt runtime quickstart)'
-	]
-])
+const PENDING_DEPLOY = new Map()
 
 async function walk(dir) {
 	const out = []


### PR DESCRIPTION
## Summary

The release-time `check-docs-links` job has been failing (e.g. the `v1.781.0` run) — not on a broken link, but on a **stale exemption**.

`PENDING_DEPLOY` in `.github/scripts/check-docs-links.mjs` let `https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt` 404 while the docs page was still unshipped. That page is now live (returns `200`), so the script failed the job by design: as its comment says, an entry that outlives its reason would exempt that URL from 404-checking forever, and a line in a green log is not read at release time.

## Changes

- Remove the dbt quickstart entry from `PENDING_DEPLOY`, leaving `const PENDING_DEPLOY = new Map()` (the mechanism and its comment stay in place for the next unshipped-docs link).

## Test plan

- [x] `curl -sIL https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt` returns `200`, confirming the exemption is stale.
- [x] `node .github/scripts/check-docs-links.mjs` exits `0` — `✅ No broken docs links (175 checked)`.

Note: the workflow is release/manual-trigger only, so it will not re-run on this PR's push; the local run above is the verification.

The run still prints a pre-existing non-fatal warning for `https://www.windmill.dev/docs/core_concepts/{service` in `NativeTriggersPanel.svelte` — a link built from a template interpolation the script cannot resolve, so it is skipped rather than checked. Left alone here to keep this change focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale dbt quickstart docs-link exemption from `PENDING_DEPLOY` in `.github/scripts/check-docs-links.mjs`. This unblocks the release `check-docs-links` job and ensures https://www.windmill.dev/docs/getting_started/scripts_quickstart/dbt is checked as a live page.

<sup>Written for commit f24a380c9548714c758f21de865b5befcd9fa7e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

