### PR TITLE
fix(ata): fall back to the npm proxy when the CDN request fails outright

### DIFF
--- a/frontend/src/lib/ata/apis.test.ts
+++ b/frontend/src/lib/ata/apis.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { workspaceStore } from '$lib/stores'
+import { getDTSFileForModuleWithVersion, getNPMVersionsForModule } from './apis'
+
+/** jsdelivr unreachable (blocked egress, DNS failure), backend proxy answering. */
+function mockUnreachableJsdelivr(proxyBody: string) {
+	return vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input)
+		if (url.includes('jsdelivr')) throw new TypeError('Failed to fetch')
+		if (url.includes('/npm_proxy/')) return new Response(proxyBody, { status: 200 })
+		throw new Error(`unexpected request to ${url}`)
+	})
+}
+
+describe('ATA backend proxy fallback', () => {
+	afterEach(() => vi.unstubAllGlobals())
+
+	it('falls back to the proxy when the jsdelivr request rejects', async () => {
+		workspaceStore.set('test-workspace')
+		vi.stubGlobal(
+			'fetch',
+			mockUnreachableJsdelivr('{"tags":{"latest":"1.0.0"},"versions":["1.0.0"]}')
+		)
+
+		const versions = await getNPMVersionsForModule('lodash', { usage: 0 })
+
+		expect(versions).not.toBeInstanceOf(Error)
+		expect((versions as { versions: string[] }).versions).toEqual(['1.0.0'])
+	})
+
+	it('falls back to the proxy for a d.ts when the jsdelivr request rejects', async () => {
+		workspaceStore.set('test-workspace')
+		vi.stubGlobal('fetch', mockUnreachableJsdelivr('declare const x: number'))
+
+		const dts = await getDTSFileForModuleWithVersion('lodash', '1.0.0', '/index.d.ts')
+
+		expect(dts).toBe('declare const x: number')
+	})
+})

--- a/frontend/src/lib/ata/apis.ts
+++ b/frontend/src/lib/ata/apis.ts
@@ -41,8 +41,8 @@ const backendProxyApi = async <T>(endpoint: string, resLimit: ResLimit): Promise
 			})
 		)
 	} catch (e) {
-		// Reachable for a failed request only now that the `await` above is there. On an
-		// instance with no route to the CDN this is the only error an operator gets.
+		// Keep the cause: where the proxy is the only reachable source, this is the sole
+		// report of a failed acquisition, since callers only test the result for `Error`.
 		console.warn(`Backend proxy request to ${endpoint} failed`, e)
 		return new Error(`Backend proxy not available: ${e}`)
 	}

--- a/frontend/src/lib/ata/apis.ts
+++ b/frontend/src/lib/ata/apis.ts
@@ -146,9 +146,13 @@ export const getDTSFileForModuleWithVersion = async (
 	try {
 		const baseUrl = getBackendProxyUrl()
 		const proxyUrl = `${baseUrl}/file/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}${file}`
-		return await text(proxyUrl, { credentials: 'include' })
+		const proxied = await text(proxyUrl, { credentials: 'include' })
+		// The callers in ata/index.ts log a fixed message and drop the value, so a cause
+		// left inside the returned `Error` is a cause nothing ever prints.
+		if (proxied instanceof Error) console.warn('Backend proxy failed for file', proxied)
+		return proxied
 	} catch (e) {
-		console.log('Backend proxy failed for file', e)
+		console.warn('Backend proxy failed for file', e)
 		return new Error(`Backend proxy not available: ${e}`)
 	}
 }

--- a/frontend/src/lib/ata/apis.ts
+++ b/frontend/src/lib/ata/apis.ts
@@ -25,7 +25,9 @@ const backendProxyApi = async <T>(endpoint: string, resLimit: ResLimit): Promise
 		const baseUrl = getBackendProxyUrl()
 		const url = `${baseUrl}${endpoint}`
 
