### PR TITLE
fix(frontend): stack login options in one column below four

### DIFF
--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -455,6 +455,8 @@
 	$effect(() => {
 		error && sendUserToast(escapeHtml(error), true)
 	})
+
+	let loginOptionCount = $derived((logins?.length ?? 0) + (saml ? 1 : 0))
 </script>
 
 <div class="bg-surface px-4 py-8 border sm:rounded-lg sm:px-10">
@@ -462,9 +464,7 @@
 		<p class="text-sm text-center text-secondary py-4">Signing you in…</p>
 	{/if}
 	<div
-		class="grid {logins && logins.length > 2 ? 'grid-cols-2' : ''} gap-4 {autoRedirecting
-			? 'hidden'
-			: ''}"
+		class="grid {loginOptionCount > 3 ? 'grid-cols-2' : ''} gap-4 {autoRedirecting ? 'hidden' : ''}"
 	>
 		{#if !logins}
 			{#each Array(4) as _}
@@ -483,17 +483,13 @@
 				{/if}
 			{/each}
 			{#each logins.filter((login) => !providersType?.includes(login.type)) as login}
-				<Button
-					variant="default"
-					btnClasses="mt-2 w-full"
-					on:click={() => storeRedirect(login.type)}
-				>
+				<Button variant="default" btnClasses="w-full" on:click={() => storeRedirect(login.type)}>
 					{login.displayName}
 				</Button>
 			{/each}
 		{/if}
 		{#if saml}
-			<Button variant="default" btnClasses="mt-2 w-full" on:click={redirectSaml}>SSO</Button>
+			<Button variant="default" btnClasses="w-full" on:click={redirectSaml}>SSO</Button>
 		{/if}
 	</div>
 	{#if !autoRedirecting && !disablePasswordLogin && (saml || (logins && logins.length > 0))}

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -483,13 +483,13 @@
 				{/if}
 			{/each}
 			{#each logins.filter((login) => !providersType?.includes(login.type)) as login}
-				<Button variant="default" btnClasses="w-full" on:click={() => storeRedirect(login.type)}>
+				<Button variant="default" on:click={() => storeRedirect(login.type)}>
 					{login.displayName}
 				</Button>
 			{/each}
 		{/if}
 		{#if saml}
-			<Button variant="default" btnClasses="w-full" on:click={redirectSaml}>SSO</Button>
+			<Button variant="default" on:click={redirectSaml}>SSO</Button>
 		{/if}
 	</div>
 	{#if !autoRedirecting && !disablePasswordLogin && (saml || (logins && logins.length > 0))}


### PR DESCRIPTION
## Summary

On the login page, the third-party login buttons switched to a two-column grid as soon as there were 3 options, leaving an orphaned button on its own row. Instances with 2 or 3 configured providers now get a single stacked column; the two-column grid kicks in from 4 options.

## Changes

- `Login.svelte`: the grid switches to `grid-cols-2` above 4 options instead of above 2.
- The option tally now includes the SAML/SSO button, which was previously excluded from the count that drove the layout.
- Dropped the stray `mt-2` on the custom-provider and SSO buttons — they are grid children, so `gap-4` already spaces them and the margin made the stacked column unevenly spaced.

## Screenshots

Before — 3 providers, orphaned third button:

![login-three-options-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/nit-connection-layout/1786113840-login-three-options-before.png)

After — 3 providers stacked in one column:

![login-three-options](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/nit-connection-layout/1786113843-login-three-options.png)

After — 4 providers, two-column grid retained:

![login-four-options](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/nit-connection-layout/1786113845-login-four-options.png)

## Test plan

- [ ] Instance with 2 or 3 OAuth providers configured: `/user/login` stacks the buttons in one full-width column.
- [ ] Instance with 4+ providers: buttons still render in the two-column grid.
- [ ] Instance with SAML plus 3 OAuth providers (4 options total): the grid is two columns and the SSO button aligns with the rest.