### PR TITLE
fix(frontend): skip reserved ids when auto-assigning flow module ids

### DIFF
--- a/frontend/src/lib/components/flows/flowModuleNextId.test.ts
+++ b/frontend/src/lib/components/flows/flowModuleNextId.test.ts
@@ -51,8 +51,7 @@ describe('nextId', () => {
 		expect(nextId(state, flowWith(ids))).toBe('c')
 	})
 
-	// A reserved id never raises the max, so assigning it ("as", the successor of "ar")
-	// would hand it out again on every later call and leave the flow with duplicate ids.
+	// "as", the successor of "ar", is the first reserved id the sequence reaches.
 	it('skips a reserved id instead of assigning it', () => {
 		expect(nextId(stateWith(['failure']), flowWith(['ar']))).toBe('at')
 	})

--- a/frontend/src/lib/components/flows/flowModuleNextId.test.ts
+++ b/frontend/src/lib/components/flows/flowModuleNextId.test.ts
@@ -50,4 +50,10 @@ describe('nextId', () => {
 		const state = stateWith([...ids, 'process', 'my_step', 'failure'])
 		expect(nextId(state, flowWith(ids))).toBe('c')
 	})
+
+	// A reserved id never raises the max, so assigning it ("as", the successor of "ar")
+	// would hand it out again on every later call and leave the flow with duplicate ids.
+	it('skips a reserved id instead of assigning it', () => {
+		expect(nextId(stateWith(['failure']), flowWith(['ar']))).toBe('at')
+	})
 })

--- a/frontend/src/lib/components/flows/flowModuleNextId.ts
+++ b/frontend/src/lib/components/flows/flowModuleNextId.ts
@@ -25,13 +25,23 @@ function autoIdNumber(key: string): number | undefined {
 
 // Computes the next available id
 export function nextId(flowState: FlowState, fullFlow: OpenFlow): string {
-	const allIds = dfs(fullFlow.value.modules, (fm) => fm.id)
+	const allKeys = dfs(fullFlow.value.modules, (fm) => fm.id).concat(Object.keys(flowState))
+	const takenIds = new Set(allKeys)
 
-	const max = allIds.concat(Object.keys(flowState)).reduce((acc, key) => {
+	const max = allKeys.reduce((acc, key) => {
 		const num = autoIdNumber(key)
 		return num === undefined ? acc : Math.max(acc, num + 1)
 	}, 0)
-	return numberToChars(max)
+
+	// A reserved id (e.g. "as", after "ar") never raises `max`, so assigning
+	// numberToChars(max) when it is reserved would make every later call return
+	// it again; skip forward to a free, allowed id instead.
+	let candidate = max
+	let id = numberToChars(candidate)
+	while (reservedIds.has(id) || takenIds.has(id)) {
+		id = numberToChars(++candidate)
+	}
+	return id
 }
 
 // Computes a copy id like "a2", "a3", etc. based on the original id


### PR DESCRIPTION
## Summary

Fixes #10610.

`nextId` returned `numberToChars(max)` without checking whether that id is reserved. Reserved ids never raise `max` — `autoIdNumber` returns `undefined` for them — so once the highest auto id reaches `ar`, its successor `as` gets assigned anyway, and then handed out again on every later call. Two modules with id `as` breaks the flow with "There are duplicate modules in the flow at id: as", and silently hides AI agent tool nodes so they can't be edited.

This is not an exotic edge case: `as` is the 45th auto-generated id, so a flow (or an agent's tool list, which shares the same id space) that grows past 45 steps hits it without anyone renaming anything. The other reserved ids the base-26 sequence can produce sit at the same kind of distance — `bg` (59th), `do` (119th), `if` (240th), `in` (248th), then `ctx`, `for`, `new`.

The fix skips forward past any reserved or already-taken id before returning, so the sequence jumps `ar` → `at`. `getNextId` in `idUtils.ts` already treats `forbiddenIds` as taken; this brings `nextId` in line with it.

Flows already poisoned by this keep their duplicate `as` and still need the id fixed by hand in the YAML editor — nothing repairs them on load.

Diagnosis and original patch by @eeshsaxena in #10650; reopened here because the CLA check blocks that branch.

## Changes

- `nextId` skips reserved and already-taken ids before returning one.
- Regression test pinning the successor of `ar` to `at`.

## Test plan

- [x] `vitest run src/lib/components/flows/flowModuleNextId.test.ts` — 6/6 pass.
- [x] Browser repro on a dev server: add a step, set its id to `ar`, add two more steps. On `main` the third add breaks the editor with "There are duplicate modules in the flow at id: as"; with the fix the ids run `ar`, `at`, `au` and the graph renders normally.

## Screenshots

**Before** (on `main`) — the third step re-uses `as` and the editor dies:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-flow-nextid-skip-reserved-ids/1786515890-wm-nextid-before-broken.png)

**After** — `as` is skipped, ids run `ar`, `at`, `au`:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-flow-nextid-skip-reserved-ids/1786515898-wm-nextid-after-fixed.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate flow module IDs by skipping reserved and already-used IDs when auto-assigning. This avoids editor crashes and hidden agent tool nodes; the sequence now goes `ar` → `at` (skips `as`) and continues normally.

- **Bug Fixes**
  - `nextId` builds a set of taken IDs from the graph and `flowState`, then skips reserved and used IDs until it finds a valid one.
  - Added a regression test asserting `ar` → `at`.

- **Migration**
  - Existing flows with duplicate `as` need a manual fix in the YAML editor; no auto-repair.

<sup>Written for commit 95d8552e97914747d825e0d5ccc2432ff98d0423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

