### PR TITLE
fix: open the flow expression property column on demand, not from focus

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -161,6 +161,7 @@
 		connectProp: focusProp,
 		propPickerConfig,
 		clearConnect: clearFocus,
+		openPicker,
 		exprBeingEdited
 	} = propPickerWrapperContext ?? {}
 
@@ -941,7 +942,12 @@
 									{/snippet}
 								</ArgInput>
 							{:else if argKind === 'javascript' && arg.expr != undefined}
+								<!-- svelte-ignore a11y_no_static_element_interactions -->
+								<!-- Reaching for the editor reveals the properties beside it. On pointerdown,
+								     not focus: an editor that was never blurred emits no focus event, so a
+								     column dismissed while it kept the caret could not be brought back. -->
 								<div
+									onpointerdown={() => openPicker?.()}
 									class={`bg-surface-input rounded-md flex flex-col pl-2 overflow-auto ${inputBorderClass({ forceFocus: focused, error: !!error })}`}
 								>
 									<SimpleEditor
@@ -956,6 +962,7 @@
 										on:focus={() => {
 											focused = true
 											updatePropsBeingEdited(true)
+											openPicker?.()
 										}}
 										on:blur={() => {
 											focused = false

--- a/frontend/src/lib/components/flows/content/FlowEnvironmentVariables.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEnvironmentVariables.svelte
@@ -234,6 +234,7 @@
 		connectProp: () => {},
 		propPickerConfig: writable(undefined),
 		clearConnect: () => {},
+		openPicker: () => {},
 		pickerMode: () => 'pane' as const,
 		setPickTarget: () => {},
 		onPick: () => {},

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -13,6 +13,10 @@
 		inputMatches: Writable<{ word: string; value: string }[] | undefined>
 		connectProp: (propName: string, onSelect: SelectCallback) => void
 		clearConnect: () => void
+		/** Reveal a `sidePane` column: its input is being written in. Reaching for the editor
+		 *  again after dismissing the column has to say so, since an editor that kept focus
+		 *  throughout emits no new focus event. */
+		openPicker: () => void
 		/** Where the properties are offered, and therefore what a pick does:
 		 *  - 'pane': the step's input form — a pick replaces the argument outright.
 		 *  - 'sidePane': a settings row — a pick lands at the expression's cursor, since a
@@ -102,8 +106,12 @@
 	setContext<PropPickerWrapperContext>('PropPickerWrapper', {
 		propPickerConfig,
 		inputMatches,
-		connectProp: (propName, onSelect) => connect.arm({ id: propName, onSelect }),
+		connectProp: (propName, onSelect) => {
+			connect.arm({ id: propName, onSelect })
+			openPicker()
+		},
 		clearConnect: closePicker,
+		openPicker,
 		pickerMode: () => (sidePane ? 'sidePane' : 'pane'),
 		setPickTarget: (target) => {
 			pickTarget = target
@@ -123,22 +131,17 @@
 
 	let pickTarget: { id: string; onSelect: (path: string) => void } | undefined = $state(undefined)
 
-	// The side column stays put once the row is being worked on: picking a property blurs
-	// the editor, so closing on blur would take the column away mid-click. It is dismissed
-	// deliberately instead — by clicking away, by the input's own connect button, or by the
-	// setting being switched off.
+	// Opened and dismissed on demand rather than derived from focus: picking a property blurs
+	// the editor, so a column that followed focus would vanish mid-click — and one that
+	// latched onto focus would never let go of an editor unmounted by its own setting.
 	let sidePaneOpen = $state(false)
-	$effect(() => {
-		if ($propPickerConfig != undefined || $exprBeingEdited.length > 0) {
-			sidePaneOpen = true
-		}
-	})
+
+	function openPicker() {
+		sidePaneOpen = true
+	}
 
 	function closePicker() {
 		connect.disarm()
-		// A switched-off setting unmounts its editor rather than blurring it, so the focus
-		// claim outlives the field — left standing, it reopens the column on the next tick.
-		exprBeingEdited.set([])
 		sidePaneOpen = false
 	}
 </script>


### PR DESCRIPTION
## Summary

Follow-up to #10555. There, the property column beside a flow expression editor was opened by
inferring it from focus — an `$effect` that latched `sidePaneOpen = true` whenever a connect was
armed or an expression editor claimed focus, and never turned it off. Inference is the wrong
mechanism here, and it left two rough edges:

- **The column would not come back.** Dismissing it by clicking elsewhere in the settings panel
  does not necessarily blur Monaco, so clicking back into the same editor emitted no new focus
  event and the column stayed closed. #10555 papered over this by clearing `exprBeingEdited`
  inside `closePicker`, which also threw away the signal `PropPicker` uses to filter as you type.
- **A latched focus claim outlived its editor.** Switching a setting off unmounts the editor
  without blurring it, so the claim stood and could reopen the column beside a bare toggle row.

Opening is now explicit: the input says when it is being written in, and the column is dismissed
by clicking away, by the connect button, or by the setting being switched off.

## Changes

- `PropPickerWrapper`: replace the focus-derived `$effect` with an `openPicker()` on the context;
  `connectProp` opens the column as it arms. `closePicker` no longer clears `exprBeingEdited`, so
  typing-based filtering in the picker keeps working.
- `InputTransformForm`: call `openPicker()` from the expression editor's `focus` **and** its
  container's `pointerdown` — focus alone misses the editor that never lost it, pointerdown alone
  would miss keyboard/Tab focus.
- `FlowEnvironmentVariables`: no-op `openPicker` in its context stub (it renders no picker).

## Screenshots

![on-demand column](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2328-expression-picker-open-on-demand/1785979986-ondemand-column.png)

## Test plan

Exercised in the browser against the running dev server, on a step's Run settings in the modal
step panel:

- [x] Click into "Skip step if" → column opens. Click elsewhere in the panel → closes. Click back
      into the same (still focused) editor → **reopens** — this is the case that used to stay shut.
- [x] Caret survives the relayout: with the column closed the editor is 811px; clicking right
      after `MIDDLE_HERE` opens the column and narrows it to 479px, and picking `flow_input.name`
      lands at the clicked caret — `AAAA_head && MIDDLE_HEREflow_input.name && ZZZZ_tail`, not at
      the end. (This was the open question left by the review round on #10555.)
- [x] `npm run check:fast` clean; prettier clean on the three changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the expression property column open on demand instead of inferring from focus, so it reliably opens when you reach for the editor and closes predictably. Addresses Linear WIN-2328.

- **Bug Fixes**
  - Open column explicitly via an `openPicker()` call on editor focus, container pointerdown, and when connect is armed.
  - Close on click-away, connect button, or when the setting is turned off to prevent stray reopenings from unmounted editors.
  - Keep typing-based filtering working by not clearing `exprBeingEdited` when closing.

- **Refactors**
  - Replaced the focus-derived effect with explicit open/close control in the picker wrapper.
  - Added a no-op `openPicker` in FlowEnvironmentVariables for consistency.

<sup>Written for commit 1a9835889309c74de80d0ee036c9f0b6945c8f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

