### PR TITLE
fix: order workspace members and invites by email

### DIFF
--- a/backend/.sqlx/query-3ce57583042b1daa2bd9d88502f6f4ab76c509dafee7371ac620c85e1b5d2498.json
+++ b/backend/.sqlx/query-3ce57583042b1daa2bd9d88502f6f4ab76c509dafee7371ac620c85e1b5d2498.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n            workspace_invite.workspace_id,\n            workspace_invite.email,\n            workspace_invite.is_admin,\n            workspace_invite.operator,\n            workspace.parent_workspace_id\n        FROM workspace_invite JOIN workspace ON workspace_invite.workspace_id = workspace.id\n        WHERE workspace_id = $1",
+  "query": "SELECT\n            workspace_invite.workspace_id,\n            workspace_invite.email,\n            workspace_invite.is_admin,\n            workspace_invite.operator,\n            workspace.parent_workspace_id\n        FROM workspace_invite JOIN workspace ON workspace_invite.workspace_id = workspace.id\n        WHERE workspace_id = $1\n        ORDER BY workspace_invite.email",
   "describe": {
     "columns": [
       {
@@ -42,5 +42,5 @@
       true
     ]
   },
-  "hash": "ce5c081bbf8322371a6ec95b6a0b033837d574a1ec72dfe42b666172daf10880"
+  "hash": "3ce57583042b1daa2bd9d88502f6f4ab76c509dafee7371ac620c85e1b5d2498"
 }

--- a/backend/.sqlx/query-e5775b1417d506e90953dc8e2b769ba049d314d93e4436f8f14f4812eb4990a0.json
+++ b/backend/.sqlx/query-e5775b1417d506e90953dc8e2b769ba049d314d93e4436f8f14f4812eb4990a0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT workspace_id, username, email, is_admin, created_at, operator, disabled, role, added_via, is_service_account\n          FROM usr\n         WHERE workspace_id = $1\n         ",
+  "query": "\n        SELECT workspace_id, username, email, is_admin, created_at, operator, disabled, role, added_via, is_service_account\n          FROM usr\n         WHERE workspace_id = $1\n         ORDER BY email\n         ",
   "describe": {
     "columns": [
       {
@@ -72,5 +72,5 @@
       false
     ]
   },
-  "hash": "704d873d4585e00aa0a88cc9949d3a6cc806b33a844b8e0e600cb8bfae428e84"
+  "hash": "e5775b1417d506e90953dc8e2b769ba049d314d93e4436f8f14f4812eb4990a0"
 }

--- a/backend/windmill-api-users/src/users.rs
+++ b/backend/windmill-api-users/src/users.rs
@@ -413,6 +413,7 @@ async fn list_users(
         SELECT workspace_id, username, email, is_admin, created_at, operator, disabled, role, added_via, is_service_account
           FROM usr
          WHERE workspace_id = $1
+         ORDER BY email
          ",
         w_id
     )

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -659,7 +659,8 @@ async fn list_pending_invites(
             workspace_invite.operator,
             workspace.parent_workspace_id
         FROM workspace_invite JOIN workspace ON workspace_invite.workspace_id = workspace.id
-        WHERE workspace_id = $1",
+        WHERE workspace_id = $1
+        ORDER BY workspace_invite.email",
         w_id
     )
     .fetch_all(&mut *tx)


### PR DESCRIPTION
## Summary

Toggling a member's role on the workspace settings Members tab reshuffled the list: the row you just edited jumped to the bottom.

`list_users` and `list_pending_invites` had no `ORDER BY`, so Postgres returned rows in heap order. An `UPDATE` rewrites the tuple at the end of the heap, and the settings page refetches the list right after the mutation — so the edited member came back last. Reproduced on a dev database:

```
before: (0,11) admin@windmill.dev | (0,70) test@mail.com | (0,77) new@mail.com
after an UPDATE on admin@windmill.dev:
        (0,70) test@mail.com | (0,77) new@mail.com | (0,117) admin@windmill.dev
```

Both list endpoints now sort by email, which also makes them deterministic for their other consumers (fork member settings, `OnBehalfOfSelector`, the CLI).

No frontend change: the members table already sorts non-instance-group members before instance-group ones, and `Array.prototype.sort` is stable, so the alphabetical order from the API carries through each block unchanged.

## Changes

- `list_users`: `ORDER BY email`
- `list_pending_invites`: `ORDER BY workspace_invite.email` (same class of instability — changing an invite's role rewrites its row too)
- `.sqlx` offline cache: two entries added for the new query text, the two pre-`ORDER BY` entries removed

## Test plan

- [x] Members tab: toggle a member's role and confirm the row stays in place (verified in the browser against a locally built backend — see screenshot)
- [x] API: after a role update, the endpoint returns `admin@windmill.dev new@mail.com test@mail.com` while the underlying heap order is `test@mail.com admin@windmill.dev new@mail.com`, i.e. the churn no longer reaches the response
- [x] Invites: created `zoe`, `alice`, `mike` out of order, then changed `alice`'s role — endpoint returns `alice mike zoe` before and after, while heap order is `zoe mike alice`

## Screenshots

Members tab immediately after toggling `new@mail.com` to Operator — the row stays second instead of jumping to the bottom:

![members list order stays put after a role toggle](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-members-shift-ws-settings/1786358987-members-order-stable.png)
