### PR TITLE
fix(cli): attach the right job path to preview runs

### DIFF
--- a/cli/src/commands/flow/flow.ts
+++ b/cli/src/commands/flow/flow.ts
@@ -13,7 +13,12 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { buildFolderPath, getMetadataFileName, loadNonDottedPathsSetting } from "../../utils/resource_folders.ts";
 
 import { requireLogin } from "../../core/auth.ts";
-import { resolveWorkspace, validatePath } from "../../core/context.ts";
+import {
+  assertRemotePath,
+  resolveWorkspace,
+  toSyncRootRelativePath,
+  validatePath,
+} from "../../core/context.ts";
 import { resolve, track_job, pollForJobResult } from "../script/script.ts";
 import { defaultFlowDefinition } from "../../../bootstrap/flow_bootstrap.ts";
 import { SyncOptions, mergeConfigWithConfigFile } from "../../core/conf.ts";
@@ -605,12 +610,17 @@ async function preview(
     log.setSilent(true);
   }
   const useLocalPathScripts = !opts.remote;
+  // Captured before the config read, which chdirs to the wmill.yaml root.
+  const cwdBeforeConfig = process.cwd();
   if (useLocalPathScripts) {
     opts = await mergeConfigWithConfigFile(opts);
   }
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
   const codebases = useLocalPathScripts ? listSyncCodebases(opts) : [];
+
+  const argPath = flowPath;
+  flowPath = toSyncRootRelativePath(flowPath, cwdBeforeConfig);
 
   // Normalize path - ensure it's a directory path to a .flow or __flow folder
   const isFlowDir = flowPath.endsWith(".flow") || flowPath.endsWith(".flow" + SEP)
