### PR TITLE
fix: home search matches each term instead of the whole query verbatim

### DIFF
--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -379,6 +379,25 @@ async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::R
         "search must substring-match the summary only"
     );
 
+    // Terms may be spread across the summary and the path, in any order and with
+    // anything in between: clients rank with a fuzzy matcher that matches this way,
+    // so a query it would accept must not come back empty from the server.
+    for query in [
+        "search=deploy%20one",
+        "search=one%20deploy",
+        "search=alpha%20tool",
+    ] {
+        assert_eq!(
+            list_once(port, query).await,
+            vec!["script:f/alpha/one".to_string()],
+            "{query} must reach 'Deploy tool' at f/alpha/one"
+        );
+    }
+
+    // Terms are AND-ed: each one matches something here, no row matches both.
+    let none = list_once(port, "search=deploy%20beta").await;
+    assert!(none.is_empty(), "terms must all match, got {none:?}");
+
     // kinds filter selects a single kind.
     let flows = list_once(port, "kinds=flow").await;
     assert_eq!(flows, vec!["flow:f/alpha/flowy".to_string()], "kinds=flow");

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -379,20 +379,14 @@ async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::R
         "search must substring-match the summary only"
     );
 
-    // Terms may be spread across the summary and the path, in any order and with
-    // anything in between: clients rank with a fuzzy matcher that matches this way,
-    // so a query it would accept must not come back empty from the server.
-    for query in [
-        "search=deploy%20one",
-        "search=one%20deploy",
-        "search=alpha%20tool",
-    ] {
-        assert_eq!(
-            list_once(port, query).await,
-            vec!["script:f/alpha/one".to_string()],
-            "{query} must reach 'Deploy tool' at f/alpha/one"
-        );
-    }
+    // Terms match independently, so one query can span the summary and the path with
+    // anything in between — what a caller's fuzzy ranking accepts but a single
+    // contiguous ILIKE would withhold.
+    assert_eq!(
+        list_once(port, "search=deploy%20one").await,
+        vec!["script:f/alpha/one".to_string()],
+        "terms may sit apart, in the summary and the path"
+    );
 
     // Terms are AND-ed: each one matches something here, no row matches both.
     let none = list_once(port, "search=deploy%20beta").await;

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -406,6 +406,45 @@ async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::R
         4,
         "kinds=script -> 4 scripts, got {scripts:?}"
     );
