### PR TITLE
fix: tell MCP clients which tool parameters may be omitted

### DIFF
--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -209,6 +209,14 @@ impl McpBackend for WindmillBackend {
 
         for (old_key, new_key, value) in replacements {
             schema_obj.properties.remove(&old_key);
+            // `required` names properties, so it has to follow the rename -- an entry
+            // left pointing at the original key names a property that no longer exists,
+            // which reads as "this parameter is optional".
+            for name in schema_obj.required.iter_mut() {
+                if *name == old_key {
+                    *name = new_key.clone();
+                }
+            }
             schema_obj.properties.insert(new_key, value);
         }
 

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use windmill_common::{db::UserDB, utils::StripPath, DB};
 use windmill_mcp::common::schema::enrich_resource_schemas;
-use windmill_mcp::common::transform::apply_key_transformation;
+use windmill_mcp::common::transform::transform_property_keys;
 use windmill_mcp::common::types::{
     FlowInfo, HubScriptInfo, ResourceInfo, ResourceType, SchemaType, ScriptInfo, WorkspaceInfo,
 };
@@ -194,31 +194,7 @@ impl McpBackend for WindmillBackend {
         let mut schema_obj = schema.clone();
 
         // Replace invalid char in property key with underscore
-        let replacements: Vec<(String, String, Value)> = schema_obj
-            .properties
-            .iter()
-            .filter_map(|(key, value)| {
-                if key.chars().any(|c| !c.is_alphanumeric() && c != '_') {
-                    let new_key = apply_key_transformation(key);
-                    Some((key.clone(), new_key, value.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        for (old_key, new_key, value) in replacements {
-            schema_obj.properties.remove(&old_key);
-            // `required` names properties, so it has to follow the rename -- an entry
-            // left pointing at the original key names a property that no longer exists,
-            // which reads as "this parameter is optional".
-            for name in schema_obj.required.iter_mut() {
-                if *name == old_key {
-                    *name = new_key.clone();
-                }
-            }
-            schema_obj.properties.insert(new_key, value);
-        }
+        transform_property_keys(&mut schema_obj);
 
         // Enrich every resource reference in the schema — including those
         // inside `items`, nested `properties`, etc. — with a description

--- a/backend/windmill-mcp/src/common/mod.rs
+++ b/backend/windmill-mcp/src/common/mod.rs
@@ -11,8 +11,8 @@ pub mod types;
 pub use schema::convert_schema_to_schema_type;
 pub use scope::{is_resource_allowed, parse_mcp_scopes, McpScopeConfig};
 pub use transform::{
-    apply_key_transformation, extract_hub_version_id_from_hashed,
-    extract_path_prefix_from_hashed, parse_tool_prefix, reverse_transform, reverse_transform_key,
-    transform_hub_path, transform_path,
+    apply_key_transformation, extract_hub_version_id_from_hashed, extract_path_prefix_from_hashed,
+    parse_tool_prefix, reverse_transform, reverse_transform_key, transform_hub_path,
+    transform_path, transform_property_keys,
 };
 pub use types::*;

--- a/backend/windmill-mcp/src/common/transform.rs
+++ b/backend/windmill-mcp/src/common/transform.rs
@@ -474,4 +474,18 @@ mod tests {
         assert!(schema.properties.contains_key("my_param"));
         assert_eq!(schema.required, vec!["my_param".to_string()]);
     }
+
+    #[test]
+    fn transform_property_keys_does_not_repeat_a_collided_required_name() {
+        let mut schema: SchemaType = serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "properties": { "a.b": { "type": "string" }, "ab": { "type": "string" } },
+            "required": ["a.b", "ab"],
+        }))
+        .unwrap();
+
+        transform_property_keys(&mut schema);
+
+        assert_eq!(schema.required, vec!["ab".to_string()]);
+    }
 }

--- a/backend/windmill-mcp/src/common/transform.rs
+++ b/backend/windmill-mcp/src/common/transform.rs
@@ -201,6 +201,32 @@ pub fn apply_key_transformation(key: &str) -> String {
         .collect::<String>()
 }
 
+/// Rename every property key that MCP argument names cannot carry, in both
+/// `properties` and `required`.
+///
+/// `required` names properties, so it has to follow the rename: an entry left
+/// pointing at the original key names a property that no longer exists, which reads
+/// to a client as "this parameter is optional".
+pub fn transform_property_keys(schema_obj: &mut SchemaType) {
+    let renames: Vec<(String, String)> = schema_obj
+        .properties
+        .keys()
+        .filter(|key| key.chars().any(|c| !c.is_alphanumeric() && c != '_'))
+        .map(|key| (key.clone(), apply_key_transformation(key)))
+        .collect();
+
+    for (old_key, new_key) in renames {
+        if let Some(value) = schema_obj.properties.remove(&old_key) {
+            schema_obj.properties.insert(new_key.clone(), value);
+        }
+        for name in schema_obj.required.iter_mut() {
+            if *name == old_key {
+                *name = new_key.clone();
+            }
+        }
+    }
+}
+
 /// Reverse the transformation of a key
 ///
 /// This function takes a transformed key and a schema object and reverses
@@ -422,5 +448,20 @@ mod tests {
         assert_eq!(apply_key_transformation("my key"), "my_key");
         assert_eq!(apply_key_transformation("key!@#"), "key");
         assert_eq!(apply_key_transformation("key_123"), "key_123");
+    }
+
+    #[test]
+    fn transform_property_keys_renames_required_alongside_properties() {
+        let mut schema: SchemaType = serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "properties": { "my param": { "type": "string" }, "kept": { "type": "string" } },
+            "required": ["my param"],
+        }))
+        .unwrap();
+
+        transform_property_keys(&mut schema);
+
+        assert!(schema.properties.contains_key("my_param"));
+        assert_eq!(schema.required, vec!["my_param".to_string()]);
     }
 }