@@ -632,6 +642,14 @@ async function preview(
   if (!flowPath.endsWith(SEP)) {
     flowPath += SEP;
   }
+
+  // The flow's windmill path (e.g. "f/cli_smoke/myrelflow"). It is what the
+  // preview job runs under, and the anchor for relative-import resolution:
+  // inline scripts in this flow are treated as living at
+  // "<flow_wm_path>/<step_id>", so "./util" resolves to
+  // "<flow_wm_path_parent>/util" — matching the keys in temp_script_refs.
+  const flowWmPath = stripFlowSuffix(flowPath).replaceAll(SEP, "/");
+  assertRemotePath(flowWmPath, argPath);
 
   // Read and parse the flow definition
   const localFlow = (await yamlParseFile(flowPath + "flow.yaml")) as FlowFile;
@@ -703,12 +721,6 @@ async function preview(
   // too — PathScript modules have already been rewritten to inline rawscript
   // when `useLocalPathScripts` is set, and tempScriptRefs covers relative
   // imports in inline scripts.
-  // Compute the flow's windmill path (e.g. "f/cli_smoke/myrelflow"). Used as
-  // the anchor for relative-import resolution: inline scripts in this flow are
-  // treated as living at "<flow_wm_path>/<step_id>", so "./util" resolves to
-  // "<flow_wm_path_parent>/util" — matching the keys in temp_script_refs.
-  const flowWmPath = stripFlowSuffix(flowPath).replaceAll(SEP, "/");
-
   if (opts.step) {
     await previewStep(opts.step, localFlow, flowWmPath, workspace, input, tempScriptRefs, opts.silent, opts.tag);
     return;

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -1,6 +1,11 @@
 import { GlobalOptions } from "../../types.ts";
 import { requireLogin } from "../../core/auth.ts";
-import { resolveWorkspace, validatePath } from "../../core/context.ts";
+import {
+  assertRemotePath,
+  resolveWorkspace,
+  toSyncRootRelativePath,
+  validatePath,
+} from "../../core/context.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
 import { applyExtraPermsDiff } from "../../core/extra_perms.ts";
 import { writeFile, stat, mkdir } from "node:fs/promises";
@@ -1808,13 +1813,16 @@ async function preview(
   if (opts.silent) {
     log.setSilent(true);
   }
+  // Captured before the config read, which chdirs to the wmill.yaml root.
+  const cwdBeforeConfig = process.cwd();
   opts = await mergeConfigWithConfigFile(opts);
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
 
-  if (!validatePath(filePath)) {
-    return;
-  }
+  const argPath = filePath;
+  filePath = toSyncRootRelativePath(filePath, cwdBeforeConfig);
+  const remotePath = scriptPathToRemotePath(filePath);
+  assertRemotePath(remotePath, argPath);
 
   // Same as push: a descriptor-less dbt project's content path is deliberately
   // absent, and the project beside it is what says the script is real.
@@ -1869,11 +1877,7 @@ async function preview(
   const { extractRelativeImports } = await import(
     "../../utils/relative_imports.ts"
   );
-  const relImports = await extractRelativeImports(
-    content,
-    scriptPathToRemotePath(filePath),
-    language
-  );
+  const relImports = await extractRelativeImports(content, remotePath, language);
   if (relImports.length > 0) {
     const { buildPreviewTempScriptRefs } = await import(
       "../generate-metadata/generate-metadata.ts"
@@ -1976,7 +1980,7 @@ async function preview(
     const form = new FormData();
     const previewPayload = {
       content: content, // Pass the original content (frontend does this too)
-      path: filePath.substring(0, filePath.indexOf(".")).replaceAll(SEP, "/"),
+      path: remotePath,
       args: input,
       language: language,
       tag: opts.tag,
@@ -2046,7 +2050,7 @@ async function preview(
       workspace: workspace.workspaceId,
       requestBody: {
         content,
-        path: filePath.substring(0, filePath.indexOf(".")).replaceAll(SEP, "/"),
+        path: remotePath,
         args: input,
         language: language as any,
         tag: opts.tag,

--- a/cli/src/core/context.ts
+++ b/cli/src/core/context.ts
@@ -766,8 +766,11 @@ function syncRoot(): string {
  * command read wmill.yaml: reading it chdirs into the directory holding it, and
  * a relative argument was written against the directory the user was in.
  * Arguments are resolved against that directory first and the sync root second,
- * so both readings work; one that exists under neither resolves against the
- * sync root and is left for the caller to reject.
+ * so both readings work.
+ *
+ * Resolving the sync root leaves the process in it, which is what makes the
+ * returned path readable by the caller — keep that in step if this ever stops
+ * going through `getWmillYamlPath`.
  */
 export function toSyncRootRelativePath(
   arg: string,
@@ -777,7 +780,14 @@ export function toSyncRootRelativePath(
   const candidates = isAbsolute(arg)
     ? [arg]
     : [resolve(cwdBeforeConfig, arg), resolve(root, arg)];
-  const abs = candidates.find((c) => existsSync(c)) ?? candidates.at(-1)!;
+  // A descriptor-less dbt project is named by a file that is deliberately not
+  // there, so an argument existing under neither reading is still a real one if
+  // the directory holding it is; only a path whose directory is missing too
+  // falls through to the sync-root reading for the caller to reject.
+  const abs =
+    candidates.find((c) => existsSync(c)) ??
+    candidates.find((c) => existsSync(dirname(c))) ??
+    candidates.at(-1)!;
   const rel = relative(root, abs);
   if (rel === "") return ".";
   if (!rel.startsWith("..")) return rel;

--- a/cli/src/core/context.ts
+++ b/cli/src/core/context.ts
@@ -26,7 +26,7 @@ import {
   WorkspaceEntryConfig,
 } from "./conf.ts";
 import { existsSync, realpathSync } from "node:fs";
-import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   getCurrentGitBranch,
   getOriginalBranchForWorkspaceForks,
@@ -796,11 +796,21 @@ export function toSyncRootRelativePath(
   // like it escapes the tree. Resolve links only then, so a symlinked file
   // *inside* the tree keeps the path it is filed under.
   try {
-    const resolved = relative(realpathSync(root), realpathSync(abs));
+    const resolved = relative(realpathSync(root), realpathOfNamed(abs));
     return resolved === "" ? "." : resolved;
   } catch {
     return rel;
   }
+}
+
+/**
+ * `realpathSync` needs its target to exist, and a dbt descriptor deliberately
+ * does not. The directory naming it does, so resolve that and reattach.
+ */
+function realpathOfNamed(p: string): string {
+  return existsSync(p)
+    ? realpathSync(p)
+    : join(realpathSync(dirname(p)), basename(p));
 }
 
 /** Windmill workspace path: `u|f|g` followed by at least a folder and a name. */

--- a/cli/src/core/context.ts
+++ b/cli/src/core/context.ts
@@ -22,8 +22,11 @@ import {
   readConfigFile,
   findWorkspaceByGitBranch,
   getEffectiveWorkspaceId,
+  getWmillYamlPath,
   WorkspaceEntryConfig,
 } from "./conf.ts";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import {
   getCurrentGitBranch,
   getOriginalBranchForWorkspaceForks,
@@ -741,6 +744,72 @@ export async function tryResolveVersion(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Directory the local tree mirrors the workspace from: the one holding
+ * wmill.yaml. Not `process.cwd()` — that only lands there once a config read
+ * has chdir'd into it, which `--remote` and fully-flagged invocations skip.
+ */
+function syncRoot(): string {
+  const wmillYaml = getWmillYamlPath();
+  return wmillYaml ? dirname(wmillYaml) : process.cwd();
+}
+
+/**
+ * Re-express a user-supplied file or folder argument as a path relative to the
+ * sync root, so the Windmill path derived from it is the same whatever shape
+ * the argument had (`./f/a/b.ts`, `/abs/repo/f/a/b.ts`, `b.ts` from inside
+ * `f/a`).
+ *
+ * `cwdBeforeConfig` must be the working directory as it was *before* the
+ * command read wmill.yaml: reading it chdirs into the directory holding it, and
+ * a relative argument was written against the directory the user was in.
+ * Arguments are resolved against that directory first and the sync root second,
+ * so both readings work; one that exists under neither resolves against the
+ * sync root and is left for the caller to reject.
+ */
+export function toSyncRootRelativePath(
+  arg: string,
+  cwdBeforeConfig: string
+): string {
+  const root = syncRoot();
+  const candidates = isAbsolute(arg)
+    ? [arg]
+    : [resolve(cwdBeforeConfig, arg), resolve(root, arg)];
+  const abs = candidates.find((c) => existsSync(c)) ?? candidates.at(-1)!;
+  const rel = relative(root, abs);
+  if (rel === "") return ".";
+  if (!rel.startsWith("..")) return rel;
+  // `relative` is purely lexical, so a root reached through a symlink (macOS'
+  // /var -> /private/var, a symlinked checkout) makes an absolute argument look
+  // like it escapes the tree. Resolve links only then, so a symlinked file
+  // *inside* the tree keeps the path it is filed under.
+  try {
+    const resolved = relative(realpathSync(root), realpathSync(abs));
+    return resolved === "" ? "." : resolved;
+  } catch {
+    return rel;
+  }
+}
+
+/** Windmill workspace path: `u|f|g` followed by at least a folder and a name. */
+const REMOTE_PATH_RE = /^[ufg](\/[^/]+){2,}$/;
+
+/**
+ * Guard the Windmill path a preview run is pushed under. A preview job carries
+ * no runnable of its own, so this path is the only identity it has: it is what
+ * `WM_JOB_PATH` reports, what the runs page links to, and what relative imports
+ * inside the previewed code resolve against.
+ */
+export function assertRemotePath(remotePath: string, arg: string): void {
+  if (REMOTE_PATH_RE.test(remotePath)) return;
+  throw new Error(
+    `Cannot derive a Windmill path from '${arg}'` +
+      (remotePath ? ` (it maps to '${remotePath}')` : "") +
+      `: a preview runs under the path of the file it previews, which must sit inside the ` +
+      `wmill.yaml root and be of the form <u|g|f>/<username|group|folder>/<name>.`
+  );
 }
 
 export function validatePath(path: string): boolean {

--- a/cli/test/preview.test.ts
+++ b/cli/test/preview.test.ts
@@ -591,16 +591,20 @@ test("flow preview: step job path is anchored on the flow's Windmill path", asyn
       scriptContent: `export function main() { return process.env.WM_JOB_PATH; }`,
     });
 
-    const invocations: Array<[string, string]> = [
-      ["f/test/job_path_flow.flow", tempDir],
-      ["./f/test/job_path_flow.flow", tempDir],
-      [`${tempDir}/f/test/job_path_flow.flow`, tempDir],
-      ["job_path_flow.flow", `${tempDir}/f/test`],
+    // The last one is `--remote` from a subdirectory: that combination reads
+    // no config of its own, so it is the one shape where nothing but the path
+    // resolution can put the process in the sync root.
+    const invocations: Array<[string[], string]> = [
+      [["f/test/job_path_flow.flow"], tempDir],
+      [["./f/test/job_path_flow.flow"], tempDir],
+      [[`${tempDir}/f/test/job_path_flow.flow`], tempDir],
+      [["job_path_flow.flow"], `${tempDir}/f/test`],
+      [["--remote", "job_path_flow.flow"], `${tempDir}/f/test`],
     ];
 
-    for (const [arg, workingDir] of invocations) {
+    for (const [args, workingDir] of invocations) {
       const result = await backend.runCLICommand(
-        ["flow", "preview", arg, "--silent"],
+        ["flow", "preview", ...args, "--silent"],
         workingDir
       );
 

--- a/cli/test/preview.test.ts
+++ b/cli/test/preview.test.ts
@@ -185,6 +185,60 @@ test("script preview: regular script (non-codebase)", async () => {
   });
 });
 
+test("script preview: job path is the script's Windmill path for every argument shape", async () => {
+  await withTestBackend(async (backend, tempDir) => {
+    await createWmillConfig(tempDir, { defaultTs: "bun" });
+    await createScript(
+      tempDir,
+      "f/test/job_path_script.ts",
+      `export function main() {
+  return process.env.WM_JOB_PATH;
+}`
+    );
+
+    const invocations: Array<[string, string]> = [
+      ["f/test/job_path_script.ts", tempDir],
+      ["./f/test/job_path_script.ts", tempDir],
+      [`${tempDir}/f/test/job_path_script.ts`, tempDir],
+      ["job_path_script.ts", `${tempDir}/f/test`],
+    ];
+
+    for (const [arg, workingDir] of invocations) {
+      const result = await backend.runCLICommand(
+        ["script", "preview", arg, "--silent"],
+        workingDir
+      );
+
+      expect(result.code).toEqual(0);
+      expect(result.stdout.trim()).toEqual(`"f/test/job_path_script"`);
+    }
+
+    // Folder layout: the job runs under the script's path, not the entry file's.
+    await createScript(
+      tempDir,
+      "f/test/job_path_module__mod/script.ts",
+      `export function main() {
+  return process.env.WM_JOB_PATH;
+}`
+    );
+    const moduleResult = await backend.runCLICommand(
+      ["script", "preview", "f/test/job_path_module__mod/script.ts", "--silent"],
+      tempDir
+    );
+    expect(moduleResult.code).toEqual(0);
+    expect(moduleResult.stdout.trim()).toEqual(`"f/test/job_path_module"`);
+
+    // A file outside the workspace tree has no Windmill path to run under, so
+    // the run is refused rather than pushed with a made-up one.
+    await writeFile(`${tempDir}/stray.ts`, `export function main() {}`, "utf-8");
+    const strayResult = await backend.runCLICommand(
+      ["script", "preview", "stray.ts", "--silent"],
+      tempDir
+    );
+    expect(strayResult.code).toEqual(1);
+  });
+});
+
 test("script preview: codebase script (CJS)", async () => {
   await withTestBackend(async (backend, tempDir) => {
     await createWmillConfig(tempDir, {
@@ -526,6 +580,33 @@ test("flow preview: simple flow", async () => {
 
     expect(result.code).toEqual(0);
     expect(result.stdout + result.stderr).toContain("Flow says: Hello, World!");
+  });
+});
+
+test("flow preview: step job path is anchored on the flow's Windmill path", async () => {
+  await withTestBackend(async (backend, tempDir) => {
+    await createWmillConfig(tempDir, { defaultTs: "bun" });
+    await createFlow(tempDir, "f/test/job_path_flow.flow", {
+      summary: "Test flow",
+      scriptContent: `export function main() { return process.env.WM_JOB_PATH; }`,
+    });
+
+    const invocations: Array<[string, string]> = [
+      ["f/test/job_path_flow.flow", tempDir],
+      ["./f/test/job_path_flow.flow", tempDir],
+      [`${tempDir}/f/test/job_path_flow.flow`, tempDir],
+      ["job_path_flow.flow", `${tempDir}/f/test`],
+    ];
+
+    for (const [arg, workingDir] of invocations) {
+      const result = await backend.runCLICommand(
+        ["flow", "preview", arg, "--silent"],
+        workingDir
+      );
+
+      expect(result.code).toEqual(0);
+      expect(result.stdout.trim()).toEqual(`"f/test/job_path_flow/a"`);
+    }
   });
 });
 

--- a/cli/test/preview_path_unit.test.ts
+++ b/cli/test/preview_path_unit.test.ts
@@ -16,14 +16,17 @@ import {
 describe("toSyncRootRelativePath", () => {
   let root: string;
   let previousCwd: string;
+  let temps: string[];
 
   beforeEach(() => {
     previousCwd = process.cwd();
+    temps = [];
     // realpath: macOS' tmpdir is /var -> /private/var, and the assertions
     // compare against what the process reports as its own directory.
     root = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), "wmill_preview_path_")),
     );
+    temps.push(root);
     fs.writeFileSync(path.join(root, "wmill.yaml"), "defaultTs: bun\n");
     fs.mkdirSync(path.join(root, "f", "test"), { recursive: true });
     fs.writeFileSync(path.join(root, "f", "test", "script.ts"), "");
@@ -32,10 +35,18 @@ describe("toSyncRootRelativePath", () => {
 
   afterEach(() => {
     process.chdir(previousCwd);
-    fs.rmSync(root, { recursive: true, force: true });
+    for (const dir of temps) fs.rmSync(dir, { recursive: true, force: true });
   });
 
   const normalized = (p: string) => p.replaceAll("\\", "/");
+
+  /** A dbt project whose descriptor is deliberately not written. */
+  function dbtProject(): string {
+    const project = path.join(root, "f", "test", "proj__dbt");
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(path.join(project, "dbt_project.yml"), "name: proj\n");
+    return project;
+  }
 
   test("every spelling of the same file lands on the same path", () => {
     const fromRoot = ["f/test/script.ts", "./f/test/script.ts"].map((arg) =>
@@ -58,14 +69,29 @@ describe("toSyncRootRelativePath", () => {
   test("a file that is deliberately absent keeps the directory it was named in", () => {
     // A dbt project's descriptor is optional; `wmill script preview
     // wm_dbt.yaml` from inside the project must still resolve to the project.
-    const project = path.join(root, "f", "test", "proj__dbt");
-    fs.mkdirSync(project, { recursive: true });
-    fs.writeFileSync(path.join(project, "dbt_project.yml"), "name: proj\n");
+    const project = dbtProject();
 
     expect(normalized(toSyncRootRelativePath("wm_dbt.yaml", project))).toEqual(
       "f/test/proj__dbt/wm_dbt.yaml",
     );
   });
+
+  // Windows only creates symlinks for a privileged process.
+  test.skipIf(process.platform === "win32")(
+    "an absent file reached through a symlinked root still lands in the tree",
+    () => {
+      dbtProject();
+      const aliasDir = fs.mkdtempSync(path.join(os.tmpdir(), "wmill_alias_"));
+      temps.push(aliasDir);
+      const alias = path.join(aliasDir, "link");
+      fs.symlinkSync(root, alias, "dir");
+
+      const arg = path.join(alias, "f", "test", "proj__dbt", "wm_dbt.yaml");
+      expect(normalized(toSyncRootRelativePath(arg, root))).toEqual(
+        "f/test/proj__dbt/wm_dbt.yaml",
+      );
+    },
+  );
 
   test("a file outside the tree stays outside it", () => {
     const outside = path.join(root, "..", "elsewhere.ts");

--- a/cli/test/preview_path_unit.test.ts
+++ b/cli/test/preview_path_unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * A preview job carries no runnable, so the path derived from the file
+ * argument is the whole of its identity — it has to come out the same
+ * whatever shape the argument had, and be refused rather than guessed when
+ * the file has no place in the workspace tree.
+ */
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  assertRemotePath,
+  toSyncRootRelativePath,
+} from "../src/core/context.ts";
+
+describe("toSyncRootRelativePath", () => {
+  let root: string;
+  let previousCwd: string;
+
+  beforeEach(() => {
+    previousCwd = process.cwd();
+    // realpath: macOS' tmpdir is /var -> /private/var, and the assertions
+    // compare against what the process reports as its own directory.
+    root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "wmill_preview_path_")),
+    );
+    fs.writeFileSync(path.join(root, "wmill.yaml"), "defaultTs: bun\n");
+    fs.mkdirSync(path.join(root, "f", "test"), { recursive: true });
+    fs.writeFileSync(path.join(root, "f", "test", "script.ts"), "");
+    process.chdir(root);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const normalized = (p: string) => p.replaceAll("\\", "/");
+
+  test("every spelling of the same file lands on the same path", () => {
+    const fromRoot = ["f/test/script.ts", "./f/test/script.ts"].map((arg) =>
+      normalized(toSyncRootRelativePath(arg, root)),
+    );
+    const absolute = normalized(
+      toSyncRootRelativePath(path.join(root, "f", "test", "script.ts"), root),
+    );
+    // As typed from the directory the file is in: the config read has already
+    // moved the process to the root by the time the argument is resolved.
+    const fromSubdir = normalized(
+      toSyncRootRelativePath("script.ts", path.join(root, "f", "test")),
+    );
+
+    expect(fromRoot).toEqual(["f/test/script.ts", "f/test/script.ts"]);
+    expect(absolute).toEqual("f/test/script.ts");
+    expect(fromSubdir).toEqual("f/test/script.ts");
+  });
+
+  test("a file that is deliberately absent keeps the directory it was named in", () => {
+    // A dbt project's descriptor is optional; `wmill script preview
+    // wm_dbt.yaml` from inside the project must still resolve to the project.
+    const project = path.join(root, "f", "test", "proj__dbt");
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(path.join(project, "dbt_project.yml"), "name: proj\n");
+
+    expect(normalized(toSyncRootRelativePath("wm_dbt.yaml", project))).toEqual(
+      "f/test/proj__dbt/wm_dbt.yaml",
+    );
+  });
+
+  test("a file outside the tree stays outside it", () => {
+    const outside = path.join(root, "..", "elsewhere.ts");
+    expect(toSyncRootRelativePath(outside, root).startsWith("..")).toBe(true);
+  });
+});
+
+describe("assertRemotePath", () => {
+  test("accepts a workspace path and refuses anything else", () => {
+    expect(() => assertRemotePath("f/test/script", "f/test/script.ts")).not.toThrow();
+    expect(() => assertRemotePath("u/admin/script", "script.ts")).not.toThrow();
+    for (const bad of ["", "script", "f/script", "../elsewhere"]) {
+      expect(() => assertRemotePath(bad, "arg.ts")).toThrow(
+        /Cannot derive a Windmill path/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes WIN-2342.

`wmill script preview` and `wmill flow preview` derived the Windmill path a preview job runs under straight from the raw CLI argument, so the path only came out right when the argument was a bare workspace-root-relative path. Every other spelling produced a job with no path, a wrong path, or no job at all:

| invocation | before | after |
|---|---|---|
| `wmill script preview ./f/a/b.ts` | **nothing ran** — `validatePath` rejected the leading `.`, logged a warning and returned exit 0 | `f/a/b` |
| `wmill script preview /abs/repo/f/a/b.ts` | **nothing ran** (same) | `f/a/b` |
| `wmill script preview b.ts` from inside `f/a` | `ENOENT: no such file or directory` (reading wmill.yaml had already chdir'd to the root) | `f/a/b` |
| `wmill script preview f/a/b__mod/script.ts` | `f/a/b__mod/script` | `f/a/b` |
| `wmill script preview wm_dbt.yaml` from inside `f/a/proj__dbt` | **nothing ran** | `f/a/proj` |
| `wmill flow preview ./f/a/b.flow` | `./f/a/b` (steps ran as `./f/a/b/<step>`) | `f/a/b` |
| `wmill flow preview /abs/repo/f/a/b.flow` | backend 400: `Invalid path for preview job: /abs/…` | `f/a/b` |
| `wmill flow preview b.flow` from inside `f/a` | junk path from whatever the cwd made it | `f/a/b` |

A preview job carries no runnable of its own, so this path is the only identity it has: it is what `WM_JOB_PATH` reports, what the runs page links to, and what relative imports inside the previewed code resolve against. Scripts that read `WM_JOB_PATH` fail when it is empty or bogus, which is what the report describes.

## Changes

- `toSyncRootRelativePath` (`cli/src/core/context.ts`): re-expresses a user-supplied file/folder argument as a path relative to the sync root, so `./f/a/b.ts`, `/abs/repo/f/a/b.ts` and `b.ts`-from-inside-`f/a` all reduce to `f/a/b.ts`. The sync root comes from the directory holding `wmill.yaml`, not `process.cwd()` — the cwd only lands there once a config read has chdir'd into it, which `flow preview --remote` and fully-flagged invocations skip. The argument is resolved against the pre-chdir cwd first and the sync root second.
- A file that exists under neither reading is still real if the directory naming it exists — a dbt project's descriptor is deliberately absent — so that reading wins over the sync-root one, which is reserved for arguments the caller should reject.
- Symlinks are resolved only when the lexical result escapes the root (macOS' `/var` → `/private/var`, symlinked checkouts), so a symlinked file *inside* the tree keeps the path it is filed under; resolution goes through the directory when the file itself is not there.
- `assertRemotePath` (same file): a preview whose file has no place in the workspace tree now fails with an explanation naming the argument the user typed, instead of exiting 0 having run nothing (`script preview`) or pushing a made-up path to the backend (`flow preview`).
- `script preview` now derives the path with `scriptPathToRemotePath`, which handles the `__mod` folder layout, instead of an inlined split-at-first-dot. The same value feeds the plain preview, the codebase/bundle preview and relative-import resolution, which had drifted apart.
- `flow preview` normalizes its argument the same way and validates the derived flow path before it reads any files or uploads temp script refs.

One deliberate behavior change beyond the table: `wmill script preview f/myflow.flow/a.inline_script.ts` used to run under `f/myflow` — the *flow's* identity, not the step's — and is now refused. `wmill flow preview --step a` is the supported way to run one step, and gives it `f/myflow/a`.

## Test plan

- [x] `cli/test/preview.test.ts`: regression tests assert the job's own `WM_JOB_PATH` for `script preview` and for a `flow preview` step, across every argument shape (including `--remote` from a subdirectory, the one shape where nothing but the path resolution can move the cwd), plus the `__mod` folder layout and a non-zero exit for a file outside the tree. Both fail on `main` (empty stdout for the `./` script case, `./f/test/job_path_flow/a` for the flow case).
- [x] `cli/test/preview_path_unit.test.ts`: unit coverage for `toSyncRootRelativePath` / `assertRemotePath`, needing no backend — every argument shape, the deliberately-absent dbt descriptor, and that descriptor reached through a symlinked root.
- [x] Full `bun test test/preview.test.ts` against a cargo backend: 17 pass, 1 skip (EE-gated), 0 fail. `test-linux` and `test-windows` green in CI.
- [x] `UNIT_ONLY=1 bun test test/*_unit*.test.ts`: 1052 pass, 0 fail.
- [x] `bunx tsc --noEmit`: 38 pre-existing errors, unchanged from `main`.
- [x] Manually against a dev backend: every row of the table above, checking `WM_JOB_PATH` in the job result and `runnable_path` in `v2_job`, and the runs page listing the jobs under `f/test/foo` / `f/test/myflow` / `f/test/myflow/a`; plus `flow preview --remote` and `--step` from a subdirectory, a descriptor-less dbt project previewed by absolute symlink-aliased path (lands on `f/test/proj`), and both error messages.
- [x] `python system_prompts/generate.py` produces no drift (no command, option or description changed).