### PR TITLE
feat: bound how much disk a single duckdb job can spill

### DIFF
--- a/backend/windmill-duckdb-ffi-internal/Cargo.lock
+++ b/backend/windmill-duckdb-ffi-internal/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 [[package]]
 name = "duckdb"
 version = "1.10505.0"
-source = "git+https://github.com/windmill-labs/duckdb-rs?rev=475383b71cde3d009ca6eaa0cd733faa52bc7393#475383b71cde3d009ca6eaa0cd733faa52bc7393"
+source = "git+https://github.com/windmill-labs/duckdb-rs?rev=7190adfcf58624e7e9a7a2a1000bac18fed64c19#7190adfcf58624e7e9a7a2a1000bac18fed64c19"
 dependencies = [
  "arrow",
  "cast",
@@ -814,7 +814,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 [[package]]
 name = "libduckdb-sys"
 version = "1.10505.0"
-source = "git+https://github.com/windmill-labs/duckdb-rs?rev=475383b71cde3d009ca6eaa0cd733faa52bc7393#475383b71cde3d009ca6eaa0cd733faa52bc7393"
+source = "git+https://github.com/windmill-labs/duckdb-rs?rev=7190adfcf58624e7e9a7a2a1000bac18fed64c19#7190adfcf58624e7e9a7a2a1000bac18fed64c19"
 dependencies = [
  "cc",
  "diffy",

--- a/backend/windmill-duckdb-ffi-internal/Cargo.toml
+++ b/backend/windmill-duckdb-ffi-internal/Cargo.toml
@@ -11,10 +11,10 @@ chrono = "0.4.41"
 # identical DECIMAL. Building one by hand would mean reimplementing that
 # f64 → (mantissa, scale) inference.
 #
-# Not crates.io: a fork of duckdb-rs 1.10505.0 carrying one patch to the bundled engine —
+# Not crates.io: a fork of duckdb-rs 1.10505.0 carrying two patches to the bundled engine —
 # see docs/duckdb-isolation.md for why, and for the exit path back to the crates.io crate.
 # Pinned by rev, not branch, so `cargo update` cannot move the engine under us.
-duckdb = { git = "https://github.com/windmill-labs/duckdb-rs", rev = "475383b71cde3d009ca6eaa0cd733faa52bc7393", features = [
+duckdb = { git = "https://github.com/windmill-labs/duckdb-rs", rev = "7190adfcf58624e7e9a7a2a1000bac18fed64c19", features = [
     "bundled",
     "rust_decimal",
 ] }

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -68,7 +68,7 @@ pub extern "C" fn run_duckdb_ffi(
     collect_first_row_only: bool,
 ) -> *mut c_char {
     let resource_limits = match (ptr_to_opt_str(memory_limit), ptr_to_opt_str(temp_directory)) {
-        (Ok(m), Ok(t)) => Ok(ResourceLimits { memory_limit: m, temp_directory: t }),
+        (Ok(m), Ok(t)) => Ok(ResourceLimits::from_ffi(m, t)),
         (Err(e), _) | (_, Err(e)) => Err(e),
     };
     let (r, column_order) = match convert_args(
@@ -195,7 +195,7 @@ pub extern "C" fn prepare_duckdb_ffi(
     temp_directory: *const c_char,
 ) -> *mut c_char {
     let resource_limits = match (ptr_to_opt_str(memory_limit), ptr_to_opt_str(temp_directory)) {
-        (Ok(m), Ok(t)) => Ok(ResourceLimits { memory_limit: m, temp_directory: t }),
+        (Ok(m), Ok(t)) => Ok(ResourceLimits::from_ffi(m, t)),
         (Err(e), _) | (_, Err(e)) => Err(e),
     };
     let r = match convert_prepare_args(
@@ -229,6 +229,21 @@ pub extern "C" fn prepare_duckdb_ffi(
 struct ResourceLimits {
     memory_limit: Option<String>,
     temp_directory: Option<String>,
+    max_temp_directory_size: Option<String>,
+}
+
+impl ResourceLimits {
+    // The spill cap comes from the environment rather than from an FFI parameter: this
+    // cdylib is versioned separately from the worker and agent workers ship it out of band,
+    // so a signature change costs an ABI bump and a coordinated redeploy for what is a
+    // config value. Unset keeps DuckDB's default of 90% of the temp volume's free space.
+    fn from_ffi(memory_limit: Option<String>, temp_directory: Option<String>) -> Self {
+        let max_temp_directory_size = std::env::var("DUCKDB_MAX_TEMP_DIRECTORY_SIZE")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        ResourceLimits { memory_limit, temp_directory, max_temp_directory_size }
+    }
 }
 
 fn sql_single_quote(s: &str) -> String {
@@ -236,9 +251,10 @@ fn sql_single_quote(s: &str) -> String {
 }
 
 // Bounds memory so DuckDB spills to disk before blowing the cgroup cap and
-// getting the worker SIGKILLed. Spill goes to the job dir (when set) so it is
-// cleaned up with the job, otherwise DuckDB's default temp_directory is kept —
-// and either way the directory is then locked for the rest of the connection.
+// getting the worker SIGKILLed, and bounds the spill itself so one query cannot
+// fill the worker's disk. Spill goes to the job dir (when set) so it is cleaned
+// up with the job, otherwise DuckDB's default temp_directory is kept — and either
+// way the directory and its cap are locked for the rest of the connection.
 fn configure_duckdb_resource_limits(
     conn: &duckdb::Connection,
     limits: &ResourceLimits,
@@ -258,10 +274,17 @@ fn configure_duckdb_resource_limits(
             sql_single_quote(tmp)
         ));
     }
-    // Freeze it before any script statement can move it: on a remote directory
-    // `~TemporaryDirectoryHandle` throws out of a `noexcept` destructor, which is
-    // `std::terminate` — an abort taking this in-process worker and every job
-    // colocated on it down, uncatchable from Rust.
+    if let Some(max) = limits.max_temp_directory_size.as_deref() {
+        config_sql.push_str(&format!(
+            "SET max_temp_directory_size='{}';\n",
+            sql_single_quote(max)
+        ));
+    }
+    // Freeze the directory and the cap on it before any script statement can touch either:
+    // on a remote directory `~TemporaryDirectoryHandle` throws out of a `noexcept`
+    // destructor, which is `std::terminate` — an abort taking this in-process worker and
+    // every job colocated on it down, uncatchable from Rust — and a cap a script can raise
+    // leaves nothing bounding how much of the worker's disk one query fills.
     config_sql.push_str("SET lock_temp_directory=true;\n");
     conn.execute_batch(&config_sql).map_err(|e| {
         format!(
@@ -1281,8 +1304,8 @@ fn string_to_duckdb_time(s: &str) -> Result<duckdb::types::Value, String> {
     ))
 }
 
-// The bundled engine is not stock (docs/duckdb-isolation.md). These two guard the ways an
-// engine bump can drop the patch without anything else noticing.
+// The bundled engine is not stock (docs/duckdb-isolation.md). These guard the ways an engine
+// bump can drop the patches without anything else noticing.
 #[cfg(test)]
 mod patched_engine_tests {
     use super::*;
@@ -1310,6 +1333,7 @@ mod patched_engine_tests {
             &ResourceLimits {
                 memory_limit: Some("2MB".to_string()),
                 temp_directory: Some(temp_dir.display().to_string()),
+                max_temp_directory_size: None,
             },
         )
         .unwrap();
@@ -1333,6 +1357,54 @@ mod patched_engine_tests {
         let spilled = conn.execute_batch(SPILLING_QUERY);
         std::fs::remove_dir_all(&temp_dir).ok();
         spilled.expect("a locked temp directory must still be usable for spilling");
+    }
+
+    /// `DUCKDB_MAX_TEMP_DIRECTORY_SIZE` is the only thing standing between one query and the
+    /// worker's whole disk, so pin that a configured connection really does stop at it, names
+    /// the setting when it does, and leaves nothing behind for the next job to trip over.
+    #[test]
+    fn spilling_past_the_configured_cap_fails_the_query_and_cleans_up() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "windmill_duckdb_capped_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+
+        let spill_under_cap = |cap: &str| {
+            let conn = duckdb::Connection::open_in_memory().unwrap();
+            configure_duckdb_resource_limits(
+                &conn,
+                &ResourceLimits {
+                    memory_limit: Some("2MB".to_string()),
+                    temp_directory: Some(temp_dir.display().to_string()),
+                    max_temp_directory_size: Some(cap.to_string()),
+                },
+            )
+            .unwrap();
+            conn.execute_batch(SPILLING_QUERY)
+                .map_err(|e| e.to_string())
+        };
+
+        let err = spill_under_cap("1MB").expect_err("the cap did not stop the spill");
+        assert!(
+            err.contains("max_temp_directory_size"),
+            "the refusal must name the setting an operator can act on, got: {err}"
+        );
+        let leftover: Vec<_> = std::fs::read_dir(&temp_dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "a query killed by the cap must not leave its spill behind: {leftover:?}"
+        );
+
+        // DuckDB compresses temp files, so the failure above is only evidence of the cap if
+        // the same query gets through once the cap is out of the way.
+        let generous = spill_under_cap("1GB");
+        std::fs::remove_dir_all(&temp_dir).ok();
+        generous.expect("the query must still spill and finish under a cap that fits it");
     }
 
     fn spill_attempt(temp_dir: &std::path::Path, lock: bool) -> Result<(), String> {
@@ -1375,9 +1447,11 @@ mod patched_engine_tests {
         locked.expect("a locked temp directory must stay usable behind disabled_filesystems");
     }
 
-    /// The exemption above is only sound while the directory cannot be moved: a script that
-    /// repointed it would get a write primitive through the very fence it is exempt from. A
-    /// rebase can drop that half of the patch while leaving the spill test green, so pin it.
+    /// The exemption above is only sound while neither where the spill goes nor how much of
+    /// it there may be can be changed: a script that repointed the directory would get a
+    /// write primitive through the very fence it is exempt from, and one that raised the cap
+    /// would be left with nothing bounding what it writes to the worker's disk. A rebase can
+    /// drop either half of the patch while leaving the spill test green, so pin both.
     #[test]
     fn locking_the_temp_directory_makes_it_immutable() {
         let conn = duckdb::Connection::open_in_memory().unwrap();
@@ -1389,6 +1463,8 @@ mod patched_engine_tests {
         for stmt in [
             "SET temp_directory='/tmp/windmill_duckdb_elsewhere';",
             "RESET temp_directory;",
+            "SET max_temp_directory_size='100GB';",
+            "RESET max_temp_directory_size;",
             "SET lock_temp_directory=false;",
             "RESET lock_temp_directory;",
         ] {

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -274,24 +274,37 @@ fn configure_duckdb_resource_limits(
             sql_single_quote(tmp)
         ));
     }
+    let run = |sql: &str| {
+        conn.execute_batch(sql).map_err(|e| {
+            format!(
+                "Error configuring DuckDB resource limits: {}",
+                e.to_string()
+            )
+        })
+    };
+    run(&config_sql)?;
+    // Applied on its own rather than batched with the rest so an unparseable value names the
+    // knob to fix: it is spelled in the same units as DUCKDB_MEMORY_LIMIT and DuckDB's parse
+    // error says only "memory", so together the two are indistinguishable to whoever set them.
     if let Some(max) = limits.max_temp_directory_size.as_deref() {
-        config_sql.push_str(&format!(
+        conn.execute_batch(&format!(
             "SET max_temp_directory_size='{}';\n",
             sql_single_quote(max)
-        ));
+        ))
+        .map_err(|e| {
+            format!(
+                "Error applying DUCKDB_MAX_TEMP_DIRECTORY_SIZE='{}': {}",
+                max,
+                e.to_string()
+            )
+        })?;
     }
     // Freeze the directory and the cap on it before any script statement can touch either:
     // on a remote directory `~TemporaryDirectoryHandle` throws out of a `noexcept`
     // destructor, which is `std::terminate` — an abort taking this in-process worker and
     // every job colocated on it down, uncatchable from Rust — and a cap a script can raise
     // leaves nothing bounding how much of the worker's disk one query fills.
-    config_sql.push_str("SET lock_temp_directory=true;\n");
-    conn.execute_batch(&config_sql).map_err(|e| {
-        format!(
-            "Error configuring DuckDB resource limits: {}",
-            e.to_string()
-        )
-    })
+    run("SET lock_temp_directory=true;\n")
 }
 
 fn setup_duckdb_connection(
@@ -1387,8 +1400,11 @@ mod patched_engine_tests {
         };
 
         let err = spill_under_cap("1MB").expect_err("the cap did not stop the spill");
+        // Verbatim because the worker matches on it (`SPILL_CAP_ENGINE_MARKER` in
+        // `duckdb_executor.rs`) to correct the engine's advice to raise the cap, which the
+        // lock refuses. An engine bump that rewords this has to update that too.
         assert!(
-            err.contains("max_temp_directory_size"),
+            err.contains("This limit was set by the 'max_temp_directory_size' setting"),
             "the refusal must name the setting an operator can act on, got: {err}"
         );
         let leftover: Vec<_> = std::fs::read_dir(&temp_dir)

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -250,11 +250,10 @@ fn sql_single_quote(s: &str) -> String {
     s.replace('\'', "''")
 }
 
-// Bounds memory so DuckDB spills to disk before blowing the cgroup cap and
-// getting the worker SIGKILLed, and bounds the spill itself so one query cannot
-// fill the worker's disk. Spill goes to the job dir (when set) so it is cleaned
-// up with the job, otherwise DuckDB's default temp_directory is kept — and either
-// way the directory and its cap are locked for the rest of the connection.
+// Bounds memory so DuckDB spills before blowing the cgroup cap and getting the worker
+// SIGKILLed, and bounds the spill so one query cannot fill its disk. Spill goes to the job
+// dir when set, so it is cleaned up with the job; either way the directory and its cap are
+// then locked for the rest of the connection.
 fn configure_duckdb_resource_limits(
     conn: &duckdb::Connection,
     limits: &ResourceLimits,
@@ -299,11 +298,10 @@ fn configure_duckdb_resource_limits(
             )
         })?;
     }
-    // Freeze the directory and the cap on it before any script statement can touch either:
-    // on a remote directory `~TemporaryDirectoryHandle` throws out of a `noexcept`
-    // destructor, which is `std::terminate` — an abort taking this in-process worker and
-    // every job colocated on it down, uncatchable from Rust — and a cap a script can raise
-    // leaves nothing bounding how much of the worker's disk one query fills.
+    // Freeze both before any script statement can touch them. A remote temp directory makes
+    // `~TemporaryDirectoryHandle` throw out of a `noexcept` destructor — `std::terminate`,
+    // taking this in-process worker and every job on it down, uncatchable from Rust — and a
+    // cap a script can raise bounds nothing.
     run("SET lock_temp_directory=true;\n")
 }
 
@@ -1463,11 +1461,10 @@ mod patched_engine_tests {
         locked.expect("a locked temp directory must stay usable behind disabled_filesystems");
     }
 
-    /// The exemption above is only sound while neither where the spill goes nor how much of
-    /// it there may be can be changed: a script that repointed the directory would get a
-    /// write primitive through the very fence it is exempt from, and one that raised the cap
-    /// would be left with nothing bounding what it writes to the worker's disk. A rebase can
-    /// drop either half of the patch while leaving the spill test green, so pin both.
+    /// The exemption above is only sound while neither the spill's destination nor its size
+    /// can be changed: repointing the directory is a write primitive through the very fence
+    /// it is exempt from, and raising the cap leaves the disk unbounded. A rebase can drop
+    /// either half while leaving the spill test green, so pin both.
     #[test]
     fn locking_the_temp_directory_makes_it_immutable() {
         let conn = duckdb::Connection::open_in_memory().unwrap();

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -2034,8 +2034,27 @@ fn cgroup_bytes_to_duckdb_memory_limit(bytes: i64) -> Option<String> {
 // to the raw slice if it is somehow not a JSON string.
 fn decode_ffi_error(result_str: &str) -> String {
     let raw = result_str.strip_prefix("ERROR ").unwrap_or(result_str);
-    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_string())
+    let msg = serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_string());
+    match msg.contains(SPILL_CAP_ENGINE_MARKER) {
+        true => format!("{msg}\n{SPILL_CAP_HINT}"),
+        false => msg,
+    }
 }
+
+/// DuckDB's own wording when a query outgrows the spill cap. Asserted against real engine
+/// output by `spilling_past_the_configured_cap_fails_the_query_and_cleans_up` in
+/// `windmill-duckdb-ffi-internal`, so an engine bump that rewords it fails there rather than
+/// silently dropping the hint below.
+const SPILL_CAP_ENGINE_MARKER: &str = "This limit was set by the 'max_temp_directory_size' setting";
+
+/// That error ends by suggesting `PRAGMA max_temp_directory_size='10GiB'`, which every
+/// windmill connection refuses: the cap is frozen along with the temp directory, so following
+/// the advice yields a second, unrelated-looking permission error.
+const SPILL_CAP_HINT: &str = "\nThis spill cap is set on the worker \
+     (DUCKDB_MAX_TEMP_DIRECTORY_SIZE) and frozen for the life of the connection, so the PRAGMA \
+     suggested above is refused — a script cannot raise it. Spill less (fewer threads, a \
+     narrower scan, aggregating before the join), or ask an operator to raise the worker's \
+     limit.";
 
 fn run_duckdb_ffi_safe<'a>(
     query_block_list: impl Iterator<Item = &'a str>,

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -2035,26 +2035,51 @@ fn cgroup_bytes_to_duckdb_memory_limit(bytes: i64) -> Option<String> {
 fn decode_ffi_error(result_str: &str) -> String {
     let raw = result_str.strip_prefix("ERROR ").unwrap_or(result_str);
     let msg = serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_string());
-    match msg.contains(SPILL_CAP_ENGINE_MARKER) {
-        true => format!("{msg}\n{SPILL_CAP_HINT}"),
-        false => msg,
+    // Mirrors the filter the FFI applies to the same variable (`ResourceLimits::from_ffi`);
+    // they live in separate crates, so the rule is stated twice and must stay one rule.
+    let configured = env::var("DUCKDB_MAX_TEMP_DIRECTORY_SIZE").is_ok_and(|v| !v.trim().is_empty());
+    match spill_cap_hint(&msg, configured) {
+        Some(hint) => format!("{msg}\n{hint}"),
+        None => msg,
     }
 }
 
 /// DuckDB's own wording when a query outgrows the spill cap. Asserted against real engine
 /// output by `spilling_past_the_configured_cap_fails_the_query_and_cleans_up` in
 /// `windmill-duckdb-ffi-internal`, so an engine bump that rewords it fails there rather than
-/// silently dropping the hint below.
+/// silently dropping the hint.
 const SPILL_CAP_ENGINE_MARKER: &str = "This limit was set by the 'max_temp_directory_size' setting";
 
-/// That error ends by suggesting `PRAGMA max_temp_directory_size='10GiB'`, which every
-/// windmill connection refuses: the cap is frozen along with the temp directory, so following
-/// the advice yields a second, unrelated-looking permission error.
-const SPILL_CAP_HINT: &str = "\nThis spill cap is set on the worker \
-     (DUCKDB_MAX_TEMP_DIRECTORY_SIZE) and frozen for the life of the connection, so the PRAGMA \
-     suggested above is refused — a script cannot raise it. Spill less (fewer threads, a \
-     narrower scan, aggregating before the join), or ask an operator to raise the worker's \
-     limit.";
+/// Split out of [`decode_ffi_error`] so the branch is testable without mutating the process
+/// environment. The engine emits the same text for a configured cap and for its own default,
+/// so which limit was hit has to come from the worker's config, not from the message.
+fn spill_cap_hint(msg: &str, configured: bool) -> Option<&'static str> {
+    if !msg.contains(SPILL_CAP_ENGINE_MARKER) {
+        return None;
+    }
+    Some(if configured {
+        SPILL_CAP_CONFIGURED
+    } else {
+        SPILL_CAP_DEFAULT
+    })
+}
+
+/// Both hints open by contradicting the engine, whose message ends by suggesting
+/// `PRAGMA max_temp_directory_size='10GiB'`: every windmill connection refuses that, since the
+/// cap is frozen along with the temp directory, so following it yields a second,
+/// unrelated-looking permission error. True either way, because the lock is unconditional.
+const SPILL_CAP_CONFIGURED: &str = "\nThe PRAGMA suggested above is refused: this connection's \
+     temp directory and the cap on it are frozen, so a script cannot raise the limit. That limit \
+     is the worker's DUCKDB_MAX_TEMP_DIRECTORY_SIZE. Spill less (fewer threads, a narrower scan, \
+     aggregating before the join), or ask an operator to raise it.";
+
+/// Nothing configured a cap, so this is DuckDB's own default and the worker is genuinely low on
+/// disk. Naming the env var here would send the reader after a knob nobody set.
+const SPILL_CAP_DEFAULT: &str = "\nThe PRAGMA suggested above is refused: this connection's temp \
+     directory and the cap on it are frozen, so a script cannot raise the limit. No cap is \
+     configured on this worker, so that limit is DuckDB's default of 90% of the free space on \
+     its temp volume: the worker is low on disk. Free space on it, or spill less (fewer threads, \
+     a narrower scan, aggregating before the join).";
 
 fn run_duckdb_ffi_safe<'a>(
     query_block_list: impl Iterator<Item = &'a str>,
@@ -2746,6 +2771,33 @@ mod tests {
         );
         // non-JSON payload falls back to the raw slice
         assert_eq!(decode_ffi_error("ERROR not json"), "not json");
+    }
+
+    /// The engine says the same thing whether the cap came from the worker or is its own
+    /// default, so the attribution has to come from the config — naming the env var on a
+    /// worker that never set it would send the reader after the wrong problem.
+    #[test]
+    fn spill_cap_hint_attributes_the_limit_to_whoever_set_it() {
+        let capped = "Out of Memory Error: failed to offload data block of size 256.0 KiB \
+             (18.9 MiB/19.0 MiB used).\nThis limit was set by the 'max_temp_directory_size' \
+             setting.\nYou can adjust this setting, by using (for example) PRAGMA \
+             max_temp_directory_size='10GiB'";
+
+        let configured = spill_cap_hint(capped, true).expect("the cap error must be recognised");
+        assert!(configured.contains("DUCKDB_MAX_TEMP_DIRECTORY_SIZE"));
+
+        let default = spill_cap_hint(capped, false).expect("the cap error must be recognised");
+        assert!(
+            !default.contains("DUCKDB_MAX_TEMP_DIRECTORY_SIZE") && default.contains("low on disk"),
+            "with nothing configured the hint must point at the disk, not at an unset variable"
+        );
+
+        // Both must contradict the PRAGMA the engine suggests, which the lock always refuses.
+        assert!([configured, default]
+            .iter()
+            .all(|h| h.contains("PRAGMA suggested above is refused")));
+
+        assert!(spill_cap_hint("Binder Error: column \"x\" not found", true).is_none());
     }
 
     fn test_ancestor(wid: &str) -> windmill_common::workspaces::DucklakeAncestorAttach {

--- a/docs/duckdb-isolation.md
+++ b/docs/duckdb-isolation.md
@@ -105,6 +105,12 @@ DuckDB's wording verbatim, which
 output so an engine bump that rewords it fails the test instead of silently dropping the
 correction.
 
+The engine emits that same message for **its own default cap**, so which limit was hit
+cannot be read off the message: with `DUCKDB_MAX_TEMP_DIRECTORY_SIZE` unset it means the
+worker is low on disk, not that anyone configured a ceiling. `spill_cap_hint` takes the
+answer from the worker's config instead and says whichever is true — naming the env var on a
+worker that never set it would point the reader at a knob that does not exist.
+
 ## Where the patched engine comes from
 
 `backend/windmill-duckdb-ffi-internal` depends on

--- a/docs/duckdb-isolation.md
+++ b/docs/duckdb-isolation.md
@@ -41,37 +41,71 @@ around.) The buffer manager, meanwhile, reaches its temp files through
 `FileSystem::GetFileSystem(db)`, an opener-wrapped virtual file system, so both the path
 allowlist and the disable apply to it.
 
-## What the patch adds
+## What the patches add
 
 `lock_temp_directory` (BOOLEAN, default false, global, irreversible). Setting it:
 
 1. fixes `temp_directory` in place — it can no longer be modified, and the setting itself
    cannot be unset or reset;
-2. routes the buffer manager's temporary files through a local file system that
+2. fixes `max_temp_directory_size` the same way, so the ceiling on what may be written
+   there cannot be raised either;
+3. routes the buffer manager's temporary files through a local file system that
    `disabled_filesystems` does not apply to.
 
-The two halves are what make it safe as a pair. The exemption is only sound because the
+The halves are what make it safe as a set. The exemption is only sound because the
 directory can no longer be redirected: without (1), a script could point `temp_directory`
-at an arbitrary path and get a blind write primitive through the exemption.
+at an arbitrary path and get a blind write primitive through the exemption. And it is only
+bounded because of (2): DuckDB accepts `SET max_temp_directory_size='100GB'` from any
+statement, so a cap a script can lift is not a cap.
 `allowed_directories` still applies either way.
 
 The isolation transform therefore emits `SET lock_temp_directory=true` **before**
 `disabled_filesystems`, while the local file system is still reachable, and after the FFI
 has already pointed `temp_directory` at the job dir
 (`configure_duckdb_resource_limits`). Everything a script authored runs after all three
-settings, so a script can never move the temp directory.
+settings, so a script can neither move the temp directory nor raise the cap on it.
+
+## Bounding the spill
+
+`configure_duckdb_resource_limits` sets `max_temp_directory_size` from
+`DUCKDB_MAX_TEMP_DIRECTORY_SIZE`, immediately before it takes the lock. Unset — the
+self-hosted default — leaves DuckDB's own default of 90% of the temp volume's free space,
+so nothing changes for an install that does not opt in. The cloud sets `6GiB` per worker
+pod (`cloudee/cloud/cloud.yml` in `infra-aws`); those pods run a single worker each, so it
+is effectively a per-pod cap and is not divided by `NUM_WORKERS`. They carry no
+`ephemeral-storage` limit, so what the cap has to stay clear of is the node's eviction
+threshold, not a per-pod one — 6 GiB against ~89 GiB of allocatable node disk shared by at
+most a handful of worker pods.
+
+It is read from the environment rather than passed across the FFI: the cdylib is versioned
+separately from the worker and agent workers ship it out of band, so a signature change
+would mean an ABI bump and a coordinated redeploy for what is a config value.
+
+The value is DuckDB's spelling, not Kubernetes': `KiB`/`MiB`/`GiB`/`TiB` for 1024-based
+units, `KB`/`MB`/`GB`/`TB` for 1000-based. Kubernetes' `6Gi` is not a unit DuckDB knows,
+and an unparseable value fails every DuckDB job on the worker rather than being ignored —
+a cap that quietly disappeared would be worse. `DUCKDB_MEMORY_LIMIT` has the same
+constraint, so the two read alike.
+
+Enforcement is graceful. A query that needs more spill than the cap fails with
+`Out of Memory Error: failed to offload data block of size … This limit was set by the
+'max_temp_directory_size' setting.`, its temp files are removed, and the worker carries on.
+Size it from measurement, not from the data: DuckDB compresses temp files, so the logical
+spill a given cap permits is well above the number set.
 
 ## Where the patched engine comes from
 
 `backend/windmill-duckdb-ffi-internal` depends on
 [`windmill-labs/duckdb-rs`](https://github.com/windmill-labs/duckdb-rs), branch
 `windmill/duckdb-1.5.5`, pinned by rev. That fork is duckdb-rs 1.10505.0 (DuckDB 1.5.5)
-plus one commit; `duckdb.tar.gz` is left byte-identical to upstream's and the patch is
-applied to the extracted sources at build time, so `git diff` against `duckdb/duckdb-rs`
-shows the whole delta as text. `crates/libduckdb-sys/windmill/README.md` in the fork
-carries the rebase recipe.
+plus the windmill commits; `duckdb.tar.gz` is left byte-identical to upstream's and
+`crates/libduckdb-sys/windmill/0*.patch` are applied to the extracted sources at build
+time, in order, so `git diff` against `duckdb/duckdb-rs` shows the whole delta as text.
+`0001` adds the setting and the exemption, `0002` extends the lock to
+`max_temp_directory_size`. `crates/libduckdb-sys/windmill/README.md` in the fork carries
+the rebase recipe.
 
-### The patch may not move a struct member
+### The patches may not move a struct member
 
 The engine loads the **prebuilt** extensions from `extensions.duckdb.org` — httpfs, azure,
 postgres, ducklake, parquet, and the rest of `EXTENSION_ALLOWLIST` — which are compiled
@@ -80,7 +114,7 @@ member those extensions reach breaks them, and not loudly: the extension reads t
 neighbouring field and `LOAD httpfs` **blocks forever** rather than failing, so every
 DuckDB job hangs until its timeout.
 
-The first revision of this patch declared its new `DatabaseInstance` member next to
+The first revision of `0001` declared its new `DatabaseInstance` member next to
 `local_db_file_system`, which pushed `create_api_v1` — the extension C-API entry point —
 8 bytes along, and every extension load hung. It is declared last for that reason, and
 `lock_temp_directory` is declared at the end of `DBConfigOptions`' run of bools so it takes
@@ -102,49 +136,58 @@ need the FFI builder stage in `Dockerfile` to copy more than
 `DUCKDB_LIB_DIR` would drop the `bundled` build, so every developer and every CI job
 would need a patched `libduckdb` on the box before `build_dev.sh` could work.
 
-## What stops the patch disappearing silently
+## What stops the patches disappearing silently
 
 An unpatched engine compiles, links and passes every existing test. Three things catch it:
 
-- **The fork's build script** asserts a marker string is present in the patched sources
-  after applying the patch, and panics if the patch no longer applies.
+- **The fork's build script** asserts each patch's marker string is present in the patched
+  sources after applying it, and panics if one no longer applies.
 - **`patched_engine_tests` in the FFI crate** runs a query that must spill, first
   without the lock (asserting the fence stops it, which is what proves the query really
-  spills) and then with it (asserting it succeeds). It fails outright on a stock engine,
-  where the `SET` is an unrecognized parameter. CI runs it via the FFI crate's own
-  `cargo test` step in `backend-test.yml`.
+  spills) and then with it (asserting it succeeds); it also pins that the lock leaves
+  neither `temp_directory` nor `max_temp_directory_size` settable, and that a configured
+  connection stops at its cap. It fails outright on a stock engine, where the `SET` is an
+  unrecognized parameter. CI runs it via the FFI crate's own `cargo test` step in
+  `backend-test.yml`.
 - **The transform itself fails closed**: on a stock engine `SET lock_temp_directory=true`
   errors, so every DuckDB job on an isolating worker fails immediately rather than
   quietly losing the ability to spill.
 
 ## Upstream
 
-The patch is written against `duckdb/duckdb` `v1.5.5` in the shape upstream takes changes.
-Besides the engine sources it carries `src/common/settings.json` (the settings generator's
-input, regenerated with `scripts/generate_settings.py` and formatted with clang-format
-11.0.1), two sqllogictests under `test/sql/settings/`, and one line in
+Both patches are written against `duckdb/duckdb` `v1.5.5` in the shape upstream takes
+changes. Besides the engine sources they carry `src/common/settings.json` (the settings
+generator's input, regenerated with `scripts/generate_settings.py` and formatted with
+clang-format 11.0.1), two sqllogictests under `test/sql/settings/`, and one line in
 `test/api/test_reset.cpp` — that test requires every setting to survive a `RESET`, so an
 irreversible one has to join the exclusion list `disabled_filesystems` and
-`lock_configuration` are already on. It is a `git format-patch` file, so it applies with
+`lock_configuration` are already on. They are `git format-patch` files, so they apply with
 `git am`:
 
 ```bash
 git clone https://github.com/duckdb/duckdb.git && cd duckdb && git checkout v1.5.5
-git am < .../crates/libduckdb-sys/windmill/0001-lock-temp-directory.patch
+git am .../crates/libduckdb-sys/windmill/0*.patch
 GEN=ninja make && ./build/release/test/unittest "test/sql/settings/lock_temp_directory*"
 ```
 
-It is filed as **[duckdb/duckdb#24694](https://github.com/duckdb/duckdb/pull/24694)**,
-against `main` rather than `v1.5.5`. Filing was a human decision on purpose: their
-`CONTRIBUTING.md` asks contributors not to submit LLM-generated pull requests, to discuss
-the change on GitHub first, and to run CI on a fork before opening one.
+`0001` is filed as
+**[duckdb/duckdb#24694](https://github.com/duckdb/duckdb/pull/24694)**, against `main`
+rather than `v1.5.5`. Filing was a human decision on purpose: their `CONTRIBUTING.md` asks
+contributors not to submit LLM-generated pull requests, to discuss the change on GitHub
+first, and to run CI on a fork before opening one.
+
+**`0002` is windmill-only and is not on #24694.** It is kept as a separate commit rather
+than folded into `0001` for exactly that reason: `0001` stays byte-identical to what the
+open PR carries, and `0002` applies to it verbatim as a second commit whenever a human
+chooses to push it. That is the one sanctioned divergence; when it is pushed, say so here
+and in the fork's `windmill/README.md`, and the "same change" rule below covers it too.
 
 **[duckdb/duckdb#24695](https://github.com/duckdb/duckdb/issues/24695)** states the
 underlying problem without prescribing a fix, and is where a different design would land:
 `lock_temp_directory` is one shape, and an enforceable `allowed_directories` would solve it
 equally well. Watch the issue rather than the PR for whether this fork can be retired.
 
-The vendored copy and #24694 are the same change and must stay that way. They differ only
+`0001` and #24694 are the same change and must stay that way. They differ only
 where the base version forces it: the `DUCKDB_SETTING_ALIAS` indices, `vfs` versus
 `db.config.file_system` in `FileSystem::GetLocal`, and the sqllogictest directory
 placeholder. Nothing else should diverge. Note that the build applies neither the `test/`

--- a/docs/duckdb-isolation.md
+++ b/docs/duckdb-isolation.md
@@ -72,10 +72,17 @@ settings, so a script can neither move the temp directory nor raise the cap on i
 self-hosted default — leaves DuckDB's own default of 90% of the temp volume's free space,
 so nothing changes for an install that does not opt in. The cloud sets `6GiB` per worker
 pod (`cloudee/cloud/cloud.yml` in `infra-aws`); those pods run a single worker each, so it
-is effectively a per-pod cap and is not divided by `NUM_WORKERS`. They carry no
-`ephemeral-storage` limit, so what the cap has to stay clear of is the node's eviction
-threshold, not a per-pod one — 6 GiB against ~89 GiB of allocatable node disk shared by at
-most a handful of worker pods.
+is effectively a per-pod cap and is not divided by `NUM_WORKERS`.
+
+Those pods carry no `ephemeral-storage` limit, so what the cap has to stay clear of is the
+node's eviction threshold rather than a per-pod one, and the budget is tighter than the
+node's size suggests: a worker pod already holds 4.7-6.9 GiB of language-runtime caches and
+job dirs before any spill, so a ~100 GB node running 5-6 of them sits at 45-60 GB used at
+rest. Every pod on the fullest node spilling to its cap at the same instant would land near
+the kubelet's default `nodefs.available<10%`. That is the tail, not the common case, and it
+is still bounded where the previous behaviour was not — one query could take all the free
+space by itself — but the cap is sized against a mostly-full node, not an empty one. Re-measure
+before raising it, and re-measure if the runtime-cache baseline grows.
 
 It is read from the environment rather than passed across the FFI: the cdylib is versioned
 separately from the worker and agent workers ship it out of band, so a signature change

--- a/docs/duckdb-isolation.md
+++ b/docs/duckdb-isolation.md
@@ -84,14 +84,26 @@ would mean an ABI bump and a coordinated redeploy for what is a config value.
 The value is DuckDB's spelling, not Kubernetes': `KiB`/`MiB`/`GiB`/`TiB` for 1024-based
 units, `KB`/`MB`/`GB`/`TB` for 1000-based. Kubernetes' `6Gi` is not a unit DuckDB knows,
 and an unparseable value fails every DuckDB job on the worker rather than being ignored —
-a cap that quietly disappeared would be worse. `DUCKDB_MEMORY_LIMIT` has the same
-constraint, so the two read alike.
+a cap that quietly disappeared would be worse. `DUCKDB_MEMORY_LIMIT` is spelled the same
+way and DuckDB's parse error says only "memory", so the cap's `SET` is issued on its own
+statement: batched together, a bad value in either would produce the same message and name
+neither.
 
 Enforcement is graceful. A query that needs more spill than the cap fails with
 `Out of Memory Error: failed to offload data block of size … This limit was set by the
 'max_temp_directory_size' setting.`, its temp files are removed, and the worker carries on.
 Size it from measurement, not from the data: DuckDB compresses temp files, so the logical
 spill a given cap permits is well above the number set.
+
+That engine message goes on to suggest `PRAGMA max_temp_directory_size='10GiB'`, which the
+lock refuses — advice that was actionable before the cap was frozen and is now a dead end
+ending in a second, unrelated-looking permission error. `decode_ffi_error`
+(`duckdb_executor.rs`) appends a correction whenever the message appears, on every worker
+rather than only isolating ones, since the lock is taken on every connection. It matches
+DuckDB's wording verbatim, which
+`spilling_past_the_configured_cap_fails_the_query_and_cleans_up` asserts against real engine
+output so an engine bump that rewords it fails the test instead of silently dropping the
+correction.
 
 ## Where the patched engine comes from
 


### PR DESCRIPTION
## Summary

DuckDB runs in-process in the worker, and since #10607 spills normally on an isolating
worker: the patched engine's `lock_temp_directory` freezes `temp_directory` and in exchange
exempts the buffer manager's spill files from `SET disabled_filesystems='LocalFileSystem'`.

Nothing bounded how much they spill. One query could fill the worker's disk, taking every
job colocated on it down with it. DuckDB has `max_temp_directory_size` for exactly this, but
setting it alone is a guardrail against accidents rather than a bound: `SET
max_temp_directory_size='100GB'` was accepted from any script statement, so a query could
lift the cap and carry on. A cap a script can raise is not a cap.

So this does both halves: the FFI sets the cap, and the engine patch freezes it under the
same lock that already freezes the directory. Unset means unchanged behaviour, so
self-hosted installs are unaffected unless an operator opts in. The cloud sets `6GiB` per
worker pod (windmill-labs/infra-aws#60, merged).

## Changes

- **`configure_duckdb_resource_limits`** emits `SET max_temp_directory_size` from
  `DUCKDB_MAX_TEMP_DIRECTORY_SIZE`, immediately before it takes the lock. The value is read
  from the environment rather than added to the FFI signature: the cdylib is versioned
  separately and agent workers ship it out of band, so a signature change would cost an ABI
  bump and a coordinated redeploy for what is a config value. It is carried on
  `ResourceLimits` so the SQL-emitting function stays a pure function of its input and the
  env is read once, at the FFI boundary.
- **Engine patch**: repins the `duckdb-rs` fork to `7190adf`, which adds
  `windmill/0002-lock-the-temp-directory-size-cap.patch` — `lock_temp_directory` now makes
  `max_temp_directory_size` immutable too, `SET` and `RESET` alike.
- **Tests**: `spilling_past_the_configured_cap_fails_the_query_and_cleans_up` pins that a
  configured connection stops at its cap, names the setting when it does, and leaves no
  spill behind (with a generous-cap control, since DuckDB compresses temp files and the
  failure is only evidence of the cap if the same query gets through without it).
  `locking_the_temp_directory_makes_it_immutable` gains the two cap statements.
- **Error messages**, added in review: DuckDB's cap error ends by suggesting `PRAGMA
  max_temp_directory_size='10GiB'`, which the lock now refuses — advice that was actionable
  before this PR and is now a dead end. `decode_ffi_error` appends a correction. The engine
  emits the same text for its *own* default cap, so `spill_cap_hint` takes the attribution
  from the worker's config: with the var set it names it, unset it says the worker is low on
  disk rather than blaming a variable nobody set. The cap's `SET` is also issued on its own
  statement, so an unparseable value names the env var instead of producing wording
  indistinguishable from a bad `DUCKDB_MEMORY_LIMIT`.
- **`docs/duckdb-isolation.md`**: the new half of the lock, the env var, the cloud default
  and its sizing, and the units gotcha.

### On the upstream patch

`0001` is filed as [duckdb/duckdb#24694](https://github.com/duckdb/duckdb/pull/24694) and is
under review. `0002` is kept as a **separate commit rather than an amendment** so `0001`
stays byte-identical to what that PR carries, and `0002` applies to it verbatim as a second
commit whenever a human chooses to push it. It is **windmill-only for now** — filing
upstream was a human decision on purpose (duckdb's `CONTRIBUTING.md` asks contributors not
to submit LLM-generated pull requests), so this is a deliberate, declared divergence rather
than drift. Both `docs/duckdb-isolation.md` and the fork's `windmill/README.md` say so and
say what to do when it is pushed.

### Sizing note for the cloud

The cloud worker pods carry **no `ephemeral-storage` limit**, so what the cap must stay
clear of is the node's eviction threshold rather than a per-pod one. They run a single worker
each (`NUM_WORKERS` unset, default 1), so no division is needed.

I initially sized this against node capacity alone and got it wrong; measured on the live
cluster instead:

| node | nodefs | used at rest | cloud worker pods | their ephemeral-storage |
|---|---|---|---|---|
| `ip-10-2-15-45` | 99.9G | 45.3G (55% free) | 6 | 33.4G |
| `ip-10-2-20-115` | 99.9G | 59.1G (41% free) | 5 | 27.6G |
| `ip-10-2-27-31` | 99.9G | 56.8G (43% free) | 3 | 14.6G |

A worker pod already holds **4.7–6.9 GiB** of language-runtime caches and job dirs before any
spill. So the budget is not "6GiB against ~89GiB free" — on the fullest node above, all five
pods spilling to the cap simultaneously would land at roughly 11% free, i.e. near the
kubelet's default `nodefs.available<10%` eviction threshold. That is the tail rather than the
common case (it needs five concurrent max-spill DuckDB jobs on one node, each in a 2Gi pod),
and it is still strictly better than today, where a single query can take all the free space
by itself. But 6GiB is sized against a mostly-full node, not an empty one — worth knowing
before raising it, and worth re-measuring if the runtime-cache baseline grows.

`6GiB`, not Kubernetes' `6Gi` — DuckDB accepts `KiB`/`MiB`/`GiB`/`TiB` and `KB`/`MB`/`GB`/`TB`
and rejects anything else outright.

## Test plan

Layout invariant (`docs/duckdb-isolation.md`: no pre-existing struct member may change offset):

- [x] `clang++ -Xclang -fdump-record-layouts` diff of `0001` vs `0001+0002` — **byte-identical**;
      this patch adds no struct member.
- [x] vs stock v1.5.5 — only the two *added* lines from `0001` and its `sizeof` growth; no
      member moved.
- [x] `prebuilt_extensions_still_load` passes (`INSTALL httpfs; LOAD httpfs;` returns, no hang).

DuckDB built from source with both patches applied:

- [x] `test/sql/settings/*` — 388 assertions, all pass (includes the extended
      `lock_temp_directory.test`).
- [x] `test/sql/storage/temp_directory/*` — 86 assertions, all pass (upstream's own
      `max_swap_space` suite).
- [x] `Test RESET statement for ClientConfig options` — 226 assertions, all pass.

FFI crate: `cargo test --release -p windmill_duckdb_ffi_internal` — 21/21 pass.

Real preview jobs on a worker built with `--features duckdb,private,parquet,quickjs` and
started with `ENABLE_UNSHARE_PID=true` (isolation transform active), `DUCKDB_MEMORY_LIMIT=32MB`,
`DUCKDB_MAX_TEMP_DIRECTORY_SIZE=20MB`:

- [x] settings read back as `cap=19.0 MiB, locked=true, tmpdir=<job dir>` — the env var
      reaches the connection.
- [x] under the cap: query spilled **15,204,352 bytes** (`duckdb_memory()`) and returned the
      right answer.
- [x] over the cap: `Out of Memory Error: failed to offload data block of size 256.0 KiB
      (18.9 MiB/19.0 MiB used). This limit was set by the 'max_temp_directory_size' setting.`
      — job dir left at **0 bytes**.
- [x] `SET max_temp_directory_size='100GB'` → `Permission Error: Modifying
      'max_temp_directory_size' is disabled - the temp directory has been locked`.
- [x] `SET temp_directory='/tmp/…'` → same refusal; `read_text('/etc/hostname')` still fenced.
- [x] worker log clean (no panic / stack overflow / SIGBUS) and the worker alive after every
      run, including the failures.
- [x] `DUCKDB_MAX_TEMP_DIRECTORY_SIZE=6GiB` (the cloud value) reads back as `6.0 GiB`.
- [x] env unset → `90% of available disk space`, DuckDB's default: self-hosted unaffected.
- [x] the over-cap error now carries the correction (`the PRAGMA suggested above is refused`).
- [x] `DUCKDB_MAX_TEMP_DIRECTORY_SIZE=6Gi` (the k8s spelling) fails closed with `Error applying
      DUCKDB_MAX_TEMP_DIRECTORY_SIZE='6Gi': Parser Error: Unknown unit for memory: 'gi'`.

No frontend surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound DuckDB temp spill per job to prevent a single query from filling a worker’s disk. The cap comes from `DUCKDB_MAX_TEMP_DIRECTORY_SIZE`, is locked, and over-cap errors include a clear hint; cloud default is 6GiB, self‑hosted unchanged unless configured.

- **New Features**
  - Set `max_temp_directory_size` from `DUCKDB_MAX_TEMP_DIRECTORY_SIZE`, then lock it with `temp_directory`; `SET`/`RESET` are blocked.
  - Over‑cap queries fail cleanly and remove temp files; the worker appends a hint and corrects DuckDB’s PRAGMA advice. Hint attributes the limit to the env var when set, or to DuckDB’s default (low disk) when unset.
  - Spill files remain usable behind `disabled_filesystems` after the lock.
  - Repinned to `duckdb-rs` `7190adf` with two engine patches; no FFI signature change.
  - Docs: added cloud sizing guidance based on real pod disk usage and unit notes; cloud default 6GiB, self‑hosted unchanged unless configured.

- **Bug Fixes**
  - Do not blame `DUCKDB_MAX_TEMP_DIRECTORY_SIZE` when unset; the hint now points to DuckDB’s default and low disk.
  - Apply the cap in its own `SET` so parse errors clearly name `DUCKDB_MAX_TEMP_DIRECTORY_SIZE`.

<sup>Written for commit b47084928f476a73b1260317610c35b967648369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

