### PR TITLE
fix: block the whole 0.0.0.0/8 range in the SSRF filters

### DIFF
--- a/backend/windmill-common/src/ssrf.rs
+++ b/backend/windmill-common/src/ssrf.rs
@@ -280,7 +280,10 @@ fn is_private_ipv4(ip: &Ipv4Addr) -> bool {
         || ip.is_private()        // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
         || ip.is_link_local()     // 169.254.0.0/16 (AWS IMDS lives here)
         || ip.is_broadcast()      // 255.255.255.255
-        || ip.is_unspecified()    // 0.0.0.0
+        // RFC 1122 "this network": the whole /8, not just the unspecified
+        // address `is_unspecified()` matches — stacks that map 0.x.y.z onto the
+        // local host make `0.0.0.1` a bypass.
+        || ip.octets()[0] == 0    // 0.0.0.0/8
         || ip.is_documentation()  // 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
         // CGNAT / shared address space
         || (ip.octets()[0] == 100 && (ip.octets()[1] & 0xC0) == 64) // 100.64.0.0/10
@@ -362,6 +365,9 @@ mod tests {
         assert!(is_private_ipv4(&"192.168.1.1".parse().unwrap()));
         assert!(is_private_ipv4(&"169.254.169.254".parse().unwrap()));
         assert!(is_private_ipv4(&"0.0.0.0".parse().unwrap()));
+        // The whole 0.0.0.0/8 block, not just the unspecified address.
+        assert!(is_private_ipv4(&"0.0.0.1".parse().unwrap()));
+        assert!(is_private_ipv4(&"0.255.255.255".parse().unwrap()));
         assert!(is_private_ipv4(&"100.64.0.1".parse().unwrap()));
         assert!(!is_private_ipv4(&"8.8.8.8".parse().unwrap()));
         assert!(!is_private_ipv4(&"1.1.1.1".parse().unwrap()));

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -2465,7 +2465,10 @@ fn is_private_or_reserved_ip(ip: &IpAddr) -> bool {
             v4.is_loopback()
                 || v4.is_private()
                 || v4.is_link_local()
-                || v4.is_unspecified()
+                // RFC 1122 "this network": the whole /8, not just the
+                // unspecified address `is_unspecified()` matches — stacks that
+                // map 0.x.y.z onto the local host make `0.0.0.1` a bypass.
+                || v4.octets()[0] == 0 // 0.0.0.0/8
                 || v4.is_broadcast()
                 // 100.64.0.0/10 (Carrier-grade NAT / CGNAT)
                 || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
@@ -3416,9 +3419,12 @@ mod tests {
         assert!(is_private_or_reserved_ip(
             &"100.64.0.1".parse::<IpAddr>().unwrap()
         ));
-        // Unspecified
+        // "This network" 0.0.0.0/8, not just the unspecified address
         assert!(is_private_or_reserved_ip(
             &"0.0.0.0".parse::<IpAddr>().unwrap()
+        ));
+        assert!(is_private_or_reserved_ip(
+            &"0.0.0.1".parse::<IpAddr>().unwrap()
         ));
         // IPv6 loopback
         assert!(is_private_or_reserved_ip(&"::1".parse::<IpAddr>().unwrap()));


### PR DESCRIPTION
## Summary

The SSRF guards rejected the 0.0.0.0/8 "this network" block with `Ipv4Addr::is_unspecified()`, which matches only the exact address `0.0.0.0`. Everything from `0.0.0.1` to `0.255.255.255` passed the filter as public. Stacks that map `0.x.y.z` onto the local host turn that into a plain localhost bypass, and URL parsing makes the shorthand forms trivial to reach: WHATWG host parsing normalizes `http://1` to `0.0.0.1` and `http://016777217` to `0.59.254.143`, so an attacker never has to type an address that looks reserved.

The same defect existed in two independent predicates, both fixed here:

- `is_private_ipv4` in `backend/windmill-common/src/ssrf.rs` — the shared `validate_url_for_ssrf` guard behind the AI proxy, WebSocket trigger validation, MCP server URLs, and SAML metadata URLs.
- `is_private_or_reserved_ip` in `backend/windmill-store/src/resources.rs` — the git repository URL guard.

The third private-IP predicate in the backend, `is_forbidden_ip` in `windmill-api-settings/src/lib.rs` (object-storage endpoints), already blocked the full /8; all three now agree.

The replacement is a strict superset of what `is_unspecified()` matched, so nothing previously blocked becomes allowed, and 0.0.0.0/8 is unroutable per RFC 1122 so no legitimate destination is lost. The IPv6 path already delegates IPv4-mapped addresses to the IPv4 predicate, so `::ffff:0.x.y.z` is covered too.

Fixes WIN-2339.

## Changes

- `backend/windmill-common/src/ssrf.rs`: `is_private_ipv4` blocks `octets()[0] == 0` (the whole 0.0.0.0/8) instead of only the unspecified address.
- `backend/windmill-store/src/resources.rs`: same fix in `is_private_or_reserved_ip`, the git-URL guard.
- Regression assertions in the two existing predicate tests: `0.0.0.1` and `0.255.255.255` in `test_private_ipv4`, `0.0.0.1` in `test_is_private_or_reserved_ip`.

## Test plan

- [x] `cargo test -p windmill-common --lib ssrf::` — 19 passed.
- [x] `cargo test -p windmill-store --lib is_private_or_reserved` — 1 passed.
- [x] Confirmed the new assertions actually guard: with the predicate reverted to `is_unspecified()`, `test_private_ipv4` fails on `0.0.0.1`.
- [x] Exercised the live guard end-to-end through the AI proxy (`POST /api/w/{ws}/ai/proxy/chat/completions` with an OpenAI resource whose `base_url` is the target). All rejected with `URL targets/resolves to a private/internal IP address`:
  - `http://0.0.0.1:11434/v1`
  - `http://1/v1` (normalizes to `0.0.0.1`)
  - `http://016777217/v1`
  - `http://[::ffff:0.0.0.1]/v1`
- [x] No over-blocking: the same proxy call with `https://api.openai.com/v1` still reaches the upstream API (it returns OpenAI's own invalid-key error).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks the entire 0.0.0.0/8 in SSRF checks to prevent localhost bypass via 0.x.y.z and shorthands (e.g., http://1); fixes WIN-2339. Aligns predicates and covers IPv6-mapped addresses; no legitimate traffic is affected.

- **Bug Fixes**
  - `backend/windmill-common/src/ssrf.rs`: `is_private_ipv4` now blocks `ip.octets()[0] == 0` (0.0.0.0/8).
  - `backend/windmill-store/src/resources.rs`: `is_private_or_reserved_ip` now blocks `v4.octets()[0] == 0` (0.0.0.0/8).
  - Added tests for `0.0.0.1` and `0.255.255.255`; end-to-end check via the AI proxy rejects `http://1` and `::ffff:0.0.0.1`.

<sup>Written for commit 6751f18cfff1076e49476e3e18b86503a7f05efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

