### PR TITLE
fix(frontend): collapse the dev-workspace edit notice into a badge

### DIFF
--- a/frontend/src/lib/components/NoDirectDeployAlert.svelte
+++ b/frontend/src/lib/components/NoDirectDeployAlert.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+	/**
+	 * Compact marker for a workspace locked against direct edits. It sits above list and detail
+	 * pages that are otherwise unremarkable, so it stays a badge: the rule names, the route into the
+	 * dev workspace and the admin bypass live in its popover. Renders nothing for operators, who
+	 * have no edit affordance for it to explain.
+	 */
 	import { userStore, userWorkspaces, workspaceStore } from '$lib/stores'
 	import {
 		canUserBypassRuleKind,
@@ -6,11 +12,13 @@
 		isRuleActive
 	} from '$lib/workspaceProtectionRules.svelte'
 	import { findCanonicalDevWorkspace } from '$lib/utils/workspaceHierarchy'
-	import { devLabelNoun } from '$lib/utils/devWorkspaceLabel'
+	import { devLabelKey, devLabelNoun } from '$lib/utils/devWorkspaceLabel'
 	import { canCreateFork } from '$lib/utils/editInFork'
 	import { switchWorkspace } from '$lib/storeUtils'
-	import { Alert, Button } from './common'
-	import { GitFork } from 'lucide-svelte'
+	import { Badge, Button } from './common'
+	import Popover from './meltComponents/Popover.svelte'
+	import Toggle from './Toggle.svelte'
+	import { GitFork, Lock, ShieldOff } from 'lucide-svelte'
 
 	let activeDeployRulesets = $derived(getActiveRulesetsForKind('DisableDirectDeployment'))
 	let canBypass = $derived(canUserBypassRuleKind('DisableDirectDeployment', $userStore))
@@ -24,7 +32,10 @@
 			: 'You will need to make your changes locally and submit a PR to an authorized user.'
 	)
 	let overrideChecked = $state(false)
