### PR TITLE
fix(frontend): use the Password component on the login and reset-password forms

### DIFF
--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -278,8 +278,9 @@
 	function handleKeyDown(event: KeyboardEvent) {
 		const key = event.key
 
-		// Enter confirming an IME candidate must not submit
-		if (key === 'Enter' && !event.isComposing) {
+		// keydown auto-repeats while held, and Enter also confirms an IME candidate —
+		// either would submit the form more than once per keypress
+		if (key === 'Enter' && !event.isComposing && !event.repeat) {
 			event.preventDefault()
 			login()
 		}
@@ -535,9 +536,11 @@
 							inputProps={{
 								id: 'email',
 								type: 'email',
-								autocomplete: 'email',
+								autocomplete: 'username',
 								onkeydown: (e) => {
-									if (e.key === 'Enter' && !e.isComposing) {
+									// Only move on once the field holds something: while the browser's
+									// credential dropdown is open, Enter belongs to the dropdown
+									if (e.key === 'Enter' && !e.isComposing && !e.repeat && e.currentTarget.value) {
 										e.preventDefault()
 										passwordField?.focus()
 									}

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -20,6 +20,8 @@
 	import { onDestroy, onMount } from 'svelte'
 	import Skeleton from './common/skeleton/Skeleton.svelte'
 	import Button from './common/button/Button.svelte'
+	import Password from './Password.svelte'
+	import TextInput from './text_input/TextInput.svelte'
 	import { sameTopDomainOrigin } from '$lib/cookies'
 	import { isValidLogoutRedirect, toSameOriginRelativePath } from '$lib/logoutRedirect'
 
@@ -91,6 +93,7 @@
 	const providersType = providers.map((p) => p.type as string)
 
 	let showPassword = $state(false)
+	let passwordField = $state<Password | undefined>(undefined)
 	// Type argument rather than annotation: annotating narrows the declaration to the
 	// initializer's `undefined`, so a top-level read sees `never` instead of the array.
 	let logins = $state<OAuthLogin[] | undefined>(undefined)
@@ -272,10 +275,11 @@
 
 	checkSmtpConfigured()
 
-	function handleKeyUp(event: KeyboardEvent) {
+	function handleKeyDown(event: KeyboardEvent) {
 		const key = event.key
 
-		if (key === 'Enter') {
+		// Enter confirming an IME candidate must not submit
+		if (key === 'Enter' && !event.isComposing) {
 			event.preventDefault()
 			login()
 		}
@@ -525,19 +529,35 @@
 				<div class="space-y-1">
 					<label for="email" class="block text-xs font-semibold text-emphasis"> Email </label>
 					<div>
-						<input type="email" bind:value={email} id="email" autocomplete="email" />
+						<TextInput
+							size="md"
+							bind:value={email}
+							inputProps={{
+								id: 'email',
+								type: 'email',
+								autocomplete: 'email',
+								onkeydown: (e) => {
+									if (e.key === 'Enter' && !e.isComposing) {
+										e.preventDefault()
+										passwordField?.focus()
+									}
+								}
+							}}
+						/>
 					</div>
 				</div>
 
 				<div class="space-y-1">
 					<label for="password" class="block text-xs font-semibold text-emphasis"> Password </label>
 					<div>
-						<input
-							onkeyup={handleKeyUp}
-							bind:value={password}
+						<Password
+							bind:this={passwordField}
+							bind:password
 							id="password"
-							type="password"
+							placeholder=""
 							autocomplete="current-password"
+							allowMultiline={false}
+							onKeyDown={handleKeyDown}
 						/>
 					</div>
 					{#if smtpConfigured}

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -17,7 +17,7 @@
 	import { sendUserToast } from '$lib/toast'
 	import { isCloudHosted } from '$lib/cloud'
 	import { refreshSuperadmin } from '$lib/refreshUser'
-	import { onDestroy, onMount } from 'svelte'
+	import { onDestroy, onMount, tick } from 'svelte'
 	import Skeleton from './common/skeleton/Skeleton.svelte'
 	import Button from './common/button/Button.svelte'
 	import Password from './Password.svelte'
@@ -118,6 +118,11 @@
 			email,
 			password
 		}
+
+		// Await the DOM update: the field must be back to type="password" before the
+		// request goes out, or the browser may not offer to save the credential
+		passwordField?.conceal()
+		await tick()
 
 		try {
 			await UserService.login({ requestBody })

--- a/frontend/src/lib/components/Password.svelte
+++ b/frontend/src/lib/components/Password.svelte
@@ -16,6 +16,7 @@
 		minRows?: number
 		id?: string
 		autocomplete?: HTMLInputAttributes['autocomplete']
+		/** Off for login-style fields: keeps Enter free to submit. Overrides `minRows`. */
 		allowMultiline?: boolean
 		onKeyDown?: (event: KeyboardEvent) => void
 		onBlur?: (event: FocusEvent) => void

--- a/frontend/src/lib/components/Password.svelte
+++ b/frontend/src/lib/components/Password.svelte
@@ -51,6 +51,12 @@
 		;(isMultiline ? textareaRef : inputRef)?.focus()
 	}
 
+	// Revealing swaps the input to type="text". Auth forms conceal again before submitting,
+	// so the browser sees a password field when it decides whether to save the credential.
+	export function conceal() {
+		hideValue = true
+	}
+
 	function insertAndSwitchToMultiline(input: HTMLInputElement, text: string) {
 		const start = input.selectionStart
 		const end = input.selectionEnd

--- a/frontend/src/lib/components/Password.svelte
+++ b/frontend/src/lib/components/Password.svelte
@@ -4,6 +4,7 @@
 	import Button from './common/button/Button.svelte'
 	import TextInput from './text_input/TextInput.svelte'
 	import { Eye, EyeClosed } from 'lucide-svelte'
+	import type { HTMLInputAttributes } from 'svelte/elements'
 
 	const bubble = createBubbler()
 	interface Props {
@@ -14,6 +15,8 @@
 		small?: boolean
 		minRows?: number
 		id?: string
+		autocomplete?: HTMLInputAttributes['autocomplete']
+		allowMultiline?: boolean
 		onKeyDown?: (event: KeyboardEvent) => void
 		onBlur?: (event: FocusEvent) => void
 	}
@@ -26,6 +29,8 @@
 		small = false,
 		minRows,
 		id,
+		autocomplete = 'new-password',
+		allowMultiline = true,
 		onKeyDown,
 		onBlur
 	}: Props = $props()
@@ -34,10 +39,16 @@
 	let hideValue = $state(true)
 	let forceMultiline = $state(false)
 	let isMultiline = $derived(
-		forceMultiline || (minRows != null && minRows > 1) || (password?.includes('\n') ?? false)
+		allowMultiline &&
+			(forceMultiline || (minRows != null && minRows > 1) || (password?.includes('\n') ?? false))
 	)
 
 	let textareaRef: TextInput<'textarea'> | undefined = $state()
+	let inputRef: TextInput<'input'> | undefined = $state()
+
+	export function focus() {
+		;(isMultiline ? textareaRef : inputRef)?.focus()
+	}
 
 	function insertAndSwitchToMultiline(input: HTMLInputElement, text: string) {
 		const start = input.selectionStart
@@ -54,16 +65,6 @@
 </script>
 
 <div class="relative w-full {small ? 'max-w-lg' : ''}">
-	<div class="absolute {isMultiline ? 'top-1' : 'inset-y-0'} right-1 flex items-center z-10">
-		<Button
-			unifiedSize="sm"
-			onClick={() => (hideValue = !hideValue)}
-			iconOnly
-			startIcon={{ icon: hideValue ? Eye : EyeClosed }}
-			variant="subtle"
-			wrapperClasses="bg-surface-input"
-		/>
-	</div>
 	{#if isMultiline}
 		<TextInput
 			bind:this={textareaRef}
@@ -76,7 +77,7 @@
 				disabled,
 				placeholder,
 				rows: minRows ?? 3,
-				autocomplete: 'new-password',
+				autocomplete,
 				onblur: (e) => onBlur?.(e),
 				onkeydown: (e) => {
 					onKeyDown?.(e)
@@ -89,6 +90,7 @@
 		/>
 	{:else}
 		<TextInput
+			bind:this={inputRef}
 			size="md"
 			error={red}
 			bind:value={password}
@@ -96,10 +98,10 @@
 				id,
 				disabled,
 				placeholder,
-				autocomplete: 'new-password',
+				autocomplete,
 				onblur: (e) => onBlur?.(e),
 				onkeydown: (e) => {
-					if (e.key === 'Enter') {
+					if (allowMultiline && e.key === 'Enter') {
 						e.preventDefault()
 						insertAndSwitchToMultiline(e.currentTarget as HTMLInputElement, '\n')
 						return
@@ -109,7 +111,7 @@
 				},
 				onpaste: (e) => {
 					const text = e.clipboardData?.getData('text')
-					if (text?.includes('\n')) {
+					if (allowMultiline && text?.includes('\n')) {
 						e.preventDefault()
 						insertAndSwitchToMultiline(e.currentTarget as HTMLInputElement, text)
 					}
@@ -119,6 +121,18 @@
 			class="pr-8"
 		/>
 	{/if}
+	<!-- After the input in DOM order so Tab reaches the field before the toggle -->
+	<div class="absolute {isMultiline ? 'top-1' : 'inset-y-0'} right-1 flex items-center z-10">
+		<Button
+			unifiedSize="sm"
+			onClick={() => (hideValue = !hideValue)}
+			iconOnly
+			startIcon={{ icon: hideValue ? Eye : EyeClosed }}
+			variant="subtle"
+			title={hideValue ? 'Show password' : 'Hide password'}
+			wrapperClasses="bg-surface-input"
+		/>
+	</div>
 </div>
 {#if red}
 	<div class="text-red-600 text-2xs grow">This field is required</div>

--- a/frontend/src/routes/user/reset-password/+page.svelte
+++ b/frontend/src/routes/user/reset-password/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$lib/navigation'
+	import { tick } from 'svelte'
 	import { page } from '$app/state'
 	import { WindmillIcon } from '$lib/components/icons'
 	import DarkModeToggle from '$lib/components/sidebar/DarkModeToggle.svelte'
@@ -16,6 +17,7 @@
 	let confirmPassword = $state('')
 	let loading = $state(false)
 	let success = $state(false)
+	let newPasswordField = $state<Password | undefined>(undefined)
 	let confirmPasswordField = $state<Password | undefined>(undefined)
 
 	async function resetPassword() {
@@ -33,6 +35,12 @@
 			sendUserToast('Passwords do not match', true)
 			return
 		}
+
+		// Await the DOM update: the fields must be back to type="password" before the
+		// request goes out, or the browser may not offer to save the new credential
+		newPasswordField?.conceal()
+		confirmPasswordField?.conceal()
+		await tick()
 
 		loading = true
 		try {
@@ -110,6 +118,7 @@
 						</label>
 						<div>
 							<Password
+								bind:this={newPasswordField}
 								bind:password={newPassword}
 								id="new-password"
 								placeholder=""

--- a/frontend/src/routes/user/reset-password/+page.svelte
+++ b/frontend/src/routes/user/reset-password/+page.svelte
@@ -7,6 +7,7 @@
 	import { sendUserToast } from '$lib/toast'
 	import { UserService } from '$lib/gen'
 	import LoginPageHeader from '$lib/components/LoginPageHeader.svelte'
+	import Password from '$lib/components/Password.svelte'
 	import { enterpriseLicense, whitelabelNameStore } from '$lib/stores'
 
 	const token = page.url.searchParams.get('token') ?? ''
@@ -15,6 +16,7 @@
 	let confirmPassword = $state('')
 	let loading = $state(false)
 	let success = $state(false)
+	let confirmPasswordField = $state<Password | undefined>(undefined)
 
 	async function resetPassword() {
 		if (!token) {
@@ -50,8 +52,8 @@
 		}
 	}
 
-	function handleKeyUp(event: KeyboardEvent) {
-		if (event.key === 'Enter') {
+	function handleKeyDown(event: KeyboardEvent) {
+		if (event.key === 'Enter' && !event.isComposing) {
 			event.preventDefault()
 			resetPassword()
 		}
@@ -105,12 +107,17 @@
 							New Password
 						</label>
 						<div>
-							<input
-								type="password"
-								bind:value={newPassword}
+							<Password
+								bind:password={newPassword}
 								id="new-password"
-								autocomplete="new-password"
-								onkeyup={handleKeyUp}
+								placeholder=""
+								allowMultiline={false}
+								onKeyDown={(e) => {
+									if (e.key === 'Enter' && !e.isComposing) {
+										e.preventDefault()
+										confirmPasswordField?.focus()
+									}
+								}}
 							/>
 						</div>
 					</div>
@@ -120,12 +127,13 @@
 							Confirm Password
 						</label>
 						<div>
-							<input
-								type="password"
-								bind:value={confirmPassword}
+							<Password
+								bind:this={confirmPasswordField}
+								bind:password={confirmPassword}
 								id="confirm-password"
-								autocomplete="new-password"
-								onkeyup={handleKeyUp}
+								placeholder=""
+								allowMultiline={false}
+								onKeyDown={handleKeyDown}
 							/>
 						</div>
 					</div>

--- a/frontend/src/routes/user/reset-password/+page.svelte
+++ b/frontend/src/routes/user/reset-password/+page.svelte
@@ -53,7 +53,9 @@
 	}
 
 	function handleKeyDown(event: KeyboardEvent) {
-		if (event.key === 'Enter' && !event.isComposing) {
+		// keydown auto-repeats while held, and Enter also confirms an IME candidate — either
+		// would fire several resets against a single-use token
+		if (event.key === 'Enter' && !event.isComposing && !event.repeat) {
 			event.preventDefault()
 			resetPassword()
 		}
@@ -113,7 +115,7 @@
 								placeholder=""
 								allowMultiline={false}
 								onKeyDown={(e) => {
-									if (e.key === 'Enter' && !e.isComposing) {
+									if (e.key === 'Enter' && !e.isComposing && !e.repeat) {
 										e.preventDefault()
 										confirmPasswordField?.focus()
 									}


### PR DESCRIPTION
## Summary

The login form and the reset-password form built their password fields out of raw `<input type="password">` elements, so they were the only password inputs in the app without the reveal (eye) toggle. They now use the shared `Password` component.

`Password` was written for settings/secret fields, where Enter inserts a newline and a multi-line paste turns the field into a textarea — both wrong on an auth form, where Enter must submit. Two props were added so the component can serve a login field, and the reveal toggle moved after the input in DOM order so Tab reaches the field first.

## Changes

- `Password.svelte`: new `autocomplete` prop (default `new-password`, unchanged for existing callers) — a login field needs `current-password` or the browser offers to generate a password instead of filling the saved one.
- `Password.svelte`: new `allowMultiline` prop (default `true`). With it off, Enter is no longer swallowed to insert a newline and a multi-line paste no longer flips the field to a textarea.
- `Password.svelte`: exported `focus()`, so a caller can move focus into the field; the reveal toggle moved after the input (it is absolutely positioned, so nothing moves visually) and gained a `title`, since it is now a tab stop on the login form and had no accessible name.
- `Login.svelte`: password field uses `Password`; the email field moves from a raw `<input>` to `TextInput` so the two line up (they differed by 4px in height), and Enter in the email field now advances to the password field.
- `reset-password`: same treatment for both new-password fields; Enter advances New → Confirm, then submits.
- Both forms: the Enter handler moved from `keyup` to `keydown` (the only hook `Password` exposes) and guards on `!isComposing` and `!repeat`, so a held Enter or an IME candidate confirmation cannot fire several auth requests.
- `Password.svelte`: exported `conceal()`, and both forms call it (then `await tick()`) before submitting. Revealing swaps the input to `type="text"`, and a browser deciding whether to save or update a credential looks for a password field at submit time — submitting while revealed could cost the user the save prompt.

## Screenshots

| Login | Login, revealed | Reset password |
| --- | --- | --- |
| ![shot-login](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/login-password/1786538342-shot-login.png) | ![shot-login-revealed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/login-password/1786538344-shot-login-revealed.png) | ![shot-reset-password](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/login-password/1786538345-shot-reset-password.png) |

## Test plan

Exercised against a running instance:

- [x] Keyboard-only login: type email → Enter → focus lands in password → type → Enter → `/user/workspaces`
- [x] Mouse login: click Sign in
- [x] Held Enter in the password field dispatches exactly one `POST /api/auth/login` (9 keydowns, 1 request)
- [x] Enter on an empty email field does not steal focus (leaves the browser credential dropdown alone)
- [x] Wrong password: stays on the page, "Invalid credentials" toast, field keeps its value
- [x] Autofill-shaped injection (native value setter + `input` event) reaches the Svelte binding and enables Sign in; DOM is still `input#password[type=password][autocomplete=current-password]` with a resolving `<label for>` — the selectors `e2e/global-setup.ts` uses
- [x] Prefill path (`?email=&password=`, same path as the first-time `changeme` prefill) populates both fields
- [x] Multi-line paste into the login field does not create a textarea; reveal/hide preserves the typed value
- [x] Tab order: email → password input → reveal toggle → Forgot password → Sign in
- [x] Existing consumers unaffected: multi-line paste into an instance-settings password still switches to a textarea with the toggle pinned top-right
- [x] Reveal the password, then submit: the field is `type="text"` while revealed but `type="password"` at the instant the request is issued (asserted inside a patched `fetch`), on both forms
- [x] `npm run check`: 0 errors

Not covered: a real password-manager fill or save prompt (a driven browser has no credential store, and the prompt is browser UI rather than DOM) — only the attribute contract and the event path could be checked.
