### PR TITLE
feat(sessions): persist artifact version selection in preview tabs

### DIFF
--- a/frontend/src/lib/components/copilot/chat/artifacts/ArtifactViewer.svelte
+++ b/frontend/src/lib/components/copilot/chat/artifacts/ArtifactViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte'
 	import Markdown from 'svelte-exmarkdown'
 	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
 	import { Code, Eye, FileText, Copy, Check, Download } from 'lucide-svelte'
@@ -25,51 +26,65 @@
 	interface Props {
 		artifact: PersistedArtifact
 		store: SessionArtifactsStore
+		/** Version being viewed, or undefined for the current one. Owned by the caller — it
+		 * outlives this component, so the viewer must not keep a copy of its own. */
+		pinned?: number
+		onPin: (version: number | undefined) => void
 	}
 
-	let { artifact, store }: Props = $props()
+	let { artifact, store, pinned, onPin }: Props = $props()
 
 	const latest = $derived(currentVersion(artifact))
 	// Nothing to pick between until a second version exists.
 	const hasHistory = $derived(latest > 1)
 
-	// undefined = following the current version. An explicit pick survives later edits, so
-	// the AI writing v8 does not yank the reader out of the v3 they chose to read.
-	let pinned = $state<number | undefined>(undefined)
 	let pinnedContent = $state<ArtifactVersion | undefined>(undefined)
+	// A pin that arrives with the tab has nothing honest to show until its snapshot lands: the
+	// latest document is not the version asked for, and the banner saying so is keyed on the
+	// snapshot itself. A pin picked while reading keeps the document already on screen instead.
+	let restoringPin = $state(untrack(() => pinned !== undefined))
+	let readAttempt = $state(0)
 
