### PR TITLE
fix(schedule): hoist non-RLS reads out of the create_schedule transaction

### DIFF
--- a/backend/windmill-api-schedule/src/lib.rs
+++ b/backend/windmill-api-schedule/src/lib.rs
@@ -260,16 +260,21 @@ async fn create_schedule(
         ));
     }
 
-    let mut tx: Transaction<'_, Postgres> = user_db.begin(&authed).await?;
+    // Check schedule for error (validate before opening the tx).
+    ScheduleType::from_str(&ns.schedule, ns.cron_version.as_deref(), true)?;
 
+    // These reads deliberately use the non-RLS `db` pool (fork-ness and
+    // permissioned_as resolution must be complete regardless of the caller's
+    // folder perms). Run them BEFORE opening the RLS transaction below: acquiring
+    // a second pooled connection while the tx is held self-deadlocks on a
+    // single-connection pool, and they don't depend on the tx.
+    //
     // A git-sync/merge/create write into a fork never sets operational state:
     // force `enabled = false` so a cloned / synced / merged / UI-created schedule
     // can't fire alongside the parent's. The fork owner re-enables locally via
     // `setenabled`. Schedule analog of the trigger rule in
     // `windmill-trigger::handler::workspace_is_fork`; the read half (parent-value
-    // substitution on fork export) lives in `workspaces_export.rs`. Read fork-ness
-    // on the non-RLS `db` pool (like the other two sites) so the determination is
-    // complete regardless of the caller's folder perms.
+    // substitution on fork export) lives in `workspaces_export.rs`.
     let target_is_fork: bool = sqlx::query_scalar!(
         "SELECT parent_workspace_id IS NOT NULL FROM workspace WHERE id = $1",
         w_id
@@ -278,17 +283,6 @@ async fn create_schedule(
     .await?
     .flatten()
     .unwrap_or(false);
-
-    // Check schedule for error
-    ScheduleType::from_str(&ns.schedule, ns.cron_version.as_deref(), true)?;
-
-    check_path_conflict(&mut tx, &w_id, &ns.path).await?;
-    check_flow_conflict(&mut tx, &w_id, &ns.path, ns.is_flow, &ns.script_path).await?;
-
-    // Validate dynamic_skip if provided
-    if let Some(handler_path) = &ns.dynamic_skip {
-        validate_dynamic_skip(&mut tx, &w_id, handler_path).await?;
-    }
 
     let resolved_edited_by = resolve_edited_by(&authed);
     let resolved_permissioned_as = resolve_permissioned_as_for_create(
@@ -307,6 +301,16 @@ async fn create_schedule(
         &db,
     )
     .await?;
+
+    let mut tx: Transaction<'_, Postgres> = user_db.begin(&authed).await?;
+
+    check_path_conflict(&mut tx, &w_id, &ns.path).await?;
+    check_flow_conflict(&mut tx, &w_id, &ns.path, ns.is_flow, &ns.script_path).await?;
+
+    // Validate dynamic_skip if provided
+    if let Some(handler_path) = &ns.dynamic_skip {
+        validate_dynamic_skip(&mut tx, &w_id, handler_path).await?;
+    }
 
     let schedule = sqlx::query_as!(
         Schedule,


### PR DESCRIPTION
## What

`create_schedule` opens the RLS transaction (`user_db.begin`) up front, then runs several reads on the **non-RLS `db` pool** while holding it — fork-ness detection and `permissioned_as`/email resolution. On a single-connection pool, acquiring that second pooled connection while the tx holds the only one **self-deadlocks**: the read waits out the sqlx acquire timeout, then errors.

This hoists those reads (and the `ScheduleType::from_str` validation) **above** `user_db.begin()`. They don't depend on the tx and bypass RLS by design, so the change is semantically identical — the RLS transaction is just opened later and held for a shorter time.

## Why it's a real fix beyond the single-connection case

- Removes a genuine deadlock for any connection-constrained deployment: embedded Postgres, PgBouncer in statement/transaction mode, or `max_connections=1`.
- Even on a roomy pool it's a small improvement: fewer queries inside the RLS tx, connection held for less time.
- Same class of fix as #9970 (migration bootstrap on the migrator's held connection).

## Scope / follow-up

Only `create_schedule`'s own reads are hoisted. `push_scheduled_job` — called here under the tx, and from `edit_schedule` / `set_enabled` — **still** checks out a second `db` connection while the tx is held, so the single-connection deadlock is not fully gone. It resurfaces when:

- the schedule carries a non-empty worker **tag** (`check_tag_available_for_workspace_internal`);
- the script has **concurrency / debounce / retry** settings (`prefetch_cached_from_handle` — a tx-holding variant `runnable_settings::prefetch_cached_tx` already exists, so this case is a cheap swap);
- or the **uncached on-behalf-of** path runs (`on_behalf_of_from_permissioned_as`).

A plain, untagged, self-permissioned **script** schedule create is safe today — partly because this hoist warms `EMAIL_CACHE`, so the in-tx email lookup inside `push_scheduled_job` resolves from cache instead of the pool. Fully closing the tagged/settings cases means routing those reads through the tx, and is left as a focused follow-up rather than bundled here.

_(Thanks to the automated review for tracing this precisely.)_

## Test

- [x] `cargo check -p windmill --lib` (offline) — clean.
- Semantically a reorder of non-RLS reads; no query or logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