-		return limit(() =>
+		// `await`, not a bare `return`: an async function adopts a returned promise after
+		// leaving the try block, so a rejection would escape the catch below.
+		return await limit(() =>
 			fetch(url, { credentials: 'include' }).then((res) => {
 				if (res.ok) {
 					return res.text().then((text) => {
@@ -131,8 +133,8 @@ export const getDTSFileForModuleWithVersion = async (
 ) => {
 	// file comes with a prefix /
 	const url = `https://cdn.jsdelivr.net/npm/${moduleName}@${version}${file}`
-	const res = await limit(() => fetch(url))
-	if (res.ok) {
+	const res = await limit(() => fetch(url).catch(() => undefined))
+	if (res?.ok) {
 		return res.text()
 	} else {
 		// Try backend proxy
@@ -166,21 +168,26 @@ function api<T>(url: string, resLimit: ResLimit, init?: RequestInit): Promise<T 
 		console.warn(
 			`Exceeded limit of types downloaded for the needs of the assistant fetching: ${url}, ${resLimit.usage}`
 		)
-		return new Promise(() => new Error('Exceeded limit of 100MB of data downloaded.'))
+		return Promise.resolve(new Error('Exceeded limit of 100MB of data downloaded.'))
 	}
 
+	// Every caller decides what to do next by testing the resolved value for `Error`, so a
+	// rejection here is not an alternative signal: it skips the backend-proxy fallback and
+	// propagates out of type acquisition entirely.
 	return limit(() =>
-		fetch(url, init).then((res) => {
-			if (res.ok) {
-				return res.text().then((text) => {
-					resLimit.usage += text.length
-					console.log('resLimit', url, resLimit.usage)
+		fetch(url, init)
+			.then((res) => {
+				if (res.ok) {
+					return res.text().then((text) => {
+						resLimit.usage += text.length
+						console.log('resLimit', url, resLimit.usage)
 
-					return JSON.parse(text) as T
-				}) as Promise<T | Error>
-			} else {
-				return new Error('OK')
-			}
-		})
+						return JSON.parse(text) as T
+					}) as Promise<T | Error>
+				} else {
+					return new Error('OK')
+				}
+			})
+			.catch((e) => new Error(`Request to ${url} failed: ${e}`))
 	)
 }

--- a/frontend/src/lib/ata/apis.ts
+++ b/frontend/src/lib/ata/apis.ts
@@ -41,7 +41,10 @@ const backendProxyApi = async <T>(endpoint: string, resLimit: ResLimit): Promise
 			})
 		)
 	} catch (e) {
-		return new Error('Backend proxy not available')
+		// Reachable for a failed request only now that the `await` above is there. On an
+		// instance with no route to the CDN this is the only error an operator gets.
+		console.warn(`Backend proxy request to ${endpoint} failed`, e)
+		return new Error(`Backend proxy not available: ${e}`)
 	}
 }
 
@@ -133,23 +136,33 @@ export const getDTSFileForModuleWithVersion = async (
 ) => {
 	// file comes with a prefix /
 	const url = `https://cdn.jsdelivr.net/npm/${moduleName}@${version}${file}`
-	const res = await limit(() => fetch(url).catch(() => undefined))
-	if (res?.ok) {
-		return res.text()
-	} else {
-		// Try backend proxy
-		console.log('jsdelivr failed for file', moduleName, version, file, 'trying backend proxy')
-		try {
-			const baseUrl = getBackendProxyUrl()
-			const proxyUrl = `${baseUrl}/file/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}${file}`
-			const proxyRes = await limit(() => fetch(proxyUrl, { credentials: 'include' }))
-			if (proxyRes.ok) {
-				return proxyRes.text()
-			}
-		} catch (e) {
-			console.log('Backend proxy failed for file', e)
-		}
-		return new Error('OK')
+	const res = await text(url)
+	if (typeof res === 'string') {
+		return res
+	}
+
+	// Try backend proxy
+	console.log('jsdelivr failed for file', moduleName, version, file, 'trying backend proxy')
+	try {
+		const baseUrl = getBackendProxyUrl()
+		const proxyUrl = `${baseUrl}/file/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}${file}`
+		return await text(proxyUrl, { credentials: 'include' })
+	} catch (e) {
+		console.log('Backend proxy failed for file', e)
+		return new Error(`Backend proxy not available: ${e}`)
+	}
+}
+
+/**
+ * Reading the body can fail as readily as connecting, and both have to surface as a value
+ * rather than a rejection for the caller's fallback to run.
+ */
+async function text(url: string, init?: RequestInit): Promise<string | Error> {
+	try {
+		const res = await limit(() => fetch(url, init))
+		return res.ok ? await res.text() : new Error(`${res.status} for ${url}`)
+	} catch (e) {
+		return new Error(`Request to ${url} failed: ${e}`)
 	}
 }
 


### PR DESCRIPTION
## Summary

Type acquisition fetches from jsdelivr and falls back to `/api/w/{w}/npm_proxy/*`, which is what makes it work on an instance with a private registry and no route to the public CDNs. The fallback is gated on the helper *resolving* to an `Error`, but nothing catches a rejected `fetch` — so it only fires when jsdelivr **answers** with a non-ok status. On exactly the network where the fallback exists to help (blocked egress, DNS failure, refused connection), `fetch` rejects, the rejection propagates out through `ata/index.ts`, which has no try/catch around these calls, and the module gets no types at all. The proxy is never tried.

Three instances of the same class, all in `frontend/src/lib/ata/apis.ts`:

- `api()` — no `.catch()`, so a rejected request skips the fallback in `getNPMVersionsForModule`, `getNPMVersionForModuleReference` and `getFiletreeForModuleWithVersion`.
- `getDTSFileForModuleWithVersion()` — calls `fetch` directly and tests `res.ok`; a rejection propagates the same way.
- `backendProxyApi()` — has a `try`/`catch`, but `return limit(...)` inside a `try` in an `async` function adopts the promise *after* the block exits, so the catch never sees a rejection. Needs `return await`.

Also in `api()`: the over-limit guard returns `new Promise(() => new Error(...))`, an executor that never calls `resolve` or `reject`. That promise never settles, so once `resLimit` is exceeded every subsequent call hangs forever instead of erroring. `backendProxyApi` already returns the `Error` directly; this makes `api` match.

Found while working on #10629 (raw app editor honouring the instance `.npmrc`); separate bug, separate PR.

## Changes

- `api()`: `.catch()` returning an `Error` so callers reach their proxy fallback; over-limit returns a settled rejection-free `Error`.
- `getDTSFileForModuleWithVersion()`: `.catch(() => undefined)` on the jsdelivr fetch so a rejection falls through to the proxy branch.
- `backendProxyApi()`: `return await` so its existing `catch` actually covers the request.
- `apis.test.ts`: two cases pinning the fallback under a *rejecting* jsdelivr, for the metadata path and the `.d.ts` path.

## Test plan

- [x] `npx vitest run src/lib/ata/apis.test.ts` — 2 passed. Both fail with `TypeError: Failed to fetch` when `apis.ts` is reverted, confirming they pin the fix rather than passing vacuously.
- [x] `npm run check` — 0 errors.

No UI surface changes, so no screenshots: this is error-path plumbing behind Monaco's type acquisition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures ATA falls back to the backend npm proxy when CDN requests reject or bodies fail to read, restoring type acquisition on networks without public CDN access. Also surfaces proxy errors, logs failed proxy d.ts fetches, and fixes a hang when the download limit is exceeded.

- **Bug Fixes**
  - api(): catch fetch rejections and return an Error; over-limit returns a resolved Error (no hang).
  - getDTSFileForModuleWithVersion(): use a `text()` helper to handle connect/body-read failures; then try the proxy with credentials; warn when the proxy d.ts fetch fails; return an Error if the proxy fails.
  - backendProxyApi(): use return await so try/catch sees rejections; log and surface proxy errors with cause.
  - text(): new helper that returns string or Error for both fetch and body-read failures.
  - Tests: added cases verifying proxy fallback for metadata and .d.ts when jsdelivr rejects.

- **Refactors**
  - Clarified comments on the proxy catch constraint and why `return await` is required.

<sup>Written for commit b4091e8f71781e4b5df1df1731ae4e5ac2c4423c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