--- a/backend/windmill-mcp/src/common/transform.rs
+++ b/backend/windmill-mcp/src/common/transform.rs
@@ -4,6 +4,7 @@
 //! to make them compatible with MCP tool naming requirements.
 
 use super::types::SchemaType;
+use std::collections::HashSet;
 use windmill_common::utils::calculate_hash;
 
 /// Max tool name length. The MCP spec allows 64 chars, but some clients
@@ -215,6 +216,10 @@ pub fn transform_property_keys(schema_obj: &mut SchemaType) {
         .map(|key| (key.clone(), apply_key_transformation(key)))
         .collect();
 
+    if renames.is_empty() {
+        return;
+    }
+
     for (old_key, new_key) in renames {
         if let Some(value) = schema_obj.properties.remove(&old_key) {
             schema_obj.properties.insert(new_key.clone(), value);
@@ -225,6 +230,11 @@ pub fn transform_property_keys(schema_obj: &mut SchemaType) {
             }
         }
     }
+
+    // Two keys can collapse onto the same name (`a.b` and `ab`). `required` is
+    // `uniqueItems`, and a strict validator rejects the whole tool over a repeat.
+    let mut seen = HashSet::new();
+    schema_obj.required.retain(|name| seen.insert(name.clone()));
 }
 
 /// Reverse the transformation of a key

