### PR TITLE
fix(frontend): keep the logins state declaration from narrowing to undefined

### DIFF
--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -91,7 +91,9 @@
 	const providersType = providers.map((p) => p.type as string)
 
 	let showPassword = $state(false)
-	let logins: OAuthLogin[] | undefined = $state(undefined)
+	// Type argument rather than annotation: annotating narrows the declaration to the
+	// initializer's `undefined`, so a top-level read sees `never` instead of the array.
+	let logins = $state<OAuthLogin[] | undefined>(undefined)
 	let saml: string | undefined = $state(undefined)
 	let smtpConfigured: boolean | undefined = $state(undefined)
 	let disablePasswordLogin = $state(false)
@@ -456,9 +458,7 @@
 		error && sendUserToast(escapeHtml(error), true)
 	})
 
-	// Read inside a closure: at this scope TS narrows `logins` to its initializer's
-	// `undefined`, which makes `logins?.length` an access on `never`.
-	let loginOptionCount = $derived.by(() => (logins?.length ?? 0) + (saml ? 1 : 0))
+	let loginOptionCount = $derived((logins?.length ?? 0) + (saml ? 1 : 0))
 </script>
 
 <div class="bg-surface px-4 py-8 border sm:rounded-lg sm:px-10">


### PR DESCRIPTION
## Summary

Follow-up to #10617, applying the P2 nit from its review round after it was merged.

#10617 unblocked the frontend check by reading `logins` inside a closure (`$derived.by`). That treats the symptom. The narrowing originates at the declaration: with an annotation, `$state(undefined)` infers `T = undefined`, so the declared `OAuthLogin[] | undefined` is narrowed away immediately and a top-level read sees `never`. Passing the type argument instead makes the initializer's type equal the declared type, so no narrowing happens and the plain `$derived` type-checks as written.

## Changes

- `Login.svelte:94`: `let logins = $state<OAuthLogin[] | undefined>(undefined)` instead of the annotated form.
- `Login.svelte:461`: revert `loginOptionCount` to the plain `$derived` #10598 originally wrote, and drop the workaround's explanatory comment.

## Screenshots

No visible UI effect: both hunks are type-level, and the resulting `loginOptionCount` expression is byte-identical to the one whose two layout branches were screenshotted in #10617 (4 options → two columns, 3 options → one column).

## Test plan

- [x] `npm run check` on this branch: `0 ERRORS 70 WARNINGS`, same as main
- [x] `npm_check` green in CI on this PR: [run 31414868872](https://github.com/windmill-labs/windmill/actions/runs/31414868872), `svelte-check found 0 errors and 70 warnings`
