### PR TITLE
fix(frontend): keep the input transform header full width

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -576,8 +576,10 @@
 {#if (arg != undefined || collapsed) && !hidden}
 	<div class={twMerge('relative group flex flex-col gap-1', className)}>
 		<!-- `relative` so the absolute button cluster below anchors to this row rather than
-		     to the whole field, letting it share the label's baseline. -->
-		<div class="relative flex flex-row flex-wrap justify-between gap-1">
+		     to the whole field, letting it share the label's baseline. `w-full` so an
+		     `align-items` on the caller's class can't shrink the row to its label and pull
+		     `right-0` onto it. -->
+		<div class="relative w-full flex flex-row flex-wrap justify-between gap-1">
 			<!-- min-h-7 reserves room for the button cluster beside a plain label; a custom
 			     header is a control of its own and sets the row's height itself. -->
 			<div class="flex grow items-end {header ? '' : 'min-h-7'}">


### PR DESCRIPTION
## Summary

In the batch re-run form, the `${}` / static-JS button cluster was painted on top of the argument label, clipping it (`name string` rendered as "name stri").

#10026 added `relative` to `InputTransformForm`'s header row so the cluster could share the label's baseline. That re-parented the `absolute right-0 bottom-0` cluster from the full-width outer field container to the header row itself. For callers that pass an `align-items` in their `class` prop, `align-items: flex-start` makes that row shrink-to-fit its content — so `right-0` resolved to the right edge of the *label text* rather than the right edge of the *field*.

The body container (`:796`) already hardcoded `w-full` for the same reason; the header row didn't. This restores the symmetry, and with it the pre-#10026 anchor point.

## Changes

- `InputTransformForm.svelte:582` — add `w-full` to the header row so the caller's `align-items` cannot decide the component's internal layout.
- Record the constraint in the comment that already explains the `relative`.

Affects the two callers passing `items-start`: `runs/BatchReRunOptionsPane.svelte:242` (batch re-run) and `flows/content/FlowModuleSuspend.svelte:232` (approval step's "groups" field), which had the same defect less visibly. It is a no-op everywhere else — the row already got its width from the default `align-items: stretch`.

## Screenshots

Batch re-run → per-argument input.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/sanity-check/1786011191-batch-rerun-before.png) | ![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/sanity-check/1786011184-batch-rerun-after-pane.png) |

## Test plan

- [ ] Runs → select jobs → Batch re-run: argument labels render in full, button cluster flush with the field's right edge
- [ ] Flow approval step → "groups" expression field (`min-h-[256px] items-start`): same, should improve rather than merely stay put
- [ ] A flow step's Inputs panel (`InputTransformSchemaForm`, passes no class): pixel-for-pixel unchanged
- [ ] A settings row with a custom `header` snippet (retry / skip / early-stop / loop iterator): row height and cluster position unchanged