### PR TITLE
fix: bound duckdb result collection so an oversized result cannot OOM the worker

### DIFF
--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -607,6 +607,30 @@ mod result_size_guard_tests {
         assert_eq!(collect_into(0, &mut 0).unwrap(), ROWS);
     }
 
+    /// A blob expands to one `serde_json::Value` per byte on the way in, so it is
+    /// the one value that can exhaust the worker between two checks of the running
+    /// total. It has to be refused on its length, before that expansion is built.
+    #[test]
+    fn a_wide_blob_is_refused_before_it_is_expanded() {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        let mut collected = 0;
+        // 1MB of blob expands to ~24MB of `Value`, well past this budget, while the
+        // running total is still zero — nothing else in the loop would catch it.
+        let err = do_duckdb_inner(
+            &conn,
+            "SELECT repeat('a', 1000000)::BLOB AS b",
+            &HashMap::new(),
+            false,
+            false,
+            &mut None,
+            1024 * 1024,
+            &mut collected,
+        )
+        .expect_err("a blob expanding past the budget must be refused");
+        assert!(err.contains("Query result too large"), "{err}");
+        assert_eq!(collected, 0, "it was refused before being counted");
+    }
+
     /// A row costs far more than the JSON it serializes to, and small rows are
     /// almost entirely that overhead. Billing only the payload would let a cap
     /// admit several times the rows the worker can actually hold.
