### PR TITLE
fix: raw app new-app modal ignores instance-level AI settings

### DIFF
--- a/frontend/src/lib/components/copilot/loadCopilot.test.ts
+++ b/frontend/src/lib/components/copilot/loadCopilot.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { get } from 'svelte/store'
+
+vi.mock('./lib', () => ({
+	workspaceAIClients: { init: () => {} }
+}))
+
+let requests: { workspace: string; resolve: (config: any) => void }[] = []
+
+vi.mock('$lib/gen', () => ({
+	WorkspaceService: {
+		getCopilotInfo: ({ workspace }: { workspace: string }) =>
+			new Promise((resolve) => requests.push({ workspace, resolve }))
+	}
+}))
+
+import { loadCopilot } from './loadCopilot'
+import { copilotWorkspace } from '$lib/aiStore'
+
+const config = { providers: { anthropic: { resource_path: 'u/admin/anthropic', models: ['m'] } } }
+
+describe('loadCopilot', () => {
+	beforeEach(() => {
+		requests = []
+		copilotWorkspace.set(undefined)
+	})
+
+	it('shares one request between callers loading the same workspace', async () => {
+		const first = loadCopilot('ws')
+		const second = loadCopilot('ws')
+
+		expect(requests.map((r) => r.workspace)).toEqual(['ws'])
+		requests[0].resolve(config)
+		await Promise.all([first, second])
+		expect(get(copilotWorkspace)).toBe('ws')
+	})
+
+	it('lets a re-requested workspace win back over the one that superseded it', async () => {
+		const a1 = loadCopilot('a')
+		const b = loadCopilot('b')
+		// Sharing `a1` here would leave `a` unapplied: only the newest request's
+		// result is written, and `a1` already lost that race to `b`.
+		const a2 = loadCopilot('a')
+		expect(requests.map((r) => r.workspace)).toEqual(['a', 'b', 'a'])
+
+		requests[0].resolve(config)
+		requests[1].resolve(config)
+		requests[2].resolve(config)
+		await Promise.all([a1, b, a2])
+
+		expect(get(copilotWorkspace)).toBe('a')
+	})
+})

