### PR TITLE
fix: authorize GET /concurrency_groups/{job_id}/key per job

### DIFF
--- a/backend/.sqlx/query-9724f8493bba07ffd480c71d65be1b3f5b18fde66d33f33c7c3136452c20d4eb.json
+++ b/backend/.sqlx/query-9724f8493bba07ffd480c71d65be1b3f5b18fde66d33f33c7c3136452c20d4eb.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT workspace_id, created_by FROM v2_job WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "workspace_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_by",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "9724f8493bba07ffd480c71d65be1b3f5b18fde66d33f33c7c3136452c20d4eb"
+}

--- a/backend/windmill-api-integration-tests/tests/concurrency_groups.rs
+++ b/backend/windmill-api-integration-tests/tests/concurrency_groups.rs
@@ -57,29 +57,40 @@ async fn test_concurrency_key_requires_job_read_access(db: Pool<Postgres>) -> an
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
 
-    let job_id = Uuid::new_v4();
-    sqlx::query(
-        "INSERT INTO v2_job (id, workspace_id, created_by, permissioned_as, runnable_path, kind, tag, args)
-         VALUES ($1, 'test-workspace', 'test-user', 'u/test-user', 'u/test-user/secret_script', 'script', 'deno', '{}'::jsonb)",
-    )
-    .bind(job_id)
-    .execute(&db)
-    .await?;
-    sqlx::query("INSERT INTO concurrency_key (key, job_id) VALUES ($1, $2)")
-        .bind("test-workspace/script/u/test-user/secret_script")
-        .bind(job_id)
-        .execute(&db)
-        .await?;
+    let insert_job = |id: Uuid, w_id: &'static str, path: &'static str| {
+        let db = db.clone();
+        async move {
+            sqlx::query(
+                "INSERT INTO v2_job (id, workspace_id, created_by, permissioned_as, runnable_path, kind, tag, args)
+                 VALUES ($1, $2, 'test-user', 'u/test-user', $3, 'script', 'deno', '{}'::jsonb)",
+            )
+            .bind(id)
+            .bind(w_id)
+            .bind(path)
+            .execute(&db)
+            .await?;
+            sqlx::query("INSERT INTO concurrency_key (key, job_id) VALUES ($1, $2)")
+                .bind(format!("{w_id}/script/{path}"))
+                .bind(id)
+                .execute(&db)
+                .await?;
+            Ok::<_, sqlx::Error>(())
+        }
+    };
+    let url = |id: Uuid| format!("http://localhost:{port}/api/concurrency_groups/{id}/key");
+    let get = |id: Uuid, token: &'static str| {
+        client()
+            .get(url(id))
+            .header("Authorization", format!("Bearer {token}"))
+            .send()
+    };
 
-    let url = format!("http://localhost:{port}/api/concurrency_groups/{job_id}/key");
+    let job_id = Uuid::new_v4();
+    insert_job(job_id, "test-workspace", "u/test-user/secret_script").await?;
 
     // test-user-2 is a member of the workspace but the run is neither theirs nor
     // visible to them.
-    let resp = client()
-        .get(&url)
-        .header("Authorization", "Bearer SECRET_TOKEN_2")
-        .send()
-        .await?;
+    let resp = get(job_id, "SECRET_TOKEN_2").await?;
     let status = resp.status().as_u16();
     let body = resp.text().await?;
     assert_eq!(status, 403, "expected 403 for a non-viewer, got {body}");
@@ -88,7 +99,32 @@ async fn test_concurrency_key_requires_job_read_access(db: Pool<Postgres>) -> an
         "denied response leaked the key: {body}"
     );
 
-    let resp = authed(client().get(&url)).send().await?;
+    // A job in a workspace the caller is not a member of must be indistinguishable
+    // from a job that does not exist.
+    sqlx::query("INSERT INTO workspace (id, name, owner) VALUES ($1, $1, 'test-user')")
+        .bind("other-workspace")
+        .execute(&db)
+        .await?;
+    let other_job_id = Uuid::new_v4();
+    insert_job(other_job_id, "other-workspace", "u/test-user/other_script").await?;
+
+    let resp = get(other_job_id, "SECRET_TOKEN_2").await?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    assert_eq!(status, 404, "expected 404 for a non-member, got {body}");
+    assert!(
+        !body.contains("other_script"),
+        "denied response leaked the key: {body}"
+    );
+
+    let resp = get(Uuid::new_v4(), "SECRET_TOKEN_2").await?;
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "an unknown job must answer like an inaccessible one"
+    );
+
+    let resp = authed(client().get(url(job_id))).send().await?;
     let status = resp.status().as_u16();
     let body = resp.text().await?;
     assert_2xx(status, &body, "GET /api/concurrency_groups/{id}/key");