-	// The store hands us a fresh object on every edit, so this effect reruns constantly.
-	// Compare the id against the last one seen: clearing on every rerun would drop the
-	// reader's pin the moment the assistant writes a new version.
-	let pinnedFor: string | undefined
-	$effect(() => {
-		if (artifact.id === pinnedFor) return
-		pinnedFor = artifact.id
-		pinned = undefined
-	})
+	/** Pick a version to show. Re-picking the one already pinned leaves the url unchanged, so
+	 * only the attempt counter can re-read it — the reader's one way back from a failed read. */
+	function selectVersion(version: number | undefined) {
+		if (version === pinned) readAttempt++
+		onPin(version)
+	}
 
 	$effect(() => {
 		const version = pinned
+		void readAttempt // dependency: see selectVersion
 		if (version === undefined) {
 			pinnedContent = undefined
+			restoringPin = false
 			return
 		}
 		const id = artifact.id
-		void store.getVersion(id, version).then((snapshot) => {
-			if (pinned !== version || artifact.id !== id) return
-			// Pruned out from under the pin (history is capped): fall back to current rather
-			// than showing an empty document.
-			if (!snapshot) {
-				pinned = undefined
-				return
+		void store.getVersion(id, version).then(
+			(snapshot) => {
+				if (pinned !== version || artifact.id !== id) return
+				restoringPin = false
+				// Pruned out from under the pin (history is capped): fall back to current rather
+				// than showing an empty document.
+				if (!snapshot) {
+					onPin(undefined)
+					return
+				}
+				pinnedContent = snapshot
+			},
+			() => {
+				// A failed read is no evidence the version is gone, so the pin stays on the tab and
+				// the document already on screen stays up — the latest, or the snapshot of whatever
+				// version was pinned before this pick.
+				if (pinned === version && artifact.id === id) restoringPin = false
 			}
-			pinnedContent = snapshot
-		})
+		)
 	})
 
 	const shown = $derived(pinnedContent ?? artifact)
-	// Label from the snapshot that is rendered, not from the one just requested: the read is
-	// async, so `pinned` names a version the body has not swapped to yet.
+	// Label the snapshot that is rendered, not the one just requested: until it lands the body
+	// is still on the previous version, and naming the new one would misreport it.
 	const shownVersion = $derived(pinnedContent?.version)
 
 	// Markdown is the only rendered kind in v1; anything else shows source only.
@@ -102,23 +117,35 @@
 				{shown.name}
 			</span>
 			{#if hasHistory}
+				<!-- The body is blank while restoring, so the chip names the version being fetched:
+				     the latest is the one version certainly not on screen. -->
 				<ArtifactVersionPicker
 					{artifact}
 					{store}
-					selected={shownVersion}
-					onSelect={(v) => (pinned = v)}
+					selected={restoringPin ? pinned : shownVersion}
+					onSelect={selectVersion}
 				/>
 			{/if}
 		</div>
 		<div class="flex items-center gap-2 shrink-0">
-			<!-- Copy raw markdown, with a dropdown for the download-as-file variant. -->
+			<!-- Copy raw markdown, with a dropdown for the download-as-file variant. Both export
+			     `shown`, which is still the current document while a pin is restoring — so both
+			     are disabled, the item explicitly: a Button's `disabled` does not reach it. -->
 			<Button
 				unifiedSize="sm"
 				variant="default"
+				disabled={restoringPin}
 				startIcon={{ icon: copied ? Check : Copy }}
 				onClick={copyRaw}
 				title="Copy raw markdown"
-				dropdownItems={[{ label: 'Download as .md', icon: Download, onClick: downloadFile }]}
+				dropdownItems={[
+					{
+						label: 'Download as .md',
+						icon: Download,
+						onClick: downloadFile,
+						disabled: restoringPin
+					}
+				]}
 			>
 				{copied ? 'Copied' : 'Copy'}
 			</Button>
@@ -157,7 +184,7 @@
 				<TimeAgo date={new Date(pinnedContent.savedAt).toISOString()} compact /> ago
 			</span>
 			<div class="ml-auto shrink-0">
-				<Button unifiedSize="xs" variant="default" onClick={() => (pinned = undefined)}>
+				<Button unifiedSize="xs" variant="default" onClick={() => selectVersion(undefined)}>
 					Back to latest
 				</Button>
 			</div>
@@ -165,7 +192,9 @@
 	{/if}
 
 	<div class="flex-1 min-h-0 overflow-auto px-8">
-		{#if source}
+		{#if restoringPin}
+			<!-- Deliberately blank until the pinned snapshot lands; see restoringPin. -->
+		{:else if source}
 			<!-- key: SimpleEditor reads `code` only on init; remount on id or content change. -->
 			{#key `${artifact.id}:${pinnedContent ? `v${pinnedContent.version}` : artifact.updatedAt}`}
 				<SimpleEditor lang="markdown" code={shown.content} readOnly class="h-full" />

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.test.ts
@@ -126,6 +126,19 @@ describe('artifact tools', () => {
 		expect(res.error).toMatch(/No artifact/)
 	})
 
+	it('read_artifact reports a failed version read as retryable, not as a missing version', async () => {
+		const a = JSON.parse(await ctx.call('create_artifact', { name: 'A', content: 'v1' }))
+		await ctx.call('update_artifact', { id: a.id, content: 'v2', change_note: 'second' })
+		vi.spyOn(ctx.dbMod, 'getArtifactVersion').mockRejectedValue(new Error('read failed'))
+
+		// Naming it absent would send the model to list_artifact_versions and have it conclude
+		// the version is gone, when nothing has been read at all.
+		const res = JSON.parse(await ctx.call('read_artifact', { id: a.id, version: 1 }))
+		expect(res.success).toBe(false)
+		expect(res.error).toMatch(/unavailable/)
+		expect(res.error).not.toMatch(/no version/)
+	})
+
 	it('read_artifact reports a missing id', async () => {
 		const res = JSON.parse(await ctx.call('read_artifact', { id: 'nope' }))
 		expect(res.success).toBe(false)

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { createToolDef, type Tool } from '../shared'
-import { currentVersion } from './artifactsDB'
+import { currentVersion, type ArtifactVersion } from './artifactsDB'
 import type { SessionArtifactsStore } from './artifactsState.svelte'
 
 // The subset of GlobalToolHelpers these tools read. Kept local (not imported from
@@ -177,7 +177,16 @@ export const artifactTools: Tool<{}>[] = [
 				return JSON.stringify({ success: false, error })
 			}
 			if (parsed.version !== undefined && parsed.version !== currentVersion(artifact)) {
-				const snapshot = await h.artifacts.getVersion(parsed.id, parsed.version, { sessionId })
+				let snapshot: ArtifactVersion | undefined
+				try {
+					snapshot = await h.artifacts.getVersion(parsed.id, parsed.version, { sessionId })
+				} catch {
+					// A read that failed says nothing about whether the version exists, so send the
+					// model back to this same call rather than to list_artifact_versions.
+					const error = `Could not read version ${parsed.version} of "${artifact.name}" — the artifact store is unavailable. Try again.`
+					toolCallbacks.setToolStatus(toolId, { content: error, error })
+					return JSON.stringify({ success: false, error })
+				}
 				if (!snapshot) {
 					// Pruned or never existed; either way the model should re-list rather than retry.
 					const error = `Artifact "${artifact.name}" has no version ${parsed.version}. Call list_artifact_versions for the versions still kept.`

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsDB.test.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsDB.test.ts
@@ -204,6 +204,34 @@ describe('artifactsDB', () => {
 		await expect(noDb.deleteArtifactsForSession('s1')).resolves.toBeUndefined()
 	})
 
+	it('rejects a version read it could not make, instead of reading as absent', async () => {
+		// The one read here that does not degrade to undefined: a caller clears a reader's pinned
+		// version on absence, and a pin cleared over a transient failure is cleared for good.
+		vi.resetModules()
+		delete (globalThis as any).indexedDB
+		;(await import('$lib/stores')).userStore.set({ email: 'a@x.com' } as never)
+		const noDb = await import('./artifactsDB')
+		await expect(noDb.getArtifactVersion('a1', 2)).rejects.toThrow(/unavailable/)
+
+		// And with a handle in hand, whose get rejects (a force-closed connection).
+		vi.resetModules()
+		vi.doMock('idb', () => ({
+			openDB: async () => ({
+				get: async () => {
+					throw new DOMException('closed', 'InvalidStateError')
+				}
+			}),
+			deleteDB: async () => {}
+		}))
+		try {
+			;(await import('$lib/stores')).userStore.set({ email: 'a@x.com' } as never)
+			const failing = await import('./artifactsDB')
+			await expect(failing.getArtifactVersion('a1', 2)).rejects.toThrow(/closed/)
+		} finally {
+			vi.doUnmock('idb')
+		}
+	})
+
 	it('swallows a write failure when the DB handle exists but the op rejects', async () => {
 		// The handle is present, but put/delete reject — the QuotaExceededError-shaped failure
 		// the plain no-handle test can't reach. Must not throw at the caller.

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsDB.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsDB.ts
@@ -287,17 +287,21 @@ export async function listArtifactVersions(artifactId: string): Promise<Artifact
 	}
 }
 
+/** A stored snapshot, or undefined when there is none. Rejects when the read could not be made
+ * at all — unlike the other reads here, which degrade to undefined. A caller that conflates the
+ * two reports a transient failure as permanent absence, and whatever it discards in response
+ * (a reader's pinned version) is discarded for good. */
 export async function getArtifactVersion(
 	artifactId: string,
 	version: number
 ): Promise<ArtifactVersion | undefined> {
 	const db = await getDB()
-	if (!db) return undefined
+	if (!db) throw new Error('Artifact store unavailable')
 	try {
 		return await db.get('versions', versionKey(artifactId, version))
 	} catch (err) {
 		console.error('Could not read artifact version', err)
-		return undefined
+		throw err
 	}
 }
 

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.svelte.ts
@@ -181,10 +181,16 @@ export class SessionArtifactsStore {
 	): Promise<ArtifactVersion | undefined> {
 		const artifact = await this.get(id)
 		if (opts?.sessionId !== undefined && artifact?.sessionId !== opts.sessionId) return undefined
-		const stored = await getArtifactVersion(id, version)
-		if (stored) return stored
-		if (artifact && currentVersion(artifact) === version) return snapshotOf(artifact, version)
-		return undefined
+		// The current content is held in memory, so it is the one version a broken store can
+		// still serve; for any older one the read failing propagates (see getArtifactVersion).
+		const live =
+			artifact && currentVersion(artifact) === version ? snapshotOf(artifact, version) : undefined
+		try {
+			return (await getArtifactVersion(id, version)) ?? live
+		} catch (err) {
+			if (live) return live
+			throw err
+		}
 	}
 
 	async remove(id: string): Promise<void> {

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.test.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.test.ts
@@ -278,6 +278,16 @@ describe('SessionArtifactsStore', () => {
 		expect(stored.some((v) => v.version === row!.version)).toBe(true)
 	})
 
+	it('serves the live version from memory when the store is unreadable, but not an older one', async () => {
+		await store.setSession('s1')
+		const created = await store.create('s1', { name: 'Plan', content: 'v1' })
+		await store.update(created.id, { content: 'v2', note: 'second' })
+		vi.spyOn(dbMod, 'getArtifactVersion').mockRejectedValue(new Error('read failed'))
+
+		expect((await store.getVersion(created.id, 2))?.content).toBe('v2')
+		await expect(store.getVersion(created.id, 1)).rejects.toThrow('read failed')
+	})
+
 	it('keeps a legacy v1 when a rename lands before the first content edit', async () => {
 		await dbMod.putArtifact(mk({ id: 'legacy', content: 'original' }))
 		await store.setSession('s1')

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -246,7 +246,12 @@
 		aria-hidden={!active}
 	>
 		{#if artifact && runtime}
-			<ArtifactViewer {artifact} store={runtime.manager.artifacts} />
+			<ArtifactViewer
+				{artifact}
+				store={runtime.manager.artifacts}
+				pinned={slot.version}
+				onPin={(version) => runtime?.previewTabs.pinArtifactVersion(artifact.id, version)}
+			/>
 		{:else if !runtime?.manager.artifacts.loading}
 			<div class="p-4 text-sm text-tertiary">This artifact is no longer available.</div>
 		{/if}

--- a/frontend/src/lib/components/sessions/previewRouter.test.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.test.ts
@@ -182,12 +182,39 @@ describe('artifact route', () => {
 			['x', 'artifact:not-an-id#nope'],
 			['y', '']
 		] as const) {
-			expect(parseArtifactRoute(artifactUrl(id, name))).toEqual({ id, name })
+			expect(parseArtifactRoute(artifactUrl(id, name))).toEqual({ id, name, version: undefined })
 		}
 	})
 
+	it('round-trips a pinned version without disturbing the id or name', () => {
+		// The version rides between the id and the name, so the id capture has to stop at it
+		// rather than swallowing it.
+		expect(parseArtifactRoute(artifactUrl('abc', 'Onboarding plan', 4))).toEqual({
+			id: 'abc',
+			name: 'Onboarding plan',
+			version: 4
+		})
+	})
+
+	it('agrees with itself on what counts as a pinned version', () => {
+		// A url that stamps a version the parser then rejects is persisted with the tab, so it
+		// would outlive the bad call.
+		for (const bad of [0, -1, 1.5, NaN]) {
+			expect(parseArtifactRoute(artifactUrl('abc', 'Plan', bad))).toEqual({
+				id: 'abc',
+				name: 'Plan',
+				version: undefined
+			})
+		}
+		expect(parseArtifactRoute('artifact:abc?v=0#Plan')?.version).toBeUndefined()
+	})
+
 	it('parses a hash-less artifact url to an empty name', () => {
-		expect(parseArtifactRoute('artifact:abc')).toEqual({ id: 'abc', name: '' })
+		expect(parseArtifactRoute('artifact:abc')).toEqual({
+			id: 'abc',
+			name: '',
+			version: undefined
+		})
 	})
 
 	it('returns null for non-artifact urls', () => {

--- a/frontend/src/lib/components/sessions/previewRouter.test.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.test.ts
@@ -199,7 +199,7 @@ describe('artifact route', () => {
 	it('agrees with itself on what counts as a pinned version', () => {
 		// A url that stamps a version the parser then rejects is persisted with the tab, so it
 		// would outlive the bad call.
-		for (const bad of [0, -1, 1.5, NaN]) {
+		for (const bad of [0, -1, 1.5, NaN, 1e21]) {
 			expect(parseArtifactRoute(artifactUrl('abc', 'Plan', bad))).toEqual({
 				id: 'abc',
 				name: 'Plan',

--- a/frontend/src/lib/components/sessions/previewRouter.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.ts
@@ -202,16 +202,29 @@ export function parsePipelineRoute(fullPath: string): string | null {
 	return m ? normalizePipelineFolder(decodeURIComponent(m[1])) : null
 }
 
-// The id (before the hash) is the artifact's stable routing identity; the name rides in
-// the hash so the tab strip labels it without a store lookup.
-export function parseArtifactRoute(url: string): { id: string; name: string } | null {
-	const m = url.match(/^artifact:([^#]+)(?:#(.*))?$/)
+// The id (before the query) is the artifact's stable routing identity; the name rides in the
+// hash so the tab strip labels it without a store lookup, and the version in the query so the
+// tab persists it.
+export function parseArtifactRoute(
+	url: string
+): { id: string; name: string; version?: number } | null {
+	const m = url.match(/^artifact:([^?#]+)(?:\?v=(\d+))?(?:#(.*))?$/)
 	if (!m) return null
-	return { id: decodeURIComponent(m[1]), name: m[2] ? decodeURIComponent(m[2]) : '' }
+	// Mirror artifactUrl: a version it would not stamp does not read back as a pin.
+	const version = Number(m[2])
+	return {
+		id: decodeURIComponent(m[1]),
+		name: m[3] ? decodeURIComponent(m[3]) : '',
+		version: version > 0 ? version : undefined
+	}
 }
 
-export function artifactUrl(id: string, name: string): string {
-	return `artifact:${encodeURIComponent(id)}#${encodeURIComponent(name)}`
+export function artifactUrl(id: string, name: string, version?: number): string {
+	// Only stamp a version parseArtifactRoute can read back: this url is persisted with the
+	// tab, so one that round-trips to null would come back as an unopenable tab every reload.
+	const pinned =
+		version !== undefined && Number.isInteger(version) && version > 0 ? `?v=${version}` : ''
+	return `artifact:${encodeURIComponent(id)}${pinned}#${encodeURIComponent(name)}`
 }
 
 /** Drill-picker leaf key for an artifact, shared by the picker tree and the
@@ -228,12 +241,12 @@ export const isArtifactKey = (key: string) => key.startsWith('artifact:')
 // other route) stays an iframe.
 export type PreviewSlot =
 	| { kind: 'editor'; editorKind: SessionTargetKind | 'pipeline'; path: string }
-	| { kind: 'artifact'; id: string }
+	| { kind: 'artifact'; id: string; version?: number }
 	| { kind: 'iframe' }
 
 export function resolvePreviewTab(url: string): PreviewSlot {
 	const artifact = parseArtifactRoute(url)
-	if (artifact) return { kind: 'artifact', id: artifact.id }
+	if (artifact) return { kind: 'artifact', id: artifact.id, version: artifact.version }
 	const pipelineFolder = parsePipelineRoute(url)
 	if (pipelineFolder) {
 		return { kind: 'editor', editorKind: 'pipeline', path: pipelineFolder }

--- a/frontend/src/lib/components/sessions/previewRouter.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.ts
@@ -222,8 +222,10 @@ export function parseArtifactRoute(
 export function artifactUrl(id: string, name: string, version?: number): string {
 	// Only stamp a version parseArtifactRoute can read back: this url is persisted with the
 	// tab, so one that round-trips to null would come back as an unopenable tab every reload.
+	// Safe integers specifically — from 1e21 up a number interpolates as `1e+21`, which the
+	// digits-only parser rejects outright.
 	const pinned =
-		version !== undefined && Number.isInteger(version) && version > 0 ? `?v=${version}` : ''
+		version !== undefined && Number.isSafeInteger(version) && version > 0 ? `?v=${version}` : ''
 	return `artifact:${encodeURIComponent(id)}${pinned}#${encodeURIComponent(name)}`
 }
 

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -51,10 +51,23 @@ function isEditorTabFor(url: string, target: SessionTarget): boolean {
 	return slot.kind === 'editor' && slot.editorKind === target.kind && slot.path === target.path
 }
 
-// URL a tab should load for a destination: a page's href, an item's edit route, or an artifact's scheme.
-function targetUrl(target: PreviewTarget): string {
+// The version a tab keeps when it is re-pointed: whatever pin is already on it. Re-pointing
+// must never double as "show the newest" — every artifact tool re-opens the document it just
+// wrote, so that would yank the reader out of the version they chose on each edit. The pin
+// belongs to a (tab, artifact) pair: a different document, or a brand-new tab, starts unpinned.
+function keptVersion(artifactId: string, onto: SessionPreviewTab | undefined): number | undefined {
+	const current = onto && parseArtifactRoute(onto.url)
+	return current?.id === artifactId ? current.version : undefined
+}
+
+// URL a tab should load for a destination: a page's href, an item's edit route, or an artifact's
+// scheme. `onto` is the tab about to be written, passed wherever one is being re-pointed so
+// that every such path keeps its pin.
+function targetUrl(target: PreviewTarget, onto?: SessionPreviewTab): string {
 	if (target.type === 'page') return target.href
-	if (target.type === 'artifact') return artifactUrl(target.id, target.name)
+	if (target.type === 'artifact') {
+		return artifactUrl(target.id, target.name, keptVersion(target.id, onto))
+	}
 	return `${base}${editPathFor(target.item)}`
 }
 
@@ -357,9 +370,12 @@ export class SessionPreviewTabs {
 		if (target.type === 'artifact') {
 			const existing = this.#tabs.find((t) => parseArtifactRoute(t.url)?.id === target.id)
 			if (existing) {
-				const same = existing.url === url
-				existing.url = url
-				existing.loc = url
+				// `same` is judged against the url actually written (which keeps the tab's pin —
+				// see keptVersion), else preserving a pin would report 'opened' with nothing moved.
+				const kept = targetUrl(target, existing)
+				const same = existing.url === kept
+				existing.url = kept
+				existing.loc = kept
 				this.#activeId = existing.id
 				this.#flush()
 				return { status: same ? 'focused' : 'opened' }
@@ -407,16 +423,15 @@ export class SessionPreviewTabs {
 				return
 			}
 		}
-		const url = targetUrl(target)
 		// Keep at most one pipeline tab (all share runtime.pipelineEditorState): if a
 		// *different* tab already hosts a pipeline, retarget and focus it rather than
 		// turning the active tab into a second pipeline editor racing the shared
 		// state. Same invariant as open(); a no-op when the active tab is that tab.
-		const pipelineFolder = parsePipelineRoute(url)
+		const pipelineFolder = parsePipelineRoute(targetUrl(target))
 		if (pipelineFolder) {
 			const existing = this.#tabs.find((x) => parsePipelineRoute(x.url) !== null)
 			if (existing && existing.id !== t.id) {
-				retargetTab(existing, url)
+				retargetTab(existing, targetUrl(target, existing))
 				this.#activeId = existing.id
 				this.#flush()
 				return
@@ -428,13 +443,13 @@ export class SessionPreviewTabs {
 		if (target.type === 'artifact') {
 			const existing = this.#tabs.find((x) => parseArtifactRoute(x.url)?.id === target.id)
 			if (existing && existing.id !== t.id) {
-				retargetTab(existing, url)
+				retargetTab(existing, targetUrl(target, existing))
 				this.#activeId = existing.id
 				this.#flush()
 				return
 			}
 		}
-		retargetTab(t, url)
+		retargetTab(t, targetUrl(target, t))
 		this.#flush()
 	}
 
@@ -480,6 +495,19 @@ export class SessionPreviewTabs {
 		if (this.#activeId === id) {
 			this.#activeId = (this.#tabs[idx] ?? this.#tabs[idx - 1] ?? this.#tabs[0])?.id ?? ''
 		}
+		this.#flush()
+	}
+
+	/** Show a version of an artifact already open, or the current one when `version` is
+	 * undefined. Reader-driven: re-pointing a tab preserves a pin instead (see keptVersion). */
+	pinArtifactVersion(artifactId: string, version: number | undefined): void {
+		const tab = this.#tabs.find((t) => parseArtifactRoute(t.url)?.id === artifactId)
+		const route = tab && parseArtifactRoute(tab.url)
+		if (!tab || !route) return
+		const url = artifactUrl(artifactId, route.name, version)
+		if (tab.url === url) return
+		tab.url = url
+		tab.loc = url
 		this.#flush()
 	}
 
@@ -596,7 +624,9 @@ export function describePreview(tabs: SessionPreviewTab[], activeId: string): st
 		const pipelineFolder = parsePipelineRoute(where)
 		const route = parsePreviewItemRoute(where)
 		const label = artifact
-			? `artifact "${artifact.name || 'Artifact'}"`
+			? // A pinned tab is not showing what the assistant last wrote, and nothing else in this
+				// summary would tell it so.
+				`artifact "${artifact.name || 'Artifact'}"${artifact.version ? ` (pinned to v${artifact.version})` : ''}`
 			: page
 				? `page "${page.label}"`
 				: pipelineFolder

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -288,6 +288,31 @@ describe('SessionPreviewTabs.open', () => {
 		expect(res.status).toBe('opened')
 	})
 
+	it('keeps the version a reader pinned across re-opens, until they move or clear it', () => {
+		const { adapter, persisted } = makeAdapter()
+		const o = owner({}, adapter)
+		o.open(artifactTarget)
+		vi.runAllTimers()
+		o.pinArtifactVersion('art1', 1)
+		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan', 1))
+		// The pin only survives a reload if it reached the durable snapshot.
+		vi.runAllTimers()
+		expect(persisted.at(-1)?.tabs.map((t) => t.url)).toEqual([artifactUrl('art1', 'Plan', 1)])
+
+		// Nothing moved, so re-opening the pinned artifact is a focus, not an open.
+		expect(o.open(artifactTarget).status).toBe('focused')
+		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan', 1))
+
+		// The re-open every artifact tool does after writing, here also carrying a rename.
+		o.open({ type: 'artifact', id: 'art1', name: 'Plan, revised' })
+		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan, revised', 1))
+
+		o.pinArtifactVersion('art1', 2)
+		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan, revised', 2))
+		o.pinArtifactVersion('art1', undefined)
+		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan, revised'))
+	})
+
 	it('opens separate tabs for different artifact ids', () => {
 		const o = owner()
 		o.open(artifactTarget)
@@ -384,6 +409,35 @@ describe('SessionPreviewTabs.navigate', () => {
 		expect(o.tabs).toHaveLength(1)
 		expect(o.activeId).toBe(tabId)
 		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan'))
+	})
+
+	// The breadcrumb picker opens highlighting the artifact the active tab already shows, so
+	// re-picking it is the modal interaction — and it must not double as a reset to latest.
+	it('keeps a pinned version when the breadcrumb re-points a tab to the artifact it shows', () => {
+		const o = owner()
+		o.open(artifactTarget)
+		o.pinArtifactVersion('art1', 1)
+		const artifactTabId = o.activeId
+
+		// Active tab *is* the artifact tab: the picker's own highlight leads here.
+		o.navigate({ type: 'artifact', id: 'art1', name: 'Plan' })
+		expect(o.tabs[0].url).toBe(artifactUrl('art1', 'Plan', 1))
+
+		// Same rule from another tab, where navigate() re-points and focuses this one instead.
+		o.open(pageTarget)
+		o.navigate({ type: 'artifact', id: 'art1', name: 'Renamed plan' })
+		expect(o.activeId).toBe(artifactTabId)
+		expect(o.tabs.find((t) => t.id === artifactTabId)?.url).toBe(
+			artifactUrl('art1', 'Renamed plan', 1)
+		)
+	})
+
+	it('carries no pin across when a tab is retargeted to a different artifact', () => {
+		const o = owner()
+		o.open(artifactTarget)
+		o.pinArtifactVersion('art1', 1)
+		o.navigate({ type: 'artifact', id: 'art2', name: 'Other' })
+		expect(o.tabs[0].url).toBe(artifactUrl('art2', 'Other'))
 	})
 
 	it('drops a stale friendly label and path when the tab is retargeted', () => {
@@ -648,6 +702,13 @@ describe('describePreview', () => {
 		const out = describePreview(tabs, 'a')
 		expect(out).toContain('page "Runs"')
 		expect(out).not.toContain('live editor')
+	})
+
+	it('reports the pinned version, so the assistant knows the reader is behind', () => {
+		const url = artifactUrl('uuid-1', 'My Plan', 2)
+		expect(describePreview([{ id: 'a', url, loc: url }], 'a')).toContain(
+			'artifact "My Plan" (pinned to v2)'
+		)
 	})
 
 	it('labels an artifact tab by name, not the raw artifact url', () => {


### PR DESCRIPTION
## Summary

The artifact viewer's version pin was component-local state, so picking an older version
from the history dropdown was lost the moment the viewer remounted — a page reload put the
reader back on the current version.

The pin now rides on the preview tab's URL (`artifact:<id>?v=<n>#<name>`), which is already
persisted with the tab, so a reload lands the reader back on the version they were reading.

Omitting a version means **"leave the reader where they are"**, not "show the latest". Every
artifact tool re-opens the document it just wrote (`artifactTools.ts` calls `openArtifact`
after both create and update), so an omitted version that cleared the pin would yank a reader
out of the version they chose on *every single edit* the model makes. That rule lives in one
place — `keptVersion()`, applied by `targetUrl()` to every path that re-points a tab — so
`open()` and `navigate()` cannot disagree about it. Moving off a pin is the reader's own
action: the version dropdown, "Back to latest", or the new `pinArtifactVersion()`.

`navigate()` matters here because the breadcrumb picker opens *highlighting* the artifact the
active tab already shows (`activePickerHighlight` → `artifactKey(activeArtifact.id)`), so
re-picking it is the modal interaction — and it must not double as an implicit reset to
latest. Keeping the pin also makes the "you clicked what's already on screen" flash correct
instead of silently swapping the content underneath it.

## Changes

- `previewRouter.ts` — the artifact URL grammar becomes `artifact:<id>?v=<n>#<name>`.
  `parseArtifactRoute` returns `version?: number` (its id capture stops at `?` rather than
  swallowing it), `artifactUrl` takes an optional third `version`, and the `artifact`
  `PreviewSlot` carries it through `resolvePreviewTab`. `artifactUrl` stamps only a version
  `parseArtifactRoute` can read back, and the parser mirrors it (`?v=0` is not a pin): this URL
  is persisted, so one the two disagreed about would come back as a broken tab every reload.
- `sessionPreviewTabs.svelte.ts` — new `keptVersion(artifactId, onto)` holds the rule; `targetUrl`
  takes the tab it is about to write (`onto`) and applies it, so `open()` and both `navigate()`
  branches keep a pin by construction rather than by remembering to. A pin belongs to a
  (tab, artifact) pair: the id guard drops it when a tab is re-pointed at a different document,
  and a brand-new tab (no `onto`) starts unpinned. `open()` judges `same` against the URL it
  actually writes (not the target's), so a preserved pin can't report `'opened'` with nothing
  moved. New `pinArtifactVersion(artifactId, version)` rewrites the tab's `url`/`loc` and
  flushes; `undefined` clears the pin. `describePreview` reports the pin, so `get_preview_status`
  can tell the assistant the reader is not on the version it just wrote — a signal that did not
  exist while the pin was component-local.
- `PreviewTabHost.svelte` — passes the slot's version down and routes the callback back up.
- `ArtifactViewer.svelte` — the pin becomes controlled (`pinned` / `onPin` props). The local
  `pinned` state and its `pinnedFor` reset effect are gone: `PreviewTabHost` is already
  per-tab, so the version is scoped by construction and a local reset would only fight the
  prop. Because a pin can now exist at mount, `restoringPin` holds the body blank until that
  snapshot lands, instead of falling back to the latest document — that fallback would paint
  the wrong version with no stale-text banner, since the banner is keyed on the snapshot
  itself. It is deliberately scoped to a pin that *arrives with the tab*: a version picked
  while reading keeps the document already on screen, labelled as the version actually
  rendered. Copy and Download are held back over that window because both export `shown`,
  which is still the current document — the dropdown item carries its own `disabled`, since a
  `Button`'s does not reach it. The version chip names the version being fetched over that
  window, since the blank body is the one thing on screen that cannot misreport. A failed read
  leaves the pin on the tab and shows the current document meanwhile; re-picking that same
  version re-reads it (the url is unchanged, so a counter is what makes the retry reachable
  rather than a dead click), and only a snapshot that is genuinely gone (history is capped)
  clears the pin.

- `artifactsDB.ts` / `artifactsState.svelte.ts` / `artifactTools.ts` — `getArtifactVersion`
  rejects a read it could not make instead of swallowing it into `undefined`. Every other read
  there degrades to a default, which is fine when the caller only renders the result; these two
  callers *act* on absence. The viewer clears the reader's pin — harmless while the pin was
  component-local, permanent now that it is persisted with the tab — and `read_artifact` tells
  the model the version no longer exists and to re-list. `SessionArtifactsStore.getVersion`
  still answers for the current version, which it holds in memory and can serve without the DB;
  anything older propagates, and both callers now treat a failure as a failure.

`openArtifact` keeps its two-arg signature and `PreviewTarget` is unchanged: no caller has a
reason to name a version when opening, so the tab model preserves an existing pin without any
caller's help.

## Test plan

- [x] `npx vitest run src/lib/components/copilot/chat/artifacts/` — 56 passing. New: the version
      read rejects rather than reading as absent, in both shapes (no handle at all, and a handle
      whose `get` rejects — the production path, not a stubbed store); the store still serves the
      current version from memory when the store is unreadable, but not an older one; and
      `read_artifact` reports a failed read as retryable instead of "no such version".
- [x] `npx vitest run src/lib/components/sessions/` — 233 passing. New: the router round-trip
      for a pinned version (which pins the regex's id boundary); that `artifactUrl` stamps
      nothing for a version it could not read back; the pin's whole lifecycle
      through `open()` — pinned, persisted, surviving a re-open that names no version, moved,
      cleared; both `navigate()` branches keeping a pin (active tab *is* the artifact tab, and
      the cross-tab re-point); and a tab re-pointed to a *different* artifact carrying nothing
      over.
- [x] Mutation-tested every new assertion. Each of these fails exactly the assertion meant to
      catch it: `open()` overwriting instead of preserving; dropping the `?` from the regex's
      id character class; skipping `#flush()` in `pinArtifactVersion`; reverting either
      `navigate()` branch to the pin-less URL; dropping the id guard in `keptVersion`; and
      stamping the version unconditionally in `artifactUrl`; and dropping the pinned suffix
      from `describePreview`.
- [x] `npm run check` — 0 errors (the two warnings in `PreviewTabHost.svelte` are at lines
      151/167, untouched by this change and present on main).
- [x] `npx prettier --check` on every changed file.
- [x] Exercised in a browser against the dev server: got an artifact to v4, picked v2 from the
      history dropdown, reloaded, still on v2 (persisted tab URL:
      `artifact:<id>?v=2#Onboarding%20plan`). Then had the model add a Phase 5 while pinned —
      the reader stayed on v2 while the header moved to "of 5". "Back to latest" clears the
      pin.
- [x] Exercised the breadcrumb path specifically: with the artifact tab active and v2 pinned,
      opened "Change preview" and re-picked the highlighted artifact — tab URL stayed
      `?v=2`. Reverting just that one line reproduces the drop (`?v=` gone, banner cleared),
      which is what confirms the browser check actually covers the path rather than no-opping.
- [x] Measured the transitions rather than the settled states, sampling the artifact pane's own
      text every frame. Reload with v2 pinned: header-only → v2 with its banner, never through
      v5 — and reverting just the `restoringPin` gate reproduces a ~27 ms frame of the full
      latest document with no banner, which is what confirms the check covers the path rather
      than no-opping. Picking v2 while unpinned: 1221 → 612 chars with no empty frame in
      between (an unscoped gate blanks the pane here). Switching v2 → v3: 612 → 819, likewise.
- [x] Held the read open with a temporary delay to make the pending window observable: over it,
      Copy is disabled and so is "Download as .md" behind the chevron; both are enabled again
      once the snapshot lands. (`DropdownV2Inner` snapshots its items on mount, so a menu left
      open across that instant needs a reopen — it cannot be opened during a real ~20 ms one.)
- [x] Exercised the pruned-snapshot fallback, which no unit test can reach: forged a persisted
      `?v=99` into IndexedDB, reloaded, and the viewer fell back to the latest document with no
      banner and cleared `?v=` from storage, rather than leaving an empty pane.
- [x] Exercised a failing read by forcing the store to reject: the viewer shows the current
      document and the pin *survives* in the persisted URL, and undoing the forced failure
      brings v2 straight back — a transient error costs the reader nothing. With only the
      *first* read of a page load forced to fail, re-picking that same version recovers the
      pinned view; dropping the effect's dependency on the retry counter reproduces the dead
      click, which is what shows the counter is load-bearing.
- [x] Sampled the version chip every frame from first paint: it reads v2 (orange) while the
      pane is blank, never v5. Reverting just that expression reproduces a first frame reading
      "Version 5 of 5" in grey over the blank pane.
- [x] "Back to latest" clears the pin and the persisted URL drops `?v=` (read back out of
      IndexedDB, not inferred from the UI), and re-picking v2 from the dropdown restores both.
- [x] No console errors attributable to the change; the only failing requests are backend
      `/api/uptodate` 500s, which reproduce by curling the backend directly.

## Screenshots

None: what changed here is what survives an interaction, not how anything looks. The viewer
renders exactly as it does on main — a still of it pinned to v2 is pixel-identical before and
after this PR, and only the *sequence* (pin, reload, still on v2) carries the difference. The
same goes for the blank-vs-wrong-document window during a restore, which is a ~27 ms
transition. The browser checks in the test plan above are the meaningful record; reproducing
them takes about a minute against a dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
