### PR TITLE
fix(python-client): return at most size bytes from S3BufferedReader.read

### DIFF
--- a/python-client/tests/wmill_client_test.py
+++ b/python-client/tests/wmill_client_test.py
@@ -168,54 +168,5 @@ class TestParseS3Object(unittest.TestCase):
     def test_s3object_passes_through(self):
         self.assertEqual(wmill.parse_s3_object(S3Object(s3="x")), S3Object(s3="x"))
 
-class TestS3BufferedReaderRead(unittest.TestCase):
-    """Pure-unit tests for S3BufferedReader.read — no network/env needed.
-
-    iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must slice
-    the last chunk and buffer the leftover for the next call.
-    """
-
-    def make_reader(self, chunks):
-        from wmill.s3_reader import S3BufferedReader
-
-        reader = object.__new__(S3BufferedReader)
-        reader._iterator = iter(chunks)
-        reader._buffer = bytearray()
-        return reader
-
-    def test_read_size_returns_exact_bytes(self):
-        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
-        self.assertEqual(reader.read(5), b"AAAAA")
-
-    def test_read_size_preserves_leftover_across_calls(self):
-        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
-        self.assertEqual(reader.read(5), b"AAAAA")
-        self.assertEqual(reader.read(5), b"AAAAA")
-        self.assertEqual(reader.read(10), b"BBBBBBBBBB")
-        self.assertEqual(reader.read(7), b"CCCCCCC")
-        self.assertEqual(reader.read(5), b"CCC")
-        self.assertEqual(reader.read(5), b"")
-
-    def test_read_all_returns_everything(self):
-        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
-        self.assertEqual(reader.read(-1), b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC")
-
-    def test_read_all_after_partial_read(self):
-        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
-        self.assertEqual(reader.read(5), b"AAAAA")
-        self.assertEqual(reader.read(-1), b"AAAAABBBBBBBBBBCCCCCCCCCC")
-
-    def test_bytes_generator_never_exceeds_50kb_chunk(self):
-        reader = self.make_reader([b"x" * 65536] * 5)
-        total = 0
-        while True:
-            byte = reader.read(50 * 1024)
-            if not byte:
-                break
-            self.assertLessEqual(len(byte), 50 * 1024)
-            total += len(byte)
-        self.assertEqual(total, 5 * 65536)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/python-client/tests/wmill_client_test.py
+++ b/python-client/tests/wmill_client_test.py
@@ -168,5 +168,54 @@ class TestParseS3Object(unittest.TestCase):
     def test_s3object_passes_through(self):
         self.assertEqual(wmill.parse_s3_object(S3Object(s3="x")), S3Object(s3="x"))
 
+class TestS3BufferedReaderRead(unittest.TestCase):
+    """Pure-unit tests for S3BufferedReader.read — no network/env needed.
+
+    iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must slice
+    the last chunk and buffer the leftover for the next call.
+    """
+
+    def make_reader(self, chunks):
+        from wmill.s3_reader import S3BufferedReader
+
+        reader = object.__new__(S3BufferedReader)
+        reader._iterator = iter(chunks)
+        reader._buffer = bytearray()
+        return reader
+
+    def test_read_size_returns_exact_bytes(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(5), b"AAAAA")
+
+    def test_read_size_preserves_leftover_across_calls(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(5), b"AAAAA")
+        self.assertEqual(reader.read(5), b"AAAAA")
+        self.assertEqual(reader.read(10), b"BBBBBBBBBB")
+        self.assertEqual(reader.read(7), b"CCCCCCC")
+        self.assertEqual(reader.read(5), b"CCC")
+        self.assertEqual(reader.read(5), b"")
+
+    def test_read_all_returns_everything(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(-1), b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC")
+
+    def test_read_all_after_partial_read(self):
+        reader = self.make_reader([b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"])
+        self.assertEqual(reader.read(5), b"AAAAA")
+        self.assertEqual(reader.read(-1), b"AAAAABBBBBBBBBBCCCCCCCCCC")
+
+    def test_bytes_generator_never_exceeds_50kb_chunk(self):
+        reader = self.make_reader([b"x" * 65536] * 5)
+        total = 0
+        while True:
+            byte = reader.read(50 * 1024)
+            if not byte:
+                break
+            self.assertLessEqual(len(byte), 50 * 1024)
+            total += len(byte)
+        self.assertEqual(total, 5 * 65536)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -41,6 +41,10 @@ def make_reader(chunks):
 
 def test_read_size_slices_chunks_and_keeps_the_remainder():
     reader = make_reader(CHUNKS)
+    # read(0) must not pull from the stream: the "drain everything" sentinel is
+    # a negative size, and widening it to any falsy size would reintroduce the
+    # whole-file buffering this reader is built to avoid.
+    assert reader.read(0) == b""
     assert reader.read(5) == b"AAAAA"
     assert reader.read(5) == b"AAAAA"
     assert reader.read(10) == b"BBBBBBBBBB"
@@ -66,3 +70,10 @@ def test_peek_does_not_consume():
     reader = make_reader(CHUNKS)
     assert reader.peek() == b"AAAAAAAAAA"
     assert reader.read(10) == b"AAAAAAAAAA"
+
+
+def test_read1_stops_after_one_chunk():
+    reader = make_reader(CHUNKS)
+    # read1(-1) must not drain the stream the way read(-1) does.
+    assert reader.read1(-1) == b"AAAAAAAAAA"
+    assert reader.read1(4) == b"BBBB"

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -1,12 +1,12 @@
-"""Unit tests for S3BufferedReader.read — no network/env needed."""
+"""Unit tests for S3BufferedReader: no network or env needed."""
 
-from wmill.s3_reader import S3BufferedReader
+from wmill.s3_reader import S3BufferedReader, bytes_generator
 
 CHUNKS = [b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"]
 
 
 class _FakeStream:
-    """Stands in for the httpx stream response S3BufferedReader reads from."""
+    """Stands in for the httpx streaming response the reader consumes."""
 
     status_code = 200
 
@@ -39,12 +39,7 @@ def make_reader(chunks):
     return reader
 
 
-def test_read_size_returns_exact_bytes():
-    reader = make_reader(CHUNKS)
-    assert reader.read(5) == b"AAAAA"
-
-
-def test_read_size_preserves_leftover_across_calls():
+def test_read_size_slices_chunks_and_keeps_the_remainder():
     reader = make_reader(CHUNKS)
     assert reader.read(5) == b"AAAAA"
     assert reader.read(5) == b"AAAAA"
@@ -54,53 +49,20 @@ def test_read_size_preserves_leftover_across_calls():
     assert reader.read(5) == b""
 
 
-def test_read_zero_returns_empty_without_consuming():
-    reader = make_reader(CHUNKS)
-    assert reader.read(0) == b""
-    assert reader.read(5) == b"AAAAA"
-
-
-def test_peek_returns_without_consuming():
-    reader = make_reader(CHUNKS)
-    assert reader.peek() == b"AAAAAAAAAA"
-    assert reader.peek(5) == b"AAAAAAAAAA"
-    assert reader.read(10) == b"AAAAAAAAAA"
-
-
-def test_peek_after_partial_read_returns_leftover():
-    reader = make_reader(CHUNKS)
-    assert reader.read(5) == b"AAAAA"
-    assert reader.peek(5) == b"AAAAA"
-    assert reader.read(5) == b"AAAAA"
-
-
-def test_peek_fills_when_buffered_bytes_are_insufficient():
-    reader = make_reader(CHUNKS)
-    assert reader.read(5) == b"AAAAA"
-    peeked = reader.peek(7)
-    assert peeked.startswith(b"AAAAA")
-    assert len(peeked) >= 7
-    assert reader.read(len(peeked)) == peeked
-
-
-def test_read_all_returns_everything():
-    reader = make_reader(CHUNKS)
-    assert reader.read(-1) == b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC"
-
-
-def test_read_all_after_partial_read():
+def test_read_all_drains_both_the_buffer_and_the_stream():
     reader = make_reader(CHUNKS)
     assert reader.read(5) == b"AAAAA"
     assert reader.read(-1) == b"AAAAABBBBBBBBBBCCCCCCCCCC"
 
 
-def test_bytes_generator_never_exceeds_50kb_chunk():
+def test_bytes_generator_yields_50kb_slices_of_64kb_chunks():
     reader = make_reader([b"x" * 65536] * 5)
-    total = 0
-    while True:
-        byte = reader.read(50 * 1024)
-        if not byte:
-            break
-        assert len(byte) <= 50 * 1024
-        total += len(byte)
-    assert total == 5 * 65536
+    sizes = [len(chunk) for chunk in bytes_generator(reader)]
+    assert max(sizes) <= 50 * 1024
+    assert sum(sizes) == 5 * 65536
+
+
+def test_peek_does_not_consume():
+    reader = make_reader(CHUNKS)
+    assert reader.peek() == b"AAAAAAAAAA"
+    assert reader.read(10) == b"AAAAAAAAAA"

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -1,0 +1,83 @@
+"""Unit tests for S3BufferedReader.read — no network/env needed."""
+
+from wmill.s3_reader import S3BufferedReader
+
+CHUNKS = [b"AAAAAAAAAA", b"BBBBBBBBBB", b"CCCCCCCCCC"]
+
+
+class _FakeStream:
+    """Stands in for the httpx stream response S3BufferedReader reads from."""
+
+    status_code = 200
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def iter_bytes(self):
+        return iter(self._chunks)
+
+
+class _FakeClient:
+    """Stands in for the httpx client, so construction never touches the network."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def stream(self, method, url, params=None, timeout=None):
+        return _FakeStream(self._chunks)
+
+
+def make_reader(chunks):
+    reader = S3BufferedReader("ws", _FakeClient(chunks), "file.txt", None, None)
+    reader.__enter__()
+    return reader
+
+
+def test_read_size_returns_exact_bytes():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+
+
+def test_read_size_preserves_leftover_across_calls():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    assert reader.read(5) == b"AAAAA"
+    assert reader.read(10) == b"BBBBBBBBBB"
+    assert reader.read(7) == b"CCCCCCC"
+    assert reader.read(5) == b"CCC"
+    assert reader.read(5) == b""
+
+
+def test_read_zero_returns_empty_without_consuming():
+    reader = make_reader(CHUNKS)
+    assert reader.read(0) == b""
+    assert reader.read(5) == b"AAAAA"
+
+
+def test_read_all_returns_everything():
+    reader = make_reader(CHUNKS)
+    assert reader.read(-1) == b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC"
+
+
+def test_read_all_after_partial_read():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    assert reader.read(-1) == b"AAAAABBBBBBBBBBCCCCCCCCCC"
+
+
+def test_bytes_generator_never_exceeds_50kb_chunk():
+    reader = make_reader([b"x" * 65536] * 5)
+    total = 0
+    while True:
+        byte = reader.read(50 * 1024)
+        if not byte:
+            break
+        assert len(byte) <= 50 * 1024
+        total += len(byte)
+    assert total == 5 * 65536

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -60,6 +60,29 @@ def test_read_zero_returns_empty_without_consuming():
     assert reader.read(5) == b"AAAAA"
 
 
+def test_peek_returns_without_consuming():
+    reader = make_reader(CHUNKS)
+    assert reader.peek() == b"AAAAAAAAAA"
+    assert reader.peek(5) == b"AAAAAAAAAA"
+    assert reader.read(10) == b"AAAAAAAAAA"
+
+
+def test_peek_after_partial_read_returns_leftover():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    assert reader.peek(5) == b"AAAAA"
+    assert reader.read(5) == b"AAAAA"
+
+
+def test_peek_fills_when_buffered_bytes_are_insufficient():
+    reader = make_reader(CHUNKS)
+    assert reader.read(5) == b"AAAAA"
+    peeked = reader.peek(7)
+    assert peeked.startswith(b"AAAAA")
+    assert len(peeked) >= 7
+    assert reader.read(len(peeked)) == peeked
+
+
 def test_read_all_returns_everything():
     reader = make_reader(CHUNKS)
     assert reader.read(-1) == b"AAAAAAAAAABBBBBBBBBBCCCCCCCCCC"

--- a/python-client/wmill/tests/test_s3_reader.py
+++ b/python-client/wmill/tests/test_s3_reader.py
@@ -23,6 +23,19 @@ class _FakeStream:
         return iter(self._chunks)
 
 
+class CountingIterator:
+    """Chunk source that records how many times the reader pulled from it."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+        self.pulls = 0
+
+    def __iter__(self):
+        for chunk in self._chunks:
+            self.pulls += 1
+            yield chunk
+
+
 class _FakeClient:
     """Stands in for the httpx client, so construction never touches the network."""
 
@@ -73,7 +86,12 @@ def test_peek_does_not_consume():
 
 
 def test_read1_stops_after_one_chunk():
-    reader = make_reader(CHUNKS)
+    counting = CountingIterator(CHUNKS)
+    reader = make_reader(counting)
+    # A zero-length read must not touch the stream at all.
+    assert reader.read1(0) == b""
+    assert counting.pulls == 0
     # read1(-1) must not drain the stream the way read(-1) does.
     assert reader.read1(-1) == b"AAAAAAAAAA"
     assert reader.read1(4) == b"BBBB"
+    assert counting.pulls == 2

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -52,20 +52,15 @@ class S3BufferedReader(BufferedReader):
     def read(self, size=-1):
         # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
         # slice the last chunk and buffer the leftover for the next call.
-        if size < 0:
-            while True:
-                try:
-                    self._buffer.extend(self._iterator.__next__())
-                except StopIteration:
-                    break
-            result = bytes(self._buffer)
-            self._buffer.clear()
-            return result
-        while len(self._buffer) < size:
+        while size < 0 or len(self._buffer) < size:
             try:
                 self._buffer.extend(self._iterator.__next__())
             except StopIteration:
                 break
+        if size < 0:
+            result = bytes(self._buffer)
+            self._buffer.clear()
+            return result
         result = bytes(self._buffer[:size])
         del self._buffer[:size]
         return result

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -47,16 +47,22 @@ class S3BufferedReader(BufferedReader):
         return self
 
     def peek(self, size=0):
-        raise Exception("Not implemented, use read() instead")
+        # Return buffered bytes without consuming them; fill to the
+        # requested amount first (one chunk when size is unset).
+        self._fill(size if size > 0 else 1)
+        return bytes(self._buffer)
 
-    def read(self, size=-1):
+    def _fill(self, limit):
         # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
         # slice the last chunk and buffer the leftover for the next call.
-        while size < 0 or len(self._buffer) < size:
+        while limit < 0 or len(self._buffer) < limit:
             try:
                 self._buffer.extend(self._iterator.__next__())
             except StopIteration:
                 break
+
+    def read(self, size=-1):
+        self._fill(size)
         if size < 0:
             result = bytes(self._buffer)
             self._buffer.clear()

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -85,6 +85,8 @@ class S3BufferedReader(BufferedReader):
         Unlike `read`, a negative `size` returns only what is already buffered
         rather than draining the whole object.
         """
+        if size == 0:
+            return b""
         if not self._buffer:
             self._fill(1)
         if size is None or size < 0:

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -28,6 +28,7 @@ class S3BufferedReader(BufferedReader):
             params=params,
             timeout=None,
         )
+        self._buffer = bytearray()
 
     def __enter__(self):
         reader = self._context_manager.__enter__()
@@ -49,19 +50,25 @@ class S3BufferedReader(BufferedReader):
         raise Exception("Not implemented, use read() instead")
 
     def read(self, size=-1):
-        read_result = []
+        # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
+        # slice the last chunk and buffer the leftover for the next call.
         if size < 0:
-            for b in self._iterator:
-                read_result.append(b)
-        else:
-            for i in range(size):
+            while True:
                 try:
-                    b = self._iterator.__next__()
+                    self._buffer.extend(self._iterator.__next__())
                 except StopIteration:
                     break
-                read_result.append(b)
-
-        return b"".join(read_result)
+            result = bytes(self._buffer)
+            self._buffer.clear()
+            return result
+        while len(self._buffer) < size:
+            try:
+                self._buffer.extend(self._iterator.__next__())
+            except StopIteration:
+                break
+        result = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        return result
 
     def read1(self, size=-1):
         return self.read(size)

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -47,17 +47,19 @@ class S3BufferedReader(BufferedReader):
         return self
 
     def peek(self, size=0):
-        # io.BufferedReader.peek: hand back buffered bytes without consuming
-        # them, doing at most one read on the underlying stream — so the amount
-        # returned may be more or less than `size`.
+        """Return buffered bytes without consuming them.
+
+        Reads the underlying stream at most once, so the amount returned may be
+        more or less than `size`.
+        """
         if not self._buffer:
             self._fill(1)
         return bytes(self._buffer)
 
     def _fill(self, limit):
-        # iter_bytes() yields whole HTTP chunks (~64KB), so serving `limit`
-        # bytes means accumulating until the buffer holds enough and keeping
-        # the remainder of the final chunk for the next call.
+        # iter_bytes() yields whole HTTP chunks (~64KB), so a caller asking for
+        # `limit` bytes has to accumulate until the buffer holds that many.
+        # A negative limit means drain the stream.
         while limit < 0 or len(self._buffer) < limit:
             try:
                 self._buffer.extend(next(self._iterator))
@@ -65,6 +67,9 @@ class S3BufferedReader(BufferedReader):
                 break
 
     def read(self, size=-1):
+        # BufferedReader.read(None) is documented as equivalent to read(-1).
+        if size is None:
+            size = -1
         self._fill(size)
         if size < 0:
             result = bytes(self._buffer)
@@ -75,7 +80,18 @@ class S3BufferedReader(BufferedReader):
         return result
 
     def read1(self, size=-1):
-        return self.read(size)
+        """Return up to `size` bytes, reading the underlying stream at most once.
+
+        Unlike `read`, a negative `size` returns only what is already buffered
+        rather than draining the whole object.
+        """
+        if not self._buffer:
+            self._fill(1)
+        if size is None or size < 0:
+            size = len(self._buffer)
+        result = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        return result
 
     def __exit__(self, *args):
         self._context_manager.__exit__(*args)

--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -47,17 +47,20 @@ class S3BufferedReader(BufferedReader):
         return self
 
     def peek(self, size=0):
-        # Return buffered bytes without consuming them; fill to the
-        # requested amount first (one chunk when size is unset).
-        self._fill(size if size > 0 else 1)
+        # io.BufferedReader.peek: hand back buffered bytes without consuming
+        # them, doing at most one read on the underlying stream — so the amount
+        # returned may be more or less than `size`.
+        if not self._buffer:
+            self._fill(1)
         return bytes(self._buffer)
 
     def _fill(self, limit):
-        # iter_bytes() yields whole HTTP chunks (~64KB), so read(size) must
-        # slice the last chunk and buffer the leftover for the next call.
+        # iter_bytes() yields whole HTTP chunks (~64KB), so serving `limit`
+        # bytes means accumulating until the buffer holds enough and keeping
+        # the remainder of the final chunk for the next call.
         while limit < 0 or len(self._buffer) < limit:
             try:
-                self._buffer.extend(self._iterator.__next__())
+                self._buffer.extend(next(self._iterator))
             except StopIteration:
                 break
 


### PR DESCRIPTION
## Summary

Continuation of #10600 by @tusharui, whose commits are preserved here and who is credited as their author. Thank you for the report and the fix.

`S3BufferedReader.read(size)` looped `range(size)` times and appended a whole `iter_bytes()` chunk each iteration. httpx yields ~64 KB chunks, so `size` counted *chunks*, not bytes, violating the `io.BufferedReader.read(n)` contract.

The production consequence is in `bytes_generator()`, which `write_s3_file` uses to stream a reader: it calls `read(50 * 1024)`, so one call could return up to 51200 × 64 KB instead of a 50 KB slice, bounded only by the file size. Piping an S3 file straight into another S3 file (`write_s3_file(dst, load_s3_file_reader(src))`) buffered the entire file in memory. `read()` with no argument and `load_s3_file` were unaffected.

Measured on a 64 MB object driven through `bytes_generator`: `main` yields a single 67108864-byte chunk at a 134.3 MB `tracemalloc` peak; this branch yields only ≤51200-byte chunks at a 0.27 MB peak.

## Changes

- Buffer chunks in a `bytearray` and slice it, so `read(size)` returns at most `size` bytes and keeps the remainder of the final chunk for the next call. `read(-1)` still drains everything, and its peak memory is unchanged.
- `read1` no longer forwards to `read`. It now fills only when the buffer is empty, honouring "at most one underlying read" — previously `read1(-1)` drained the whole object, the same unbounded buffering this branch removes from `read`. `read1(0)` returns without touching the stream.
- Implement `peek()`, which previously raised `Not implemented`, now that the buffer exists. It follows `io.BufferedReader.peek`: at most one read on the underlying stream, so the amount returned may be more or less than requested.
- Treat `read(None)` as `read(-1)`, per the `BufferedReader` contract.
- Add `python-client/wmill/tests/test_s3_reader.py` covering chunk slicing across calls (including that `read(0)` does not pull from the stream), `read(-1)` after a partial read, the `bytes_generator` bound, `read1`'s single-fill behaviour, and that `peek` does not consume.

## Test plan

- [x] `cd python-client/wmill && PYTHONPATH=. uv run --frozen --python 3.14 pytest tests/ -q` — 112 pass
- [x] `bytes_generator` over a 5 × 64 KB stream yields `[51200, 51200, 51200, 43008]`, total preserved; before the fix the first call returned everything
- [x] Edge cases exercised by hand: `read(0)` returns `b""` without consuming, reads past EOF return `b""`, empty stream, `read(None)`

Note that `sdk-tests.yml` runs on release tags and `workflow_dispatch` only, so these tests do not execute on this PR — the local run above is the signal until the next tag.

## Known, pre-existing, out of scope

`S3BufferedReader` never calls `BufferedReader.__init__`, so the rest of the inherited API (`readline`, `readinto`, `__iter__`) raises `ValueError: I/O operation on uninitialized object`. Implementing `peek` makes the class look more complete to sniffing code, so that failure now surfaces one call later than it used to. Worth a follow-up rather than a change here.