### PR TITLE
fix(sdk): unbreak the JSR publish of the typescript client

### DIFF
--- a/typescript-client/build.jsr.sh
+++ b/typescript-client/build.jsr.sh
@@ -13,9 +13,17 @@ cp "${script_dirpath}/client.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/wacError.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/s3Types.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/sqlUtils.ts" "${script_dirpath}/src/"
+# Two rules the JSR package must satisfy that the npm one does not, both
+# enforced by `jsr publish` (which publish.jsr.sh runs without
+# --allow-slow-types), and neither reachable before a release tag:
+#   - a type has to be re-exported as `type X`, or deno fails with TS1205
+#     under isolatedModules;
+#   - anything listed here needs an explicit return type, or it is rejected
+#     as a "slow type".
+# `cd typescript-client && ./build.jsr.sh && deno publish --dry-run` checks both.
 echo "" >> "${script_dirpath}/src/index.ts"
 echo 'export type { DenoS3LightClientSettings } from "./s3Types";' >> "${script_dirpath}/src/index.ts"
 echo "" >> "${script_dirpath}/src/index.ts"
-echo 'export { type Base64, setClient, getVariable, setVariable, getResource, setResource, getResumeUrls, setState, setProgress, getProgress, getState, getIdToken, denoS3LightClientSettings, cancelJob, loadS3FileStream, loadS3File, writeS3File, deleteS3File, signS3Objects, signS3Object, getPresignedS3PublicUrls, getPresignedS3PublicUrl, task, runScript, runScriptAsync, runScriptByPath, runScriptByHash, runScriptByPathAsync, runScriptByHashAsync, runFlow, runFlowAsync, waitJob, getRootJobId, setFlowUserState, getFlowUserState, usernameToEmail, requestInteractiveSlackApproval, Sql, requestInteractiveTeamsApproval, appendToResultStream, streamResult, datatable, ducklake, upsertPartition, appendPartition, type DucklakeMaterializeOptions, type SqlStatement, type DatatableSqlTemplateFunction, type SqlTemplateFunction, type S3Object, type S3ObjectRecord, type S3ObjectURI } from "./client";' >> "${script_dirpath}/src/index.ts"
+echo 'export { type Base64, setClient, getVariable, setVariable, getResource, setResource, getResumeUrls, setState, setProgress, getProgress, getState, getIdToken, denoS3LightClientSettings, cancelJob, loadS3FileStream, loadS3File, writeS3File, deleteS3File, signS3Objects, signS3Object, getPresignedS3PublicUrls, getPresignedS3PublicUrl, task, runScript, runScriptAsync, runScriptByPath, runScriptByHash, runScriptByPathAsync, runScriptByHashAsync, runFlow, runFlowAsync, waitJob, getRootJobId, setFlowUserState, getFlowUserState, usernameToEmail, requestInteractiveSlackApproval, type Sql, requestInteractiveTeamsApproval, appendToResultStream, streamResult, datatable, ducklake, upsertPartition, appendPartition, type DucklakeMaterializeOptions, type SqlStatement, type DatatableSqlTemplateFunction, type SqlTemplateFunction, type S3Object, type S3ObjectRecord, type S3ObjectURI } from "./client";' >> "${script_dirpath}/src/index.ts"
 
 

--- a/typescript-client/build.jsr.sh
+++ b/typescript-client/build.jsr.sh
@@ -13,14 +13,12 @@ cp "${script_dirpath}/client.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/wacError.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/s3Types.ts" "${script_dirpath}/src/"
 cp "${script_dirpath}/sqlUtils.ts" "${script_dirpath}/src/"
-# Two rules the JSR package must satisfy that the npm one does not, both
-# enforced by `jsr publish` (which publish.jsr.sh runs without
-# --allow-slow-types), and neither reachable before a release tag:
-#   - a type has to be re-exported as `type X`, or deno fails with TS1205
-#     under isolatedModules;
-#   - anything listed here needs an explicit return type, or it is rejected
-#     as a "slow type".
-# `cd typescript-client && ./build.jsr.sh && deno publish --dry-run` checks both.
+# Two JSR-only rules, enforced by `jsr publish` (which publish.jsr.sh runs
+# without --allow-slow-types) and so not reachable before a release tag:
+# a type must be re-exported as `type X`, or deno fails with TS1205 under
+# isolatedModules; and an exported function whose return type deno cannot
+# trivially infer needs an explicit annotation, or it is a "slow type".
+# `./build.jsr.sh && deno publish --dry-run` checks both.
 echo "" >> "${script_dirpath}/src/index.ts"
 echo 'export type { DenoS3LightClientSettings } from "./s3Types";' >> "${script_dirpath}/src/index.ts"
 echo "" >> "${script_dirpath}/src/index.ts"


### PR DESCRIPTION
## Summary

`deno publish` fails on `main`, so every `v*` tag since the regression has published nothing to JSR. `jsr_on_release.yml` runs `publish.jsr.sh` → `npx jsr publish`, which type-checks the generated `src/index.ts` and dies before uploading.

The cause is one word. `client.ts` declares `export type Sql = string`, but `build.jsr.sh` re-exports it as a value:

```
TS1205 [ERROR]: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.
    at src/index.ts:9:577
```

The npm build never noticed, because `build.sh` lists the same symbol as `type Sql`. The two scripts keep separate copies of the export list, so a fix to one does not reach the other.

## Changes

- `build.jsr.sh`: export `Sql` as `type Sql`.
- Record the two JSR-only constraints next to the export list. Neither is reachable before a release tag, and the second one bites the moment anything with an inferred return type is added to that list, since `publish.jsr.sh` runs without `--allow-slow-types`.

## Test plan

- [x] `cd typescript-client && npm install && ./build.jsr.sh && deno publish --dry-run` on `main` — fails with `TS1205`
- [x] same on this branch — passes type-checking, passes the slow-types check, reaches `Success Dry run complete` for `@windmill/windmill@1.784.0`
- [x] npm package unaffected: `./build.sh && npx tsc` clean (0 errors), `bun test tests/` 167 pass

## Note

Nothing runs `deno publish --dry-run` before a tag, which is why this sat unnoticed. A CI job on `pull_request` with `paths: typescript-client/**` would catch it at review time — happy to add it here or separately if you want it, but I did not want to add a new per-PR CI job unasked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JSR publishing for the TypeScript client by re-exporting `Sql` as a type in the JSR build, resolving TS1205 under `isolatedModules`. Restores successful `npx jsr publish` on release; npm build is unchanged.

- **Bug Fixes**
  - In `typescript-client/build.jsr.sh`, re-export `type Sql` from `client` to satisfy `deno publish` checks.
  - Clarified the JSR-only note: only exports with return types Deno cannot trivially infer need explicit annotations; `deno publish --dry-run` passes.

<sup>Written for commit adc4e859311063c803c44ca1ef3ad81e92d9503a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

