### PR TITLE
fix: lock the duckdb temp directory so no script can move it

### DIFF
--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -237,7 +237,8 @@ fn sql_single_quote(s: &str) -> String {
 
 // Bounds memory so DuckDB spills to disk before blowing the cgroup cap and
 // getting the worker SIGKILLed. Spill goes to the job dir (when set) so it is
-// cleaned up with the job, otherwise DuckDB's default temp_directory is kept.
+// cleaned up with the job, otherwise DuckDB's default temp_directory is kept —
+// and either way the directory is then locked for the rest of the connection.
 fn configure_duckdb_resource_limits(
     conn: &duckdb::Connection,
     limits: &ResourceLimits,
@@ -257,9 +258,11 @@ fn configure_duckdb_resource_limits(
             sql_single_quote(tmp)
         ));
     }
-    if config_sql.is_empty() {
-        return Ok(());
-    }
+    // Freeze it before any script statement can move it: on a remote directory
+    // `~TemporaryDirectoryHandle` throws out of a `noexcept` destructor, which is
+    // `std::terminate` — an abort taking this in-process worker and every job
+    // colocated on it down, uncatchable from Rust.
+    config_sql.push_str("SET lock_temp_directory=true;\n");
     conn.execute_batch(&config_sql).map_err(|e| {
         format!(
             "Error configuring DuckDB resource limits: {}",
@@ -1282,9 +1285,55 @@ fn string_to_duckdb_time(s: &str) -> Result<duckdb::types::Value, String> {
 // engine bump can drop the patch without anything else noticing.
 #[cfg(test)]
 mod patched_engine_tests {
+    use super::*;
+
     /// Too large to be answered within the `memory_limit` `spill_attempt` sets, so the engine
     /// has to reach the temp directory to finish it.
     const SPILLING_QUERY: &str = "CREATE TABLE t AS SELECT * FROM range(1000000)";
+
+    /// Every connection is locked at setup, so no script statement can move the temp
+    /// directory onto a remote filesystem — where the spill fails and the
+    /// `~TemporaryDirectoryHandle` cleaning up throws out of a `noexcept` destructor,
+    /// aborting the worker and every job colocated on it.
+    #[test]
+    fn configured_connections_cannot_have_their_temp_directory_moved() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "windmill_duckdb_locked_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        configure_duckdb_resource_limits(
+            &conn,
+            &ResourceLimits {
+                memory_limit: Some("2MB".to_string()),
+                temp_directory: Some(temp_dir.display().to_string()),
+            },
+        )
+        .unwrap();
+
+        for stmt in [
+            "SET temp_directory='s3://bucket/tmp'",
+            "SET temp_directory TO 's3://bucket/tmp'",
+            "PRAGMA temp_directory='s3://bucket/tmp'",
+            "RESET temp_directory",
+        ] {
+            let err = conn
+                .execute_batch(stmt)
+                .expect_err(&format!("engine accepted `{stmt}` on a locked connection"));
+            assert!(
+                err.to_string().contains("temp directory has been locked"),
+                "unexpected refusal for `{stmt}`: {err}"
+            );
+        }
+
+        // The lock must not cost the spilling it exists to protect.
+        let spilled = conn.execute_batch(SPILLING_QUERY);
+        std::fs::remove_dir_all(&temp_dir).ok();
+        spilled.expect("a locked temp directory must still be usable for spilling");
+    }
 
     fn spill_attempt(temp_dir: &std::path::Path, lock: bool) -> Result<(), String> {
         let conn = duckdb::Connection::open_in_memory().unwrap();


### PR DESCRIPTION
**Stacked on #10607** — review that first; this PR's diff against `main` includes it until it
merges. My own change is 4 lines of `configure_duckdb_resource_limits` plus a test.

## Summary

A DuckDB script that points `temp_directory` at a remote path and then runs a query large enough
to spill **aborts the entire worker process**. Not the job — the process. DuckDB runs in-process
through the FFI cdylib, so `SIGABRT` takes down every other job on that worker, and the offending
job is left `running = true` in `v2_job_queue` as a zombie until the sweep. Any user who can run a
DuckDB script can trigger it, on any worker.

From the coredump, the mechanism is a **throwing destructor**:

```
duckdb::FileSystem::ListFiles(...)                 ← throws on the httpfs path
_Unwind_Resume → __gxx_personality_v0 → __cxa_call_terminate → abort
duckdb::TemporaryDirectoryHandle::~TemporaryDirectoryHandle()
duckdb::StandardBufferManager::~StandardBufferManager()
duckdb::DatabaseInstance::~DatabaseInstance()
duckdb_close
```

`~TemporaryDirectoryHandle` sweeps spill files with `ListFiles`; against a remote path that
throws; destructors are implicitly `noexcept`, so it is `__cxa_call_terminate` **at the throw
site**. There is no unwind to intercept and no frame where a `catch` could sit — not in C++ and
not from Rust, which is why #10591's `catch_unwind` does not cover it (its own description says
so). A `std::set_terminate` handler may not return; recovering via `siglongjmp` out of `SIGABRT`
would resume on a half-destructed `DatabaseInstance`, trading a loud crash for silent corruption.

So the value must never take effect. #10607 adds `lock_temp_directory` to the bundled engine,
which fixes `temp_directory` in place irreversibly. It emits that from the isolation transform,
which is EE-only and only on workers that actually isolate — so CE workers, and any worker with
`DISABLE_DUCKDB_FS_SANDBOX=true` or no isolation configured, stay exposed.

**This sets it unconditionally, for every connection the FFI configures.** The engine then refuses
the move itself, rather than us detecting it afterwards.

## Changes

- `configure_duckdb_resource_limits` appends `SET lock_temp_directory=true` after pointing
  `temp_directory` at the job dir. That runs during connection setup, before any script statement,
  so nothing a user writes can move it.
- The isolation transform's own `SET lock_temp_directory=true` is unaffected: re-setting it to
  `true` is a no-op on an already-locked connection (verified), so EE needs no companion change and
  its ordering requirement relative to `disabled_filesystems` still holds.
- One test pins that a configured connection refuses every spelling of the move and still spills.

## Behaviour change

`SET temp_directory='/some/local/path'` **now fails** for everyone, with:

```
Permission Error: Modifying the temp_directory is disabled - the temp directory has been locked
```

Scripts that relocate the spill directory to a different local disk stop working. That is a
deliberate trade, chosen over a value-inspecting guard: the engine enforcing an invariant beats us
policing one, and a script has no reason to need the spill directory somewhere other than the job
dir the worker cleans up. Worth a changelog line.

## Verification

Real-worker runs on a dedicated tag, **CE build** (`--features duckdb,parquet,quickjs`, no
`private`) with `DISABLE_DUCKDB_FS_SANDBOX=true` — i.e. exactly the configuration #10607 alone does
not cover.

| script | outcome |
|---|---|
| `SET temp_directory='s3://bucket/tmp'` | refused by the engine |
| `SET temp_directory TO 's3://bucket/tmp'` | refused |
| `PRAGMA temp_directory='s3://bucket/tmp'` | refused |
| `SET temp_directory='s3:' \|\| '//bucket/tmp'` | refused |
| `SET temp_directory='/tmp/wm-duckdb-spill'` (local) | refused — see above |
| spilling query, no override (job dir) | **succeeds, 3000000 rows** |
| trivial job after a refusal | **succeeds on the same worker** |

Worker alive throughout, `terminate called` count in its log: **0**.

**Before**, on the same engine `main` now ships (duckdb 1.5.5, bumped since this was first
written — the bug is *not* fixed upstream): the worker died with
`terminate called without an active exception`, `coredumpctl` recorded `SIGABRT` with a core, and
the job was left `running = t` in `v2_job_queue`. Standalone against plain duckdb 1.5.5 the same
script exits 134 (core dumped) after
`Not implemented Error: Cannot open an HTTP file for both reading and writing`.

`cargo test` in `backend/windmill-duckdb-ffi-internal`: 19 passed, including #10607's
`patched_engine_tests`. These run in CI via the FFI-crate step in `backend-test.yml`.

## Note

This depends on the patched engine. On a stock build `SET lock_temp_directory=true` is an
unrecognized parameter, so **every** DuckDB job fails at connection setup rather than quietly
losing the protection — the same fail-closed property #10607 relies on for its transform, now on
the path every job takes. That is the intended behaviour, but it does mean the fork and the worker
have to ship together.