-	let canEdit = $derived(!isRuleActive('DisableDirectDeployment') || (canBypass && overrideChecked))
+	// The toggle is only offered to a user who can bypass, but the answer can change under a
+	// workspace switch, so the checked flag alone never grants the edit.
+	let bypassActive = $derived(canBypass && overrideChecked)
+	let canEdit = $derived(!isRuleActive('DisableDirectDeployment') || bypassActive)
 
 	let {
 		onUpdateCanEditStatus = (value) => {}
@@ -35,50 +46,82 @@
 	$effect(() => {
 		onUpdateCanEditStatus(canEdit)
 	})
+
+	// Short enough to read as a chip: the destination workspace and the rules behind it are one
+	// click away in the popover.
+	let badgeLabel = $derived(
+		bypassActive
+			? 'Protection bypassed'
+			: canonicalDev
+				? `Edits in ${devLabelKey(canonicalDev.dev_workspace_label)}`
+				: 'Edits restricted'
+	)
 </script>
 
 {#if !$userStore?.operator && activeDeployRulesets.length > 0}
 	<div class="my-2">
-		<Alert
-			type="info"
-			title={canonicalDev
-				? `Edits happen in the ${devLabelNoun(canonicalDev.dev_workspace_label)}`
-				: 'Workspace protection active'}
+		<Popover
+			placement="bottom-start"
+			class="inline-flex items-center"
+			triggerAttrs={{ 'aria-label': badgeLabel }}
 		>
-			<div class="flex flex-col gap-2">
-				{#if canonicalDev}
-					<p>
-						Edits to this workspace are made in its {devLabelNoun(canonicalDev.dev_workspace_label)}
-						<b>{canonicalDev.name}</b> ({canonicalDev.id}) and promoted here.
-					</p>
-					<div>
-						<Button
-							btnClasses="w-auto"
+			{#snippet trigger()}
+				<Badge
+					small
+					color={bypassActive ? 'yellow' : 'blue'}
+					class={bypassActive
+						? 'cursor-pointer hover:bg-yellow-200 dark:hover:bg-yellow-500/25'
+						: 'cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-700/60'}
+				>
+					{#if bypassActive}
+						<ShieldOff class="h-3 w-3" />
+					{:else if canonicalDev}
+						<GitFork class="h-3 w-3" />
+					{:else}
+						<Lock class="h-3 w-3" />
+					{/if}
+					{badgeLabel}
+				</Badge>
+			{/snippet}
+			{#snippet content()}
+				<div class="flex flex-col gap-3 p-4 text-xs max-w-sm">
+					{#if canonicalDev}
+						<p class="text-primary">
+							Edits to this workspace are made in its {devLabelNoun(
+								canonicalDev.dev_workspace_label
+							)}
+							<b>{canonicalDev.name}</b> ({canonicalDev.id}) and promoted here.
+						</p>
+						<div>
+							<Button
+								btnClasses="w-auto"
+								size="xs"
+								variant="accent"
+								startIcon={{ icon: GitFork }}
+								onclick={() => {
+									if (canonicalDev) switchWorkspace(canonicalDev.id)
+								}}
+							>
+								Go to {devLabelNoun(canonicalDev.dev_workspace_label)}
+							</Button>
+						</div>
+					{:else}
+						<p class="text-primary">
+							The rule{activeDeployRulesets.length > 1 ? 's' : ''}
+							<b>{activeDeployRulesets.map((r) => r.name).join(', ')}</b>
+							restrict{activeDeployRulesets.length > 1 ? '' : 's'} direct edits to this workspace.
+							{editAdvice}
+						</p>
+					{/if}
+					{#if canBypass}
+						<Toggle
 							size="xs"
-							variant="accent"
-							startIcon={{ icon: GitFork }}
-							onclick={() => {
-								if (canonicalDev) switchWorkspace(canonicalDev.id)
-							}}
-						>
-							Go to {devLabelNoun(canonicalDev.dev_workspace_label)}
-						</Button>
-					</div>
-				{:else}
-					<p>
-						The rule{activeDeployRulesets.length > 1 ? 's' : ''}
-						<b>{activeDeployRulesets.map((r) => r.name).join(', ')}</b>
-						restrict{activeDeployRulesets.length > 1 ? '' : 's'} direct edits to this workspace.
-						{editAdvice}
-					</p>
-				{/if}
-				{#if canBypass}
-					<label class="flex items-center gap-2 cursor-pointer">
-						<input class="rounded max-w-4" type="checkbox" bind:checked={overrideChecked} />
-						<span class="text-xs">Bypass restriction</span>
-					</label>
-				{/if}
-			</div>
-		</Alert>
+							bind:checked={overrideChecked}
+							options={{ right: 'Bypass restriction' }}
+						/>
+					{/if}
+				</div>
+			{/snippet}
+		</Popover>
 	</div>
 {/if}


### PR DESCRIPTION
## Summary

On a workspace locked against direct edits (the prod side of a dev/prod pairing), a full-width
"Edits happen in the dev workspace" alert sat at the top of the home, variables, resources, script
and flow pages. It restates the same thing on every page and pushes the actual page content down.

It is now a small badge — `Edits in dev` / `Edits in staging` — that opens the same content in a
popover: the destination workspace, the "Go to dev workspace" button, and the admin bypass toggle.
When the bypass is on, the badge turns yellow and reads `Protection bypassed`, so the elevated
state is still visible at a glance without the panel being open.

Fixes WIN-2333

## Changes

- `NoDirectDeployAlert.svelte`: `Alert` → `Badge` + `Popover`. Same content, same
  `onUpdateCanEditStatus` contract, so the create/edit gating on all five call sites is unchanged.
- Badge label tracks state: `Edits in <label>` (canonical dev workspace, git-fork icon),
  `Edits restricted` (rule with no dev workspace to route to, lock icon), `Protection bypassed`
  (bypass on, yellow).
- Bypass control is now a `Toggle` instead of a raw `<input type=checkbox>`, per the frontend
  design-system rule.
- Operators still never see it (`!$userStore?.operator` guard, unchanged), verified below.

## Test plan

- [x] `npm run check` — 0 errors (69 pre-existing warnings, none in this file)
- [x] Prod workspace paired with a dev workspace: badge renders on home / variables / script detail;
      create + edit buttons stay hidden
- [x] Popover opens with the dev-workspace copy; "Go to dev workspace" switches workspace
- [x] Bypass toggle → badge turns yellow, `+ New` and Edit reappear
- [x] Rule active with no canonical dev workspace → `Edits restricted` + rule name in the popover
- [x] Operator in the locked workspace → nothing rendered (home and script detail)
- [x] Dark mode

## Screenshots

**Home page — before / after**

![win2333-before-home](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-before-home.png)

![win2333-after-home](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-after-home.png)

**Script detail — before / after**

![win2333-script-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-script-before.png)

![win2333-script-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-script-after.png)

**Popover expanded**

![win2333-after-popover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-after-popover.png)

**Bypass on — badge turns yellow, `+ New` reappears**

![win2333-bypass](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-bypass.png)

**Rule active with no dev workspace to route to**

![win2333-nodev](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-nodev.png)

**Dark mode**

![win2333-dark2](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-dark2.png)

**Same workspace as an operator — nothing rendered**

![win2333-operator-home](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-make-the-edit-happens-in-the-dev-workspace-more-discrete/1786028395-win2333-operator-home.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed the full-width “Edits happen in dev workspace” alert into a small `Badge` with a popover to reduce clutter while keeping the same actions visible. Aligns with WIN-2333 by making the notice discrete without changing permissions or workflows.

- **Refactors**
  - Replaced `Alert` with `Badge` + `Popover`; keeps the same `onUpdateCanEditStatus` contract and “Go to dev workspace” action.
  - Badge shows state: “Edits in <label>” (fork icon), “Edits restricted” (lock), and “Protection bypassed” (yellow with shield-off).
  - Switched bypass control to `Toggle` per design system.
  - Hidden for operators; create/edit gating unchanged across pages.

<sup>Written for commit eb486aba567b3b207243dba15b19356880e1a8b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