--- a/backend/windmill-api-integration-tests/tests/concurrency_groups.rs
+++ b/backend/windmill-api-integration-tests/tests/concurrency_groups.rs
@@ -1,4 +1,5 @@
 use sqlx::{Pool, Postgres};
+use uuid::Uuid;
 use windmill_test_utils::*;
 
 fn client() -> reqwest::Client {
@@ -43,6 +44,55 @@ async fn test_concurrency_groups_2xx(db: Pool<Postgres>) -> anyhow::Result<()> {
         &resp.text().await?,
         "GET /api/w/test-workspace/concurrency_groups/list_jobs",
     );
+
+    Ok(())
+}
+
+/// A concurrency key names the workspace, the runnable path and any `$args`-templated
+/// argument values, so it must not be readable by a member who cannot read the run it
+/// belongs to — the route is global, so nothing in the path scopes it to a workspace.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_concurrency_key_requires_job_read_access(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let job_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO v2_job (id, workspace_id, created_by, permissioned_as, runnable_path, kind, tag, args)
+         VALUES ($1, 'test-workspace', 'test-user', 'u/test-user', 'u/test-user/secret_script', 'script', 'deno', '{}'::jsonb)",
+    )
+    .bind(job_id)
+    .execute(&db)
+    .await?;
+    sqlx::query("INSERT INTO concurrency_key (key, job_id) VALUES ($1, $2)")
+        .bind("test-workspace/script/u/test-user/secret_script")
+        .bind(job_id)
+        .execute(&db)
+        .await?;
+
+    let url = format!("http://localhost:{port}/api/concurrency_groups/{job_id}/key");
+
+    // test-user-2 is a member of the workspace but the run is neither theirs nor
+    // visible to them.
+    let resp = client()
+        .get(&url)
+        .header("Authorization", "Bearer SECRET_TOKEN_2")
+        .send()
+        .await?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    assert_eq!(status, 403, "expected 403 for a non-viewer, got {body}");
+    assert!(
+        !body.contains("secret_script"),
+        "denied response leaked the key: {body}"
+    );
+
+    let resp = authed(client().get(&url)).send().await?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    assert_2xx(status, &body, "GET /api/concurrency_groups/{id}/key");
+    assert_eq!(body, "\"test-workspace/script/u/test-user/secret_script\"");
 
     Ok(())
 }

--- a/backend/windmill-api-jobs/src/concurrency_groups.rs
+++ b/backend/windmill-api-jobs/src/concurrency_groups.rs
@@ -22,11 +22,12 @@ use sql_builder::bind::Bind;
 use sql_builder::SqlBuilder;
 use uuid::Uuid;
 
+/// `/{job_id}/key` is added by `windmill-api`, which is where the shared job read gate
+/// it needs lives.
 pub fn global_service() -> Router {
     Router::new()
         .route("/list", get(list_concurrency_groups))
         .route("/prune/{*concurrency_key}", delete(prune_concurrency_group))
-        .route("/{job_id}/key", get(get_concurrency_key))
 }
 
 pub fn workspaced_service() -> Router {
@@ -355,15 +356,4 @@ async fn get_concurrent_intervals(
             omitted_obscured_jobs: !should_fetch_obscured_jobs,
         }))
     }
-}
-
-async fn get_concurrency_key(
-    _authed: ApiAuthed,
-    Extension(db): Extension<DB>,
-    Path(job_id): Path<Uuid>,
-) -> JsonResult<Option<String>> {
-    let key = sqlx::query_scalar!("SELECT key FROM concurrency_key WHERE job_id = $1", job_id)
-        .fetch_optional(&db)
-        .await?;
-    Ok(Json(key))
 }

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -22861,6 +22861,7 @@ paths:
   /concurrency_groups/{id}/key:
     get:
       summary: Get the concurrency key for a job that has concurrency limits enabled
