### PR TITLE
fix(duckdb): cast list columns in quicksearch so tables containing them can be previewed

### DIFF
--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -524,6 +524,27 @@ fn cols_to_simple(cols: &[ColumnDef]) -> Vec<SimpleColumn> {
         .collect()
 }
 
+/// DuckDB's `CONCAT` implicitly casts scalars — `VARCHAR`, `BIGINT`, `DOUBLE`,
+/// `BOOLEAN`, `DATE` and `TIMESTAMPTZ` all concatenate — but rejects nested
+/// types:
+///
+/// ```text
+/// D SELECT CONCAT(' ', ['a','b']);
+/// Binder Error: Cannot concatenate types VARCHAR and VARCHAR[] - an explicit
+/// cast is required
+/// ```
+///
+/// Quicksearch concatenates every visible column, so a single LIST, STRUCT or
+/// MAP column makes the whole table impossible to preview. Casting each column
+/// is also what a text search wants: the comparison is textual either way.
+fn duckdb_searchable_columns(columns: &[String]) -> String {
+    columns
+        .iter()
+        .map(|col| format!("CAST({} AS VARCHAR)", col))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// MSSQL `text`, `ntext`, and `image` types cannot be used with the `=` operator.
 /// This function wraps the column/param in CAST(...) when needed.
 fn mssql_needs_cast_for_eq(datatype: &str) -> bool {
@@ -1019,7 +1040,7 @@ pub fn make_select_query(
 
             let quicksearch = format!(
                 "($quicksearch = '' OR CONCAT({}) ILIKE '%' || $quicksearch || '%')",
-                filtered_columns.join(", ")
+                duckdb_searchable_columns(&filtered_columns)
             );
 
             query.push_str(&format!(
@@ -1188,7 +1209,7 @@ pub fn make_count_query(
             if !filtered_columns.is_empty() {
                 quicksearch_condition.push_str(&format!(
                     " ($quicksearch = '' OR CONCAT(' ', {}) LIKE CONCAT('%', $quicksearch, '%'))",
-                    filtered_columns.join(", ")
+                    duckdb_searchable_columns(&filtered_columns)
                 ));
             } else {
                 quicksearch_condition.push_str(" ($quicksearch = '' OR 1 = 1)");
@@ -3126,8 +3147,103 @@ mod tests {
 
         assert!(result.starts_with("-- $limit (int)\n-- $offset (int)\n-- $quicksearch (text)\n-- $order_by (text)\n-- $is_desc (boolean)\n"));
         assert!(result.contains("SELECT \"id\", \"name\" FROM \"my_table\"\n"));
-        assert!(result.contains("CONCAT(\"id\", \"name\") ILIKE '%' || $quicksearch || '%'"));
+        // Columns are cast for the search but NOT for the projection.
+        assert!(result.contains(
+            "CONCAT(CAST(\"id\" AS VARCHAR), CAST(\"name\" AS VARCHAR)) ILIKE '%' || $quicksearch || '%'"
+        ));
         assert!(result.contains("LIMIT $limit::INT OFFSET $offset::INT"));
+    }
+
+    /// DuckDB's CONCAT implicitly casts scalars but rejects nested types, so a
+    /// single LIST column used to make a whole table impossible to preview:
+    ///
+    /// ```text
+    /// Binder Error: Cannot concatenate types VARCHAR and VARCHAR[] - an
+    /// explicit cast is required
+    /// ```
+    /// The live path: the frontend sends a `WM_INTERNAL_DB_SELECT` marker and the
+    /// backend expands it. Column definitions below are the real ones captured
+    /// from a failing job on a DuckLake table — 27 columns, one of them
+    /// `sync_id VARCHAR[]`, which is what made the expansion produce SQL DuckDB
+    /// refused:
+    ///
+    /// ```text
+    /// Binder Error: Cannot concatenate types VARCHAR, VARCHAR, BIGINT, ...,
+    /// VARCHAR[], ... and TIMESTAMP WITH TIME ZONE - an explicit cast is required
+    /// ```
+    #[test]
+    fn test_duckdb_marker_expansion_casts_nested_types() {
+        let cols = vec![
+            col("id", "VARCHAR"),
+            col("changed", "BIGINT"),
+            col("user_id", "INTEGER"),
+            col("role", "INTEGER"),
+            col("instrument", "INTEGER"),
+            col("company", "INTEGER"),
+            col("type", "VARCHAR"),
+            col("title", "VARCHAR"),
+            col("sync_id", "VARCHAR[]"),
+            col("balance", "DOUBLE"),
+            col("start_balance", "DOUBLE"),
+            col("credit_limit", "DOUBLE"),
+            col("in_balance", "BOOLEAN"),
+            col("savings", "BOOLEAN"),
+            col("enable_correction", "BOOLEAN"),
+            col("enable_sms", "BOOLEAN"),
+            col("archive", "BOOLEAN"),
+            col("capitalization", "BOOLEAN"),
+            col("percent", "DOUBLE"),
+            col("start_date", "DATE"),
+            col("end_date_offset", "INTEGER"),
+            col("end_date_offset_interval", "VARCHAR"),
+            col("payoff_step", "INTEGER"),
+            col("payoff_interval", "VARCHAR"),
+            col("balance_correction_type", "VARCHAR"),
+            col("private", "BOOLEAN"),
+            col("_loaded_at", "TIMESTAMP WITH TIME ZONE")
+        ];
+        let result =
+            make_select_query("raw.zenmoney__accounts", &cols, None, DbType::Duckdb, None, None)
+                .unwrap();
+
+        assert!(
+            result.contains("CAST(\"sync_id\" AS VARCHAR)"),
+            "the array column must be cast in quicksearch, got:\n{}",
+            result
+        );
+        // Every column is cast, not just the nested one — a partial cast would
+        // still fail the moment the types are mixed.
+        for (field, _) in [("id", ""), ("changed", ""), ("balance", "")] {
+            assert!(
+                result.contains(&format!("CAST(\"{}\" AS VARCHAR)", field)),
+                "column {} not cast",
+                field
+            );
+        }
+    }
+
+    #[test]
+    fn test_select_duckdb_quicksearch_casts_nested_types() {
+        let cols = vec![
+            col("id", "text"),
+            col("tag", "VARCHAR[]"),
+            col("points", "BIGINT[]"),
+            col("ts", "TIMESTAMP WITH TIME ZONE"),
+        ];
+        let result =
+            make_select_query("my_table", &cols, None, DbType::Duckdb, None, None).unwrap();
+
+        for column in ["\"id\"", "\"tag\"", "\"points\"", "\"ts\""] {
+            assert!(
+                result.contains(&format!("CAST({} AS VARCHAR)", column)),
+                "quicksearch must cast {}, got:\n{}",
+                column,
+                result
+            );
+        }
+        // The projection stays untouched: casting there would change the types
+        // the caller reads back.
+        assert!(result.contains("SELECT \"id\", \"tag\", \"points\", \"ts\" FROM \"my_table\""));
     }
 
     // -----------------------------------------------------------------------
@@ -3275,9 +3391,21 @@ mod tests {
 
         assert!(result.contains("-- $quicksearch (text)"));
         assert!(result.contains("SELECT COUNT(*) as count FROM \"my_table\""));
-        assert!(
-            result.contains("CONCAT(' ', \"id\", \"name\") LIKE CONCAT('%', $quicksearch, '%')")
-        );
+        assert!(result.contains(
+            "CONCAT(' ', CAST(\"id\" AS VARCHAR), CAST(\"name\" AS VARCHAR)) LIKE CONCAT('%', $quicksearch, '%')"
+        ));
+    }
+
+    /// COUNT shares the quicksearch predicate with SELECT, so a nested-type
+    /// column has to be cast here too — otherwise the row count fails while
+    /// the page itself renders.
+    #[test]
+    fn test_count_duckdb_quicksearch_casts_nested_types() {
+        let cols = vec![col("id", "text"), col("tag", "VARCHAR[]")];
+        let result = make_count_query(DbType::Duckdb, "my_table", None, &cols, None).unwrap();
+
+        assert!(result.contains("CAST(\"tag\" AS VARCHAR)"), "got:\n{}", result);
+        assert!(result.contains("CAST(\"id\" AS VARCHAR)"), "got:\n{}", result);
     }
 
     // -----------------------------------------------------------------------

--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -524,23 +524,22 @@ fn cols_to_simple(cols: &[ColumnDef]) -> Vec<SimpleColumn> {
         .collect()
 }
 
-/// DuckDB's `CONCAT` implicitly casts scalars — `VARCHAR`, `BIGINT`, `DOUBLE`,
-/// `BOOLEAN`, `DATE` and `TIMESTAMPTZ` all concatenate — but rejects nested
-/// types:
-///
-/// ```text
-/// D SELECT CONCAT(' ', ['a','b']);
-/// Binder Error: Cannot concatenate types VARCHAR and VARCHAR[] - an explicit
-/// cast is required
-/// ```
-///
-/// Quicksearch concatenates every visible column, so a single LIST, STRUCT or
-/// MAP column makes the whole table impossible to preview. Casting each column
-/// is also what a text search wants: the comparison is textual either way.
-fn duckdb_searchable_columns(columns: &[String]) -> String {
-    columns
-        .iter()
-        .map(|col| format!("CAST({} AS VARCHAR)", col))
+/// DuckDB's `concat` doubles as list concatenation, so a LIST or ARRAY beside a
+/// VARCHAR is a binder error rather than an implicit cast, and quicksearch
+/// concatenates every visible column, so one of them makes the table
+/// unpreviewable. Everything else concatenates as text and stays uncast: the
+/// frontend twin of this predicate feeds app policy digests that a changed
+/// string invalidates.
+fn duckdb_quicksearch_columns(column_defs: &[ColumnDef]) -> String {
+    visible_column_defs(column_defs)
+        .map(|c| {
+            let quoted = render_db_quoted_identifier(&c.field, DbType::Duckdb);
+            if c.datatype.trim_end().ends_with(']') {
+                format!("CAST({} AS VARCHAR)", quoted)
+            } else {
+                quoted
+            }
+        })
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -599,10 +598,14 @@ fn qi(identifier: &str, db_type: DbType) -> String {
     render_db_quoted_identifier(identifier, db_type)
 }
 
+/// The columns a table preview shows, in the order [`build_visible_field_list`]
+/// renders them.
+fn visible_column_defs(column_defs: &[ColumnDef]) -> impl Iterator<Item = &ColumnDef> {
+    column_defs.iter().filter(|c| c.ignored != Some(true))
+}
+
 pub fn build_visible_field_list(column_defs: &[ColumnDef], db_type: DbType) -> Vec<String> {
-    column_defs
-        .iter()
-        .filter(|c| c.ignored != Some(true))
+    visible_column_defs(column_defs)
         .map(|c| render_db_quoted_identifier(&c.field, db_type))
         .collect()
 }
@@ -1040,7 +1043,7 @@ pub fn make_select_query(
 
             let quicksearch = format!(
                 "($quicksearch = '' OR CONCAT({}) ILIKE '%' || $quicksearch || '%')",
-                duckdb_searchable_columns(&filtered_columns)
+                duckdb_quicksearch_columns(column_defs)
             );
 
             query.push_str(&format!(
@@ -1209,7 +1212,7 @@ pub fn make_count_query(
             if !filtered_columns.is_empty() {
                 quicksearch_condition.push_str(&format!(
                     " ($quicksearch = '' OR CONCAT(' ', {}) LIKE CONCAT('%', $quicksearch, '%'))",
-                    duckdb_searchable_columns(&filtered_columns)
+                    duckdb_quicksearch_columns(column_defs)
                 ));
             } else {
                 quicksearch_condition.push_str(" ($quicksearch = '' OR 1 = 1)");
@@ -3147,103 +3150,42 @@ mod tests {
 
         assert!(result.starts_with("-- $limit (int)\n-- $offset (int)\n-- $quicksearch (text)\n-- $order_by (text)\n-- $is_desc (boolean)\n"));
         assert!(result.contains("SELECT \"id\", \"name\" FROM \"my_table\"\n"));
-        // Columns are cast for the search but NOT for the projection.
-        assert!(result.contains(
-            "CONCAT(CAST(\"id\" AS VARCHAR), CAST(\"name\" AS VARCHAR)) ILIKE '%' || $quicksearch || '%'"
-        ));
+        assert!(result.contains("CONCAT(\"id\", \"name\") ILIKE '%' || $quicksearch || '%'"));
         assert!(result.contains("LIMIT $limit::INT OFFSET $offset::INT"));
     }
 
-    /// DuckDB's CONCAT implicitly casts scalars but rejects nested types, so a
-    /// single LIST column used to make a whole table impossible to preview:
-    ///
-    /// ```text
-    /// Binder Error: Cannot concatenate types VARCHAR and VARCHAR[] - an
-    /// explicit cast is required
-    /// ```
-    /// The live path: the frontend sends a `WM_INTERNAL_DB_SELECT` marker and the
-    /// backend expands it. Column definitions below are the real ones captured
-    /// from a failing job on a DuckLake table — 27 columns, one of them
-    /// `sync_id VARCHAR[]`, which is what made the expansion produce SQL DuckDB
-    /// refused:
-    ///
-    /// ```text
-    /// Binder Error: Cannot concatenate types VARCHAR, VARCHAR, BIGINT, ...,
-    /// VARCHAR[], ... and TIMESTAMP WITH TIME ZONE - an explicit cast is required
-    /// ```
+    /// Both the SELECT and the COUNT build the quicksearch predicate; fixing only
+    /// one leaves the grid rendering while the row count errors out.
     #[test]
-    fn test_duckdb_marker_expansion_casts_nested_types() {
+    fn test_duckdb_quicksearch_casts_only_list_columns() {
         let cols = vec![
             col("id", "VARCHAR"),
-            col("changed", "BIGINT"),
-            col("user_id", "INTEGER"),
-            col("role", "INTEGER"),
-            col("instrument", "INTEGER"),
-            col("company", "INTEGER"),
-            col("type", "VARCHAR"),
-            col("title", "VARCHAR"),
-            col("sync_id", "VARCHAR[]"),
-            col("balance", "DOUBLE"),
-            col("start_balance", "DOUBLE"),
-            col("credit_limit", "DOUBLE"),
-            col("in_balance", "BOOLEAN"),
-            col("savings", "BOOLEAN"),
-            col("enable_correction", "BOOLEAN"),
-            col("enable_sms", "BOOLEAN"),
-            col("archive", "BOOLEAN"),
-            col("capitalization", "BOOLEAN"),
-            col("percent", "DOUBLE"),
-            col("start_date", "DATE"),
-            col("end_date_offset", "INTEGER"),
-            col("end_date_offset_interval", "VARCHAR"),
-            col("payoff_step", "INTEGER"),
-            col("payoff_interval", "VARCHAR"),
-            col("balance_correction_type", "VARCHAR"),
-            col("private", "BOOLEAN"),
-            col("_loaded_at", "TIMESTAMP WITH TIME ZONE")
+            col("tags", "VARCHAR[]"),
+            col("pos", "INTEGER[3]"),
+            col("meta", "STRUCT(a INTEGER)"),
         ];
-        let result =
-            make_select_query("raw.zenmoney__accounts", &cols, None, DbType::Duckdb, None, None)
-                .unwrap();
 
-        assert!(
-            result.contains("CAST(\"sync_id\" AS VARCHAR)"),
-            "the array column must be cast in quicksearch, got:\n{}",
-            result
-        );
-        // Every column is cast, not just the nested one — a partial cast would
-        // still fail the moment the types are mixed.
-        for (field, _) in [("id", ""), ("changed", ""), ("balance", "")] {
-            assert!(
-                result.contains(&format!("CAST(\"{}\" AS VARCHAR)", field)),
-                "column {} not cast",
-                field
-            );
-        }
-    }
-
-    #[test]
-    fn test_select_duckdb_quicksearch_casts_nested_types() {
-        let cols = vec![
-            col("id", "text"),
-            col("tag", "VARCHAR[]"),
-            col("points", "BIGINT[]"),
-            col("ts", "TIMESTAMP WITH TIME ZONE"),
-        ];
-        let result =
+        let select =
             make_select_query("my_table", &cols, None, DbType::Duckdb, None, None).unwrap();
-
-        for column in ["\"id\"", "\"tag\"", "\"points\"", "\"ts\""] {
-            assert!(
-                result.contains(&format!("CAST({} AS VARCHAR)", column)),
-                "quicksearch must cast {}, got:\n{}",
-                column,
-                result
-            );
-        }
+        assert!(
+            select.contains(
+                "CONCAT(\"id\", CAST(\"tags\" AS VARCHAR), CAST(\"pos\" AS VARCHAR), \"meta\") ILIKE"
+            ),
+            "got:\n{}",
+            select
+        );
         // The projection stays untouched: casting there would change the types
         // the caller reads back.
-        assert!(result.contains("SELECT \"id\", \"tag\", \"points\", \"ts\" FROM \"my_table\""));
+        assert!(select.contains("SELECT \"id\", \"tags\", \"pos\", \"meta\" FROM \"my_table\""));
+
+        let count = make_count_query(DbType::Duckdb, "my_table", None, &cols, None).unwrap();
+        assert!(
+            count.contains(
+                "CONCAT(' ', \"id\", CAST(\"tags\" AS VARCHAR), CAST(\"pos\" AS VARCHAR), \"meta\") LIKE"
+            ),
+            "got:\n{}",
+            count
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -3391,21 +3333,9 @@ mod tests {
 
         assert!(result.contains("-- $quicksearch (text)"));
         assert!(result.contains("SELECT COUNT(*) as count FROM \"my_table\""));
-        assert!(result.contains(
-            "CONCAT(' ', CAST(\"id\" AS VARCHAR), CAST(\"name\" AS VARCHAR)) LIKE CONCAT('%', $quicksearch, '%')"
-        ));
-    }
-
-    /// COUNT shares the quicksearch predicate with SELECT, so a nested-type
-    /// column has to be cast here too — otherwise the row count fails while
-    /// the page itself renders.
-    #[test]
-    fn test_count_duckdb_quicksearch_casts_nested_types() {
-        let cols = vec![col("id", "text"), col("tag", "VARCHAR[]")];
-        let result = make_count_query(DbType::Duckdb, "my_table", None, &cols, None).unwrap();
-
-        assert!(result.contains("CAST(\"tag\" AS VARCHAR)"), "got:\n{}", result);
-        assert!(result.contains("CAST(\"id\" AS VARCHAR)"), "got:\n{}", result);
+        assert!(
+            result.contains("CONCAT(' ', \"id\", \"name\") LIKE CONCAT('%', $quicksearch, '%')")
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/frontend/src/lib/components/apps/components/display/dbtable/duckdbQuicksearchColumns.test.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/duckdbQuicksearchColumns.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { buildVisibleFieldList, duckdbQuicksearchColumns, type ColumnDef } from './utils'
+
+function col(field: string, datatype: string, extra: Partial<ColumnDef> = {}): ColumnDef {
+	return { field, datatype, ...extra } as ColumnDef
+}
+
+describe('duckdbQuicksearchColumns', () => {
+	it('casts list and array columns, and nothing else', () => {
+		expect(
+			duckdbQuicksearchColumns([
+				col('id', 'VARCHAR'),
+				col('tags', 'VARCHAR[]'),
+				col('pos', 'INTEGER[3]'),
+				col('meta', 'STRUCT(a INTEGER)')
+			])
+		).toBe('"id", CAST("tags" AS VARCHAR), CAST("pos" AS VARCHAR), "meta"')
+	})
+
+	// This byte-identity is what keeps the policy digest of an already-deployed
+	// Database Studio app valid; a table with no list column must produce the
+	// query it produced before quicksearch learned to cast anything.
+	it('emits the plain column list when no column is a list', () => {
+		const columnDefs = [col('id', 'VARCHAR'), col('n', 'INTEGER'), col('at', 'TIMESTAMP')]
+		expect(duckdbQuicksearchColumns(columnDefs)).toBe(
+			buildVisibleFieldList(columnDefs, 'duckdb').join(', ')
+		)
+	})
+
+	it('skips ignored columns', () => {
+		expect(
+			duckdbQuicksearchColumns([col('id', 'VARCHAR'), col('tags', 'VARCHAR[]', { ignored: true })])
+		).toBe('"id"')
+	})
+})

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/count.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/count.ts
@@ -11,8 +11,12 @@ import type { AppInput, RunnableByName } from '$lib/components/apps/inputType'
 import { wrapDucklakeQuery } from '../../../../../ducklake'
 import type { DbType, DbInput } from '$lib/components/dbTypes'
 import { buildParameters } from '../utils'
-import { getLanguageByResourceType, type ColumnDef, buildVisibleFieldList } from '../utils'
-import { duckdbSearchableColumns } from './select'
+import {
+	getLanguageByResourceType,
+	type ColumnDef,
+	buildVisibleFieldList,
+	duckdbQuicksearchColumns
+} from '../utils'
 
 export function makeCountQuery(
 	dbType: DbType,
@@ -119,8 +123,8 @@ export function makeCountQuery(
 		}
 		case 'duckdb':
 			if (filteredColumns.length > 0) {
-				quicksearchCondition += ` ($quicksearch = '' OR CONCAT(' ', ${duckdbSearchableColumns(
-					filteredColumns
+				quicksearchCondition += ` ($quicksearch = '' OR CONCAT(' ', ${duckdbQuicksearchColumns(
+					columnDefs
 				)}) LIKE CONCAT('%', $quicksearch, '%'))`
 			} else {
 				quicksearchCondition += ` ($quicksearch = '' OR 1 = 1)`

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/count.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/count.ts
@@ -12,6 +12,7 @@ import { wrapDucklakeQuery } from '../../../../../ducklake'
 import type { DbType, DbInput } from '$lib/components/dbTypes'
 import { buildParameters } from '../utils'
 import { getLanguageByResourceType, type ColumnDef, buildVisibleFieldList } from '../utils'
+import { duckdbSearchableColumns } from './select'
 
 export function makeCountQuery(
 	dbType: DbType,
@@ -118,8 +119,8 @@ export function makeCountQuery(
 		}
 		case 'duckdb':
 			if (filteredColumns.length > 0) {
-				quicksearchCondition += ` ($quicksearch = '' OR CONCAT(' ', ${filteredColumns.join(
-					', '
+				quicksearchCondition += ` ($quicksearch = '' OR CONCAT(' ', ${duckdbSearchableColumns(
+					filteredColumns
 				)}) LIKE CONCAT('%', $quicksearch, '%'))`
 			} else {
 				quicksearchCondition += ` ($quicksearch = '' OR 1 = 1)`

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/select.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/select.ts
@@ -11,7 +11,12 @@ import type { AppInput, RunnableByName } from '$lib/components/apps/inputType'
 import { wrapDucklakeQuery } from '../../../../../ducklake'
 import type { DbType, DbInput } from '$lib/components/dbTypes'
 import { buildParameters } from '../utils'
-import { getLanguageByResourceType, type ColumnDef, buildVisibleFieldList } from '../utils'
+import {
+	getLanguageByResourceType,
+	type ColumnDef,
+	buildVisibleFieldList,
+	duckdbQuicksearchColumns
+} from '../utils'
 
 function makeSnowflakeSelectQuery(
 	table: string,
@@ -88,17 +93,6 @@ function makeSnowflakeSelectQuery(
 	query = buildParameters(headers, 'snowflake') + '\n' + query
 
 	return query
-}
-
-/**
- * DuckDB's CONCAT implicitly casts scalars but rejects nested types:
- * `CONCAT(' ', ['a','b'])` fails with "Cannot concatenate types VARCHAR and
- * VARCHAR[] - an explicit cast is required". Quicksearch concatenates every
- * visible column, so one LIST, STRUCT or MAP column makes the whole table
- * impossible to preview. Casting is also what a text search wants.
- */
-export function duckdbSearchableColumns(columns: string[]): string {
-	return columns.map((column) => `CAST(${column} AS VARCHAR)`).join(', ')
 }
 
 export function makeSelectQuery(
@@ -309,8 +303,8 @@ CASE WHEN :order_by = '${column.field}' AND :is_desc IS true THEN \`${column.fie
 				)
 				.join(',\n')}`
 
-			quicksearchCondition = `($quicksearch = '' OR CONCAT(${duckdbSearchableColumns(
-				filteredColumns
+			quicksearchCondition = `($quicksearch = '' OR CONCAT(${duckdbQuicksearchColumns(
+				columnDefs
 			)}) ILIKE '%' || $quicksearch || '%')`
 
 			query += `SELECT ${filteredColumns.join(', ')} FROM ${table}\n`

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/select.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/select.ts
@@ -90,6 +90,17 @@ function makeSnowflakeSelectQuery(
 	return query
 }
 
+/**
+ * DuckDB's CONCAT implicitly casts scalars but rejects nested types:
+ * `CONCAT(' ', ['a','b'])` fails with "Cannot concatenate types VARCHAR and
+ * VARCHAR[] - an explicit cast is required". Quicksearch concatenates every
+ * visible column, so one LIST, STRUCT or MAP column makes the whole table
+ * impossible to preview. Casting is also what a text search wants.
+ */
+export function duckdbSearchableColumns(columns: string[]): string {
+	return columns.map((column) => `CAST(${column} AS VARCHAR)`).join(', ')
+}
+
 export function makeSelectQuery(
 	table: string,
 	columnDefs: ColumnDef[],
@@ -298,8 +309,8 @@ CASE WHEN :order_by = '${column.field}' AND :is_desc IS true THEN \`${column.fie
 				)
 				.join(',\n')}`
 
-			quicksearchCondition = `($quicksearch = '' OR CONCAT(${filteredColumns.join(
-				', '
+			quicksearchCondition = `($quicksearch = '' OR CONCAT(${duckdbSearchableColumns(
+				filteredColumns
 			)}) ILIKE '%' || $quicksearch || '%')`
 
 			query += `SELECT ${filteredColumns.join(', ')} FROM ${table}\n`

--- a/frontend/src/lib/components/apps/components/display/dbtable/utils.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/utils.ts
@@ -305,11 +305,32 @@ export async function formatGraphqlSchema(schema: IntrospectionQuery): Promise<s
 	return printSchema(buildClientSchema(schema))
 }
 
+// Filter out hidden columns to avoid counting the wrong number of rows
+function visibleColumnDefs(columnDefs: ColumnDef[]): ColumnDef[] {
+	return columnDefs.filter((columnDef: ColumnDef) => columnDef && columnDef.ignored !== true)
+}
+
 export function buildVisibleFieldList(columnDefs: ColumnDef[], dbType: DbType) {
-	// Filter out hidden columns to avoid counting the wrong number of rows
-	return columnDefs
-		.filter((columnDef: ColumnDef) => columnDef && columnDef.ignored !== true)
-		.map((column) => renderDbQuotedIdentifier(column?.field, dbType))
+	return visibleColumnDefs(columnDefs).map((column) =>
+		renderDbQuotedIdentifier(column?.field, dbType)
+	)
+}
+
+/**
+ * DuckDB's `concat` doubles as list concatenation, so a LIST or ARRAY beside a
+ * VARCHAR is a binder error rather than an implicit cast, and quicksearch
+ * concatenates every visible column, so one of them makes the table
+ * unpreviewable. Everything else concatenates as text and stays uncast: this
+ * query is digested into the policy of every deployed Database Studio app, and
+ * a changed string invalidates it until the app is redeployed.
+ */
+export function duckdbQuicksearchColumns(columnDefs: ColumnDef[]): string {
+	return visibleColumnDefs(columnDefs)
+		.map((column) => {
+			const quoted = renderDbQuotedIdentifier(column?.field, 'duckdb')
+			return column?.datatype?.trimEnd().endsWith(']') ? `CAST(${quoted} AS VARCHAR)` : quoted
+		})
+		.join(', ')
 }
 
 export function renderDbQuotedIdentifier(identifier: string, dbType: DbType): string {


### PR DESCRIPTION
### Problem

A DuckLake (or DuckDB) table with a `LIST` or `ARRAY` column cannot be previewed at all. The grid fails, and so does its row count:

```
Binder Error: Cannot concatenate types VARCHAR, VARCHAR, BIGINT, INTEGER, ...,
VARCHAR[], DOUBLE, ..., BOOLEAN and TIMESTAMP WITH TIME ZONE - an explicit cast
is required

LINE 1: ... FROM "raw"."zenmoney__accounts" WHERE ($1 = '' OR CONCAT(' ', "id",
"changed", "user_id", ...
```

### Cause

Quicksearch concatenates every visible column. DuckDB's `concat` doubles as *list* concatenation, so a `LIST`/`ARRAY` argument next to a `VARCHAR` is ambiguous and rejected outright, where every other type is implicitly cast to text:

```
D SELECT CONCAT(' ', ['a','b']);
Binder Error: Cannot concatenate types VARCHAR and VARCHAR[] - an explicit cast is required
```

Only the list family is affected. Checked against the bundled engine (DuckDB 1.5.2), one column per type: `BOOLEAN`, every int width, `FLOAT`/`DOUBLE`/`DECIMAL`, `VARCHAR`, `BLOB`, `DATE`, `TIME`, `TIMETZ`, `TIMESTAMP`, `TIMESTAMPTZ`, `INTERVAL`, `UUID`, `JSON`, `BIT`, `ENUM`, `STRUCT`, `MAP` and `UNION` all concatenate; `VARCHAR[]`, `INTEGER[3]` and `VARCHAR[][]` are the three that fail.

### Fix

Cast the list columns, and only those, inside the quicksearch predicate. The comparison is textual either way, so no result changes, and the projection is left untouched: casting there would change the types the caller reads back.

Casting *every* column also fixes the error, but it rewrites the query for tables that never had a problem, and that string is not free to change: the frontend builder below is hashed into the policy of every deployed Database Studio app (`rawscript/<sha256(content)>` in `triggerables_v2`). A changed string turns a working app into `Path rawscript/... forbidden by policy` until it is redeployed. Restricting the cast to the columns DuckDB actually rejects keeps the emitted SQL byte-identical for every table without a list column, so only tables that are already broken see their query change.

### Note for the release notes

An app deployed *before* this fix, against a table that **has** a list column, swaps its binder error for `Path rawscript/... forbidden by policy` until it is redeployed. It was already unusable either way, so this is not a new breakage, but the error text changes. Tables without a list column are unaffected, which is what the narrow cast buys.

### Two code paths, both fixed

- **Backend, and the one that produced the error above.** The Database Manager does not send SQL; it sends a `-- WM_INTERNAL_DB_SELECT {...}` marker carrying the table and its column definitions, which `query_builders.rs` expands. That is the live path for DuckLake browsing.
- **Frontend.** `AppDbExplorer` builds SQL client-side for the app Database Studio component, with the same defect in `dbtable/queries/{select,count}.ts`.

They are independent implementations of the same predicate, so both are fixed; leaving either would fix one feature and not the other. Both are covered at `SELECT` and at `COUNT`, since fixing only one leaves the grid rendering while the row count still errors.

### Verification

`cargo test -p windmill-common --lib query_builders` → 187 passed. The one new test pins that a list column is cast and a scalar is not, in both the `SELECT` and the `COUNT`; it fails without the fix (confirmed by disabling the predicate and re-running). The pre-existing DuckDB assertions are untouched, which is the point: their SQL does not move.

Exercised end-to-end against a live DuckLake table (`accounts`, with `sync_id VARCHAR[]`) on a backend built with `--features quickjs,duckdb,parquet,private`:

| | result |
|---|---|
| before, same table, same engine | `Binder Error: Cannot concatenate types VARCHAR, VARCHAR, VARCHAR, VARCHAR[], DECIMAL(5,2), BOOLEAN and TIMESTAMP WITH TIME ZONE` |
| after, `SELECT` + `COUNT` | 3 rows, count 3, array column intact |
| after, search `Tinkoff` (scalar column) | 1 row |
| after, search `s2` (inside the array) | 1 row |

**Database Manager** (backend marker path): grid, row count and quicksearch on the array column:

![Database Manager preview of a DuckLake table with a VARCHAR[] column](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/duckdb-cast/1786384768-wm-dbm-1.png)

![Quicksearch "s2" matching inside the array column, count 1 of 1](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/duckdb-cast/1786384770-wm-dbm-search3.png)

**Database Studio app component** (frontend builder path): same table, quicksearch `s2` matching inside `sync_id`:

![Database Studio app component, quicksearch s2 on the same table](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/duckdb-cast/1786384772-wm-app-10.png)

The byte-identity claim was also checked the way it actually matters, against a **deployed** app rather than a draft: an app was deployed over a DuckLake table with no list column while the frontend was still at `main`, so its policy carried the pre-fix digests (`a:rawscript/941c1fa8…`, `a_count:rawscript/cdd20261…`). Loading that same deployed app with this branch's frontend renders and searches normally, with no `forbidden by policy`. Casting every column would have broken exactly this.

![Deployed pre-fix app running on the patched frontend, quicksearch returning 1 of 1](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/duckdb-cast/1786385527-wm-deployed-search.png)

Finally, a table mixing all the nested kinds (`tags VARCHAR[]`, `meta STRUCT(city VARCHAR, n INTEGER)`, `attrs MAP(VARCHAR, INTEGER)`) previews, and quicksearch on `Berlin`, which lives inside the **uncast** `STRUCT`, returns 1 of 1. Leaving `STRUCT` and `MAP` uncast costs nothing in search behavior. (DuckLake rejects fixed-size `INTEGER[3]` at write time, so that spelling is covered by the unit tests rather than end to end; it reaches this predicate only on plain DuckDB.)

![Quicksearch matching inside an uncast STRUCT column on a table that also has a list and a map](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/duckdb-cast/1786386770-wm-mixed-struct-map.png)
