### PR TITLE
feat(frontend): show prod and dev as sibling choices in the workspace picker

### DIFF
--- a/frontend/src/lib/components/workspace/WorkspaceCard.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceCard.svelte
@@ -12,15 +12,17 @@
 	import WorkspaceIcon from './WorkspaceIcon.svelte'
 	import WorkspaceCard from './WorkspaceCard.svelte'
 	import { twMerge } from 'tailwind-merge'
-	import { devBadgeText } from '$lib/utils/devWorkspaceLabel'
+	import { devBadgeText, devLabelWord } from '$lib/utils/devWorkspaceLabel'
 
 	interface ExtendedWorkspace extends UserWorkspace {
 		_children?: ExtendedWorkspace[]
+		_dev?: ExtendedWorkspace
 		marked?: string
 	}
 
 	interface Props {
 		workspace: UserWorkspace & { marked?: string }
+		dev?: ExtendedWorkspace
 		isForked?: boolean
 		depth?: number
 		children?: ExtendedWorkspace[]
@@ -37,6 +39,7 @@
 
 	let {
 		workspace,
+		dev,
 		isForked = false,
 		depth = 0,
 		children = [],
@@ -57,12 +60,23 @@
 	// picker convention); the icon side is handled inside WorkspaceIcon.
 	const forkAccent = $derived(isForked ? forkAccentStyle(workspace.color) : undefined)
 
-	// The canonical dev workspace sorts before throwaway forks.
+	// A dev workspace only reaches the fork list when it hangs off another dev workspace; it still
+	// sorts before throwaway forks.
 	const sortedChildren = $derived(
 		[...children].sort((a, b) => {
 			if (!!a.is_dev_workspace !== !!b.is_dev_workspace) return a.is_dev_workspace ? -1 : 1
 			return a.name.localeCompare(b.name)
 		})
+	)
+
+	// With a dev workspace present the two environment cards below own the choice, so the header
+	// stops being an entry point of its own.
+	const headerEntersWorkspace = $derived(dev === undefined)
+	const headerClass = $derived(
+		twMerge(
+			'px-4 py-2 transition-colors w-full',
+			children.length === 0 ? 'rounded-lg' : 'rounded-b-none'
+		)
 	)
 
 	// Helper functions
@@ -74,124 +88,184 @@
 		return workspace.disabled === true
 	}
 
-	async function handleUnarchive() {
+	async function handleUnarchive(target: UserWorkspace) {
 		if (onUnarchive) {
-			await WorkspaceService.unarchiveWorkspace({ workspace: workspace.id })
-			await onUnarchive(workspace.id)
+			await WorkspaceService.unarchiveWorkspace({ workspace: target.id })
+			await onUnarchive(target.id)
 			// Restore sessions auto-archived when this workspace was archived.
 			await reconcileAfterWorkspaceChange()
 		}
 	}
+
+	function enter(target: UserWorkspace) {
+		onMouseClick?.()
+		if (!isWorkspaceDisabled(target)) {
+			onEnterWorkspace(target.id)
+		}
+	}
+
+	function enterOnKey(e: KeyboardEvent, target: UserWorkspace) {
+		if ((e.key === 'Enter' || e.key === ' ') && !isWorkspaceDisabled(target)) {
+			e.preventDefault()
+			onKeyboardNavigation?.()
+			onEnterWorkspace(target.id)
+		}
+	}
 </script>
+
+{#snippet header()}
+	<div class="flex flex-row items-center justify-between">
+		<div class="flex flex-row items-center gap-3 flex-1 min-w-0">
+			<div class="flex flex-row items-center gap-2 flex-1 min-w-0">
+				<div class="flex-shrink-0">
+					<WorkspaceIcon
+						workspaceColor={workspace.color}
+						{isForked}
+						isDevWorkspace={workspace.is_dev_workspace}
+						devWorkspaceLabel={workspace.dev_workspace_label}
+						parentName={workspace.parent_workspace_id ?? undefined}
+						size={12}
+					/>
+				</div>
+
+				<div class="min-w-0 flex-1">
+					<div class="flex flex-row items-center gap-2 flex-wrap">
+						<span
+							class="text-xs font-semibold truncate {forkAccent
+								? 'text-[color:var(--fork-accent-text)] dark:text-[color:var(--fork-accent-text-dark)]'
+								: 'text-primary'}"
+							style={forkAccent}
+						>
+							{#if workspace.marked}
+								{@html workspace.marked}
+							{:else}
+								{workspace.name}
+							{/if}
+						</span>
+						{#if workspace.is_dev_workspace}
+							<Badge
+								color="dark-blue"
+								small
+								class="text-3xs px-1 py-0 dark:bg-surface-accent-primary text-white dark:text-white"
+								>{devBadgeText(workspace.dev_workspace_label)}</Badge
+							>
+						{/if}
+						<span class="text-secondary text-xs">-</span>
+						{#if workspace.id === 'admins'}
+							<Badge color="blue">{workspace.id}</Badge>
+						{:else}
+							<span class="font-mono text-2xs text-secondary truncate">
+								{workspace.id}
+							</span>
+						{/if}
+					</div>
+
+					{#if headerEntersWorkspace}
+						{@render identity(workspace)}
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/snippet}
+
+{#snippet identity(target: UserWorkspace & { marked?: string })}
+	<div class="text-xs text-secondary">
+		as <span class="font-mono">{target.username}</span>
+		{#if isWorkspaceArchived(target)}
+			<span class="text-red-500 ml-1">(archived)</span>
+			{#if $superadmin && onUnarchive}
+				<Button
+					size="xs2"
+					variant="default"
+					btnClasses="ml-1"
+					propagateEvent={false}
+					onClick={() => handleUnarchive(target)}
+					startIcon={{ icon: ArchiveRestore }}
+				>
+					Unarchive
+				</Button>
+			{/if}
+		{/if}
+		{#if isWorkspaceDisabled(target)}
+			<span class="text-red-500 ml-1">(user disabled in this workspace)</span>
+		{/if}
+		{#if target.id === 'admins'}
+			<span class="text-accent ml-1">Used to manage your Windmill instance</span>
+		{/if}
+	</div>
+{/snippet}
+
+<!-- One half of the prod/dev pair: the two environments are siblings, so each carries its own
+     entry affordance and the card header above them is inert. -->
+{#snippet environment(target: ExtendedWorkspace, label: string)}
+	<div
+		class={twMerge(
+			'flex-1 min-w-0 border border-border-light rounded-md px-3 py-2 transition-colors',
+			selectedWorkspaceId === target.id ? 'bg-surface-hover' : 'bg-surface',
+			isWorkspaceDisabled(target)
+				? 'opacity-60 cursor-not-allowed'
+				: 'cursor-pointer hover:bg-surface-hover'
+		)}
+		data-workspace-id={target.id}
+		role="button"
+		tabindex="0"
+		onclick={() => enter(target)}
+		onkeydown={(e) => enterOnKey(e, target)}
+		onmouseenter={() => onMouseEnter?.(target.id)}
+	>
+		<div class="flex flex-row items-center gap-2 min-w-0">
+			<span class="text-xs font-semibold text-primary truncate">{label}</span>
+			{#if target.id !== workspace.id}
+				<span class="font-mono text-2xs text-secondary truncate">
+					{#if target.marked}
+						{@html target.marked}
+					{:else}
+						{target.id}
+					{/if}
+				</span>
+			{/if}
+		</div>
+		{@render identity(target)}
+	</div>
+{/snippet}
 
 <div class="block pb-2" style:padding-left={`${paddingLeft}px`}>
 	<div
 		class={twMerge(
 			'border border-border-light rounded-md overflow-hidden transition-all duration-150',
-			isSelected ? 'bg-surface-hover' : 'bg-surface-tertiary'
+			isSelected && headerEntersWorkspace ? 'bg-surface-hover' : 'bg-surface-tertiary'
 		)}
 		data-workspace-id={workspace.id}
 	>
-		<!-- Main workspace card - clickable to enter workspace -->
-		<div
-			class="px-4 py-2 hover:bg-surface-hover transition-colors w-full"
-			class:rounded-lg={children.length === 0}
-			class:rounded-b-none={children.length > 0}
-			class:opacity-60={isWorkspaceDisabled(workspace)}
-			class:cursor-not-allowed={isWorkspaceDisabled(workspace)}
-			class:cursor-pointer={!isWorkspaceDisabled(workspace)}
-			role="button"
-			tabindex="0"
-			onclick={async () => {
-				onMouseClick?.()
-				if (!isWorkspaceDisabled(workspace)) {
-					await onEnterWorkspace(workspace.id)
-				}
-			}}
-			onkeydown={(e) => {
-				if ((e.key === 'Enter' || e.key === ' ') && !isWorkspaceDisabled(workspace)) {
-					e.preventDefault()
-					onKeyboardNavigation?.()
-					onEnterWorkspace(workspace.id)
-				}
-			}}
-			onmouseenter={() => onMouseEnter?.(workspace.id)}
-		>
-			<div class="flex flex-row items-center justify-between">
-				<div class="flex flex-row items-center gap-3 flex-1 min-w-0">
-					<div class="flex flex-row items-center gap-2 flex-1 min-w-0">
-						<div class="flex-shrink-0">
-							<WorkspaceIcon
-								workspaceColor={workspace.color}
-								{isForked}
-								isDevWorkspace={workspace.is_dev_workspace}
-								devWorkspaceLabel={workspace.dev_workspace_label}
-								parentName={workspace.parent_workspace_id ?? undefined}
-								size={12}
-							/>
-						</div>
-
-						<div class="min-w-0 flex-1">
-							<div class="flex flex-row items-center gap-2 flex-wrap">
-								<span
-									class="text-xs font-semibold truncate {forkAccent
-										? 'text-[color:var(--fork-accent-text)] dark:text-[color:var(--fork-accent-text-dark)]'
-										: 'text-primary'}"
-									style={forkAccent}
-								>
-									{#if workspace.marked}
-										{@html workspace.marked}
-									{:else}
-										{workspace.name}
-									{/if}
-								</span>
-								{#if workspace.is_dev_workspace}
-									<Badge
-										color="dark-blue"
-										small
-										class="text-3xs px-1 py-0 dark:bg-surface-accent-primary text-white dark:text-white"
-										>{devBadgeText(workspace.dev_workspace_label)}</Badge
-									>
-								{/if}
-								<span class="text-secondary text-xs">-</span>
-								{#if workspace.id === 'admins'}
-									<Badge color="blue">{workspace.id}</Badge>
-								{:else}
-									<span class="font-mono text-2xs text-secondary truncate">
-										{workspace.id}
-									</span>
-								{/if}
-							</div>
-
-							<div class="text-xs text-secondary">
-								as <span class="font-mono">{workspace.username}</span>
-								{#if isWorkspaceArchived(workspace)}
-									<span class="text-red-500 ml-1">(archived)</span>
-									{#if $superadmin && onUnarchive}
-										<Button
-											size="xs2"
-											variant="default"
-											btnClasses="ml-1"
-											propagateEvent={false}
-											onClick={handleUnarchive}
-											startIcon={{ icon: ArchiveRestore }}
-										>
-											Unarchive
-										</Button>
-									{/if}
-								{/if}
-								{#if isWorkspaceDisabled(workspace)}
-									<span class="text-red-500 ml-1">(user disabled in this workspace)</span>
-								{/if}
-								{#if workspace.id === 'admins'}
-									<span class="text-accent ml-1">Used to manage your Windmill instance</span>
-								{/if}
-							</div>
-						</div>
-					</div>
-				</div>
+		{#if headerEntersWorkspace}
+			<!-- Main workspace card - clickable to enter workspace -->
+			<div
+				class={twMerge(
+					headerClass,
+					'hover:bg-surface-hover',
+					isWorkspaceDisabled(workspace) ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'
+				)}
+				role="button"
+				tabindex="0"
+				onclick={() => enter(workspace)}
+				onkeydown={(e) => enterOnKey(e, workspace)}
+				onmouseenter={() => onMouseEnter?.(workspace.id)}
+			>
+				{@render header()}
 			</div>
-		</div>
+		{:else}
+			<div class={headerClass}>
+				{@render header()}
+			</div>
+		{/if}
+
+		{#if dev}
+			<div class="flex flex-row gap-2 px-4 pb-3">
+				{@render environment(workspace, 'Production')}
+				{@render environment(dev, devLabelWord(dev.dev_workspace_label))}
+			</div>
+		{/if}
 
 		<!-- Forks section - clickable to expand -->
 		{#if children.length > 0}
@@ -239,6 +313,7 @@
 			{#each sortedChildren as child (child.id)}
 				<WorkspaceCard
 					workspace={child}
+					dev={child._dev}
 					isForked={true}
 					depth={depth + 1}
 					children={child._children || []}

--- a/frontend/src/lib/components/workspace/WorkspaceTreeView.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceTreeView.svelte
@@ -41,7 +41,6 @@
 
 	// Computed expansion states that include auto-expansion for search results
 	let expansionStates = $derived.by(() => {
-		// Every family starts collapsed — only a manual toggle or a search match opens one.
 		if (!searchFilter || !filteredWorkspaces || !workspaces) {
 			return manualExpansionStates
 		}
@@ -76,7 +75,6 @@
 			}
 		})
 
-		// Combine manual and auto-expanded states
 		return { ...manualExpansionStates, ...autoExpanded }
 	})
 

--- a/frontend/src/lib/components/workspace/WorkspaceTreeView.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceTreeView.svelte
@@ -7,6 +7,7 @@
 
 	interface ExtendedWorkspace extends UserWorkspace {
 		_children?: ExtendedWorkspace[]
+		_dev?: ExtendedWorkspace
 		marked?: string
 	}
 
@@ -120,12 +121,22 @@
 			const directChildren = childrenMap.get(workspace.id) || []
 			const thisWorkspaceMatches = matchedWorkspaceIds.has(workspace.id)
 
+			// The canonical dev workspace is presented on its parent's own card, as the second half of
+			// a prod/dev pair, so it never enters the fork list. Forks branched off it come up beside
+			// the parent's own forks — `findDefaultForkBase` bases a fork on the dev workspace whenever
+			// one exists, so that is where most forks of a family hang.
+			const dev = directChildren.find((child) => child.is_dev_workspace)
+			const forkChildren = [
+				...directChildren.filter((child) => child !== dev),
+				...(dev ? (childrenMap.get(dev.id) ?? []) : [])
+			]
+
 			// If this workspace or a parent matches, show all children
 			// Otherwise, only show children that match or have matching descendants
 			const visibleChildren =
 				searchFilter && !parentMatched && !thisWorkspaceMatches
-					? directChildren.filter((child) => hasMatchingDescendant(child.id))
-					: directChildren
+					? forkChildren.filter((child) => hasMatchingDescendant(child.id))
+					: forkChildren
 
 			const childrenWithNestedStructure = visibleChildren.map((child) =>
 				buildWorkspaceWithChildren(child, parentMatched || thisWorkspaceMatches)
@@ -137,6 +148,7 @@
 			return {
 				...workspace,
 				marked: filteredWorkspace?.marked,
+				_dev: dev,
 				_children: childrenWithNestedStructure
 			}
 		}
@@ -168,13 +180,17 @@
 		manualExpansionStates = { ...manualExpansionStates, [workspaceId]: !currentState }
 	}
 
-	// Get IDs of workspaces that have children (can be expanded)
+	// Ids of the cards that actually render a fork section. Read off the built tree, not off
+	// `parent_workspace_id`: a workspace whose only child is its dev workspace shows the pair inline
+	// and has nothing to expand.
 	let workspacesWithChildren = $derived.by(() => {
-		if (!workspaces) return []
-		const parentIds = new Set(
-			workspaces.filter((w) => w.parent_workspace_id).map((w) => w.parent_workspace_id)
-		)
-		return workspaces.filter((w) => parentIds.has(w.id)).map((w) => w.id)
+		const ids: string[] = []
+		function collect(workspace: ExtendedWorkspace) {
+			if (workspace._children?.length) ids.push(workspace.id)
+			workspace._children?.forEach(collect)
+		}
+		rootWorkspaces.forEach(collect)
+		return ids
 	})
 
 	// Check if all expandable workspaces are currently expanded
@@ -207,6 +223,8 @@
 
 		function addWorkspaceAndChildren(workspace: ExtendedWorkspace) {
 			result.push(workspace.id)
+			// The dev half of the pair sits on the same card, so it is always reachable.
+			if (workspace._dev) result.push(workspace._dev.id)
 			if (workspace._children && expansionStates[workspace.id]) {
 				workspace._children.forEach((child) => addWorkspaceAndChildren(child))
 			}
@@ -386,6 +404,7 @@
 		{#each rootWorkspaces as workspace (workspace.id)}
 			<WorkspaceCard
 				{workspace}
+				dev={workspace._dev}
 				children={workspace._children || []}
 				isExpanded={expansionStates[workspace.id] ?? false}
 				{expansionStates}

--- a/frontend/src/lib/components/workspace/WorkspaceTreeView.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceTreeView.svelte
@@ -41,15 +41,9 @@
 
 	// Computed expansion states that include auto-expansion for search results
 	let expansionStates = $derived.by(() => {
-		// Prod nodes that have a canonical dev start expanded so the dev is visible without a click;
-		// manual toggles still win, so the user can collapse them.
-		const devExpanded: Record<string, boolean> = {}
-		workspaces?.forEach((w) => {
-			if (w.is_dev_workspace && w.parent_workspace_id) devExpanded[w.parent_workspace_id] = true
-		})
-
+		// Every family starts collapsed — only a manual toggle or a search match opens one.
 		if (!searchFilter || !filteredWorkspaces || !workspaces) {
-			return { ...devExpanded, ...manualExpansionStates }
+			return manualExpansionStates
 		}
 
 		const matchedWorkspaceIds = new Set(filteredWorkspaces.map((w) => w.id))
@@ -82,8 +76,8 @@
 			}
 		})
 
-		// Combine dev-default, manual, and auto-expanded states
-		return { ...devExpanded, ...manualExpansionStates, ...autoExpanded }
+		// Combine manual and auto-expanded states
+		return { ...manualExpansionStates, ...autoExpanded }
 	})
 
 	// Build nested hierarchy correctly - always use full workspace list for hierarchy

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -611,15 +611,16 @@
 	onMount(() => {
 		loadWorkspaces()
 
-		// Fail open: the section is gated on this, and `edit_auto_invite` rejects a
-		// banned domain anyway, so a failed check costs an error on submit rather
-		// than hiding auto-invite from an allowed domain for good.
+		// Settle on a value rather than leaving the section stuck in its in-flight
+		// state, and settle on `false`: `createWorkspace` commits the workspace
+		// before `editAutoInvite`, so offering the toggle to a domain the backend
+		// then rejects leaves a created workspace behind a failed submit.
 		WorkspaceService.isDomainAllowed()
 			.then((x) => {
 				isDomainAllowed = x
 			})
 			.catch(() => {
-				isDomainAllowed = true
+				isDomainAllowed = false
 			})
 	})
 

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -611,9 +611,16 @@
 	onMount(() => {
 		loadWorkspaces()
 
-		WorkspaceService.isDomainAllowed().then((x) => {
-			isDomainAllowed = x
-		})
+		// Fail open: the section is gated on this, and `edit_auto_invite` rejects a
+		// banned domain anyway, so a failed check costs an error on submit rather
+		// than hiding auto-invite from an allowed domain for good.
+		WorkspaceService.isDomainAllowed()
+			.then((x) => {
+				isDomainAllowed = x
+			})
+			.catch(() => {
+				isDomainAllowed = true
+			})
 	})
 
 	let isDomainAllowed: undefined | boolean = $state(undefined)
@@ -1030,9 +1037,8 @@
 						</div>
 					{/if}
 				</div>
-				<!-- On cloud, generic mail domains (gmail and friends) can't be auto-joined:
-				     the whole section is dropped rather than shown as a dead control.
-				     Also dropped until the check resolves, so it never flashes in and out. -->
+				<!-- Strict `=== true`: undefined means the domain check is still in flight,
+				     and rendering then is a section that flashes in and back out. -->
 				{#if !isCloudHosted() || isDomainAllowed === true}
 					<div class="flex flex-col gap-1">
 						<label for="auto-invite" class="text-xs font-semibold text-emphasis"

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -1030,64 +1030,62 @@
 						</div>
 					{/if}
 				</div>
-				<div class="flex flex-col gap-1">
-					<label for="auto-invite" class="text-xs font-semibold text-emphasis"
-						>{isCloudHosted()
-							? `Auto-${autoAdd ? 'add' : 'invite'} anyone from ${domain}`
-							: `Auto-${autoAdd ? 'add' : 'invite'} anyone joining the instance`}</label
-					>
-					<Toggle
-						id="auto-invite"
-						disabled={isCloudHosted() && !isDomainAllowed}
-						bind:checked={auto_invite}
-					/>
-					{#if isCloudHosted() && isDomainAllowed == false}
-						<div class="text-secondary text-2xs">{domain} domain not allowed for auto-invite</div>
-					{/if}
+				<!-- On cloud, generic mail domains (gmail and friends) can't be auto-joined:
+				     the whole section is dropped rather than shown as a dead control.
+				     Also dropped until the check resolves, so it never flashes in and out. -->
+				{#if !isCloudHosted() || isDomainAllowed === true}
+					<div class="flex flex-col gap-1">
+						<label for="auto-invite" class="text-xs font-semibold text-emphasis"
+							>{isCloudHosted()
+								? `Auto-${autoAdd ? 'add' : 'invite'} anyone from ${domain}`
+								: `Auto-${autoAdd ? 'add' : 'invite'} anyone joining the instance`}</label
+						>
+						<Toggle id="auto-invite" bind:checked={auto_invite} />
 
-					{#if auto_invite}
-						<div class="bg-surface-tertiary p-4 rounded-md flex flex-col gap-8">
-							<!-- svelte-ignore a11y_label_has_associated_control -->
-							{#if isCloudHosted()}
-								<label class="flex flex-col gap-1">
-									<span class="text-xs font-semibold text-emphasis">Mode</span>
+						{#if auto_invite}
+							<div class="bg-surface-tertiary p-4 rounded-md flex flex-col gap-8">
+								<!-- svelte-ignore a11y_label_has_associated_control -->
+								{#if isCloudHosted()}
+									<label class="flex flex-col gap-1">
+										<span class="text-xs font-semibold text-emphasis">Mode</span>
+										<span class="text-xs text-secondary font-normal"
+											>Whether to invite or add users directly to the workspace.</span
+										>
+										<ToggleButtonGroup
+											selected={autoAdd ? 'add' : 'invite'}
+											on:selected={async (e) => {
+												autoAdd = e.detail === 'add'
+											}}
+										>
+											{#snippet children({ item })}
+												<ToggleButton value="invite" label="Auto-invite" {item} />
+												<ToggleButton value="add" label="Auto-add" {item} />
+											{/snippet}
+										</ToggleButtonGroup>
+									</label>
+								{/if}
+
+								<label class="font-semibold flex flex-col gap-1">
+									<span class="text-xs font-semibold text-emphasis">Role</span>
 									<span class="text-xs text-secondary font-normal"
-										>Whether to invite or add users directly to the workspace.</span
+										>Role of the auto-invited users</span
 									>
 									<ToggleButtonGroup
-										selected={autoAdd ? 'add' : 'invite'}
-										on:selected={async (e) => {
-											autoAdd = e.detail === 'add'
+										selected={operatorOnly ? 'operator' : 'developer'}
+										on:selected={(e) => {
+											operatorOnly = e.detail == 'operator'
 										}}
 									>
 										{#snippet children({ item })}
-											<ToggleButton value="invite" label="Auto-invite" {item} />
-											<ToggleButton value="add" label="Auto-add" {item} />
+											<ToggleButton value="operator" label="Operator" {item} />
+											<ToggleButton value="developer" label="Developer" {item} />
 										{/snippet}
 									</ToggleButtonGroup>
 								</label>
-							{/if}
-
-							<label class="font-semibold flex flex-col gap-1">
-								<span class="text-xs font-semibold text-emphasis">Role</span>
-								<span class="text-xs text-secondary font-normal"
-									>Role of the auto-invited users</span
-								>
-								<ToggleButtonGroup
-									selected={operatorOnly ? 'operator' : 'developer'}
-									on:selected={(e) => {
-										operatorOnly = e.detail == 'operator'
-									}}
-								>
-									{#snippet children({ item })}
-										<ToggleButton value="operator" label="Operator" {item} />
-										<ToggleButton value="developer" label="Developer" {item} />
-									{/snippet}
-								</ToggleButtonGroup>
-							</label>
-						</div>
-					{/if}
-				</div>
+							</div>
+						{/if}
+					</div>
+				{/if}
 			{/if}
 		</div>
 	</div>

--- a/frontend/src/routes/(root)/(logged)/user/(user)/workspaces/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/workspaces/+page.svelte
@@ -285,8 +285,6 @@
 			</div>
 		{/if}
 
-		<!-- Nothing pending at all — neither a workspace nor a fork invite — so the
-		     whole section, toggle included, has nothing to reveal. -->
 		{#if invites.length > 0}
 			<div class="flex flex-row items-center justify-between mt-8">
 				<h2 class="text-sm font-semibold text-emphasis">Invites to join a Workspace</h2>

--- a/frontend/src/routes/(root)/(logged)/user/(user)/workspaces/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/workspaces/+page.svelte
@@ -285,104 +285,43 @@
 			</div>
 		{/if}
 
-		<div class="flex flex-row items-center justify-between mt-8">
-			<h2 class="text-sm font-semibold text-emphasis">Invites to join a Workspace</h2>
-			{#if workspaces}
-				<Toggle size="xs" bind:checked={showAllForks} options={{ right: 'Show workspace forks' }} />
-			{/if}
-		</div>
-
-		<div class="mt-4"></div>
-
-		{#if nonForkInvites.length == 0}
-			<p class="text-xs text-secondary"> You don't have new invites at the moment. </p>
-		{/if}
-
-		{#each nonForkInvites as invite}
-			<div
-				class="w-full mx-auto py-1 px-2 rounded-md border border-border-light
-			text-xs mt-1 flex flex-row justify-between items-center"
-			>
-				<div class="grow">
-					<span class="font-mono font-semibold text-emphasis">{invite.workspace_id}</span>
-					{#if invite.is_admin}
-						<span class="text-xs text-primary">as an admin</span>
-					{:else if invite.operator}
-						<span class="text-xs text-primary">as an operator</span>
-					{/if}
-				</div>
-				<div class="flex justify-end items-center flex-col sm:flex-row gap-1">
-					<Button
-						variant="accent"
-						size="xs2"
-						href="{base}/user/accept_invite?workspace={encodeURIComponent(invite.workspace_id)}{rd
-							? `&rd=${encodeURIComponent(rd)}`
-							: ''}"
-					>
-						Accept
-					</Button>
-
-					<Button
-						variant="subtle"
-						size="xs2"
-						onClick={async () => {
-							await UserService.declineInvite({
-								requestBody: { workspace_id: invite.workspace_id }
-							})
-							sendUserToast(`Declined invite to ${invite.workspace_id}`)
-							loadInvites()
-						}}
-						destructive
-					>
-						Decline
-					</Button>
-				</div>
+		<!-- Nothing pending at all — neither a workspace nor a fork invite — so the
+		     whole section, toggle included, has nothing to reveal. -->
+		{#if invites.length > 0}
+			<div class="flex flex-row items-center justify-between mt-8">
+				<h2 class="text-sm font-semibold text-emphasis">Invites to join a Workspace</h2>
+				{#if workspaces}
+					<Toggle
+						size="xs"
+						bind:checked={showAllForks}
+						options={{ right: 'Show workspace forks' }}
+					/>
+				{/if}
 			</div>
-		{/each}
-
-		{#if showAllForks}
-			{@const allWorkspacesList = workspaces || []}
-			{@const filteredInvites = invites.filter((invite) => invite.parent_workspace_id)}
 
 			<div class="mt-4"></div>
-			{#if filteredInvites.length == 0}
-				<p class="text-xs text-secondary"
-					>There are no invites to join the forks of any workspace you're in.</p
-				>
-			{:else}
-				<span class="mb-2 text-xs font-normal text-secondary"
-					>Forks of the workspaces you're in</span
-				>
+
+			{#if nonForkInvites.length == 0}
+				<p class="text-xs text-secondary"> You don't have new invites at the moment. </p>
 			{/if}
 
-			{#each filteredInvites as invite}
-				{@const inviteWorkspace = allWorkspacesList.find((w) => w.id === invite.workspace_id)}
+			{#each nonForkInvites as invite}
 				<div
 					class="w-full mx-auto py-1 px-2 rounded-md border border-border-light
 			text-xs mt-1 flex flex-row justify-between items-center"
 				>
 					<div class="grow">
-						<div class="flex items-center gap-2">
-							{#if inviteWorkspace?.parent_workspace_id}
-								<GitFork size={12} class="text-secondary flex-shrink-0" />
-							{/if}
-							<span class="font-mono font-semibold text-emphasis">{invite.workspace_id}</span>
-						</div>
+						<span class="font-mono font-semibold text-emphasis">{invite.workspace_id}</span>
 						{#if invite.is_admin}
 							<span class="text-xs text-primary">as an admin</span>
 						{:else if invite.operator}
 							<span class="text-xs text-primary">as an operator</span>
 						{/if}
-						{#if invite.parent_workspace_id}
-							<div class="text-secondary text-2xs mt-1">
-								Fork of {invite.parent_workspace_id}
-							</div>
-						{/if}
 					</div>
 					<div class="flex justify-end items-center flex-col sm:flex-row gap-1">
 						<Button
 							variant="accent"
-							unifiedSize="xs"
+							size="xs2"
 							href="{base}/user/accept_invite?workspace={encodeURIComponent(invite.workspace_id)}{rd
 								? `&rd=${encodeURIComponent(rd)}`
 								: ''}"
@@ -392,8 +331,7 @@
 
 						<Button
 							variant="subtle"
-							unifiedSize="xs"
-							destructive
+							size="xs2"
 							onClick={async () => {
 								await UserService.declineInvite({
 									requestBody: { workspace_id: invite.workspace_id }
@@ -401,12 +339,82 @@
 								sendUserToast(`Declined invite to ${invite.workspace_id}`)
 								loadInvites()
 							}}
+							destructive
 						>
 							Decline
 						</Button>
 					</div>
 				</div>
 			{/each}
+
+			{#if showAllForks}
+				{@const allWorkspacesList = workspaces || []}
+				{@const filteredInvites = invites.filter((invite) => invite.parent_workspace_id)}
+
+				<div class="mt-4"></div>
+				{#if filteredInvites.length == 0}
+					<p class="text-xs text-secondary"
+						>There are no invites to join the forks of any workspace you're in.</p
+					>
+				{:else}
+					<span class="mb-2 text-xs font-normal text-secondary"
+						>Forks of the workspaces you're in</span
+					>
+				{/if}
+
+				{#each filteredInvites as invite}
+					{@const inviteWorkspace = allWorkspacesList.find((w) => w.id === invite.workspace_id)}
+					<div
+						class="w-full mx-auto py-1 px-2 rounded-md border border-border-light
+			text-xs mt-1 flex flex-row justify-between items-center"
+					>
+						<div class="grow">
+							<div class="flex items-center gap-2">
+								{#if inviteWorkspace?.parent_workspace_id}
+									<GitFork size={12} class="text-secondary flex-shrink-0" />
+								{/if}
+								<span class="font-mono font-semibold text-emphasis">{invite.workspace_id}</span>
+							</div>
+							{#if invite.is_admin}
+								<span class="text-xs text-primary">as an admin</span>
+							{:else if invite.operator}
+								<span class="text-xs text-primary">as an operator</span>
+							{/if}
+							{#if invite.parent_workspace_id}
+								<div class="text-secondary text-2xs mt-1">
+									Fork of {invite.parent_workspace_id}
+								</div>
+							{/if}
+						</div>
+						<div class="flex justify-end items-center flex-col sm:flex-row gap-1">
+							<Button
+								variant="accent"
+								unifiedSize="xs"
+								href="{base}/user/accept_invite?workspace={encodeURIComponent(
+									invite.workspace_id
+								)}{rd ? `&rd=${encodeURIComponent(rd)}` : ''}"
+							>
+								Accept
+							</Button>
+
+							<Button
+								variant="subtle"
+								unifiedSize="xs"
+								destructive
+								onClick={async () => {
+									await UserService.declineInvite({
+										requestBody: { workspace_id: invite.workspace_id }
+									})
+									sendUserToast(`Declined invite to ${invite.workspace_id}`)
+									loadInvites()
+								}}
+							>
+								Decline
+							</Button>
+						</div>
+					</div>
+				{/each}
+			{/if}
 		{/if}
 
 		<div class="flex justify-between items-center mt-10 flex-wrap gap-2">


### PR DESCRIPTION
## Summary

Rework the workspace picker (`/user/workspaces`) around the prod/dev pair, plus two smaller declutters on that page and on the create-workspace form.

A dev workspace is a fork mechanically, but it isn't one conceptually: prod and dev are siblings — two environments of the same thing — and burying dev under a collapsed "1 fork" row turned that duality into a hierarchy. This restores it: the card header names the family, and the two environments sit side by side underneath as the actual choice. Genuine throwaway forks keep their collapsed section below.

## Changes

- **`WorkspaceCard` — prod/dev pair.** When a workspace has a canonical dev workspace, the header (icon, name, id) becomes inert and two cards render below it: **Production** and **Dev** (or **Staging**, following `dev_workspace_label`), each with its own `as <username>`, hover/selection state, disabled and archived treatment, and Unarchive button. The dev card also shows the dev workspace's id, which the header doesn't carry. With no dev workspace the card is unchanged — whole card clickable, identity line in the header.
- **`WorkspaceTreeView` — dev lifted out of the fork list.** The canonical dev child moves to a `_dev` slot on its parent instead of into `_children`. Forks branched off the dev workspace are lifted beside the parent's own forks: `findDefaultForkBase` bases a fork on the dev workspace whenever one exists, so that is where most of a family's forks hang, and they would otherwise disappear along with it. Two consequences handled: `workspacesWithChildren` (which drives `hasForks` and the Expand/Collapse-all button) is now read off the built tree rather than off `parent_workspace_id`, so a family whose only child is its dev workspace correctly reports nothing to expand; and keyboard navigation pushes the dev id right after its parent's, since it is always visible.
- **`WorkspaceTreeView` — families start collapsed.** Previously a prod workspace with a canonical dev under it was expanded by default, so fork-heavy instances opened part-unfolded. Manual chevron toggles, Expand-all, and search auto-expansion are unchanged; as a side effect the Expand/Collapse button label now starts correctly at "Expand".
- **`/user/workspaces` invites section.** The "Invites to join a Workspace" heading, the "Show workspace forks" toggle, the "You don't have new invites at the moment." line and both invite lists are gated on `invites.length > 0`. When there are only fork invites the section still renders, so the toggle can reveal them.
- **`CreateWorkspaceInner`.** On cloud, the auto-add/auto-invite block (label, toggle, Mode/Role sub-panel) is hidden when the account's mail domain isn't allowed, replacing the disabled toggle plus the "`<domain>` domain not allowed for auto-invite" message. It is also hidden until the `isDomainAllowed()` check resolves — and the check fails closed, because `createWorkspace` commits the workspace *before* `editAutoInvite`, so offering the toggle to a domain the backend then rejects would leave a created workspace behind a failed submit. Self-hosted is unaffected; the section always renders there.

`auto_invite` defaults to `false` and the create path only calls the invite API under `if (auto_invite)`, so hiding the control cannot change what gets submitted. The component is only ever used for workspace/fork *creation*, never as an edit form, so the guard can't hide an existing setting.

## Screenshots

`/user/workspaces` — "AI Meta E2E" shows the Production/Dev pair with its 12 forks collapsed below (those forks hang off the dev workspace and were previously reachable only by unfolding it); "Debug sessions" and "Diff testing" have no dev workspace and keep the plain clickable card:

![wsnits-prod-dev-pair](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/nit-workspace-picker/1786452969-wsnits-prod-dev-pair.png)

Create workspace, self-hosted — the auto-add section renders as before (the hidden case is cloud-only and can't be reproduced on a local instance):

![create-workspace-autoadd](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/nit-workspace-picker/1786084036-wsnits-create-workspace-autoadd.png)

## Test plan

- [ ] Prod workspace with a canonical dev child: the card shows Production and Dev side by side, clicking each enters the right workspace, and clicking the header does nothing.
- [ ] Same family with forks branched off the dev workspace: they appear in the family's collapsed fork section rather than vanishing with the dev workspace.
- [ ] Workspace with a dev child and no other forks: no fork row, and the Expand/Collapse-all button reflects that it has nothing to expand.
- [ ] Keyboard navigation walks prod → dev → forks (when expanded), and Enter on the dev row enters the dev workspace.
- [ ] Searching a dev workspace's name or id still surfaces its family.
- [ ] Zero pending invites: the "Invites to join a Workspace" heading and the "Show workspace forks" toggle are both gone; with a fork-only invite the section appears and the toggle reveals it.
- [ ] Create workspace, cloud, gmail-domain account: the auto-add section is absent rather than disabled; an allowed-domain account still gets the toggle.
