### PR TITLE
fix(frontend): address review nits on the dev-workspace edit badge

### DIFF
--- a/frontend/src/lib/components/NoDirectDeployAlert.svelte
+++ b/frontend/src/lib/components/NoDirectDeployAlert.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	/**
-	 * Compact marker for a workspace locked against direct edits. It sits above list and detail
-	 * pages that are otherwise unremarkable, so it stays a badge: the rule names, the route into the
-	 * dev workspace and the admin bypass live in its popover. Renders nothing for operators, who
-	 * have no edit affordance for it to explain.
+	 * Badge for a workspace locked against direct edits, with the rule names, the route into the dev
+	 * workspace and the admin bypass in its popover. Renders nothing for operators, who have no edit
+	 * affordance for it to explain.
 	 */
 	import { userStore, userWorkspaces, workspaceStore } from '$lib/stores'
 	import {
@@ -47,8 +46,6 @@
 		onUpdateCanEditStatus(canEdit)
 	})
 
-	// Short enough to read as a chip: the destination workspace and the rules behind it are one
-	// click away in the popover.
 	let badgeLabel = $derived(
 		bypassActive
 			? 'Protection bypassed'
@@ -66,13 +63,9 @@
 			triggerAttrs={{ 'aria-label': badgeLabel }}
 		>
 			{#snippet trigger()}
-				<Badge
-					small
-					color={bypassActive ? 'yellow' : 'blue'}
-					class={bypassActive
-						? 'cursor-pointer hover:bg-yellow-200 dark:hover:bg-yellow-500/25'
-						: 'cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-700/60'}
-				>
+				<!-- `clickable` is unusable here: it renders the badge as a <button>, nested inside the
+				     one Popover wraps its trigger in. -->
+				<Badge small color={bypassActive ? 'yellow' : 'blue'} class="cursor-pointer">
 					{#if bypassActive}
 						<ShieldOff class="h-3 w-3" />
 					{:else if canonicalDev}


### PR DESCRIPTION
## Summary

Follow-up to #10576 (WIN-2333), which was merged while its review round was still in flight. The
round came back `Good to merge` from Codex and Pi and `Mergeable, but should ideally address nits`
from Claude, with two P2s. This applies them.

## Changes

- Drop the two comments that justified the design to the reviewer rather than recording a
  constraint (the layout rationale in the module doc, and the `badgeLabel` chip note). `AGENTS.md`:
  *comments record constraints, not narration*.
- Drop the hardcoded `hover:bg-*` classes on the badge, which were verbatim copies of `Badge`'s own
  `hovers` map — a design-system palette change would not have reached them. Replaced by a one-line
  comment recording the non-obvious reason `Badge`'s `clickable` prop cannot be used here: it
  renders the badge as a `<button>`, which would nest inside the `<button>` `Popover` wraps its
  trigger in.

No behavior change: the badge keeps `cursor-pointer`, and the popover, gating contract and operator
guard are untouched.

## Test plan

- [x] `npm run check:fast` — 0 problems; prettier clean
- [x] Badge still renders and opens its popover on home, variables and script detail in a prod
      workspace paired with a dev workspace
- [x] Keyboard flow (raised by two reviewers, not covered by #10576's screenshots): focus the badge
      → `Enter` opens the popover and moves focus into it (lands on "Go to dev workspace") → `Tab`
      reaches the bypass toggle → `Space` flips it (trigger `aria-label` becomes
      `Protection bypassed`, `+ New` reappears) → `Escape` closes the popover and returns focus to
      the badge
- [x] Narrow viewport (600×420) on script detail: badge stays compact, popover fits without
      clipping

## Screenshots

**Narrow viewport (600×420), script detail, popover open**

![win2333-narrow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2333-review-nits/1786030730-win2333-narrow.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up the dev-workspace edit badge per WIN-2333 review nits to align with the design system. No UI or behavior changes.

- **Refactors**
  - Removed non-constraint comments; added a brief note on why `Badge` `clickable` isn’t used (would nest a button inside the `Popover` trigger).
  - Dropped hardcoded `hover:bg-*` classes to rely on `Badge` defaults so palette updates propagate.

<sup>Written for commit d9da8cce752a339d5593534acc4c0771d8133553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

