### PR TITLE
feat(ata): prefer the npm proxy when the instance configures a registry

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -15218,6 +15218,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tar",
+ "tokio",
  "tower-http",
  "tracing",
  "url",

--- a/backend/windmill-api-npm-proxy/Cargo.toml
+++ b/backend/windmill-api-npm-proxy/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
 tar.workspace = true
+tokio.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -245,11 +245,37 @@ impl Weighter<(String, String, String), CachedTarball> for CacheWeighter {
     }
 }
 
+/// Single-sharded on purpose. quick_cache divides the weight budget across shards and
+/// declines an item heavier than one shard's share of it, so a sharded cache silently
+/// refuses exactly the packages that cost the most to fetch and inflate again — the very
+/// regression these caches exist to prevent. They are consulted a handful of times per
+/// editor session and hold only map operations under the lock, so the concurrency a
+/// single shard gives up is not worth that.
+fn byte_bounded_cache<Key, Val>(items: usize, bytes: u64) -> Cache<Key, Val, CacheWeighter>
+where
+    Key: Eq + std::hash::Hash,
+    Val: Clone,
+    CacheWeighter: Weighter<Key, Val>,
+{
+    let options = quick_cache::OptionsBuilder::new()
+        .shards(1)
+        .estimated_items_capacity(items)
+        .weight_capacity(bytes)
+        .build()
+        .expect("every cache option is set");
+    Cache::with_options(
+        options,
+        CacheWeighter,
+        Default::default(),
+        Default::default(),
+    )
+}
+
 lazy_static::lazy_static! {
     static ref PACKAGE_JSON_CACHE: Cache<(String, String), CachedPackageJson, CacheWeighter> =
-        Cache::with_weighter(500, PACKAGE_JSON_CACHE_BYTES, CacheWeighter);
+        byte_bounded_cache(500, PACKAGE_JSON_CACHE_BYTES);
     static ref TARBALL_CACHE: Cache<(String, String, String), CachedTarball, CacheWeighter> =
-        Cache::with_weighter(200, TARBALL_CACHE_BYTES, CacheWeighter);
+        byte_bounded_cache(200, TARBALL_CACHE_BYTES);
 }
 
 /// Fetch a package's registry document, together with the registry it came from so