+      description: Requires read access to the job, the same as reading the run itself. Returns 403 for a workspace member who cannot see the run, and 404 when the caller is not a member of the job's workspace.
       operationId: getConcurrencyKey
       tags:
         - concurrencyGroups

--- a/backend/windmill-api/src/concurrency_groups.rs
+++ b/backend/windmill-api/src/concurrency_groups.rs
@@ -29,7 +29,8 @@ pub fn global_service() -> Router {
 /// The route carries no workspace, so `authed` is not workspace-scoped (no groups, no
 /// folders, `is_admin` only for superadmins). Re-resolve the caller's token against the
 /// job's own workspace before evaluating access — that also rejects non-members, for whom
-/// the job does not exist.
+/// the job does not exist. Members reaching [`require_job_read_access`] get its 403, which
+/// discloses existence only inside a workspace they belong to.
 async fn get_concurrency_key(
     _authed: ApiAuthed,
     Tokened { token }: Tokened,
@@ -39,20 +40,22 @@ async fn get_concurrency_key(
     OptViewToken(view_token): OptViewToken,
     Path(job_id): Path<Uuid>,
 ) -> JsonResult<Option<String>> {
-    let Some(job) = sqlx::query!(
+    let not_found = || Error::NotFound(format!("Job {job_id} not found"));
+
+    // A caller who cannot reach the job must not be able to tell it apart from a job
+    // that does not exist, so both answer with the same 404.
+    let job = sqlx::query!(
         "SELECT workspace_id, created_by FROM v2_job WHERE id = $1",
         job_id
     )
     .fetch_optional(&db)
     .await?
-    else {
-        return Ok(Json(None));
-    };
+    .ok_or_else(not_found)?;
 
     let authed_in_workspace = cache
         .get_authed(Some(job.workspace_id.clone()), &token)
         .await
-        .ok_or_else(|| Error::NotFound(format!("Job {job_id} not found")))?;
+        .ok_or_else(not_found)?;
 
     require_job_read_access(
         &db,

--- a/backend/windmill-api/src/concurrency_groups.rs
+++ b/backend/windmill-api/src/concurrency_groups.rs
@@ -1,1 +1,72 @@
-pub use windmill_api_jobs::concurrency_groups::*;
+use std::sync::Arc;
+
+use axum::{extract::Path, routing::get, Extension, Json, Router};
+use uuid::Uuid;
+use windmill_common::{
+    db::UserDB,
+    error::{Error, JsonResult},
+};
+
+pub use windmill_api_jobs::concurrency_groups::{join_concurrency_key, workspaced_service};
+
+use crate::{
+    auth::{AuthCache, Tokened},
+    db::{ApiAuthed, DB},
+    jobs::{require_job_read_access, OptViewToken},
+};
+
+pub fn global_service() -> Router {
+    windmill_api_jobs::concurrency_groups::global_service()
+        .route("/{job_id}/key", get(get_concurrency_key))
+}
+
+/// A concurrency key embeds the job's workspace, its runnable path and any
+/// `$args[...]`-templated argument values, so reading one is gated on the same access as
+/// reading the run itself. `ApiAuthed` is taken here rather than left to the router: this
+/// service is nested after `route_layer(from_extractor::<ApiAuthed>())`, which only wraps
+/// the routes present at its call site.
+///
+/// The route carries no workspace, so `authed` is not workspace-scoped (no groups, no
+/// folders, `is_admin` only for superadmins). Re-resolve the caller's token against the
+/// job's own workspace before evaluating access — that also rejects non-members, for whom
+/// the job does not exist.
+async fn get_concurrency_key(
+    _authed: ApiAuthed,
+    Tokened { token }: Tokened,
+    Extension(cache): Extension<Arc<AuthCache>>,
+    Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
+    OptViewToken(view_token): OptViewToken,
+    Path(job_id): Path<Uuid>,
+) -> JsonResult<Option<String>> {
+    let Some(job) = sqlx::query!(
+        "SELECT workspace_id, created_by FROM v2_job WHERE id = $1",
+        job_id
+    )
+    .fetch_optional(&db)
+    .await?
+    else {
+        return Ok(Json(None));
+    };
+
+    let authed_in_workspace = cache
+        .get_authed(Some(job.workspace_id.clone()), &token)
+        .await
+        .ok_or_else(|| Error::NotFound(format!("Job {job_id} not found")))?;
+
+    require_job_read_access(
+        &db,
+        &user_db,
+        &authed_in_workspace,
+        &job.workspace_id,
+        &job_id,
+        &job.created_by,
+        view_token.as_deref(),
+    )
+    .await?;
+
+    let key = sqlx::query_scalar!("SELECT key FROM concurrency_key WHERE job_id = $1", job_id)
+        .fetch_optional(&db)
+        .await?;
+    Ok(Json(key))
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1426,7 +1426,7 @@ impl<S: Send + Sync> axum::extract::FromRequestParts<S> for OptViewToken {
 }
 
 /// Otherwise returns 404 — matching `scripts/get` and avoiding existence disclosure.
-async fn require_job_read_access(
+pub(crate) async fn require_job_read_access(
     db: &DB,
     user_db: &UserDB,
     authed: &ApiAuthed,


### PR DESCRIPTION
## Summary

`GET /api/concurrency_groups/{job_id}/key` required authentication (#10221) but no
authorization: any authenticated user of the instance could read the concurrency key of
**any** job, in any workspace, from its UUID. A concurrency key embeds the workspace id,
the runnable path and any `$args[...]`-templated argument values
(`wsa/script/u/admin/concurrent_demo`), so this leaked cross-workspace metadata.

The endpoint is now gated on read access to the job itself, i.e. exactly what the run
page that consumes it already requires. Fixes WIN-2353.

## Changes

- `get_concurrency_key` moves from `windmill-api-jobs` to `windmill-api`, where the shared
  `require_job_read_access` gate lives, so this route uses the same predicate as every
  other job-read route (share read links, tag scopes, flow-lineage visibility and the
  created-by fast path all come for free) instead of a second, divergent check.
- The route carries no workspace, so the extracted `ApiAuthed` is not workspace-scoped
  (no groups/folders, `is_admin` only for superadmins). The handler resolves the job's
  workspace from `v2_job`, re-resolves the caller's token against that workspace via
  `AuthCache`, and evaluates access there.
- A caller outside the job's workspace and a caller naming a job that does not exist get
  the same `404`, so the route is not an instance-wide job-existence oracle. Members reach
  `require_job_read_access` and get its `403`, which discloses existence only inside a
  workspace they belong to.
- `require_job_read_access` is now `pub(crate)`; `ApiAuthed` stays an explicit handler
  extractor because this service is nested after `route_layer(from_extractor::<ApiAuthed>())`
  and would otherwise be unauthenticated again.
- Integration test pinning each direction: same-workspace non-viewer → 403 and no key,
  cross-workspace → 404 identical to an unknown UUID, owner → 200 and the key.
- OpenAPI: documents the access requirement and the 403/404 semantics.

Resulting matrix (verified against a local instance, workspaces `wsa`/`wsb`):

| caller | before | after |
|---|---|---|
| unauthenticated | 401 | 401 |
| member of another workspace | 200 + key | 404 |
| any caller, unknown job UUID | 200 + `null` | 404 |
| workspace member who cannot see the run | 200 + key | 403 |
| same member holding a share read link | 200 + key | 200 + key |
| the run's owner / a workspace admin | 200 + key | 200 + key |

No frontend change: the run page only calls this for a run it has already loaded, and the
share-link page keeps working through the existing `X-View-Token` interceptor.

## Test plan

- [x] `cargo test -p windmill-api-integration-tests --test concurrency_groups` (2 passed)
- [x] Manual matrix above with `curl` against a local backend, including share read links
      (`X-View-Token` header and `view_token` query param) and a forged token (403)
- [x] Inaccessible job and random UUID return byte-identical responses
- [x] Run page still renders the "Concurrency: …" link for an authorized viewer
      (`GET /api/concurrency_groups/{id}/key => 200`, checked in the browser)
- [x] `SQLX_OFFLINE=true cargo check -p windmill-api` passes with the added `.sqlx` entry
      (and fails without it, so the entry is the one CI needs)