### PR TITLE
fix: correct typo in NATS trigger consumer name description

### DIFF
--- a/frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte
@@ -83,7 +83,7 @@
 				customErrorMessage: 'Invalid consumer name',
 				showExpr: 'fields.use_jetstream',
 				description:
-					'Required is using JetStream. If a consumer with the same name already exists, it will be overwritten. It is also used as the deliver subject.'
+					'Required if using JetStream. If a consumer with the same name already exists, it will be overwritten. It is also used as the deliver subject.'
 			}
 		},
 		required: ['subjects', 'use_jetstream', 'stream_name', 'consumer_name']


### PR DESCRIPTION
## Summary

The consumer name field in the NATS+JetStream trigger configuration read "Required **is** using JetStream." The sibling stream name field already reads "Required **if** using JetStream." — this aligns the two.

Fixes WIN-2335

## Changes

- `frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte`: `'Required is using JetStream.'` → `'Required if using JetStream.'` in the `consumer_name` schema description.

## Screenshots

New NATS trigger drawer with **Use JetStream** enabled, showing both descriptions now reading "Required if using JetStream.":

![nats-consumer-name](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/win-2335/1786050689-nats-consumer-name.png)

## Test plan

- [x] `npm run check:fast` — no problems found
- [x] Opened the New NATS trigger drawer in the running dev frontend, picked a `nats` resource, toggled **Use JetStream** on, and confirmed the consumer name description renders "Required if using JetStream. If a consumer with the same name already exists, it will be overwritten. It is also used as the deliver subject."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the consumer name description in the NATS+JetStream trigger config to say "Required if using JetStream," matching the stream name field. Fixes WIN-2335.

<sup>Written for commit 4645a324843e57aa47b318905a50c73fc5edd446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

