### PR TITLE
fix(frontend): shimmer highlight uses text-emphasis, not white

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatCollapsibleCard.svelte
@@ -41,8 +41,14 @@
 </script>
 
 <div class={twMerge('font-mono text-xs', className)}>
-	{#snippet labelText()}
-		<span class={twMerge('text-secondary font-medium text-2xs', labelClass)}>
+	{#snippet labelText(highlight: boolean)}
+		<span
+			class={twMerge(
+				'text-secondary font-medium text-2xs',
+				labelClass,
+				highlight && 'text-emphasis'
+			)}
+		>
 			{label}
 		</span>
 	{/snippet}
@@ -58,13 +64,13 @@
 		>
 			{#if shimmer}
 				<span class="shimmer inline-flex items-center min-w-0">
-					{@render labelText()}
+					{@render labelText(false)}
 					<span class="shimmer-band inline-flex items-center min-w-0" aria-hidden="true">
-						{@render labelText()}
+						{@render labelText(true)}
 					</span>
 				</span>
 			{:else}
-				{@render labelText()}
+				{@render labelText(false)}
 			{/if}
 			{#if toggleable}
 				<ChevronRight
@@ -99,9 +105,9 @@
 </div>
 
 <style>
-	/* A white copy of the label sits on top of the coloured one and is revealed
-	   through a travelling band, so the highlight is a colour change rather than
-	   an opacity change and the row keeps its own colour underneath. */
+	/* An emphasis-coloured copy of the label sits on top of the muted one and is
+	   revealed through a travelling band, so the highlight is a colour change
+	   rather than an opacity change and the row keeps its own colour underneath. */
 	.shimmer {
 		position: relative;
 	}
@@ -109,9 +115,6 @@
 		position: absolute;
 		inset: 0;
 		pointer-events: none;
-		/* Forces the copy white whatever colour the caller gives the label, without
-		   having to out-specify its utility classes. */
-		filter: brightness(0) invert(1);
 		--wm-shimmer-band: linear-gradient(
 			100deg,
 			rgba(0, 0, 0, 0.2) 40%,


### PR DESCRIPTION
## Summary

The loading shimmer on AI-chat tool rows swept a **white** copy of the label across the muted one. In dark mode that reads as a highlight; in light mode a white sweep over a light surface is close to invisible. The highlight is now `text-emphasis`, which is the emphatic end of the text scale in whichever theme is active.

## Changes

- `ChatCollapsibleCard.svelte`: `labelText` takes a `highlight` flag; the band copy renders with `text-emphasis` appended (twMerge lets it win over `text-secondary` / any caller `labelClass`).
- Dropped the `filter: brightness(0) invert(1)` hack on `.shimmer-band` — it existed only to force the copy white without out-specifying the label's utility classes, which the flag now does directly.

Effect per theme:
- **light**: highlight goes from `#ffffff` to `#1d2430`, so the sweep now darkens against the muted label instead of washing out.
- **dark**: `text-emphasis` is `#f3f4f6`, visually the same as the previous white.

## Screenshots

None attached: the change is a colour swap inside an animated sweep, so a still frame conveys little and staging one means catching a tool call mid-flight. Verified by reading the rendered token values; the sweep itself is unchanged.

## Test plan

- [ ] In light mode, run an AI chat tool call and confirm the running row's label sweeps to a dark highlight and is legible.
- [ ] In dark mode, confirm the sweep looks unchanged from before.
- [ ] Confirm the reasoning card in `AssistantMessage.svelte` (the other `shimmer` caller) still sweeps while streaming.