### PR TITLE
fix(cli): sync push crashed on edited fileset children; reject non-canonical fileset dirs

### DIFF
--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -3,6 +3,7 @@ import { Confirm } from "@cliffy/prompt/confirm";
 import { colors } from "@cliffy/ansi/colors";
 import { sep as SEP } from "node:path";
 import { GlobalOptions, isDatatableMigrationPath } from "../../types.ts";
+import { isFileResource, isFilesetResource } from "../../utils/utils.ts";
 import { SyncOptions, mergeConfigWithConfigFile } from "../../core/conf.ts";
 import { resolveWorkspace } from "../../core/context.ts";
 import { requireLogin } from "../../core/auth.ts";
@@ -56,6 +57,9 @@ async function walkLocalScripts(
       isFolderResourcePathAnyFormat(p) ||
       // Datatable migration `.sql` files aren't Windmill scripts.
       isDatatableMigrationPath(p) ||
+      // Neither are file/fileset resource content files (.sql, .ts, …).
+      isFileResource(p) ||
+      isFilesetResource(p) ||
       (isScriptModulePath(p) && !isModuleEntryPoint(p)),
     false,
     {},
@@ -225,6 +229,9 @@ function categorizeLocalFiles(
       !isFolderResourcePathAnyFormat(p) &&
       // Datatable migration `.sql` files aren't Windmill scripts.
       !isDatatableMigrationPath(p) &&
+      // Neither are file/fileset resource content files (.sql, .ts, …).
+      !isFileResource(p) &&
+      !isFilesetResource(p) &&
       !(isScriptModulePath(p) && !isModuleEntryPoint(p))
     ) {
       scripts.push(p);

--- a/cli/src/commands/resource/resource.ts
+++ b/cli/src/commands/resource/resource.ts
@@ -47,34 +47,22 @@ async function readFilesetDirectory(dirPath: string): Promise<Record<string, str
 }
 
 /**
- * A fileset directory must live next to its resource file at
+ * A fileset directory must live at the server-canonical location
  * `<resource path>.fileset` — that is the only layout the sync diff engine
- * can round-trip. Any other pointer breaks change detection: children are
- * planned as full delete/re-add churn and adds under the custom directory
- * are dropped, which manifests as erased or stale fileset content.
+ * can round-trip (remote state is always rendered there, including for
+ * workspace-specific resources). Any other pointer breaks change detection:
+ * children are planned as full delete/re-add churn and adds under the custom
+ * directory are dropped, which manifests as erased or stale fileset content.
  */
 export function validateFilesetPointer(
   dirPath: string,
   remotePath: string,
-  originalLocalPath: string | undefined,
 ): void {
   const normalize = (p: string) =>
     p.replaceAll("\\", "/").replace(/\/+$/, "");
   const pointer = normalize(dirPath);
-  const canonicalFromRemote =
-    normalize(remotePath.replaceAll(SEP, "/")) + ".fileset";
-  // For branch/workspace-specific metadata files the local file name differs
-  // from the server path, so the directory adjacent to the local file is also
-  // canonical.
-  const canonicalFromLocal = originalLocalPath
-    ? normalize(
-        originalLocalPath
-          .replaceAll(SEP, "/")
-          .replace(/\.resource\.(yaml|json)$/, ""),
-      ) + ".fileset"
-    : undefined;
-  if (pointer !== canonicalFromRemote && pointer !== canonicalFromLocal) {
-    const expected = canonicalFromLocal ?? canonicalFromRemote;
+  const expected = normalize(remotePath.replaceAll(SEP, "/")) + ".fileset";
+  if (pointer !== expected) {
     throw new Error(
       `Resource ${remotePath.replaceAll(SEP, "/")} uses '!inline_fileset ${dirPath}', ` +
         `but a fileset directory must live next to its resource file, at '${expected}'. ` +
@@ -111,7 +99,7 @@ export async function pushResource(
     if (typeof localResource.value === "string" && localResource.value.startsWith("!inline_fileset ")) {
       const dirPath = localResource.value.split(" ")[1];
       if (enforceCanonicalFileset) {
-        validateFilesetPointer(dirPath, remotePath, originalLocalPath);
+        validateFilesetPointer(dirPath, remotePath);
       }
       localResource.value = await readFilesetDirectory(dirPath.replaceAll("/", SEP));
     } else if (localResource.value["content"]?.startsWith("!inline ")) {

--- a/cli/src/commands/resource/resource.ts
+++ b/cli/src/commands/resource/resource.ts
@@ -91,6 +91,10 @@ export async function pushResource(
   localResource: ResourceFile,
   originalLocalPath?: string,
   wsSpecific?: boolean,
+  // Sync pushes reject non-canonical fileset pointers (the diff engine can
+  // only round-trip the canonical layout); the standalone `resource push`
+  // command pushes a single explicit file, where any pointer is fine.
+  enforceCanonicalFileset?: boolean,
 ): Promise<void> {
   remotePath = removeType(remotePath, "resource");
   try {
@@ -106,7 +110,9 @@ export async function pushResource(
   const resolveInlineContent = async () => {
     if (typeof localResource.value === "string" && localResource.value.startsWith("!inline_fileset ")) {
       const dirPath = localResource.value.split(" ")[1];
-      validateFilesetPointer(dirPath, remotePath, originalLocalPath);
+      if (enforceCanonicalFileset) {
+        validateFilesetPointer(dirPath, remotePath, originalLocalPath);
+      }
       localResource.value = await readFilesetDirectory(dirPath.replaceAll("/", SEP));
     } else if (localResource.value["content"]?.startsWith("!inline ")) {
       const basePath = localResource.value["content"].split(" ")[1];

--- a/cli/src/commands/resource/resource.ts
+++ b/cli/src/commands/resource/resource.ts
@@ -46,6 +46,44 @@ async function readFilesetDirectory(dirPath: string): Promise<Record<string, str
   return result;
 }
 
+/**
+ * A fileset directory must live next to its resource file at
+ * `<resource path>.fileset` — that is the only layout the sync diff engine
+ * can round-trip. Any other pointer breaks change detection: children are
+ * planned as full delete/re-add churn and adds under the custom directory
+ * are dropped, which manifests as erased or stale fileset content.
+ */
+export function validateFilesetPointer(
+  dirPath: string,
+  remotePath: string,
+  originalLocalPath: string | undefined,
+): void {
+  const normalize = (p: string) =>
+    p.replaceAll("\\", "/").replace(/\/+$/, "");
+  const pointer = normalize(dirPath);
+  const canonicalFromRemote =
+    normalize(remotePath.replaceAll(SEP, "/")) + ".fileset";
+  // For branch/workspace-specific metadata files the local file name differs
+  // from the server path, so the directory adjacent to the local file is also
+  // canonical.
+  const canonicalFromLocal = originalLocalPath
+    ? normalize(
+        originalLocalPath
+          .replaceAll(SEP, "/")
+          .replace(/\.resource\.(yaml|json)$/, ""),
+      ) + ".fileset"
+    : undefined;
+  if (pointer !== canonicalFromRemote && pointer !== canonicalFromLocal) {
+    const expected = canonicalFromLocal ?? canonicalFromRemote;
+    throw new Error(
+      `Resource ${remotePath.replaceAll(SEP, "/")} uses '!inline_fileset ${dirPath}', ` +
+        `but a fileset directory must live next to its resource file, at '${expected}'. ` +
+        `Move the directory there (e.g. 'git mv ${pointer} ${expected}') and update the ` +
+        `'!inline_fileset' value to match.`,
+    );
+  }
+}
+
 export async function pushResource(
   workspace: string,
   remotePath: string,
@@ -68,6 +106,7 @@ export async function pushResource(
   const resolveInlineContent = async () => {
     if (typeof localResource.value === "string" && localResource.value.startsWith("!inline_fileset ")) {
       const dirPath = localResource.value.split(" ")[1];
+      validateFilesetPointer(dirPath, remotePath, originalLocalPath);
       localResource.value = await readFilesetDirectory(dirPath.replaceAll("/", SEP));
     } else if (localResource.value["content"]?.startsWith("!inline ")) {
       const basePath = localResource.value["content"].split(" ")[1];

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -188,6 +188,12 @@ async function push(opts: PushOptions, filePath: string) {
     );
   }
 
+  if (isFileResource(filePath) || isFilesetResource(filePath)) {
+    throw Error(
+      "Cannot push a file/fileset resource content file as a script, push its .resource.yaml with 'wmill resource push' instead"
+    );
+  }
+
   await requireLogin(opts);
 
   // Warn about metadata state before pushing

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -13,7 +13,7 @@ import * as log from "../../core/log.ts";
 import { sep as SEP } from "node:path";
 import * as path from "node:path";
 import { stringify as yamlStringify } from "yaml";
-import { deepEqual, getHeaders, readTextFile, readTextFileSync } from "../../utils/utils.ts";
+import { deepEqual, getHeaders, isFileResource, isFilesetResource, readTextFile, readTextFileSync } from "../../utils/utils.ts";
 import { detectAuthGatewayChallenge } from "../../utils/http_guards.ts";
 import * as wmill from "../../../gen/services.gen.ts";
 import * as specificItems from "../../core/specific_items.ts";
@@ -344,6 +344,12 @@ export async function handleFile(
   codebases: SyncCodebase[],
   permissionedAsContext?: PermissionedAsContext
 ): Promise<boolean> {
+  // A file/fileset resource's content file can carry a script extension
+  // (.sql, .ts, …) but belongs to its parent resource, never to a
+  // standalone script.
+  if (isFileResource(path) || isFilesetResource(path)) {
+    return false;
+  }
   // Detect module entry point: e.g., my_script__mod/script.ts
   const moduleEntryPoint = isModuleEntryPoint(path);
   if (

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -127,7 +127,7 @@ import {
   NativeServiceName,
   ScriptModule,
 } from "../../../gen/types.gen.ts";
-import { pushResource } from "../resource/resource.ts";
+import { pushResource, validateFilesetPointer } from "../resource/resource.ts";
 import {
   newPathAssigner,
   newRawAppPathAssigner,
@@ -4968,6 +4968,43 @@ export async function push(
     // Cache git branch at the start to avoid repeated execSync calls per change
     const cachedWsNameForPush =
       wsNameForFiles || (isGitRepository() ? getCurrentGitBranch() : null);
+
+    // Fail fast on non-canonical fileset pointers: deletes are applied first
+    // below, so a pointer that would be rejected mid-apply must abort the
+    // push before any change reaches the remote.
+    for (const change of changes) {
+      if (change.name !== "added" && change.name !== "edited") {
+        continue;
+      }
+      const normalizedPath = change.path.replaceAll(SEP, "/");
+      if (
+        !normalizedPath.endsWith(".resource.yaml") &&
+        !normalizedPath.endsWith(".resource.json")
+      ) {
+        continue;
+      }
+      const content = change.name === "added" ? change.content : change.after;
+      let parsed: any;
+      try {
+        parsed = parseFromPath(change.path, content);
+      } catch {
+        // Malformed files surface their own error in the apply loop.
+        continue;
+      }
+      if (
+        typeof parsed?.value === "string" &&
+        parsed.value.startsWith("!inline_fileset ")
+      ) {
+        const serverPath =
+          cachedWsNameForPush && isWorkspaceSpecificFile(change.path)
+            ? fromWorkspaceSpecificPath(change.path, cachedWsNameForPush)
+            : change.path;
+        validateFilesetPointer(
+          parsed.value.split(" ")[1],
+          removeType(serverPath, "resource"),
+        );
+      }
+    }
 
     // Datatable migrations are two files (.up.sql/.down.sql) for one record, so
     // dedupe upsert/delete by (datatable, version) across the whole push.

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -909,8 +909,10 @@ export async function findFilesetResourceFile(
   const candidates = [basePath + ".resource.json", basePath + ".resource.yaml"];
   // A workspace-specific resource keeps its children at the server-canonical
   // `<base>.fileset/` while its metadata file carries the workspace suffix.
+  // The suffixed file is this workspace's authoritative metadata, so it must
+  // win over a base file that coexists with it.
   if (wsName) {
-    candidates.push(
+    candidates.unshift(
       toWorkspaceSpecificPath(basePath + ".resource.json", wsName),
       toWorkspaceSpecificPath(basePath + ".resource.yaml", wsName),
     );

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -961,6 +961,7 @@ async function pushFilesetParentResource(
     newObj,
     resourceFilePath,
     wsSpecific ? true : undefined,
+    true,
   );
   return { status: "pushed", resourceFilePath };
 }
@@ -5082,6 +5083,7 @@ export async function push(
                     newObj,
                     resourceFilePath,
                     isFileResWsSpecific ? true : undefined,
+                    true,
                   );
                 }
                 // Already-synced parents got the full content this run.

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -5039,6 +5039,77 @@ export async function push(
             }
 
             if (change.name === "edited") {
+              // A file/fileset resource's content file can carry a script
+              // extension (.sql, .ts, …), so it must be routed to its parent
+              // resource before the script handlers get a chance to treat it
+              // as a standalone script.
+              if (isFileResource(change.path)) {
+                const resourceFilePath = await findResourceFile(change.path);
+                if (!alreadySynced.includes(resourceFilePath)) {
+                  alreadySynced.push(resourceFilePath);
+
+                  const newObj = parseFromPath(
+                    resourceFilePath,
+                    await readTextFile(resourceFilePath),
+                  );
+
+                  // For branch-specific resources, push to the base path on the workspace server
+                  // This ensures workspace-specific files are stored with their base names in the workspace
+                  let serverPath = resourceFilePath;
+                  const currentBranch = cachedWsNameForPush;
+                  let isFileResWsSpecific = false;
+
+                  if (
+                    currentBranch &&
+                    isWorkspaceSpecificFile(resourceFilePath)
+                  ) {
+                    serverPath = fromWorkspaceSpecificPath(
+                      resourceFilePath,
+                      currentBranch,
+                    );
+                    isFileResWsSpecific = true;
+                  } else if (
+                    specificItems &&
+                    isSpecificItem(change.path, specificItems)
+                  ) {
+                    isFileResWsSpecific = true;
+                  }
+
+                  await pushResource(
+                    workspace.workspaceId,
+                    serverPath,
+                    undefined,
+                    newObj,
+                    resourceFilePath,
+                    isFileResWsSpecific ? true : undefined,
+                  );
+                }
+                // Already-synced parents got the full content this run.
+                if (stateTarget) {
+                  await writeFile(stateTarget, change.after, "utf-8");
+                }
+                continue;
+              }
+              if (isFilesetResource(change.path)) {
+                const result = await pushFilesetParentResource(
+                  change.path,
+                  workspace.workspaceId,
+                  alreadySynced,
+                  cachedWsNameForPush,
+                  specificItems,
+                );
+                if (result.status === "parent-missing") {
+                  throw new Error(
+                    `No resource metadata file found for fileset resource: ${change.path}`,
+                  );
+                }
+                // Pushed or already-synced: the parent resource carries the
+                // whole fileset, so this child's content is on the remote.
+                if (stateTarget) {
+                  await writeFile(stateTarget, change.after, "utf-8");
+                }
+                continue;
+              }
               if (
                 await handleScriptMetadata(
                   change.path,
@@ -5092,74 +5163,6 @@ export async function push(
                 log.info(
                   `Editing ${getTypeStrFromPath(change.path)} ${change.path}`,
                 );
-              }
-
-              if (isFileResource(change.path)) {
-                const resourceFilePath = await findResourceFile(change.path);
-                if (!alreadySynced.includes(resourceFilePath)) {
-                  alreadySynced.push(resourceFilePath);
-
-                  const newObj = parseFromPath(
-                    resourceFilePath,
-                    await readTextFile(resourceFilePath),
-                  );
-
-                  // For branch-specific resources, push to the base path on the workspace server
-                  // This ensures workspace-specific files are stored with their base names in the workspace
-                  let serverPath = resourceFilePath;
-                  const currentBranch = cachedWsNameForPush;
-                  let isFileResWsSpecific = false;
-
-                  if (
-                    currentBranch &&
-                    isWorkspaceSpecificFile(resourceFilePath)
-                  ) {
-                    serverPath = fromWorkspaceSpecificPath(
-                      resourceFilePath,
-                      currentBranch,
-                    );
-                    isFileResWsSpecific = true;
-                  } else if (
-                    specificItems &&
-                    isSpecificItem(change.path, specificItems)
-                  ) {
-                    isFileResWsSpecific = true;
-                  }
-
-                  await pushResource(
-                    workspace.workspaceId,
-                    serverPath,
-                    undefined,
-                    newObj,
-                    resourceFilePath,
-                    isFileResWsSpecific ? true : undefined,
-                  );
-                  if (stateTarget) {
-                    await writeFile(stateTarget, change.after, "utf-8");
-                  }
-                  continue;
-                }
-              }
-              if (isFilesetResource(change.path)) {
-                const result = await pushFilesetParentResource(
-                  change.path,
-                  workspace.workspaceId,
-                  alreadySynced,
-                  cachedWsNameForPush,
-                  specificItems,
-                );
-                if (result.status === "parent-missing") {
-                  throw new Error(
-                    `No resource metadata file found for fileset resource: ${change.path}`,
-                  );
-                }
-                if (result.status === "pushed") {
-                  if (stateTarget) {
-                    await writeFile(stateTarget, change.after, "utf-8");
-                  }
-                  continue;
-                }
-                // "already-synced": fall through (pre-existing behavior).
               }
               const oldObj = parseFromPath(change.path, change.before);
               const newObj = parseFromPath(change.path, change.after);

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -87,6 +87,7 @@ import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
 import { preCheckPermissionedAs } from "../../core/permissioned_as.ts";
 import {
   fromWorkspaceSpecificPath,
+  toWorkspaceSpecificPath,
   getWorkspaceSpecificPath,
   getSpecificItemsForCurrentBranch,
   isWorkspaceSpecificFile,
@@ -895,7 +896,10 @@ function parseFileResourceTypeMap(
   return { formatExtMap, filesetMap };
 }
 
-async function findFilesetResourceFile(changePath: string): Promise<string> {
+export async function findFilesetResourceFile(
+  changePath: string,
+  wsName?: string | null,
+): Promise<string> {
   // Extract the base path before .fileset/
   const filesetIdx = changePath.indexOf(".fileset" + SEP);
   if (filesetIdx === -1) {
@@ -903,6 +907,14 @@ async function findFilesetResourceFile(changePath: string): Promise<string> {
   }
   const basePath = changePath.substring(0, filesetIdx);
   const candidates = [basePath + ".resource.json", basePath + ".resource.yaml"];
+  // A workspace-specific resource keeps its children at the server-canonical
+  // `<base>.fileset/` while its metadata file carries the workspace suffix.
+  if (wsName) {
+    candidates.push(
+      toWorkspaceSpecificPath(basePath + ".resource.json", wsName),
+      toWorkspaceSpecificPath(basePath + ".resource.yaml", wsName),
+    );
+  }
 
   for (const candidate of candidates) {
     try {
@@ -931,7 +943,7 @@ async function pushFilesetParentResource(
 ): Promise<FilesetPushResult> {
   let resourceFilePath: string;
   try {
-    resourceFilePath = await findFilesetResourceFile(childPath);
+    resourceFilePath = await findFilesetResourceFile(childPath, cachedWsName);
   } catch {
     return { status: "parent-missing" };
   }
@@ -4732,6 +4744,56 @@ export async function push(
     }
   }
 
+  // Non-canonical fileset pointers abort here — before the dry-run output and
+  // before any change is applied (deletes run first in the apply loop, so a
+  // mid-apply rejection would leave a partial deploy). All violations are
+  // reported at once.
+  {
+    const wsNameForPointerCheck =
+      wsNameForFiles || (isGitRepository() ? getCurrentGitBranch() : null);
+    const pointerErrors: string[] = [];
+    for (const change of changes) {
+      if (change.name !== "added" && change.name !== "edited") {
+        continue;
+      }
+      const normalizedPath = change.path.replaceAll(SEP, "/");
+      if (
+        !normalizedPath.endsWith(".resource.yaml") &&
+        !normalizedPath.endsWith(".resource.json")
+      ) {
+        continue;
+      }
+      const content = change.name === "added" ? change.content : change.after;
+      let parsed: any;
+      try {
+        parsed = parseFromPath(change.path, content);
+      } catch {
+        // Malformed files surface their own error in the apply loop.
+        continue;
+      }
+      if (
+        typeof parsed?.value === "string" &&
+        parsed.value.startsWith("!inline_fileset ")
+      ) {
+        const serverPath =
+          wsNameForPointerCheck && isWorkspaceSpecificFile(change.path)
+            ? fromWorkspaceSpecificPath(change.path, wsNameForPointerCheck)
+            : change.path;
+        try {
+          validateFilesetPointer(
+            parsed.value.split(" ")[1],
+            removeType(serverPath, "resource"),
+          );
+        } catch (e) {
+          pointerErrors.push(e instanceof Error ? e.message : String(e));
+        }
+      }
+    }
+    if (pointerErrors.length > 0) {
+      throw new Error(pointerErrors.join("\n"));
+    }
+  }
+
   // Handle JSON output for dry-run
   if (opts.dryRun && opts.jsonOutput) {
     const result = {
@@ -4969,43 +5031,6 @@ export async function push(
     const cachedWsNameForPush =
       wsNameForFiles || (isGitRepository() ? getCurrentGitBranch() : null);
 
-    // Fail fast on non-canonical fileset pointers: deletes are applied first
-    // below, so a pointer that would be rejected mid-apply must abort the
-    // push before any change reaches the remote.
-    for (const change of changes) {
-      if (change.name !== "added" && change.name !== "edited") {
-        continue;
-      }
-      const normalizedPath = change.path.replaceAll(SEP, "/");
-      if (
-        !normalizedPath.endsWith(".resource.yaml") &&
-        !normalizedPath.endsWith(".resource.json")
-      ) {
-        continue;
-      }
-      const content = change.name === "added" ? change.content : change.after;
-      let parsed: any;
-      try {
-        parsed = parseFromPath(change.path, content);
-      } catch {
-        // Malformed files surface their own error in the apply loop.
-        continue;
-      }
-      if (
-        typeof parsed?.value === "string" &&
-        parsed.value.startsWith("!inline_fileset ")
-      ) {
-        const serverPath =
-          cachedWsNameForPush && isWorkspaceSpecificFile(change.path)
-            ? fromWorkspaceSpecificPath(change.path, cachedWsNameForPush)
-            : change.path;
-        validateFilesetPointer(
-          parsed.value.split(" ")[1],
-          removeType(serverPath, "resource"),
-        );
-      }
-    }
-
     // Datatable migrations are two files (.up.sql/.down.sql) for one record, so
     // dedupe upsert/delete by (datatable, version) across the whole push.
     const pushedMigrationKeys = new Set<string>();
@@ -5081,6 +5106,17 @@ export async function push(
               // extension (.sql, .ts, …), so it must be routed to its parent
               // resource before the script handlers get a chance to treat it
               // as a standalone script.
+              if (
+                isFileResource(change.path) ||
+                isFilesetResource(change.path)
+              ) {
+                if (stateTarget) {
+                  await mkdir(path.dirname(stateTarget), { recursive: true });
+                  log.info(
+                    `Editing ${getTypeStrFromPath(change.path)} ${change.path}`,
+                  );
+                }
+              }
               if (isFileResource(change.path)) {
                 const resourceFilePath = await findResourceFile(change.path);
                 if (!alreadySynced.includes(resourceFilePath)) {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4765,6 +4765,11 @@ export async function push(
       ) {
         continue;
       }
+      // Fileset content is arbitrary: a child may itself be named
+      // `*.resource.yaml`, and its body is not this resource's metadata.
+      if (isFilesetResource(change.path)) {
+        continue;
+      }
       const content = change.name === "added" ? change.content : change.after;
       let parsed: any;
       try {
@@ -5119,6 +5124,30 @@ export async function push(
                   );
                 }
               }
+              // Fileset routing must precede the single-file check (as it does
+              // in the added/deleted branches): a fileset accepts arbitrary
+              // child names, so a child like `<res>.fileset/q.resource.file.sql`
+              // matches both predicates and belongs to its fileset parent.
+              if (isFilesetResource(change.path)) {
+                const result = await pushFilesetParentResource(
+                  change.path,
+                  workspace.workspaceId,
+                  alreadySynced,
+                  cachedWsNameForPush,
+                  specificItems,
+                );
+                if (result.status === "parent-missing") {
+                  throw new Error(
+                    `No resource metadata file found for fileset resource: ${change.path}`,
+                  );
+                }
+                // Pushed or already-synced: the parent resource carries the
+                // whole fileset, so this child's content is on the remote.
+                if (stateTarget) {
+                  await writeFile(stateTarget, change.after, "utf-8");
+                }
+                continue;
+              }
               if (isFileResource(change.path)) {
                 const resourceFilePath = await findResourceFile(change.path);
                 if (!alreadySynced.includes(resourceFilePath)) {
@@ -5162,26 +5191,6 @@ export async function push(
                   );
                 }
                 // Already-synced parents got the full content this run.
-                if (stateTarget) {
-                  await writeFile(stateTarget, change.after, "utf-8");
-                }
-                continue;
-              }
-              if (isFilesetResource(change.path)) {
-                const result = await pushFilesetParentResource(
-                  change.path,
-                  workspace.workspaceId,
-                  alreadySynced,
-                  cachedWsNameForPush,
-                  specificItems,
-                );
-                if (result.status === "parent-missing") {
-                  throw new Error(
-                    `No resource metadata file found for fileset resource: ${change.path}`,
-                  );
-                }
-                // Pushed or already-synced: the parent resource carries the
-                // whole fileset, so this child's content is on the remote.
                 if (stateTarget) {
                   await writeFile(stateTarget, change.after, "utf-8");
                 }

--- a/cli/src/core/specific_items.ts
+++ b/cli/src/core/specific_items.ts
@@ -429,6 +429,15 @@ const workspacePatternCache = new Map<string, RegExp>();
  * workspaceNameOverride is the effective git branch name (for file naming on disk).
  */
 export function isCurrentWorkspaceFile(path: string, workspaceNameOverride?: string): boolean {
+  // Fileset children are never workspace-specific: only the parent's metadata
+  // file carries the suffix, children stay in the shared canonical directory.
+  // Their names are arbitrary, so one can look like typed metadata — and since
+  // the patterns match a workspace-name segment with `[^.]` (which spans `/`),
+  // an unguarded child is dropped from the diff or, worse, remapped onto a
+  // sibling's key and deployed over it.
+  if (isFilesetResource(path)) {
+    return false;
+  }
   let currentWorkspace: string | null = null;
   if (workspaceNameOverride) {
     currentWorkspace = workspaceNameOverride;
@@ -464,11 +473,7 @@ export function isCurrentWorkspaceFile(path: string, workspaceNameOverride?: str
  * Used to identify and skip files from other branches during sync operations
  */
 export function isWorkspaceSpecificFile(path: string): boolean {
-  // Fileset children are never workspace-specific: only the parent's metadata
-  // file carries the suffix, children stay in the shared canonical directory.
-  // The patterns below read any dot-free run as a workspace name, and `[^.]`
-  // spans `/`, so a child named `q.resource.file.sql` would otherwise be taken
-  // for a workspace-specific file and dropped from every diff.
+  // Same fileset exemption as isCurrentWorkspaceFile.
   if (isFilesetResource(path)) {
     return false;
   }

--- a/cli/src/core/specific_items.ts
+++ b/cli/src/core/specific_items.ts
@@ -464,6 +464,14 @@ export function isCurrentWorkspaceFile(path: string, workspaceNameOverride?: str
  * Used to identify and skip files from other branches during sync operations
  */
 export function isWorkspaceSpecificFile(path: string): boolean {
+  // Fileset children are never workspace-specific: only the parent's metadata
+  // file carries the suffix, children stay in the shared canonical directory.
+  // The patterns below read any dot-free run as a workspace name, and `[^.]`
+  // spans `/`, so a child named `q.resource.file.sql` would otherwise be taken
+  // for a workspace-specific file and dropped from every diff.
+  if (isFilesetResource(path)) {
+    return false;
+  }
   const typePattern = buildItemTypePattern();
   return new RegExp(
     `\\.[^.]+\\.${typePattern}\\.(yaml|json)$|` +

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -244,7 +244,7 @@ export async function pushObj(
   } else if (typeEnding === "resource") {
     if (!alreadySynced.includes(p)) {
       alreadySynced.push(p);
-      await pushResource(workspace, p, befObj, newObj, originalLocalPath || p, wsSpecific);
+      await pushResource(workspace, p, befObj, newObj, originalLocalPath || p, wsSpecific, true);
     }
   } else if (typeEnding === "resource-type") {
     await pushResourceType(workspace, p, befObj, newObj);

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -4,13 +4,18 @@
  */
 
 import { expect, test, describe } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep as SEP } from "node:path";
 import { handleFile } from "../src/commands/script/script.ts";
 import { validateFilesetPointer } from "../src/commands/resource/resource.ts";
+import { findFilesetResourceFile } from "../src/commands/sync/sync.ts";
 
 describe("handleFile routing", () => {
   test("returns false for fileset children with script extensions", async () => {
-    // A fileset child is part of its parent resource's value; treating it as
-    // a standalone script used to crash the push (`Invalid language: .sql`).
+    // A fileset child belongs to its parent resource's value, never to a
+    // standalone script: bare `.sql` has no script language (only `.pg.sql`
+    // etc. do), so routing it to the script pusher aborts the whole push.
     for (const p of [
       "f/resources/data.fileset/energy/queries/report.sql",
       "f/resources/data.fileset/scripts/main.ts",
@@ -57,6 +62,31 @@ describe("validateFilesetPointer", () => {
         "f/resources/analytics_data",
       ),
     ).toThrow(/must live next to its resource file, at 'f\/resources\/analytics_data\.fileset'/);
+  });
+
+  test("resolves workspace-specific metadata for canonical children", async () => {
+    // The metadata file carries the workspace suffix while children stay at
+    // the server-canonical `<base>.fileset/` directory.
+    const dir = mkdtempSync(join(tmpdir(), "fileset-ws-"));
+    const cwd = process.cwd();
+    try {
+      mkdirSync(join(dir, "f/res"), { recursive: true });
+      writeFileSync(
+        join(dir, "f/res/data.ws_main.resource.yaml"),
+        "resource_type: c_files\nvalue: '!inline_fileset f/res/data.fileset'\n",
+      );
+      process.chdir(dir);
+      const childPath = ["f", "res", "data.fileset", "q.sql"].join(SEP);
+      expect(await findFilesetResourceFile(childPath, "ws_main")).toBe(
+        "f/res/data.ws_main.resource.yaml",
+      );
+      await expect(findFilesetResourceFile(childPath, null)).rejects.toThrow(
+        /No resource metadata file found/,
+      );
+    } finally {
+      process.chdir(cwd);
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("rejects a branch-suffixed directory for a workspace-specific resource", () => {

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -76,9 +76,15 @@ describe("validateFilesetPointer", () => {
         "resource_type: c_files\nvalue: '!inline_fileset f/res/data.fileset'\n",
       );
       process.chdir(dir);
+      // findFilesetResourceFile derives the metadata path from the child
+      // path, so both use the platform separator.
       const childPath = ["f", "res", "data.fileset", "q.sql"].join(SEP);
+      const wsMetadataPath = ["f", "res", "data.ws_main.resource.yaml"].join(
+        SEP,
+      );
+      const baseMetadataPath = ["f", "res", "data.resource.yaml"].join(SEP);
       expect(await findFilesetResourceFile(childPath, "ws_main")).toBe(
-        "f/res/data.ws_main.resource.yaml",
+        wsMetadataPath,
       );
       await expect(findFilesetResourceFile(childPath, null)).rejects.toThrow(
         /No resource metadata file found/,
@@ -90,10 +96,10 @@ describe("validateFilesetPointer", () => {
         "resource_type: c_files\nvalue: '!inline_fileset f/res/data.fileset'\n",
       );
       expect(await findFilesetResourceFile(childPath, "ws_main")).toBe(
-        "f/res/data.ws_main.resource.yaml",
+        wsMetadataPath,
       );
       expect(await findFilesetResourceFile(childPath, null)).toBe(
-        "f/res/data.resource.yaml",
+        baseMetadataPath,
       );
     } finally {
       process.chdir(cwd);

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -83,6 +83,18 @@ describe("validateFilesetPointer", () => {
       await expect(findFilesetResourceFile(childPath, null)).rejects.toThrow(
         /No resource metadata file found/,
       );
+      // The suffixed file is the workspace's authoritative metadata: it wins
+      // even when a base metadata file coexists with it.
+      writeFileSync(
+        join(dir, "f/res/data.resource.yaml"),
+        "resource_type: c_files\nvalue: '!inline_fileset f/res/data.fileset'\n",
+      );
+      expect(await findFilesetResourceFile(childPath, "ws_main")).toBe(
+        "f/res/data.ws_main.resource.yaml",
+      );
+      expect(await findFilesetResourceFile(childPath, null)).toBe(
+        "f/res/data.resource.yaml",
+      );
     } finally {
       process.chdir(cwd);
       rmSync(dir, { recursive: true, force: true });

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -10,6 +10,7 @@ import { join, sep as SEP } from "node:path";
 import { handleFile } from "../src/commands/script/script.ts";
 import { validateFilesetPointer } from "../src/commands/resource/resource.ts";
 import { findFilesetResourceFile } from "../src/commands/sync/sync.ts";
+import { isWorkspaceSpecificFile } from "../src/core/specific_items.ts";
 
 describe("handleFile routing", () => {
   test("returns false for fileset children with script extensions", async () => {
@@ -39,6 +40,26 @@ describe("handleFile routing", () => {
         [],
       ),
     ).toBe(false);
+  });
+});
+
+describe("workspace-specific classification", () => {
+  test("fileset children are never workspace-specific", () => {
+    // The workspace-name segment of the pattern spans `/`, so a child whose
+    // own name looks like a typed metadata file would otherwise be read as
+    // belonging to another workspace and dropped from every diff — i.e.
+    // silently never deployed.
+    for (const p of [
+      "f/resources/data.fileset/edge/q.resource.file.sql",
+      "f/resources/data.fileset/edge/inner.resource.yaml",
+      "f/resources/data.fileset/queries/report.sql",
+    ]) {
+      expect(isWorkspaceSpecificFile(p)).toBe(false);
+    }
+    // The parent's own metadata still carries the suffix.
+    expect(isWorkspaceSpecificFile("f/resources/data.ws_main.resource.yaml")).toBe(
+      true,
+    );
   });
 });
 

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -10,7 +10,10 @@ import { join, sep as SEP } from "node:path";
 import { handleFile } from "../src/commands/script/script.ts";
 import { validateFilesetPointer } from "../src/commands/resource/resource.ts";
 import { findFilesetResourceFile } from "../src/commands/sync/sync.ts";
-import { isWorkspaceSpecificFile } from "../src/core/specific_items.ts";
+import {
+  isCurrentWorkspaceFile,
+  isWorkspaceSpecificFile,
+} from "../src/core/specific_items.ts";
 
 describe("handleFile routing", () => {
   test("returns false for fileset children with script extensions", async () => {
@@ -56,10 +59,21 @@ describe("workspace-specific classification", () => {
     ]) {
       expect(isWorkspaceSpecificFile(p)).toBe(false);
     }
+    // A child carrying the active workspace's own suffix must not be remapped
+    // onto the unsuffixed sibling key, which would deploy over that sibling.
+    expect(
+      isCurrentWorkspaceFile(
+        "f/resources/data.fileset/edge/inner.ws_main.resource.yaml",
+        "ws_main",
+      ),
+    ).toBe(false);
     // The parent's own metadata still carries the suffix.
     expect(isWorkspaceSpecificFile("f/resources/data.ws_main.resource.yaml")).toBe(
       true,
     );
+    expect(
+      isCurrentWorkspaceFile("f/resources/data.ws_main.resource.yaml", "ws_main"),
+    ).toBe(true);
   });
 });
 

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -38,49 +38,35 @@ describe("handleFile routing", () => {
 });
 
 describe("validateFilesetPointer", () => {
-  test("accepts the canonical pointer", () => {
+  test("accepts the server-canonical pointer", () => {
     expect(() =>
-      validateFilesetPointer(
-        "f/resources/data.fileset",
-        "f/resources/data",
-        "f/resources/data.resource.yaml",
-      ),
+      validateFilesetPointer("f/resources/data.fileset", "f/resources/data"),
     ).not.toThrow();
   });
 
-  test("accepts the canonical pointer without a local path", () => {
+  test("normalizes trailing slashes", () => {
     expect(() =>
-      validateFilesetPointer("f/resources/data.fileset", "f/resources/data", undefined),
-    ).not.toThrow();
-  });
-
-  test("normalizes trailing slashes and backslashes", () => {
-    expect(() =>
-      validateFilesetPointer(
-        "f/resources/data.fileset/",
-        "f/resources/data",
-        "f\\resources\\data.resource.yaml",
-      ),
-    ).not.toThrow();
-  });
-
-  test("accepts a pointer canonical for the local (branch-specific) file", () => {
-    expect(() =>
-      validateFilesetPointer(
-        "f/resources/data.ws_main.fileset",
-        "f/resources/data",
-        "f/resources/data.ws_main.resource.yaml",
-      ),
+      validateFilesetPointer("f/resources/data.fileset/", "f/resources/data"),
     ).not.toThrow();
   });
 
   test("rejects a custom pointer with an actionable message", () => {
     expect(() =>
       validateFilesetPointer(
-        "f/zoho-analytics.fileset",
-        "f/resources/zoho_analytics_iac_data",
-        "f/resources/zoho_analytics_iac_data.resource.yaml",
+        "f/queries.fileset",
+        "f/resources/analytics_data",
       ),
-    ).toThrow(/must live next to its resource file, at 'f\/resources\/zoho_analytics_iac_data\.fileset'/);
+    ).toThrow(/must live next to its resource file, at 'f\/resources\/analytics_data\.fileset'/);
+  });
+
+  test("rejects a branch-suffixed directory for a workspace-specific resource", () => {
+    // The remote exporter always renders children at the server-canonical
+    // location, so a `.ws_<branch>.fileset` directory would never round-trip.
+    expect(() =>
+      validateFilesetPointer(
+        "f/resources/data.ws_main.fileset",
+        "f/resources/data",
+      ),
+    ).toThrow(/at 'f\/resources\/data\.fileset'/);
   });
 });

--- a/cli/test/fileset_sync_unit.test.ts
+++ b/cli/test/fileset_sync_unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for fileset resource sync routing and pointer validation.
+ * These tests require no backend — they test standalone logic.
+ */
+
+import { expect, test, describe } from "bun:test";
+import { handleFile } from "../src/commands/script/script.ts";
+import { validateFilesetPointer } from "../src/commands/resource/resource.ts";
+
+describe("handleFile routing", () => {
+  test("returns false for fileset children with script extensions", async () => {
+    // A fileset child is part of its parent resource's value; treating it as
+    // a standalone script used to crash the push (`Invalid language: .sql`).
+    for (const p of [
+      "f/resources/data.fileset/energy/queries/report.sql",
+      "f/resources/data.fileset/scripts/main.ts",
+      "f/resources/data.fileset/scripts/main.py",
+    ]) {
+      expect(
+        await handleFile(p, {} as any, [], undefined, undefined, {}, []),
+      ).toBe(false);
+    }
+  });
+
+  test("returns false for single-file resource content files", async () => {
+    expect(
+      await handleFile(
+        "f/resources/query.resource.file.sql",
+        {} as any,
+        [],
+        undefined,
+        undefined,
+        {},
+        [],
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("validateFilesetPointer", () => {
+  test("accepts the canonical pointer", () => {
+    expect(() =>
+      validateFilesetPointer(
+        "f/resources/data.fileset",
+        "f/resources/data",
+        "f/resources/data.resource.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("accepts the canonical pointer without a local path", () => {
+    expect(() =>
+      validateFilesetPointer("f/resources/data.fileset", "f/resources/data", undefined),
+    ).not.toThrow();
+  });
+
+  test("normalizes trailing slashes and backslashes", () => {
+    expect(() =>
+      validateFilesetPointer(
+        "f/resources/data.fileset/",
+        "f/resources/data",
+        "f\\resources\\data.resource.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("accepts a pointer canonical for the local (branch-specific) file", () => {
+    expect(() =>
+      validateFilesetPointer(
+        "f/resources/data.ws_main.fileset",
+        "f/resources/data",
+        "f/resources/data.ws_main.resource.yaml",
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects a custom pointer with an actionable message", () => {
+    expect(() =>
+      validateFilesetPointer(
+        "f/zoho-analytics.fileset",
+        "f/resources/zoho_analytics_iac_data",
+        "f/resources/zoho_analytics_iac_data.resource.yaml",
+      ),
+    ).toThrow(/must live next to its resource file, at 'f\/resources\/zoho_analytics_iac_data\.fileset'/);
+  });
+});


### PR DESCRIPTION
## Summary

`wmill sync push` mishandled fileset resources (`is_fileset` resource types with `!inline_fileset` values) in two independent ways, together capable of erasing or deploying stale fileset content:

1. **Any push containing an *edited* fileset child crashed the CLI** — even in the canonical layout. In the apply loop's `edited` branch, `handleScriptMetadata`/`handleFile` ran before the `isFileResource`/`isFilesetResource` routing, so a child like `<resource>.fileset/query.sql` was treated as a standalone script: bare `.sql` has no script language, so `inferContentTypeFromFilePath` threw `Invalid language: .sql` and aborted the whole push mid-apply (a push with only edits deployed **nothing**). Children with `.ts`/`.py` extensions were silently deployed as standalone scripts instead. The same unguarded pattern in `generate-metadata` made `sync pull` warn and exit non-zero on such children.

2. **A non-canonical `!inline_fileset` pointer was silently half-accepted.** The diff engine only round-trips the canonical layout (`<resource-path>.fileset/` next to the resource yaml — what `sync pull` generates), but `pushResource` resolved any directory the yaml named, so the first push worked. Every later sync then planned full delete/re-add churn for all children, silently dropped adds under the custom directory (parent lookup fails → skipped without warning), and — when a stale copy of the canonical directory existed in the repo (e.g. committed `sync pull` output) — deployed stale content, resurrecting deleted files and erasing current ones.

Both were reproduced end-to-end against a dev backend before fixing; the fixes were verified the same way (transcript below).

## Changes

- `sync.ts` apply loop, `edited` branch: route `isFileResource`/`isFilesetResource` paths to their parent resource **before** the script handlers (matching the `added`/`deleted` branches), and turn the already-synced fall-throughs into `continue` + state write — the parent's push this run already resolved current child content from disk, and falling through ran `parseFromPath`/`pushObj` on a raw child file.
- `handleFile` returns `false` for file/fileset resource content files (defense in depth for every caller, incl. `wmill dev`); the standalone `wmill script push` now errors explicitly on such paths instead of no-op'ing with a success message.
- `generate-metadata`: exclude file/fileset resource content files from script candidacy (both walk paths), fixing spurious `Skipping …: Invalid language` warnings and non-zero `sync pull` exits.
- New `validateFilesetPointer` in `resource.ts`: **sync pushes** reject a pointer that isn't the **server-canonical** `<resource-path>.fileset` location with an actionable error (`git mv … && update the !inline_fileset value`). This is the only location the remote exporter renders children at — including for workspace-specific resources, so a `.ws_<branch>.fileset` directory is rejected too. The validation runs as a **fail-fast pre-flight** before any change is applied (deletes run first in the apply loop, so a mid-apply abort would leave a partial deploy); `resolveInlineContent` keeps a backstop check for the re-push paths. The standalone `wmill resource push` intentionally keeps accepting any pointer — it pushes one explicit file and no sync diff is involved.
- `isWorkspaceSpecificFile` returns `false` for fileset children. Its patterns match the workspace-name segment with `[^.]+`, and `[^.]` spans `/`, so in `<res>.fileset/edge/q.resource.file.sql` the run `fileset/edge/q` was read as a workspace name: the child was taken for another workspace's file, dropped by `elementsToMap`, and **silently never deployed** — no diff entry, no warning. Only the parent's metadata file carries the workspace suffix; children stay in the shared canonical directory.
- Routing precedence: the `edited` branch checks `isFilesetResource` before `isFileResource` (as `added`/`deleted` already did) — a fileset accepts arbitrary child names, so `<res>.fileset/q.resource.file.sql` satisfies both predicates and belongs to its fileset parent. The pointer pre-flight likewise excludes fileset children before treating a path as resource metadata, since a child may itself be named `*.resource.yaml`.
- New unit tests: `cli/test/fileset_sync_unit.test.ts` (routing guard + pointer validation, incl. normalization and workspace-specific rejection, and the fileset-child classification guard).

## Behavior change note (for the changelog)

`wmill sync push` now **fails with an explicit error** (also surfaced by `--dry-run`, all violations listed at once, before anything is applied) when a resource's `!inline_fileset` value points anywhere other than the server-canonical `<resource-path>.fileset`. Repos that relied on a custom fileset directory location were silently corrupting their sync (full delete/re-add churn, dropped adds, stale content) — they now get a clear message with the exact `git mv` to run. No action needed for repos using the layout `wmill sync pull` generates.

A consequence of the server-canonical contract: workspace-specific (branch-specific) resources get their own `<base>.<workspace>.resource.yaml` metadata file, but their fileset **children** always live in the shared `<base>.fileset/` directory — per-workspace fileset *content* is not supported (the remote exporter renders one canonical location for all workspaces). `findFilesetResourceFile` now resolves the workspace-suffixed metadata file for children in that canonical directory, so editing a child of a workspace-specific fileset pushes correctly.

## Demo (patched CLI against a dev backend)

```text
$ tree f
f
└── resources
    ├── sales_queries.fileset
    │   └── reports
    │       └── query_b.sql
    └── sales_queries.resource.yaml

$ # edit one child, add another, then push
$ wmill sync push --yes --plain-secrets
remote (admins) <- local: 3 changes to apply
~ resource f/resources/sales_queries.fileset/reports/query_b.sql
+ resource f/resources/sales_queries.fileset/reports/query_d.sql
Done! All 3 changes pushed to the remote workspace admins (26ms)
   # previously: crash — "Error: Invalid language: .sql", nothing deployed

$ # a non-canonical '!inline_fileset' pointer now fails fast with a clear error
$ wmill sync push --yes --plain-secrets
error: Resource f/resources/sales_queries uses '!inline_fileset f/sales.fileset', but a fileset
directory must live next to its resource file, at 'f/resources/sales_queries.fileset'. Move the
directory there (e.g. 'git mv f/sales.fileset f/resources/sales_queries.fileset') and update the
'!inline_fileset' value to match.
```

(Resource/file names in the demo are illustrative; the recorded run used a local scratch repo.)

## Test plan

- [x] `UNIT_ONLY=1 bun test test/*_unit*` — 1055 pass (8 new)
- [x] Manual: fileset children named `q.resource.file.sql` / `inner.resource.yaml` now appear in the diff, deploy on add, and update on edit (previously absent from the plan entirely); an `inner.resource.yaml` carrying an `!inline_fileset` value pushes as ordinary content instead of aborting the push
- [x] Manual, canonical layout vs dev backend: push with two edited children succeeds and updates the remote value (previously crashed with nothing deployed); deleted child is removed from the value; follow-up push plans no fileset changes
- [x] Manual: `sync pull` of a workspace with a fileset resource exits 0 with no `Invalid language` warnings (previously exit 1)
- [x] Manual: sync push with a non-canonical pointer fails fast with the actionable message; standalone `wmill resource push` with the same pointer still succeeds
- [x] Manual: `wmill script push <fileset child>` errors explicitly instead of reporting a false success
- [x] `bunx tsc --noEmit` introduces no new errors (pre-existing failures identical on main)

## Out of scope

- **Workspace-specific fileset diff mapping** (pre-existing): `elementsToMap` drops `<base>.fileset/*` children from local diffs when the parent is flagged workspace-specific, so a clean ws-specific fileset still plans full delete/re-add churn (the parent re-push keeps content correct, but plans are never clean). The fileset and specific-items features never composed in the diff engine; this PR fixes the crash, parent resolution, and metadata precedence for that combination, and the map handling is left as a follow-up rather than growing this fix into diff-engine surgery.

- Resource types with `format_extension: null` diff as edited on every push (unrelated churn observed while reproducing).
- `specific_items.ts` workspace-specific matching assumes canonical fileset paths — consistent with this PR's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `wmill sync push` for fileset resources by routing edited children to their parent and rejecting non‑canonical `!inline_fileset` pointers to prevent crashes, stale deploys, and dropped diffs (WIN‑2338).
Sync now validates pointers before dry‑run, prefers workspace‑specific metadata, and excludes fileset children from both workspace-specific and current‑workspace classifiers.

- **Bug Fixes**
  - Route fileset and single‑file resource content to their parent before script handlers; `wmill script push <fileset child>` now errors.
  - Exclude file/fileset content from `generate-metadata` script detection to remove "Invalid language" warnings and non‑zero `sync pull` exits.
  - Fileset child handling: never treat as workspace‑specific or current‑workspace to avoid drops/remaps; prefer workspace‑specific metadata over base; metadata lookup is platform‑separator safe.

- **Migration**
  - Sync pushes now fail fast if `!inline_fileset` is not `<resource-path>.fileset`. Move the directory next to the resource file and update the pointer. Standalone `wmill resource push` still accepts custom pointers.

<sup>Written for commit c39456beb1c6e4e3d6357169c3d417ab2103b3b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

