### PR TITLE
fix(cli): bundle Svelte raw apps by loading the app's ESM compiler

### DIFF
--- a/cli/src/commands/app/bundle.ts
+++ b/cli/src/commands/app/bundle.ts
@@ -80,6 +80,51 @@ export function detectFrameworks(appDir: string): { svelte: boolean; vue: boolea
   }
 }
 
+/** What an `import()` matches — the point being that it never matches "require". */
+const ESM_CONDITIONS = ["node", "import", "default"];
+
+/**
+ * Walks one subpath of an exports map the way Node's ESM resolver would: first
+ * key in declaration order whose condition an `import()` matches wins.
+ */
+function esmConditionTarget(subpath: unknown): string | undefined {
+  if (typeof subpath === "string") return subpath;
+  if (!subpath || typeof subpath !== "object" || Array.isArray(subpath)) {
+    return undefined;
+  }
+  for (const [condition, target] of Object.entries(subpath)) {
+    if (!ESM_CONDITIONS.includes(condition)) continue;
+    const entry = esmConditionTarget(target);
+    if (entry) return entry;
+  }
+  return undefined;
+}
+
+/**
+ * `require.resolve` answers with the `require` condition, which Svelte maps at a
+ * minified UMD bundle. Only the CJS loader can read that file's exports, so
+ * `import()`ing it yields a namespace holding nothing but `default` and every
+ * named export reads undefined. The exports map is the only place to ask for the
+ * ESM entry instead — `require.resolve` takes no conditions.
+ */
+function resolveAppSvelteCompiler(appDir: string): string {
+  const requireFromApp = createRequire(
+    path.join(path.resolve(appDir), "package.json")
+  );
+  try {
+    const pkgPath = requireFromApp.resolve("svelte/package.json");
+    const exportsMap = JSON.parse(readTextFileSync(pkgPath))?.exports;
+    const target = esmConditionTarget(exportsMap?.["./compiler"]);
+    if (target?.startsWith(".")) {
+      const entry = path.resolve(path.dirname(pkgPath), target);
+      if (fs.existsSync(entry)) return entry;
+    }
+  } catch {
+    // No exports map to read (or an unexpected shape) — let the CJS resolver try.
+  }
+  return requireFromApp.resolve("svelte/compiler");
+}
+
 /**
  * Loads the Svelte compiler out of the *app's* node_modules.
  *
@@ -94,15 +139,14 @@ export function detectFrameworks(appDir: string): { svelte: boolean; vue: boolea
  * Falls back to the CLI's own compiler when the app has none resolvable.
  */
 export async function loadSvelteCompiler(appDir: string): Promise<any> {
+  let mod: any;
   try {
-    const requireFromApp = createRequire(
-      path.join(path.resolve(appDir), "package.json")
-    );
-    const entry = requireFromApp.resolve("svelte/compiler");
-    return await import(pathToFileURL(entry).href);
+    mod = await import(pathToFileURL(resolveAppSvelteCompiler(appDir)).href);
   } catch {
-    return await import("svelte/compiler");
+    mod = await import("svelte/compiler");
   }
+  // A CJS entry still imports as a namespace whose only key is `default`.
+  return typeof mod?.compile === "function" ? mod : (mod?.default ?? mod);
 }
 
 /**

--- a/cli/test/raw_app_svelte_compiler_resolution_unit.test.ts
+++ b/cli/test/raw_app_svelte_compiler_resolution_unit.test.ts
@@ -42,6 +42,50 @@ function installStubSvelte(dir: string, version: string) {
   );
 }
 
+/**
+ * A stand-in shaped like the real svelte: `./compiler` maps `require` at a UMD
+ * bundle and `default` at the ESM sources, and only the ESM half survives an
+ * `import()` with its named exports intact.
+ */
+function installDualStubSvelte(dir: string) {
+  const pkgDir = path.join(dir, "node_modules", "svelte");
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: "svelte",
+      version: "0.0.0-dual",
+      type: "module",
+      exports: {
+        "./package.json": "./package.json",
+        "./compiler": {
+          types: "./types/index.d.ts",
+          require: "./compiler/index.cjs",
+          default: "./src/compiler/index.js",
+        },
+      },
+    }),
+    "utf-8",
+  );
+  fs.mkdirSync(path.join(pkgDir, "src", "compiler"), { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, "src", "compiler", "index.js"),
+    `export const VERSION = "0.0.0-esm";\n` +
+      `export function compile() { return { js: { code: "", map: null }, warnings: [] }; }\n`,
+    "utf-8",
+  );
+  fs.mkdirSync(path.join(pkgDir, "compiler"), { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, "compiler", "index.cjs"),
+    // The UMD wrapper the published bundle uses: no static `exports.x = ...` for
+    // a lexer to find, so an `import()` of this file sees only `default`.
+    `!function(e,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports):e(t)}` +
+      `(0,function(e){e.VERSION="0.0.0-cjs";` +
+      `e.compile=function(){return{js:{code:"",map:null},warnings:[]}}});\n`,
+    "utf-8",
+  );
+}
+
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "raw-app-svelte-compiler-"));
   fs.writeFileSync(
@@ -62,6 +106,15 @@ describe("loadSvelteCompiler", () => {
     const compiler = await loadSvelteCompiler(tempDir);
 
     expect(compiler.VERSION).toBe("0.0.0-app-local");
+  });
+
+  test("takes the ESM entry, not the `require` one, off a dual exports map", async () => {
+    installDualStubSvelte(tempDir);
+
+    const compiler = await loadSvelteCompiler(tempDir);
+
+    expect(compiler.VERSION).toBe("0.0.0-esm");
+    expect(typeof compiler.compile).toBe("function");
   });
 
   test("resolves against the app even when given a relative dir", async () => {


### PR DESCRIPTION
Fixes GIT-958

## Summary

Since 1.775.2, `wmill sync push` fails to bundle any Svelte raw app under Node with `svelte.compile is not a function`, aborting the push on the first raw app it reaches.

1.775.2 started resolving the Svelte compiler out of the *app's* `node_modules` (so compiler and runtime agree on internals) via `createRequire(<app>/package.json).resolve("svelte/compiler")`. `require.resolve` answers with the **`require`** condition of Svelte's exports map:

```json
"./compiler": {
  "types": "./types/index.d.ts",
  "require": "./compiler/index.js",     // minified UMD/CJS bundle
  "default": "./src/compiler/index.js"  // ESM, named exports
}
```

Only the CJS loader can read that UMD file's exports — `cjs-module-lexer` can't see the assignments through the wrapper — so `import()`ing it under Node yields a namespace whose only keys are `default` and `module.exports`, and `svelte.compile` reads `undefined`.

The app-local resolution itself is right and is kept; the fix is to ask for the entry Node's *ESM* resolver would pick, since `require.resolve` takes no `conditions` option.

Bun masks this (it synthesizes named exports from `module.exports`), which is why the bun-run test suite never saw it while the published, Node-targeted CLI broke.

## Changes

- `cli/src/commands/app/bundle.ts`: read the app's `svelte/package.json` exports map and take the `./compiler` target the ESM resolver would pick (`node` / `import` / `default`, in declaration order), falling back to `require.resolve` when there is no usable exports map.
- Same file: unwrap a CJS `default` namespace in `loadSvelteCompiler`, so the `require.resolve` fallback still hands back a usable compiler.
- `cli/test/raw_app_svelte_compiler_resolution_unit.test.ts`: one regression case against a stub shaped like the real package (`require` → UMD, `default` → ESM), pinning which condition wins. It fails on the pre-fix code.

Out of scope: the reporter also noted the failure surfaces as an unhandled esbuild rejection with a raw Node stack trace rather than a handled push error. That error-handling papercut in the sync path is untouched here.

## Test plan

Verified with the npm-built CLI running under **Node** (`bun run src/main.ts` masks the bug), against a raw app whose only dependency is `svelte@5.56.8`:

- [x] `wmill sync push --yes` against a local backend: fails pre-fix with the exact reported error and Node stack trace; **succeeds** post-fix (5 files pushed, bundle 46.9kb).
- [x] `wmill app bundle`: same before/after result.
- [x] The deployed raw app renders in the Windmill UI and its `onclick` increments the counter — the compiler that produced the bundle agrees with the app's own runtime (screenshot below).
- [x] Compiler still resolves per app, not from the CLI: an app pinned to `svelte@5.45.2` loads `VERSION 5.45.2`, one pinned to `5.56.8` loads `5.56.8`.
- [x] `UNIT_ONLY=1 bun test test/*_unit*` — 1053 pass, 0 fail.
- [x] `bunx tsc --noEmit` — no new errors (18 pre-existing, unchanged with the diff reverted).

## Screenshots

Deployed Svelte raw app, pushed with the fixed CLI, after clicking the counter:

![deployed-svelte-raw-app](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/git-958/1786390671-deployed-svelte-raw-app.png)

## Note on `wmill app dev`

The issue reports `wmill app dev` as unaffected. It isn't: `dev.ts:581` calls the same `createFrameworkPlugins` → `loadSvelteCompiler`. On the pre-fix build under Node, `wmill app dev` fails with the identical `svelte.compile is not a function`; on this branch it builds and serves. There is no separate compiler-loading path to explain the difference.
