### PR TITLE
fix(frontend): take the editor's post-edit content, not setCode's argument

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -2762,11 +2762,12 @@
 			awareness={wsProvider?.awareness}
 			on:change={(e) => {
 				if (activeModuleTab === null) {
-					// The payload, not `editorCode`: the editor also fires this while it is
-					// being torn down (the unmount flush), and a destroyed component's
-					// `bind:` writes no longer reach us — re-reading would take the value
-					// from before the change and write it back over `code`.
-					code = e.detail
+					// `editorCode`, not the payload: `setCode` dispatches the string it was
+					// handed, but Monaco may have normalized it (EOL) while applying it, and
+					// the re-entrant `updateCode` that runs inside `setCode` has already put
+					// that normalized text here. Taking the payload would leave `code`
+					// disagreeing with the buffer.
+					code = editorCode
 					lastSyncedCode = code
 					inferSchema(e.detail)
 				} else {


### PR DESCRIPTION
## Summary

Follow-up to #10560. That PR carried two changes; the language-switch fix is correct and stays, but the second change was justified by a claim I got wrong, so this reverts it.

#10560 changed the script editor's `on:change` handler from `code = editorCode` to `code = e.detail`, on the reasoning that the two can only disagree while the editor is being torn down (where the bound read goes stale). They also disagree in a fully live editor:

```js
export function setCode(ncode: string, noHistory = false): void {
    const changed = code != ncode
    if (changed) code = ncode
    cancelPendingChanges()
    alignCodeWithEditor(!noHistory)   // executeEdits → onDidChangeModelContent → updateCode(), re-entrantly
    if (changed) dispatch('change', ncode)   // ← the ORIGINAL string
```

`executeEdits` fires `onDidChangeModelContent` synchronously, and with `changeChainStart` cleared that handler calls `updateCode()` on the spot. If the model normalized the text while applying it, `updateCode` has already written Monaco's version into `code`/`editorCode` and dispatched it — and then the outer `dispatch('change', ncode)` fires with the pre-normalization string.

EOL normalization makes this reachable rather than theoretical: `ScriptBuilder` builds template content with `script.content += '\r\n' + templateScript`, so a model's EOL can differ from the string handed to `setCode`, and `getValue()` returns the model's.

Taking the payload there leaves `code` disagreeing with the buffer, and `lastSyncedCode` is set to the same wrong value so the sync effect won't correct it — while `Editor`'s external-write effect sees `code !== lastEditorCode` and keeps trying to reconcile. `editorCode` is the buffer-true read, so the handler goes back to it.

## Changes

- `ScriptEditor.svelte`: restore `code = editorCode` in the main-script branch of the editor's `on:change`, with a comment recording why the payload is the wrong side of this.

## What is not changed

The actual WIN-2330 fix — `alignCodeWithEditor` clearing the debounce its own write armed (`Editor.svelte`, #10560) — is untouched. That is what stops the unmount flush from firing on the editor's own programmatic write and resurrecting the previous language's template.

## Verification

Re-ran the full WIN-2330 check on this branch (dev server, `/scripts/add`, admins workspace), i.e. with the revert applied on top of main:

- [x] bun → python3 → go → bash → bun → postgresql: each switch renders that language's template
- [x] type into the editor, then switch language inside the 800ms debounce window: typed text discarded, new template shown
- [x] `npm run check:fast` clean

## Test plan

- [ ] Open `/scripts/add`, switch through several languages, confirm the content matches the selected language each time (WIN-2330 must stay fixed)
- [ ] Type in the editor, wait, reload, confirm the draft kept the typed content


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the script editor change handler to use the editor’s post-edit content so `code` stays in sync with the buffer, even when EOLs are normalized. Keeps the WIN-2330 language switch fix intact.

- **Bug Fixes**
  - Use `editorCode` in the main-script `on:change` handler and update `lastSyncedCode`.
  - Prevents `code`/buffer drift and the external-write reconciliation loop when EOL normalization occurs.
  - Leaves `alignCodeWithEditor` debounce clearing unchanged (WIN-2330).

<sup>Written for commit 6efc0d69626e577a4d329cc430a8cac55dfae8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

