### PR TITLE
fix(frontend): reset the editor content when the script language changes

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -2203,6 +2203,12 @@
 		} else {
 			ed.setValue(next)
 		}
+		// The write above went through `onDidChangeModelContent`, which arms the
+		// keystroke debounce as if the user had typed. Monaco now holds exactly
+		// `code`, so there is nothing to flush — and leaving the timer armed makes
+		// every "is Monaco the newer side?" check (notably the unmount flush) answer
+		// yes on the strength of our own write.
+		cancelPendingChanges()
 	}
 
 	// External `code` prop changes should flow into the Monaco editor. Skip

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -2762,7 +2762,11 @@
 			awareness={wsProvider?.awareness}
 			on:change={(e) => {
 				if (activeModuleTab === null) {
-					code = editorCode
+					// The payload, not `editorCode`: the editor also fires this while it is
+					// being torn down (the unmount flush), and a destroyed component's
+					// `bind:` writes no longer reach us — re-reading would take the value
+					// from before the change and write it back over `code`.
+					code = e.detail
 					lastSyncedCode = code
 					inferSchema(e.detail)
 				} else {


### PR DESCRIPTION
## Summary

Switching the language in the script editor left the previous language's template on screen. The language, tag and icon all flipped, but the code did not.

Picking a language calls `initContent`, which seeds the new template into `script.content`. `ScriptEditor`'s sync effect writes that into Monaco via `Editor.setCode` → `alignCodeWithEditor` → `executeEdits`. That programmatic edit goes through `onDidChangeModelContent`, which arms the keystroke debounce exactly as if the user had typed.

`ScriptEditor` renders the editor inside `{#key effectiveLang}`, so the language change immediately tears that editor down. Its `onDestroy` flush (added in #10026) fires on `timeoutModel !== undefined` — the timer our own write just armed — and calls `updateCode()`. During teardown the component's `bind:code` read is stale, so `code != ncode` holds and a `change` event is dispatched; `ScriptEditor`'s handler then re-read `editorCode` (also stale) and wrote the **previous** language's template back over `script.content`.

## Changes

- `Editor.svelte`: `alignCodeWithEditor` clears the debounce its own write armed. The write is only reachable when no user keystroke is pending (the function returns early otherwise), so this can never discard typed text — it restores the premise the unmount flush is guarded on: a pending timer means Monaco holds something newer than `code`.
- `ScriptEditor.svelte`: the `on:change` handler takes `e.detail` instead of re-reading `editorCode`. A destroyed component's `bind:` writes no longer reach the parent, so the re-read returned the value from before the change. This is what actually wrote the old template back, and it would equally have made the unmount flush persist stale text after real typing.

## Regression range

Works in v1.780.0, broken on main (1.781.x). Introduced by #10026 (`feat: redesign flow step, loop and branch settings panels`), whose commit `fix: don't open settings on error-handler delete, flush editors on unmount` added the `onDestroy` flush to `Editor.svelte`. That flush is correct for its own purpose (typing then unmounting a flow step panel); it just had no way to tell a user keystroke from the editor's own programmatic write.

## Verification

Driven in the browser against the dev server (`/scripts/add`, admins workspace).

Switching TypeScript (Bun) → Python, before and after:

| before | after |
| --- | --- |
| ![win2330-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/win-2330/1786002467-win2330-before.png) | ![win2330-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/win-2330/1786002469-win2330-after.png) |

- [x] bun → python3 → go → bash → bun → postgresql: each switch renders that language's template
- [x] type into the editor, then switch language inside the 800ms debounce window: the typed text is discarded and the new template is shown
- [x] type, wait, reload: the typed text still materializes into the draft and survives the reload (the debounce → `code` → autosave chain is intact)
- [x] "Reset Content" still restores the template
- [x] `npm run check:fast` clean

## Test plan

- [ ] Open `/scripts/add`, switch through several languages, confirm the editor content matches the selected language each time
- [ ] Type in the editor, immediately switch language, confirm the typed content is replaced by the new template
- [ ] Type in the editor, wait a second, reload, confirm the draft kept the typed content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the script editor content on language change so the selected language’s template is shown immediately and stale content is not re-applied. Addresses WIN-2330.

- **Bug Fixes**
  - In `Editor.svelte`, clear the debounce timer after programmatic edits to prevent the unmount flush from re-writing old content.
  - In `ScriptEditor.svelte`, use the change event payload (`e.detail`) instead of re-reading `editorCode` to avoid persisting stale values during teardown.

<sup>Written for commit 24ff4000331d3eb31fedc6f8e89455a9f575d58e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

