### PR TITLE
fix: unblock the frontend check (type error + svelte-check OOM)

### DIFF
--- a/.github/workflows/frontend-check.yml
+++ b/.github/workflows/frontend-check.yml
@@ -23,5 +23,8 @@ jobs:
           cache-dependency-path: "frontend/package-lock.json"
       - name: "npm check"
         timeout-minutes: 5
+        env:
+          # svelte-check peaks past node's ~4GB default ceiling on this runner and aborts.
+          NODE_OPTIONS: --max-old-space-size=8192
         run: cd frontend && npm ci && npm run generate-backend-client && npm run
           check

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -456,7 +456,9 @@
 		error && sendUserToast(escapeHtml(error), true)
 	})
 
-	let loginOptionCount = $derived((logins?.length ?? 0) + (saml ? 1 : 0))
+	// Read inside a closure: at this scope TS narrows `logins` to its initializer's
+	// `undefined`, which makes `logins?.length` an access on `never`.
+	let loginOptionCount = $derived.by(() => (logins?.length ?? 0) + (saml ? 1 : 0))
 </script>
 
 <div class="bg-surface px-4 py-8 border sm:rounded-lg sm:px-10">


### PR DESCRIPTION
## Summary

`check frontend build` has been red on main since Aug 7 (last green run: `099efa358a`, release 1.783.0). There are two independent causes, and they mask each other: a run either OOMs before finishing or finishes and reports the type error.

**1. `svelte-check` OOM (`exit code 134`).** The step sets no `NODE_OPTIONS`, so node uses its default ~4GB old-space limit on `ubicloud-standard-8`, and the type-check now peaks past it:

```
[2168] 61317 ms: Mark-Compact (reduce) 4058.2 (4088.1) -> 3312.3 (3823.7) MB ...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Measured locally on the same tree, peak RSS is **4,500,904 KB (~4.29 GB)**, so the job is a coin flip against the default ceiling rather than a hard failure. Classifying the last ~19 failures: 6 OOM, 7 real type error, rest infra. Earliest OOM I found is Aug 6 (run `31127770374`), most recent Aug 10 (run `31409484911`), so this is gradual growth crossing the line, not one commit.

**2. A real type error**, introduced by #10598 in `Login.svelte`:

```
Error: Property 'length' does not exist on type 'never'. (ts)
svelte-check found 1 error and 70 warnings in 48 files
```

`logins` is declared `let logins: OAuthLogin[] | undefined = $state(undefined)`. At top-level script scope TS narrows it by its initializer to `undefined`, so the non-nullish branch of `logins?.length` is `never`. Every other `logins?.` read is inside a function or in markup, where narrowing resets to the declared type, which is why the new top-level `$derived` is the first to trip it. Reading through a closure keeps the declared type.

## Changes

- `frontend/src/lib/components/Login.svelte`: compute `loginOptionCount` with `$derived.by(() => …)` so the reads happen inside a closure. Same value, same reactivity.
- `.github/workflows/frontend-check.yml`: give the `npm check` step `NODE_OPTIONS: --max-old-space-size=8192` (the runner has 16GB).

## Screenshots

Verified against a local dev server with the provider list stubbed, since no OAuth provider is configured locally. Both branches of the count that #10598 added still behave:

4 login options → two columns

![login-4-providers](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/frontend-check-oom-and-login-derived/1786381872-login-4-providers.png)

3 login options (2 OAuth + SAML) → one column

![login-3-providers](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/frontend-check-oom-and-login-derived/1786381875-login-3-providers.png)

## Test plan

- [x] `npm run check` on this branch: `0 ERRORS 70 WARNINGS`, peak RSS 4.29GB
- [x] Login page renders with 4 options (two columns) and 3 options (one column)
- [x] `npm_check` green in CI on this PR: [run 31413185947](https://github.com/windmill-labs/windmill/actions/runs/31413185947), `svelte-check found 0 errors and 70 warnings`, no OOM
