### PR TITLE
S3BufferedReader.read(size) returns whole HTTP chunks, not size bytes — up to ~3.3 GB in memory via write_s3_file

### DIFF
--- a/python-client/tests/wmill_client_test.py
+++ b/python-client/tests/wmill_client_test.py
@@ -168,5 +168,54 @@ class TestParseS3Object(unittest.TestCase):
     def test_s3object_passes_through(self):
         self.assertEqual(wmill.parse_s3_object(S3Object(s3="x")), S3Object(s3="x"))
 
+class TestS3BufferedReaderRead(unittest.TestCase):
+    """Pure-unit tests for S3BufferedReader.read — no network/env needed.
+
+    iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must slice
+    the last chunk and buffer the leftover for the next call.
+    """
+
+    def make_reader(self, chunks):
+        from wmill.s3_reader import S3BufferedReader
+
+        reader = object.__new__(S3BufferedReader)
+        reader._iterator = iter(chunks)
+        reader._buffer = bytearray()
+        return reader
+
+    def test_read_size_returns_exact_bytes(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(5), b"AAAAA")
+
+    def test_read_size_preserves_leftover_across_calls(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(5), b"AAAAA")
+        self.assertEqual(reader.read(5), b"AAAAA")
+        self.assertEqual(reader.read(10), b"BBBBBBBBBB")
+        self.assertEqual(reader.read(7), b"CCCCCCC")
+        self.assertEqual(reader.read(5), b"CCC")
+        self.assertEqual(reader.read(5), b"")
+
+    def test_read_all_returns_everything(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(-1), b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC")
+
+    def test_read_all_after_partial_read(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(5), b"AAAAA")
+        self.assertEqual(reader.read(-1), b"AAAAABBBBBBBBBBCCCCCCCCCC")
+
+    def test_bytes_generator_never_exceeds_50kb_chunk(self):
+        reader = self.make_reader([b"x" * 65536] * 5)
+        total = 0
+        while True:
+            byte = reader.read(50 * 1024)
+            if not byte:
+                break
+            self.assertLessEqual(len(byte), 50 * 1024)
+            total += len(byte)
+        self.assertEqual(total, 5 * 65536)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -1,0 +1,83 @@
+"""Unit tests for S3BufferedReader.read — no network/env needed."""
+
+from wmill.s3_reader import S3BufferedReader
+
+CHUNKS = [b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"]
+
+
+class _FakeStream:
+    """Stands in for the httpx stream response S3BufferedReader reads from."""
+
+    status_code = 200
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def iter_bytes(self):
+        return iter(self._chunks)
+
+
+class _FakeClient:
+    """Stands in for the httpx client, so construction never touches the network."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def stream(self, method, url, params=None, timeout=None):
+        return _FakeStream(self._chunks)
+
+
+def make_reader(chunks):
+    reader = S3BufferedReader("ws", _FakeClient(chunks), "file.txt", None, None)
+    reader.__enter__()
+    return reader
+
+
+def test_read_size_returns_exact_bytes():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+
+
+def test_read_size_preserves_leftover_across_calls():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    assert reader.read(5) == b"AAAAA"
+    assert reader.read(10) == b"BBBBBBBBBB"
+    assert reader.read(7) == b"CCCCCCC"
+    assert reader.read(5) == b"CCC"
+    assert reader.read(5) == b""
+
+
+def test_read_zero_returns_empty_without_consuming():
+    reader = make_reader(CHUNKS)
+    assert reader.read(0) == b""
+    assert reader.read(5) == b"AAAAA"
+
+
+def test_read_all_returns_everything():
+    reader = make_reader(CHUNKS)
+    assert reader.read(-1) == b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC"
+
+
+def test_read_all_after_partial_read():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    assert reader.read(-1) == b"AAAAABBBBBBBBBBCCCCCCCCCC"
+
+
+def test_bytes_generator_never_exceeds_50kb_chunk():
+    reader = make_reader([b"x" * 65536] * 5)
+    total = 0
+    while True:
+        byte = reader.read(50 * 1024)
+        if not byte:
+            break
+        assert len(byte) <= 50 * 1024
+        total += len(byte)
+    assert total == 5 * 65536

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -60,6 +60,29 @@ def test_read_zero_returns_empty_without_consuming():
     assert reader.read(5) == b"AAAAA"
 
 
+def test_peek_returns_without_consuming():
+    reader = make_reader(CHUNKS)
+    assert reader.peek() == b"AAAAAAAAAA"
+    assert reader.peek(5) == b"AAAAAAAAAA"
+    assert reader.read(10) == b"AAAAAAAAAA"
+
+
+def test_peek_after_partial_read_returns_leftover():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    assert reader.peek(5) == b"AAAAA"
+    assert reader.read(5) == b"AAAAA"
+
+
+def test_peek_fills_when_buffered_bytes_are_insufficient():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    peeked = reader.peek(7)
+    assert peeked.startswith(b"AAAAA")
+    assert len(peeked) >= 7
+    assert reader.read(len(peeked)) == peeked
+
+
 def test_read_all_returns_everything():
     reader = make_reader(CHUNKS)
     assert reader.read(-1) == b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC"

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -52,20 +52,15 @@ class S3BufferedReader(BufferedReader):
     def read(self, size=-1):
         # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
         # slice the last chunk and buffer the leftover for the next call.
-        if size < 0:
-            while True:
-                try:
-                    self._buffer.extend(self._iterator.__next__())
-                except StopIteration:
-                    break
-            result = bytes(self._buffer)
-            self._buffer.clear()
-            return result
-        while len(self._buffer) < size:
+        while size < 0 or len(self._buffer) < size:
             try:
                 self._buffer.extend(self._iterator.__next__())
             except StopIteration:
                 break
+        if size < 0:
+            result = bytes(self._buffer)
+            self._buffer.clear()
+            return result
         result = bytes(self._buffer[:size])
         del self._buffer[:size]
         return result

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -47,16 +47,22 @@ class S3BufferedReader(BufferedReader):
         return self
 
     def peek(self, size=0):
-        raise Exception("Not implemented, use read() instead")
+        # Return buffered bytes without consuming them; fill to the
+        # requested amount first (one chunk when size is unset).
+        self._fill(size if size > 0 else 1)
+        return bytes(self._buffer)
 
-    def read(self, size=-1):
+    def _fill(self, limit):
         # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
         # slice the last chunk and buffer the leftover for the next call.
-        while size < 0 or len(self._buffer) < size:
+        while limit < 0 or len(self._buffer) < limit:
             try:
                 self._buffer.extend(self._iterator.__next__())
             except StopIteration:
                 break
+
+    def read(self, size=-1):
+        self._fill(size)
         if size < 0:
             result = bytes(self._buffer)
             self._buffer.clear()

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -28,6 +28,7 @@ class S3BufferedReader(BufferedReader):
             params=params,
             timeout=None,
         )
+        self._buffer = bytearray()
 
     def __enter__(self):
         reader = self._context_manager.__enter__()
@@ -49,19 +50,25 @@ class S3BufferedReader(BufferedReader):
         raise Exception("Not implemented, use read() instead")
 
     def read(self, size=-1):
-        read_result = []
+        # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
+        # slice the last chunk and buffer the leftover for the next call.
         if size < 0:
-            for b in self._iterator:
-                read_result.append(b)
-        else:
-            for i in range(size):
+            while True:
                 try:
-                    b = self._iterator.__next__()
+                    self._buffer.extend(self._iterator.__next__())
                 except StopIteration:
                     break
-                read_result.append(b)
-
-        return b"".join(read_result)
+            result = bytes(self._buffer)
+            self._buffer.clear()
+            return result
+        while len(self._buffer) < size:
+            try:
+                self._buffer.extend(self._iterator.__next__())
+            except StopIteration:
+                break
+        result = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        return result
 
     def read1(self, size=-1):
         return self.read(size)


### PR DESCRIPTION
Description
python-client/wmill/wmill/s3_reader.py — S3BufferedReader.read(size) loops range(size) times and appends the whole chunk from iter_bytes() each iteration. httpx streams yield ~64 KB (65536-byte) chunks, so size counts chunks: read(5) returns up to 5 chunks (~320 KB), violating the io.BufferedReader.read(n) contract of returning at most n bytes.
Production impact: bytes_generator() (used by write_s3_file) calls read(50 * 1024), so a single call can return up to 51200 × 64 KB ≈ 3.3 GB instead of a 50 KB slice (bounded by the file size). read() with no args and load_s3_file are unaffected.
Steps to reproduce (no network)
import sys
sys.path.insert(0, "python-client/wmill")
from wmill.s3_reader import S3BufferedReader

r = object.__new__(S3BufferedReader)
r._iterator = iter([b"A" * 10, b"B" * 10, b"C" * 10])
print(r.read(5))  # b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC" (30 bytes), expected b"AAAAA"
Expected
read(size) returns at most size bytes, buffering the remainder of the final chunk for the next call; read(-1) returns everything.
Environment
wmill 1.783.0, httpx >= 0.24
Introduced by the object_store migration in #3116.