--- a/backend/windmill-mcp/src/server/tools.rs
+++ b/backend/windmill-mcp/src/server/tools.rs
@@ -134,6 +134,10 @@ impl ToolableItem for HubScriptInfo {
 /// far more weight for that decision than the caller's system prompt, so the rule has
 /// to live here rather than being left to whoever configures the client.
 ///
+/// Kept terse: it repeats on every tool in the list. It also promises nothing about
+/// what an omitted parameter becomes -- a script falls back to its signature default,
+/// a flow input is simply absent.
+///
 /// Returns `None` when there is no optional parameter to mention.
 fn optional_params_hint(input_schema: &Map<String, Value>) -> Option<String> {
     let properties = input_schema.get("properties")?.as_object()?;
@@ -162,7 +166,7 @@ fn optional_params_hint(input_schema: &Map<String, Value>) -> Option<String> {
         .join(", ");
 
     Some(format!(
-        " Optional parameters: {}. Omit any parameter the request does not call for, and it falls back to its default. Never pass an empty string, empty array, empty object, `false`, or `0` as a placeholder for a value you were not given.",
+        " Optional parameters: {}. Omit any you were not given a value for rather than sending `\"\"`, `[]`, `{{}}`, `false`, or `0` as a placeholder.",
         names
     ))
 }

--- a/backend/windmill-mcp/src/server/tools.rs
+++ b/backend/windmill-mcp/src/server/tools.rs
@@ -4,8 +4,9 @@
 //! into MCP tools.
 
 use rmcp::model::{Tool, ToolAnnotations};
+use serde_json::{Map, Value};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::common::schema::{convert_schema_to_schema_type, make_schema_compatible};
@@ -124,6 +125,48 @@ impl ToolableItem for HubScriptInfo {
     }
 }
 
+/// Spell out, in the tool's own description, which parameters may be left out.
+///
+/// A tool schema that does not opt into strict function calling lets the model omit
+/// anything outside `required`, but models routinely fill every advertised property
+/// with a placeholder (`""`, `[]`, `false`, `0`) instead, which the script then reads
+/// as an explicit empty value rather than an absent one. The tool description carries
+/// far more weight for that decision than the caller's system prompt, so the rule has
+/// to live here rather than being left to whoever configures the client.
+///
+/// Returns `None` when there is no optional parameter to mention.
+fn optional_params_hint(input_schema: &Map<String, Value>) -> Option<String> {
+    let properties = input_schema.get("properties")?.as_object()?;
+
+    let required: HashSet<&str> = input_schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|names| names.iter().filter_map(|n| n.as_str()).collect())
+        .unwrap_or_default();
+
+    let mut optional: Vec<&str> = properties
+        .keys()
+        .map(String::as_str)
+        .filter(|name| !required.contains(name))
+        .collect();
+    if optional.is_empty() {
+        return None;
+    }
+    // `properties` comes from an unordered map, so sort for a stable description.
+    optional.sort_unstable();
+
+    let names = optional
+        .iter()
+        .map(|name| format!("`{}`", name))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Some(format!(
+        " Optional parameters: {}. Omit any parameter the request does not call for, and it falls back to its default. Never pass an empty string, empty array, empty object, `false`, or `0` as a placeholder for a value you were not given.",
+        names
+    ))
+}
+
 /// Create an MCP Tool from a ToolableItem
 ///
 /// The resources_cache should be pre-populated with all resource types
