### PR TITLE
fix: accept a bodyless request that advertises a JSON content type

### DIFF
--- a/backend/windmill-api/src/args.rs
+++ b/backend/windmill-api/src/args.rs
@@ -479,7 +479,10 @@ where
         let bytes = Bytes::from_request(request, _state)
             .await
             .map_err(IntoResponse::into_response)?;
-        if no_content_type && bytes.is_empty() {
+        // A request carries a body only when it signals one with Content-Length or
+        // Transfer-Encoding (RFC 9112 §6), yet it may advertise a Content-Type
+        // regardless. An empty body is therefore no args, not a malformed document.
+        if bytes.is_empty() {
             Ok(RawWebhookArgs { body: RawBody::Empty, metadata })
         } else {
             let str = String::from_utf8(bytes.to_vec())
@@ -710,6 +713,26 @@ impl WebhookArgs {
 mod tests {
 
     use super::*;
+
+    #[tokio::test]
+    async fn test_bodyless_request_with_json_content_type() {
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .uri("/api/r/customer/test")
+            .header(CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let args = try_from_request_body(request, &(), true)
+            .await
+            .unwrap_or_else(|_| panic!("bodyless GET should be accepted"));
+
+        assert!(
+            matches!(args.body, RawBody::Empty),
+            "bodyless GET should carry no args, got {:?}",
+            args.body
+        );
+    }
 
     #[tokio::test]
     async fn test_cloudevents_json_payload() {


### PR DESCRIPTION
## Summary

A `GET` carrying `Content-Type: application/json` but no body was rejected with `400 Bad request: invalid json: EOF while parsing a value at line 1 column 0`.

Per RFC 9112 §6, a request carries a message body only when it signals one with `Content-Length` or `Transfer-Encoding`. A bodyless request is free to advertise a `Content-Type` regardless, and several HTTP clients set one by default, so the header alone must not be read as "there is a document here to parse".

`try_from_request_body` already short-circuited an empty body to `RawBody::Empty`, but only when the request had *no* `Content-Type` at all. With the header present the empty body became `RawBody::Json("")`, which then failed to parse downstream in `WebhookArgs::from_json`. This widens that short-circuit to any empty body on the JSON branch.

This is not GET-specific: a plain `curl -X POST -H "Content-Type: application/json"` (which sends `Content-Length: 0`) failed identically and is fixed too.

## Changes

- `backend/windmill-api/src/args.rs`: in `try_from_request_body`, treat an empty body as `RawBody::Empty` whenever the JSON branch is taken, instead of only when no `Content-Type` header was sent.
- Regression test pinning that a bodyless request advertising `application/json` yields `RawBody::Empty`.

### Scope notes

- The check is on the *collected* body being empty rather than on the absence of `Content-Length`/`Transfer-Encoding`. Testing the headers directly would silently discard a real body on an HTTP/2 request that streams without a content-length — a worse failure than the 400. Reading the collected bytes cannot drop a body that actually arrived, and additionally covers `Content-Length: 0`.
- `application/cloudevents+json` is deliberately left alone. In structured CloudEvents mode the event *is* the body, so an empty one is malformed; it also keeps the invariant that every cloudevents request carries `WEBHOOK__METADATA__` in its args, which an empty-args short-circuit would break.
- The other content types (`text/plain`, xml, urlencoded, multipart, raw bytes) already tolerate an empty body and are untouched, so `raw_string` semantics for existing triggers are unchanged.

## Test plan

Verified end-to-end against real builds on an `/api/r/...` HTTP trigger route, before and after the change:

- [x] `GET` + `Content-Type: application/json` + no body: `400 invalid json: EOF…` before, `200` after (the reported case)
- [x] `POST` + `Content-Type: application/json` + `Content-Length: 0`: `400` before, `200` after
- [x] `POST` + `Content-Type: application/json` + `{"x":"hi"}` still returns `{"received": "hi"}`
- [x] `POST` + `Content-Type: application/json` + malformed `{oops` still returns `400 invalid json: key must be a string at line 1 column 2`
- [x] `POST` + `Content-Type: application/cloudevents+json` + real event still parses and still receives `WEBHOOK__METADATA__`
- [x] Bodyless `GET` with no `Content-Type` and with `text/plain` still return `200` (unchanged)
- [x] Signature-authenticated route, bodyless `GET`: missing signature header rejected (`400`), wrong signature rejected (`401`), valid HMAC accepted — forging still requires the secret
- [x] `cargo check`, `cargo test -p windmill-api --lib args::tests` (2/2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept bodyless requests that send `Content-Type: application/json` without a body. Previously these returned 400; now they are treated as empty args per RFC 9112 §6.

- **Bug Fixes**
  - In `backend/windmill-api/src/args.rs`, `try_from_request_body` returns `RawBody::Empty` when the collected body is empty, even on the JSON branch.
  - Added a regression test for a bodyless request with `application/json`.
  - `application/cloudevents+json` handling is unchanged.

<sup>Written for commit 44343110ad66674a6889c14ed96c7eaec82b9596. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Fixes WIN-2347