### PR TITLE
fix: harden custom env var name handling in the nativets/bun prologue

### DIFF
--- a/backend/.sqlx/query-6b9d8d54771a850a86787172bbf65804aefcf7d8d4cc9b71a9d70c86ea380d1e.json
+++ b/backend/.sqlx/query-6b9d8d54771a850a86787172bbf65804aefcf7d8d4cc9b71a9d70c86ea380d1e.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM workspace_env WHERE workspace_id = $1 AND name = $2)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6b9d8d54771a850a86787172bbf65804aefcf7d8d4cc9b71a9d70c86ea380d1e"
+}

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4677,26 +4677,26 @@ async fn set_environment_variable(
 
     match value {
         Some(value) => {
-            // The name is spliced into the NativeTS/Bun worker prologue. The
-            // worker escapes it regardless, so this write-time check is a friendly
-            // guard against new non-identifier names, not the injection defense.
-            // Enforce it only for names that don't already exist so a value edit of
-            // a grandfathered non-identifier name (the edit UI resubmits the name)
-            // isn't rejected with no in-product way to fix it. Deletion (the None
-            // branch) stays unrestricted so already-planted names remain removable.
-            let already_exists = sqlx::query_scalar!(
-                "SELECT EXISTS(SELECT 1 FROM workspace_env WHERE workspace_id = $1 AND name = $2)",
-                &w_id,
-                name
-            )
-            .fetch_one(&mut *tx)
-            .await?
-            .unwrap_or(false);
+            // The worker escapes the name when it splices it into the NativeTS/Bun
+            // prologue, so this is a friendly guard against new non-identifier
+            // names, not the injection defense. Skip it for names that already
+            // exist so a value edit of a grandfathered name (the edit UI resubmits
+            // the name) isn't rejected with no in-product way to fix it.
+            if !windmill_common::variables::is_valid_js_identifier(&name) {
+                let already_exists = sqlx::query_scalar!(
+                    "SELECT EXISTS(SELECT 1 FROM workspace_env WHERE workspace_id = $1 AND name = $2)",
+                    &w_id,
+                    name
+                )
+                .fetch_one(&mut *tx)
+                .await?
+                .unwrap_or(false);
 
-            if !already_exists && !windmill_common::variables::is_valid_js_identifier(&name) {
-                return Err(Error::BadRequest(format!(
-                    "Invalid environment variable name '{name}': must start with a letter, underscore or '$' and contain only letters, digits, underscores or '$'"
-                )));
+                if !already_exists {
+                    return Err(Error::BadRequest(format!(
+                        "Invalid environment variable name '{name}': must start with a letter, underscore or '$' and contain only letters, digits, underscores or '$'"
+                    )));
+                }
             }
 
             sqlx::query!(

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4677,11 +4677,23 @@ async fn set_environment_variable(
 
     match value {
         Some(value) => {
-            // The name is spliced into the NativeTS/Bun worker prologue; reject
-            // anything that isn't a plain identifier so it can't inject JS.
-            // (Deletion, in the None branch, stays unrestricted so already-planted
-            // names remain removable.)
-            if !windmill_common::variables::is_valid_js_identifier(&name) {
+            // The name is spliced into the NativeTS/Bun worker prologue. The
+            // worker escapes it regardless, so this write-time check is a friendly
+            // guard against new non-identifier names, not the injection defense.
+            // Enforce it only for names that don't already exist so a value edit of
+            // a grandfathered non-identifier name (the edit UI resubmits the name)
+            // isn't rejected with no in-product way to fix it. Deletion (the None
+            // branch) stays unrestricted so already-planted names remain removable.
+            let already_exists = sqlx::query_scalar!(
+                "SELECT EXISTS(SELECT 1 FROM workspace_env WHERE workspace_id = $1 AND name = $2)",
+                &w_id,
+                name
+            )
+            .fetch_one(&mut *tx)
+            .await?
+            .unwrap_or(false);
+
+            if !already_exists && !windmill_common::variables::is_valid_js_identifier(&name) {
                 return Err(Error::BadRequest(format!(
                     "Invalid environment variable name '{name}': must start with a letter, underscore or '$' and contain only letters, digits, underscores or '$'"
                 )));

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4677,6 +4677,16 @@ async fn set_environment_variable(
 
     match value {
         Some(value) => {
+            // The name is spliced into the NativeTS/Bun worker prologue; reject
+            // anything that isn't a plain identifier so it can't inject JS.
+            // (Deletion, in the None branch, stays unrestricted so already-planted
+            // names remain removable.)
+            if !windmill_common::variables::is_valid_js_identifier(&name) {
+                return Err(Error::BadRequest(format!(
+                    "Invalid environment variable name '{name}': must start with a letter, underscore or '$' and contain only letters, digits, underscores or '$'"
+                )));
+            }
+
             sqlx::query!(
                 "INSERT INTO workspace_env (workspace_id, name, value) VALUES ($1, $2, $3) ON CONFLICT (workspace_id, name) DO UPDATE SET value = EXCLUDED.value",
                 &w_id,

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -5725,6 +5725,12 @@ paths:
               properties:
                 name:
                   type: string
+                  description: >-
+                    Environment variable name. New names must be a plain JS
+                    identifier (matching ^[A-Za-z_$][A-Za-z0-9_$]*$) since the
+                    name is spliced into the NativeTS/Bun worker prologue;
+                    otherwise the request is rejected with 400. Existing names
+                    can still be updated regardless of shape.
                 value:
                   type: string
               required: [name]

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -96,7 +96,6 @@ fn is_js_reserved_word(name: &str) -> bool {
             | "let"
             | "static"
             | "await"
-            | "async"
             | "implements"
             | "interface"
             | "package"
@@ -107,7 +106,8 @@ fn is_js_reserved_word(name: &str) -> bool {
 }
 
 /// Identifiers the generated prologue already binds; a second `const {name}`
-/// for them would be a redeclaration SyntaxError.
+/// for them would be a redeclaration SyntaxError. Keep in sync with the prologue
+/// head emitted in worker.rs and bun_executor.rs (`build_nativets_env_code`).
 const PROLOGUE_RESERVED_BINDINGS: &[&str] = &["process", "BASE_URL", "BASE_INTERNAL_URL"];
 
 /// True when `name` can be emitted as a `const {name}` binding in the NativeTS/
@@ -761,7 +761,8 @@ mod tests {
 
     #[test]
     fn can_bind_as_prologue_const_excludes_reserved_and_owned_names() {
-        for ok in ["FOO", "_bar", "$x", "myVar"] {
+        // `async` is a contextual keyword, not reserved — `const async` is valid.
+        for ok in ["FOO", "_bar", "$x", "myVar", "async"] {
             assert!(can_bind_as_prologue_const(ok), "{ok} should be bindable");
         }
         // Valid identifiers that would still break `const {name}`: reserved words

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -32,11 +32,12 @@ pub fn escape_js_single_quoted(s: &str) -> String {
         .replace('\r', "\\r")
 }
 
-/// True when `name` is a plain ASCII JS identifier and can therefore sit in
-/// `const {name}` position of a generated prologue without smuggling statement
-/// terminators, quotes, or comments. Custom workspace env-var names are
-/// attacker-controllable (any workspace admin sets them), so a non-identifier
-/// name must never reach an identifier position in generated JS.
+/// True when `name` is a plain ASCII JS identifier and can therefore sit in a
+/// single-quoted string literal or identifier context of a generated prologue
+/// without smuggling statement terminators, quotes, or comments. Custom
+/// workspace env-var names are attacker-controllable (any workspace admin sets
+/// them), so a non-identifier name must never reach an identifier position in
+/// generated JS.
 pub fn is_valid_js_identifier(name: &str) -> bool {
     let mut chars = name.chars();
     match chars.next() {
@@ -44,6 +45,78 @@ pub fn is_valid_js_identifier(name: &str) -> bool {
         _ => return false,
     }
     chars.all(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric())
+}
+
+/// Reserved words that cannot be used as a binding name — `const {word} = ...`
+/// is a SyntaxError. Includes the strict-mode/module reserved set since the
+/// generated prologue runs as a module.
+fn is_js_reserved_word(name: &str) -> bool {
+    matches!(
+        name,
+        "break"
+            | "case"
+            | "catch"
+            | "class"
+            | "const"
+            | "continue"
+            | "debugger"
+            | "default"
+            | "delete"
+            | "do"
+            | "else"
+            | "enum"
+            | "export"
+            | "extends"
+            | "false"
+            | "finally"
+            | "for"
+            | "function"
+            | "if"
+            | "import"
+            | "in"
+            | "instanceof"
+            | "new"
+            | "null"
+            | "return"
+            | "super"
+            | "switch"
+            | "this"
+            | "throw"
+            | "true"
+            | "try"
+            | "typeof"
+            | "var"
+            | "void"
+            | "while"
+            | "with"
+            | "yield"
+            | "let"
+            | "static"
+            | "await"
+            | "async"
+            | "implements"
+            | "interface"
+            | "package"
+            | "private"
+            | "protected"
+            | "public"
+    )
+}
+
+/// Identifiers the generated prologue already binds; a second `const {name}`
+/// for them would be a redeclaration SyntaxError.
+const PROLOGUE_RESERVED_BINDINGS: &[&str] = &["process", "BASE_URL", "BASE_INTERNAL_URL"];
+
+/// True when `name` can be emitted as a `const {name}` binding in the NativeTS/
+/// Bun prologue: a valid identifier that is neither a JS reserved word nor a
+/// name the prologue already binds. Names failing this are still exposed via
+/// `process.env['{name}']` (with the name escaped), so nothing is lost — a
+/// `const` for such a name would only ever be a SyntaxError that breaks every
+/// NativeTS run in the workspace.
+pub fn can_bind_as_prologue_const(name: &str) -> bool {
+    is_valid_js_identifier(name)
+        && !is_js_reserved_word(name)
+        && !PROLOGUE_RESERVED_BINDINGS.contains(&name)
 }
 
 #[derive(Serialize, Clone)]
@@ -655,12 +728,15 @@ pub async fn get_variable_or_self_as<T: Authable + Sync>(
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_js_single_quoted, is_valid_js_identifier};
+    use super::{can_bind_as_prologue_const, escape_js_single_quoted, is_valid_js_identifier};
 
     #[test]
     fn is_valid_js_identifier_gates_prologue_injection() {
         for ok in ["FOO", "_bar", "$x", "a1_2", "WM_CUSTOM"] {
-            assert!(is_valid_js_identifier(ok), "{ok} should be a valid identifier");
+            assert!(
+                is_valid_js_identifier(ok),
+                "{ok} should be a valid identifier"
+            );
         }
         // Custom workspace env-var names are attacker-controllable; none of these
         // may reach `const {name}` position in the NativeTS/Bun prologue.
@@ -673,7 +749,34 @@ mod tests {
             "_x=1;globalThis.PWNED=1//",
             "x'];globalThis.PWNED=1;process.env['y",
         ] {
-            assert!(!is_valid_js_identifier(bad), "{bad:?} must not be a valid identifier");
+            assert!(
+                !is_valid_js_identifier(bad),
+                "{bad:?} must not be a valid identifier"
+            );
+        }
+    }
+
+    #[test]
+    fn can_bind_as_prologue_const_excludes_reserved_and_owned_names() {
+        for ok in ["FOO", "_bar", "$x", "myVar"] {
+            assert!(can_bind_as_prologue_const(ok), "{ok} should be bindable");
+        }
+        // Valid identifiers that would still break `const {name}`: reserved words
+        // (SyntaxError) and names the prologue already binds (redeclaration).
+        for bad in [
+            "class",
+            "const",
+            "await",
+            "return",
+            "process",
+            "BASE_URL",
+            "BASE_INTERNAL_URL",
+        ] {
+            assert!(is_valid_js_identifier(bad), "{bad} is a valid identifier");
+            assert!(
+                !can_bind_as_prologue_const(bad),
+                "{bad} must not bind as a prologue const"
+            );
         }
     }
 

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -47,13 +47,16 @@ pub fn is_valid_js_identifier(name: &str) -> bool {
     chars.all(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric())
 }
 
-/// Reserved words that cannot be used as a binding name — `const {word} = ...`
-/// is a SyntaxError. Includes the strict-mode/module reserved set since the
-/// generated prologue runs as a module.
+/// Names that cannot be used as a binding — `const {word} = ...` is a
+/// SyntaxError. The generated prologue runs as an ES module (always strict), so
+/// this includes the strict-mode reserved words and the two names that strict
+/// mode additionally forbids as bindings: `eval` and `arguments`.
 fn is_js_reserved_word(name: &str) -> bool {
     matches!(
         name,
-        "break"
+        "arguments"
+            | "eval"
+            | "break"
             | "case"
             | "catch"
             | "class"
@@ -762,12 +765,15 @@ mod tests {
             assert!(can_bind_as_prologue_const(ok), "{ok} should be bindable");
         }
         // Valid identifiers that would still break `const {name}`: reserved words
-        // (SyntaxError) and names the prologue already binds (redeclaration).
+        // (SyntaxError), the two names strict mode forbids as bindings (`eval`,
+        // `arguments`), and names the prologue already binds (redeclaration).
         for bad in [
             "class",
             "const",
             "await",
             "return",
+            "eval",
+            "arguments",
             "process",
             "BASE_URL",
             "BASE_INTERNAL_URL",

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -23,6 +23,29 @@ lazy_static::lazy_static! {
     static ref RESERVED_WM_VAR_NAME: regex::Regex = regex::Regex::new(r"^WM_[A-Z_]+$").unwrap();
 }
 
+/// Escape a string so it can be safely embedded inside a single-quoted JS
+/// string literal in a generated NativeTS/Bun prologue.
+pub fn escape_js_single_quoted(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('\'', "\\'")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+/// True when `name` is a plain ASCII JS identifier and can therefore sit in
+/// `const {name}` position of a generated prologue without smuggling statement
+/// terminators, quotes, or comments. Custom workspace env-var names are
+/// attacker-controllable (any workspace admin sets them), so a non-identifier
+/// name must never reach an identifier position in generated JS.
+pub fn is_valid_js_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c == '$' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric())
+}
+
 #[derive(Serialize, Clone)]
 
 pub struct ContextualVariable {
@@ -627,5 +650,42 @@ pub async fn get_variable_or_self_as<T: Authable + Sync>(
             "Variable not found when resolving `$var:{}`",
             var_path
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{escape_js_single_quoted, is_valid_js_identifier};
+
+    #[test]
+    fn is_valid_js_identifier_gates_prologue_injection() {
+        for ok in ["FOO", "_bar", "$x", "a1_2", "WM_CUSTOM"] {
+            assert!(is_valid_js_identifier(ok), "{ok} should be a valid identifier");
+        }
+        // Custom workspace env-var names are attacker-controllable; none of these
+        // may reach `const {name}` position in the NativeTS/Bun prologue.
+        for bad in [
+            "",
+            "1BAD",
+            "has space",
+            "dotted.name",
+            "kebab-case",
+            "_x=1;globalThis.PWNED=1//",
+            "x'];globalThis.PWNED=1;process.env['y",
+        ] {
+            assert!(!is_valid_js_identifier(bad), "{bad:?} must not be a valid identifier");
+        }
+    }
+
+    #[test]
+    fn escape_js_single_quoted_neutralizes_string_breakout() {
+        assert_eq!(escape_js_single_quoted("a'b"), "a\\'b");
+        assert_eq!(escape_js_single_quoted("a\\b"), "a\\\\b");
+        assert_eq!(escape_js_single_quoted("a\nb\rc"), "a\\nb\\rc");
+        // A key crafted to break out of process.env['...'] is fully contained.
+        assert_eq!(
+            escape_js_single_quoted("x'];danger();['y"),
+            "x\\'];danger();[\\'y"
+        );
     }
 }

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -2896,8 +2896,9 @@ pub async fn handle_wac_v2_output(
                                     version: flow_info.version,
                                     labels: flow_info.labels.clone(),
                                 };
-                                let on_behalf_of =
-                                    flow_info.on_behalf_of(&job.workspace_id, db).await?;
+                                let on_behalf_of = flow_info
+                                    .on_behalf_of(&job.workspace_id, db)
+                                    .await?;
                                 let step_args: HashMap<String, Box<RawValue>> = step
                                     .args
                                     .iter()

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -2896,9 +2896,8 @@ pub async fn handle_wac_v2_output(
                                     version: flow_info.version,
                                     labels: flow_info.labels.clone(),
                                 };
-                                let on_behalf_of = flow_info
-                                    .on_behalf_of(&job.workspace_id, db)
-                                    .await?;
+                                let on_behalf_of =
+                                    flow_info.on_behalf_of(&job.workspace_id, db).await?;
                                 let step_args: HashMap<String, Box<RawValue>> = step
                                     .args
                                     .iter()
@@ -3519,8 +3518,11 @@ pub fn build_nativets_env_code(
         reserved_variables
             .iter()
             .map(|(k, v)| {
-                let escaped = v.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n").replace('\r', "\\r");
-                format!("process.env['{}'] = '{}';", k, escaped)
+                // The key is attacker-controllable (custom workspace env vars), so
+                // escape it as a string literal too, not just the value.
+                let key_literal = windmill_common::variables::escape_js_single_quoted(k);
+                let escaped = windmill_common::variables::escape_js_single_quoted(v);
+                format!("process.env['{key_literal}'] = '{escaped}';")
             })
             .collect::<Vec<String>>()
             .join("\n")

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1708,7 +1708,10 @@ pub fn log_context_for_job(
         flow_step_id: arc_job.flow_step_id.clone(),
         parent_job: arc_job.parent_job.map(|id| id.to_string()),
         root_job: arc_job.flow_innermost_root_job.map(|id| id.to_string()),
-        trigger_kind: arc_job.trigger_kind.as_ref().map(|k| k.as_str().to_string()),
+        trigger_kind: arc_job
+            .trigger_kind
+            .as_ref()
+            .map(|k| k.as_str().to_string()),
         trigger: arc_job.trigger.clone(),
         hostname: hostname.map(|h| h.to_string()),
         inbound_traceparent: job_inbound_traceparent(arc_job),
@@ -5266,8 +5269,16 @@ pub async fn run_language_executor(
             reserved_variables
                 .iter()
                 .map(|(k, v)| {
-                    let escaped = v.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n").replace('\r', "\\r");
-                    format!("const {} = '{}';\nprocess.env['{}'] = '{}';\n", k, escaped, k, escaped)
+                    let escaped = windmill_common::variables::escape_js_single_quoted(v);
+                    let key_literal = windmill_common::variables::escape_js_single_quoted(k);
+                    if windmill_common::variables::is_valid_js_identifier(k) {
+                        format!("const {k} = '{escaped}';\nprocess.env['{key_literal}'] = '{escaped}';\n")
+                    } else {
+                        // Non-identifier names (e.g. attacker-planted workspace env
+                        // vars) can't bind to `const {k}` without executing as code;
+                        // expose them only through process.env with the key escaped.
+                        format!("process.env['{key_literal}'] = '{escaped}';\n")
+                    }
                 })
                 .collect::<Vec<String>>()
                 .join("\n"));

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1708,10 +1708,7 @@ pub fn log_context_for_job(
         flow_step_id: arc_job.flow_step_id.clone(),
         parent_job: arc_job.parent_job.map(|id| id.to_string()),
         root_job: arc_job.flow_innermost_root_job.map(|id| id.to_string()),
-        trigger_kind: arc_job
-            .trigger_kind
-            .as_ref()
-            .map(|k| k.as_str().to_string()),
+        trigger_kind: arc_job.trigger_kind.as_ref().map(|k| k.as_str().to_string()),
         trigger: arc_job.trigger.clone(),
         hostname: hostname.map(|h| h.to_string()),
         inbound_traceparent: job_inbound_traceparent(arc_job),
@@ -5271,12 +5268,13 @@ pub async fn run_language_executor(
                 .map(|(k, v)| {
                     let escaped = windmill_common::variables::escape_js_single_quoted(v);
                     let key_literal = windmill_common::variables::escape_js_single_quoted(k);
-                    if windmill_common::variables::is_valid_js_identifier(k) {
+                    if windmill_common::variables::can_bind_as_prologue_const(k) {
                         format!("const {k} = '{escaped}';\nprocess.env['{key_literal}'] = '{escaped}';\n")
                     } else {
-                        // Non-identifier names (e.g. attacker-planted workspace env
-                        // vars) can't bind to `const {k}` without executing as code;
-                        // expose them only through process.env with the key escaped.
+                        // Names that can't safely bind to `const {k}` (non-identifiers,
+                        // reserved words, prologue-owned names) are exposed only through
+                        // process.env with the key escaped — a `const` for them would be
+                        // an injection or a SyntaxError.
                         format!("process.env['{key_literal}'] = '{escaped}';\n")
                     }
                 })


### PR DESCRIPTION
## Summary

Custom workspace environment variable **names** are spliced into the generated
NativeTS / Bun worker prologue (`const {name}` and `process.env['{name}']`), but
only the value was ever escaped. A non-identifier name could therefore alter the
generated program rather than just supplying data. This hardens name handling at
the point the prologue is built, and adds a light guard at the write path.

Every other executor passes env vars to the OS via `Command::envs` (real process
env, not generated code), so those paths are unaffected.

## Changes

- Add `escape_js_single_quoted` and `is_valid_js_identifier` / `can_bind_as_prologue_const`
  helpers in `windmill-common`.
- `worker.rs` (standalone NativeTS) and `bun_executor.rs` (`//native`): escape the
  name as a string literal in `process.env['…']`, and emit the `const {name}`
  binding only when the name can safely bind (valid identifier, not a reserved word,
  not a name the prologue already declares). Names that can't bind are still exposed
  via `process.env['…']`.
- `set_environment_variable`: reject non-identifier names for **new** names only, so
  editing the value of a pre-existing name still works. Deletion stays unrestricted.
- Document the name constraint on the endpoint in `openapi.yaml`.

## Test plan

- [x] `cargo check` clean under `quickjs` and `quickjs,deno_core`
- [x] Unit tests for the new helpers (`windmill-common variables::tests`, 3 passing)
- [x] Live API: new non-identifier / injection-shaped names → 400; valid new name → 200;
      value edit of a pre-existing non-identifier name → 200; deletion unrestricted
- [x] Modeled the exact generated prologue in V8 (Node) with hostile names: no code
      executes, values preserved, reserved/owned names produce a valid (non-erroring)
      prologue
- [x] Ran a real standalone NativeTS job and a `//native` Bun job in a `deno_core`
      worker with hostile env-var names planted directly in `workspace_env`
      (`_p=1;globalThis.PWNED_CONST=1//` and `a'];globalThis.PWNED_STR=1;process.env['b`):
      both jobs completed successfully, the hostile names came back verbatim as
      `process.env` data, no injected global was set, normal names still bind, and the
      worker log showed no panic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents code injection via custom env var names in the NativeTS/Bun worker prologue. Names are escaped and only bound as constants when safe; reserved words and strict-mode forbidden bindings (`eval`/`arguments`) are excluded, `async` is allowed, and unsafe new names are rejected by the API.

- **Bug Fixes**
  - Escape both keys and values in generated `process.env['…']` assignments.
  - Guard `const {name}` with `can_bind_as_prologue_const`: allow identifiers (including `async`); exclude JS reserved words, strict-mode forbidden (`eval`/`arguments`), and prologue-owned names (`process`, `BASE_URL`, `BASE_INTERNAL_URL`); otherwise use `process.env` only.
  - Validate on write: block new non-identifier names; allow edits/deletes of existing names; skip the existence check for valid names.
  - Add `escape_js_single_quoted`, `is_valid_js_identifier`, `can_bind_as_prologue_const` in `windmill-common`; update `worker.rs` and `bun_executor.rs`; document the constraint in `openapi.yaml`; add unit tests.

<sup>Written for commit 86683d258371c40489ef2a1afd5512ec22091b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


