### PR TITLE
fix: avoid content shift on home page load and in the script editor logs pane

### DIFF
--- a/frontend/src/lib/components/LogViewer.svelte
+++ b/frontend/src/lib/components/LogViewer.svelte
@@ -367,7 +367,9 @@
 			>
 				{#if isLoading}
 					<div class="flex gap-2 items-center">
-						<Loader2 class="animate-spin" />
+						<!-- Same size as the Timer icon this swaps out for: an unsized (24px) spinner makes
+						     this header taller than the settled state and shoves the logs down while queued -->
+						<Loader2 size={small ? 10 : 12} class="animate-spin" />
 						{#if tag}
 							<div class="flex flex-row items-center gap-1">
 								<div class="text-secondary text-2xs">{tagLabel ?? 'tag'}: {tag}</div>

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -2270,14 +2270,10 @@
 							</div>
 						{:else}
 							{#key previewLayout}
-								<Splitpanes
-									horizontal={previewLayout !== 'bottom'}
-									class="!max-h-[calc(100%-{debugMode && isDebuggableScript
-										? '83'
-										: previewLayout === 'bottom'
-											? '0'
-											: '43'}px)]"
-								>
+								<!-- min-h-0 lets this shrink to the space the header row leaves it. Without it the
+								     100% height wins, the panes settle one header too tall, and any reflow during a
+								     run snaps them up and back. -->
+								<Splitpanes horizontal={previewLayout !== 'bottom'} class="min-h-0">
 									<Pane size={previewLayout === 'bottom' ? 40 : 33}>
 										{#if previewLayout === 'bottom' && !(debugMode && isDebuggableScript)}
 											<div class="px-3 pt-2 pb-1 flex items-center gap-2">

--- a/frontend/src/lib/components/home/TutorialBanner.svelte
+++ b/frontend/src/lib/components/home/TutorialBanner.svelte
@@ -61,6 +61,16 @@
 		hasCompletedAny = state === 'new'
 	}
 
+	// The banner is interactive while the initial sync is still in flight, so a dismiss or a skip
+	// can land mid-await. Once that happens the user's choice wins and the sync must not resurrect
+	// the banner.
+	let userHidBanner = false
+
+	function hideBannerForUser() {
+		userHidBanner = true
+		resolveState('hidden')
+	}
+
 	onMount(async () => {
 		// Manually dismissed via the X button (soft dismiss, per-device). Checked before the network
 		// call so a dismissed banner can never flash back in.
@@ -75,6 +85,10 @@
 		} catch (error) {
 			console.error('Failed to sync tutorial progress:', error)
 			// Keep whatever the last successful sync resolved to rather than guessing again
+			return
+		}
+
+		if (userHidBanner) {
 			return
 		}
 
@@ -108,12 +122,12 @@
 		await skipAllTodos()
 		await syncTutorialsTodos()
 		// No need to set the dismissed flag - backend skipped_all flag is the source of truth
-		resolveState('hidden')
+		hideBannerForUser()
 	}
 
 	function dismissBanner() {
 		storeLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY, 'true')
