### PR TITLE
docs(openapi): add FilesystemStorage to LargeFileStorage

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -31993,6 +31993,7 @@ components:
               "S3Storage",
               "AzureBlobStorage",
               "AzureWorkloadIdentity",
+              "FilesystemStorage",
               "S3AwsOidc",
               "GoogleCloudStorage",
             ]
@@ -32002,6 +32003,9 @@ components:
           type: string
         gcs_resource_path:
           type: string
+        root_path:
+          type: string
+          description: Absolute path on the worker filesystem, for FilesystemStorage.
         public_resource:
           type: boolean
         advanced_permissions:
@@ -32020,6 +32024,7 @@ components:
                     "S3Storage",
                     "AzureBlobStorage",
                     "AzureWorkloadIdentity",
+                    "FilesystemStorage",
                     "S3AwsOidc",
                     "GoogleCloudStorage",
                   ]
@@ -32029,6 +32034,9 @@ components:
                 type: string
               gcs_resource_path:
                 type: string
+              root_path:
+                type: string
+                description: Absolute path on the worker filesystem, for FilesystemStorage.
               public_resource:
                 type: boolean
 


### PR DESCRIPTION
### Problem

`LargeFileStorage.type` in the OpenAPI spec lists only:

```
S3Storage | AzureBlobStorage | AzureWorkloadIdentity | S3AwsOidc | GoogleCloudStorage
```

`FilesystemStorage` is missing, so reading the spec says a filesystem-backed object store is not supported — and a self-hosted DuckLake on a local filesystem looks impossible.

### It is supported

- `windmill-object-store` has `build_filesystem_client`, backed by `object_store::local::LocalFileSystem`, with a `FilesystemStoreIgnoringAttributes` wrapper for the attribute-rejection case and a dozen unit tests.
- `LargeFileStorage::FilesystemStorage(..) => ObjectStoreResource::Filesystem(..)` is a real arm of the resolver.
- `LargeFileStorage` in `windmill-types` has the variant.
- CE 1.783.0 accepts `POST /w/{workspace}/workspaces/edit_large_file_storage_config` with `{"type": "FilesystemStorage", "root_path": "/..."}`, persists it, reads it back, and DuckLake then works end to end against a local tree.

### Change

Adds the variant to both `type` enums — the primary block and `secondary_storage` — and documents `root_path`, so a generated client can construct the variant rather than only name it.

Only `openapi.yaml` is touched; `openapi-deref.{yaml,json}` are generated by `build_openapi.sh` and are left for that script.

### Why it is worth a patch

The omission costs real time: it is the difference between "configure this" and "this needs an upstream contribution". Working from the spec led to exactly the wrong conclusion until the code said otherwise.

One adjacent nicety, not included here: the DuckLake `storage.path` must be a prefix *relative* to the object-store root. An absolute path produces `s3_proxy/_default_//Volumes/...` — note the doubled slash — and a 401 that says nothing about the cause. Rejecting an absolute `path`, or documenting it, would save the next person an hour.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `FilesystemStorage` to `LargeFileStorage` in the OpenAPI spec and document `root_path`, so clients can configure filesystem-backed storage and generated clients can construct this variant. Aligns the spec with the existing implementation and enables DuckLake on local filesystems.

<sup>Written for commit 67d2f13dbfaac739ca669b823a9cf716371fde06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