+
+    // Seeded last: the counts above are asserted exactly.
+    // Without a summary the haystack is the bare path, so such a row stays findable.
+    let r = authed(
+        client().post(format!("{base}/scripts/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&new_script("f/alpha/unsummarized", ""))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 201, "create: {}", r.text().await?);
+    assert_eq!(
+        list_once(port, "search=alpha%20unsummarized").await,
+        vec!["script:f/alpha/unsummarized".to_string()],
+        "a row with no summary is searchable by its path"
+    );
+
+    // A draft is named by the path typed in the editor, so that is what a search has
+    // to match — never the generated `draft_<uuid>` it is parked at.
+    let r = authed(
+        client().post(format!(
+            "{base}/drafts/update/script/u/test-user/draft_9f2a"
+        )),
+        "SECRET_TOKEN",
+    )
+    .json(&json!({ "value": { "path": "f/beta/typed_name", "summary": "" } }))
+    .send()
+    .await?;
+    assert_eq!(r.status(), 200, "save draft: {}", r.text().await?);
+    assert_eq!(
+        list_once(port, "search=beta%20typed&include_draft_only=true").await,
+        vec!["script:u/test-user/draft_9f2a".to_string()],
+        "a draft-only row is searchable by its typed path"
+    );
+    let by_storage_path = list_once(port, "search=9f2a&include_draft_only=true").await;
+    assert!(
+        by_storage_path.is_empty(),
+        "the draft_<uuid> path is not searchable, got {by_storage_path:?}"
+    );
     Ok(())
 }
 

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -379,22 +379,21 @@ async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::R
         "search must substring-match the summary only"
     );
 
-    // Terms match independently, so one query can span the summary and the path with
-    // anything in between — what a caller's fuzzy ranking accepts but a single
-    // contiguous ILIKE would withhold.
+    // Terms may sit apart and span the summary and the path — what the homepage's
+    // fuzzy ranking accepts but a single contiguous ILIKE would withhold.
     assert_eq!(
         list_once(port, "search=deploy%20one").await,
         vec!["script:f/alpha/one".to_string()],
         "terms may sit apart, in the summary and the path"
     );
 
-    // Terms are AND-ed: each one matches something here, no row matches both.
-    let none = list_once(port, "search=deploy%20beta").await;
-    assert!(none.is_empty(), "terms must all match, got {none:?}");
-
-    // A search holding no terms must not degrade into an unfiltered page.
-    let blank = list_once(port, "search=%20").await;
-    assert!(blank.is_empty(), "whitespace-only search, got {blank:?}");
+    // The three rules that bound it, each pinned by a query that must return nothing:
+    // terms hold their order, every term must appear, and a query of pure separators
+    // is a search that matches nothing rather than no search at all.
+    for query in ["search=one%20deploy", "search=deploy%20beta", "search=%20"] {
+        let none = list_once(port, query).await;
+        assert!(none.is_empty(), "{query} must match nothing, got {none:?}");
+    }
 
     // kinds filter selects a single kind.
     let flows = list_once(port, "kinds=flow").await;

--- a/backend/tests/runnables_list_pagination.rs
+++ b/backend/tests/runnables_list_pagination.rs
@@ -392,6 +392,10 @@ async fn test_runnables_search_and_kind_filters(db: Pool<Postgres>) -> anyhow::R
     let none = list_once(port, "search=deploy%20beta").await;
     assert!(none.is_empty(), "terms must all match, got {none:?}");
 
+    // A search holding no terms must not degrade into an unfiltered page.
+    let blank = list_once(port, "search=%20").await;
+    assert!(blank.is_empty(), "whitespace-only search, got {blank:?}");
+
     // kinds filter selects a single kind.
     let flows = list_once(port, "kinds=flow").await;
     assert_eq!(flows, vec!["flow:f/alpha/flowy".to_string()], "kinds=flow");

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10960,11 +10960,13 @@ paths:
           in: query
           description: >-
             case-insensitive fuzzy match on "summary (path)": the query is split into
-            terms on runs of anything but letters, digits and apostrophes, and each of
-            the first 8 must appear whole and in order, with anything in between. Terms
-            past the 8th are ignored, so an over-long query matches more rows rather
-            than fewer. Omitted or empty filters nothing; a query that holds characters
-            but no terms, such as a lone space, matches nothing.
+            terms on runs of anything but ASCII letters, digits and apostrophes, and
+            each of the first 8 must appear whole and in order, with anything in
+            between. Terms past the 8th are ignored, so an over-long query matches more
+            rows rather than fewer. Omitted or empty filters nothing; a query holding no
+            ASCII-alphanumeric character at all (a lone space, "_", or text in a
+            non-Latin script) yields no terms and matches nothing, mirroring the
+            homepage, whose matcher discards those queries too.
           schema:
             type: string
         - $ref: "#/components/parameters/PerPage"

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10960,8 +10960,8 @@ paths:
           in: query
           description: >-
             case-insensitive fuzzy match on "summary (path)": the query is split into
-            terms on non-alphanumerics, and each of the first 8 must appear whole and
-            in order, with anything in between. Terms past the 8th are ignored, so an
+            terms on runs of anything but letters, digits and apostrophes, and each of
+            the first 8 must appear whole and in order, with anything in between. Terms past the 8th are ignored, so an
             over-long query matches more rows rather than fewer; a query holding no
             terms at all matches nothing.
           schema:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10959,11 +10959,11 @@ paths:
         - name: search
           in: query
           description: >-
-            case-insensitive match on summary or path; whitespace separates terms and
-            a row must match each of the first 8, in any order and not necessarily
-            adjacent. Terms past the 8th are ignored, so an over-long query matches
-            more rows rather than fewer; a query holding only whitespace matches
-            nothing.
+            case-insensitive fuzzy match on "summary (path)": the query is split into
+            terms on non-alphanumerics, and each of the first 8 must appear whole and
+            in order, with anything in between. Terms past the 8th are ignored, so an
+            over-long query matches more rows rather than fewer; a query holding no
+            terms at all matches nothing.
           schema:
             type: string
         - $ref: "#/components/parameters/PerPage"

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10959,8 +10959,10 @@ paths:
         - name: search
           in: query
           description: >-
-            case-insensitive match on summary or path; every whitespace-separated
-            term must match, in any order and not necessarily adjacent
+            case-insensitive match on summary or path; whitespace separates terms and
+            a row must match each of the first 8, in any order and not necessarily
+            adjacent. Terms past the 8th are ignored, so an over-long query matches
+            more rows rather than fewer.
           schema:
             type: string
         - $ref: "#/components/parameters/PerPage"

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10962,7 +10962,7 @@ paths:
             case-insensitive match on summary or path; whitespace separates terms and
             a row must match each of the first 8, in any order and not necessarily
             adjacent. Terms past the 8th are ignored, so an over-long query matches
-            more rows rather than fewer; a blank or whitespace-only query filters
+            more rows rather than fewer; a query holding only whitespace matches
             nothing.
           schema:
             type: string

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10958,7 +10958,9 @@ paths:
             type: string
         - name: search
           in: query
-          description: case-insensitive substring match on summary or path
+          description: >-
+            case-insensitive match on summary or path; every whitespace-separated
+            term must match, in any order and not necessarily adjacent
           schema:
             type: string
         - $ref: "#/components/parameters/PerPage"

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10961,9 +10961,10 @@ paths:
           description: >-
             case-insensitive fuzzy match on "summary (path)": the query is split into
             terms on runs of anything but letters, digits and apostrophes, and each of
-            the first 8 must appear whole and in order, with anything in between. Terms past the 8th are ignored, so an
-            over-long query matches more rows rather than fewer; a query holding no
-            terms at all matches nothing.
+            the first 8 must appear whole and in order, with anything in between. Terms
+            past the 8th are ignored, so an over-long query matches more rows rather
+            than fewer. Omitted or empty filters nothing; a query that holds characters
+            but no terms, such as a lone space, matches nothing.
           schema:
             type: string
         - $ref: "#/components/parameters/PerPage"

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10962,7 +10962,8 @@ paths:
             case-insensitive match on summary or path; whitespace separates terms and
             a row must match each of the first 8, in any order and not necessarily
             adjacent. Terms past the 8th are ignored, so an over-long query matches
-            more rows rather than fewer.
+            more rows rather than fewer; a blank or whitespace-only query filters
+            nothing.
           schema:
             type: string
         - $ref: "#/components/parameters/PerPage"

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -61,7 +61,8 @@ struct ListRunnablesQuery {
     label: Option<String>,
     /// Case-insensitive match on summary or path. Whitespace separates terms; a
     /// row must match each of the first `MAX_SEARCH_TERMS`, in any order and not
-    /// necessarily adjacent. Terms past that bound are ignored.
+    /// necessarily adjacent. Terms past that bound are ignored, and a query with
+    /// no terms at all filters nothing.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.
@@ -411,13 +412,11 @@ async fn list_runnables(
         // `u/<caller>/draft_<uuid>` it is parked at.
         draft_common.push(format!("COALESCE(o.draft_path, o.path) LIKE {}", p));
     }
-    if let Some(search) = q.search.as_ref().filter(|s| !s.is_empty()) {
-        // Every whitespace-separated term must match, rather than the query having to
-        // appear verbatim: callers rank these results with a fuzzy matcher that tolerates
-        // gaps between terms, so one contiguous ILIKE would withhold rows the caller would
-        // have shown — "kafka dashboard" never reaching "Kafka offsets dashboard".
-        // Terms only ever narrow and the caller re-filters what comes back, so dropping
-        // the tail of an absurd query widens the response at worst.
+    if let Some(search) = q.search.as_ref().filter(|s| !s.trim().is_empty()) {
+        // A row must match every term rather than the query verbatim: callers rank with a
+        // fuzzy matcher that tolerates gaps, so one contiguous ILIKE would withhold rows
+        // they would have shown — "kafka dashboard" never reaching "Kafka offsets
+        // dashboard". Terms past the cap are dropped, which only widens the response.
         for term in search.split_whitespace().take(MAX_SEARCH_TERMS) {
             let p = add_bind(&mut binds, format!("%{}%", escape_like(term)));
             common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -59,10 +59,10 @@ struct ListRunnablesQuery {
     path_start: Option<String>,
     /// Comma-separated labels; a row matches if it (or its folder) carries all.
     label: Option<String>,
-    /// Case-insensitive match on summary or path. Whitespace separates terms; a
-    /// row must match each of the first `MAX_SEARCH_TERMS`, in any order and not
-    /// necessarily adjacent. Terms past that bound are ignored; a query holding
-    /// only whitespace matches nothing.
+    /// Case-insensitive fuzzy match on `summary (path)`, mirroring how the homepage
+    /// ranks: split on non-alphanumerics, every term must appear whole and in order,
+    /// with anything in between. Only the first `MAX_SEARCH_TERMS` apply; a query
+    /// holding no terms at all matches nothing.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.
@@ -170,9 +170,27 @@ fn decode_cursor(raw: &str) -> Result<Cursor, Error> {
     serde_json::from_slice(&bytes).map_err(|_| Error::BadRequest("invalid cursor".to_string()))
 }
 
-/// Upper bound on the terms one search query contributes to the predicate, so a
+/// Upper bound on the terms one search query contributes to the pattern, so a
 /// pasted paragraph cannot grow it without limit.
 const MAX_SEARCH_TERMS: usize = 8;
+
+/// Split a query into terms on runs of anything that is not an ASCII letter, digit
+/// or apostrophe — the rule the homepage's fuzzy matcher uses, so `f/foo_bar` looks
+/// for `foo` then `bar` rather than for the punctuation between them.
+fn search_terms(search: &str) -> Vec<&str> {
+    search
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '\''))
+        .filter(|t| !t.is_empty())
+        .take(MAX_SEARCH_TERMS)
+        .collect()
+}
+
+/// The string a search matches against: `summary (path)`, or the bare path when
+/// there is no summary — what the homepage concatenates before ranking, so both
+/// halves are searchable as one and a query may span them.
+fn searchable_name(path_expr: &str) -> String {
+    format!("COALESCE(NULLIF(o.summary, '') || ' (' || {path_expr} || ')', {path_expr})")
+}
 
 /// Escape LIKE/ILIKE wildcards so a caller value (search term, path/scope
 /// prefix) matches literally. Relies on the default `\` escape character.
@@ -413,22 +431,32 @@ async fn list_runnables(
         draft_common.push(format!("COALESCE(o.draft_path, o.path) LIKE {}", p));
     }
     if let Some(search) = q.search.as_ref().filter(|s| !s.is_empty()) {
-        // A row must match every term rather than the query verbatim: callers rank with a
-        // fuzzy matcher that tolerates gaps, so one contiguous ILIKE would withhold rows
-        // they would have shown — "kafka dashboard" never reaching "Kafka offsets
-        // dashboard". Terms past the cap are dropped, which only widens the response.
-        let terms: Vec<&str> = search.split_whitespace().take(MAX_SEARCH_TERMS).collect();
+        let terms = search_terms(search);
         if terms.is_empty() {
-            // Whitespace with nothing in it is still a search, and must match nothing —
-            // falling through to no predicate would answer it with the whole workspace.
+            // A search of nothing but separators is still a search: it must match nothing,
+            // where no predicate at all would answer it with the whole workspace.
             common.push("false".to_string());
             draft_common.push("false".to_string());
-        }
-        for term in terms {
-            let p = add_bind(&mut binds, format!("%{}%", escape_like(term)));
-            common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));
+        } else {
+            // `%` between the terms is what makes them a fuzzy match rather than a literal
+            // one: each must appear whole, in this order, with anything in between. The
+            // haystack is the summary-and-path string the homepage matches on, so a query
+            // may span the two and the endpoint withholds nothing the homepage would rank.
+            let p = add_bind(
+                &mut binds,
+                format!(
+                    "%{}%",
+                    terms
+                        .iter()
+                        .map(|t| escape_like(t))
+                        .collect::<Vec<_>>()
+                        .join("%")
+                ),
+            );
+            common.push(format!("{} ILIKE {p}", searchable_name("o.path")));
             draft_common.push(format!(
-                "(o.summary ILIKE {p} OR o.path ILIKE {p} OR o.draft_path ILIKE {p})"
+                "{} ILIKE {p}",
+                searchable_name("COALESCE(o.draft_path, o.path)")
             ));
         }
     }

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -59,8 +59,9 @@ struct ListRunnablesQuery {
     path_start: Option<String>,
     /// Comma-separated labels; a row matches if it (or its folder) carries all.
     label: Option<String>,
-    /// Case-insensitive match on summary or path. Whitespace separates terms,
-    /// all of which must match, in any order and not necessarily adjacent.
+    /// Case-insensitive match on summary or path. Whitespace separates terms; a
+    /// row must match each of the first `MAX_SEARCH_TERMS`, in any order and not
+    /// necessarily adjacent. Terms past that bound are ignored.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -62,7 +62,8 @@ struct ListRunnablesQuery {
     /// Case-insensitive fuzzy match on `summary (path)`, mirroring how the homepage
     /// ranks: split into terms on anything but letters, digits and apostrophes, then
     /// every term must appear whole and in order, with anything in between. Only the
-    /// first `MAX_SEARCH_TERMS` apply; a query holding no terms matches nothing.
+    /// first `MAX_SEARCH_TERMS` apply. Omitted or empty filters nothing; a query that
+    /// holds characters but no terms, such as `" "`, matches nothing.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -59,7 +59,8 @@ struct ListRunnablesQuery {
     path_start: Option<String>,
     /// Comma-separated labels; a row matches if it (or its folder) carries all.
     label: Option<String>,
-    /// Case-insensitive substring match on summary or path.
+    /// Case-insensitive match on summary or path. Whitespace separates terms,
+    /// all of which must match, in any order and not necessarily adjacent.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.
@@ -166,6 +167,10 @@ fn decode_cursor(raw: &str) -> Result<Cursor, Error> {
         .map_err(|_| Error::BadRequest("invalid cursor".to_string()))?;
     serde_json::from_slice(&bytes).map_err(|_| Error::BadRequest("invalid cursor".to_string()))
 }
+
+/// Upper bound on the terms one search query contributes to the predicate, so a
+/// pasted paragraph cannot grow it without limit.
+const MAX_SEARCH_TERMS: usize = 8;
 
 /// Escape LIKE/ILIKE wildcards so a caller value (search term, path/scope
 /// prefix) matches literally. Relies on the default `\` escape character.
@@ -406,11 +411,19 @@ async fn list_runnables(
         draft_common.push(format!("COALESCE(o.draft_path, o.path) LIKE {}", p));
     }
     if let Some(search) = q.search.as_ref().filter(|s| !s.is_empty()) {
-        let p = add_bind(&mut binds, format!("%{}%", escape_like(search)));
-        common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));
-        draft_common.push(format!(
-            "(o.summary ILIKE {p} OR o.path ILIKE {p} OR o.draft_path ILIKE {p})"
-        ));
+        // Every whitespace-separated term must match, rather than the query having to
+        // appear verbatim: callers rank these results with a fuzzy matcher that tolerates
+        // gaps between terms, so one contiguous ILIKE would withhold rows the caller would
+        // have shown — "kafka dashboard" never reaching "Kafka offsets dashboard".
+        // Terms only ever narrow and the caller re-filters what comes back, so dropping
+        // the tail of an absurd query widens the response at worst.
+        for term in search.split_whitespace().take(MAX_SEARCH_TERMS) {
+            let p = add_bind(&mut binds, format!("%{}%", escape_like(term)));
+            common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));
+            draft_common.push(format!(
+                "(o.summary ILIKE {p} OR o.path ILIKE {p} OR o.draft_path ILIKE {p})"
+            ));
+        }
     }
     if let Some(label) = q.label.as_ref().filter(|s| !s.is_empty()) {
         for l in label.split(',') {

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -61,8 +61,8 @@ struct ListRunnablesQuery {
     label: Option<String>,
     /// Case-insensitive match on summary or path. Whitespace separates terms; a
     /// row must match each of the first `MAX_SEARCH_TERMS`, in any order and not
-    /// necessarily adjacent. Terms past that bound are ignored, and a query with
-    /// no terms at all filters nothing.
+    /// necessarily adjacent. Terms past that bound are ignored; a query holding
+    /// only whitespace matches nothing.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.
@@ -412,12 +412,19 @@ async fn list_runnables(
         // `u/<caller>/draft_<uuid>` it is parked at.
         draft_common.push(format!("COALESCE(o.draft_path, o.path) LIKE {}", p));
     }
-    if let Some(search) = q.search.as_ref().filter(|s| !s.trim().is_empty()) {
+    if let Some(search) = q.search.as_ref().filter(|s| !s.is_empty()) {
         // A row must match every term rather than the query verbatim: callers rank with a
         // fuzzy matcher that tolerates gaps, so one contiguous ILIKE would withhold rows
         // they would have shown — "kafka dashboard" never reaching "Kafka offsets
         // dashboard". Terms past the cap are dropped, which only widens the response.
-        for term in search.split_whitespace().take(MAX_SEARCH_TERMS) {
+        let terms: Vec<&str> = search.split_whitespace().take(MAX_SEARCH_TERMS).collect();
+        if terms.is_empty() {
+            // Whitespace with nothing in it is still a search, and must match nothing —
+            // falling through to no predicate would answer it with the whole workspace.
+            common.push("false".to_string());
+            draft_common.push("false".to_string());
+        }
+        for term in terms {
             let p = add_bind(&mut binds, format!("%{}%", escape_like(term)));
             common.push(format!("(o.summary ILIKE {p} OR o.path ILIKE {p})"));
             draft_common.push(format!(

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -60,10 +60,11 @@ struct ListRunnablesQuery {
     /// Comma-separated labels; a row matches if it (or its folder) carries all.
     label: Option<String>,
     /// Case-insensitive fuzzy match on `summary (path)`, mirroring how the homepage
-    /// ranks: split into terms on anything but letters, digits and apostrophes, then
-    /// every term must appear whole and in order, with anything in between. Only the
-    /// first `MAX_SEARCH_TERMS` apply. Omitted or empty filters nothing; a query that
-    /// holds characters but no terms, such as `" "`, matches nothing.
+    /// ranks: split into terms on anything but ASCII letters, digits and apostrophes,
+    /// then every term must appear whole and in order, with anything in between. Only
+    /// the first `MAX_SEARCH_TERMS` apply. Omitted or empty filters nothing; a query
+    /// that holds no ASCII-alphanumeric character at all — `" "`, `"_"`, `"привет"` —
+    /// yields no terms and matches nothing, as it does on the homepage.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.

--- a/backend/windmill-api/src/runnables.rs
+++ b/backend/windmill-api/src/runnables.rs
@@ -60,9 +60,9 @@ struct ListRunnablesQuery {
     /// Comma-separated labels; a row matches if it (or its folder) carries all.
     label: Option<String>,
     /// Case-insensitive fuzzy match on `summary (path)`, mirroring how the homepage
-    /// ranks: split on non-alphanumerics, every term must appear whole and in order,
-    /// with anything in between. Only the first `MAX_SEARCH_TERMS` apply; a query
-    /// holding no terms at all matches nothing.
+    /// ranks: split into terms on anything but letters, digits and apostrophes, then
+    /// every term must appear whole and in order, with anything in between. Only the
+    /// first `MAX_SEARCH_TERMS` apply; a query holding no terms matches nothing.
     search: Option<String>,
     per_page: Option<usize>,
     /// Opaque keyset cursor from a previous page's `next_cursor`.


### PR DESCRIPTION
## Summary

Since #10297 the homepage loads a 100-row browse window and augments it with a debounced server-side search, instead of loading the whole workspace and filtering it client-side. The server predicate was a single contiguous `ILIKE '%<query>%'` over `summary` or `path`, so the space in a two-word query had to appear literally in one column. Any item outside the browse window whose words are separated — or split across the summary and the path — became unreachable from the search box, even though the client's fuzzy ranking would happily have shown it.

Reproduced on a 290-runnable workspace against `f/reporting/email_digest_dashboard`, summary "Email digest dashboard", sitting past row 100:

| query | before | after |
|---|---|---|
| `reporting email` (folder + summary word) | **0** — `No items match the current filters` | 1 |
| `integrations kafka` (space instead of `/`) | **0** | 1 |
| `kafka dashboard` (words not adjacent) | **0** | 1 |
| `kafka` (single word) | 11 | 11 |

The result also depended on session history: search results merge into the client pool, so after searching `kafka offsets` the *same* `kafka dashboard` query then found the row.

## Changes

The endpoint now reproduces the homepage's fuzzy matcher (uFuzzy) exactly, rather than approximating it:

- `search` is split into terms on runs of anything but letters, digits and apostrophes — uFuzzy's `interSplit` rule, so `f/foo_bar` looks for `foo` then `bar`.
- The terms are joined with `%` into one `ILIKE` pattern, so each must appear whole, **in order**, with anything in between.
- It matches against `COALESCE(NULLIF(summary,'') || ' (' || path || ')', path)` — the same `summary (path)` string `ItemsList.svelte` builds, so a query may span the two halves. Draft-only rows use their typed `draft_path`, never the generated `draft_<uuid>` they are stored at.
- `MAX_SEARCH_TERMS = 8` bounds the pattern; surplus terms are dropped, which only widens the result.
- A query that holds characters but no terms (`" "`) matches nothing rather than degrading into an unfiltered page.

This is deliberately parity, not a superset: the endpoint no longer returns rows the client would discard, so the search fetch and its "load more results" cursor page over exactly the rows that get displayed. It is *not* a strict superset of the old predicate — matching is now order-dependent, and a query with no ASCII-alphanumeric characters matches nothing where `%q%` previously matched.

No frontend change: the client's matcher is unchanged and remains the authority on what is displayed.

## Verification

- Equivalence established before writing the SQL: **657** offline queries (fragments, punctuation, 3-term, repeated terms) comparing uFuzzy against the candidate pattern — 0 mismatches. An earlier attempt mismatched on 82/615, which is what surfaced that uFuzzy splits on all punctuation rather than whitespace.
- End-to-end: **220** live-API queries against a 290-item workspace, comparing returned paths to uFuzzy's own output — 0 mismatches, both directions.
- Integration tests pin one rule each: terms may sit apart and span summary/path; order is enforced; every term must appear; a separator-only query matches nothing; a summary-less row is findable by its path; a draft is findable by its typed path and not by its storage path. Verified non-vacuous by mutating `searchable_name` to drop the `COALESCE` fallback and confirming failure.
- 7/7 in `runnables_list_pagination` against a live database.

## Test plan

- [x] `cargo test --test runnables_list_pagination` passes
- [x] Tests confirmed to fail without the handler change
- [x] On a >100-runnable workspace, fresh load, `reporting email` finds a row that previously read `No items match`
- [x] Single-word search returns the same set as before
- [ ] Path-only term (`integrations`) still resolves, now served by the concatenated haystack rather than `o.path ILIKE`

## Follow-up, kept separate

The predicate is unindexed, so each debounced keystroke sequential-scans `script` + `flow` + `app`. A `pg_trgm` GIN index is the one index type that can accelerate an unanchored `ILIKE` — measured on a 52k-row table, `Seq Scan` cost 1381 → `Bitmap Index Scan` cost 736, identical rows. Worth doing on its own merits, not a blocker at current sizes.