-		resolveState('hidden')
+		hideBannerForUser()
 
 		const actions: ToastAction[] = [
 			{

--- a/frontend/src/lib/components/home/TutorialBanner.svelte
+++ b/frontend/src/lib/components/home/TutorialBanner.svelte
@@ -15,8 +15,21 @@
 	import { hasRoleAccess } from '$lib/tutorials/roleUtils'
 	import { onMount } from 'svelte'
 
-	let isDismissed = $state(false)
-	let hasCompletedAny = $state(false)
+	type BannerState = 'hidden' | 'start' | 'new'
+
+	// Caches the last resolved BannerState. Deciding what to show needs an API round-trip, so the
+	// banner paints this first: guessing wrong once in a while beats reflowing the home page on
+	// every load.
+	const TUTORIAL_BANNER_STATE_KEY = 'tutorial_banner_state'
+
+	// A brand-new device has nothing cached and stays hidden until the sync answers, which is the
+	// direction that keeps the page from jumping.
+	const cachedState =
+		getLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY) === 'true'
+			? 'hidden'
+			: getLocalSetting(TUTORIAL_BANNER_STATE_KEY)
+	let isDismissed = $state(cachedState !== 'start' && cachedState !== 'new')
+	let hasCompletedAny = $state(cachedState === 'new')
 
 	/**
 	 * Get all tutorial indexes that are accessible to the current user based on their role.
@@ -42,60 +55,65 @@
 		return indexes
 	})
 
+	function resolveState(state: BannerState) {
+		storeLocalSetting(TUTORIAL_BANNER_STATE_KEY, state)
+		isDismissed = state === 'hidden'
+		hasCompletedAny = state === 'new'
+	}
+
 	onMount(async () => {
+		// Manually dismissed via the X button (soft dismiss, per-device). Checked before the network
+		// call so a dismissed banner can never flash back in.
+		if (getLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY) === 'true') {
+			resolveState('hidden')
+			return
+		}
+
 		try {
 			// Sync tutorial progress from backend first
 			await syncTutorialsTodos()
-
-			// Check if banner has been manually dismissed via X button (soft dismiss, per-device)
-			const manuallyDismissed = getLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY) === 'true'
-			if (manuallyDismissed) {
-				isDismissed = true
-				return
-			}
-
-			// Check if user deliberately skipped all tutorials (permanent dismiss, from backend)
-			if ($skippedAll) {
-				isDismissed = true
-				return
-			}
-
-			// Safe to check tutorialsToDo here since we awaited syncTutorialsTodos() above
-			// Filter tutorialsToDo to only include tutorials accessible to the user's role
-			const remainingAccessibleTutorials = $tutorialsToDo.filter((index) =>
-				accessibleTutorialIndexes.has(index)
-			)
-
-			// Calculate if user has completed at least one tutorial (for banner wording)
-			// This determines whether to show "New tutorial available!" or "Learn with interactive tutorials"
-			hasCompletedAny = remainingAccessibleTutorials.length < accessibleTutorialIndexes.size
-
-			// Hide banner if all accessible tutorials are completed (but can reappear with new tutorials)
-			if (remainingAccessibleTutorials.length === 0) {
-				isDismissed = true
-				return
-			}
-
-			// Show banner - user has accessible tutorials to complete
-			isDismissed = false
 		} catch (error) {
 			console.error('Failed to sync tutorial progress:', error)
-			// Fallback to manual dismissal check only if API call fails
-			isDismissed = getLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY) === 'true'
+			// Keep whatever the last successful sync resolved to rather than guessing again
+			return
 		}
+
+		// Check if user deliberately skipped all tutorials (permanent dismiss, from backend)
+		if ($skippedAll) {
+			resolveState('hidden')
+			return
+		}
+
+		// Safe to check tutorialsToDo here since we awaited syncTutorialsTodos() above
+		// Filter tutorialsToDo to only include tutorials accessible to the user's role
+		const remainingAccessibleTutorials = $tutorialsToDo.filter((index) =>
+			accessibleTutorialIndexes.has(index)
+		)
+
+		// Hide banner if all accessible tutorials are completed (but can reappear with new tutorials)
+		if (remainingAccessibleTutorials.length === 0) {
+			resolveState('hidden')
+			return
+		}
+
+		// Having completed at least one accessible tutorial switches the wording to
+		// "New tutorial available!" instead of "Learn with interactive tutorials"
+		resolveState(
+			remainingAccessibleTutorials.length < accessibleTutorialIndexes.size ? 'new' : 'start'
+		)
 	})
 
 	async function handleSkipAllTutorials() {
 		// Skip all tutorials and set skipped_all flag in backend (permanent)
 		await skipAllTodos()
 		await syncTutorialsTodos()
-		// No need to set localStorage - backend skipped_all flag is the source of truth
-		isDismissed = true
+		// No need to set the dismissed flag - backend skipped_all flag is the source of truth
+		resolveState('hidden')
 	}
 
 	function dismissBanner() {
 		storeLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY, 'true')
-		isDismissed = true
+		resolveState('hidden')
 
 		const actions: ToastAction[] = [
 			{

--- a/frontend/src/lib/components/home/TutorialBanner.svelte
+++ b/frontend/src/lib/components/home/TutorialBanner.svelte
@@ -17,13 +17,12 @@
 
 	type BannerState = 'hidden' | 'start' | 'new'
 
-	// Caches the last resolved BannerState. Deciding what to show needs an API round-trip, so the
-	// banner paints this first: guessing wrong once in a while beats reflowing the home page on
-	// every load.
+	// Deciding what to show needs an API round-trip, so the banner paints the state the last visit
+	// resolved to and reconciles once the sync answers. Guessing wrong once in a while beats
+	// reflowing the home page on every load; nothing cached means hidden, the direction that does
+	// not push the page down.
 	const TUTORIAL_BANNER_STATE_KEY = 'tutorial_banner_state'
 
-	// A brand-new device has nothing cached and stays hidden until the sync answers, which is the
-	// direction that keeps the page from jumping.
 	const cachedState =
 		getLocalSetting(TUTORIAL_BANNER_DISMISSED_KEY) === 'true'
 			? 'hidden'
@@ -56,9 +55,11 @@
 	})
 
 	function resolveState(state: BannerState) {
-		storeLocalSetting(TUTORIAL_BANNER_STATE_KEY, state)
 		isDismissed = state === 'hidden'
 		hasCompletedAny = state === 'new'
+		// Last: persisting is best-effort, and a storage failure must not leave the banner stuck on
+		// whatever the cache said
+		storeLocalSetting(TUTORIAL_BANNER_STATE_KEY, state)
 	}
 
 	// The banner is interactive while the initial sync is still in flight, so a dismiss or a skip

--- a/frontend/src/lib/components/scriptEditor/LogPanel.svelte
+++ b/frontend/src/lib/components/scriptEditor/LogPanel.svelte
@@ -225,7 +225,8 @@
 										<div class="text-sm text-primary p-2 flex justify-between items-center">
 											<span>
 												{#if previewIsLoading}
-													<Loader2 class="animate-spin" />
+													<!-- Sized to the text line it replaces so the placeholder row keeps its height -->
+													<Loader2 size={14} class="animate-spin" />
 												{:else}
 													Test to see the result here
 												{/if}

--- a/frontend/src/lib/components/scriptEditor/LogPanel.svelte
+++ b/frontend/src/lib/components/scriptEditor/LogPanel.svelte
@@ -223,9 +223,10 @@
 										</div>
 									{:else}
 										<div class="text-sm text-primary p-2 flex justify-between items-center">
-											<span>
+											<!-- min-h pins this to the text-sm line box, and tracks it across root font
+											     sizes, so swapping the text for the spinner does not resize the row -->
+											<span class="flex items-center min-h-5">
 												{#if previewIsLoading}
-													<!-- Sized to the text line it replaces so the placeholder row keeps its height -->
 													<Loader2 size={14} class="animate-spin" />
 												{:else}
 													Test to see the result here


### PR DESCRIPTION
## Summary

Two layout-shift nits, both caused by an element rendering at one size before the real answer arrived and then changing size.

**Home page.** `TutorialBanner` initialized `isDismissed = false`, so the 58px banner painted on every load and was removed only once `syncTutorialsTodos()` returned — jumping everything below it up. Measured on a workspace where the banner should stay hidden: it appeared at t=1090ms and was gone at t=1113ms.

It now caches the state the last visit resolved to (`hidden` / `start` / `new`) in localStorage and paints that first, reconciling after the sync. A device with nothing cached stays hidden until the sync answers — the direction that does not push the page down. The manual-dismiss check also moved ahead of the network call, with a guard so a dismiss landing mid-flight is not undone by the continuation.

This was shipped once before in `eb4ec4da3b` ("tutorials dismissed by default") and reverted by `e96da54001`; caching the resolved state avoids the tradeoff that made the plain default-hidden version lossy for users who do have tutorials pending.

**Script editor.** Not the pane itself: the `Loader2` in the LogViewer header had no `size` prop, so lucide's 24px default stood in for the 12px `Timer` it swaps out for. The header grew 17px→24px while the job was queued and shrank back when it started, shoving the log body down and up again. The result-pane placeholder had the same defect against its `text-sm` line box.

## Changes

- `TutorialBanner.svelte`: cache the resolved banner state in localStorage and paint it on the first frame; check the dismissed flag before the sync, and guard the continuation so a mid-flight dismiss or skip wins
- `LogViewer.svelte`: size the header spinner to match the `Timer`/`Cpu` icons it replaces
- `LogPanel.svelte`: pin the result-placeholder row to the `text-sm` line box so the text→spinner swap cannot resize it

## Test plan

- [x] Home, cached "show" state: banner present in the first content frame (t=805ms), zero toggles
- [x] Home, cached "hidden" state: banner never renders; pre-fix it appeared at t=1090ms and was removed at t=1113ms
- [x] Home, cold device: banner appears once after the sync (accepted one-time reflow, downward), cache written
- [x] Dismiss while `tutorial_progress` is stalled 6s: banner stays hidden, cache `hidden`. Verified load-bearing — with the guard disabled the banner comes back and the cache reverts to `start`
- [x] Script editor at 1100x600, job run: logs header holds y=338 h=17 throughout and the log body never moves. Pre-fix the body went y=364 h=119 → y=371 h=112 → back within ~16ms. Remaining layout-shift entries are purely horizontal (Test↔Cancel width) with identical y and height
- [x] Result placeholder across the swap: row 36px, span 20px in both the idle and spinner states
- [x] `npm run check:fast`: same 7 pre-existing errors (stale generated client in `ResourceVersionHistory` / `CloudQuotas`), none in the touched files

## Screenshots

Home page with the banner:

![home-banner](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/home-and-logs-pane-content-shift/1786517498-home-banner-AFTER.png)

Script editor logs & result pane after a run:

![logs-pane](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/home-and-logs-pane-content-shift/1786517510-logs-queued-AFTER.png)

Both fixes concern motion between frames rather than a static appearance, so the settled states above look unchanged by design; the timings in the test plan are the actual evidence. The queued-state header with the spinner on screen is a sub-second window I could not hold open for a capture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents layout shifts on the home page and in the script editor by caching the tutorial banner state and fixing spinner/pane sizing so rows don’t jump during runs.

- **Bug Fixes**
  - Home: cache resolved tutorial banner state in localStorage and render it first; check manual dismiss before syncing; guard so dismiss/skip during sync stays hidden.
  - Logs header: size `Loader2` to match the `Timer`/`Cpu` icons, keeping the queued-state row height stable.
  - Result pane: pin the placeholder row to the text-sm line box and size the spinner to 14px so text↔spinner swaps don’t change height.
  - Test panel: let `Splitpanes` flex with `min-h-0` so panes fit under the header; removes the ~12px snap during runs.

<sup>Written for commit 92d359a5b0f0c1a80dc3b35e5d502271a24d3420. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

