### PR TITLE
feat(sdk): add S3 connection settings helpers and cancelJob

### DIFF
--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -1297,6 +1297,25 @@ class Windmill:
             params=params,
         ).json()
 
+    def database_url_from_resource(self, path: str) -> str:
+        """Build a PostgreSQL connection URL from a database resource.
+
+        Args:
+            path: Path to the database resource in Windmill
+
+        Returns:
+            PostgreSQL connection URL string
+        """
+        resource = self.get_resource(path)
+        return "postgresql://{}:{}@{}:{}/{}?sslmode={}".format(
+            resource["user"],
+            resource["password"],
+            resource["host"],
+            resource["port"],
+            resource["dbname"],
+            resource["sslmode"],
+        )
+
     def request_interactive_slack_approval(
         self,
         slack_resource_path: str,
@@ -1722,6 +1741,19 @@ def get_result(job_id: str, assert_result_is_not_none=True) -> Dict[str, Any]:
     return _client.get_result(
         job_id=job_id, assert_result_is_not_none=assert_result_is_not_none
     )
+
+
+@init_global_client
+def database_url_from_resource(path: str) -> str:
+    """Build a PostgreSQL connection URL from a database resource.
+
+    Args:
+        path: Path to the database resource in Windmill
+
+    Returns:
+        PostgreSQL connection URL string
+    """
+    return _client.database_url_from_resource(path)
 
 
 @init_global_client

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -1306,14 +1306,21 @@ class Windmill:
         Returns:
             PostgreSQL connection URL string
         """
+        from urllib.parse import quote
+
         resource = self.get_resource(path)
+        # Defaults mirror PgDatabase::to_uri(); quote each component so that
+        # credentials containing '@', '/', '?' etc. cannot reshape the URI.
+        host = resource["host"]
+        if not (host.startswith("[") and host.endswith("]")):
+            host = quote(host, safe="")
         return "postgresql://{}:{}@{}:{}/{}?sslmode={}".format(
-            resource["user"],
-            resource["password"],
-            resource["host"],
-            resource["port"],
-            resource["dbname"],
-            resource["sslmode"],
+            quote(str(resource.get("user") or "postgres"), safe=""),
+            quote(str(resource.get("password") or ""), safe=""),
+            host,
+            resource.get("port") or 5432,
+            quote(resource["dbname"], safe=""),
+            resource.get("sslmode") or "prefer",
         )
 
     def request_interactive_slack_approval(

--- a/typescript-client/build.sh
+++ b/typescript-client/build.sh
@@ -44,9 +44,9 @@ cp "${script_dirpath}/wacError.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/s3Types.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/sqlUtils.ts" "${script_dirpath}/src/"
 echo "" >> "${script_dirpath}/src/index.ts"
-echo 'export type { DenoS3LightClientSettings } from "./s3Types";' >> "${script_dirpath}/src/index.ts"
+echo 'export type { DenoS3LightClientSettings, DuckDbConnectionSettings, PolarsConnectionSettings, Boto3ConnectionSettings } from "./s3Types";' >> "${script_dirpath}/src/index.ts"
 echo "" >> "${script_dirpath}/src/index.ts"
-echo 'export { type Base64, setClient, getVariable, setVariable, getResource, setResource, getResumeUrls, setState, setProgress, getProgress, getState, getIdToken, denoS3LightClientSettings, loadS3FileStream, loadS3File, writeS3File, deleteS3File, signS3Objects, signS3Object, getPresignedS3PublicUrls, getPresignedS3PublicUrl, task, taskScript, taskFlow, workflow, step, sleep, parallel, waitForApproval, getApprovalUrls, type TaskOptions, type Jsonified, type JsonifiedFn, WorkflowCtx, _workflowCtx, setWorkflowCtx, StepSuspend, runScript, runScriptAsync, runScriptByPath, runScriptByHash, runScriptByPathAsync, runScriptByHashAsync, runFlow, runFlowAsync, waitJob, getRootJobId, setFlowUserState, getFlowUserState, usernameToEmail, requestInteractiveSlackApproval, type Sql, requestInteractiveTeamsApproval, appendToResultStream, streamResult, datatable, ducklake, upsertPartition, appendPartition, type DucklakeMaterializeOptions, type SqlStatement, type DatatableSqlTemplateFunction, type SqlTemplateFunction, type S3Object, type S3ObjectRecord, type S3ObjectURI, commitKafkaOffsets } from "./client";' >> "${script_dirpath}/src/index.ts"
+echo 'export { type Base64, setClient, getVariable, setVariable, getResource, setResource, getResumeUrls, setState, setProgress, getProgress, getState, getIdToken, denoS3LightClientSettings, duckdbConnectionSettings, polarsConnectionSettings, boto3ConnectionSettings, cancelJob, loadS3FileStream, loadS3File, writeS3File, deleteS3File, signS3Objects, signS3Object, getPresignedS3PublicUrls, getPresignedS3PublicUrl, task, taskScript, taskFlow, workflow, step, sleep, parallel, waitForApproval, getApprovalUrls, type TaskOptions, type Jsonified, type JsonifiedFn, WorkflowCtx, _workflowCtx, setWorkflowCtx, StepSuspend, runScript, runScriptAsync, runScriptByPath, runScriptByHash, runScriptByPathAsync, runScriptByHashAsync, runFlow, runFlowAsync, waitJob, getRootJobId, setFlowUserState, getFlowUserState, usernameToEmail, requestInteractiveSlackApproval, type Sql, requestInteractiveTeamsApproval, appendToResultStream, streamResult, datatable, ducklake, upsertPartition, appendPartition, type DucklakeMaterializeOptions, type SqlStatement, type DatatableSqlTemplateFunction, type SqlTemplateFunction, type S3Object, type S3ObjectRecord, type S3ObjectURI, commitKafkaOffsets } from "./client";' >> "${script_dirpath}/src/index.ts"
 
 # Build default export by combining client utilities + services
 # This preserves backward compatibility for `import wmill from "windmill-client"`
@@ -66,6 +66,10 @@ import {
   getState,
   getIdToken,
   denoS3LightClientSettings,
+  duckdbConnectionSettings,
+  polarsConnectionSettings,
+  boto3ConnectionSettings,
+  cancelJob,
   loadS3FileStream,
   loadS3File,
   writeS3File,
@@ -155,6 +159,10 @@ const wmill = {
   getState,
   getIdToken,
   denoS3LightClientSettings,
+  duckdbConnectionSettings,
+  polarsConnectionSettings,
+  boto3ConnectionSettings,
+  cancelJob,
   loadS3FileStream,
   loadS3File,
   writeS3File,

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -11,6 +11,7 @@ import {
   UserService,
   KafkaTriggerService,
 } from "./services.gen";
+import type { S3Resource } from "./types.gen";
 import { OpenAPI } from "./core/OpenAPI";
 import { isSuspendSignal, stepErrorMarker, taskErrorFromMarker } from "./wacError";
 // import type { DenoS3LightClientSettings } from "./index";
@@ -19,6 +20,9 @@ import {
   S3ObjectRecord,
   parseS3Object,
   type S3Object,
+  type Boto3ConnectionSettings,
+  type DuckDbConnectionSettings,
+  type PolarsConnectionSettings,
 } from "./s3Types";
 
 export {
@@ -335,6 +339,26 @@ export async function getResult(jobId: string): Promise<any> {
 export async function getResultMaybe(jobId: string): Promise<any> {
   const workspace = getWorkspace();
   return await JobService.getCompletedJobResultMaybe({ workspace, id: jobId });
+}
+
+/**
+ * Cancel a specific job by ID.
+ * @param jobId - UUID of the job to cancel
+ * @param reason - Optional reason for cancellation
+ * @returns Response message from the cancel endpoint
+ */
+export async function cancelJob(
+  jobId: string,
+  reason: string | undefined = undefined
+): Promise<string> {
+  const workspace = getWorkspace();
+  return await JobService.cancelQueuedJob({
+    workspace,
+    id: jobId,
+    requestBody: {
+      reason: reason ?? "cancelled via cancel_job method",
+    },
+  });
 }
 const STRIP_COMMENTS =
   /(\/\/.*$)|(\/\*[\s\S]*?\*\/)|(\s*=[^,\)]*(('(?:\\'|[^'\r\n])*')|("(?:\\"|[^"\r\n])*"))|(\s*=[^,\)]*))/gm;
@@ -819,26 +843,83 @@ export async function databaseUrlFromResource(path: string): Promise<string> {
   return `postgresql://${resource.user}:${resource.password}@${resource.host}:${resource.port}/${resource.dbname}?sslmode=${resource.sslmode}`;
 }
 
-// TODO(gb): need to investigate more how Polars and DuckDB work in TS
-// export async function polarsConnectionSettings(s3_resource_path: string | undefined): Promise<any> {
-//   const workspace = getWorkspace();
-//   return await HelpersService.polarsConnectionSettingsV2({
-//     workspace: workspace,
-// 		requestBody: {
-// 			s3_resource_path: s3_resource_path
-// 		}
-//   });
-// }
+/**
+ * Get the settings necessary to connect Polars to an S3 bucket
+ * @param s3_resource_path - Path to S3 resource (uses workspace default if undefined)
+ * @param workspace - Workspace to read from (defaults to the `WM_WORKSPACE` env var)
+ * @returns S3 connection settings for Polars
+ */
+export async function polarsConnectionSettings(
+  s3_resource_path: string | undefined,
+  workspace: string | undefined = undefined
+): Promise<PolarsConnectionSettings> {
+  return await HelpersService.polarsConnectionSettingsV2({
+    workspace: workspace ?? getWorkspace(),
+    requestBody: {
+      s3_resource_path:
+        parseResourceSyntax(s3_resource_path) ?? s3_resource_path,
+    },
+  });
+}
 
-// export async function duckdbConnectionSettings(s3_resource_path: string | undefined): Promise<any> {
-//   const workspace = getWorkspace();
-//   return await HelpersService.duckdbConnectionSettingsV2({
-//     workspace: workspace,
-// 		requestBody: {
-// 			s3_resource_path: s3_resource_path
-// 		}
-//   });
-// }
+/**
+ * Get the settings necessary to connect DuckDB to an S3 bucket
+ * @param s3_resource_path - Path to S3 resource (uses workspace default if undefined)
+ * @param workspace - Workspace to read from (defaults to the `WM_WORKSPACE` env var)
+ * @returns S3 connection settings for DuckDB
+ */
+export async function duckdbConnectionSettings(
+  s3_resource_path: string | undefined,
+  workspace: string | undefined = undefined
+): Promise<DuckDbConnectionSettings> {
+  return await HelpersService.duckdbConnectionSettingsV2({
+    workspace: workspace ?? getWorkspace(),
+    requestBody: {
+      s3_resource_path:
+        parseResourceSyntax(s3_resource_path) ?? s3_resource_path,
+    },
+  });
+}
+
+/**
+ * Get the settings necessary to connect a boto3 client to an S3 bucket
+ * @param s3_resource_path - Path to S3 resource (uses workspace default if undefined)
+ * @param workspace - Workspace to read from (defaults to the `WM_WORKSPACE` env var)
+ * @returns S3 connection settings for boto3
+ */
+export async function boto3ConnectionSettings(
+  s3_resource_path: string | undefined,
+  workspace: string | undefined = undefined
+): Promise<Boto3ConnectionSettings> {
+  const s3Resource = (await HelpersService.s3ResourceInfo({
+    workspace: workspace ?? getWorkspace(),
+    requestBody: {
+      s3_resource_path:
+        parseResourceSyntax(s3_resource_path) ?? s3_resource_path,
+    },
+  })) as S3Resource & {
+    port?: number | string;
+    token?: string;
+    accessKey: string;
+    secretKey: string;
+  };
+  const endpoint_url_prefix = s3Resource.useSSL ? "https://" : "http://";
+  const endpoint = s3Resource.endPoint;
+  const endpointUrl = s3Resource.port
+    ? `${endpoint_url_prefix}${endpoint}:${s3Resource.port}`
+    : `${endpoint_url_prefix}${endpoint}`;
+  const settings: Boto3ConnectionSettings = {
+    endpoint_url: endpointUrl,
+    region_name: s3Resource.region,
+    use_ssl: s3Resource.useSSL,
+    aws_access_key_id: s3Resource.accessKey,
+    aws_secret_access_key: s3Resource.secretKey,
+  };
+  if (s3Resource.token) {
+    settings.aws_session_token = s3Resource.token;
+  }
+  return settings;
+}
 
 /**
  * Get S3 client settings from a resource or workspace default

--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -356,7 +356,7 @@ export async function cancelJob(
     workspace,
     id: jobId,
     requestBody: {
-      reason: reason ?? "cancelled via cancel_job method",
+      reason: reason ?? "cancelled via cancelJob method",
     },
   });
 }

--- a/typescript-client/s3Types.ts
+++ b/typescript-client/s3Types.ts
@@ -102,7 +102,7 @@ export type PolarsStorageOptions = {
  */
 export type PolarsConnectionSettings = {
   s3fs_args: PolarsS3FsArgs;
-  storage_options?: PolarsStorageOptions;
+  storage_options: PolarsStorageOptions;
 };
 
 /**

--- a/typescript-client/s3Types.ts
+++ b/typescript-client/s3Types.ts
@@ -63,3 +63,56 @@ export function parseS3Object(s3Object: S3Object): S3ObjectRecord {
     `Invalid s3 object ${JSON.stringify(s3Object)}: expected an s3://<storage>/<key> URI (e.g. "s3:///${s3Object}" for key "${s3Object}" in the default storage) or { s3: <key> }`
   );
 }
+
+/**
+ * Settings necessary to connect DuckDB to an S3 bucket
+ */
+export type DuckDbConnectionSettings = {
+  /** DuckDB SET statements to configure the S3 connection */
+  connection_settings_str: string;
+  /** Azure container path when the target storage is Azure */
+  azure_container_path?: string;
+};
+
+/**
+ * S3 filesystem arguments consumed by Python's Polars `scan_parquet`/`read_parquet`
+ */
+export type PolarsS3FsArgs = {
+  endpoint_url: string;
+  key?: string;
+  secret?: string;
+  use_ssl: boolean;
+  cache_regions?: boolean;
+  client_kwargs?: Record<string, unknown>;
+};
+
+/**
+ * Object-storage options consumed by Python's Polars when reading S3 data
+ */
+export type PolarsStorageOptions = {
+  aws_endpoint_url: string;
+  aws_region: string;
+  aws_allow_http: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+};
+
+/**
+ * Settings necessary to connect Polars to an S3 bucket
+ */
+export type PolarsConnectionSettings = {
+  s3fs_args: PolarsS3FsArgs;
+  storage_options?: PolarsStorageOptions;
+};
+
+/**
+ * Settings necessary to connect a boto3 client to an S3 bucket
+ */
+export type Boto3ConnectionSettings = {
+  endpoint_url: string;
+  region_name: string;
+  use_ssl: boolean;
+  aws_access_key_id: string;
+  aws_secret_access_key: string;
+  aws_session_token?: string;
+};


### PR DESCRIPTION
Description
Adds missing S3/database connection-settings helpers to the TypeScript and Python SDKs so both clients expose the same surface, and fixes a gap where the TS SDK had no job-cancellation helper.
TypeScript client (typescript-client/)
- Re-enable duckdbConnectionSettings and polarsConnectionSettings, which were previously stubbed out behind a TODO(gb). They now call the v2 helpers endpoints, strip $res:/res:// prefixes via parseResourceSyntax, and honor an explicit workspace arg (falling back to the WM_WORKSPACE env var), matching the Python SDK's behavior.
- Add boto3ConnectionSettings, mirroring Python's __boto3_connection_settings: resolves the S3 resource via the s3_resource_info endpoint and builds the endpoint_url (including port when set) plus aws_session_token for OIDC/STS temporary credentials.
- Add cancelJob(jobId, reason?), mirroring Python's cancel_job, with a default reason when none is supplied.
- Add DuckDbConnectionSettings, PolarsConnectionSettings, and Boto3ConnectionSettings types in s3Types.ts, matching the s3_types.py models.
- Wire the new functions into the package's named and default exports in build.sh.
Python client (python-client/)
- Add database_url_from_resource(path) (class method + module-level convenience), mirroring the TS databaseUrlFromResource — builds a postgresql:// URL from a database resource. This closes the last remaining SDK parity gap in the database-helper surface.
Verification
- npx tsc --noEmit passes (client is rebuilt from openapi.yaml via build.sh).
- bun test — 167 pass.
- python -m pytest tests/ -q — 116 pass.
- Smoke-tested all new TS functions with a stubbed fetch: correct endpoints, $res:/res:// stripping, endpoint/port/token composition, and cancelJob request body verified. Smoke-tested database_url_from_resource against the mock API.
Impact
- Additive only; no breaking changes to existing exports or behavior.
- No new dependencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3 connection settings helpers (DuckDB, Polars, boto3) and a job-cancel helper to the TypeScript SDK, plus a database URL helper to the Python SDK. Addresses review feedback with refined exports and safer URL construction.

- **New Features**
  - TypeScript SDK: added `duckdbConnectionSettings`, `polarsConnectionSettings`, `boto3ConnectionSettings` (v2 helpers, strips `$res:`/`res://`, optional `workspace`, builds endpoint with protocol/port and optional `aws_session_token`), and `cancelJob(jobId, reason?)`; added types `DuckDbConnectionSettings`, `PolarsConnectionSettings`, `Boto3ConnectionSettings`; exported in named and default exports.
  - Python SDK: added `database_url_from_resource(path)` to build `postgresql://` URLs with percent-encoded components and sensible defaults.

No breaking changes.

<sup>Written for commit 292929c57ad79b90d71b31c332fe7b7efa0148f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

