### PR TITLE
fix(frontend): skip reserved ids when auto-assigning flow module ids

### DIFF
--- a/frontend/src/lib/components/flows/flowModuleNextId.test.ts
+++ b/frontend/src/lib/components/flows/flowModuleNextId.test.ts
@@ -50,4 +50,15 @@ describe('nextId', () => {
 		const state = stateWith([...ids, 'process', 'my_step', 'failure'])
 		expect(nextId(state, flowWith(ids))).toBe('c')
 	})
+
+	// Regression for #10610: "ar" + 1 is "as", a reserved id. It must be skipped
+	// rather than assigned, otherwise it is reissued on every later call and the
+	// flow ends up with duplicate ids.
+	it('skips a reserved id instead of assigning it', () => {
+		expect(nextId(stateWith(['failure']), flowWith(['ar']))).toBe('at')
+	})
+
+	it('does not reissue a reserved id already present in the flow', () => {
+		expect(nextId(stateWith(['failure']), flowWith(['ar', 'as']))).toBe('at')
+	})
 })

--- a/frontend/src/lib/components/flows/flowModuleNextId.ts
+++ b/frontend/src/lib/components/flows/flowModuleNextId.ts
@@ -25,13 +25,22 @@ function autoIdNumber(key: string): number | undefined {
 
 // Computes the next available id
 export function nextId(flowState: FlowState, fullFlow: OpenFlow): string {
-	const allIds = dfs(fullFlow.value.modules, (fm) => fm.id)
+	const allKeys = dfs(fullFlow.value.modules, (fm) => fm.id).concat(Object.keys(flowState))
+	const takenIds = new Set(allKeys)
 
-	const max = allIds.concat(Object.keys(flowState)).reduce((acc, key) => {
+	const max = allKeys.reduce((acc, key) => {
 		const num = autoIdNumber(key)
 		return num === undefined ? acc : Math.max(acc, num + 1)
 	}, 0)
-	return numberToChars(max)
+
+	// A reserved id (e.g. "as", after "ar") never raises `max`, so assigning
+	// numberToChars(max) when it is reserved would make every later call return
+	// it again; skip forward to a free, allowed id instead.
+	let candidate = max
+	while (reservedIds.has(numberToChars(candidate)) || takenIds.has(numberToChars(candidate))) {
+		candidate++
+	}
+	return numberToChars(candidate)
 }
 
 // Computes a copy id like "a2", "a3", etc. based on the original id


### PR DESCRIPTION
Fixes #10610

`nextId` in `flowModuleNextId.ts` returned `numberToChars(max)` without checking whether that id was reserved. Once the highest existing module id reached `ar`, its successor `as` (which is in `forbiddenIds`) got assigned anyway. Reserved ids never raise `max` (`autoIdNumber` returns undefined for them), so the very next module was handed `as` again. Two modules with id `as` breaks the flow with "error parsing the flow" in normal steps, and silently hides ai agent tool nodes so they can't be edited.

The fix skips forward past any reserved or already-taken id before returning, so the sequence jumps `ar` -> `at` instead of landing on `as`. `getNextId` in `idUtils.ts` already treats `forbiddenIds` as taken, this brings `nextId` in line with that.

To reproduce on `main`: add a step, set its id to `ar`, add another step and it becomes `as`, add a third and the flow breaks with a duplicate `as`.

I extended `flowModuleNextId.test.ts` with two cases: the successor of `ar` skips the reserved `as` and lands on `at`, and a flow that already contains a leaked `as` does not get it reissued. I verified the generation logic against the real `numberToChars`/`charsToNumber`/`forbiddenIds` across the existing and new cases, all pass, and the change is a no-op for ids that were never reserved so the existing sequential and poisoning tests are unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip reserved ids when auto-assigning flow module ids to prevent duplicates and flow breakage. Fixes the `ar` → `as` collision by jumping to `at`, avoiding parse errors and hidden AI agent tool nodes.

- **Bug Fixes**
  - `nextId` now skips reserved or already-taken ids before returning, aligning with `getNextId`.
  - Added tests to confirm `ar` → `at` and that a leaked `as` is not reissued.

<sup>Written for commit e84c102bfa9a0ee0419f36c4876e7713799de34c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

