### PR TITLE
fix(cli): delete file resources at the right path on sync push

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -72,6 +72,7 @@ import {
   isRawAppFile,
   isWorkspaceDependencies,
   readTextFile,
+  removeResourceSuffix,
 } from "../../utils/utils.ts";
 import {
   getEffectiveSettings,
@@ -5397,7 +5398,7 @@ export async function push(
                   });
                   break;
                 case "resource": {
-                  const resourcePath = removeSuffix(target, ".resource.json");
+                  const resourcePath = removeResourceSuffix(target);
                   try {
                     await wmill.deleteResource({
                       workspace: workspaceId,

--- a/cli/src/utils/utils.ts
+++ b/cli/src/utils/utils.ts
@@ -200,6 +200,20 @@ export function isFileResource(path: string): boolean {
   );
 }
 
+/**
+ * Local resource path -> the resource's path on the server. The suffix is
+ * `.resource.<yaml|json>` on a metadata file but `.resource.file.<ext>` on a
+ * file resource, so its length depends on which of the two the path is.
+ */
+export function removeResourceSuffix(path: string): string {
+  if (isFileResource(path)) {
+    // isFileResource only matches a dotless extension, so the resource path is
+    // everything before the trailing `resource`, `file`, `<ext>` segments.
+    return path.split(".").slice(0, -3).join(".");
+  }
+  return path.replace(/\.resource\.(yaml|json)$/, "");
+}
+
 /** Matches children inside a .fileset/ directory, not the directory itself. */
 export function isFilesetResource(path: string): boolean {
   return path.includes(".fileset/") || path.includes(".fileset\\");

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { expect, test, describe } from "bun:test";
-import { deepEqual, isFileResource, isFilesetResource, toCamel, capitalize, validateRequiredArgs, stripBom, readTextFile, readTextFileSync } from "../src/utils/utils.ts";
+import { deepEqual, isFileResource, isFilesetResource, removeResourceSuffix, toCamel, capitalize, validateRequiredArgs, stripBom, readTextFile, readTextFileSync } from "../src/utils/utils.ts";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -156,6 +156,30 @@ describe("isFileResource", () => {
 
   test("detects branch-specific resource file paths", () => {
     expect(isFileResource("f/test/config.main.resource.file.json")).toBe(true);
+  });
+});
+
+// =============================================================================
+// removeResourceSuffix
+// =============================================================================
+
+describe("removeResourceSuffix", () => {
+  test("strips the metadata suffix", () => {
+    expect(removeResourceSuffix("f/test/my_resource.resource.yaml")).toBe(
+      "f/test/my_resource"
+    );
+    expect(removeResourceSuffix("f/test/my_resource.resource.json")).toBe(
+      "f/test/my_resource"
+    );
+  });
+
+  test("strips the file-resource suffix", () => {
+    expect(removeResourceSuffix("f/test/my_file.resource.file.txt")).toBe(
+      "f/test/my_file"
+    );
+    expect(removeResourceSuffix("u/admin/config.resource.file.json")).toBe(
+      "u/admin/config"
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

`wmill sync push` could not delete a file resource (`<path>.resource.file.<ext>`). The
delete branch derived the server path by slicing a fixed 14 characters off the end — the
length of `.resource.json` — which is right for a `.resource.<yaml|json>` metadata file
but too short for the longer `.resource.file.<ext>` suffix. `f/test/myfile.resource.file.ini`
became `f/test/myfile.res`, and the push aborted on the resulting 404.

The add/edit branches already special-case file resources; only the delete branch was
missing the handling.

Fixes WIN-2348

## Changes

- Add `removeResourceSuffix` in `cli/src/utils/utils.ts`, next to `isFileResource`: it
  strips `.resource.<yaml|json>` or, for a file resource, the `.resource.file.<ext>`
  suffix, so the suffix length no longer has to be assumed by the caller.
- Use it for the `case "resource"` delete in `cli/src/commands/sync/sync.ts`.
- Unit test for both suffix shapes in `cli/test/utils_unit.test.ts`.

Deleting a file resource and its metadata file in the same push now resolves both changes
to the same server path; the second delete 404s and is swallowed by the existing
`deletedVarsResPaths` guard, as it already is for a resource and its linked variable.

## Test plan

- [x] `bun test test/utils_unit.test.ts` (119 pass) and the full CLI unit suite
      `UNIT_ONLY=1 bun test test/*_unit*` (1055 pass, 0 fail).
- [x] End-to-end against a local backend: created a resource type with
      `format_extension: ini` plus a resource of that type, `wmill sync pull`, deleted both
      `myfile.resource.yaml` and `myfile.resource.file.ini` locally, then `wmill sync push`.

  Before (stashed fix) — reproduces the bug:

  ```
  Deleting resource f/test2348/myfile.resource.file.ini
  Server failed. Not Found: Not found: Resource not found at name f/test2348/myfile.res
  ApiError: Not Found
       url: ".../api/w/wintest2348/resources/delete/f/test2348/myfile.res", status: 404
  ```

  After:

  ```
  Deleting resource f/test2348/myfile.resource.file.ini
  Deleting resource f/test2348/myfile.resource.yaml
  Done! All 2 changes pushed to the remote workspace wintest2348
  ```

  `GET /api/w/wintest2348/resources/list` returns `[]` afterwards.
- [x] `bunx tsc --noEmit` reports no new errors (the pre-existing ones in
      `merge.ts`, `settings.ts`, `main.ts`, `local_path_scripts.ts` and
      `windmill-utils-internal/` are unchanged).

## Not covered

Workspace-specific resources (`<path>.<ws>.resource.yaml`) still keep the workspace
suffix in the path sent to the delete endpoint. That is pre-existing and affects plain
resources and file resources identically, so it is left out of this fix.

Deleting *only* the content file and leaving `myfile.resource.yaml` in place (a malformed
local state — the metadata still `!inline`s a file that is gone) now deletes the remote
resource, where before it aborted the push with the 404. I verified this end-to-end: the
push reports one change, deletes `f/test2348/myfile`, and the local yaml survives pointing
at nothing. Whether that case should instead be a no-op (the resource is still declared
locally, so a later `sync pull` would restore the content file) or stay an error is a
judgement call I have deliberately left out of this fix — it needs a `stat` on the sibling
metadata file in the delete branch and is a behaviour change beyond the reported bug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2348 by making `wmill sync push` delete file resources at the correct server path. Prevents 404s when removing `<path>.resource.file.<ext>` files.

- **Bug Fixes**
  - Added removeResourceSuffix(path) to strip either `.resource.(yaml|json)` or `.resource.file.<ext>`.
  - Used it in the resource delete code path to avoid hardcoded suffix trimming.
  - Added unit tests for both suffix shapes.

<sup>Written for commit c376b2d1165775fd199b764063841f6bf1b53147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


