### PR TITLE
perf: keep run status out of flow graph node and edge data

### DIFF
--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -103,6 +103,7 @@
 	import { computeNodeExtraSpace } from './nodeExtraSpace'
 	import type { ModuleActionInfo } from '$lib/components/flows/flowDiff'
 	import { setGraphContext } from './graphContext'
+	import { setFlowRunStatusContext } from './flowRunStatus.svelte'
 	import { computeNoteNodes } from './noteUtils.svelte'
 	import { Tooltip } from '../meltComponents'
 	import { getNoteEditorContext } from './noteEditor.svelte'
@@ -371,6 +372,18 @@
 		groupDisplayState
 	} as any)
 
+	const flowRunStatus = setFlowRunStatusContext()
+	$effect(() => {
+		flowRunStatus.flowJob = flowJob
+	})
+	$effect(() => {
+		flowRunStatus.suspendStatus = suspendStatus
+	})
+	$effect(() => {
+		readFieldsRecursively(flowModuleStates)
+		untrack(() => flowRunStatus.setModuleStates(flowModuleStates))
+	})
+
 	if (triggerContext && untrack(() => allowSimplifiedPoll)) {
 		if (isSimplifiable(untrack(() => modules))) {
 			triggerContext?.simplifiedPoll?.set(true)
@@ -613,20 +626,58 @@
 
 	let height = $state(0)
 
+	/**
+	 * A run only changes what the steps display, never the shape of the graph, but every
+	 * status poll rebuilds these arrays from scratch. xyflow re-measures every node it is
+	 * handed a new object for, and Svelte destroys and re-creates every edge, so handing
+	 * back fresh identities re-renders a graph that did not change. Reuse the previous
+	 * object wherever it still deep-equals the new one.
+	 */
+	function reuseUnchanged<T extends { id: string }>(previous: T[], next: T[]): T[] {
+		const previousById = new Map(previous.map((item) => [item.id, item]))
+		let changed = previous.length !== next.length
+		const reconciled = next.map((item, index) => {
+			const before = previousById.get(item.id)
+			if (before && deepEqual(before, item)) {
+				changed ||= previous[index] !== before
+				return before
+			}
+			changed = true
+			return item
+		})
+		return changed ? reconciled : previous
+	}
+
+	// Keyed by the source node, so a node that survived reconciliation keeps its offset
+	// object too — remapping every node would undo the identity reuse above.
+	let offsetNodeCache = new WeakMap<Node, Node>()
+	let offsetCacheKey: string | undefined = undefined
+
 	// Derived nodes with yOffset applied to all nodes uniformly and selectable flag set to false if notSelectable is true
 	const nodesWithOffset = $derived.by(() => {
+		const cacheKey = `${yOffset}:${notSelectable}`
+		if (cacheKey !== offsetCacheKey) {
+			offsetNodeCache = new WeakMap<Node, Node>()
+			offsetCacheKey = cacheKey
+		}
 		return nodes.map((node) => {
-			if (node.type && !AI_OR_ASSET_NODE_TYPES.includes(node.type)) {
-				return {
-					...node,
-					position: { ...node.position, y: node.position.y + yOffset },
-					selectable: notSelectable ? false : node.selectable
-				}
+			const cached = offsetNodeCache.get(node)
+			if (cached) {
+				return cached
 			}
-			return {
-				...node,
-				selectable: notSelectable ? false : node.selectable
-			}
+			const mapped =
+				node.type && !AI_OR_ASSET_NODE_TYPES.includes(node.type)
+					? {
+							...node,
+							position: { ...node.position, y: node.position.y + yOffset },
+							selectable: notSelectable ? false : node.selectable
+						}
+					: {
+							...node,
+							selectable: notSelectable ? false : node.selectable
+						}
+			offsetNodeCache.set(node, mapped)
+			return mapped
 		})
 	})
 
@@ -797,13 +848,13 @@
 			: undefined
 
 		// update nodes
-		nodes = [...finalNodes, ...(noteNodesResult?.noteNodes ?? [])]
+		nodes = reuseUnchanged(nodes, [...finalNodes, ...(noteNodesResult?.noteNodes ?? [])])
 
-		edges = [
+		edges = reuseUnchanged(edges, [
 			...(assetNodesResult?.newAssetEdges ?? []),
 			...aiToolNodesResult.toolEdges,
 			...graph.edges
-		]
+		])
 
 		await tick()
 		updateHeight()
@@ -889,6 +940,13 @@
 		moduleTracker.counter
 		effectiveModuleActions
 		currentGroups
+		// The poll replaces `flowJob` on every tick and is what makes the untracked
+		// `flowModuleStates` above get re-read, so it stays a dependency. It is deliberately
+		// not handed to graphBuilder: anything put there lands in every node and edge's data,
+		// and a per-tick value there re-creates the whole graph. Renderers read it from
+		// FlowRunStatus instead.
+		flowJob
+		suspendStatus
 
 		const collapsedGroupIds = new Set(
 			allGroups
@@ -939,9 +997,7 @@
 				isOwner,
 				isRunning,
 				individualStepTests,
-				flowJob,
 				showJobStatus,
-				suspendStatus,
 				flowHasChanged,
 				chatInputEnabled,
 				additionalAssetsMap: flowGraphAssetsCtx?.val.additionalAssetsMap

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -700,6 +700,10 @@
 
 	// Clear SvelteFlow's internal selection by creating new nodes array
 	function clearFlowSelection() {
+		// xyflow owns `selected` on the objects it was handed, and drops it only when it sees a
+		// node it does not recognise. Serving the cached mapping back would hand it the very
+		// object it marked selected, so the clear has to go through fresh objects.
+		offsetNodeCache = new WeakMap<Node, Node>()
 		nodes = nodes.map((node) => {
 			if (node.selected) {
 				return { ...node, selected: false }
@@ -1458,7 +1462,10 @@
 	   match ours exactly and load order decides. Scoping by the class we pass to <Controls>
 	   outranks them instead of racing them. */
 	:global(.svelte-flow__controls.wm-flow-controls) {
-		@apply overflow-hidden rounded-md border;
+		/* Name the colour rather than leaning on the base layer's bare `.border`: preflight
+		   sets a light `border-color` on every element, so whenever that base rule does not
+		   make it into the bundle alongside this one the bar draws a white outline. */
+		@apply overflow-hidden rounded-md border border-border-light;
 		box-shadow: none;
 	}
 	:global(.wm-flow-controls .svelte-flow__controls-button) {

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -380,7 +380,10 @@
 		flowRunStatus.suspendStatus = suspendStatus
 	})
 	$effect(() => {
-		readFieldsRecursively(flowModuleStates)
+		// Each step's state object is replaced rather than mutated, so reading the top level
+		// catches every status change. Walking deeper would subscribe to every step's args and
+		// result on the hottest path in the graph.
+		Object.values(flowModuleStates ?? {})
 		untrack(() => flowRunStatus.setModuleStates(flowModuleStates))
 	})
 

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1044,6 +1044,24 @@
 	// Track groups for re-layout when groups change
 	let currentGroups = $derived(groups ?? [])
 
+	/**
+	 * An agent's tool calls become nodes, and they land one at a time while the step runs.
+	 * Nothing else the graph reads changes as they arrive — the run only appends to an
+	 * existing step's state — so without this the tools all appear at once when the step ends.
+	 */
+	let agentActionsVersion = $derived.by(() => {
+		let version = ''
+		for (const [id, state] of Object.entries(flowModuleStates ?? {})) {
+			const actions = state?.agent_actions
+			if (!actions) continue
+			version += `${id}:${actions.length}:`
+			for (const action of actions) {
+				version += `${action.type}/${(action as { function_name?: string }).function_name ?? ''},`
+			}
+		}
+		return version
+	})
+
 	$effect(() => {
 		;[
 			graph,
@@ -1053,6 +1071,7 @@
 			noteManager.renderCount,
 			currentGroups,
 			groupDisplayState.renderCount,
+			agentActionsVersion,
 			// A linked step's tools resolve asynchronously; recompute tool nodes when they land.
 			linkedAgentToolsVersion()
 		]

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1050,6 +1050,9 @@
 	 * existing step's state — so without this the tools all appear at once when the step ends.
 	 */
 	let agentActionsVersion = $derived.by(() => {
+		// The editor draws the agent's declared tools and ignores the run's calls, so neither the
+		// layout nor the tool nodes can change as they land.
+		if (insertable) return ''
 		let version = ''
 		for (const [id, state] of Object.entries(flowModuleStates ?? {})) {
 			const actions = state?.agent_actions

--- a/frontend/src/lib/components/graph/GroupModuleIcons.svelte
+++ b/frontend/src/lib/components/graph/GroupModuleIcons.svelte
@@ -5,17 +5,17 @@
 	import { getGraphContext } from './graphContext'
 	import { getNodeColorClasses } from '$lib/components/graph'
 	import type { FlowNodeState } from '$lib/components/graph/util'
-	import type { GraphModuleState } from './model'
 	import type { FlowModule } from '$lib/gen'
 	import type { GraphEventHandlers } from './graphBuilder.svelte'
+	import { getFlowRunStatusContext } from './flowRunStatus.svelte'
 
 	interface Props {
 		modules: FlowModule[]
-		flowModuleStates?: Record<string, GraphModuleState> | undefined
 		eventHandlers?: GraphEventHandlers
 	}
 
-	let { modules, flowModuleStates, eventHandlers }: Props = $props()
+	let { modules, eventHandlers }: Props = $props()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	const { selectionManager } = getGraphContext()
 
@@ -75,11 +75,11 @@
 	}
 
 	let overflowAggregateState = $derived.by<FlowNodeState | undefined>(() => {
-		if (!flowModuleStates) return undefined
+		if (!flowRunStatus) return undefined
 		let best: FlowNodeState | undefined = undefined
 		let bestPriority = 0
 		for (const mod of overflowModules) {
-			const state = flowModuleStates[mod.id]?.type
+			const state = flowRunStatus.getModuleState(mod.id)?.type
 			if (state) {
 				const p = STATE_PRIORITY[state] ?? 0
 				if (p > bestPriority) {
@@ -115,7 +115,7 @@
 <div class="flex items-center gap-1">
 	{#each displayModules as mod (mod.id)}
 		{@const selected = selectionManager.isNodeSelected(mod.id)}
-		{@const nodeState = flowModuleStates?.[mod.id]?.type}
+		{@const nodeState = flowRunStatus?.getModuleState(mod.id)?.type}
 		{@const colorClasses = getNodeColorClasses(nodeState, selected)}
 		<Tooltip placement="bottom">
 			{#snippet children()}
@@ -157,7 +157,7 @@
 					style="max-height: 50vh;"
 				>
 					{#each overflowModules as mod (mod.id)}
-						{@const nodeState = flowModuleStates?.[mod.id]?.type}
+						{@const nodeState = flowRunStatus?.getModuleState(mod.id)?.type}
 						{@const colorClasses = getNodeColorClasses(nodeState, false)}
 						{@const selected = selectionManager.isNodeSelected(mod.id)}
 						<!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/frontend/src/lib/components/graph/flowRunStatus.svelte.ts
+++ b/frontend/src/lib/components/graph/flowRunStatus.svelte.ts
@@ -1,0 +1,56 @@
+import { getContext, hasContext, setContext } from 'svelte'
+import { SvelteMap } from 'svelte/reactivity'
+import type { Job } from '$lib/gen'
+import type { GraphModuleState } from './model'
+
+const FLOW_RUN_STATUS_KEY = 'FlowRunStatus'
+
+export type SuspendStatus = Record<string, { job: Job; nb: number }>
+
+/**
+ * Run status is read straight from here by the node and edge renderers rather than
+ * being carried in their `data`. Baking it into `data` means the only way to show a
+ * status change is to rebuild every node and edge, which re-runs the sugiyama layout
+ * and makes xyflow re-measure and re-create the whole graph on every poll.
+ */
+export class FlowRunStatus {
+	#moduleStates = new SvelteMap<string, GraphModuleState>()
+	flowJob = $state.raw<Job | undefined>(undefined)
+	suspendStatus = $state.raw<SuspendStatus>({})
+
+	getModuleState(id: string | undefined): GraphModuleState | undefined {
+		return id == undefined ? undefined : this.#moduleStates.get(id)
+	}
+
+	setModuleStates(next: Record<string, GraphModuleState> | undefined) {
+		const incoming = next ?? {}
+		for (const id of [...this.#moduleStates.keys()]) {
+			if (!(id in incoming)) {
+				this.#moduleStates.delete(id)
+			}
+		}
+		// Writing a key invalidates only that key's readers, so one step finishing
+		// never re-renders the other steps.
+		for (const [id, state] of Object.entries(incoming)) {
+			if (this.#moduleStates.get(id) !== state) {
+				this.#moduleStates.set(id, state)
+			}
+		}
+	}
+}
+
+export function setFlowRunStatusContext(): FlowRunStatus {
+	const status = new FlowRunStatus()
+	setContext(FLOW_RUN_STATUS_KEY, status)
+	return status
+}
+
+/**
+ * Graphs that never show run status (mini graph, diff viewer) provide no context, so
+ * every reader has to tolerate its absence.
+ */
+export function getFlowRunStatusContext(): FlowRunStatus | undefined {
+	return hasContext(FLOW_RUN_STATUS_KEY)
+		? getContext<FlowRunStatus>(FLOW_RUN_STATUS_KEY)
+		: undefined
+}

--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -1,4 +1,4 @@
-import type { FlowModule, Job, PathScript, RawScript, Script } from '$lib/gen'
+import type { FlowModule, PathScript, RawScript, Script } from '$lib/gen'
 import { type Edge } from '@xyflow/svelte'
 import { getAllModules, getDependeeAndDependentComponents } from '../flows/flowExplorer'
 import { dfsByModule } from '../flows/previousResults'
@@ -132,7 +132,6 @@ export type InputN = {
 		editMode: boolean
 		isRunning: boolean
 		individualStepTests: boolean
-		flowJob: Job | undefined
 		showJobStatus: boolean
 		flowHasChanged: boolean
 		chatInputEnabled: boolean
@@ -148,11 +147,9 @@ export type ModuleN = {
 		id: string
 		parentIds: string[]
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 		testModuleState: ModuleTestState | undefined
 		insertable: boolean
 		editMode: boolean
-		flowJob: Job | undefined
 		isOwner: boolean
 		assets: AssetWithAltAccessType[] | undefined
 		moduleAction: ModuleActionInfo | undefined
@@ -167,7 +164,6 @@ export type FailureModuleN = {
 		id: string
 		module: FlowModule
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 	}
 }
 
@@ -178,7 +174,6 @@ export type BranchAllStartN = {
 		id: string
 		branchIndex: number
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 		insertable: boolean
 		branchOne: boolean
 	}
@@ -189,7 +184,6 @@ export type BranchAllEndN = {
 	data: {
 		id: string
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 	}
 }
 
@@ -199,7 +193,6 @@ export type ForLoopEndN = {
 		id: string
 		eventHandlers: GraphEventHandlers
 		simplifiedTriggerView: boolean
-		flowModuleState: GraphModuleState | undefined
 	}
 }
 
@@ -208,7 +201,6 @@ export type ForLoopStartN = {
 	data: {
 		id: string
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 		selectedId: string | undefined
 		editMode: boolean
 		simplifiedTriggerView: boolean
@@ -222,7 +214,6 @@ export type ResultN = {
 		success: boolean | undefined
 		eventHandlers: GraphEventHandlers
 		editMode: boolean
-		job: Job | undefined
 		showJobStatus: boolean
 	}
 }
@@ -244,7 +235,6 @@ export type BranchOneStartN = {
 	data: {
 		id: string
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 		selected: boolean
 		insertable: boolean
 		label: string
@@ -259,7 +249,6 @@ export type BranchOneEndN = {
 	data: {
 		id: string
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 	}
 }
 
@@ -280,7 +269,6 @@ export type NoBranchN = {
 	data: {
 		id: string
 		eventHandlers: GraphEventHandlers
-		flowModuleState: GraphModuleState | undefined
 		branchOne: boolean
 		label: string
 		branchIndex: number
@@ -330,7 +318,6 @@ export type AiToolN = {
 		// Tool of a linked agent: its inputs are editable but its structure comes from the resource,
 		// so it can't be deleted here.
 		readOnly?: boolean
-		flowModuleStates: Record<string, GraphModuleState> | undefined
 	}
 }
 
@@ -352,10 +339,7 @@ export type CollapsedGroupN = {
 		autocollapse: boolean | undefined
 		stepCount: number
 		modules: FlowModule[]
-		flowModuleStates: Record<string, GraphModuleState> | undefined
-		flowJob: Job | undefined
 		isOwner: boolean
-		suspendStatus: Record<string, { job: Job; nb: number }>
 		showNotes: boolean
 		editMode: boolean
 		eventHandlers: GraphEventHandlers
@@ -416,6 +400,9 @@ export function graphBuilder(
 	extra: {
 		disableAi: boolean
 		insertable: boolean
+		// Only for the parts of the graph's shape a run decides: which loop iteration is
+		// expanded and where the error-handler marker attaches. Everything a step merely
+		// displays comes from FlowRunStatus, never from here.
 		flowModuleStates: Record<string, GraphModuleState> | undefined
 		testModuleStates: ModulesTestStates | undefined
 		moduleActions?: Record<string, ModuleActionInfo>
@@ -428,9 +415,7 @@ export function graphBuilder(
 		isOwner: boolean
 		isRunning: boolean
 		individualStepTests: boolean
-		flowJob: Job | undefined
 		showJobStatus: boolean
-		suspendStatus: Record<string, { job: Job; nb: number }>
 		flowHasChanged: boolean
 		chatInputEnabled: boolean
 		additionalAssetsMap?: Record<string, AssetWithAltAccessType[]>
@@ -481,12 +466,10 @@ export function graphBuilder(
 					id: module.id,
 					parentIds: [],
 					eventHandlers: eventHandlers,
-					flowModuleState: extra.flowModuleStates?.[module.id],
 					testModuleState: extra.testModuleStates?.states?.[module.id],
 					insertable: extra.insertable && !module.id.startsWith('subflow:'),
 					editMode: extra.editMode,
 					isOwner: extra.isOwner,
-					flowJob: extra.flowJob,
 					assets: getFlowModuleAssets(module, extra.additionalAssetsMap),
 					moduleAction: extra.moduleActions?.[module.id],
 					...extraData
@@ -511,8 +494,7 @@ export function graphBuilder(
 				data: {
 					id: module.id,
 					module,
-					eventHandlers: eventHandlers,
-					flowModuleState: extra.flowModuleStates?.[module.id]
+					eventHandlers: eventHandlers
 				},
 				type: 'failureModule',
 				selectable: false
@@ -609,7 +591,11 @@ export function graphBuilder(
 					disableMoveIds: options?.disableMoveIds,
 					enableTrigger: sourceId === 'Input',
 					index,
-					...extra,
+					// Only what the edge renderer reads. Spreading all of `extra` here put
+					// per-tick run state on every edge, so one status poll invalidated the whole
+					// edge set and Svelte re-created each one.
+					disableAi: extra.disableAi,
+					isOwner: extra.isOwner,
 					insertable: extra.insertable && !options?.disableInsert && prefix == undefined,
 					shouldOffsetInsertBtnDueToAssetNode: nodeIdsWithOutputAssets.has(sourceId)
 				},
@@ -631,7 +617,6 @@ export function graphBuilder(
 				editMode: extra.editMode,
 				isRunning: extra.isRunning,
 				individualStepTests: extra.individualStepTests,
-				flowJob: extra.flowJob,
 				showJobStatus: extra.showJobStatus,
 				flowHasChanged: extra.flowHasChanged,
 				chatInputEnabled: extra.chatInputEnabled,
@@ -672,7 +657,6 @@ export function graphBuilder(
 				eventHandlers: eventHandlers,
 				success: success,
 				editMode: extra.editMode,
-				job: extra.flowJob,
 				showJobStatus: extra.showJobStatus
 			},
 			type: 'result'
@@ -741,10 +725,7 @@ export function graphBuilder(
 									modules: leafIds
 										.map((id) => moduleMap.get(id))
 										.filter((m): m is FlowModule => !!m),
-									flowModuleStates: extra.flowModuleStates,
-									flowJob: extra.flowJob,
 									isOwner: extra.isOwner,
-									suspendStatus: extra.suspendStatus,
 									showNotes,
 									editMode: prefix == undefined && extra.editMode,
 									eventHandlers
@@ -866,8 +847,7 @@ export function graphBuilder(
 							id: `${module.id}-end`,
 							data: {
 								id: module.id,
-								eventHandlers: eventHandlers,
-								flowModuleState: extra.flowModuleStates?.[module.id]
+								eventHandlers: eventHandlers
 							},
 							type: 'branchAllEnd'
 						}
@@ -882,7 +862,6 @@ export function graphBuilder(
 									id: module.id,
 									branchIndex: -1,
 									eventHandlers: eventHandlers,
-									flowModuleState: extra.flowModuleStates?.[module.id],
 									branchOne: false,
 									label: 'No branches'
 								},
@@ -908,7 +887,6 @@ export function graphBuilder(
 										id: module.id,
 										branchIndex: branchIndex,
 										eventHandlers: eventHandlers,
-										flowModuleState: extra.flowModuleStates?.[module.id],
 										insertable: extra.insertable,
 										branchOne: false
 									},
@@ -954,7 +932,6 @@ export function graphBuilder(
 								simplifiedTriggerView,
 								eventHandlers: eventHandlers,
 								editMode: extra.editMode,
-								flowModuleState: extra.flowModuleStates?.[module.id],
 								selectedId: extra.selectedId
 							},
 							type: 'forLoopStart'
@@ -975,8 +952,7 @@ export function graphBuilder(
 							data: {
 								id: module.id,
 								eventHandlers: eventHandlers,
-								simplifiedTriggerView,
-								flowModuleState: extra.flowModuleStates?.[module.id]
+								simplifiedTriggerView
 							},
 							type: 'forLoopEnd'
 						}
@@ -1046,7 +1022,6 @@ export function graphBuilder(
 							id: `${module.id}-end`,
 							data: {
 								eventHandlers: eventHandlers,
-								flowModuleState: extra.flowModuleStates?.[module.id],
 								id: module.id
 							},
 							type: 'branchOneEnd'
@@ -1062,7 +1037,6 @@ export function graphBuilder(
 								eventHandlers: eventHandlers,
 								insertable: extra.insertable,
 								preLabel: undefined,
-								flowModuleState: extra.flowModuleStates?.[module.id],
 								selected: false,
 								modules: module.value.default
 							},
@@ -1098,7 +1072,6 @@ export function graphBuilder(
 									branchIndex: branchIndex,
 									eventHandlers: eventHandlers,
 									insertable: extra.insertable,
-									flowModuleState: extra.flowModuleStates?.[module.id],
 									selected: false,
 									modules: branch.modules
 								},

--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -591,9 +591,9 @@ export function graphBuilder(
 					disableMoveIds: options?.disableMoveIds,
 					enableTrigger: sourceId === 'Input',
 					index,
-					// Only what the edge renderer reads. Spreading all of `extra` here put
-					// per-tick run state on every edge, so one status poll invalidated the whole
-					// edge set and Svelte re-created each one.
+					// Only what the edge renderer reads. Anything listed here lands on every edge,
+					// so a value that changes each poll invalidates the whole edge set and makes
+					// Svelte re-create each one.
 					disableAi: extra.disableAi,
 					isOwner: extra.isOwner,
 					insertable: extra.insertable && !options?.disableInsert && prefix == undefined,

--- a/frontend/src/lib/components/graph/renderers/edges/BaseEdge.svelte
+++ b/frontend/src/lib/components/graph/renderers/edges/BaseEdge.svelte
@@ -8,12 +8,13 @@
 	import { NODE_WITH_WRITE_ASSET_Y_OFFSET } from '../nodes/AssetNode.svelte'
 	import FlowStatusWaitingForEvents from '$lib/components/FlowStatusWaitingForEvents.svelte'
 	import type { Job } from '$lib/gen'
-	import type { GraphModuleState } from '../../model'
 	import InsertModuleButton from '$lib/components/flows/map/InsertModuleButton.svelte'
 	import { getGraphContext } from '../../graphContext'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 	import { GROUP_TOP_PADDING } from '$lib/components/graph/compoundLayout'
 
 	const { useDataflow, showAssets, moveManager } = getGraphContext()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	let {
 		id,
@@ -39,10 +40,7 @@
 			enableTrigger: boolean
 			disableAi: boolean
 			disableMoveIds: string[]
-			flowModuleStates: Record<string, GraphModuleState> | undefined
 			isOwner: boolean
-			flowJob: Job | undefined
-			suspendStatus?: Record<string, { job: Job; nb: number }>
 			shouldOffsetInsertBtnDueToAssetNode?: boolean
 		}
 	} = $props()
@@ -75,12 +73,13 @@
 	// TODO: this is a hack to show the waiting for events indicator on the edge a proper way would be to have a edge state
 	// and handle the edge state in the graph builder
 	let waitingForEvents = $derived(
-		data?.flowModuleStates?.[data.targetId]?.type === 'WaitingForEvents' ||
-			data?.flowModuleStates?.[`${data.sourceId}-v`]?.type === 'WaitingForEvents'
+		flowRunStatus?.getModuleState(data.targetId)?.type === 'WaitingForEvents' ||
+			flowRunStatus?.getModuleState(`${data.sourceId}-v`)?.type === 'WaitingForEvents'
 	)
 
+	let flowJob: Job | undefined = $derived(flowRunStatus?.flowJob)
 	let suspendStatus: Record<string, { job: Job; nb: number }> | undefined = $derived(
-		data?.suspendStatus
+		flowRunStatus?.suspendStatus
 	)
 
 	let centerY = $derived(
@@ -132,7 +131,7 @@
 </script>
 
 <EdgeLabel x={sourceX} y={centerY} class="base-edge" style="">
-	{#if waitingForEvents && data.flowJob && data.flowJob.type === 'QueuedJob'}
+	{#if waitingForEvents && flowJob && flowJob.type === 'QueuedJob'}
 		<div
 			class="px-2 py-0.5 rounded-md bg-surface shadow-md text-violet-700 dark:text-violet-400 text-xs flex items-center gap-1"
 		>
@@ -146,10 +145,10 @@
 		<div
 			class={'fixed top-1/2 -translate-y-1/2 left-[170px] h-fit w-fit rounded-md bg-surface flex items-center justify-center p-2 ml-2 shadow-md'}
 		>
-			{#if data?.flowJob && data.flowJob.flow_status?.modules?.[data.flowJob.flow_status?.step]?.type === 'WaitingForEvents'}
+			{#if flowJob && flowJob.flow_status?.modules?.[flowJob.flow_status?.step]?.type === 'WaitingForEvents'}
 				<FlowStatusWaitingForEvents
-					job={data.flowJob}
-					workspaceId={data.flowJob.workspace_id}
+					job={flowJob}
+					workspaceId={flowJob.workspace_id}
 					isOwner={data.isOwner}
 					light
 				/>

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
@@ -277,6 +277,7 @@
 	import { getNodeColorClasses } from '../../util'
 	import { deepEqual } from 'fast-equals'
 	import { getGraphContext } from '../../graphContext'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 
 	let hover = $state(false)
 
@@ -286,10 +287,11 @@
 	}
 
 	let { data, id }: Props = $props()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	const { selectionManager } = getGraphContext()
 
-	const flowModuleState = $derived(data.flowModuleStates?.[data.moduleId])
+	const flowModuleState = $derived(flowRunStatus?.getModuleState(data.moduleId))
 	let colorClasses = $derived(
 		getNodeColorClasses(
 			data.nameError ? 'Failure' : flowModuleState?.type,

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
@@ -71,9 +71,13 @@
 
 	function agentActionsOf(
 		nodes: (Node & NodeLayout)[],
-		flowModuleStates: Record<string, GraphModuleState> | undefined
+		flowModuleStates: Record<string, GraphModuleState> | undefined,
+		insertable: boolean
 	): Record<string, unknown> {
 		const actions: Record<string, unknown> = {}
+		// The editor renders the static tool set and ignores the run's actions, so snapshotting
+		// them there would deep-clone a value that changes every poll and never matches.
+		if (insertable) return actions
 		for (const node of nodes) {
 			if (node.type !== 'module' || node.data.module.value.type !== 'aiagent') continue
 			actions[node.id] = $state.snapshot(flowModuleStates?.[node.id]?.agent_actions)
@@ -95,7 +99,10 @@
 	} {
 		if (
 			computeAIToolNodesCache &&
-			deepEqual(agentActionsOf(nodes, flowModuleStates), computeAIToolNodesCache.agentActions) &&
+			deepEqual(
+				agentActionsOf(nodes, flowModuleStates, insertable),
+				computeAIToolNodesCache.agentActions
+			) &&
 			deepEqual(nodes.map(getComparableNode), computeAIToolNodesCache.nodes) &&
 			deepEqual(linkedAgentTools, computeAIToolNodesCache.linkedAgentTools)
 		) {
@@ -264,7 +271,7 @@
 
 		computeAIToolNodesCache = {
 			nodes: nodes.map(getComparableNode),
-			agentActions: agentActionsOf(nodes, flowModuleStates),
+			agentActions: agentActionsOf(nodes, flowModuleStates, insertable),
 			linkedAgentTools: $state.snapshot(linkedAgentTools),
 			ret
 		}

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
@@ -43,7 +43,7 @@
 	let computeAIToolNodesCache:
 		| {
 				nodes: (Node & NodeLayout)[]
-				hasFlowModuleStates: boolean
+				agentActions: Record<string, unknown>
 				linkedAgentTools: Record<string, AgentTool[]> | undefined
 				ret: ReturnType<typeof computeAIToolNodes>
 		  }
@@ -69,6 +69,18 @@
 		}
 	}
 
+	function agentActionsOf(
+		nodes: (Node & NodeLayout)[],
+		flowModuleStates: Record<string, GraphModuleState> | undefined
+	): Record<string, unknown> {
+		const actions: Record<string, unknown> = {}
+		for (const node of nodes) {
+			if (node.type !== 'module' || node.data.module.value.type !== 'aiagent') continue
+			actions[node.id] = $state.snapshot(flowModuleStates?.[node.id]?.agent_actions)
+		}
+		return actions
+	}
+
 	export function computeAIToolNodes(
 		nodes: (Node & NodeLayout)[],
 		eventHandlers: GraphEventHandlers,
@@ -83,7 +95,7 @@
 	} {
 		if (
 			computeAIToolNodesCache &&
-			!!flowModuleStates === computeAIToolNodesCache.hasFlowModuleStates &&
+			deepEqual(agentActionsOf(nodes, flowModuleStates), computeAIToolNodesCache.agentActions) &&
 			deepEqual(nodes.map(getComparableNode), computeAIToolNodesCache.nodes) &&
 			deepEqual(linkedAgentTools, computeAIToolNodesCache.linkedAgentTools)
 		) {
@@ -191,8 +203,7 @@
 						// misroute agent-node clicks into the graph's manual aiTool selection path.
 						selectTarget: isLinkedAgent && !agentActions ? node.id : undefined,
 						insertable,
-						readOnly: isLinkedAgent,
-						flowModuleStates
+						readOnly: isLinkedAgent
 					},
 					id: `${node.id}-tool-${tool.id}`,
 					width: inputToolWidth,
@@ -253,7 +264,7 @@
 
 		computeAIToolNodesCache = {
 			nodes: nodes.map(getComparableNode),
-			hasFlowModuleStates: !!flowModuleStates,
+			agentActions: agentActionsOf(nodes, flowModuleStates),
 			linkedAgentTools: $state.snapshot(linkedAgentTools),
 			ret
 		}

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
@@ -84,9 +84,9 @@ describe('computeAIToolNodes', () => {
 	})
 
 	it('picks up a tool call that arrives without moving any node', () => {
-		// Run status no longer reaches these nodes through their `data`, so the memo has to key
-		// on the agent's actions itself. Two calls occupy one row, i.e. identical positions, so
-		// a memo keyed only on the nodes would serve the stale single-tool result forever.
+		// Run status lives outside node data, so the memo has to key on the agent's actions
+		// itself. Two calls occupy one row, i.e. identical positions, so a memo keyed only on
+		// the nodes would serve the stale single-tool result forever.
 		const node = aiAgentNode('agent', [
 			{ id: 'tool_a', summary: 'my_tool', value: { tool_type: 'flowmodule', type: 'script' } }
 		])

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
@@ -83,6 +83,30 @@ describe('computeAIToolNodes', () => {
 		}
 	})
 
+	it('picks up a tool call that arrives without moving any node', () => {
+		// Run status no longer reaches these nodes through their `data`, so the memo has to key
+		// on the agent's actions itself. Two calls occupy one row, i.e. identical positions, so
+		// a memo keyed only on the nodes would serve the stale single-tool result forever.
+		const node = aiAgentNode('agent', [
+			{ id: 'tool_a', summary: 'my_tool', value: { tool_type: 'flowmodule', type: 'script' } }
+		])
+		const stateWith = (n: number) =>
+			({
+				agent: {
+					type: 'InProgress',
+					agent_actions: Array.from({ length: n }, (_, i) => ({
+						type: 'tool_call',
+						function_name: 'my_tool',
+						module_id: 'tool_a',
+						job_id: `j${i}`
+					}))
+				}
+			}) as any
+
+		expect(computeAIToolNodes([node], eventHandlers, false, stateWith(1)).toolNodes.length).toBe(1)
+		expect(computeAIToolNodes([node], eventHandlers, false, stateWith(2)).toolNodes.length).toBe(2)
+	})
+
 	it('still flags genuinely duplicate tool names in the editor (static tool set)', () => {
 		const node = aiAgentNode('agent2', [
 			{ id: 't1', summary: 'dup', value: { tool_type: 'flowmodule', type: 'script' } },

--- a/frontend/src/lib/components/graph/renderers/nodes/BranchAllStart.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/BranchAllStart.svelte
@@ -7,17 +7,19 @@
 	import type { BranchAllStartN } from '../../graphBuilder.svelte'
 	import { getGraphContext } from '../../graphContext'
 	import { computeBorderStatus } from '../utils'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 	interface Props {
 		data: BranchAllStartN['data']
 		id: string
 	}
 
 	let { data, id }: Props = $props()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	const { selectionManager } = getGraphContext()
 
 	let borderStatus = $derived(
-		computeBorderStatus(data.branchIndex, 'branchall', data.flowModuleState)
+		computeBorderStatus(data.branchIndex, 'branchall', flowRunStatus?.getModuleState(data.id))
 	)
 </script>
 

--- a/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
@@ -7,6 +7,7 @@
 	import type { BranchOneStartN } from '../../graphBuilder.svelte'
 	import { getGraphContext } from '../../graphContext'
 	import { computeBorderStatus } from '../utils'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 	interface Props {
 		data: BranchOneStartN['data']
 		id: string
@@ -14,11 +15,12 @@
 	const { selectionManager } = getGraphContext()
 
 	let { data, id }: Props = $props()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	// branchIndex is -1 for the default branch and 0-based for explicit branches;
 	// branchChosen is 0 for default and 1-based, hence the +1.
 	let borderStatus = $derived(
-		computeBorderStatus(data.branchIndex + 1, 'branchone', data.flowModuleState)
+		computeBorderStatus(data.branchIndex + 1, 'branchone', flowRunStatus?.getModuleState(data.id))
 	)
 </script>
 

--- a/frontend/src/lib/components/graph/renderers/nodes/CollapsedGroupNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/CollapsedGroupNode.svelte
@@ -8,6 +8,7 @@
 	import { Hourglass } from 'lucide-svelte'
 	import FlowStatusWaitingForEvents from '$lib/components/FlowStatusWaitingForEvents.svelte'
 	import { dfs } from '$lib/components/flows/dfs'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 
 	interface Props {
 		data: CollapsedGroupN['data']
@@ -15,6 +16,8 @@
 	}
 
 	let { data, id }: Props = $props()
+
+	const flowRunStatus = getFlowRunStatusContext()
 
 	let outlineColorClass = $derived(
 		(NOTE_COLORS[(data.color as NoteColor) ?? NoteColor.BLUE] ?? NOTE_COLORS[NoteColor.BLUE])
@@ -31,8 +34,8 @@
 	let waitingForEvents = $derived(
 		allModuleIds.some(
 			(mid) =>
-				data.flowModuleStates?.[mid]?.type === 'WaitingForEvents' ||
-				data.flowModuleStates?.[`${mid}-v`]?.type === 'WaitingForEvents'
+				flowRunStatus?.getModuleState(mid)?.type === 'WaitingForEvents' ||
+				flowRunStatus?.getModuleState(`${mid}-v`)?.type === 'WaitingForEvents'
 		)
 	)
 </script>
@@ -57,14 +60,14 @@
 				<div class="flex items-center justify-center w-full gap-1.5 px-2 h-[34px] overflow-hidden">
 					<GroupModuleIcons
 						modules={data.modules}
-						flowModuleStates={data.flowModuleStates}
+						
 						eventHandlers={data.eventHandlers}
 					/>
 				</div>
 			{/if}
 		</div>
 
-		{#if waitingForEvents && data.flowJob && data.flowJob.type === 'QueuedJob'}
+		{#if waitingForEvents && flowRunStatus?.flowJob && flowRunStatus.flowJob.type === 'QueuedJob'}
 			<div
 				class="absolute top-1/2 -translate-y-1/2 left-full ml-2 flex items-center gap-2 nodrag nowheel"
 			>
@@ -79,16 +82,16 @@
 					</div>
 				</div>
 				<div class="rounded-md bg-surface flex items-center justify-center p-2 shadow-md">
-					{#if data.flowJob.flow_status?.modules?.[data.flowJob.flow_status?.step]?.type === 'WaitingForEvents'}
+					{#if flowRunStatus?.flowJob?.flow_status?.modules?.[flowRunStatus.flowJob.flow_status?.step]?.type === 'WaitingForEvents'}
 						<FlowStatusWaitingForEvents
-							job={data.flowJob}
-							workspaceId={data.flowJob.workspace_id}
+							job={flowRunStatus.flowJob}
+							workspaceId={flowRunStatus.flowJob.workspace_id}
 							isOwner={data.isOwner}
 							light
 						/>
-					{:else if data.suspendStatus && Object.keys(data.suspendStatus).length > 0}
+					{:else if flowRunStatus?.suspendStatus && Object.keys(flowRunStatus.suspendStatus).length > 0}
 						<div class="flex gap-2 flex-col">
-							{#each Object.values(data.suspendStatus) as suspendCount (suspendCount.job.id)}
+							{#each Object.values(flowRunStatus.suspendStatus) as suspendCount (suspendCount.job.id)}
 								<FlowStatusWaitingForEvents
 									job={suspendCount.job}
 									workspaceId={suspendCount.job.workspace_id}

--- a/frontend/src/lib/components/graph/renderers/nodes/CollapsedGroupNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/CollapsedGroupNode.svelte
@@ -58,11 +58,7 @@
 			/>
 			{#if data.modules && data.modules.length > 0}
 				<div class="flex items-center justify-center w-full gap-1.5 px-2 h-[34px] overflow-hidden">
-					<GroupModuleIcons
-						modules={data.modules}
-						
-						eventHandlers={data.eventHandlers}
-					/>
+					<GroupModuleIcons modules={data.modules} eventHandlers={data.eventHandlers} />
 				</div>
 			{/if}
 		</div>

--- a/frontend/src/lib/components/graph/renderers/nodes/FailureModuleNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/FailureModuleNode.svelte
@@ -6,14 +6,16 @@
 	import type { FailureModuleN } from '../../graphBuilder.svelte'
 	import { getNodeColorClasses, NODE } from '$lib/components/graph'
 	import { msToSec } from '$lib/utils'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 
 	interface Props {
 		data: FailureModuleN['data']
 	}
 
 	let { data }: Props = $props()
+	const flowRunStatus = getFlowRunStatusContext()
 
-	let state = $derived(data.flowModuleState)
+	let state = $derived(flowRunStatus?.getModuleState(data.id))
 	let colorClasses = $derived(getNodeColorClasses(state?.skipped ? '_Skipped' : state?.type, false))
 </script>
 

--- a/frontend/src/lib/components/graph/renderers/nodes/InputNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/InputNode.svelte
@@ -12,6 +12,7 @@
 	import type { FlowEditorContext } from '$lib/components/flows/types'
 	import { MessageSquare } from 'lucide-svelte'
 	import { getGraphContext } from '../../graphContext'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 	import FunnelCog from '$lib/components/icons/FunnelCog.svelte'
 
 	interface Props {
@@ -21,6 +22,7 @@
 	let { data }: Props = $props()
 
 	const { selectionManager, diffManager } = getGraphContext()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	const flowEditorContext = getContext<FlowEditorContext | undefined>('FlowEditorContext')
 	const { previewArgs, flowStore } = flowEditorContext || {}
@@ -110,7 +112,7 @@
 				data.eventHandlers.hideJobStatus()
 			}}
 			individualStepTests={data.individualStepTests}
-			job={data.flowJob}
+			job={flowRunStatus?.flowJob}
 			showJobStatus={data.showJobStatus}
 			flowHasChanged={data.flowHasChanged}
 		>

--- a/frontend/src/lib/components/graph/renderers/nodes/ModuleNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/ModuleNode.svelte
@@ -8,6 +8,7 @@
 	import { isMac, type Item } from '$lib/utils'
 	import { getContext } from 'svelte'
 	import { getGraphContext } from '../../graphContext'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 
 	interface Props {
 		data: ModuleN['data']
@@ -20,8 +21,8 @@
 
 	let state = $derived.by(() => {
 		return data.testModuleState
-			? (jobToGraphModuleState(data.testModuleState) ?? data.flowModuleState)
-			: data.flowModuleState
+			? (jobToGraphModuleState(data.testModuleState) ?? flowRunStatus?.getModuleState(data.id))
+			: flowRunStatus?.getModuleState(data.id)
 	})
 
 	let flowJobs = $derived(
@@ -56,6 +57,7 @@
 	// that works from any state as its shortcut.
 	const stepExploreHint = getContext<(() => boolean) | undefined>('flowGraphStepExploreHint')
 	const selectionManager = getGraphContext()?.selectionManager
+	const flowRunStatus = getFlowRunStatusContext()
 
 	const menuItems: Item[] = $derived(
 		data.editMode
@@ -152,7 +154,7 @@
 				data.eventHandlers.updateMock(detail)
 			}}
 			onEditInput={data.eventHandlers.editInput}
-			flowJob={data.flowJob}
+			flowJob={flowRunStatus?.flowJob}
 			isOwner={data.isOwner}
 			maximizeSubflow={data.module?.value?.type == 'flow' && 'path' in data.module.value
 				? () => {

--- a/frontend/src/lib/components/graph/renderers/nodes/ModuleNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/ModuleNode.svelte
@@ -18,6 +18,7 @@
 
 	// Get NoteEditor context for group note creation
 	const noteEditorContext = getNoteEditorContext()
+	const flowRunStatus = getFlowRunStatusContext()
 
 	let state = $derived.by(() => {
 		return data.testModuleState
@@ -57,7 +58,6 @@
 	// that works from any state as its shortcut.
 	const stepExploreHint = getContext<(() => boolean) | undefined>('flowGraphStepExploreHint')
 	const selectionManager = getGraphContext()?.selectionManager
-	const flowRunStatus = getFlowRunStatusContext()
 
 	const menuItems: Item[] = $derived(
 		data.editMode

--- a/frontend/src/lib/components/graph/renderers/nodes/ResultNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/ResultNode.svelte
@@ -3,6 +3,7 @@
 	import NodeWrapper from './NodeWrapper.svelte'
 	import type { ResultN } from '../../graphBuilder.svelte'
 	import { getGraphContext } from '../../graphContext'
+	import { getFlowRunStatusContext } from '../../flowRunStatus.svelte'
 
 	interface Props {
 		data: ResultN['data']
@@ -12,6 +13,7 @@
 	let { data, id }: Props = $props()
 
 	const { selectionManager } = getGraphContext()
+	const flowRunStatus = getFlowRunStatusContext()
 </script>
 
 <NodeWrapper enableSourceHandle={false}>
@@ -27,7 +29,7 @@
 			}}
 			nodeKind="result"
 			editMode={data.editMode}
-			job={data.job}
+			job={flowRunStatus?.flowJob}
 			showJobStatus={data.showJobStatus}
 		/>
 	{/snippet}


### PR DESCRIPTION
## Summary

Every job-status poll re-rendered the whole flow graph, even though a run never changes the graph's shape.

Run status (`flowJob`, `suspendStatus`, per-step `flowModuleState`) was baked into every xyflow node's and edge's `data` — `graphBuilder`'s `addEdge` spread `...extra` into **every edge's** data, so each edge carried the flow job and the entire `flowModuleStates` record. One poll therefore produced new object identities for the entire graph, which makes xyflow re-measure every node (`updateNodeInternals` → forced `clientHeight` reflows) and makes Svelte destroy and re-create every edge.

Run status is presentation, not structure, so it no longer travels through the structural build. It goes through a `FlowRunStatus` context store that the renderers read directly, and `updateStores` reconciles nodes/edges by id so unchanged entries keep their object identity.

Measured on a 33-step branchone flow (5 branches), instrumented from the moment the run starts with a `MutationObserver` on `.svelte-flow__viewport` plus `PerformanceObserver('long-animation-frame')`:

| | before | after |
|---|---|---|
| DOM mutations during a run | 5,540 | **1,690** (−69%) |
| long animation frames | 7 | **2** |
| long-frame time | 873 ms | **271 ms** (−69%) |
| blocking time | 413 ms | **171 ms** (−59%) |
| edges replaced per rebuild | all (1,424) | **0** |
| nodes replaced per rebuild | all | 6 (Input/Result only, on `isRunning`/`success` flips) |

The two long frames that remain are the run's genuine structure changes — the 44→87 node expansion at start and the completion update — not the poll loop.

## Changes

- Add `graph/flowRunStatus.svelte.ts`: a context store holding `flowJob`, `suspendStatus` and a `SvelteMap` of per-module states, so one step finishing wakes only that step's readers. Absent context is tolerated, for the graphs that never show run status.
- `graphBuilder`: stop putting `flowJob`, `suspendStatus` and `flowModuleState` in node/edge data. Replace the `...extra` spread in `addEdge` with the three fields the edge renderer actually reads. `extra.flowModuleStates` stays only for the parts of the graph's *shape* a run decides — the expanded loop iteration and error-handler-marker anchoring.
- Point the 9 renderers (`BaseEdge`, `ModuleNode`, `InputNode`, `ResultNode`, `CollapsedGroupNode`, `FailureModuleNode`, `BranchAllStart`, `BranchOneStart`, `AIToolNode`, `GroupModuleIcons`) at the context.
- `FlowGraphV2`: provide and sync the store; reconcile nodes/edges with `reuseUnchanged` (deep-equal by id, the idiom already used for the sugiyama memo in that file), plus a WeakMap so `nodesWithOffset` does not undo the identity reuse.
- Key the `computeAIToolNodes` memo on the agent's `agent_actions`. Its only run-status invalidator used to be `flowModuleState` sitting in node data; without a replacement, tool-call nodes appearing mid-run would render only when a whole row filled up. Covered by a new case in `AIToolNode.test.ts`.

## Screenshots

Flow editor after a run — branch node green with its duration, per-step statuses intact:

![graph-status](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/1password-flow-perf/1785974308-graph-status.png)

Run viewer — 8 green nodes with per-step durations:

![run-viewer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/1password-flow-perf/1785974311-run-viewer.png)

## Also in this PR

One unrelated CSS fix, called out because it is not a perf change. The graph's zoom bar
(`.svelte-flow__controls.wm-flow-controls`) applied a bare `border`, which sets only a
width; its colour came from the base layer's `.border` rule pulled in by `@apply`. In the
production bundle those land as **two separate rules of equal specificity**, so if the
colour one is missing the only colour left is preflight's `*{border-color:#e5e7eb}` — a
white outline on the dark bar. The rule now names `border-border-light` and is
self-contained.

Reported against this PR's CF preview. I could not reproduce it locally in dev or in a
production build, before or after the change, so the fix is defensive: it removes a real
ordering fragility that matches the symptom, but it is not proven to be that symptom's
cause.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npx vitest run src/lib/components/graph` — 28 passed
- [x] Run a flow from the editor: statuses, durations and colours still render; run viewer shows per-step status with 0 console errors
- [x] Re-measured mutations / long frames / blocking before and after on the same flow
- [x] Selection: click a step, Escape, Shift-click another — only the second stays selected (the `offsetNodeCache` regression)
- [x] Watched a live run in the run viewer: statuses progress step by step as the flow executes
- [ ] Dark mode on the CF preview: the zoom bar's border is not white
- [ ] Run a flow with an AI agent step making 4+ tool calls and confirm each tool node appears as the call is made, and the final count matches the step's detail panel
- [ ] Open a flow with an approval/suspend step in the editor preview and confirm the hourglass and "waiting for events" card still render on the edge and on a collapsed group
- [ ] Run a for-loop flow, switch the displayed iteration mid-run, and confirm the graph still follows `selectedForloopIndex` and statuses keep updating after the last poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move run status out of node/edge data into a shared context and reuse node/edge identities so job-status polls no longer rebuild the graph. This cuts long frames and DOM churn, fixes selection clearing, and shows AI tool nodes as calls arrive without rebuilding the editor; also pins the zoom bar border color.

- **Refactors**
  - Added `graph/flowRunStatus.svelte.ts` context for `flowJob`, `suspendStatus`, and per-module state via `SvelteMap`; renderers now read status from context.
  - `FlowGraphV2`: provides/syncs the context; reconciles nodes/edges with `reuseUnchanged`; caches y‑offset mappings to preserve object identity.
  - `graphBuilder`: removed run-status from node/edge `data`; edges now carry only fields the renderer reads.
  - `AIToolNode`: memo keys on each agent’s `agent_actions` so tool nodes update mid‑run, but ignores them in the editor to avoid rebuilds; documented invariants (no per‑poll values in edge `data`, tool memo keying).

- **Bug Fixes**
  - Tool-call nodes appear as each call is made; added a test for calls arriving without moving nodes.
  - Clearing selection works again by resetting the offset cache.
  - Zoom bar uses `border-border-light` to avoid white outlines.

<sup>Written for commit b514c8eccf4375668a1093b3b49abc0c8e70de98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

