### PR TITLE
fix: align variable value font size with the rest of the table

### DIFF
--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -412,7 +412,7 @@
 									</Cell>
 									<Cell>
 										<span class="inline-flex flex-row items-center gap-2">
-											<div class="text-sm break-words">
+											<div class="text-xs break-words">
 												{#if value}
 													{truncate(value, 20)}
 												{:else}


### PR DESCRIPTION
## Summary

On the Variables page, the Value column rendered its text one step larger than every other column. `Cell` already applies `text-xs text-primary` to body cells, but the value cell wrapped its content in an inner `div.text-sm`, overriding it — so Value looked bigger than Path and Description in the same row.

## Changes

- `frontend/src/routes/(root)/(logged)/variables/+page.svelte`: value cell `text-sm` → `text-xs`, matching the table's default cell size.

The contextual-variables tables below use `TableSimple`, which inherits `Cell`'s `text-xs`, so they were already correct and are untouched.

## Screenshots

Before (value at `text-sm`, larger than the neighbouring columns):

![variables-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-var-value-font-size/1786471052-variables-before.png)

After (value at `text-xs`, aligned with Path/Description):

![variables-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-var-value-font-size/1786471055-variables-after.png)

## Test plan

- [x] Variables page renders the value at the same size as the path and description columns
- [x] Secret variables still show the masked `****` placeholder and the eye-off icon, aligned with the value text