@@ -702,8 +726,14 @@ fn do_duckdb_inner(
 
                 // let type_aliases = (0..stmt.column_count()).map(|_| None).collect::<Vec<_>>();
 
-                let row = row_to_value(row, &column_names.as_slice(), &type_aliases.as_slice())
-                    .map_err(|e| e.to_string())?;
+                let row = row_to_value(
+                    row,
+                    &column_names.as_slice(),
+                    &type_aliases.as_slice(),
+                    max_result_size.saturating_sub(*collected),
+                    max_result_size,
+                )
+                .map_err(|e| e.to_string())?;
                 *collected += row_storage_cost(row.get().len());
                 if max_result_size > 0 && *collected > max_result_size {
                     return Err(result_too_large_message(max_result_size));
@@ -751,10 +781,25 @@ fn row_to_value(
     row: &Row<'_>,
     column_names: &[String],
     type_aliases: &[Option<String>],
+    budget: usize,
+    max_result_size: usize,
 ) -> Result<Box<RawValue>, String> {
     let mut obj = serde_json::Map::new();
     for (i, key) in column_names.iter().enumerate() {
         let value: duckdb::types::Value = row.get(i).map_err(|e| e.to_string())?;
+        // A blob renders one JSON number per byte, so its in-memory form is
+        // `size_of::<Value>()` times the blob and is entirely live before the row
+        // can be weighed. Weighed rows are the only thing the running total sees,
+        // so a single wide blob would exhaust the worker between two checks.
+        // The length is known now, which is the last moment refusing is cheap.
+        if let duckdb::types::Value::Blob(b) | duckdb::types::Value::Geometry(b) = &value {
+            let expanded = b
+                .len()
+                .saturating_mul(std::mem::size_of::<serde_json::Value>());
+            if max_result_size > 0 && expanded > budget {
+                return Err(result_too_large_message(max_result_size));
+            }
+        }
         let type_alias = &type_aliases[i];
         let json_value = duckdb_value_to_json_value(value, type_alias)
             .map_err(|e| format!("column \"{key}\": {e}"))?;

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -550,10 +550,14 @@ fn format_byte_size(bytes: usize) -> String {
     }
 }
 
-/// Size is counted as serialized JSON, which is what the rows become: they are
-/// collected in full here, cross the FFI boundary as one string, and land in the
-/// job result. Rows whose destination is storage should never take that path, so
-/// lead with the way to keep them out of it.
+/// The limit is on what the collection *retains* — each row's JSON plus the
+/// storage holding it (`row_storage_cost`) — not on how large the result reads.
+/// For narrow rows that storage dominates, so the guard can fire while the JSON
+/// alone is well under the quoted figure. That is the number worth defending:
+/// the worker dies on what it holds, not on what it would have returned.
+///
+/// Rows whose destination is storage should never be collected at all, so lead
+/// with the way to keep them out of it.
 ///
 /// Only the limit is quoted. Collection stops on the row that crosses it, so the
 /// running total is just the threshold plus one row — naming it as the result

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -632,6 +632,32 @@ mod result_size_guard_tests {
         assert_eq!(collected, 0, "it was refused before being counted");
     }
 
+    /// A JSON column is parsed into a tree before anything can weigh it, and
+    /// compact JSON is the densest way to ask for `Value`s: `[1,1,1,…]` costs two
+    /// bytes per 72-byte `Value`. The text length is the only signal available
+    /// while refusing is still possible.
+    #[test]
+    fn a_dense_json_column_is_refused_before_it_is_parsed() {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        let attempt = |budget: usize| {
+            do_duckdb_inner(
+                &conn,
+                // ~200KB of text, ~7MB once it is a tree of `Value`s.
+                "SELECT ('[' || repeat('1,', 99999) || '1]')::JSON AS j",
+                &HashMap::new(),
+                false,
+                false,
+                &mut None,
+                budget,
+                &mut 0,
+            )
+        };
+
+        let err = attempt(1024 * 1024).expect_err("the parsed tree does not fit 1MB");
+        assert!(err.contains("Query result too large"), "{err}");
+        assert_eq!(attempt(64 * 1024 * 1024).unwrap().len(), 1);
+    }
+
     /// `Budget` charges expansions visible in the value tree, and escaping is not
     /// one of them — it happens while the finished row is written, which is before
     /// anything weighs it. Only bounding the writer catches that.
@@ -846,6 +872,16 @@ fn interpolate_named_args<'a>(
 /// `\u0001`, so a row that fit the budget as `Value`s can still allocate several
 /// times it while being written — and the write happens before the finished row
 /// is ever weighed. Bounding the writer keeps that inside the budget.
+///
+/// `None` is reported to the caller as "too large", which is only honest because
+/// the callers pass a `serde_json::Map` of `Value`s: serializing one cannot fail
+/// for any reason except the budget. A caller passing a type with a fallible
+/// `Serialize` would have its error silently retold as a size limit.
+///
+/// The bytes come back through `RawValue::from_string`, which re-parses to
+/// validate what `serde_json` just wrote. `to_raw_value` skipped that, so this
+/// costs one extra pass per row — the price of getting the bytes through a writer
+/// we can bound, since the unchecked constructor is not public.
 fn to_raw_value_within<T: serde::Serialize>(value: &T, budget: usize) -> Option<Box<RawValue>> {
     struct Budgeted {
         buf: Vec<u8>,
@@ -949,6 +985,22 @@ fn duckdb_value_to_json_value(
             serde_json::Value::String(duckdb_timestamp_to_iso(unit, ts))
         }
         duckdb::types::Value::Text(s) if type_alias.as_deref().unwrap_or_default() == "JSON" => {
+            // Parsing builds one `Value` per element, and an element can be as
+            // little as two bytes of text (`1,`), so the tree can reach half
+            // `size_of::<Value>()` times the text — 57MB of `[1,1,1,…]` becomes
+            // over 2GB. Charged before parsing, because afterwards the memory is
+            // already committed and nothing downstream can give it back.
+            //
+            // Deliberately the worst case, so ordinary JSON (longer tokens, fewer
+            // values per byte) is over-charged. The alternative is learning the
+            // real size only once it is too late to refuse.
+            let expanded = s
+                .len()
+                .saturating_mul(std::mem::size_of::<serde_json::Value>() / 2);
+            if expanded > budget.remaining {
+                return Err(result_too_large_message(budget.limit));
+            }
+            budget.remaining -= expanded;
             serde_json::from_str(&s)
                 .map_err(|e| format!("Error parsing JSON text: {}", e.to_string()))?
         }

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -632,10 +632,8 @@ mod result_size_guard_tests {
         assert_eq!(collected, 0, "it was refused before being counted");
     }
 
-    /// A JSON column is parsed into a tree before anything can weigh it, and
-    /// compact JSON is the densest way to ask for `Value`s: `[1,1,1,…]` costs two
-    /// bytes per 72-byte `Value`. The text length is the only signal available
-    /// while refusing is still possible.
+    /// The text length is the only signal available while refusing is still
+    /// possible — once the tree exists the memory is committed.
     #[test]
     fn a_dense_json_column_is_refused_before_it_is_parsed() {
         let conn = duckdb::Connection::open_in_memory().unwrap();
@@ -918,6 +916,10 @@ fn to_raw_value_within<T: serde::Serialize>(value: &T, budget: usize) -> Option<
 /// byte, and both several sibling columns and one nested deep in a `LIST`/`STRUCT`
 /// can each be individually modest while summing past what the worker can hold.
 /// One shared, decrementing budget is what makes those cases add up.
+/// Not covered: `row.get` materializes a `LIST`/`STRUCT` column before any budget
+/// exists, and `Debug`-rendered `MAP` keys and `UNION`s expand ~5x. All are
+/// upstream of or far cheaper than the 36x/72x paths above, and the first needs a
+/// streaming accessor from `duckdb-rs` to fix at all.
 struct Budget {
     remaining: usize,
     /// The configured cap, kept only so the error can quote it rather than the
@@ -985,15 +987,10 @@ fn duckdb_value_to_json_value(
             serde_json::Value::String(duckdb_timestamp_to_iso(unit, ts))
         }
         duckdb::types::Value::Text(s) if type_alias.as_deref().unwrap_or_default() == "JSON" => {
-            // Parsing builds one `Value` per element, and an element can be as
-            // little as two bytes of text (`1,`), so the tree can reach half
-            // `size_of::<Value>()` times the text — 57MB of `[1,1,1,…]` becomes
-            // over 2GB. Charged before parsing, because afterwards the memory is
-            // already committed and nothing downstream can give it back.
-            //
-            // Deliberately the worst case, so ordinary JSON (longer tokens, fewer
-            // values per byte) is over-charged. The alternative is learning the
-            // real size only once it is too late to refuse.
+            // An element can be two bytes of text (`1,`) and becomes a whole
+            // `Value`, so the retained tree reaches half `size_of::<Value>()`
+            // times the text, and the parser's own growth can hold ~2x that
+            // again. Charged before parsing; afterwards the memory is committed.
             let expanded = s
                 .len()
                 .saturating_mul(std::mem::size_of::<serde_json::Value>() / 2);

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -631,6 +631,41 @@ mod result_size_guard_tests {
         assert_eq!(collected, 0, "it was refused before being counted");
     }
 
+    /// The budget is per row, not per value: a blob nested in a container reaches
+    /// the same expansion by a path the top-level columns never touch, and several
+    /// modest sibling blobs reach it by summing. Both are invisible to a check
+    /// that only looks at one value at a time.
+    #[test]
+    fn nested_and_sibling_blobs_share_one_budget() {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        let attempt = |query: &str| {
+            do_duckdb_inner(
+                &conn,
+                query,
+                &HashMap::new(),
+                false,
+                false,
+                &mut None,
+                8 * 1024 * 1024,
+                &mut 0,
+            )
+        };
+
+        // One 1MB blob expands to ~24MB, over the 8MB cap, but it is reached only
+        // by descending into the LIST.
+        let nested = attempt("SELECT [repeat('a', 1000000)::BLOB] AS b")
+            .expect_err("a blob inside a LIST must be charged too");
+        assert!(nested.contains("Query result too large"), "{nested}");
+
+        // Four 100KB blobs are ~2.4MB each — each fits, the row does not.
+        let siblings = attempt(
+            "SELECT repeat('a', 100000)::BLOB AS a, repeat('b', 100000)::BLOB AS b,
+                    repeat('c', 100000)::BLOB AS c, repeat('d', 100000)::BLOB AS d",
+        )
+        .expect_err("sibling blobs must be charged against one shared budget");
+        assert!(siblings.contains("Query result too large"), "{siblings}");
+    }
+
     /// A row costs far more than the JSON it serializes to, and small rows are
     /// almost entirely that overhead. Billing only the payload would let a cap
     /// admit several times the rows the worker can actually hold.
@@ -777,6 +812,20 @@ fn interpolate_named_args<'a>(
     (query, values)
 }
 
+/// How much a row may still expand to, carried through every value it contains.
+///
+/// Only weighed rows reach the running total, so anything that balloons *during*
+/// conversion is invisible to it — a blob becomes one `serde_json::Value` per
+/// byte, and both several sibling columns and one nested deep in a `LIST`/`STRUCT`
+/// can each be individually modest while summing past what the worker can hold.
+/// One shared, decrementing budget is what makes those cases add up.
+struct Budget {
+    remaining: usize,
+    /// The configured cap, kept only so the error can quote it rather than the
+    /// remainder, which would be a different number every time.
+    limit: usize,
+}
+
 fn row_to_value(
     row: &Row<'_>,
     column_names: &[String],
@@ -784,24 +833,21 @@ fn row_to_value(
     budget: usize,
     max_result_size: usize,
 ) -> Result<Box<RawValue>, String> {
+    // Shared by every value in the row, and decremented as each is built, so
+    // columns that are individually under the cap cannot add up past it.
+    let mut budget = Budget {
+        remaining: if max_result_size == 0 {
+            usize::MAX
+        } else {
+            budget
+        },
+        limit: max_result_size,
+    };
     let mut obj = serde_json::Map::new();
     for (i, key) in column_names.iter().enumerate() {
         let value: duckdb::types::Value = row.get(i).map_err(|e| e.to_string())?;
-        // A blob renders one JSON number per byte, so its in-memory form is
-        // `size_of::<Value>()` times the blob and is entirely live before the row
-        // can be weighed. Weighed rows are the only thing the running total sees,
-        // so a single wide blob would exhaust the worker between two checks.
-        // The length is known now, which is the last moment refusing is cheap.
-        if let duckdb::types::Value::Blob(b) | duckdb::types::Value::Geometry(b) = &value {
-            let expanded = b
-                .len()
-                .saturating_mul(std::mem::size_of::<serde_json::Value>());
-            if max_result_size > 0 && expanded > budget {
-                return Err(result_too_large_message(max_result_size));
-            }
-        }
         let type_alias = &type_aliases[i];
-        let json_value = duckdb_value_to_json_value(value, type_alias)
+        let json_value = duckdb_value_to_json_value(value, type_alias, &mut budget)
             .map_err(|e| format!("column \"{key}\": {e}"))?;
         obj.insert(key.clone(), json_value);
     }
@@ -811,6 +857,7 @@ fn row_to_value(
 fn duckdb_value_to_json_value(
     value: duckdb::types::Value,
     type_alias: &Option<String>,
+    budget: &mut Budget,
 ) -> Result<serde_json::Value, String> {
     let json_value = match value {
         duckdb::types::Value::Null => serde_json::Value::Null,
@@ -844,6 +891,21 @@ fn duckdb_value_to_json_value(
         duckdb::types::Value::Text(s) => serde_json::Value::String(s),
         // GEOMETRY surfaces as WKB bytes; render it like any other byte string.
         duckdb::types::Value::Blob(b) | duckdb::types::Value::Geometry(b) => {
+            // Refused on the length, which is known now — once the array below
+            // exists the memory is already spent, and the row is not weighed
+            // until every one of its columns has been built.
+            //
+            // The multiplier is not the modest number it looks like: `Value` is
+            // 72 bytes here, because `preserve_order` backs objects with an
+            // IndexMap. A 50MB blob becomes ~3.6GB of `Value` before anything
+            // has had a chance to object.
+            let expanded = b
+                .len()
+                .saturating_mul(std::mem::size_of::<serde_json::Value>());
+            if expanded > budget.remaining {
+                return Err(result_too_large_message(budget.limit));
+            }
+            budget.remaining -= expanded;
             serde_json::Value::Array(
                 b.into_iter()
                     .map(|byte| serde_json::Value::Number(byte.into()))
@@ -867,20 +929,22 @@ fn duckdb_value_to_json_value(
         duckdb::types::Value::List(values) => serde_json::Value::Array(
             values
                 .into_iter()
-                .map(|v| duckdb_value_to_json_value(v, &None))
+                .map(|v| duckdb_value_to_json_value(v, &None, budget))
                 .collect::<Result<Vec<_>, _>>()?,
         ),
         duckdb::types::Value::Enum(e) => serde_json::Value::String(e),
         duckdb::types::Value::Struct(fields) => serde_json::Value::Object(
             fields
                 .iter()
-                .map(|(k, v)| duckdb_value_to_json_value(v.clone(), &None).map(|v| (k.clone(), v)))
+                .map(|(k, v)| {
+                    duckdb_value_to_json_value(v.clone(), &None, budget).map(|v| (k.clone(), v))
+                })
                 .collect::<Result<serde_json::Map<_, _>, _>>()?,
         ),
         duckdb::types::Value::Array(values) => serde_json::Value::Array(
             values
                 .into_iter()
-                .map(|v| duckdb_value_to_json_value(v, &None))
+                .map(|v| duckdb_value_to_json_value(v, &None, budget))
                 .collect::<Result<Vec<_>, _>>()?,
         ),
         duckdb::types::Value::Map(map) => serde_json::Value::Object(
@@ -890,7 +954,7 @@ fn duckdb_value_to_json_value(
                         duckdb::types::Value::Text(s) | duckdb::types::Value::Enum(s) => s.clone(),
                         _ => format!("{:?}", k),
                     };
-                    duckdb_value_to_json_value(v.clone(), &None).map(|v| (k, v))
+                    duckdb_value_to_json_value(v.clone(), &None, budget).map(|v| (k, v))
                 })
                 .collect::<Result<serde_json::Map<_, _>, _>>()?,
         ),
@@ -997,7 +1061,8 @@ mod temporal_json_tests {
         let row = rows.next().unwrap().unwrap();
         let json_of = |i: usize| {
             let v: duckdb::types::Value = row.get(i).unwrap();
-            duckdb_value_to_json_value(v, &None).unwrap()
+            let mut budget = Budget { remaining: usize::MAX, limit: 0 };
+            duckdb_value_to_json_value(v, &None, &mut budget).unwrap()
         };
         assert_eq!(json_of(0), serde_json::json!("2026-07-01T23:13:42.218435"));
         assert_eq!(json_of(1), serde_json::json!("2026-07-01T23:13:42"));
@@ -1029,7 +1094,8 @@ mod temporal_json_tests {
         let row = rows.next().unwrap().unwrap();
         let json_of = |i: usize| {
             let v: duckdb::types::Value = row.get(i).unwrap();
-            duckdb_value_to_json_value(v, &None).unwrap()
+            let mut budget = Budget { remaining: usize::MAX, limit: 0 };
+            duckdb_value_to_json_value(v, &None, &mut budget).unwrap()
         };
         assert_eq!(json_of(0), serde_json::json!("-1.05"));
         assert_eq!(json_of(1), serde_json::json!("1.50"));

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -559,9 +559,10 @@ fn format_byte_size(bytes: usize) -> String {
 /// Rows whose destination is storage should never be collected at all, so lead
 /// with the way to keep them out of it.
 ///
-/// Only the limit is quoted. Collection stops on the row that crosses it, so the
-/// running total is just the threshold plus one row — naming it as the result
-/// size would be inventing a number nobody measured.
+/// Only the limit is quoted. Neither caller knows a number worth naming: the row
+/// loop stops on the row that crosses the threshold, so its total is the threshold
+/// plus one row, and the expansion guard refuses on a projection while the total
+/// can still be zero.
 fn result_too_large_message(max_result_size: usize) -> String {
     format!(
         "Query result too large: collecting it passed the {} limit.\n\
@@ -614,7 +615,7 @@ mod result_size_guard_tests {
     fn a_wide_blob_is_refused_before_it_is_expanded() {
         let conn = duckdb::Connection::open_in_memory().unwrap();
         let mut collected = 0;
-        // 1MB of blob expands to ~24MB of `Value`, well past this budget, while the
+        // 1MB of blob expands to ~72MB of `Value`, well past this budget, while the
         // running total is still zero — nothing else in the loop would catch it.
         let err = do_duckdb_inner(
             &conn,
@@ -629,6 +630,32 @@ mod result_size_guard_tests {
         .expect_err("a blob expanding past the budget must be refused");
         assert!(err.contains("Query result too large"), "{err}");
         assert_eq!(collected, 0, "it was refused before being counted");
+    }
+
+    /// `Budget` charges expansions visible in the value tree, and escaping is not
+    /// one of them — it happens while the finished row is written, which is before
+    /// anything weighs it. Only bounding the writer catches that.
+    #[test]
+    fn escaping_cannot_outgrow_the_row_budget() {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        // 100k control characters: ~100KB of `String`, ~600KB once escaped.
+        let attempt = |budget: usize| {
+            do_duckdb_inner(
+                &conn,
+                "SELECT repeat(chr(1), 100000) AS a",
+                &HashMap::new(),
+                false,
+                false,
+                &mut None,
+                budget,
+                &mut 0,
+            )
+        };
+
+        let err = attempt(300_000).expect_err("the escaped form does not fit 300KB");
+        assert!(err.contains("Query result too large"), "{err}");
+        // Room for the escaped form, so the same row goes through.
+        assert_eq!(attempt(2_000_000).unwrap().len(), 1);
     }
 
     /// The budget is per row, not per value: a blob nested in a container reaches
@@ -651,16 +678,16 @@ mod result_size_guard_tests {
             )
         };
 
-        // One 1MB blob expands to ~24MB, over the 8MB cap, but it is reached only
+        // One 1MB blob expands to ~72MB, over the 8MB cap, but it is reached only
         // by descending into the LIST.
         let nested = attempt("SELECT [repeat('a', 1000000)::BLOB] AS b")
             .expect_err("a blob inside a LIST must be charged too");
         assert!(nested.contains("Query result too large"), "{nested}");
 
-        // Four 100KB blobs are ~2.4MB each — each fits, the row does not.
+        // Four 30KB blobs are ~2.2MB each — every one fits on its own, the row does not.
         let siblings = attempt(
-            "SELECT repeat('a', 100000)::BLOB AS a, repeat('b', 100000)::BLOB AS b,
-                    repeat('c', 100000)::BLOB AS c, repeat('d', 100000)::BLOB AS d",
+            "SELECT repeat('a', 30000)::BLOB AS a, repeat('b', 30000)::BLOB AS b,
+                    repeat('c', 30000)::BLOB AS c, repeat('d', 30000)::BLOB AS d",
         )
         .expect_err("sibling blobs must be charged against one shared budget");
         assert!(siblings.contains("Query result too large"), "{siblings}");
@@ -812,6 +839,42 @@ fn interpolate_named_args<'a>(
     (query, values)
 }
 
+/// Serializes to JSON without letting the output outgrow `budget`.
+///
+/// The expansions the `Budget` charges are the ones visible in the value tree;
+/// escaping is not one of them. A control character becomes the six-byte
+/// `\u0001`, so a row that fit the budget as `Value`s can still allocate several
+/// times it while being written — and the write happens before the finished row
+/// is ever weighed. Bounding the writer keeps that inside the budget.
+fn to_raw_value_within<T: serde::Serialize>(value: &T, budget: usize) -> Option<Box<RawValue>> {
+    struct Budgeted {
+        buf: Vec<u8>,
+        left: usize,
+    }
+    impl std::io::Write for Budgeted {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if bytes.len() > self.left {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "row over budget",
+                ));
+            }
+            self.left -= bytes.len();
+            self.buf.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut writer = Budgeted { buf: Vec::new(), left: budget };
+    serde_json::to_writer(&mut writer, value).ok()?;
+    String::from_utf8(writer.buf)
+        .ok()
+        .and_then(|s| RawValue::from_string(s).ok())
+}
+
 /// How much a row may still expand to, carried through every value it contains.
 ///
 /// Only weighed rows reach the running total, so anything that balloons *during*
@@ -851,7 +914,8 @@ fn row_to_value(
             .map_err(|e| format!("column \"{key}\": {e}"))?;
         obj.insert(key.clone(), json_value);
     }
-    serde_json::value::to_raw_value(&obj).map_err(|e| e.to_string())
+    to_raw_value_within(&obj, budget.remaining)
+        .ok_or_else(|| result_too_large_message(budget.limit))
 }
 
 fn duckdb_value_to_json_value(

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -50,7 +50,7 @@ pub extern "C" fn get_version() -> c_uint {
     // Increment when making breaking changes to the FFI interface.
     // The windmill worker will check that the version matches or else refuse to call
     // the FFI functions to avoid undefined behavior.
-    return 2;
+    return 3;
 }
 
 #[unsafe(no_mangle)]
@@ -63,6 +63,8 @@ pub extern "C" fn run_duckdb_ffi(
     w_id: *const c_char,
     memory_limit: *const c_char,
     temp_directory: *const c_char,
+    // 0 means unbounded; the worker sends its own budget-derived cap.
+    max_result_size: usize,
     column_order_ptr: *mut *mut c_char,
     collect_last_only: bool,
     collect_first_row_only: bool,
@@ -90,6 +92,7 @@ pub extern "C" fn run_duckdb_ffi(
                 base_internal_url,
                 w_id,
                 limits,
+                max_result_size,
                 collect_last_only,
                 collect_first_row_only,
             )
@@ -486,6 +489,7 @@ fn run_duckdb_internal<'a>(
     base_internal_url: &str,
     w_id: &str,
     limits: ResourceLimits,
+    max_result_size: usize,
     collect_last_only: bool,
     collect_first_row_only: bool,
 ) -> Result<(String, Option<Vec<String>>), String> {
@@ -495,6 +499,9 @@ fn run_duckdb_internal<'a>(
 
     let mut results: Vec<Vec<Box<RawValue>>> = vec![];
     let mut column_order = None;
+    // Carried across blocks: what the worker cannot survive is the total it ends
+    // up holding, not any one statement's share of it.
+    let mut collected = 0usize;
 
     for (query_block_index, query_block) in query_block_list.enumerate() {
         let result = do_duckdb_inner(
@@ -504,12 +511,127 @@ fn run_duckdb_internal<'a>(
             collect_last_only && query_block_index != query_block_list_count - 1,
             collect_first_row_only,
             &mut column_order,
+            max_result_size,
+            &mut collected,
         )
         .map_err(|e| e.to_string())?;
         results.push(result);
     }
-    let results = serde_json::value::to_raw_value(&results).map_err(|e| e.to_string())?;
-    Ok((results.get().to_string(), column_order))
+    // Serializing straight to the String that crosses the FFI boundary; going
+    // through a RawValue first would hold a second copy of the whole result.
+    serde_json::to_string(&results)
+        .map(|results| (results, column_order))
+        .map_err(|e| e.to_string())
+}
+
+/// Beyond its JSON, every collected row costs a fat pointer parked in `rows_vec`
+/// plus its own heap allocation, which the allocator rounds up and prefixes with
+/// a header. Measured at 64 bytes resident for a 14-byte row, falling to a flat
+/// ~34 bytes of overhead once rows are wide; 56 sits above that whole range, so
+/// the charge is never less than what a row actually occupies.
+///
+/// Charging the payload alone is what makes small rows dangerous: `{"a":0}` is
+/// seven bytes but occupies 64, so a cap counting only JSON would admit nine
+/// times the rows the worker can hold.
+const ROW_STORAGE_OVERHEAD: usize = 56;
+
+fn row_storage_cost(json_len: usize) -> usize {
+    json_len + ROW_STORAGE_OVERHEAD
+}
+
+// Duplicated from windmill-worker rather than shared: this crate is deliberately
+// outside the workspace so the bundled engine compiles on its own.
+fn format_byte_size(bytes: usize) -> String {
+    match bytes {
+        b if b >= 1 << 30 => format!("{:.1}GB", b as f64 / (1u64 << 30) as f64),
+        b if b >= 1 << 20 => format!("{}MB", b >> 20),
+        b if b >= 1 << 10 => format!("{}KB", b >> 10),
+        b => format!("{b}B"),
+    }
+}
+
+/// Size is counted as serialized JSON, which is what the rows become: they are
+/// collected in full here, cross the FFI boundary as one string, and land in the
+/// job result. Rows whose destination is storage should never take that path, so
+/// lead with the way to keep them out of it.
+///
+/// Only the limit is quoted. Collection stops on the row that crosses it, so the
+/// running total is just the threshold plus one row — naming it as the result
+/// size would be inventing a number nobody measured.
+fn result_too_large_message(max_result_size: usize) -> String {
+    format!(
+        "Query result too large: collecting it passed the {} limit.\n\
+         Write the rows out from the query instead of returning them:\n  \
+         COPY (<your query>) TO 's3://<bucket>/<file>.parquet' (FORMAT PARQUET);\n\
+         Or return fewer rows — aggregate, or add a LIMIT. On a self-hosted \
+         worker, MAX_SQL_RESULT_SIZE raises the limit.",
+        format_byte_size(max_result_size),
+    )
+}
+
+#[cfg(test)]
+mod result_size_guard_tests {
+    use super::*;
+
+    const ROWS: usize = 100_000;
+
+    fn collect_into(max_result_size: usize, collected: &mut usize) -> Result<usize, String> {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        do_duckdb_inner(
+            &conn,
+            &format!("SELECT i FROM range({ROWS}) t(i)"),
+            &HashMap::new(),
+            false,
+            false,
+            &mut None,
+            max_result_size,
+            collected,
+        )
+        .map(|rows| rows.len())
+    }
+
+    #[test]
+    fn oversized_result_is_refused_mid_collection() {
+        let err = collect_into(1024, &mut 0).expect_err("1KB cannot hold 100k rows");
+        assert!(err.contains("Query result too large"), "{err}");
+        // The limit alone leaves the user stuck; the way out has to travel with it.
+        assert!(err.contains("COPY ("), "no remedy in the error: {err}");
+    }
+
+    #[test]
+    fn zero_is_unbounded() {
+        assert_eq!(collect_into(0, &mut 0).unwrap(), ROWS);
+    }
+
+    /// A row costs far more than the JSON it serializes to, and small rows are
+    /// almost entirely that overhead. Billing only the payload would let a cap
+    /// admit several times the rows the worker can actually hold.
+    #[test]
+    fn a_row_costs_more_than_its_payload() {
+        assert_eq!(row_storage_cost(7), 7 + ROW_STORAGE_OVERHEAD);
+
+        let mut collected = 0;
+        collect_into(usize::MAX, &mut collected).unwrap();
+        assert!(
+            collected >= ROWS * ROW_STORAGE_OVERHEAD,
+            "charged {collected} for {ROWS} rows, so containers went unbilled"
+        );
+    }
+
+    /// The worker dies on the total it holds, not on any one statement, so the
+    /// budget has to carry across blocks — a per-statement reset would let N
+    /// statements each pass the check and still OOM the worker together.
+    #[test]
+    fn the_budget_is_shared_across_statements() {
+        let mut collected = 0;
+        let first = collect_into(usize::MAX, &mut collected).unwrap();
+        assert_eq!(first, ROWS);
+        assert!(collected > 0);
+
+        let err = collect_into(collected, &mut collected)
+            .expect_err("the first statement already spent the whole budget");
+        assert!(err.contains("Query result too large"), "{err}");
+    }
 }
 
 fn do_duckdb_inner(
@@ -519,6 +641,8 @@ fn do_duckdb_inner(
     skip_collect: bool,
     collect_first_row_only: bool,
     column_order: &mut Option<Vec<String>>,
+    max_result_size: usize,
+    collected: &mut usize,
 ) -> Result<Vec<Box<RawValue>>, String> {
     let mut rows_vec = vec![];
 
@@ -576,6 +700,10 @@ fn do_duckdb_inner(
 
                 let row = row_to_value(row, &column_names.as_slice(), &type_aliases.as_slice())
                     .map_err(|e| e.to_string())?;
+                *collected += row_storage_cost(row.get().len());
+                if max_result_size > 0 && *collected > max_result_size {
+                    return Err(result_too_large_message(max_result_size));
+                }
                 rows_vec.push(row);
             }
             Ok(None) => break,

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -25,6 +25,7 @@ use windmill_types::s3::S3Object;
 use crate::agent_workers::{get_datatable_resource_from_agent_http, get_ducklake_from_agent_http};
 use crate::common::{build_args_values, get_reserved_variables, OccupancyMetrics};
 use crate::handle_child::run_future_with_polling_update_job_poller;
+use crate::max_sql_result_size;
 #[cfg(feature = "mysql")]
 use crate::mysql_executor::MysqlDatabase;
 use crate::sanitized_sql_params::sanitize_and_interpolate_unsafe_sql_args;
@@ -1910,6 +1911,7 @@ struct DuckDbFfiLib {
             w_id: *const c_char,
             memory_limit: *const c_char,
             temp_directory: *const c_char,
+            max_result_size: usize,
             column_order_ptr: *mut *mut c_char,
             collect_last_only: bool,
             collect_first_row_only: bool,
@@ -1972,7 +1974,7 @@ impl DuckDbFfiLib {
         // Version mismatch should only be possible on Windows agent workers
         // We check for it because FFI interface mismatch will cause undefined behavior / crashes
         unsafe {
-            let expected_version: c_uint = 2;
+            let expected_version: c_uint = 3;
             let get_version: Symbol<'static, unsafe extern "C" fn() -> c_uint> = 
             lib.get(b"get_version")
                 .map_err(|e| return Error::ExecutionErr(format!("Could not find get_version in the duckdb ffi library. If you are not using docker, consider manually upgrading windmill_duckdb_ffi_lib. {}", e.to_string())))?;
@@ -2081,6 +2083,7 @@ fn run_duckdb_ffi_safe<'a>(
             w_id.as_ptr(),
             memory_limit.as_ptr(),
             temp_directory.as_ptr(),
+            max_sql_result_size(),
             &mut column_order,
             collection_strategy.collect_last_statement_only(query_block_list_count),
             collection_strategy.collect_first_row_only(),

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -25,11 +25,11 @@ use windmill_types::s3::S3Object;
 use crate::agent_workers::{get_datatable_resource_from_agent_http, get_ducklake_from_agent_http};
 use crate::common::{build_args_values, get_reserved_variables, OccupancyMetrics};
 use crate::handle_child::run_future_with_polling_update_job_poller;
-use crate::max_sql_result_size;
 #[cfg(feature = "mysql")]
 use crate::mysql_executor::MysqlDatabase;
 use crate::sanitized_sql_params::sanitize_and_interpolate_unsafe_sql_args;
 use crate::sql_utils::remove_comments;
+use crate::MAX_SQL_RESULT_SIZE;
 use windmill_common::client::AuthedClient;
 use windmill_object_store::DEFAULT_STORAGE;
 
@@ -2083,7 +2083,7 @@ fn run_duckdb_ffi_safe<'a>(
             w_id.as_ptr(),
             memory_limit.as_ptr(),
             temp_directory.as_ptr(),
-            max_sql_result_size(),
+            *MAX_SQL_RESULT_SIZE,
             &mut column_order,
             collection_strategy.collect_last_statement_only(query_block_list_count),
             collection_strategy.collect_first_row_only(),

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1266,6 +1266,104 @@ impl std::ops::Deref for NextJob {
 //only matter if CLOUD_HOSTED
 pub const MAX_RESULT_SIZE: usize = 1024 * 1024 * 2; // 2MB
 
+// Share of the worker's memory budget one SQL result may occupy. Collecting rows
+// costs several times the JSON they serialize to — a separately allocated value
+// per row, then a contiguous buffer holding all of them — and the worker still
+// needs the rest of its budget for what it already has resident.
+const SQL_RESULT_SIZE_FRACTION: f64 = 0.15;
+// Under this a result cannot threaten a worker of any size, so capping it would
+// only reject work that would have succeeded.
+const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
+
+/// `"512"`, `"512MB"`, `"2GiB"`, `"1.5GB"` -> bytes. Suffixes are case-insensitive
+/// and binary, so `MB` and `MiB` both mean 1024².
+///
+/// Fractions are accepted because `format_byte_size` emits them, and the limit it
+/// renders into an error is meant to be usable as a setting verbatim.
+fn parse_byte_size(v: &str) -> Option<usize> {
+    let upper = v.trim().to_ascii_uppercase();
+    // Longest-first: `GB` would otherwise swallow `GIB`, and `B` every other suffix.
+    let (digits, mult) = [
+        ("GIB", 1u64 << 30),
+        ("GB", 1u64 << 30),
+        ("MIB", 1u64 << 20),
+        ("MB", 1u64 << 20),
+        ("KIB", 1u64 << 10),
+        ("KB", 1u64 << 10),
+        ("B", 1),
+    ]
+    .into_iter()
+    .find_map(|(suffix, mult)| upper.strip_suffix(suffix).map(|d| (d, mult)))
+    .unwrap_or((upper.as_str(), 1));
+    let n = digits.trim().parse::<f64>().ok()?;
+    if !n.is_finite() || n < 0.0 {
+        return None;
+    }
+    let bytes = n * mult as f64;
+    (bytes <= usize::MAX as f64).then(|| bytes as usize)
+}
+
+lazy_static::lazy_static! {
+    /// Bytes one SQL job may collect before the executor gives up — the budget
+    /// spans every statement in the job, since what the worker cannot survive is
+    /// the total it ends up holding. Nothing else bounds it: the executors
+    /// accumulate every row before anything can stream the result out, so an
+    /// oversized one grows past the cgroup and the
+    /// OOM killer takes the worker process down — every job colocated on it, not
+    /// just the one that asked. `MAX_SQL_RESULT_SIZE` overrides it; `0` and a
+    /// worker with no cgroup reading to scale from both mean no cap.
+    static ref MAX_SQL_RESULT_SIZE: usize = {
+        let explicit = std::env::var("MAX_SQL_RESULT_SIZE").ok().and_then(|v| {
+            let parsed = parse_byte_size(&v);
+            if parsed.is_none() {
+                // Falling back silently would leave the operator believing a
+                // limit is in force that never parsed.
+                tracing::warn!(
+                    "MAX_SQL_RESULT_SIZE={v:?} is not a byte size (e.g. 512MB, 2GiB); \
+                     falling back to the memory-derived limit"
+                );
+            }
+            parsed
+        });
+        match explicit {
+            // `0` turns the cap off. It is the sentinel the duckdb FFI already
+            // takes for unbounded, so both engines spell "no limit" the same way;
+            // anything else and one of them would reject every non-empty result.
+            Some(0) => usize::MAX,
+            // The floor guards the derived value only. An explicit setting is
+            // taken at face value, including one deliberately below it.
+            Some(limit) => limit,
+            None => windmill_common::worker::get_memory()
+                .filter(|bytes| *bytes > 0)
+                .map(|bytes| ((bytes as f64 * SQL_RESULT_SIZE_FRACTION) as usize)
+                    .max(MIN_MAX_SQL_RESULT_SIZE))
+                .unwrap_or(usize::MAX),
+        }
+    };
+}
+
+/// The cloud cap is a product limit and stays where it was; off-cloud the only
+/// thing worth enforcing is the worker's own survival.
+///
+/// The callers do not all measure against it in the same unit: postgres charges
+/// the larger of an in-memory estimate and the serialized length, duckdb the
+/// serialized length plus what the row's container costs. Both are proxies for
+/// what collecting the result costs, and the derived limits sit far enough above
+/// real results that the difference does not decide anything; unifying them would
+/// move the cloud cap, which is a product decision, not this one.
+///
+/// This bounds what is *collected*, not the process: `-- raw_output` holds the
+/// accumulated text and then serializes it, so that path peaks near twice the cap.
+/// The derived default leaves room for that — it is a fraction of the worker's
+/// budget, not the whole of it.
+pub fn max_sql_result_size() -> usize {
+    if *CLOUD_HOSTED {
+        MAX_RESULT_SIZE * 4
+    } else {
+        *MAX_SQL_RESULT_SIZE
+    }
+}
+
 #[derive(Clone)]
 pub struct SameWorkerSender(pub Sender<SameWorkerPayload>, pub Arc<AtomicU16>);
 
@@ -4867,6 +4965,39 @@ pub async fn write_module_files(
         tokio::fs::write(&full_path, &module.content).await?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod byte_size_tests {
+    use super::*;
+
+    /// The suffix table is order-sensitive: `GB` matches the tail of `GIB` and
+    /// `B` the tail of every other suffix, so a reordering silently truncates
+    /// the multiplier instead of failing to parse.
+    #[test]
+    fn suffixes_do_not_shadow_each_other() {
+        assert_eq!(parse_byte_size("512"), Some(512));
+        assert_eq!(parse_byte_size("512B"), Some(512));
+        assert_eq!(parse_byte_size("512KB"), Some(512 << 10));
+        assert_eq!(parse_byte_size("300mb"), Some(300 << 20));
+        assert_eq!(parse_byte_size("2GiB"), Some(2 << 30));
+        assert_eq!(parse_byte_size("2 gb "), Some(2 << 30));
+        assert_eq!(parse_byte_size("many"), None);
+    }
+
+    /// The duckdb error renders the limit so it can be pasted straight into
+    /// `MAX_SQL_RESULT_SIZE`. That renderer lives in the FFI crate and emits a
+    /// fraction above 1 GiB, so an integer-only parser here would silently reject
+    /// the very value the error told the user to set.
+    #[test]
+    fn the_shapes_the_error_renders_all_parse() {
+        for rendered in ["512B", "8KB", "307MB", "1.0GB", "2.4GB"] {
+            assert!(
+                parse_byte_size(rendered).is_some(),
+                "{rendered} is rendered into errors but does not parse back"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1337,9 +1337,9 @@ lazy_static::lazy_static! {
             parsed
         });
         match explicit {
-            // `0` turns the cap off. It is the sentinel the duckdb FFI already
-            // takes for unbounded, so both engines spell "no limit" the same way;
-            // anything else and one of them would reject every non-empty result.
+            // `0` turns the cap off, matching the sentinel the FFI takes for
+            // unbounded. Passing it through as a literal zero would instead reject
+            // every non-empty result, which is the opposite of what it reads as.
             Some(0) => usize::MAX,
             // The floor guards the derived value only. An explicit setting is
             // taken at face value, including one deliberately below it.

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1270,9 +1270,11 @@ pub const MAX_RESULT_SIZE: usize = 1024 * 1024 * 2; // 2MB
 // costs several times the JSON they serialize to — a separately allocated value
 // per row, then a contiguous buffer holding all of them — and the worker still
 // needs the rest of its budget for what it already has resident.
+#[cfg(feature = "duckdb")]
 const SQL_RESULT_SIZE_FRACTION: f64 = 0.15;
 // Under this a result cannot threaten a worker of any size, so capping it would
 // only reject work that would have succeeded.
+#[cfg(feature = "duckdb")]
 const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 
 /// `"512"`, `"512MB"`, `"2GiB"`, `"1.5GB"` -> bytes. Suffixes are case-insensitive
@@ -1280,6 +1282,7 @@ const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 ///
 /// Fractions are accepted because `format_byte_size` emits them, and the limit it
 /// renders into an error is meant to be usable as a setting verbatim.
+#[cfg(feature = "duckdb")]
 fn parse_byte_size(v: &str) -> Option<usize> {
     let upper = v.trim().to_ascii_uppercase();
     // Longest-first: `GB` would otherwise swallow `GIB`, and `B` every other suffix.
@@ -1303,6 +1306,7 @@ fn parse_byte_size(v: &str) -> Option<usize> {
     (bytes <= usize::MAX as f64).then(|| bytes as usize)
 }
 
+#[cfg(feature = "duckdb")]
 lazy_static::lazy_static! {
     /// Bytes one duckdb job may collect before the executor gives up — the budget
     /// spans every query block in the job, since what the worker cannot survive is
@@ -4956,7 +4960,7 @@ pub async fn write_module_files(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "duckdb"))]
 mod byte_size_tests {
     use super::*;
 

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1304,15 +1304,26 @@ fn parse_byte_size(v: &str) -> Option<usize> {
 }
 
 lazy_static::lazy_static! {
-    /// Bytes one SQL job may collect before the executor gives up — the budget
-    /// spans every statement in the job, since what the worker cannot survive is
-    /// the total it ends up holding. Nothing else bounds it: the executors
-    /// accumulate every row before anything can stream the result out, so an
-    /// oversized one grows past the cgroup and the
-    /// OOM killer takes the worker process down — every job colocated on it, not
-    /// just the one that asked. `MAX_SQL_RESULT_SIZE` overrides it; `0` and a
-    /// worker with no cgroup reading to scale from both mean no cap.
-    static ref MAX_SQL_RESULT_SIZE: usize = {
+    /// Bytes one duckdb job may collect before the executor gives up — the budget
+    /// spans every query block in the job, since what the worker cannot survive is
+    /// the total it ends up holding. Nothing else bounds it at collection time:
+    /// every row is accumulated before anything can stream the result out, so an
+    /// oversized one grows past the cgroup and the OOM killer takes the worker
+    /// process down — every job colocated on it, not just the one that asked.
+    /// (`MAX_RESULT_SIZE_MB` does bound the finished result, but only once the job
+    /// completes, which is after the memory has already been spent.)
+    ///
+    /// This is a worker-survival limit, not a product one, so it applies the same
+    /// on cloud as off it. `MAX_SQL_RESULT_SIZE` overrides it; `0` and a worker
+    /// with no cgroup reading to scale from both mean no cap.
+    ///
+    /// It bounds what is *collected*, not the process: the collected rows are
+    /// still live while `serde_json::to_string` builds a second whole copy, and
+    /// the worker parses that copy back for every strategy but
+    /// `AllStatementsAllRows`, so peak sits near twice the cap. The derived
+    /// default leaves room for that — it is a fraction of the worker's budget,
+    /// not the whole of it.
+    pub(crate) static ref MAX_SQL_RESULT_SIZE: usize = {
         let explicit = std::env::var("MAX_SQL_RESULT_SIZE").ok().and_then(|v| {
             let parsed = parse_byte_size(&v);
             if parsed.is_none() {
@@ -1340,28 +1351,6 @@ lazy_static::lazy_static! {
                 .unwrap_or(usize::MAX),
         }
     };
-}
-
-/// The cloud cap is a product limit and stays where it was; off-cloud the only
-/// thing worth enforcing is the worker's own survival.
-///
-/// The callers do not all measure against it in the same unit: postgres charges
-/// the larger of an in-memory estimate and the serialized length, duckdb the
-/// serialized length plus what the row's container costs. Both are proxies for
-/// what collecting the result costs, and the derived limits sit far enough above
-/// real results that the difference does not decide anything; unifying them would
-/// move the cloud cap, which is a product decision, not this one.
-///
-/// This bounds what is *collected*, not the process: `-- raw_output` holds the
-/// accumulated text and then serializes it, so that path peaks near twice the cap.
-/// The derived default leaves room for that — it is a fraction of the worker's
-/// budget, not the whole of it.
-pub fn max_sql_result_size() -> usize {
-    if *CLOUD_HOSTED {
-        MAX_RESULT_SIZE * 4
-    } else {
-        *MAX_SQL_RESULT_SIZE
-    }
 }
 
 #[derive(Clone)]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1337,9 +1337,9 @@ lazy_static::lazy_static! {
             parsed
         });
         match explicit {
-            // `0` turns the cap off, matching the sentinel the FFI takes for
-            // unbounded. Passing it through as a literal zero would instead reject
-            // every non-empty result, which is the opposite of what it reads as.
+            // `0` turns the cap off. Normalized here rather than forwarded,
+            // so "no cap" is expressed as a limit nothing can exceed instead of
+            // a sentinel every consumer has to know to special-case.
             Some(0) => usize::MAX,
             // The floor guards the derived value only. An explicit setting is
             // taken at face value, including one deliberately below it.


### PR DESCRIPTION
## Summary

A DuckDB step that returns a large result set OOM-kills the worker **process** —
taking down every job colocated on it, not just the offending one. The job comes back
as a zombie (`no ping from job since …`), which reads as an infrastructure fault rather
than "this query returned too much". Nothing bounded the collection.

Spilling is not involved and raising `memory_limit` does not help: a
`SELECT … FROM read_parquet(…)` is a streaming scan, so DuckDB's buffer manager never
grows and has nothing to spill. The memory is Windmill's own row materialization on the
Rust side of the FFI, which sits outside `memory_limit` and has no spill path.

**Scope**: DuckDB only. The Postgres executor has the same failure shape and its guard
is also cloud-only, but bounding it turned out to need a rework of its collection path;
that is a follow-up PR rather than more surface here.

### Measured

A 79 MiB ZSTD parquet of one timestamp column is **30M rows** → 829 MiB of JSON.
Collecting it costs **3950 MiB peak RSS**, ~4.8x the JSON and ~50x the file. The row
accumulation alone is 2290 MiB, already past a 2 GiB worker before serialization starts
— which is why the memory curve sits flat and then dies inside one scrape interval
instead of ramping.

## Changes

- **New cap, `MAX_SQL_RESULT_SIZE`.** Defaults to 15% of the worker's cgroup budget
  (same source as `DUCKDB_MEMORY_LIMIT`), floored at 8MB. `0`, and a worker with no
  cgroup reading to scale from, both mean no cap. An explicit setting is taken at face
  value; the floor only guards the derived value. This is a **worker-survival** limit,
  not a product one, so it applies the same on cloud as off it — duckdb deliberately
  does not route through the cloud `MAX_RESULT_SIZE * 4` product cap, which would be
  ~9x the payload for narrow rows and is not something a cloud user can raise.
- **Blobs are refused on their length, before expansion.** A `BLOB`/`GEOMETRY` renders
  one `serde_json::Value` per byte, and `Value` is **72 bytes** here (`preserve_order`
  backs objects with an IndexMap), so a 50MB blob becomes ~3.6GB in memory — entirely
  live before the row can be weighed, and therefore invisible to a running total. The
  budget is shared across every value in a row and carried into nested containers, since
  sibling columns and a blob buried in a `LIST`/`STRUCT` both reach the same total by
  paths a per-value check never sees.
- **DuckDB collection is now bounded.** The budget is carried across query blocks, since
  what the worker cannot survive is the total. Needs a new FFI parameter, so the ABI
  version goes **2 → 3**.
- **Rows are charged for their container, not just their payload.** Measured: a row
  occupies 16 bytes of fat pointer in `rows_vec` plus a separate allocation the allocator
  rounds up and prefixes with a header — 64 bytes resident for a 14-byte row, ~34 bytes
  of overhead once rows are wide. `{"a":0}` is 7 bytes but occupies 64, so counting only
  JSON would admit ~9x the rows the worker can hold.
- **JSON columns are charged before parsing.** A `JSON`-typed cell is parsed into a
  `Value` tree before anything can weigh it, and compact JSON is the densest possible
  request for `Value`s — `[1,1,1,…]` costs two bytes per 72-byte `Value`, so 57MB of text
  becomes over 2GB. Charged at that worst case, which deliberately over-charges ordinary
  JSON; the alternative is learning the real size once it is too late to refuse.

- **Row serialization is bounded, not estimated.** JSON escaping is invisible to any
  count taken over the value tree — a control character becomes the six-byte `\^A` —
  and the write happens before the finished row is weighed, so a row that fit as `Value`s
  could still allocate several times the cap on the way out. The writer now refuses past
  the remaining budget instead of discovering the size afterwards.
- **The blob refusal names the offending column** (`column "b": Query result too large: …`),
  since it fires inside per-column conversion. Deliberate — it is the one message where
  knowing which column is actionable. The row-level refusals are unprefixed.

- **One redundant full copy removed.** `to_raw_value(&results)` followed by
  `.get().to_string()` held two copies of the entire result; serializing straight into
  the String that crosses the FFI drops one. Peak for the 30M-row case goes
  **3950 → 3492 MiB** end-to-end (‑12%), and 3950 → 3120 at the FFI boundary (‑21%).
- **The error carries the remedy**, since the limit alone leaves the user stuck:

  ```
  Query result too large: collecting it passed the 307MB limit.
  Write the rows out from the query instead of returning them:
    COPY (<your query>) TO 's3://<bucket>/<file>.parquet' (FORMAT PARQUET);
  Or return fewer rows — aggregate, or add a LIMIT. On a self-hosted worker,
  MAX_SQL_RESULT_SIZE raises the limit.
  ```

  `COPY TO` is the real fix for this shape of job: every DuckDB script already gets an S3
  secret wired to the workspace S3 proxy, and the write streams in constant memory.
  Returning 30M rows would also have written 829 MiB into `v2_job_completed.result`.

## Notes for reviewers

- **Behavior change**: queries that returned very large results and happened to survive
  will now fail with the message above. This includes **cloud**, where duckdb previously
  had no collection-time cap at all (only `MAX_RESULT_SIZE_MB`, 500MB, applied after the
  job completes — i.e. after the memory was already spent). The default scales with
  worker memory (a 2Gi worker gets ~307MB, a 16Gi worker ~2.4GB) and is overridable, so
  this should only bite jobs that were already close to killing their worker.
- **Single wide cells now have a ceiling too**, which is not obvious from a note about
  row counts. Because the guards charge what a value *expands to*, one cell is bounded at
  roughly `cap ÷ 72` for `BLOB`/`GEOMETRY` and `cap ÷ 36` for `JSON` — about 4MB and
  8.5MB on a 2Gi worker, refused with a message quoting the 307MB cap. The `JSON` surface
  is the wider one: `x::JSON`, `read_json_objects`, and a `JSON`-typed parquet column are
  shapes nobody would file under "large result", and a 10MB document in one of them now
  fails by default. `MAX_SQL_RESULT_SIZE` raises it.

- **Agent workers**: the ABI bump means a manually-installed `windmill_duckdb_ffi_lib`
  must be updated alongside the worker. Docker images build both together; the existing
  version check produces a clear error rather than UB.
- The cap bounds what is *collected*, not the process — peak RSS is a multiple of it,
  which is why the default is a fraction of the worker's budget rather than all of it.
- `MAX_SQL_RESULT_SIZE` needs a docs entry in `windmilldocs`; not in this repo.

## Test plan

- [x] `cargo test -p windmill-worker --lib` — 274 pass
- [x] `cargo test` in `windmill-duckdb-ffi-internal` — 24 pass, including the existing
      patched-engine spill/lock guards
- [x] Regression tests: guard fires mid-collection with the remedy in the message, `0`
      means unbounded, budget shared across statements, a row costs more than its
      payload, and every byte-size shape the error renders parses back
- [x] FFI ABI harness: `dlopen`s the built `.so` and calls `run_duckdb_ffi` through the
      worker's exact signature — `get_version() == 3`, result shape unchanged (proving no
      parameter slid), guard reachable across the boundary
- [x] Real DuckDB jobs on a dev backend: small query succeeds; 2M rows trips the guard;
      20M tiny rows (payload dwarfed by container overhead) trips it at 275 MiB peak;
      **the worker survives and keeps running jobs** (no panic, no restart); the same 2M
      rows via `COPY TO … (FORMAT PARQUET)` succeeds, returning `Count: 2000000`






Fixes WIN-2352