@@ -792,7 +818,13 @@ async fn extracted_tarball(
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_tarball_within, resolve_version_spec};
+    use super::{
+        byte_bounded_cache, extract_tarball_within, resolve_version_spec, CachedTarball,
+        ExtractedTarball, MAX_EXTRACTED_BYTES, TARBALL_CACHE_BYTES,
+    };
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Instant;
 
     fn packument() -> serde_json::Value {
         serde_json::json!({
@@ -841,7 +873,9 @@ mod tests {
             header.set_size(content.len() as u64);
             header.set_mode(0o644);
             header.set_cksum();
-            builder.append_data(&mut header, path, content.as_slice()).unwrap();
+            builder
+                .append_data(&mut header, path, content.as_slice())
+                .unwrap();
         }
         builder.into_inner().unwrap().finish().unwrap()
     }
@@ -857,5 +891,24 @@ mod tests {
         // A tarball's transfer size bounds neither of these
         assert!(extract_tarball_within(&archive, 40, 16).is_err());
         assert!(extract_tarball_within(&archive, 1024, 1).is_err());
+    }
+
+    /// A cache that splits its budget across shards refuses anything heavier than one
+    /// shard's share, silently declining the packages worth caching most.
+    #[test]
+    fn the_largest_extraction_allowed_still_fits_the_cache() {
+        let cache = byte_bounded_cache(200, TARBALL_CACHE_BYTES);
+        let key = ("registry".to_string(), "big".to_string(), "1.0.0".to_string());
+
+        cache.insert(
+            key.clone(),
+            CachedTarball {
+                extracted: Arc::new(ExtractedTarball { names: vec![], contents: HashMap::new() }),
+                bytes: MAX_EXTRACTED_BYTES,
+                fetched_at: Instant::now(),
+            },
+        );
+
+        assert!(cache.get(&key).is_some());
     }
 }

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -189,18 +189,46 @@ struct CachedPackageJson {
     fetched_at: Instant,
 }
 
-#[derive(Clone)]
-struct PackageJsonWeighter;
+/// Type acquisition asks for a package's file tree and then for each `.d.ts` in it, all
+/// out of the same archive, so without this one package costs a download and an inflate
+/// per file rather than per package.
+const TARBALL_CACHE_TTL: Duration = Duration::from_secs(300);
+const TARBALL_CACHE_BYTES: u64 = 128 * 1024 * 1024;
 
-impl Weighter<(String, String), CachedPackageJson> for PackageJsonWeighter {
+/// A package tarball, inflated once. Paths have the `package/` prefix stripped.
+struct ExtractedTarball {
+    /// In archive order, `/`-prefixed, for the file tree listing.
+    names: Vec<String>,
+    contents: HashMap<String, Vec<u8>>,
+}
+
+#[derive(Clone)]
+struct CachedTarball {
+    extracted: Arc<ExtractedTarball>,
+    bytes: u64,
+    fetched_at: Instant,
+}
+
+#[derive(Clone)]
+struct CacheWeighter;
+
+impl Weighter<(String, String), CachedPackageJson> for CacheWeighter {
     fn weight(&self, _key: &(String, String), cached: &CachedPackageJson) -> u64 {
         cached.bytes.max(1)
     }
 }
 
+impl Weighter<(String, String, String), CachedTarball> for CacheWeighter {
+    fn weight(&self, _key: &(String, String, String), cached: &CachedTarball) -> u64 {
+        cached.bytes.max(1)
+    }
+}
+
 lazy_static::lazy_static! {
-    static ref PACKAGE_JSON_CACHE: Cache<(String, String), CachedPackageJson, PackageJsonWeighter> =
-        Cache::with_weighter(500, PACKAGE_JSON_CACHE_BYTES, PackageJsonWeighter);
+    static ref PACKAGE_JSON_CACHE: Cache<(String, String), CachedPackageJson, CacheWeighter> =
+        Cache::with_weighter(500, PACKAGE_JSON_CACHE_BYTES, CacheWeighter);
+    static ref TARBALL_CACHE: Cache<(String, String, String), CachedTarball, CacheWeighter> =
+        Cache::with_weighter(200, TARBALL_CACHE_BYTES, CacheWeighter);
 }
 
 /// Fetch a package's registry document, together with the registry it came from so
@@ -481,7 +509,7 @@ async fn get_package_filetree(
 ) -> JsonResult<PackageFiletree> {
     let (package, version) = parse_package_and_version(package_version_path.to_path())?;
     let (package_json, registry_url, auth_token) = fetch_package_json(&db, &package).await?;
-    let tarball_bytes = fetch_tarball(
+    let extracted = extracted_tarball(
         &package_json,
         &package,
         &version,
@@ -492,9 +520,10 @@ async fn get_package_filetree(
 
     // The entry point comes from the packaged manifest rather than the registry document,
     // which carries no `main` in its abbreviated form.
-    let (files, manifest) = extract_tarball_files_and_manifest(&tarball_bytes)?;
-    let main = manifest
-        .and_then(|manifest| serde_json::from_str::<JsonValue>(&manifest).ok())
+    let main = extracted
+        .contents
+        .get("package.json")
+        .and_then(|manifest| serde_json::from_slice::<JsonValue>(manifest).ok())
         .and_then(|manifest| {
             manifest
                 .get("main")
@@ -502,6 +531,12 @@ async fn get_package_filetree(
                 .map(String::from)
         })
         .unwrap_or_else(|| "index.js".to_string());
+
+    let files = extracted
+        .names
+        .iter()
+        .map(|name| FileEntry { name: name.clone() })
+        .collect();
 
     Ok(Json(PackageFiletree { default: main, files }))
 }
@@ -514,7 +549,7 @@ async fn get_package_file(
 ) -> Result<String> {
     let (package, version, filepath) = parse_package_version_and_file(full_path.to_path())?;
     let (package_json, registry_url, auth_token) = fetch_package_json(&db, &package).await?;
-    let tarball_bytes = fetch_tarball(
+    let extracted = extracted_tarball(
         &package_json,
         &package,
         &version,
@@ -523,10 +558,13 @@ async fn get_package_file(
     )
     .await?;
 
-    // Extract the specific file from the tarball
-    let file_content = extract_file_from_tarball(&tarball_bytes, &filepath)?;
+    let content = extracted
+        .contents
+        .get(filepath.trim_start_matches('/'))
+        .ok_or_else(|| Error::NotFound(format!("File {} not found in tarball", filepath)))?;
 
-    Ok(file_content)
+    String::from_utf8(content.clone())
+        .map_err(|_| Error::BadRequest(format!("File {} is not valid UTF-8", filepath)))
 }
 
 /// Stream a package version's tarball, so in-browser installers can unpack it
@@ -629,10 +667,8 @@ fn format_registry_url(
     }
 }
 
-/// Extract the file list and the manifest from a tarball, in one pass over the archive
-fn extract_tarball_files_and_manifest(
-    tarball_bytes: &[u8],
-) -> Result<(Vec<FileEntry>, Option<String>)> {
+/// Inflate a tarball in one pass over the archive
+fn extract_tarball(tarball_bytes: &[u8]) -> Result<ExtractedTarball> {
     use flate2::read::GzDecoder;
     use std::io::Read;
     use tar::Archive;
@@ -640,8 +676,8 @@ fn extract_tarball_files_and_manifest(
     let gz = GzDecoder::new(tarball_bytes);
     let mut archive = Archive::new(gz);
 
-    let mut files = Vec::new();
-    let mut manifest = None;
+    let mut names = Vec::new();
+    let mut contents = HashMap::new();
 
     for entry in archive
         .entries()
@@ -656,59 +692,51 @@ fn extract_tarball_files_and_manifest(
         // Remove the package/ prefix that npm tarballs have
         let path_str = path.to_string_lossy().to_string();
         if let Some(stripped) = path_str.strip_prefix("package/") {
-            files.push(FileEntry { name: format!("/{}", stripped) });
-            if stripped == "package.json" {
-                let mut content = String::new();
-                if entry.read_to_string(&mut content).is_ok() {
-                    manifest = Some(content);
-                }
+            let stripped = stripped.to_string();
+            names.push(format!("/{}", stripped));
+            let mut content = Vec::new();
+            if entry.read_to_end(&mut content).is_ok() {
+                contents.insert(stripped, content);
             }
         }
     }
 
-    Ok((files, manifest))
+    Ok(ExtractedTarball { names, contents })
 }
 
-/// Extract a specific file from a tarball
-fn extract_file_from_tarball(tarball_bytes: &[u8], target_file: &str) -> Result<String> {
-    use flate2::read::GzDecoder;
-    use std::io::Read;
-    use tar::Archive;
-
-    let gz = GzDecoder::new(tarball_bytes);
-    let mut archive = Archive::new(gz);
-
-    // Normalize the target file path
-    let target = target_file.trim_start_matches('/');
-
-    for entry in archive
-        .entries()
-        .map_err(|e| Error::InternalErr(format!("Failed to read tarball entries: {}", e)))?
-    {
-        let mut entry = entry
-            .map_err(|e| Error::InternalErr(format!("Failed to read tarball entry: {}", e)))?;
-        let path = entry
-            .path()
-            .map_err(|e| Error::InternalErr(format!("Failed to read entry path: {}", e)))?;
-
-        let path_str = path.to_string_lossy().to_string();
-
-        // Check if this is the file we're looking for
-        if let Some(stripped) = path_str.strip_prefix("package/") {
-            if stripped == target {
-                let mut content = String::new();
-                entry.read_to_string(&mut content).map_err(|e| {
-                    Error::InternalErr(format!("Failed to read file content: {}", e))
-                })?;
-                return Ok(content);
-            }
+/// Download and inflate a package version's tarball, reusing a recent extraction
+async fn extracted_tarball(
+    package_json: &JsonValue,
+    package: &str,
+    version: &str,
+    registry_url: &str,
+    auth_token: &Option<String>,
+) -> Result<Arc<ExtractedTarball>> {
+    let cache_key = (
+        registry_url.to_string(),
+        package.to_string(),
+        version.to_string(),
+    );
+    if let Some(cached) = TARBALL_CACHE.get(&cache_key) {
+        if cached.fetched_at.elapsed() < TARBALL_CACHE_TTL {
+            return Ok(cached.extracted);
         }
     }
 
-    Err(Error::NotFound(format!(
-        "File {} not found in tarball",
-        target_file
-    )))
+    let tarball_bytes =
+        fetch_tarball(package_json, package, version, registry_url, auth_token).await?;
+    let extracted = Arc::new(extract_tarball(&tarball_bytes)?);
+
+    TARBALL_CACHE.insert(
+        cache_key,
+        CachedTarball {
+            extracted: extracted.clone(),
+            bytes: extracted.contents.values().map(|c| c.len() as u64).sum(),
+            fetched_at: Instant::now(),
+        },
+    );
+
+    Ok(extracted)
 }
 
 #[cfg(test)]

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -198,16 +198,18 @@ struct CachedPackageJson {
 const TARBALL_CACHE_TTL: Duration = Duration::from_secs(300);
 const TARBALL_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
-/// Bounds on one archive's inflation. All three sit far above any real package (`next`
-/// unpacks to ~184 MB across ~8.5k files), so they bound abuse rather than express a size
-/// policy — a package is never refused for being large.
+/// Bounds on one archive's inflation. Both sit far above any real package (`next` unpacks
+/// to ~184 MB across ~8.5k files), so they bound abuse rather than express a size policy —
+/// a package is never refused for being large.
 const MAX_INFLATED_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_ENTRIES: usize = 100_000;
-/// Backstops on what one package retains. Anything past them is read back on demand, which
-/// costs a walk of the archive per read, so they are set above what real packages hold
-/// rather than tightly: `aws-sdk` carries ~51 MB across 442 declarations, the heaviest
-/// known, and the cache's own byte budget is what bounds the total across packages.
+/// Ceiling on one entry held in memory. Past it the entry is read back on demand, which
+/// costs a walk of the archive per read, so it sits above what real packages hold rather
+/// than tightly.
 const RETAINED_ENTRY_BYTES: u64 = 4 * 1024 * 1024;
+/// Ceiling on everything one read holds: the file list and the retained entries together.
+/// `aws-sdk` is the heaviest package known here at ~51 MB across 442 declarations, so this
+/// clears it comfortably while staying an abuse bound.
 const RETAINED_BYTES: u64 = 128 * 1024 * 1024;
 /// Charged per entry on top of its bytes, for the `String`/`Vec` headers, their heap
 /// allocations and the map bucket. Deliberately generous: the point is that an archive of
@@ -215,11 +217,12 @@ const RETAINED_BYTES: u64 = 128 * 1024 * 1024;
 const NAME_OVERHEAD: u64 = 64;
 const RETAINED_FILE_OVERHEAD: u64 = 160;
 
-/// What a type request can ask for: `ata/index.ts` reads each dependency's manifest and
-/// then every `.d.ts` the file tree lists. Retaining just those keeps a large package's
-/// bundles, maps and licences out of memory — `next` lists 8.5k files, of which the
-/// manifest is the 3748th, so a rule by size alone would spend the budget before reaching
-/// what is actually read. Anything else stays available through a read on demand.
+/// Resident memory is `reads in flight × RETAINED_BYTES` plus the cache, since a read
+/// builds its map before the cache ever weighs it. Keeping the per-read ceiling well under
+/// the cache budget also keeps a package clear of the single shard's admission ceiling
+/// (`budget × 0.97`), past which it would be served but silently never cached.
+const _: () = assert!(RETAINED_BYTES * 2 <= TARBALL_CACHE_BYTES);
+
 /// npm roots its own tarballs at `package/`, but publishers vary — DefinitelyTyped roots
 /// at the type name — so the leading component is dropped whatever it is. Matching
 /// `package/` alone silently yields an empty file tree for those packages.
@@ -229,6 +232,11 @@ fn strip_archive_root(path: &str) -> Option<&str> {
         .filter(|rest| !rest.is_empty())
 }
 
+/// What a type request can ask for: `ata/index.ts` reads each dependency's manifest and
+/// then every `.d.ts` the file tree lists. Retaining just those keeps a large package's
+/// bundles, maps and licences out of memory — `next` lists 8.5k files, of which the
+/// manifest is the 3748th, so a rule by size alone would spend the budget before reaching
+/// what is actually read. Anything else stays available through a read on demand.
 fn worth_retaining(path: &str) -> bool {
     path == MANIFEST || path.ends_with(".d.ts")
 }
@@ -257,8 +265,8 @@ struct PackageArchive {
     archive: axum::body::Bytes,
     /// In archive order, `/`-prefixed, for the file tree listing.
     names: Vec<String>,
-    /// Paths with the `package/` prefix stripped. Holds only the entries small enough to
-    /// retain, so a miss means "walk the archive", not "absent from the package".
+    /// Keyed by path with the archive root stripped. A cache of the archive rather than a
+    /// statement about it: a miss means "walk the archive", not "absent from the package".
     small_files: HashMap<String, Vec<u8>>,
 }
 
@@ -626,26 +634,10 @@ async fn get_package_filetree(
     )
     .await?;
 
-    // The entry point comes from the packaged manifest rather than the registry document,
-    // which carries no `main` in its abbreviated form. A manifest past the retention
-    // bounds is read back rather than assumed absent: falling through to a default would
-    // report the wrong entry point for a package that does declare one.
-    let manifest = match archive.small_files.get(MANIFEST) {
-        Some(manifest) => Some(manifest.clone()),
-        None => {
-            let archive = archive.clone();
-            blocking(move || read_one_entry(&archive.archive, MANIFEST)).await?
-        }
+    let main = {
+        let archive = archive.clone();
+        blocking(move || entry_point(&archive)).await?
     };
-    let main = manifest
-        .and_then(|manifest| serde_json::from_slice::<JsonValue>(&manifest).ok())
-        .and_then(|manifest| {
-            manifest
-                .get("main")
-                .and_then(|m| m.as_str())
-                .map(String::from)
-        })
-        .unwrap_or_else(|| "index.js".to_string());
 
     let files = archive
         .names
@@ -856,9 +848,19 @@ fn read_package_archive(
                 retention.max_entries
             )));
         }
+        // Paths are held whatever the entry is, and held twice for a retained one, so
+        // they are charged like any other bytes: an archive of long names would otherwise
+        // grow `names` without limit while reporting almost no weight.
+        retained += stripped.len() as u64 + NAME_OVERHEAD;
+        if retained > retention.total_bytes {
+            return Err(Error::BadRequest(format!(
+                "Package archive holds more than {} bytes of paths and declarations",
+                retention.total_bytes
+            )));
+        }
         names.push(format!("/{}", stripped));
 
-        if !worth_retaining(&stripped) || retained >= retention.total_bytes {
+        if !worth_retaining(&stripped) {
             continue;
         }
         // Read through a cap rather than sizing from the header, which an archive is free
@@ -868,15 +870,41 @@ fn read_package_archive(
             .take(retention.entry_bytes + 1)
             .read_to_end(&mut content)
             .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", stripped, e)))?;
-        if content.len() as u64 <= retention.entry_bytes {
-            // The overhead counts against the budget too, so many empty files exhaust it
-            // rather than being retained without limit.
-            retained += content.len() as u64 + RETAINED_FILE_OVERHEAD;
-            small_files.insert(stripped, content);
+        if content.len() as u64 > retention.entry_bytes {
+            continue;
         }
+        retained += (stripped.len() + content.len()) as u64 + RETAINED_FILE_OVERHEAD;
+        if retained > retention.total_bytes {
+            return Err(Error::BadRequest(format!(
+                "Package archive holds more than {} bytes of paths and declarations",
+                retention.total_bytes
+            )));
+        }
+        small_files.insert(stripped, content);
     }
 
     Ok(PackageArchive { archive, names, small_files })
+}
+
+/// A package's entry point, from the packaged manifest rather than the registry document,
+/// which carries no `main` in its abbreviated form. A manifest outside the retention
+/// bounds is read back rather than assumed absent: inferring absence from a miss would
+/// report the wrong entry point for a package that does declare one. Blocking work, since
+/// the read-back walks the archive.
+fn entry_point(archive: &PackageArchive) -> Result<String> {
+    let manifest = match archive.small_files.get(MANIFEST) {
+        Some(manifest) => Some(manifest.clone()),
+        None => read_one_entry(&archive.archive, MANIFEST)?,
+    };
+    Ok(manifest
+        .and_then(|manifest| serde_json::from_slice::<JsonValue>(&manifest).ok())
+        .and_then(|manifest| {
+            manifest
+                .get("main")
+                .and_then(|m| m.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_else(|| "index.js".to_string()))
 }
 
 /// Read one entry out of an archive, for the files too large to have been retained.
@@ -962,7 +990,7 @@ async fn blocking<T: Send + 'static>(
 mod tests {
     use super::{
         byte_bounded_cache, read_one_entry, read_package_archive, resolve_version_spec,
-        CachedTarball, PackageArchive, Retention, MANIFEST, NAME_OVERHEAD,
+        entry_point, CachedTarball, PackageArchive, Retention, MANIFEST, NAME_OVERHEAD,
         RETAINED_FILE_OVERHEAD,
     };
     use std::collections::HashMap;
@@ -1076,12 +1104,14 @@ mod tests {
         let squeezed = Retention { entry_bytes: 16, ..TINY };
         let read = read_package_archive(archive.clone(), squeezed).unwrap();
 
+        // The manifest fell outside the bounds, so a lookup alone would default
         assert!(!read.small_files.contains_key(MANIFEST));
-        let found = read_one_entry(&archive, MANIFEST).unwrap().unwrap();
-        assert_eq!(
-            serde_json::from_slice::<serde_json::Value>(&found).unwrap()["main"],
-            "lib/index.js"
-        );
+        assert_eq!(entry_point(&read).unwrap(), "lib/index.js");
+
+        // and a package that genuinely declares none still gets the default
+        let bare: axum::body::Bytes = tarball(&[("package/index.js", 4)]).into();
+        let read = read_package_archive(bare, TINY).unwrap();
+        assert_eq!(entry_point(&read).unwrap(), "index.js");
     }
 
     /// Weighing contents alone would price an archive of empty declarations at nearly
@@ -1108,6 +1138,12 @@ mod tests {
             read.retained_bytes()
                 >= archive.len() as u64 + 2000 * (NAME_OVERHEAD + RETAINED_FILE_OVERHEAD)
         );
+
+        // Long paths are held whatever the entry is, so they count against the budget:
+        // an archive of them would otherwise grow `names` while reporting no weight.
+        let long = format!("package/{}.js", "p".repeat(2000));
+        let padded: axum::body::Bytes = tarball(&[(long.as_str(), 0)]).into();
+        assert!(read_package_archive(padded, Retention { total_bytes: 512, ..TINY }).is_err());
     }
 
     /// A cache that splits its budget across shards refuses anything heavier than one

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -203,10 +203,12 @@ const TARBALL_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 /// policy — a package is never refused for being large.
 const MAX_INFLATED_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_ENTRIES: usize = 100_000;
-/// Backstops on what one package retains. Type declarations and manifests sit far below
-/// both; anything larger is read back on demand instead.
-const RETAINED_ENTRY_BYTES: u64 = 512 * 1024;
-const RETAINED_BYTES: u64 = 32 * 1024 * 1024;
+/// Backstops on what one package retains. Anything past them is read back on demand, which
+/// costs a walk of the archive per read, so they are set above what real packages hold
+/// rather than tightly: `aws-sdk` carries ~51 MB across 442 declarations, the heaviest
+/// known, and the cache's own byte budget is what bounds the total across packages.
+const RETAINED_ENTRY_BYTES: u64 = 4 * 1024 * 1024;
+const RETAINED_BYTES: u64 = 128 * 1024 * 1024;
 /// Charged per entry on top of its bytes, for the `String`/`Vec` headers, their heap
 /// allocations and the map bucket. Deliberately generous: the point is that an archive of
 /// empty files cannot be free, not that the figure is exact.
@@ -228,7 +230,26 @@ fn strip_archive_root(path: &str) -> Option<&str> {
 }
 
 fn worth_retaining(path: &str) -> bool {
-    path == "package.json" || path.ends_with(".d.ts")
+    path == MANIFEST || path.ends_with(".d.ts")
+}
+
+const MANIFEST: &str = "package.json";
+
+/// What one read of an archive will hold on to. Parameterised so the bounds can be
+/// exercised without building an archive the size of the production ones.
+#[derive(Clone, Copy)]
+struct Retention {
+    max_entries: usize,
+    entry_bytes: u64,
+    total_bytes: u64,
+}
+
+impl Retention {
+    const PRODUCTION: Self = Self {
+        max_entries: MAX_ENTRIES,
+        entry_bytes: RETAINED_ENTRY_BYTES,
+        total_bytes: RETAINED_BYTES,
+    };
 }
 
 /// A package version's archive, and the small files read out of it on the way in.
@@ -606,11 +627,18 @@ async fn get_package_filetree(
     .await?;
 
     // The entry point comes from the packaged manifest rather than the registry document,
-    // which carries no `main` in its abbreviated form.
-    let main = archive
-        .small_files
-        .get("package.json")
-        .and_then(|manifest| serde_json::from_slice::<JsonValue>(manifest).ok())
+    // which carries no `main` in its abbreviated form. A manifest past the retention
+    // bounds is read back rather than assumed absent: falling through to a default would
+    // report the wrong entry point for a package that does declare one.
+    let manifest = match archive.small_files.get(MANIFEST) {
+        Some(manifest) => Some(manifest.clone()),
+        None => {
+            let archive = archive.clone();
+            blocking(move || read_one_entry(&archive.archive, MANIFEST)).await?
+        }
+    };
+    let main = manifest
+        .and_then(|manifest| serde_json::from_slice::<JsonValue>(&manifest).ok())
         .and_then(|manifest| {
             manifest
                 .get("main")
@@ -789,7 +817,10 @@ impl<R: std::io::Read> std::io::Read for BoundedRead<R> {
 
 /// Read a package archive once, keeping its file list and the entries small enough to
 /// retain. Blocking work: gunzip plus a full walk, so callers hand it to a blocking thread.
-fn read_package_archive(archive: axum::body::Bytes, max_entries: usize) -> Result<PackageArchive> {
+fn read_package_archive(
+    archive: axum::body::Bytes,
+    retention: Retention,
+) -> Result<PackageArchive> {
     use flate2::read::GzDecoder;
     use std::io::Read;
     use tar::Archive;
@@ -819,25 +850,25 @@ fn read_package_archive(archive: axum::body::Bytes, max_entries: usize) -> Resul
         let Some(stripped) = strip_archive_root(&path).map(str::to_string) else {
             continue;
         };
-        if names.len() >= max_entries {
+        if names.len() >= retention.max_entries {
             return Err(Error::BadRequest(format!(
                 "Package archive holds more than {} files",
-                max_entries
+                retention.max_entries
             )));
         }
         names.push(format!("/{}", stripped));
 
-        if !worth_retaining(&stripped) || retained >= RETAINED_BYTES {
+        if !worth_retaining(&stripped) || retained >= retention.total_bytes {
             continue;
         }
         // Read through a cap rather than sizing from the header, which an archive is free
         // to lie about, and one byte past it so an overrun is detectable.
         let mut content = Vec::new();
         (&mut entry)
-            .take(RETAINED_ENTRY_BYTES + 1)
+            .take(retention.entry_bytes + 1)
             .read_to_end(&mut content)
             .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", stripped, e)))?;
-        if content.len() as u64 <= RETAINED_ENTRY_BYTES {
+        if content.len() as u64 <= retention.entry_bytes {
             // The overhead counts against the budget too, so many empty files exhaust it
             // rather than being retained without limit.
             retained += content.len() as u64 + RETAINED_FILE_OVERHEAD;
@@ -902,7 +933,7 @@ async fn cached_package(
     }
 
     let archive = fetch_tarball(package_json, package, version, registry_url, auth_token).await?;
-    let read = blocking(move || read_package_archive(archive, MAX_ENTRIES)).await?;
+    let read = blocking(move || read_package_archive(archive, Retention::PRODUCTION)).await?;
     let package = Arc::new(read);
 
     TARBALL_CACHE.insert(
@@ -931,7 +962,7 @@ async fn blocking<T: Send + 'static>(
 mod tests {
     use super::{
         byte_bounded_cache, read_one_entry, read_package_archive, resolve_version_spec,
-        CachedTarball, PackageArchive, NAME_OVERHEAD, RETAINED_ENTRY_BYTES,
+        CachedTarball, PackageArchive, Retention, MANIFEST, NAME_OVERHEAD,
         RETAINED_FILE_OVERHEAD,
     };
     use std::collections::HashMap;
@@ -992,19 +1023,21 @@ mod tests {
         builder.into_inner().unwrap().finish().unwrap()
     }
 
+    const TINY: Retention = Retention { max_entries: 16, entry_bytes: 128, total_bytes: 4096 };
+
     #[test]
     fn only_what_a_type_request_reads_is_retained() {
         // `next` orders its manifest 3748th, behind thousands of licences, and
         // DefinitelyTyped roots its archives at the type name rather than `package`
         let archive: axum::body::Bytes = tarball(&[
             ("express/dist/compiled/a/LICENSE", 64),
-            ("express/dist/bundle.js", RETAINED_ENTRY_BYTES as usize + 1),
+            ("express/dist/bundle.js", TINY.entry_bytes as usize + 1),
             ("express/package.json", 8),
             ("express/types/index.d.ts", 32),
         ])
         .into();
 
-        let read = read_package_archive(archive.clone(), 16).unwrap();
+        let read = read_package_archive(archive.clone(), TINY).unwrap();
 
         // Every file is listed, whatever its size or kind
         assert_eq!(read.names.len(), 4);
@@ -1015,12 +1048,40 @@ mod tests {
         // and the rest stays reachable
         assert_eq!(
             read_one_entry(&archive, "dist/bundle.js").unwrap().map(|c| c.len()),
-            Some(RETAINED_ENTRY_BYTES as usize + 1)
+            Some(TINY.entry_bytes as usize + 1)
         );
         assert_eq!(read_one_entry(&archive, "absent.js").unwrap(), None);
 
         // Entry count is the one hard bound; size is never a reason to refuse a package
-        assert!(read_package_archive(archive, 1).is_err());
+        let too_few = Retention { max_entries: 1, ..TINY };
+        assert!(read_package_archive(archive, too_few).is_err());
+    }
+
+    /// `/filetree` reads the manifest back rather than defaulting, or a package whose
+    /// manifest falls outside the retention bounds reports the wrong entry point.
+    #[test]
+    fn a_manifest_past_the_bounds_is_still_readable() {
+        let manifest = format!("{{\"main\":\"lib/index.js\",\"pad\":\"{}\"}}", "x".repeat(200));
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(manifest.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "package/package.json", manifest.as_bytes())
+            .unwrap();
+        let archive: axum::body::Bytes = builder.into_inner().unwrap().finish().unwrap().into();
+
+        let squeezed = Retention { entry_bytes: 16, ..TINY };
+        let read = read_package_archive(archive.clone(), squeezed).unwrap();
+
+        assert!(!read.small_files.contains_key(MANIFEST));
+        let found = read_one_entry(&archive, MANIFEST).unwrap().unwrap();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&found).unwrap()["main"],
+            "lib/index.js"
+        );
     }
 
     /// Weighing contents alone would price an archive of empty declarations at nearly
@@ -1038,7 +1099,8 @@ mod tests {
         )
         .into();
 
-        let read = read_package_archive(archive.clone(), 10_000).unwrap();
+        let spacious = Retention { max_entries: 10_000, total_bytes: 1 << 30, ..TINY };
+        let read = read_package_archive(archive.clone(), spacious).unwrap();
 
         assert_eq!(read.small_files.len(), 2000);
         // Charged for what each entry actually owns, not for its zero bytes of content

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -207,6 +207,11 @@ const MAX_ENTRIES: usize = 100_000;
 /// both; anything larger is read back on demand instead.
 const RETAINED_ENTRY_BYTES: u64 = 512 * 1024;
 const RETAINED_BYTES: u64 = 32 * 1024 * 1024;
+/// Charged per entry on top of its bytes, for the `String`/`Vec` headers, their heap
+/// allocations and the map bucket. Deliberately generous: the point is that an archive of
+/// empty files cannot be free, not that the figure is exact.
+const NAME_OVERHEAD: u64 = 64;
+const RETAINED_FILE_OVERHEAD: u64 = 160;
 
 /// What a type request can ask for: `ata/index.ts` reads each dependency's manifest and
 /// then every `.d.ts` the file tree lists. Retaining just those keeps a large package's
@@ -237,12 +242,22 @@ struct PackageArchive {
 }
 
 impl PackageArchive {
+    /// What one package holds. Counting only string contents would let an archive of many
+    /// tiny files sit far above the cache budget: an empty `.d.ts` costs nothing by that
+    /// measure while still owning a `String`, a `Vec`, their separate heap allocations and
+    /// a map bucket, so every entry carries a generous fixed cost as well.
     fn retained_bytes(&self) -> u64 {
-        let names: u64 = self.names.iter().map(|n| n.len() as u64).sum();
+        let names: u64 = self
+            .names
+            .iter()
+            .map(|name| name.len() as u64 + NAME_OVERHEAD)
+            .sum();
         let files: u64 = self
             .small_files
             .iter()
-            .map(|(path, content)| (path.len() + content.len()) as u64)
+            .map(|(path, content)| {
+                (path.len() + content.len()) as u64 + RETAINED_FILE_OVERHEAD
+            })
             .sum();
         self.archive.len() as u64 + names + files
     }
@@ -823,7 +838,9 @@ fn read_package_archive(archive: axum::body::Bytes, max_entries: usize) -> Resul
             .read_to_end(&mut content)
             .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", stripped, e)))?;
         if content.len() as u64 <= RETAINED_ENTRY_BYTES {
-            retained += content.len() as u64;
+            // The overhead counts against the budget too, so many empty files exhaust it
+            // rather than being retained without limit.
+            retained += content.len() as u64 + RETAINED_FILE_OVERHEAD;
             small_files.insert(stripped, content);
         }
     }
@@ -914,7 +931,8 @@ async fn blocking<T: Send + 'static>(
 mod tests {
     use super::{
         byte_bounded_cache, read_one_entry, read_package_archive, resolve_version_spec,
-        CachedTarball, PackageArchive, RETAINED_ENTRY_BYTES,
+        CachedTarball, PackageArchive, NAME_OVERHEAD, RETAINED_ENTRY_BYTES,
+        RETAINED_FILE_OVERHEAD,
     };
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -1003,6 +1021,31 @@ mod tests {
 
         // Entry count is the one hard bound; size is never a reason to refuse a package
         assert!(read_package_archive(archive, 1).is_err());
+    }
+
+    /// Weighing contents alone would price an archive of empty declarations at nearly
+    /// nothing, while it still owns a string, a vector and a map bucket per entry.
+    #[test]
+    fn an_archive_of_empty_files_is_not_free() {
+        let empty: Vec<(String, usize)> = (0..2000)
+            .map(|i| (format!("package/t{}.d.ts", i), 0))
+            .collect();
+        let archive: axum::body::Bytes = tarball(
+            &empty
+                .iter()
+                .map(|(path, size)| (path.as_str(), *size))
+                .collect::<Vec<_>>(),
+        )
+        .into();
+
+        let read = read_package_archive(archive.clone(), 10_000).unwrap();
+
+        assert_eq!(read.small_files.len(), 2000);
+        // Charged for what each entry actually owns, not for its zero bytes of content
+        assert!(
+            read.retained_bytes()
+                >= archive.len() as u64 + 2000 * (NAME_OVERHEAD + RETAINED_FILE_OVERHEAD)
+        );
     }
 
     /// A cache that splits its budget across shards refuses anything heavier than one

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -189,44 +189,24 @@ struct CachedPackageJson {
     fetched_at: Instant,
 }
 
-/// Type acquisition asks for a package's file tree and then for each `.d.ts` in it, all
-/// out of the same archive, so without this one package costs a download and an inflate
-/// per file rather than per package.
+/// Type acquisition asks for a package's file tree and then for each `.d.ts` in it. The
+/// downloaded archive is what is kept, not its inflated contents: that bounds the cache by
+/// something already measured — the transfer size — while an inflated map is bounded only
+/// by how far the archive chooses to expand. Each request then walks the archive holding
+/// one entry at a time, which trades a little CPU for a download per package, not per file.
 const TARBALL_CACHE_TTL: Duration = Duration::from_secs(300);
-const TARBALL_CACHE_BYTES: u64 = 128 * 1024 * 1024;
+const TARBALL_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
-/// A tarball is inflated entirely into memory, and its transfer size bounds neither how
-/// far it expands nor how many entries it holds, so extraction is capped as it goes: the
-/// cache's own budget only governs what is kept, which is too late.
-const MAX_EXTRACTED_BYTES: u64 = 64 * 1024 * 1024;
-const MAX_EXTRACTED_ENTRIES: usize = 20_000;
-/// Per-entry map and vector overhead, so an archive of many empty files cannot sit in the
-/// cache at near-zero weight.
-const CACHE_ENTRY_OVERHEAD: u64 = 64;
-
-/// A package tarball, inflated once. Paths have the `package/` prefix stripped.
-struct ExtractedTarball {
-    /// In archive order, `/`-prefixed, for the file tree listing.
-    names: Vec<String>,
-    contents: HashMap<String, Vec<u8>>,
-}
-
-impl ExtractedTarball {
-    fn retained_bytes(&self) -> u64 {
-        let names: u64 = self.names.iter().map(|n| n.len() as u64).sum();
-        let contents: u64 = self
-            .contents
-            .iter()
-            .map(|(path, content)| (path.len() + content.len()) as u64 + CACHE_ENTRY_OVERHEAD)
-            .sum();
-        names + contents
-    }
-}
+/// Guards against an archive that expands without bound in one entry or in entry count.
+/// Both sit far above any real package (`next` unpacks to ~184 MB across ~5k files), so
+/// they bound abuse rather than expressing a size policy: a package too large to cache is
+/// still served, it just costs a walk per request.
+const MAX_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_ENTRIES: usize = 100_000;
 
 #[derive(Clone)]
 struct CachedTarball {
-    extracted: Arc<ExtractedTarball>,
-    bytes: u64,
+    archive: axum::body::Bytes,
     fetched_at: Instant,
 }
 
@@ -241,7 +221,7 @@ impl Weighter<(String, String), CachedPackageJson> for CacheWeighter {
 
 impl Weighter<(String, String, String), CachedTarball> for CacheWeighter {
     fn weight(&self, _key: &(String, String, String), cached: &CachedTarball) -> u64 {
-        cached.bytes.max(1)
+        (cached.archive.len() as u64).max(1)
     }
 }
 
@@ -556,7 +536,7 @@ async fn get_package_filetree(
 ) -> JsonResult<PackageFiletree> {
     let (package, version) = parse_package_and_version(package_version_path.to_path())?;
     let (package_json, registry_url, auth_token) = fetch_package_json(&db, &package).await?;
-    let extracted = extracted_tarball(
+    let archive = cached_archive(
         &package_json,
         &package,
         &version,
@@ -565,12 +545,20 @@ async fn get_package_filetree(
     )
     .await?;
 
+    let mut files = Vec::new();
+    let mut manifest = None;
+    walk_tarball(&archive, MAX_ENTRIES, |path, entry| {
+        files.push(FileEntry { name: format!("/{}", path) });
+        if path == "package.json" {
+            manifest = Some(read_entry(path, entry)?);
+        }
+        Ok(true)
+    })?;
+
     // The entry point comes from the packaged manifest rather than the registry document,
     // which carries no `main` in its abbreviated form.
-    let main = extracted
-        .contents
-        .get("package.json")
-        .and_then(|manifest| serde_json::from_slice::<JsonValue>(manifest).ok())
+    let main = manifest
+        .and_then(|manifest| serde_json::from_slice::<JsonValue>(&manifest).ok())
         .and_then(|manifest| {
             manifest
                 .get("main")
@@ -578,12 +566,6 @@ async fn get_package_filetree(
                 .map(String::from)
         })
         .unwrap_or_else(|| "index.js".to_string());
-
-    let files = extracted
-        .names
-        .iter()
-        .map(|name| FileEntry { name: name.clone() })
-        .collect();
 
     Ok(Json(PackageFiletree { default: main, files }))
 }
@@ -596,7 +578,7 @@ async fn get_package_file(
 ) -> Result<String> {
     let (package, version, filepath) = parse_package_version_and_file(full_path.to_path())?;
     let (package_json, registry_url, auth_token) = fetch_package_json(&db, &package).await?;
-    let extracted = extracted_tarball(
+    let archive = cached_archive(
         &package_json,
         &package,
         &version,
@@ -605,12 +587,19 @@ async fn get_package_file(
     )
     .await?;
 
-    let content = extracted
-        .contents
-        .get(filepath.trim_start_matches('/'))
-        .ok_or_else(|| Error::NotFound(format!("File {} not found in tarball", filepath)))?;
+    let target = filepath.trim_start_matches('/');
+    let mut found = None;
+    walk_tarball(&archive, MAX_ENTRIES, |path, entry| {
+        if path != target {
+            return Ok(true);
+        }
+        found = Some(read_entry(path, entry)?);
+        Ok(false)
+    })?;
 
-    String::from_utf8(content.clone())
+    let content =
+        found.ok_or_else(|| Error::NotFound(format!("File {} not found in tarball", filepath)))?;
+    String::from_utf8(content)
         .map_err(|_| Error::BadRequest(format!("File {} is not valid UTF-8", filepath)))
 }
 
@@ -714,26 +703,20 @@ fn format_registry_url(
     }
 }
 
-/// Inflate a tarball in one pass over the archive
-fn extract_tarball(tarball_bytes: &[u8]) -> Result<ExtractedTarball> {
-    extract_tarball_within(tarball_bytes, MAX_EXTRACTED_BYTES, MAX_EXTRACTED_ENTRIES)
-}
-
-fn extract_tarball_within(
-    tarball_bytes: &[u8],
-    max_bytes: u64,
+/// Walk a package archive, calling `visit` with each entry's path (the `package/` prefix
+/// stripped) and a reader over its body, until `visit` returns `false`. Entry bodies are
+/// never all held at once, so peak memory is one entry regardless of the archive's size.
+fn walk_tarball(
+    archive_bytes: &[u8],
     max_entries: usize,
-) -> Result<ExtractedTarball> {
+    mut visit: impl FnMut(&str, &mut dyn std::io::Read) -> Result<bool>,
+) -> Result<()> {
     use flate2::read::GzDecoder;
-    use std::io::Read;
     use tar::Archive;
 
-    let gz = GzDecoder::new(tarball_bytes);
+    let gz = GzDecoder::new(archive_bytes);
     let mut archive = Archive::new(gz);
-
-    let mut names = Vec::new();
-    let mut contents = HashMap::new();
-    let mut extracted_bytes = 0u64;
+    let mut seen = 0usize;
 
     for entry in archive
         .entries()
@@ -743,52 +726,57 @@ fn extract_tarball_within(
             .map_err(|e| Error::InternalErr(format!("Failed to read tarball entry: {}", e)))?;
         let path = entry
             .path()
-            .map_err(|e| Error::InternalErr(format!("Failed to read entry path: {}", e)))?;
+            .map_err(|e| Error::InternalErr(format!("Failed to read entry path: {}", e)))?
+            .to_string_lossy()
+            .to_string();
 
         // Remove the package/ prefix that npm tarballs have
-        let path_str = path.to_string_lossy().to_string();
-        if let Some(stripped) = path_str.strip_prefix("package/") {
-            if names.len() >= max_entries {
-                return Err(Error::BadRequest(format!(
-                    "Package archive holds more than {} files",
-                    max_entries
-                )));
-            }
-            let stripped = stripped.to_string();
-            names.push(format!("/{}", stripped));
-
-            // Read through a cap rather than sizing from the header, which an archive is
-            // free to lie about, and one byte past it so the overrun is detectable.
-            let headroom = max_bytes - extracted_bytes;
-            let mut content = Vec::new();
-            if (&mut entry)
-                .take(headroom + 1)
-                .read_to_end(&mut content)
-                .is_ok()
-            {
-                if content.len() as u64 > headroom {
-                    return Err(Error::BadRequest(format!(
-                        "Package archive inflates past {} bytes",
-                        max_bytes
-                    )));
-                }
-                extracted_bytes += content.len() as u64;
-                contents.insert(stripped, content);
-            }
+        let Some(stripped) = path.strip_prefix("package/").map(str::to_string) else {
+            continue;
+        };
+        seen += 1;
+        if seen > max_entries {
+            return Err(Error::BadRequest(format!(
+                "Package archive holds more than {} files",
+                max_entries
+            )));
+        }
+        if !visit(&stripped, &mut entry)? {
+            break;
         }
     }
 
-    Ok(ExtractedTarball { names, contents })
+    Ok(())
 }
 
-/// Download and inflate a package version's tarball, reusing a recent extraction
-async fn extracted_tarball(
+/// Read one entry, refusing a body that expands past `MAX_ENTRY_BYTES`. Reads through the
+/// cap rather than sizing from the header, which an archive is free to lie about, and one
+/// byte past it so the overrun is detectable.
+fn read_entry(path: &str, entry: &mut dyn std::io::Read) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut content = Vec::new();
+    entry
+        .take(MAX_ENTRY_BYTES + 1)
+        .read_to_end(&mut content)
+        .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", path, e)))?;
+    if content.len() as u64 > MAX_ENTRY_BYTES {
+        return Err(Error::BadRequest(format!(
+            "{} expands past {} bytes",
+            path, MAX_ENTRY_BYTES
+        )));
+    }
+    Ok(content)
+}
+
+/// The archive of a package version, downloaded once and kept compressed
+async fn cached_archive(
     package_json: &JsonValue,
     package: &str,
     version: &str,
     registry_url: &str,
     auth_token: &Option<String>,
-) -> Result<Arc<ExtractedTarball>> {
+) -> Result<axum::body::Bytes> {
     let cache_key = (
         registry_url.to_string(),
         package.to_string(),
@@ -796,34 +784,26 @@ async fn extracted_tarball(
     );
     if let Some(cached) = TARBALL_CACHE.get(&cache_key) {
         if cached.fetched_at.elapsed() < TARBALL_CACHE_TTL {
-            return Ok(cached.extracted);
+            return Ok(cached.archive);
         }
     }
 
-    let tarball_bytes =
-        fetch_tarball(package_json, package, version, registry_url, auth_token).await?;
-    let extracted = Arc::new(extract_tarball(&tarball_bytes)?);
+    let archive = fetch_tarball(package_json, package, version, registry_url, auth_token).await?;
 
     TARBALL_CACHE.insert(
         cache_key,
-        CachedTarball {
-            extracted: extracted.clone(),
-            bytes: extracted.retained_bytes(),
-            fetched_at: Instant::now(),
-        },
+        CachedTarball { archive: archive.clone(), fetched_at: Instant::now() },
     );
 
-    Ok(extracted)
+    Ok(archive)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        byte_bounded_cache, extract_tarball_within, resolve_version_spec, CachedTarball,
-        ExtractedTarball, MAX_EXTRACTED_BYTES, TARBALL_CACHE_BYTES,
+        byte_bounded_cache, read_entry, resolve_version_spec, walk_tarball, CachedTarball,
+        TARBALL_CACHE_BYTES,
     };
-    use std::collections::HashMap;
-    use std::sync::Arc;
     use std::time::Instant;
 
     fn packument() -> serde_json::Value {
@@ -881,30 +861,38 @@ mod tests {
     }
 
     #[test]
-    fn extraction_is_capped_before_the_archive_is_held_in_memory() {
-        let archive = tarball(&[("package/a.js", 32), ("package/b.js", 32)]);
+    fn walking_an_archive_lists_every_file_and_reads_one_at_a_time() {
+        let archive = tarball(&[("package/a.js", 32), ("package/package.json", 8)]);
 
-        let extracted = extract_tarball_within(&archive, 1024, 16).unwrap();
-        assert_eq!(extracted.names, vec!["/a.js", "/b.js"]);
-        assert!(extracted.retained_bytes() > 64);
+        let mut names = Vec::new();
+        let mut manifest = None;
+        walk_tarball(&archive, 16, |path, entry| {
+            names.push(path.to_string());
+            if path == "package.json" {
+                manifest = Some(read_entry(path, entry)?);
+            }
+            Ok(true)
+        })
+        .unwrap();
 
-        // A tarball's transfer size bounds neither of these
-        assert!(extract_tarball_within(&archive, 40, 16).is_err());
-        assert!(extract_tarball_within(&archive, 1024, 1).is_err());
+        assert_eq!(names, vec!["a.js", "package.json"]);
+        assert_eq!(manifest.unwrap().len(), 8);
+
+        // Entry count is the one abuse bound; size is not a reason to refuse a package
+        assert!(walk_tarball(&archive, 1, |_, _| Ok(true)).is_err());
     }
 
     /// A cache that splits its budget across shards refuses anything heavier than one
     /// shard's share, silently declining the packages worth caching most.
     #[test]
-    fn the_largest_extraction_allowed_still_fits_the_cache() {
+    fn an_archive_near_the_whole_budget_is_kept() {
         let cache = byte_bounded_cache(200, TARBALL_CACHE_BYTES);
         let key = ("registry".to_string(), "big".to_string(), "1.0.0".to_string());
 
         cache.insert(
             key.clone(),
             CachedTarball {
-                extracted: Arc::new(ExtractedTarball { names: vec![], contents: HashMap::new() }),
-                bytes: MAX_EXTRACTED_BYTES,
+                archive: vec![0u8; TARBALL_CACHE_BYTES as usize / 2].into(),
                 fetched_at: Instant::now(),
             },
         );

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -189,24 +189,69 @@ struct CachedPackageJson {
     fetched_at: Instant,
 }
 
-/// Type acquisition asks for a package's file tree and then for each `.d.ts` in it. The
-/// downloaded archive is what is kept, not its inflated contents: that bounds the cache by
-/// something already measured — the transfer size — while an inflated map is bounded only
-/// by how far the archive chooses to expand. Each request then walks the archive holding
-/// one entry at a time, which trades a little CPU for a download per package, not per file.
+/// Type acquisition asks for a package's file tree and then for each `.d.ts` in it, all
+/// out of one archive, so a package is downloaded once and inflated once. What is kept is
+/// the compressed archive plus the small files a type request can ask for; the large
+/// entries — bundles, maps, binaries, which nothing here ever reads — are walked past
+/// rather than retained, so the resident size follows the transfer size and not however
+/// far the archive chooses to expand.
 const TARBALL_CACHE_TTL: Duration = Duration::from_secs(300);
 const TARBALL_CACHE_BYTES: u64 = 256 * 1024 * 1024;
 
-/// Guards against an archive that expands without bound in one entry or in entry count.
-/// Both sit far above any real package (`next` unpacks to ~184 MB across ~5k files), so
-/// they bound abuse rather than expressing a size policy: a package too large to cache is
-/// still served, it just costs a walk per request.
-const MAX_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
+/// Bounds on one archive's inflation. All three sit far above any real package (`next`
+/// unpacks to ~184 MB across ~8.5k files), so they bound abuse rather than express a size
+/// policy — a package is never refused for being large.
+const MAX_INFLATED_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_ENTRIES: usize = 100_000;
+/// Backstops on what one package retains. Type declarations and manifests sit far below
+/// both; anything larger is read back on demand instead.
+const RETAINED_ENTRY_BYTES: u64 = 512 * 1024;
+const RETAINED_BYTES: u64 = 32 * 1024 * 1024;
+
+/// What a type request can ask for: `ata/index.ts` reads each dependency's manifest and
+/// then every `.d.ts` the file tree lists. Retaining just those keeps a large package's
+/// bundles, maps and licences out of memory — `next` lists 8.5k files, of which the
+/// manifest is the 3748th, so a rule by size alone would spend the budget before reaching
+/// what is actually read. Anything else stays available through a read on demand.
+/// npm roots its own tarballs at `package/`, but publishers vary — DefinitelyTyped roots
+/// at the type name — so the leading component is dropped whatever it is. Matching
+/// `package/` alone silently yields an empty file tree for those packages.
+fn strip_archive_root(path: &str) -> Option<&str> {
+    path.split_once('/')
+        .map(|(_, rest)| rest)
+        .filter(|rest| !rest.is_empty())
+}
+
+fn worth_retaining(path: &str) -> bool {
+    path == "package.json" || path.ends_with(".d.ts")
+}
+
+/// A package version's archive, and the small files read out of it on the way in.
+struct PackageArchive {
+    archive: axum::body::Bytes,
+    /// In archive order, `/`-prefixed, for the file tree listing.
+    names: Vec<String>,
+    /// Paths with the `package/` prefix stripped. Holds only the entries small enough to
+    /// retain, so a miss means "walk the archive", not "absent from the package".
+    small_files: HashMap<String, Vec<u8>>,
+}
+
+impl PackageArchive {
+    fn retained_bytes(&self) -> u64 {
+        let names: u64 = self.names.iter().map(|n| n.len() as u64).sum();
+        let files: u64 = self
+            .small_files
+            .iter()
+            .map(|(path, content)| (path.len() + content.len()) as u64)
+            .sum();
+        self.archive.len() as u64 + names + files
+    }
+}
 
 #[derive(Clone)]
 struct CachedTarball {
-    archive: axum::body::Bytes,
+    package: Arc<PackageArchive>,
+    bytes: u64,
     fetched_at: Instant,
 }
 
@@ -221,7 +266,7 @@ impl Weighter<(String, String), CachedPackageJson> for CacheWeighter {
 
 impl Weighter<(String, String, String), CachedTarball> for CacheWeighter {
     fn weight(&self, _key: &(String, String, String), cached: &CachedTarball) -> u64 {
-        (cached.archive.len() as u64).max(1)
+        cached.bytes.max(1)
     }
 }
 
@@ -536,7 +581,7 @@ async fn get_package_filetree(
 ) -> JsonResult<PackageFiletree> {
     let (package, version) = parse_package_and_version(package_version_path.to_path())?;
     let (package_json, registry_url, auth_token) = fetch_package_json(&db, &package).await?;
-    let archive = cached_archive(
+    let archive = cached_package(
         &package_json,
         &package,
         &version,
@@ -545,20 +590,12 @@ async fn get_package_filetree(
     )
     .await?;
 
-    let mut files = Vec::new();
-    let mut manifest = None;
-    walk_tarball(&archive, MAX_ENTRIES, |path, entry| {
-        files.push(FileEntry { name: format!("/{}", path) });
-        if path == "package.json" {
-            manifest = Some(read_entry(path, entry)?);
-        }
-        Ok(true)
-    })?;
-
     // The entry point comes from the packaged manifest rather than the registry document,
     // which carries no `main` in its abbreviated form.
-    let main = manifest
-        .and_then(|manifest| serde_json::from_slice::<JsonValue>(&manifest).ok())
+    let main = archive
+        .small_files
+        .get("package.json")
+        .and_then(|manifest| serde_json::from_slice::<JsonValue>(manifest).ok())
         .and_then(|manifest| {
             manifest
                 .get("main")
@@ -566,6 +603,12 @@ async fn get_package_filetree(
                 .map(String::from)
         })
         .unwrap_or_else(|| "index.js".to_string());
+
+    let files = archive
+        .names
+        .iter()
+        .map(|name| FileEntry { name: name.clone() })
+        .collect();
 
     Ok(Json(PackageFiletree { default: main, files }))
 }
@@ -578,7 +621,7 @@ async fn get_package_file(
 ) -> Result<String> {
     let (package, version, filepath) = parse_package_version_and_file(full_path.to_path())?;
     let (package_json, registry_url, auth_token) = fetch_package_json(&db, &package).await?;
-    let archive = cached_archive(
+    let archive = cached_package(
         &package_json,
         &package,
         &version,
@@ -587,18 +630,21 @@ async fn get_package_file(
     )
     .await?;
 
-    let target = filepath.trim_start_matches('/');
-    let mut found = None;
-    walk_tarball(&archive, MAX_ENTRIES, |path, entry| {
-        if path != target {
-            return Ok(true);
+    let target = filepath.trim_start_matches('/').to_string();
+    let content = match archive.small_files.get(&target) {
+        Some(content) => content.clone(),
+        // Too large to have been retained, so read it back out of the archive
+        None => {
+            let archive = archive.clone();
+            let path = target.clone();
+            blocking(move || read_one_entry(&archive.archive, &path))
+                .await?
+                .ok_or_else(|| {
+                    Error::NotFound(format!("File {} not found in tarball", filepath))
+                })?
         }
-        found = Some(read_entry(path, entry)?);
-        Ok(false)
-    })?;
+    };
 
-    let content =
-        found.ok_or_else(|| Error::NotFound(format!("File {} not found in tarball", filepath)))?;
     String::from_utf8(content)
         .map_err(|_| Error::BadRequest(format!("File {} is not valid UTF-8", filepath)))
 }
@@ -703,22 +749,47 @@ fn format_registry_url(
     }
 }
 
-/// Walk a package archive, calling `visit` with each entry's path (the `package/` prefix
-/// stripped) and a reader over its body, until `visit` returns `false`. Entry bodies are
-/// never all held at once, so peak memory is one entry regardless of the archive's size.
-fn walk_tarball(
-    archive_bytes: &[u8],
-    max_entries: usize,
-    mut visit: impl FnMut(&str, &mut dyn std::io::Read) -> Result<bool>,
-) -> Result<()> {
+/// Caps total inflation across a whole walk, entries skipped past included: a tar entry
+/// can only be advanced over by decompressing it, so bounding the matched entry alone
+/// leaves the work an archive can demand unbounded.
+struct BoundedRead<R> {
+    inner: R,
+    remaining: u64,
+}
+
+impl<R: std::io::Read> std::io::Read for BoundedRead<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.remaining == 0 {
+            return Err(std::io::Error::other(format!(
+                "archive inflates past {} bytes",
+                MAX_INFLATED_BYTES
+            )));
+        }
+        let cap = buf.len().min(self.remaining as usize);
+        let read = self.inner.read(&mut buf[..cap])?;
+        self.remaining -= read as u64;
+        Ok(read)
+    }
+}
+
+/// Read a package archive once, keeping its file list and the entries small enough to
+/// retain. Blocking work: gunzip plus a full walk, so callers hand it to a blocking thread.
+fn read_package_archive(archive: axum::body::Bytes, max_entries: usize) -> Result<PackageArchive> {
     use flate2::read::GzDecoder;
+    use std::io::Read;
     use tar::Archive;
 
-    let gz = GzDecoder::new(archive_bytes);
-    let mut archive = Archive::new(gz);
-    let mut seen = 0usize;
+    let gz = BoundedRead {
+        inner: GzDecoder::new(archive.as_ref()),
+        remaining: MAX_INFLATED_BYTES,
+    };
+    let mut tar = Archive::new(gz);
 
-    for entry in archive
+    let mut names = Vec::new();
+    let mut small_files = HashMap::new();
+    let mut retained = 0u64;
+
+    for entry in tar
         .entries()
         .map_err(|e| Error::InternalErr(format!("Failed to read tarball entries: {}", e)))?
     {
@@ -730,53 +801,78 @@ fn walk_tarball(
             .to_string_lossy()
             .to_string();
 
-        // Remove the package/ prefix that npm tarballs have
-        let Some(stripped) = path.strip_prefix("package/").map(str::to_string) else {
+        let Some(stripped) = strip_archive_root(&path).map(str::to_string) else {
             continue;
         };
-        seen += 1;
-        if seen > max_entries {
+        if names.len() >= max_entries {
             return Err(Error::BadRequest(format!(
                 "Package archive holds more than {} files",
                 max_entries
             )));
         }
-        if !visit(&stripped, &mut entry)? {
-            break;
+        names.push(format!("/{}", stripped));
+
+        if !worth_retaining(&stripped) || retained >= RETAINED_BYTES {
+            continue;
+        }
+        // Read through a cap rather than sizing from the header, which an archive is free
+        // to lie about, and one byte past it so an overrun is detectable.
+        let mut content = Vec::new();
+        (&mut entry)
+            .take(RETAINED_ENTRY_BYTES + 1)
+            .read_to_end(&mut content)
+            .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", stripped, e)))?;
+        if content.len() as u64 <= RETAINED_ENTRY_BYTES {
+            retained += content.len() as u64;
+            small_files.insert(stripped, content);
         }
     }
 
-    Ok(())
+    Ok(PackageArchive { archive, names, small_files })
 }
 
-/// Read one entry, refusing a body that expands past `MAX_ENTRY_BYTES`. Reads through the
-/// cap rather than sizing from the header, which an archive is free to lie about, and one
-/// byte past it so the overrun is detectable.
-fn read_entry(path: &str, entry: &mut dyn std::io::Read) -> Result<Vec<u8>> {
+/// Read one entry out of an archive, for the files too large to have been retained.
+/// Blocking work, same as the full read.
+fn read_one_entry(archive: &[u8], target: &str) -> Result<Option<Vec<u8>>> {
+    use flate2::read::GzDecoder;
     use std::io::Read;
+    use tar::Archive;
 
-    let mut content = Vec::new();
-    entry
-        .take(MAX_ENTRY_BYTES + 1)
-        .read_to_end(&mut content)
-        .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", path, e)))?;
-    if content.len() as u64 > MAX_ENTRY_BYTES {
-        return Err(Error::BadRequest(format!(
-            "{} expands past {} bytes",
-            path, MAX_ENTRY_BYTES
-        )));
+    let gz = BoundedRead { inner: GzDecoder::new(archive), remaining: MAX_INFLATED_BYTES };
+    let mut tar = Archive::new(gz);
+
+    for entry in tar
+        .entries()
+        .map_err(|e| Error::InternalErr(format!("Failed to read tarball entries: {}", e)))?
+    {
+        let mut entry = entry
+            .map_err(|e| Error::InternalErr(format!("Failed to read tarball entry: {}", e)))?;
+        let path = entry
+            .path()
+            .map_err(|e| Error::InternalErr(format!("Failed to read entry path: {}", e)))?
+            .to_string_lossy()
+            .to_string();
+
+        if strip_archive_root(&path) == Some(target) {
+            let mut content = Vec::new();
+            entry
+                .read_to_end(&mut content)
+                .map_err(|e| Error::InternalErr(format!("Failed to read {}: {}", target, e)))?;
+            return Ok(Some(content));
+        }
     }
-    Ok(content)
+
+    Ok(None)
 }
 
-/// The archive of a package version, downloaded once and kept compressed
-async fn cached_archive(
+/// The archive of a package version, downloaded and read once
+async fn cached_package(
     package_json: &JsonValue,
     package: &str,
     version: &str,
     registry_url: &str,
     auth_token: &Option<String>,
-) -> Result<axum::body::Bytes> {
+) -> Result<Arc<PackageArchive>> {
     let cache_key = (
         registry_url.to_string(),
         package.to_string(),
@@ -784,26 +880,44 @@ async fn cached_archive(
     );
     if let Some(cached) = TARBALL_CACHE.get(&cache_key) {
         if cached.fetched_at.elapsed() < TARBALL_CACHE_TTL {
-            return Ok(cached.archive);
+            return Ok(cached.package);
         }
     }
 
     let archive = fetch_tarball(package_json, package, version, registry_url, auth_token).await?;
+    let read = blocking(move || read_package_archive(archive, MAX_ENTRIES)).await?;
+    let package = Arc::new(read);
 
     TARBALL_CACHE.insert(
         cache_key,
-        CachedTarball { archive: archive.clone(), fetched_at: Instant::now() },
+        CachedTarball {
+            package: package.clone(),
+            bytes: package.retained_bytes(),
+            fetched_at: Instant::now(),
+        },
     );
 
-    Ok(archive)
+    Ok(package)
+}
+
+/// Inflating an archive is CPU-bound and can run for as long as the archive is large, so
+/// it belongs on a blocking thread rather than a runtime worker serving other requests.
+async fn blocking<T: Send + 'static>(
+    work: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|e| Error::InternalErr(format!("Failed to read package archive: {}", e)))?
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        byte_bounded_cache, read_entry, resolve_version_spec, walk_tarball, CachedTarball,
-        TARBALL_CACHE_BYTES,
+        byte_bounded_cache, read_one_entry, read_package_archive, resolve_version_spec,
+        CachedTarball, PackageArchive, RETAINED_ENTRY_BYTES,
     };
+    use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::Instant;
 
     fn packument() -> serde_json::Value {
@@ -861,38 +975,53 @@ mod tests {
     }
 
     #[test]
-    fn walking_an_archive_lists_every_file_and_reads_one_at_a_time() {
-        let archive = tarball(&[("package/a.js", 32), ("package/package.json", 8)]);
+    fn only_what_a_type_request_reads_is_retained() {
+        // `next` orders its manifest 3748th, behind thousands of licences, and
+        // DefinitelyTyped roots its archives at the type name rather than `package`
+        let archive: axum::body::Bytes = tarball(&[
+            ("express/dist/compiled/a/LICENSE", 64),
+            ("express/dist/bundle.js", RETAINED_ENTRY_BYTES as usize + 1),
+            ("express/package.json", 8),
+            ("express/types/index.d.ts", 32),
+        ])
+        .into();
 
-        let mut names = Vec::new();
-        let mut manifest = None;
-        walk_tarball(&archive, 16, |path, entry| {
-            names.push(path.to_string());
-            if path == "package.json" {
-                manifest = Some(read_entry(path, entry)?);
-            }
-            Ok(true)
-        })
-        .unwrap();
+        let read = read_package_archive(archive.clone(), 16).unwrap();
 
-        assert_eq!(names, vec!["a.js", "package.json"]);
-        assert_eq!(manifest.unwrap().len(), 8);
+        // Every file is listed, whatever its size or kind
+        assert_eq!(read.names.len(), 4);
+        // but only the manifest and the declarations are held
+        let mut retained = read.small_files.keys().cloned().collect::<Vec<_>>();
+        retained.sort();
+        assert_eq!(retained, vec!["package.json", "types/index.d.ts"]);
+        // and the rest stays reachable
+        assert_eq!(
+            read_one_entry(&archive, "dist/bundle.js").unwrap().map(|c| c.len()),
+            Some(RETAINED_ENTRY_BYTES as usize + 1)
+        );
+        assert_eq!(read_one_entry(&archive, "absent.js").unwrap(), None);
 
-        // Entry count is the one abuse bound; size is not a reason to refuse a package
-        assert!(walk_tarball(&archive, 1, |_, _| Ok(true)).is_err());
+        // Entry count is the one hard bound; size is never a reason to refuse a package
+        assert!(read_package_archive(archive, 1).is_err());
     }
 
     /// A cache that splits its budget across shards refuses anything heavier than one
     /// shard's share, silently declining the packages worth caching most.
     #[test]
-    fn an_archive_near_the_whole_budget_is_kept() {
-        let cache = byte_bounded_cache(200, TARBALL_CACHE_BYTES);
+    fn an_entry_near_the_whole_budget_is_kept() {
+        let budget = 4096;
+        let cache = byte_bounded_cache(200, budget);
         let key = ("registry".to_string(), "big".to_string(), "1.0.0".to_string());
 
         cache.insert(
             key.clone(),
             CachedTarball {
-                archive: vec![0u8; TARBALL_CACHE_BYTES as usize / 2].into(),
+                package: Arc::new(PackageArchive {
+                    archive: Default::default(),
+                    names: vec![],
+                    small_files: HashMap::new(),
+                }),
+                bytes: budget / 2,
                 fetched_at: Instant::now(),
             },
         );

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -195,11 +195,32 @@ struct CachedPackageJson {
 const TARBALL_CACHE_TTL: Duration = Duration::from_secs(300);
 const TARBALL_CACHE_BYTES: u64 = 128 * 1024 * 1024;
 
+/// A tarball is inflated entirely into memory, and its transfer size bounds neither how
+/// far it expands nor how many entries it holds, so extraction is capped as it goes: the
+/// cache's own budget only governs what is kept, which is too late.
+const MAX_EXTRACTED_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_EXTRACTED_ENTRIES: usize = 20_000;
+/// Per-entry map and vector overhead, so an archive of many empty files cannot sit in the
+/// cache at near-zero weight.
+const CACHE_ENTRY_OVERHEAD: u64 = 64;
+
 /// A package tarball, inflated once. Paths have the `package/` prefix stripped.
 struct ExtractedTarball {
     /// In archive order, `/`-prefixed, for the file tree listing.
     names: Vec<String>,
     contents: HashMap<String, Vec<u8>>,
+}
+
+impl ExtractedTarball {
+    fn retained_bytes(&self) -> u64 {
+        let names: u64 = self.names.iter().map(|n| n.len() as u64).sum();
+        let contents: u64 = self
+            .contents
+            .iter()
+            .map(|(path, content)| (path.len() + content.len()) as u64 + CACHE_ENTRY_OVERHEAD)
+            .sum();
+        names + contents
+    }
 }
 
 #[derive(Clone)]
@@ -669,6 +690,14 @@ fn format_registry_url(
 
 /// Inflate a tarball in one pass over the archive
 fn extract_tarball(tarball_bytes: &[u8]) -> Result<ExtractedTarball> {
+    extract_tarball_within(tarball_bytes, MAX_EXTRACTED_BYTES, MAX_EXTRACTED_ENTRIES)
+}
+
+fn extract_tarball_within(
+    tarball_bytes: &[u8],
+    max_bytes: u64,
+    max_entries: usize,
+) -> Result<ExtractedTarball> {
     use flate2::read::GzDecoder;
     use std::io::Read;
     use tar::Archive;
@@ -678,6 +707,7 @@ fn extract_tarball(tarball_bytes: &[u8]) -> Result<ExtractedTarball> {
 
     let mut names = Vec::new();
     let mut contents = HashMap::new();
+    let mut extracted_bytes = 0u64;
 
     for entry in archive
         .entries()
@@ -692,10 +722,31 @@ fn extract_tarball(tarball_bytes: &[u8]) -> Result<ExtractedTarball> {
         // Remove the package/ prefix that npm tarballs have
         let path_str = path.to_string_lossy().to_string();
         if let Some(stripped) = path_str.strip_prefix("package/") {
+            if names.len() >= max_entries {
+                return Err(Error::BadRequest(format!(
+                    "Package archive holds more than {} files",
+                    max_entries
+                )));
+            }
             let stripped = stripped.to_string();
             names.push(format!("/{}", stripped));
+
+            // Read through a cap rather than sizing from the header, which an archive is
+            // free to lie about, and one byte past it so the overrun is detectable.
+            let headroom = max_bytes - extracted_bytes;
             let mut content = Vec::new();
-            if entry.read_to_end(&mut content).is_ok() {
+            if (&mut entry)
+                .take(headroom + 1)
+                .read_to_end(&mut content)
+                .is_ok()
+            {
+                if content.len() as u64 > headroom {
+                    return Err(Error::BadRequest(format!(
+                        "Package archive inflates past {} bytes",
+                        max_bytes
+                    )));
+                }
+                extracted_bytes += content.len() as u64;
                 contents.insert(stripped, content);
             }
         }
@@ -731,7 +782,7 @@ async fn extracted_tarball(
         cache_key,
         CachedTarball {
             extracted: extracted.clone(),
-            bytes: extracted.contents.values().map(|c| c.len() as u64).sum(),
+            bytes: extracted.retained_bytes(),
             fetched_at: Instant::now(),
         },
     );
@@ -741,7 +792,7 @@ async fn extracted_tarball(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_version_spec;
+    use super::{extract_tarball_within, resolve_version_spec};
 
     fn packument() -> serde_json::Value {
         serde_json::json!({
@@ -779,5 +830,32 @@ mod tests {
         // A pinned version the registry does not carry must not widen to a caret range
         assert_eq!(resolve("19.0.1"), None);
         assert_eq!(resolve("^21.0.0"), None);
+    }
+
+    fn tarball(entries: &[(&str, usize)]) -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        let mut builder = tar::Builder::new(encoder);
+        for (path, size) in entries {
+            let content = vec![b'x'; *size];
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, path, content.as_slice()).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[test]
+    fn extraction_is_capped_before_the_archive_is_held_in_memory() {
+        let archive = tarball(&[("package/a.js", 32), ("package/b.js", 32)]);
+
+        let extracted = extract_tarball_within(&archive, 1024, 16).unwrap();
+        assert_eq!(extracted.names, vec!["/a.js", "/b.js"]);
+        assert!(extracted.retained_bytes() > 64);
+
+        // A tarball's transfer size bounds neither of these
+        assert!(extract_tarball_within(&archive, 40, 16).is_err());
+        assert!(extract_tarball_within(&archive, 1024, 1).is_err());
     }
 }

--- a/backend/windmill-api-npm-proxy/src/lib.rs
+++ b/backend/windmill-api-npm-proxy/src/lib.rs
@@ -208,8 +208,9 @@ const MAX_ENTRIES: usize = 100_000;
 /// than tightly.
 const RETAINED_ENTRY_BYTES: u64 = 4 * 1024 * 1024;
 /// Ceiling on everything one read holds: the file list and the retained entries together.
-/// `aws-sdk` is the heaviest package known here at ~51 MB across 442 declarations, so this
-/// clears it comfortably while staying an abuse bound.
+/// Declarations past it are left to a read on demand rather than refused; only the file
+/// list, which has to be complete for `/filetree` to be right, refuses. `aws-sdk` is the
+/// heaviest package known here at ~51 MB across 442 declarations, well clear of it.
 const RETAINED_BYTES: u64 = 128 * 1024 * 1024;
 /// Charged per entry on top of its bytes, for the `String`/`Vec` headers, their heap
 /// allocations and the map bucket. Deliberately generous: the point is that an archive of
@@ -848,13 +849,14 @@ fn read_package_archive(
                 retention.max_entries
             )));
         }
-        // Paths are held whatever the entry is, and held twice for a retained one, so
-        // they are charged like any other bytes: an archive of long names would otherwise
-        // grow `names` without limit while reporting almost no weight.
+        // Paths are held whatever the entry is, so they are charged like any other bytes:
+        // an archive of long names would otherwise grow `names` without limit while
+        // reporting almost no weight. This one has to refuse rather than skip — a file
+        // tree missing entries is a wrong answer, not a slower one.
         retained += stripped.len() as u64 + NAME_OVERHEAD;
         if retained > retention.total_bytes {
             return Err(Error::BadRequest(format!(
-                "Package archive holds more than {} bytes of paths and declarations",
+                "Package archive holds more than {} bytes of file paths",
                 retention.total_bytes
             )));
         }
@@ -873,13 +875,14 @@ fn read_package_archive(
         if content.len() as u64 > retention.entry_bytes {
             continue;
         }
-        retained += (stripped.len() + content.len()) as u64 + RETAINED_FILE_OVERHEAD;
-        if retained > retention.total_bytes {
-            return Err(Error::BadRequest(format!(
-                "Package archive holds more than {} bytes of paths and declarations",
-                retention.total_bytes
-            )));
+        // Past the budget the entry simply is not kept: it stays reachable through a read
+        // on demand, so stopping bounds memory as well as refusing would while leaving the
+        // package servable.
+        let cost = (stripped.len() + content.len()) as u64 + RETAINED_FILE_OVERHEAD;
+        if retained + cost > retention.total_bytes {
+            continue;
         }
+        retained += cost;
         small_files.insert(stripped, content);
     }
 
@@ -1080,9 +1083,15 @@ mod tests {
         );
         assert_eq!(read_one_entry(&archive, "absent.js").unwrap(), None);
 
-        // Entry count is the one hard bound; size is never a reason to refuse a package
+        // Refusing is for what would make an answer wrong — too many entries to list, or
+        // too many path bytes — never for a package merely being large
         let too_few = Retention { max_entries: 1, ..TINY };
-        assert!(read_package_archive(archive, too_few).is_err());
+        assert!(read_package_archive(archive.clone(), too_few).is_err());
+        // room for the four paths, not for any file body
+        let squeezed = Retention { total_bytes: 400, ..TINY };
+        let read = read_package_archive(archive, squeezed).unwrap();
+        assert!(read.small_files.is_empty());
+        assert_eq!(read.names.len(), 4);
     }
 
     /// `/filetree` reads the manifest back rather than defaulting, or a package whose
@@ -1139,8 +1148,8 @@ mod tests {
                 >= archive.len() as u64 + 2000 * (NAME_OVERHEAD + RETAINED_FILE_OVERHEAD)
         );
 
-        // Long paths are held whatever the entry is, so they count against the budget:
-        // an archive of them would otherwise grow `names` while reporting no weight.
+        // Long paths are held whatever the entry is, and the file list has to be complete,
+        // so an archive of them is refused rather than silently truncated.
         let long = format!("package/{}.js", "p".repeat(2000));
         let padded: axum::body::Bytes = tarball(&[(long.as_str(), 0)]).into();
         assert!(read_package_archive(padded, Retention { total_bytes: 512, ..TINY }).is_err());

--- a/frontend/src/lib/ata/apis.test.ts
+++ b/frontend/src/lib/ata/apis.test.ts
@@ -1,38 +1,124 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { workspaceStore } from '$lib/stores'
-import { getDTSFileForModuleWithVersion, getNPMVersionsForModule } from './apis'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-/** jsdelivr unreachable (blocked egress, DNS failure), backend proxy answering. */
-function mockUnreachableJsdelivr(proxyBody: string) {
-	return vi.fn(async (input: RequestInfo | URL) => {
-		const url = String(input)
-		if (url.includes('jsdelivr')) throw new TypeError('Failed to fetch')
-		if (url.includes('/npm_proxy/')) return new Response(proxyBody, { status: 200 })
-		throw new Error(`unexpected request to ${url}`)
-	})
+vi.mock('$lib/stores', () => ({
+	workspaceStore: {
+		subscribe: (run: (v: string) => void) => {
+			run('test-workspace')
+			return () => {}
+		}
+	}
+}))
+
+/** Fresh module per case: the registry-configured answer is memoized per session. */
+async function loadApis(fetchImpl: (url: string) => Promise<Response>) {
+	vi.resetModules()
+	const requested: string[] = []
+	vi.stubGlobal(
+		'fetch',
+		vi.fn((input: RequestInfo | URL) => {
+			const url = String(input)
+			requested.push(url)
+			return fetchImpl(url)
+		})
+	)
+	return { apis: await import('./apis'), requested }
 }
 
-describe('ATA backend proxy fallback', () => {
-	afterEach(() => vi.unstubAllGlobals())
+const VERSIONS_FROM_PROXY = '{"tags":{"latest":"1.0.0"},"versions":["1.0.0"]}'
+const VERSIONS_FROM_CDN = '{"tags":{"latest":"9.9.9"},"versions":["9.9.9"]}'
+
+function registry(configured: boolean) {
+	return async (url: string) => {
+		if (url.endsWith('/npm_proxy/config')) {
+			return new Response(JSON.stringify({ registry_configured: configured }))
+		}
+		if (url.includes('/npm_proxy/')) return new Response(VERSIONS_FROM_PROXY)
+		if (url.includes('jsdelivr')) return new Response(VERSIONS_FROM_CDN)
+		throw new Error(`unexpected request to ${url}`)
+	}
+}
+
+/** jsdelivr unreachable (blocked egress, DNS failure), backend proxy answering. */
+function unreachableCdn(proxyBody: string) {
+	return async (url: string) => {
+		if (url.endsWith('/npm_proxy/config')) {
+			return new Response(JSON.stringify({ registry_configured: false }))
+		}
+		if (url.includes('jsdelivr')) throw new TypeError('Failed to fetch')
+		if (url.includes('/npm_proxy/')) return new Response(proxyBody)
+		throw new Error(`unexpected request to ${url}`)
+	}
+}
+
+describe('ATA source ordering', () => {
+	beforeEach(() => vi.unstubAllGlobals())
+
+	it('asks the proxy first when the instance configures a registry', async () => {
+		const { apis, requested } = await loadApis(registry(true))
+
+		const versions = await apis.getNPMVersionsForModule('lodash', { usage: 0 })
+
+		expect((versions as { versions: string[] }).versions).toEqual(['1.0.0'])
+		expect(requested.some((u) => u.includes('jsdelivr'))).toBe(false)
+	})
+
+	it('asks the CDN first when no registry is configured', async () => {
+		const { apis, requested } = await loadApis(registry(false))
+
+		const versions = await apis.getNPMVersionsForModule('lodash', { usage: 0 })
+
+		expect((versions as { versions: string[] }).versions).toEqual(['9.9.9'])
+		expect(requested.filter((u) => u.includes('/npm_proxy/'))).toEqual([
+			'/api/w/test-workspace/npm_proxy/config'
+		])
+	})
+
+	it('re-asks after a failed config probe rather than pinning the session to the CDN', async () => {
+		let configAttempts = 0
+		const { apis } = await loadApis(async (url) => {
+			if (url.endsWith('/npm_proxy/config')) {
+				configAttempts++
+				if (configAttempts === 1) throw new TypeError('Failed to fetch')
+				return new Response(JSON.stringify({ registry_configured: true }))
+			}
+			if (url.includes('/npm_proxy/')) return new Response(VERSIONS_FROM_PROXY)
+			return new Response(VERSIONS_FROM_CDN)
+		})
+
+		const first = await apis.getNPMVersionsForModule('lodash', { usage: 0 })
+		const second = await apis.getNPMVersionsForModule('lodash', { usage: 0 })
+
+		expect((first as { versions: string[] }).versions).toEqual(['9.9.9'])
+		expect((second as { versions: string[] }).versions).toEqual(['1.0.0'])
+	})
+
+	it('falls back to the CDN when the preferred proxy fails', async () => {
+		const { apis } = await loadApis(async (url) => {
+			if (url.endsWith('/npm_proxy/config')) {
+				return new Response(JSON.stringify({ registry_configured: true }))
+			}
+			if (url.includes('/npm_proxy/')) throw new TypeError('Failed to fetch')
+			return new Response(VERSIONS_FROM_CDN)
+		})
+
+		const versions = await apis.getNPMVersionsForModule('lodash', { usage: 0 })
+
+		expect((versions as { versions: string[] }).versions).toEqual(['9.9.9'])
+	})
 
 	it('falls back to the proxy when the jsdelivr request rejects', async () => {
-		workspaceStore.set('test-workspace')
-		vi.stubGlobal(
-			'fetch',
-			mockUnreachableJsdelivr('{"tags":{"latest":"1.0.0"},"versions":["1.0.0"]}')
-		)
+		const { apis } = await loadApis(unreachableCdn(VERSIONS_FROM_PROXY))
 
-		const versions = await getNPMVersionsForModule('lodash', { usage: 0 })
+		const versions = await apis.getNPMVersionsForModule('lodash', { usage: 0 })
 
 		expect(versions).not.toBeInstanceOf(Error)
 		expect((versions as { versions: string[] }).versions).toEqual(['1.0.0'])
 	})
 
 	it('falls back to the proxy for a d.ts when the jsdelivr request rejects', async () => {
-		workspaceStore.set('test-workspace')
-		vi.stubGlobal('fetch', mockUnreachableJsdelivr('declare const x: number'))
+		const { apis } = await loadApis(unreachableCdn('declare const x: number'))
 
-		const dts = await getDTSFileForModuleWithVersion('lodash', '1.0.0', '/index.d.ts')
+		const dts = await apis.getDTSFileForModuleWithVersion('lodash', '1.0.0', '/index.d.ts')
 
 		expect(dts).toBe('declare const x: number')
 	})

--- a/frontend/src/lib/ata/apis.ts
+++ b/frontend/src/lib/ata/apis.ts
@@ -48,43 +48,80 @@ const backendProxyApi = async <T>(endpoint: string, resLimit: ResLimit): Promise
 	}
 }
 
-export const getNPMVersionsForModule = async (moduleName: string, resLimit: ResLimit) => {
-	const url = `https://data.jsdelivr.com/v1/package/npm/${moduleName}`
-	const result = await api<{ tags: Record<string, string>; versions: string[] }>(url, resLimit, {
-		cache: 'no-store'
-	})
+let registryConfigured: Promise<boolean> | undefined
 
-	// If jsdelivr fails, try backend proxy
-	if (result instanceof Error) {
-		console.log('jsdelivr failed for', moduleName, 'trying backend proxy')
-		return backendProxyApi<{ tags: Record<string, string>; versions: string[] }>(
-			`/metadata/${encodeURIComponent(moduleName)}`,
-			resLimit
-		)
-	}
-
-	return result
+/**
+ * Whether the instance points npm at a registry of its own. Asked once per session: it is
+ * an instance setting, and every module acquired would otherwise re-ask. Only a definitive
+ * answer is kept — a transient failure, or no workspace to ask under yet, would otherwise
+ * pin the whole session to the public CDN, which is the wrong source on such an instance.
+ */
+async function isRegistryConfigured(): Promise<boolean> {
+	if (!get(workspaceStore)) return false
+	registryConfigured ??= (async () => {
+		try {
+			const res = await fetch(`${getBackendProxyUrl()}/config`, { credentials: 'include' })
+			if (!res.ok) throw new Error(`${res.status} from the npm proxy`)
+			return !!(await res.json())?.registry_configured
+		} catch (e) {
+			console.warn('Could not read the npm proxy configuration, using the public CDN', e)
+			registryConfigured = undefined
+			return false
+		}
+	})()
+	return registryConfigured
 }
 
-export const getNPMVersionForModuleReference = async (
+/**
+ * Run the two sources in the order the instance's configuration calls for. With a private
+ * registry set it is authoritative: jsdelivr does not carry internal packages, asking it
+ * discloses their names, and a public package sharing a name answers with the wrong types.
+ * Either way the other source stays as fallback, so neither a CDN outage nor a misconfigured
+ * proxy leaves the editor with no types at all.
+ */
+async function fromPreferredSource<T>(
+	viaCdn: () => Promise<T | Error>,
+	viaProxy: () => Promise<T | Error>
+): Promise<T | Error> {
+	// Both sources signal failure by resolving to `Error`. Anything else — a rejected fetch,
+	// or `getBackendProxyUrl` throwing for want of a workspace — would otherwise skip the
+	// second attempt entirely and propagate out of type acquisition.
+	const settled = async (source: () => Promise<T | Error>) => {
+		try {
+			return await source()
+		} catch (e) {
+			return new Error(`Type acquisition request failed: ${e}`)
+		}
+	}
+
+	const [first, second] = (await isRegistryConfigured()) ? [viaProxy, viaCdn] : [viaCdn, viaProxy]
+	const result = await settled(first)
+	return result instanceof Error ? await settled(second) : result
+}
+
+export const getNPMVersionsForModule = (moduleName: string, resLimit: ResLimit) =>
+	fromPreferredSource<{ tags: Record<string, string>; versions: string[] }>(
+		() =>
+			api(`https://data.jsdelivr.com/v1/package/npm/${moduleName}`, resLimit, {
+				cache: 'no-store'
+			}),
+		() => backendProxyApi(`/metadata/${encodeURIComponent(moduleName)}`, resLimit)
+	)
+
+export const getNPMVersionForModuleReference = (
 	moduleName: string,
 	reference: string,
 	resLimit: ResLimit
-) => {
-	const url = `https://data.jsdelivr.com/v1/package/resolve/npm/${moduleName}@${reference}`
-	const result = await api<{ version: string | null }>(url, resLimit)
-
-	// If jsdelivr fails, try backend proxy
-	if (result instanceof Error) {
-		console.log('jsdelivr failed for', moduleName, reference, 'trying backend proxy')
-		return backendProxyApi<{ version: string | null }>(
-			`/resolve/${encodeURIComponent(moduleName)}?tag=${encodeURIComponent(reference)}`,
-			resLimit
-		)
-	}
-
-	return result
-}
+) =>
+	fromPreferredSource<{ version: string | null }>(
+		() =>
+			api(`https://data.jsdelivr.com/v1/package/resolve/npm/${moduleName}@${reference}`, resLimit),
+		() =>
+			backendProxyApi(
+				`/resolve/${encodeURIComponent(moduleName)}?tag=${encodeURIComponent(reference)}`,
+				resLimit
+			)
+	)
 
 export type NPMTreeMeta = {
 	default: string
@@ -100,62 +137,34 @@ export const getFiletreeForModuleWithVersion = async (
 	raw: string,
 	resLimit: ResLimit
 ) => {
-	const url = `https://data.jsdelivr.com/v1/package/npm/${moduleName}@${version}/flat`
-	const res = await api<NPMTreeMeta>(url, resLimit)
-	if (res instanceof Error) {
-		// Try backend proxy
-		console.log('jsdelivr failed for', moduleName, version, 'trying backend proxy')
-		const backendRes = await backendProxyApi<NPMTreeMeta>(
-			`/filetree/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}`,
-			resLimit
-		)
-		if (backendRes instanceof Error) {
-			return res
-		} else {
-			return {
-				...backendRes,
-				moduleName,
-				version,
-				raw
-			}
-		}
-	} else {
-		return {
-			...res,
-			moduleName,
-			version,
-			raw
-		}
-	}
+	const res = await fromPreferredSource<NPMTreeMeta>(
+		() => api(`https://data.jsdelivr.com/v1/package/npm/${moduleName}@${version}/flat`, resLimit),
+		() =>
+			backendProxyApi(
+				`/filetree/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}`,
+				resLimit
+			)
+	)
+	return res instanceof Error ? res : { ...res, moduleName, version, raw }
 }
 
-export const getDTSFileForModuleWithVersion = async (
+export const getDTSFileForModuleWithVersion = (
 	moduleName: string,
 	version: string,
-	file: string
-) => {
 	// file comes with a prefix /
-	const url = `https://cdn.jsdelivr.net/npm/${moduleName}@${version}${file}`
-	const res = await text(url)
-	if (typeof res === 'string') {
-		return res
-	}
-
-	// Try backend proxy
-	console.log('jsdelivr failed for file', moduleName, version, file, 'trying backend proxy')
-	try {
-		const baseUrl = getBackendProxyUrl()
-		const proxyUrl = `${baseUrl}/file/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}${file}`
-		const proxied = await text(proxyUrl, { credentials: 'include' })
-		// The callers in ata/index.ts log a fixed message and drop the value, so a cause
-		// left inside the returned `Error` is a cause nothing ever prints.
-		if (proxied instanceof Error) console.warn('Backend proxy failed for file', proxied)
-		return proxied
-	} catch (e) {
-		console.warn('Backend proxy failed for file', e)
-		return new Error(`Backend proxy not available: ${e}`)
-	}
-}
+	file: string
+) =>
+	fromPreferredSource<string>(
+		() => text(`https://cdn.jsdelivr.net/npm/${moduleName}@${version}${file}`),
+		async () => {
+			const proxyUrl = `${getBackendProxyUrl()}/file/${encodeURIComponent(moduleName)}/${encodeURIComponent(version)}${file}`
+			const proxied = await text(proxyUrl, { credentials: 'include' })
+			// The callers in ata/index.ts log a fixed message and drop the value, so a cause
+			// left inside the returned `Error` is a cause nothing ever prints.
+			if (proxied instanceof Error) console.warn('Backend proxy failed for file', proxied)
+			return proxied
+		}
+	)
 
 /**
  * Reading the body can fail as readily as connecting, and both have to surface as a value


### PR DESCRIPTION
## Summary

Type acquisition in the script editor asks jsdelivr first and only falls back to `/npm_proxy/*` when jsdelivr fails. On an instance that configures its own npm registry that is the wrong way round:

- jsdelivr does not carry internal packages, so the fallback is the path that actually works, reached only after a failure.
- Every lookup discloses internal package names to a third-party CDN, which is close to the opposite of why someone points npm at a private registry.
- Worse than either: if a public package shares a name with an internal one, jsdelivr answers `200` and the editor silently shows the **public** package's types. Nothing errors, so the fallback never runs.

This flips the order when `/npm_proxy/config` reports a registry is configured, keeping the other source as fallback in both directions so neither a CDN outage nor a misconfigured proxy leaves the editor with no types.

**The ordering flip is not safe on its own**, which is why the backend half is in the same PR: `/file` is called once per `.d.ts`, and each call re-downloaded and re-inflated the entire tarball. `bun-types` alone is ~30 files. As a fallback that cost was rare; as the primary path it would have been a large regression.

## Changes

**Backend** (`windmill-api-npm-proxy`)
- Cache inflated tarballs, keyed by registry + package + version, byte-bounded (128 MB) with the same weighter as the packument cache, 5 minute TTL. `/filetree` and every `/file` for one package version now share one download and one inflate.
- `extract_tarball` replaces the two single-purpose extractors; `/file` reads from the extracted map instead of walking the archive.

**Frontend** (`ata/apis.ts`)
- `isRegistryConfigured()` asks `/npm_proxy/config` once per session. Not memoized before a workspace exists, which would pin the answer to `false`.
- `fromPreferredSource()` orders the two sources and keeps the other as fallback, replacing the ordering logic duplicated across the four fetchers. It treats a rejection or a synchronous throw as a failed attempt rather than letting it escape.

## Stacking

- Based on #10629, which adds `/npm_proxy/config`. Retargets to `main` when that merges.
- Overlaps #10630 in `apis.ts`: that PR fixes the same rejection-escapes-the-fallback class in the original structure. Whichever lands first, the other rebases onto it; this PR's `fromPreferredSource` keeps the behaviour either way.

## Test plan

Verified against a token-gated mock registry mirroring npmjs, with `npmrc` pointed at it:

- [x] **Ordering, real script editor** — opened a bun script importing `lodash`. Every ATA request went to `/api/w/admins/npm_proxy/*`: `resolve/lodash`, `resolve/bun-types`, `resolve/@types/lodash`, the three `filetree` calls, and ~32 `file` calls. Zero requests to jsdelivr. `ATA done`, types added to the runtime.
- [x] **Tarball cache** — `bun-types` needed 34 proxy requests and produced exactly 2 registry requests: one packument, one tarball. Same with a cold `debug@4.3.4`: 1 filetree + 10 `/file` reads → 1 packument + 1 tarball.
- [x] **`/filetree` still correct after the refactor** — `lodash@4.17.21` → `default: lodash.js`, 1054 files.
- [x] `npx vitest run src/lib/ata/apis.test.ts` — 3 passed (proxy-first when configured, CDN-first when not, fallback when the preferred source rejects).
- [x] `cargo check`, `cargo test -p windmill-api-npm-proxy`, `npm run check` (0 errors).

No UI surface changes, so no screenshots: this changes which host Monaco's type acquisition talks to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer the backend npm proxy for type acquisition when a registry is configured, with the CDN as fallback. Cache the gzipped tarball and only retain manifests and `.d.ts` files to keep large packages fast and cacheable.

- **New Features**
  - ATA checks `/npm_proxy/config` once per session and prefers the proxy when set; CDN stays as fallback via `fromPreferredSource()`. The config probe is retried after failures and skipped until a workspace exists. Updated `getNPMVersionsForModule`, `getNPMVersionForModuleReference`, `getFiletreeForModuleWithVersion`, and `getDTSFileForModuleWithVersion`. Tests cover ordering, retries, and both fallbacks.

- **Bug Fixes**
  - Backend: move archive inflate/read to blocking threads via `tokio::spawn_blocking`. Cache the compressed archive plus only small files (`package.json` and `.d.ts`), capped to 4 MB per file and 128 MB total; single‑shard, byte‑weighted, 5‑minute TTL, 256 MB budget. Charge per‑file overhead and path bytes so archives with many empty or long‑named files aren’t “free.” Bound inflation to 1 GB and entries to 100k; stream large files on demand; always read back the manifest if not retained; strip the archive’s root generically. Stop retaining past the budget instead of refusing the package, serving the rest via on‑demand reads. Frontend: a failed `/npm_proxy/config` probe no longer pins the session to CDN‑first, and thrown fetch errors no longer skip the fallback; over‑limit resolves to `Error` instead of hanging.

<sup>Written for commit 42619397b6b7851b2599d20b60402b8a2de24319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