@@ -137,7 +180,7 @@ pub fn create_tool_from_item<T: ToolableItem, B: McpBackend>(
     let is_hub = item.is_hub();
     let path = item.get_transformed_path();
     let item_type = item.item_type();
-    let description = format!(
+    let mut description = format!(
         "This is a {} named `{}` with the following description: `{}`.{}",
         item_type,
         item.get_summary(),
@@ -181,6 +224,10 @@ pub fn create_tool_from_item<T: ToolableItem, B: McpBackend>(
         }
     };
 
+    if let Some(hint) = optional_params_hint(&input_schema_map) {
+        description.push_str(&hint);
+    }
+
     let title = {
         let summary = item.get_summary();
         if summary == "No summary" {
@@ -203,4 +250,44 @@ pub fn create_tool_from_item<T: ToolableItem, B: McpBackend>(
             .idempotent(false) // Are not guaranteed to be idempotent
             .open_world(true), // Can interact with external services
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn input_schema(raw: Value) -> Map<String, Value> {
+        raw.as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn hint_lists_optional_params_and_never_a_required_one() {
+        let hint = optional_params_hint(&input_schema(json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "page": { "type": "number", "default": 1 },
+                "filters": { "type": "object" },
+            },
+            "required": ["query"],
+        })))
+        .expect("a schema with optional params gets a hint");
+
+        assert!(
+            hint.contains("Optional parameters: `filters`, `page`."),
+            "{hint}"
+        );
+        assert!(!hint.contains("`query`"), "{hint}");
+    }
+
+    #[test]
+    fn no_hint_when_every_param_is_required() {
+        assert!(optional_params_hint(&input_schema(json!({
+            "type": "object",
+            "properties": { "query": { "type": "string" } },
+            "required": ["query"],
+        })))
+        .is_none());
+    }
 }

--- a/backend/windmill-mcp/src/server/tools.rs
+++ b/backend/windmill-mcp/src/server/tools.rs
@@ -135,6 +135,11 @@ const PLACEHOLDERS: &str = "`\"\"`, `[]`, `{}`, `false`, or `0`";
 /// runs, and they weigh a tool's own description far more heavily than the caller's
 /// system prompt. Kept terse: this repeats on every tool in the list.
 fn omission_hint(input_schema: &Map<String, Value>, item_type: &str) -> Option<String> {
+    let properties = input_schema.get("properties")?.as_object()?;
+    if properties.is_empty() {
+        return None;
+    }
+
     // A script's `required` is derived from its signature, so "not required" means the
     // parameter has a default and may genuinely be left out. A flow's is a per-input
     // toggle that defaults to off, so naming its inputs optional would invite the model
@@ -144,8 +149,6 @@ fn omission_hint(input_schema: &Map<String, Value>, item_type: &str) -> Option<S
             " Never send {PLACEHOLDERS} as a placeholder for a parameter you were not given a value for."
         ));
     }
-
-    let properties = input_schema.get("properties")?.as_object()?;
 
     let required: HashSet<&str> = input_schema
         .get("required")
@@ -304,6 +307,16 @@ mod tests {
         .clone();
 
         assert!(omission_hint(&all_required, "script").is_none());
+    }
+
+    #[test]
+    fn no_hint_for_a_parameterless_tool() {
+        let empty = json!({ "type": "object", "properties": {}, "required": [] })
+            .as_object()
+            .unwrap()
+            .clone();
+
+        assert!(omission_hint(&empty, "flow").is_none());
     }
 
     #[test]

--- a/backend/windmill-mcp/src/server/tools.rs
+++ b/backend/windmill-mcp/src/server/tools.rs
@@ -125,21 +125,26 @@ impl ToolableItem for HubScriptInfo {
     }
 }
 
-/// Spell out, in the tool's own description, which parameters may be left out.
+/// Placeholder values a model reaches for when it will not leave a parameter out.
+const PLACEHOLDERS: &str = "`\"\"`, `[]`, `{}`, `false`, or `0`";
+
+/// State the omission rule in the tool's own description.
 ///