--- a/frontend/src/lib/components/copilot/loadCopilot.test.ts
+++ b/frontend/src/lib/components/copilot/loadCopilot.test.ts
@@ -38,8 +38,8 @@ describe('loadCopilot', () => {
 	it('lets a re-requested workspace win back over the one that superseded it', async () => {
 		const a1 = loadCopilot('a')
 		const b = loadCopilot('b')
-		// Sharing `a1` here would leave `a` unapplied: only the newest request's
-		// result is written, and `a1` already lost that race to `b`.
+		// A per-workspace cache would hand back `a1` here — which has already lost the
+		// apply race to `b`, so `a` would silently never be written.
 		const a2 = loadCopilot('a')
 		expect(requests.map((r) => r.workspace)).toEqual(['a', 'b', 'a'])
 

--- a/frontend/src/lib/components/copilot/loadCopilot.ts
+++ b/frontend/src/lib/components/copilot/loadCopilot.ts
@@ -15,21 +15,20 @@ let loadCopilotToken = 0
 
 // Consumers load the config for the workspace they operate on rather than trusting an
 // ancestor to have done it, and they mount together — so share the in-flight request
-// instead of firing one GET each. Only the newest load applies its result, hence only
-// the newest is shareable: a superseded workspace needs a fresh request to win again.
-let inFlight: { workspace: string; token: number; promise: Promise<void> } | undefined
+// instead of firing one GET each. Only ever hold the newest request here: an older one
+// has lost the token, so handing it back would leave its workspace never applied.
+let inFlight: { workspace: string; promise: Promise<void> } | undefined
 
 export function loadCopilot(workspace: string): Promise<void> {
-	if (inFlight && inFlight.workspace === workspace && inFlight.token === loadCopilotToken) {
+	if (inFlight?.workspace === workspace) {
 		return inFlight.promise
 	}
-	const token = ++loadCopilotToken
-	const promise = fetchAndApply(workspace, token).finally(() => {
-		if (inFlight?.token === token) {
+	const promise = fetchAndApply(workspace, ++loadCopilotToken).finally(() => {
+		if (inFlight?.promise === promise) {
 			inFlight = undefined
 		}
 	})
-	inFlight = { workspace, token, promise }
+	inFlight = { workspace, promise }
 	return promise
 }
 

--- a/frontend/src/lib/components/copilot/loadCopilot.ts
+++ b/frontend/src/lib/components/copilot/loadCopilot.ts
@@ -12,8 +12,28 @@ import { workspaceAIClients } from './lib'
 // result via a monotonic token — last invocation wins regardless of resolution
 // order. init() is synchronous so its ordering already matches.
 let loadCopilotToken = 0
-export async function loadCopilot(workspace: string) {
+
+// Consumers load the config for the workspace they operate on rather than trusting an
+// ancestor to have done it, and they mount together — so share the in-flight request
+// instead of firing one GET each. Only the newest load applies its result, hence only
+// the newest is shareable: a superseded workspace needs a fresh request to win again.
+let inFlight: { workspace: string; token: number; promise: Promise<void> } | undefined
+
+export function loadCopilot(workspace: string): Promise<void> {
+	if (inFlight && inFlight.workspace === workspace && inFlight.token === loadCopilotToken) {
+		return inFlight.promise
+	}
 	const token = ++loadCopilotToken
+	const promise = fetchAndApply(workspace, token).finally(() => {
+		if (inFlight?.token === token) {
+			inFlight = undefined
+		}
+	})
+	inFlight = { workspace, token, promise }
+	return promise
+}
+
+async function fetchAndApply(workspace: string, token: number) {
 	workspaceAIClients.init(workspace)
 	try {
 		const info = await WorkspaceService.getCopilotInfo({ workspace })

--- a/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
@@ -123,7 +123,7 @@
 	// `enabled` alone cannot tell "no providers" from "not loaded yet" and the modal
 	// would announce AI as unconfigured while it is merely unknown. Gate on the
 	// config describing opWs, and load it here so the claim owns its own evidence.
-	const aiConfigLoaded = $derived($copilotWorkspace === opWs)
+	const aiConfigLoaded = $derived(!!opWs && $copilotWorkspace === opWs)
 	const isAiEnabled = $derived(aiConfigLoaded && $copilotInfo.enabled)
 
 	$effect(() => {

--- a/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Sparkles, Plus, List, Ban, ExternalLinkIcon } from 'lucide-svelte'
+	import { Sparkles, Plus, List, Ban, ExternalLinkIcon, Loader2 } from 'lucide-svelte'
 	import type { Policy } from '$lib/gen'
 	import { userStore, workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
@@ -13,7 +13,8 @@
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import { Alert } from '$lib/components/common'
 	import { AIBtnClasses } from '$lib/components/copilot/chat/AIButtonStyle'
-	import { copilotInfo } from '$lib/aiStore'
+	import { copilotInfo, copilotWorkspace } from '$lib/aiStore'
+	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
 	import { react18Template, react19Template, svelte5Template } from './templates'
 	import type { Runnable } from './rawAppPolicy'
 	import { type DataTableRef, type RawAppData, formatDataTableRef } from './dataTableRefUtils'
@@ -117,7 +118,19 @@
 	)
 
 	const hasNoDatatables = $derived(availableDatatables?.length === 0)
-	const isAiEnabled = $derived($copilotInfo.enabled)
+
+	// copilotInfo is a global that stays empty until some ancestor's fetch lands, so
+	// `enabled` alone cannot tell "no providers" from "not loaded yet" and the modal
+	// would announce AI as unconfigured while it is merely unknown. Gate on the
+	// config describing opWs, and load it here so the claim owns its own evidence.
+	const aiConfigLoaded = $derived($copilotWorkspace === opWs)
+	const isAiEnabled = $derived(aiConfigLoaded && $copilotInfo.enabled)
+
+	$effect(() => {
+		if (open && opWs && !aiConfigLoaded) {
+			loadCopilot(opWs)
+		}
+	})
 
 	async function start(withPrompt: boolean) {
 		const template = templates[selectedTemplateIndex]
@@ -334,8 +347,13 @@
 					<span class="text-xs font-normal text-tertiary">(optional)</span>
 				</h2>
 
-				{#if !isAiEnabled}
-					<Alert type="info" title="AI is not configured for this workspace.">
+				{#if !aiConfigLoaded}
+					<div class="flex items-center gap-2 text-xs text-tertiary">
+						<Loader2 size={14} class="animate-spin" />
+						Loading AI settings...
+					</div>
+				{:else if !isAiEnabled}
+					<Alert type="info" title="AI is not configured.">
 						You can still create an app manually but using AI is highly recommended.
 						<br />
 						{#if $userStore?.is_admin}

--- a/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { Sparkles, Plus, List, Ban, ExternalLinkIcon, Loader2 } from 'lucide-svelte'
 	import type { Policy } from '$lib/gen'
-	import { userStore, workspaceStore } from '$lib/stores'
+	import { superadmin, userStore, workspaceStore } from '$lib/stores'
+	import { base } from '$lib/base'
 	import { sendUserToast } from '$lib/toast'
 	import { getRawAppOperatingWorkspace } from './rawAppWorkspace'
 	import Modal from '$lib/components/common/modal/Modal.svelte'
@@ -359,11 +360,20 @@
 						{#if $userStore?.is_admin}
 							Configure AI in
 							<a
-								href="/workspace_settings?tab=ai"
+								href="{base}/workspace_settings?tab=ai"
 								target="_blank"
 								class="inline-flex items-center gap-1 font-semibold"
 								>workspace settings <ExternalLinkIcon size={16} />
-							</a> to enable this feature.
+							</a>
+							{#if $superadmin}
+								or
+								<a
+									href="{base}/?workspace=admins#superadmin-settings"
+									target="_blank"
+									class="inline-flex items-center gap-1 font-semibold"
+									>instance settings <ExternalLinkIcon size={16} />
+								</a>
+							{/if} to enable this feature.
 						{:else}
 							Ask your workspace admin to configure AI in workspace settings to enable this feature.
 						{/if}

--- a/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
@@ -374,6 +374,14 @@
 									>instance settings <ExternalLinkIcon size={16} />
 								</a>
 							{/if} to enable this feature.
+						{:else if $superadmin}
+							Configure AI in
+							<a
+								href="{base}/?workspace=admins#superadmin-settings"
+								target="_blank"
+								class="inline-flex items-center gap-1 font-semibold"
+								>instance settings <ExternalLinkIcon size={16} />
+							</a> to enable this feature.
 						{:else}
 							Ask your workspace admin to configure AI in workspace settings to enable this feature.
 						{/if}


### PR DESCRIPTION
## Summary

Fixes WIN-2343.

The raw-app "New App setup" modal read the global `copilotInfo` store and rendered
**"AI is not configured for this workspace"** whenever `enabled` was false. That store
is empty until *some ancestor* fetches the config, so `enabled === false` conflates two
very different states: "this workspace has no AI providers" and "nobody has told us yet".

On 1.778.0 the second state was permanent for this route. The root layout only called
`loadCopilot` when the docked chat was enabled (`!disableAi`), and `disableAi` is `true`
for every non-operator once the AI Sessions beta gate is on — so the workspace AI config
was never loaded on any page that lacks its own `AiChatLayout`. Script and flow editors
mount their own (`ScriptWrapper` / `FlowWrapper`) and kept working, which is exactly the
reported asymmetry: AI configured at the instance level worked for scripts and flows but
the raw-app modal insisted it had to be set in workspace settings.

99e7661a1b (v1.779.0) untied the load from `disableAi`, which fixes the permanent case.
This PR removes the fragility that made it possible: the picker no longer trusts an
ancestor to have loaded the config, and never states AI is unconfigured until it has the
evidence. Without that, the alert still lies during the initial fetch — and this route
forces a full page reload, so the modal always opens on a cold store.

## Changes

- `RawAppTemplatePicker.svelte`: gate the AI section on the config actually describing the
  operating workspace (`copilotWorkspace === opWs`), not on `enabled` alone. While unknown,
  show "Loading AI settings..." instead of the alert.
- `RawAppTemplatePicker.svelte`: load the config for the operating workspace when the modal
  opens and nothing else has, so the claim owns its own evidence.
- `loadCopilot.ts`: share the in-flight request between callers loading the same workspace
  (the layout and the picker mount together) instead of firing one GET each. Only the newest
  load applies its result, so only the newest is shareable — a superseded workspace still
  gets a fresh request so it can win the token back.
- Reword the alert title to "AI is not configured." — with instance-level settings the
  config need not be a workspace one.
- Regression test for the `loadCopilot` sharing/token interaction.

## Screenshots

Instance-level AI configured (`global_settings.ai_config`), workspace `ai_config` NULL.
"Before"/"after-loading" are captured with `get_copilot_info` held open, which is the state
1.778.0 was stuck in permanently.

**Before** — the modal asserts AI is unconfigured while the config is merely unknown:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2343-fix-raw-app-not-recognizing-instance-level-ai-settings/1786384192-win2343-before.png)

**After, config not yet known** — no claim either way:

![after-loading](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2343-fix-raw-app-not-recognizing-instance-level-ai-settings/1786384194-win2343-after-loading.png)

**After, config resolved from the instance settings** — the AI prompt is offered:

![after-enabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2343-fix-raw-app-not-recognizing-instance-level-ai-settings/1786384195-win2343-after-enabled.png)

## Test plan

- [x] `npm run check` — 0 errors (70 pre-existing warnings, none in the touched files)
- [x] `npx vitest run src/lib/components/copilot/loadCopilot.test.ts src/lib/aiStore.test.ts` — 4 passed
- [x] Instance-level AI config set, workspace config empty → `/apps_raw/add` offers "Start with AI"
- [x] `get_copilot_info` held open → "Loading AI settings...", no alert (old code showed the alert)
- [x] No AI config anywhere → alert still shown after the fetch resolves
- [x] Exactly one `get_copilot_info` request on a cold load of `/apps_raw/add`, despite both
      the layout and the picker asking for it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the raw-app “New App” modal showing “AI is not configured” before the config is known, respects instance-level AI settings, and shows an instance settings link for superadmins (even if they aren’t workspace admins). Addresses WIN-2343.

- **Bug Fixes**
  - Require a resolved workspace; only trust AI config when `copilotWorkspace === opWs`; show “Loading AI settings...” until known.
  - Load the operating workspace’s config on modal open; update alert title to “AI is not configured.”
  - Share in-flight `get_copilot_info` calls per workspace; keep only the newest request and allow a re-requested workspace to win back; remove the unused token guard.
  - Link workspace settings via `{base}/workspace_settings?tab=ai`; for `$superadmin`, also show an instance settings link even when not a workspace admin.

<sup>Written for commit fd5a70cb3cef6d13bb709a1545e39f4f0ddb985a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

