### PR TITLE
fix: decycle the recursive TriggerFilter schema in the python client

### DIFF
--- a/python-client/build.sh
+++ b/python-client/build.sh
@@ -22,11 +22,18 @@ sed -z "
 
 npx @redocly/openapi-cli@latest bundle openapi/openapi.yaml > openapi-bundled.yaml
 
-sed -z 's/FlowModuleValue:/FlowModuleValue2:/;s/RestartedFrom:/RestartedFrom2:/' openapi-bundled.yaml > openapi-decycled.yaml
+# The dereferenced JSON below cannot express a cycle, so every self-referencing schema
+# must be renamed and left with an empty stub under its original name: the refs pointing
+# back at it then resolve to the stub. A new recursive schema fails the bundle step with
+# "Detected circular reference which can't be converted to JSON" until it is listed here.
+sed -z 's/FlowModuleValue:/FlowModuleValue2:/;s/RestartedFrom:/RestartedFrom2:/;s/TriggerFilter:/TriggerFilter2:/' openapi-bundled.yaml > openapi-decycled.yaml
 
 echo "    FlowModuleValue: {}" >> openapi-decycled.yaml
 echo "    RestartedFrom: {}" >> openapi-decycled.yaml
+echo "    TriggerFilter: {}" >> openapi-decycled.yaml
 npx @redocly/openapi-cli@latest bundle openapi-decycled.yaml --ext json -d > openapi-deref.json
+# redocly reports a bundling error on stderr but still exits 0, leaving the file empty
+[ -s openapi-deref.json ] || { echo "openapi-deref.json is empty: bundling failed" >&2; exit 1; }
 
 sed '$d' .gitignore > .gitignore2
 mv .gitignore2 .gitignore


### PR DESCRIPTION
## Summary

The `Publish python-client` workflow failed on tag v1.785.0 ([run 31522779400](https://github.com/windmill-labs/windmill/actions/runs/31522779400/job/93883730065)).

`python-client/build.sh` dereferences the bundled OpenAPI spec into **JSON**, which cannot express a cycle. #10625 added `TriggerFilter`, which `$ref`s itself for its `any_of` / `all_of` / `none_of` groups, so redocly printed `Detected circular reference which can't be converted to JSON` and wrote an empty file. Because it still exits 0, the build carried on and only failed two steps later at the generator with the misleading `Invalid JSON from provided source`.

The script already has a decycling convention for exactly this (`FlowModuleValue`, `RestartedFrom`): the schema is renamed to `<Name>2` and an empty `<Name>: {}` stub is appended, so the refs pointing back at it resolve to the stub. `TriggerFilter` now gets the same treatment, which makes trigger `filters` untyped in the generated python client and keeps the real definition under `TriggerFilter2`.

Other clients are unaffected: `backend/windmill-api/build_openapi.sh` dereferences to YAML (which represents cycles with anchors) and `go-client/build.sh` does not pass `-d`.

## Changes

- Decycle `TriggerFilter` in `python-client/build.sh`, alongside the existing `FlowModuleValue` and `RestartedFrom` entries
- Fail the build when the dereferenced bundle comes out empty, so the next recursive schema stops at the step that actually broke instead of surfacing as a JSON parse error downstream
- Comment the constraint at the decycle step, since the failure only ever appears at release time

## Test plan

- [x] Reproduced the CI failure locally by replaying the pipeline against current `openapi.yaml` (empty `openapi-deref.json`, same redocly error)
- [x] With the fix, `redocly bundle --ext json -d` produces a valid 7.5 MB spec; `TriggerFilter` is the `{}` stub and `TriggerFilter2` keeps all five `oneOf` variants
- [x] `openapi-python-client==0.15.1` (the version pinned in `.github/DockerfilePypiBuilder`) generates the client from it: 7532 models, only the pre-existing `FlowModuleValue2` union warnings
- [x] Verified the new guard exits 1 with a clear message when given the unfixed input

## Note on releasing 1.785.0

The publish workflow is gated on `refs/tags/v*` and the `v1.785.0` tag points at the commit without this fix, so re-running the job will not publish it. Either force-move that tag onto a commit containing this fix and re-dispatch, or let the next release carry it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix python client OpenAPI bundling by decycling the recursive `TriggerFilter` schema and failing fast on empty deref output. This unblocks JSON generation with `@redocly/openapi-cli` and prevents misleading downstream errors.

- **Bug Fixes**
  - Include `TriggerFilter` in the decycle step: rename to `TriggerFilter2` and add a `{}` stub to break self-references.
  - Fail the build if `openapi-deref.json` is empty, since `@redocly/openapi-cli` can exit 0 on bundling errors.
  - Scope: changes limited to `python-client/build.sh`; other clients unchanged.

<sup>Written for commit e56bc6893202e7368e6fbf9e467fd6cdd39e918e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

