### PR TITLE
test: fix repro_diffname CLI flake by draining the app dependency job

### DIFF
--- a/cli/test/repro_diffname.test.ts
+++ b/cli/test/repro_diffname.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import { writeFile, readdir } from "node:fs/promises";
 import path from "node:path";
-import { withTestBackend } from "./test_backend.ts";
+import { withTestBackend, type TestBackend } from "./test_backend.ts";
 import { addWorkspace } from "../src/commands/workspace/workspace.ts";
 
 /**
@@ -13,6 +13,49 @@ import { addWorkspace } from "../src/commands/workspace/workspace.ts";
  * generate-metadata created duplicate content files (e.g., fetch_users.ts alongside a.ts).
  * On next push, loadRunnablesFromBackend auto-detected the orphans as new runnables.
  */
+
+/**
+ * Deploying an app queues a dependency job that writes the generated locks back
+ * into the app value. Pulling while it is still in flight yields a local copy
+ * with no lock files, so the push below stops being the no-op this test asserts:
+ * it becomes a real change, and rebuilding a raw app bundle needs a package.json
+ * this fixture has no reason to carry.
+ */
+async function waitForQueueToDrain(
+  backend: TestBackend,
+  timeoutMs = 60000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const resp = await fetch(
+      `${backend.baseUrl}/api/w/${backend.workspace}/jobs/queue/list`,
+      { headers: { Authorization: `Bearer ${backend.token}` } },
+    );
+    if (!resp.ok) {
+      throw new Error(`failed to list the queue: ${resp.status}`);
+    }
+    if (((await resp.json()) as unknown[]).length === 0) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`queue still not empty after ${timeoutMs}ms`);
+}
+
+/** Fails with the CLI's own output, which is otherwise swallowed. */
+async function runCLI(
+  backend: TestBackend,
+  args: string[],
+  tempDir: string,
+): Promise<void> {
+  const result = await backend.runCLICommand(args, tempDir);
+  if (result.code !== 0) {
+    throw new Error(
+      `wmill ${args.join(" ")} exited with ${result.code}\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+}
+
 test("Raw app: generate-metadata must not create duplicate files when runnable key != name", async () => {
   await withTestBackend(async (backend, tempDir) => {
     const testWorkspace = {
@@ -70,23 +113,21 @@ test("Raw app: generate-metadata must not create duplicate files when runnable k
       { method: "POST", headers: { Authorization: `Bearer ${backend.token}` }, body: formData },
     );
     expect(createResp.ok).toBeTruthy();
+    await waitForQueueToDrain(backend);
 
     // Pull the app
-    const pullResult = await backend.runCLICommand(["sync", "pull", "--yes"], tempDir);
-    expect(pullResult.code).toEqual(0);
+    await runCLI(backend, ["sync", "pull", "--yes"], tempDir);
 
     const backendDir = path.join(tempDir, "f/test/diffname_app.raw_app", "backend");
     let files = await readdir(backendDir);
 
-    // After pull: files named by KEY (a, b).
-    // Lock files are generated asynchronously by the backend worker and may not
-    // have landed yet — exclude them from this precondition to avoid a Windows race.
+    // After pull: files named by KEY (a, b). Lock files are not what this test
+    // pins, so they are left out of the precondition.
     const nonLockFiles = files.filter((f) => !f.endsWith(".lock")).sort();
     expect(nonLockFiles).toEqual(["a.ts", "a.yaml", "b.ts", "b.yaml"]);
 
     // Run generate-metadata — this previously created duplicate files named by NAME
-    const metaResult = await backend.runCLICommand(["generate-metadata", "--yes"], tempDir);
-    expect(metaResult.code).toEqual(0);
+    await runCLI(backend, ["generate-metadata", "--yes"], tempDir);
 
     // After generate-metadata: must still only have KEY-based files, no NAME-based duplicates
     files = await readdir(backendDir);
@@ -102,8 +143,7 @@ test("Raw app: generate-metadata must not create duplicate files when runnable k
     expect(files).not.toContain("update_record.lock");
 
     // Push should be a no-op (no phantom changes)
-    const pushResult = await backend.runCLICommand(["sync", "push", "--yes"], tempDir);
-    expect(pushResult.code).toEqual(0);
+    await runCLI(backend, ["sync", "push", "--yes"], tempDir);
 
     // Backend should still have exactly 2 runnables
     const getResp = await fetch(

--- a/cli/test/repro_diffname.test.ts
+++ b/cli/test/repro_diffname.test.ts
@@ -86,10 +86,9 @@ test("Raw app: generate-metadata must not create duplicate files when runnable k
       { method: "POST", headers: { Authorization: `Bearer ${backend.token}` }, body: formData },
     );
     expect(createResp.ok).toBeTruthy();
-    // Deploying the app queues a dependency job that writes the generated locks
-    // back into the app value. Pulling while it is in flight yields a local copy
-    // with no lock files, so the push below stops being the no-op this test
-    // asserts: it becomes a real change, and rebuilding a raw app bundle needs a
+    // Deploying queues a dependency job that writes the generated locks back into
+    // the app value. Pulling mid-flight leaves the locks out locally, which turns
+    // the push below into a real change — and rebuilding a raw app bundle needs a
     // package.json this fixture has no reason to carry.
     await waitForDeploymentJobs(backend);
 

--- a/cli/test/repro_diffname.test.ts
+++ b/cli/test/repro_diffname.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { writeFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { withTestBackend, type TestBackend } from "./test_backend.ts";
+import { waitForDeploymentJobs } from "./new_commands_helpers.ts";
 import { addWorkspace } from "../src/commands/workspace/workspace.ts";
 
 /**
@@ -13,34 +14,6 @@ import { addWorkspace } from "../src/commands/workspace/workspace.ts";
  * generate-metadata created duplicate content files (e.g., fetch_users.ts alongside a.ts).
  * On next push, loadRunnablesFromBackend auto-detected the orphans as new runnables.
  */
-
-/**
- * Deploying an app queues a dependency job that writes the generated locks back
- * into the app value. Pulling while it is still in flight yields a local copy
- * with no lock files, so the push below stops being the no-op this test asserts:
- * it becomes a real change, and rebuilding a raw app bundle needs a package.json
- * this fixture has no reason to carry.
- */
-async function waitForQueueToDrain(
-  backend: TestBackend,
-  timeoutMs = 60000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const resp = await fetch(
-      `${backend.baseUrl}/api/w/${backend.workspace}/jobs/queue/list`,
-      { headers: { Authorization: `Bearer ${backend.token}` } },
-    );
-    if (!resp.ok) {
-      throw new Error(`failed to list the queue: ${resp.status}`);
-    }
-    if (((await resp.json()) as unknown[]).length === 0) {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-  throw new Error(`queue still not empty after ${timeoutMs}ms`);
-}
 
 /** Fails with the CLI's own output, which is otherwise swallowed. */
 async function runCLI(
@@ -113,7 +86,12 @@ test("Raw app: generate-metadata must not create duplicate files when runnable k
       { method: "POST", headers: { Authorization: `Bearer ${backend.token}` }, body: formData },
     );
     expect(createResp.ok).toBeTruthy();
-    await waitForQueueToDrain(backend);
+    // Deploying the app queues a dependency job that writes the generated locks
+    // back into the app value. Pulling while it is in flight yields a local copy
+    // with no lock files, so the push below stops being the no-op this test
+    // asserts: it becomes a real change, and rebuilding a raw app bundle needs a
+    // package.json this fixture has no reason to carry.
+    await waitForDeploymentJobs(backend);
 
     // Pull the app
     await runCLI(backend, ["sync", "pull", "--yes"], tempDir);
@@ -121,10 +99,10 @@ test("Raw app: generate-metadata must not create duplicate files when runnable k
     const backendDir = path.join(tempDir, "f/test/diffname_app.raw_app", "backend");
     let files = await readdir(backendDir);
 
-    // After pull: files named by KEY (a, b). Lock files are not what this test
-    // pins, so they are left out of the precondition.
-    const nonLockFiles = files.filter((f) => !f.endsWith(".lock")).sort();
-    expect(nonLockFiles).toEqual(["a.ts", "a.yaml", "b.ts", "b.yaml"]);
+    // After pull: files named by KEY (a, b), locks included.
+    expect(files.sort()).toEqual([
+      "a.lock", "a.ts", "a.yaml", "b.lock", "b.ts", "b.yaml",
+    ]);
 
     // Run generate-metadata — this previously created duplicate files named by NAME
     await runCLI(backend, ["generate-metadata", "--yes"], tempDir);


### PR DESCRIPTION
## Summary

`cli/test/repro_diffname.test.ts` flakes on the linux CI runner ([run 31574940152](https://github.com/windmill-labs/windmill/actions/runs/31574940152/job/94044847310)) with a bare `Expected: 0 / Received: 1` on the final `sync push`.

Root cause is a race with the app dependency job, not the code under test:

1. `POST /apps/create_raw` queues an `AppDependencies` job in the same transaction (`backend/windmill-api/src/apps.rs`), and the worker later writes the generated inline-script locks back into the app value (`backend/windmill-worker/src/worker_lockfiles.rs`).
2. The test pulled immediately, so the local copy had no `a.lock` / `b.lock`.
3. When the job landed *between* the pull and the push, `sync push` saw a real diff (`- raw_app .../a.lock`) instead of a no-op, so it took the bundle-rebuild branch in `cli/src/commands/app/raw_apps.ts`.
4. Rebuilding runs `npm install`, and this fixture — a raw app created straight through the API — has no `package.json`:

```
📦 node_modules not found, running npm install...
npm error enoent Could not read package.json: .../diffname_app.raw_app/package.json
npm install failed with exit code 254
```

The window is ~600ms wide, which is why only the slower runner hits it. The earlier Windows fix (#8811) excluded lock files from the precondition, which papered over the same race one step earlier.

## Changes

- Wait for the deployment jobs to drain (existing `waitForDeploymentJobs` helper) after creating the app, so the pull captures the locks and the final push is the no-op the test intends to assert.
- Assert the pulled file list including `a.lock` / `b.lock`: now that lock generation is deterministic, a lock that never lands fails as a named precondition instead of resurfacing later as an opaque npm error.
- Add a `runCLI` helper that throws with the CLI's stdout/stderr on a non-zero exit — the previous `expect(result.code).toEqual(0)` swallowed the CLI output, which is why CI showed nothing but `Received: 1`.

## Test plan

- [x] `bun test test/repro_diffname.test.ts` passes.
- [x] Reproduced the flake deterministically by making the worker poll lazily (temporarily overriding the hardcoded `SLEEP_QUEUE` in `cli/test/cargo_backend.ts`) to steer the dependency job into the pull→push window: before the fix `SLEEP_QUEUE=400` and `800` fail with the npm ENOENT, after the fix `300/400/800/900` all pass.
- [x] Full `bun test test/` on linux: 1490 pass, 36 skip, 0 fail. This matters because the suite shares one backend whose reset never clears the queue — `repro_diffname` runs after the tests that leave enabled schedules parked in `v2_job_queue`, and the helper's `job_kinds` filter keeps the wait from being held by them.
- [ ] Windows CI job green (the runner where the earlier variant of this race was first seen).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky CLI test by waiting for the app dependency job to finish before pulling, so the final `sync push` is a no-op instead of triggering a bundle rebuild and `npm` error.

- **Bug Fixes**
  - Wait for deployment jobs (`waitForDeploymentJobs`) after creating the app so pull includes generated lock files and avoids the race.
  - Assert pulled files include `a.lock` and `b.lock` to fail early if locks are missing.
  - Add a `runCLI` helper that throws with stdout/stderr on non-zero exit to make failures actionable.

<sup>Written for commit 00bcdcd19471a946b25b52e79fa393b0c9c58d1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