-/// A tool schema that does not opt into strict function calling lets the model omit
-/// anything outside `required`, but models routinely fill every advertised property
-/// with a placeholder (`""`, `[]`, `false`, `0`) instead, which the script then reads
-/// as an explicit empty value rather than an absent one. The tool description carries
-/// far more weight for that decision than the caller's system prompt, so the rule has
-/// to live here rather than being left to whoever configures the client.
-///
-/// Kept terse: it repeats on every tool in the list. It also promises nothing about
-/// what an omitted parameter becomes -- a script falls back to its signature default,
-/// a flow input is simply absent.
-///
-/// Returns `None` when there is no optional parameter to mention.
-fn optional_params_hint(input_schema: &Map<String, Value>) -> Option<String> {
+/// Models routinely fill every property of a non-strict tool schema with a placeholder
+/// rather than omitting it, turning "absent" into "explicitly empty" for the code that
+/// runs, and they weigh a tool's own description far more heavily than the caller's
+/// system prompt. Kept terse: this repeats on every tool in the list.
+fn omission_hint(input_schema: &Map<String, Value>, item_type: &str) -> Option<String> {
+    // A script's `required` is derived from its signature, so "not required" means the
+    // parameter has a default and may genuinely be left out. A flow's is a per-input
+    // toggle that defaults to off, so naming its inputs optional would invite the model
+    // to drop inputs the flow needs -- flows get the rule without the list.
+    if item_type == "flow" {
+        return Some(format!(
+            " Never send {PLACEHOLDERS} as a placeholder for a parameter you were not given a value for."
+        ));
+    }
+
     let properties = input_schema.get("properties")?.as_object()?;
 
     let required: HashSet<&str> = input_schema
@@ -166,8 +171,7 @@ fn optional_params_hint(input_schema: &Map<String, Value>) -> Option<String> {
         .join(", ");
 
     Some(format!(
-        " Optional parameters: {}. Omit any you were not given a value for rather than sending `\"\"`, `[]`, `{{}}`, `false`, or `0` as a placeholder.",
-        names
+        " Optional parameters: {names}. Omit any you were not given a value for rather than sending {PLACEHOLDERS} as a placeholder."
     ))
 }
 
@@ -228,7 +232,7 @@ pub fn create_tool_from_item<T: ToolableItem, B: McpBackend>(
         }
     };
 
-    if let Some(hint) = optional_params_hint(&input_schema_map) {
+    if let Some(hint) = omission_hint(&input_schema_map, item_type) {
         description.push_str(&hint);
     }
 
@@ -261,13 +265,8 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    fn input_schema(raw: Value) -> Map<String, Value> {
-        raw.as_object().unwrap().clone()
-    }
-
-    #[test]
-    fn hint_lists_optional_params_and_never_a_required_one() {
-        let hint = optional_params_hint(&input_schema(json!({
+    fn script_schema() -> Map<String, Value> {
+        json!({
             "type": "object",
             "properties": {
                 "query": { "type": "string" },
@@ -275,8 +274,16 @@ mod tests {
                 "filters": { "type": "object" },
             },
             "required": ["query"],
-        })))
-        .expect("a schema with optional params gets a hint");
+        })
+        .as_object()
+        .unwrap()
+        .clone()
+    }
+
+    #[test]
+    fn hint_lists_optional_params_and_never_a_required_one() {
+        let hint = omission_hint(&script_schema(), "script")
+            .expect("a schema with optional params gets a hint");
 
         assert!(
             hint.contains("Optional parameters: `filters`, `page`."),
@@ -287,11 +294,25 @@ mod tests {
 
     #[test]
     fn no_hint_when_every_param_is_required() {
-        assert!(optional_params_hint(&input_schema(json!({
+        let all_required = json!({
             "type": "object",
             "properties": { "query": { "type": "string" } },
             "required": ["query"],
-        })))
-        .is_none());
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert!(omission_hint(&all_required, "script").is_none());
+    }
+
+    #[test]
+    fn flow_hint_names_no_parameter() {
+        // A flow's `required` does not track defaults, so its inputs must never be
+        // advertised as optional.
+        let hint = omission_hint(&script_schema(), "flow").expect("flows still get the rule");
+
+        assert!(!hint.contains("Optional parameters"), "{hint}");
+        assert!(!hint.contains("`page`"), "{hint}");
     }
 }


### PR DESCRIPTION
## Summary

Closes #10640. An AI agent calling a Windmill script through a Windmill MCP resource fills
every optional parameter with a placeholder (`[]`, `false`, `0`, `""`) instead of leaving it
out, so a script that distinguishes "absent" from "empty" receives the wrong input.

Nothing in Windmill synthesizes those values. The advertised schema is correct (only
non-defaulted args land in `required`), the agent step forwards it to the provider untouched,
we do not enable OpenAI strict function calling, and `agent_actions` records the model's
arguments verbatim. The model over-fills a non-strict tool schema on its own, and a system
prompt is a weak lever against it because a tool's own description weighs far more heavily in
that decision.

So the instruction now travels with the tool instead of depending on whoever configures the
client. Every script, flow, and hub-script tool the MCP server advertises gets one sentence
appended to its description. For a script the sentence is derived from the schema's `required`
list — for the script in the issue:

> This is a script named `search catalog` with the following description: `Search the product
> catalog`. **Optional parameters: `filters`, `page`, `session_id`, `sort`. Omit any you were
> not given a value for rather than sending `""`, `[]`, `{}`, `false`, or `0` as a
> placeholder.**

A **flow** gets the placeholder rule without the parameter list:

> Never send `""`, `[]`, `{}`, `false`, or `0` as a placeholder for a parameter you were not
> given a value for.

A script's `required` is derived from its signature, so "not required" reliably means "has a
default and may be left out". A flow's is a per-input toggle that defaults to off
(`AddPropertyV2.svelte`, `EditableSchemaForm.svelte`) and no flow input default is applied
server-side, so listing a flow's inputs as optional would invite the model to drop inputs the
flow needs.

This benefits every MCP client, not only the AI agent step. The sentence is deliberately terse
because it repeats on every tool in a `tools/list`, and it promises nothing about what an
omitted parameter becomes.

What this deliberately does not do is strip "empty-looking" optional arguments server-side:
`[]`, `false` and `""` are all legal intentional values, so guessing would silently corrupt
correct calls, which is a worse failure than the current one.

## Changes

- `backend/windmill-mcp/src/server/tools.rs` — derive the optional-parameter list from the
  input schema that is actually advertised (post key-transformation and compatibility fixes,
  so the names match what the client sees) and append the omission rule to the tool
  description. Nothing is appended when every parameter is required.
- `backend/windmill-mcp/src/common/transform.rs` — new `transform_property_keys`, holding the
  property-key rename that previously lived inline in the MCP backend impl. It now renames the
  key in `required` as well: a `required` entry left pointing at the original name (`my param`
  when the property became `my_param`) named a property that no longer exists, which reads to
  a client as "this parameter is optional" — and would have made the new hint list a required
  parameter as optional. Entries are de-duplicated afterwards, since two keys can collapse onto
  one name (`a.b` and `ab`) and `required` is `uniqueItems`.
- `backend/windmill-api/src/mcp/core.rs` — call the extracted helper.

## Test plan

- [x] `cargo test -p windmill-mcp --features server` (74 passed) — four unit tests: the
      optional-list derivation, the all-required case, the flow variant, and the `required`
      rename
- [x] `cargo check -p windmill-api --features mcp`
- [x] Live `tools/list` against a local backend built with `--features quickjs,mcp`, using the
      exact script from the issue: description carries the hint, `required` is still
      `["query"]`
- [x] Live `tools/list` for a script whose parameters are all required: no hint appended
- [x] Live `tools/list` for a schema with a required key containing a space: advertised as
      `required: ["my_key"]` matching the renamed property, and only the genuinely optional
      parameter listed in the hint
- [x] Live `tools/list` for a flow whose two inputs are neither marked required: description
      carries the placeholder rule and names neither input

Not verified: whether the hint actually changes an OpenAI model's behaviour. No OpenAI
credentials are available in this environment, and the over-filling did not reproduce on the
models that were reachable, so the effect on a model that exhibits it is unmeasured. The issue
reporter has been asked to re-run their repro once this ships.

## Deliberately out of scope

The auto-generated API endpoint tools (`endpoint_tool_to_mcp_tool`) do not get the hint. They
have the most optional parameters of any tool in the list, and `build_query_string` filters
only `null`, so a model-supplied `""` is forwarded as a real query param (`?created_by=`) and
silently narrows the result set. That is worth fixing, but it is a different surface than the
issue reports and the better fix there is probably to drop empty query params server-side
rather than to spend prose on ~40 more tools. Happy to fold it in if preferred.
