### PR TITLE
feat: add memory limits to the go build subprocess

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,14 @@ A crash like this takes down every job on that worker, not just yours, so check 
 backend log after the run rather than only the job's own status. If you cannot run one,
 say which path went unexercised instead of implying it was verified.
 
+### A worker runs one job at a time
+
+`NUM_WORKERS > 1` falls back to 1 outside native mode (`backend/src/main.rs`, unless
+`I_ACK_NUM_WORKERS_IS_UNSAFE`), and native workers only serve the lightweight tags in
+`NATIVE_TAGS` — no `go`, `python3`, `dependency` or `flow`. So anything sizing a per-job
+resource budget (memory, CPU, temp space) is sharing the worker with the worker process
+itself, not with a second script job.
+
 ## Banned Patterns
 
 ### `$bindable(default_value)` on optional props

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,13 +120,17 @@ A crash like this takes down every job on that worker, not just yours, so check 
 backend log after the run rather than only the job's own status. If you cannot run one,
 say which path went unexercised instead of implying it was verified.
 
-### A worker runs one job at a time
+### How many jobs a worker runs at once
 
 `NUM_WORKERS > 1` falls back to 1 outside native mode (`backend/src/main.rs`, unless
-`I_ACK_NUM_WORKERS_IS_UNSAFE`), and native workers only serve the lightweight tags in
-`NATIVE_TAGS` — no `go`, `python3`, `dependency` or `flow`. So anything sizing a per-job
-resource budget (memory, CPU, temp space) is sharing the worker with the worker process
-itself, not with a second script job.
+`I_ACK_NUM_WORKERS_IS_UNSAFE`), so a worker serving script tags — `go`, `python3`,
+`dependency`, `flow`, … — runs one job at a time: a per-job resource budget (memory, CPU,
+temp space) shares the worker with the worker process alone.
+
+Native mode is the exception, and budgets for its tags must divide by its concurrency:
+it forces 8 workers, and `NATIVE_TAGS` includes executors that already claim a per-job
+share of the worker's memory (`postgresql` and `mysql` through `MAX_SQL_RESULT_SIZE`), so
+up to 8 of those run against the same limit at once.
 
 ## Banned Patterns
 

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -1528,6 +1528,12 @@ pub fn get_affinity_cpus() -> Option<usize> {
 
 #[cfg(windows)]
 pub fn get_affinity_cpus() -> Option<usize> {
+    // The 1CU cap is a policy rather than a bandwidth quota, so it is the whole
+    // answer here as it is for `get_vcpus` and `get_memory` — a consumer that reads
+    // this as the hardware count would raise the worker back above the cap.
+    if *LIMIT_WINDOWS_TO_1CU {
+        return Some(1);
+    }
     let mut sys = System::new();
     sys.refresh_cpu_all();
     Some(sys.cpus().len()).filter(|cpus| *cpus > 0)

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -1497,6 +1497,42 @@ pub fn get_cpu_period() -> Option<i64> {
     Some(100000)
 }
 
+/// CPUs the process is allowed to run on, ignoring any bandwidth quota — the count
+/// Go's `NumCPU` reports. `available_parallelism` cannot stand in for it: that folds
+/// the quota in, so a fraction of a CPU makes it report a single-core machine.
+#[cfg(not(windows))]
+pub fn get_affinity_cpus() -> Option<usize> {
+    // "Cpus_allowed_list:\t0-7,16-23"
+    let status = parse_file::<String>("/proc/self/status")?;
+    let list = status
+        .split("Cpus_allowed_list:")
+        .nth(1)?
+        .lines()
+        .next()?
+        .trim();
+
+    let cpus = list
+        .split(',')
+        .map(|range| {
+            let (first, last) = range.split_once('-').unwrap_or((range, range));
+            let (first, last) = (first.trim().parse::<usize>(), last.trim().parse::<usize>());
+            match (first, last) {
+                (Ok(first), Ok(last)) if last >= first => Some(last - first + 1),
+                _ => None,
+            }
+        })
+        .sum::<Option<usize>>()?;
+
+    (cpus > 0).then_some(cpus)
+}
+
+#[cfg(windows)]
+pub fn get_affinity_cpus() -> Option<usize> {
+    let mut sys = System::new();
+    sys.refresh_cpu_all();
+    Some(sys.cpus().len()).filter(|cpus| *cpus > 0)
+}
+
 #[cfg(not(windows))]
 fn get_memory_from_meminfo() -> Option<i64> {
     let memory_info = parse_file::<String>("/proc/meminfo")?;

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -1472,6 +1472,31 @@ pub fn get_vcpus() -> Option<i64> {
     (sys.cpus().len() * 100000).try_into().ok()
 }
 
+/// The window `get_vcpus`'s quota is spent over, in the same microseconds. Only
+/// their ratio is a number of CPUs, and the window is configurable — 100ms is
+/// merely its usual value.
+#[cfg(not(windows))]
+pub fn get_cpu_period() -> Option<i64> {
+    if Path::new("/sys/fs/cgroup/cpu/cpu.cfs_period_us").exists() {
+        // cgroup v1
+        parse_file("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    } else {
+        // cgroup v2: `cpu.max` is "<quota|max> <period>"
+        let cgroup_path = get_cgroupv2_path()?;
+        parse_file::<String>(&format!("{cgroup_path}/cpu.max"))?
+            .split_whitespace()
+            .nth(1)?
+            .parse()
+            .ok()
+    }
+    .filter(|period| *period > 0)
+}
+
+#[cfg(windows)]
+pub fn get_cpu_period() -> Option<i64> {
+    Some(100000)
+}
+
 #[cfg(not(windows))]
 fn get_memory_from_meminfo() -> Option<i64> {
     let memory_info = parse_file::<String>("/proc/meminfo")?;

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -95,26 +95,45 @@ pub const GO_OBJECT_STORE_PREFIX: &str =
 /// entry — including the one shared through the object store.
 const GO_TOOLCHAIN_TUNING_ENVS: [&str; 3] = ["GOMEMLIMIT", "GOGC", "GOMAXPROCS"];
 
+/// The two shapes a Go toolchain invocation takes, which spend the budget
+/// differently: a build fans out into a driver plus compilers, while the module
+/// steps are one process with nothing else running.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GoToolchainStep {
+    Build,
+    Mod,
+}
+
+impl GoToolchainStep {
+    fn label(&self) -> &'static str {
+        match self {
+            GoToolchainStep::Build => "Go compilation",
+            GoToolchainStep::Mod => "Go dependency resolution",
+        }
+    }
+}
+
 /// Memory and parallelism settings for the Go toolchain subprocesses, which
 /// otherwise inherit nothing (they are spawned with a cleared environment).
 ///
 /// Must be applied before the explicit `.env` calls of each command so the
 /// worker's own `PATH`/`GOPATH`/`GOCACHE`/`HOME` win over a worker group setting
 /// the same names, as they do on the run step.
-fn go_toolchain_envs() -> Vec<(String, String)> {
+fn go_toolchain_envs(step: GoToolchainStep) -> Vec<(String, String)> {
     let worker_config = windmill_common::worker::WORKER_CONFIG.load();
-    let envs = merge_go_toolchain_envs(&worker_config.env_vars, *GO_BUILD_LIMITS);
-    log_go_toolchain_limits(&envs);
+    let envs = merge_go_toolchain_envs(&worker_config.env_vars, *GO_BUILD_LIMITS, step);
+    log_go_toolchain_limits(step, &envs);
     envs
 }
 
 /// A slow compilation is the symptom of a limit set too low, and nothing else would
 /// tell an operator that one is in force or what it resolved to. Reports what the
-/// toolchain is actually given, since a worker group can pin values of its own —
-/// on change rather than per job, because it can also do so at runtime.
-fn log_go_toolchain_limits(envs: &[(String, String)]) {
+/// toolchain is actually given, since a worker group can pin values of its own, and
+/// once per distinct setting rather than per job, since it can move them at runtime.
+fn log_go_toolchain_limits(step: GoToolchainStep, envs: &[(String, String)]) {
     lazy_static::lazy_static! {
-        static ref LAST_LOGGED: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+        static ref LOGGED: std::sync::Mutex<std::collections::HashSet<String>> =
+            Default::default();
     }
 
     let limits = envs
@@ -122,24 +141,24 @@ fn log_go_toolchain_limits(envs: &[(String, String)]) {
         .map(|(k, v)| format!("{k}={v}"))
         .collect::<Vec<_>>()
         .join(" ");
+    let line = if limits.is_empty() {
+        format!("{} is unlimited", step.label())
+    } else {
+        format!("{} limited to {limits}", step.label())
+    };
 
-    let Ok(mut last_logged) = LAST_LOGGED.lock() else {
+    let Ok(mut logged) = LOGGED.lock() else {
         return;
     };
-    if last_logged.as_deref() == Some(limits.as_str()) {
-        return;
+    if logged.insert(line.clone()) {
+        tracing::info!("{line}");
     }
-    if limits.is_empty() {
-        tracing::info!("Go compilation is unlimited");
-    } else {
-        tracing::info!("Go compilation limited to {limits}");
-    }
-    *last_logged = Some(limits);
 }
 
 fn merge_go_toolchain_envs(
     worker_envs: &HashMap<String, String>,
     derived: Option<GoBuildLimits>,
+    step: GoToolchainStep,
 ) -> Vec<(String, String)> {
     // Values reach the toolchain as the worker group wrote them, the same way they
     // reach the run step: a `GOMEMLIMIT` the Go runtime rejects then fails both
@@ -159,10 +178,36 @@ fn merge_go_toolchain_envs(
         .iter()
         .any(|(k, _)| k == "GOMEMLIMIT" || k == "GOMAXPROCS");
     if let (false, Some(limits)) = (pinned_by_worker_group, derived) {
-        envs.push(("GOMEMLIMIT".to_string(), limits.memlimit.to_string()));
-        envs.push(("GOMAXPROCS".to_string(), limits.parallelism.to_string()));
+        match step {
+            GoToolchainStep::Build => {
+                envs.push(("GOMEMLIMIT".to_string(), limits.memlimit.to_string()));
+                envs.push(("GOMAXPROCS".to_string(), limits.parallelism.to_string()));
+            }
+            // Nothing shares the budget with a single process, and its work queue
+            // is sized from `GOMAXPROCS` — throttling it would only slow fetches
+            // down without bounding anything.
+            GoToolchainStep::Mod => {
+                envs.push(("GOMEMLIMIT".to_string(), limits.budget.to_string()));
+            }
+        }
     }
     envs
+}
+
+/// `go build`'s `-p`, so the parallelism the aggregate assumes is the one it gets.
+///
+/// `GOMAXPROCS` only supplies the *default* for `-p`, which a `GOFLAGS=-p=…`
+/// persisted in the toolchain's own env file outranks — and that file is read,
+/// since the command keeps `HOME`. A flag on the command line is applied last.
+fn go_build_parallelism_args(envs: &[(String, String)]) -> Vec<String> {
+    envs.iter()
+        .find(|(k, _)| k == "GOMAXPROCS")
+        // A worker group's value is forwarded verbatim, so it is not necessarily a
+        // number; leaving `-p` off keeps a typo as harmless as the Go runtime
+        // makes it rather than failing the build on it.
+        .filter(|(_, v)| v.trim().parse::<usize>().is_ok_and(|p| p > 0))
+        .map(|(_, v)| vec!["-p".to_string(), v.trim().to_string()])
+        .unwrap_or_default()
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
@@ -310,11 +355,19 @@ func Run(req Req) (interface{{}}, error){{
             }
         }
 
+        let toolchain_envs = go_toolchain_envs(GoToolchainStep::Build);
+        let build_args = [
+            vec!["build".to_string()],
+            go_build_parallelism_args(&toolchain_envs),
+            vec!["main.go".to_string()],
+        ]
+        .concat();
+
         let mut build_go_cmd = Command::new(GO_PATH.as_str());
         build_go_cmd
             .current_dir(job_dir)
             .env_clear()
-            .envs(go_toolchain_envs())
+            .envs(toolchain_envs)
             .env("PATH", PATH_ENV.as_str())
             .env("BASE_INTERNAL_URL", base_internal_url)
             .env("GOPATH", {
@@ -330,7 +383,7 @@ func Run(req Req) (interface{{}}, error){{
             .env("HOME", HOME_ENV.as_str())
             .env("GOCACHE", GO_CACHE_DIR.as_str())
             .envs(PROXY_ENVS.clone())
-            .args(vec!["build", "main.go"])
+            .args(build_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
@@ -608,7 +661,7 @@ pub async fn install_go_dependencies(
                     child_cmd
                         .current_dir(job_dir)
                         .env_clear()
-                        .envs(go_toolchain_envs())
+                        .envs(go_toolchain_envs(GoToolchainStep::Mod))
                         .args(vec!["mod", "init", "mymod"])
                         .stdout(Stdio::piped())
                         .stderr(Stdio::piped());
@@ -693,7 +746,7 @@ pub async fn install_go_dependencies(
     child_cmd
         .current_dir(job_dir)
         .env_clear()
-        .envs(go_toolchain_envs())
+        .envs(go_toolchain_envs(GoToolchainStep::Mod))
         .env("HOME", HOME_ENV.as_str())
         .env("PATH", PATH_ENV.as_str())
         .envs(PROXY_ENVS.clone())
@@ -806,9 +859,12 @@ async fn gen_go_mymod(code: &str, job_dir: &str) -> error::Result<()> {
 
 #[cfg(test)]
 mod go_toolchain_envs_tests {
-    use super::{merge_go_toolchain_envs, GoBuildLimits, HashMap};
+    use super::{
+        go_build_parallelism_args, merge_go_toolchain_envs, GoBuildLimits, GoToolchainStep, HashMap,
+    };
 
-    const DERIVED: Option<GoBuildLimits> = Some(GoBuildLimits { memlimit: 512, parallelism: 3 });
+    const DERIVED: Option<GoBuildLimits> =
+        Some(GoBuildLimits { budget: 2048, memlimit: 512, parallelism: 3 });
 
     fn worker_envs(pairs: &[(&str, &str)]) -> HashMap<String, String> {
         pairs
@@ -818,7 +874,8 @@ mod go_toolchain_envs_tests {
     }
 
     fn merged(pairs: &[(&str, &str)], derived: Option<GoBuildLimits>) -> Vec<(String, String)> {
-        let mut envs = merge_go_toolchain_envs(&worker_envs(pairs), derived);
+        let mut envs =
+            merge_go_toolchain_envs(&worker_envs(pairs), derived, GoToolchainStep::Build);
         envs.sort();
         envs
     }
@@ -865,5 +922,26 @@ mod go_toolchain_envs_tests {
             expect(&[("GOMEMLIMIT", "512"), ("GOMAXPROCS", "3")])
         );
         assert_eq!(merged(&[], None), expect(&[]));
+    }
+
+    #[test]
+    fn the_module_steps_get_the_whole_budget() {
+        // One process, nothing sharing with it, and no compilers to hold back.
+        assert_eq!(
+            merge_go_toolchain_envs(&worker_envs(&[]), DERIVED, GoToolchainStep::Mod),
+            expect(&[("GOMEMLIMIT", "2048")])
+        );
+    }
+
+    #[test]
+    fn parallelism_is_passed_on_the_command_line_when_it_is_a_number() {
+        assert_eq!(
+            go_build_parallelism_args(&merged(&[], DERIVED)),
+            vec!["-p".to_string(), "3".to_string()]
+        );
+        // A worker group value is forwarded verbatim, so `-p` is only asserted over
+        // `GOFLAGS` when it is one the toolchain would accept.
+        assert!(go_build_parallelism_args(&merged(&[("GOMAXPROCS", "many")], DERIVED)).is_empty());
+        assert!(go_build_parallelism_args(&merged(&[], None)).is_empty());
     }
 }

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -202,11 +202,14 @@ fn merge_go_toolchain_envs(
 fn go_build_parallelism_args(envs: &[(String, String)]) -> Vec<String> {
     envs.iter()
         .find(|(k, _)| k == "GOMAXPROCS")
-        // A worker group's value is forwarded verbatim, so it is not necessarily a
-        // number; leaving `-p` off keeps a typo as harmless as the Go runtime
-        // makes it rather than failing the build on it.
-        .filter(|(_, v)| v.trim().parse::<usize>().is_ok_and(|p| p > 0))
-        .map(|(_, v)| vec!["-p".to_string(), v.trim().to_string()])
+        // A worker group's value is forwarded verbatim, so it is neither necessarily
+        // a number — leaving `-p` off keeps a typo as harmless as the Go runtime
+        // makes it, rather than failing the build on it — nor necessarily spelled
+        // the way the flag parser accepts: `-p` infers the base, so it rejects the
+        // zero-padded `08` that the runtime reads happily as 8.
+        .and_then(|(_, v)| v.trim().parse::<u32>().ok())
+        .filter(|parallelism| *parallelism > 0)
+        .map(|parallelism| vec!["-p".to_string(), parallelism.to_string()])
         .unwrap_or_default()
 }
 
@@ -942,6 +945,12 @@ mod go_toolchain_envs_tests {
         // A worker group value is forwarded verbatim, so `-p` is only asserted over
         // `GOFLAGS` when it is one the toolchain would accept.
         assert!(go_build_parallelism_args(&merged(&[("GOMAXPROCS", "many")], DERIVED)).is_empty());
+        // `-p` infers the base and rejects `08`, which the runtime reads as 8, so
+        // the number is emitted rather than the spelling it arrived in.
+        assert_eq!(
+            go_build_parallelism_args(&merged(&[("GOMAXPROCS", "08")], DERIVED)),
+            vec!["-p".to_string(), "8".to_string()]
+        );
         assert!(go_build_parallelism_args(&merged(&[], None)).is_empty());
     }
 }

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -202,12 +202,14 @@ fn merge_go_toolchain_envs(
 fn go_build_parallelism_args(envs: &[(String, String)]) -> Vec<String> {
     envs.iter()
         .find(|(k, _)| k == "GOMAXPROCS")
-        // A worker group's value is forwarded verbatim, so it is neither necessarily
-        // a number — leaving `-p` off keeps a typo as harmless as the Go runtime
-        // makes it, rather than failing the build on it — nor necessarily spelled
-        // the way the flag parser accepts: `-p` infers the base, so it rejects the
-        // zero-padded `08` that the runtime reads happily as 8.
-        .and_then(|(_, v)| v.trim().parse::<u32>().ok())
+        // A worker group's value is forwarded verbatim, so it is not necessarily one
+        // the flag would take. Parsing it the way the Go runtime does keeps `-p` in
+        // step with `GOMAXPROCS` on both edges: the runtime reads a signed 32-bit
+        // decimal, so it ignores `2147483648` — while `-p` would accept it and spawn
+        // that many workers — and reads the zero-padded `08` as 8, where `-p` infers
+        // the base and rejects it. A value the runtime ignores leaves `-p` off, so
+        // the build keeps the default the runtime itself would have used.
+        .and_then(|(_, v)| v.trim().parse::<i32>().ok())
         .filter(|parallelism| *parallelism > 0)
         .map(|parallelism| vec!["-p".to_string(), parallelism.to_string()])
         .unwrap_or_default()
@@ -950,6 +952,11 @@ mod go_toolchain_envs_tests {
         assert_eq!(
             go_build_parallelism_args(&merged(&[("GOMAXPROCS", "08")], DERIVED)),
             vec!["-p".to_string(), "8".to_string()]
+        );
+        // Past the signed 32-bit range the runtime ignores the value, so `-p` has
+        // to as well: the flag would take it and start that many workers.
+        assert!(
+            go_build_parallelism_args(&merged(&[("GOMAXPROCS", "2147483648")], DERIVED)).is_empty()
         );
         assert!(go_build_parallelism_args(&merged(&[], None)).is_empty());
     }

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -26,8 +26,8 @@ use crate::{
         OccupancyMetrics, DEV_CONF_NSJAIL,
     },
     handle_child::handle_child,
-    is_sandboxing_enabled, read_ee_registry, DISABLE_NUSER, GOPRIVATE, GOPROXY, GO_BIN_CACHE_DIR,
-    GO_BUILD_LIMITS, GO_CACHE_DIR, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS,
+    is_sandboxing_enabled, read_ee_registry, GoBuildLimits, DISABLE_NUSER, GOPRIVATE, GOPROXY,
+    GO_BIN_CACHE_DIR, GO_BUILD_LIMITS, GO_CACHE_DIR, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS,
     TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
 };
 use windmill_common::client::AuthedClient;
@@ -103,31 +103,33 @@ const GO_TOOLCHAIN_TUNING_ENVS: [&str; 3] = ["GOMEMLIMIT", "GOGC", "GOMAXPROCS"]
 /// the same names, as they do on the run step.
 fn go_toolchain_envs() -> Vec<(String, String)> {
     let worker_config = windmill_common::worker::WORKER_CONFIG.load();
-    let configured = |k: &str| {
-        worker_config
-            .env_vars
-            .get(k)
-            .map(|v| v.trim())
-            .filter(|v| !v.is_empty())
-    };
+    merge_go_toolchain_envs(&worker_config.env_vars, *GO_BUILD_LIMITS)
+}
 
-    let mut envs: Vec<(String, String)> = GO_TOOLCHAIN_TUNING_ENVS
-        .iter()
-        .filter_map(|k| configured(k).map(|v| (k.to_string(), v.to_string())))
-        .collect();
-
+fn merge_go_toolchain_envs(
+    worker_envs: &HashMap<String, String>,
+    derived: Option<GoBuildLimits>,
+) -> Vec<(String, String)> {
     // Values reach the toolchain as the worker group wrote them, the same way they
     // reach the run step: a `GOMEMLIMIT` the Go runtime rejects then fails both
     // steps alike instead of compiling under a rewritten value and dying on the
-    // binary it produced.
-    let pinned_by_worker_group = envs.iter().any(|(k, _)| k == "GOMEMLIMIT");
-    if let (false, Some(limits)) = (pinned_by_worker_group, *GO_BUILD_LIMITS) {
+    // binary it produced. An allowlisted name the worker never set resolves to an
+    // empty string, which would shadow the derived pair with nothing.
+    let configured = |k: &str| worker_envs.get(k).filter(|v| !v.trim().is_empty());
+
+    let mut envs: Vec<(String, String)> = GO_TOOLCHAIN_TUNING_ENVS
+        .iter()
+        .filter_map(|k| configured(k).map(|v| (k.to_string(), v.clone())))
+        .collect();
+
+    // Half of the derived pair is not a weaker limit but no limit (see
+    // `resolve_go_build_limits`), so a worker group that sets either one owns both.
+    let pinned_by_worker_group = envs
+        .iter()
+        .any(|(k, _)| k == "GOMEMLIMIT" || k == "GOMAXPROCS");
+    if let (false, Some(limits)) = (pinned_by_worker_group, derived) {
         envs.push(("GOMEMLIMIT".to_string(), limits.memlimit.to_string()));
-        // The per-process cap only adds up to the budget while the number of
-        // compilers sharing it is held down too.
-        if !envs.iter().any(|(k, _)| k == "GOMAXPROCS") {
-            envs.push(("GOMAXPROCS".to_string(), limits.parallelism.to_string()));
-        }
+        envs.push(("GOMAXPROCS".to_string(), limits.parallelism.to_string()));
     }
     envs
 }
@@ -769,4 +771,72 @@ async fn gen_go_mymod(code: &str, job_dir: &str) -> error::Result<()> {
     write_file(&mymod_dir, "inner_main.go", &code)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod go_toolchain_envs_tests {
+    use super::{merge_go_toolchain_envs, GoBuildLimits, HashMap};
+
+    const DERIVED: Option<GoBuildLimits> = Some(GoBuildLimits { memlimit: 512, parallelism: 3 });
+
+    fn worker_envs(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn merged(pairs: &[(&str, &str)], derived: Option<GoBuildLimits>) -> Vec<(String, String)> {
+        let mut envs = merge_go_toolchain_envs(&worker_envs(pairs), derived);
+        envs.sort();
+        envs
+    }
+
+    fn expect(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        let mut envs: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        envs.sort();
+        envs
+    }
+
+    #[test]
+    fn worker_group_settings_replace_the_derived_pair_whole() {
+        assert_eq!(
+            merged(&[], DERIVED),
+            expect(&[("GOMEMLIMIT", "512"), ("GOMAXPROCS", "3")])
+        );
+        // Either half configured hands the whole policy over, since a cap without a
+        // process count (or the reverse) bounds nothing.
+        assert_eq!(
+            merged(&[("GOMEMLIMIT", "2GiB")], DERIVED),
+            expect(&[("GOMEMLIMIT", "2GiB")])
+        );
+        assert_eq!(
+            merged(&[("GOMAXPROCS", "32")], DERIVED),
+            expect(&[("GOMAXPROCS", "32")])
+        );
+        // GOGC is orthogonal to the pair, so it rides along with it.
+        assert_eq!(
+            merged(&[("GOGC", "50")], DERIVED),
+            expect(&[
+                ("GOGC", "50"),
+                ("GOMEMLIMIT", "512"),
+                ("GOMAXPROCS", "3")
+            ])
+        );
+        // Forwarded untouched: a trimmed value would compile under a spelling the
+        // run step then rejects.
+        assert_eq!(
+            merged(&[("GOMEMLIMIT", " 2GiB ")], DERIVED),
+            expect(&[("GOMEMLIMIT", " 2GiB ")])
+        );
+        // An allowlisted name the worker never set must not shadow the pair.
+        assert_eq!(
+            merged(&[("GOMEMLIMIT", "  ")], DERIVED),
+            expect(&[("GOMEMLIMIT", "512"), ("GOMAXPROCS", "3")])
+        );
+        assert_eq!(merged(&[], None), expect(&[]));
+    }
 }

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -27,7 +27,7 @@ use crate::{
     },
     handle_child::handle_child,
     is_sandboxing_enabled, read_ee_registry, DISABLE_NUSER, GOPRIVATE, GOPROXY, GO_BIN_CACHE_DIR,
-    GO_BUILD_MEMLIMIT, GO_CACHE_DIR, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS,
+    GO_BUILD_LIMITS, GO_CACHE_DIR, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS,
     TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
 };
 use windmill_common::client::AuthedClient;
@@ -103,19 +103,30 @@ const GO_TOOLCHAIN_TUNING_ENVS: [&str; 3] = ["GOMEMLIMIT", "GOGC", "GOMAXPROCS"]
 /// the same names, as they do on the run step.
 fn go_toolchain_envs() -> Vec<(String, String)> {
     let worker_config = windmill_common::worker::WORKER_CONFIG.load();
+    let configured = |k: &str| {
+        worker_config
+            .env_vars
+            .get(k)
+            .map(|v| v.trim())
+            .filter(|v| !v.is_empty())
+    };
+
     let mut envs: Vec<(String, String)> = GO_TOOLCHAIN_TUNING_ENVS
         .iter()
-        .filter_map(|k| {
-            worker_config
-                .env_vars
-                .get(*k)
-                .map(|v| (k.to_string(), v.clone()))
-        })
+        .filter_map(|k| configured(k).map(|v| (k.to_string(), v.to_string())))
         .collect();
 
-    if !envs.iter().any(|(k, _)| k == "GOMEMLIMIT") {
-        if let Some(memlimit) = *GO_BUILD_MEMLIMIT {
-            envs.push(("GOMEMLIMIT".to_string(), memlimit.to_string()));
+    // Values reach the toolchain as the worker group wrote them, the same way they
+    // reach the run step: a `GOMEMLIMIT` the Go runtime rejects then fails both
+    // steps alike instead of compiling under a rewritten value and dying on the
+    // binary it produced.
+    let pinned_by_worker_group = envs.iter().any(|(k, _)| k == "GOMEMLIMIT");
+    if let (false, Some(limits)) = (pinned_by_worker_group, *GO_BUILD_LIMITS) {
+        envs.push(("GOMEMLIMIT".to_string(), limits.memlimit.to_string()));
+        // The per-process cap only adds up to the budget while the number of
+        // compilers sharing it is held down too.
+        if !envs.iter().any(|(k, _)| k == "GOMAXPROCS") {
+            envs.push(("GOMAXPROCS".to_string(), limits.parallelism.to_string()));
         }
     }
     envs

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -103,7 +103,38 @@ const GO_TOOLCHAIN_TUNING_ENVS: [&str; 3] = ["GOMEMLIMIT", "GOGC", "GOMAXPROCS"]
 /// the same names, as they do on the run step.
 fn go_toolchain_envs() -> Vec<(String, String)> {
     let worker_config = windmill_common::worker::WORKER_CONFIG.load();
-    merge_go_toolchain_envs(&worker_config.env_vars, *GO_BUILD_LIMITS)
+    let envs = merge_go_toolchain_envs(&worker_config.env_vars, *GO_BUILD_LIMITS);
+    log_go_toolchain_limits(&envs);
+    envs
+}
+
+/// A slow compilation is the symptom of a limit set too low, and nothing else would
+/// tell an operator that one is in force or what it resolved to. Reports what the
+/// toolchain is actually given, since a worker group can pin values of its own —
+/// on change rather than per job, because it can also do so at runtime.
+fn log_go_toolchain_limits(envs: &[(String, String)]) {
+    lazy_static::lazy_static! {
+        static ref LAST_LOGGED: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+    }
+
+    let limits = envs
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let Ok(mut last_logged) = LAST_LOGGED.lock() else {
+        return;
+    };
+    if last_logged.as_deref() == Some(limits.as_str()) {
+        return;
+    }
+    if limits.is_empty() {
+        tracing::info!("Go compilation is unlimited");
+    } else {
+        tracing::info!("Go compilation limited to {limits}");
+    }
+    *last_logged = Some(limits);
 }
 
 fn merge_go_toolchain_envs(
@@ -820,11 +851,7 @@ mod go_toolchain_envs_tests {
         // GOGC is orthogonal to the pair, so it rides along with it.
         assert_eq!(
             merged(&[("GOGC", "50")], DERIVED),
-            expect(&[
-                ("GOGC", "50"),
-                ("GOMEMLIMIT", "512"),
-                ("GOMAXPROCS", "3")
-            ])
+            expect(&[("GOGC", "50"), ("GOMEMLIMIT", "512"), ("GOMAXPROCS", "3")])
         );
         // Forwarded untouched: a trimmed value would compile under a spelling the
         // run step then rejects.

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -27,7 +27,8 @@ use crate::{
     },
     handle_child::handle_child,
     is_sandboxing_enabled, read_ee_registry, DISABLE_NUSER, GOPRIVATE, GOPROXY, GO_BIN_CACHE_DIR,
-    GO_CACHE_DIR, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS, TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
+    GO_BUILD_MEMLIMIT, GO_CACHE_DIR, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS,
+    TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
 };
 use windmill_common::client::AuthedClient;
 
@@ -84,6 +85,42 @@ lazy_static::lazy_static! {
 
 pub const GO_OBJECT_STORE_PREFIX: &str =
     const_format::concatcp!(crate::global_cache::TARGET, "_gobin/");
+
+/// Worker group env vars forwarded to the Go toolchain (`go build`, `go mod …`).
+///
+/// Restricted to the GC and scheduler knobs, which bound what a compilation costs
+/// without changing what it produces: the built binary is cached under a hash of
+/// the source and lockfile alone, so a var that alters codegen (`GOFLAGS`, build
+/// tags) would let two worker groups disagree about the contents of one cache
+/// entry — including the one shared through the object store.
+const GO_TOOLCHAIN_TUNING_ENVS: [&str; 3] = ["GOMEMLIMIT", "GOGC", "GOMAXPROCS"];
+
+/// Memory and parallelism settings for the Go toolchain subprocesses, which
+/// otherwise inherit nothing (they are spawned with a cleared environment).
+///
+/// Must be applied before the explicit `.env` calls of each command so the
+/// worker's own `PATH`/`GOPATH`/`GOCACHE`/`HOME` win over a worker group setting
+/// the same names, as they do on the run step.
+fn go_toolchain_envs() -> Vec<(String, String)> {
+    let worker_config = windmill_common::worker::WORKER_CONFIG.load();
+    let mut envs: Vec<(String, String)> = GO_TOOLCHAIN_TUNING_ENVS
+        .iter()
+        .filter_map(|k| {
+            worker_config
+                .env_vars
+                .get(*k)
+                .map(|v| (k.to_string(), v.clone()))
+        })
+        .collect();
+
+    if !envs.iter().any(|(k, _)| k == "GOMEMLIMIT") {
+        if let Some(memlimit) = *GO_BUILD_MEMLIMIT {
+            envs.push(("GOMEMLIMIT".to_string(), memlimit.to_string()));
+        }
+    }
+    envs
+}
+
 #[tracing::instrument(level = "trace", skip_all)]
 pub async fn handle_go_job(
     mem_peak: &mut i32,
@@ -233,6 +270,7 @@ func Run(req Req) (interface{{}}, error){{
         build_go_cmd
             .current_dir(job_dir)
             .env_clear()
+            .envs(go_toolchain_envs())
             .env("PATH", PATH_ENV.as_str())
             .env("BASE_INTERNAL_URL", base_internal_url)
             .env("GOPATH", {
@@ -526,6 +564,7 @@ pub async fn install_go_dependencies(
                     child_cmd
                         .current_dir(job_dir)
                         .env_clear()
+                        .envs(go_toolchain_envs())
                         .args(vec!["mod", "init", "mymod"])
                         .stdout(Stdio::piped())
                         .stderr(Stdio::piped());
@@ -610,6 +649,7 @@ pub async fn install_go_dependencies(
     child_cmd
         .current_dir(job_dir)
         .env_clear()
+        .envs(go_toolchain_envs())
         .env("HOME", HOME_ENV.as_str())
         .env("PATH", PATH_ENV.as_str())
         .envs(PROXY_ENVS.clone())

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -141,10 +141,13 @@ fn log_go_toolchain_limits(step: GoToolchainStep, envs: &[(String, String)]) {
         .map(|(k, v)| format!("{k}={v}"))
         .collect::<Vec<_>>()
         .join(" ");
+    // Neutral wording: the settings are reported rather than characterized, since
+    // a worker group can pin ones that lift the limit (`GOMEMLIMIT=off`) as easily
+    // as ones that impose it.
     let line = if limits.is_empty() {
-        format!("{} is unlimited", step.label())
+        format!("{} runs with no limits", step.label())
     } else {
-        format!("{} limited to {limits}", step.label())
+        format!("{} runs with {limits}", step.label())
     };
 
     let Ok(mut logged) = LOGGED.lock() else {
@@ -202,17 +205,27 @@ fn merge_go_toolchain_envs(
 fn go_build_parallelism_args(envs: &[(String, String)]) -> Vec<String> {
     envs.iter()
         .find(|(k, _)| k == "GOMAXPROCS")
-        // A worker group's value is forwarded verbatim, so it is not necessarily one
-        // the flag would take. Parsing it the way the Go runtime does keeps `-p` in
-        // step with `GOMAXPROCS` on both edges: the runtime reads a signed 32-bit
-        // decimal, so it ignores `2147483648` — while `-p` would accept it and spawn
-        // that many workers — and reads the zero-padded `08` as 8, where `-p` infers
-        // the base and rejects it. A value the runtime ignores leaves `-p` off, so
-        // the build keeps the default the runtime itself would have used.
-        .and_then(|(_, v)| v.trim().parse::<i32>().ok())
+        .and_then(|(_, v)| go_runtime_int32(v))
         .filter(|parallelism| *parallelism > 0)
         .map(|parallelism| vec!["-p".to_string(), parallelism.to_string()])
         .unwrap_or_default()
+}
+
+/// `GOMAXPROCS` as the Go runtime reads it: a signed 32-bit decimal, no padding of
+/// any kind, and `None` for everything else — which the runtime silently ignores.
+///
+/// A worker group's value is forwarded verbatim, so it is not necessarily one the
+/// `-p` flag would take, and the two parsers disagree in both directions: `-p`
+/// infers the base and rejects the `08` the runtime reads as 8, while it accepts
+/// the `2147483648` and the `"8 "` the runtime discards — and it would then start
+/// that many build workers. Reading the value the runtime's way keeps `-p` in step
+/// with it, so a spelling the runtime ignores leaves the flag off and the build
+/// keeps the default the runtime itself would have used.
+fn go_runtime_int32(v: &str) -> Option<i32> {
+    let digits = v.strip_prefix(['+', '-']).unwrap_or(v);
+    (!digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()))
+        .then(|| v.parse::<i32>().ok())
+        .flatten()
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
@@ -953,10 +966,20 @@ mod go_toolchain_envs_tests {
             go_build_parallelism_args(&merged(&[("GOMAXPROCS", "08")], DERIVED)),
             vec!["-p".to_string(), "8".to_string()]
         );
-        // Past the signed 32-bit range the runtime ignores the value, so `-p` has
-        // to as well: the flag would take it and start that many workers.
+        // Past the signed 32-bit range, and padded with whitespace, the runtime
+        // ignores the value, so `-p` has to as well: the flag would take either and
+        // start that many workers.
         assert!(
             go_build_parallelism_args(&merged(&[("GOMAXPROCS", "2147483648")], DERIVED)).is_empty()
+        );
+        assert!(
+            go_build_parallelism_args(&merged(&[("GOMAXPROCS", "2147483647 ")], DERIVED))
+                .is_empty()
+        );
+        // A leading `+` is one the runtime does take, so the flag keeps it too.
+        assert_eq!(
+            go_build_parallelism_args(&merged(&[("GOMAXPROCS", "+8")], DERIVED)),
+            vec!["-p".to_string(), "8".to_string()]
         );
         assert!(go_build_parallelism_args(&merged(&[], None)).is_empty());
     }

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1450,7 +1450,9 @@ fn resolve_go_build_limits(
     let cap = vcpus.max(1) + 1;
     let processes = (budget / GO_BUILD_TARGET_MEMLIMIT).clamp(MIN_GO_BUILD_PROCESSES.min(cap), cap);
     Some(GoBuildLimits {
-        budget,
+        // Floored like the share it is an alternative to: a step that holds the
+        // whole budget must never end up with less than one of six compilers.
+        budget: budget.max(MIN_GO_BUILD_MEMLIMIT),
         memlimit: (budget / processes).max(MIN_GO_BUILD_MEMLIMIT),
         parallelism: processes - 1,
     })
@@ -1493,7 +1495,7 @@ mod go_build_limits_tests {
         // Under the floor the budget gives instead of the share.
         assert_eq!(
             resolve_go_build_limits(None, Some(GIB / 8), 4),
-            limits(3 * GIB as usize / 32, MIN_GO_BUILD_MEMLIMIT, 4)
+            limits(MIN_GO_BUILD_MEMLIMIT, MIN_GO_BUILD_MEMLIMIT, 4)
         );
         assert_eq!(
             resolve_go_build_limits(Some("2GiB"), Some(4 * GIB), 4),

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1275,6 +1275,14 @@ const SQL_RESULT_SIZE_FRACTION: f64 = 0.15;
 // only reject work that would have succeeded.
 const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 
+// Share of the worker's memory budget a Go compilation is told to keep its heap
+// under. Set high enough that an ordinary build never approaches it, so the only
+// builds whose behavior changes are those that were about to take the worker down.
+const GO_BUILD_MEMLIMIT_FRACTION: f64 = 0.75;
+// Below this the toolchain would spend more time collecting than compiling, and a
+// build confined to that little cannot threaten a worker anyway.
+const MIN_GO_BUILD_MEMLIMIT: usize = 256 * 1024 * 1024;
+
 /// `"512"`, `"512MB"`, `"2GiB"`, `"1.5GB"` -> bytes. Suffixes are case-insensitive
 /// and binary, so `MB` and `MiB` both mean 1024².
 ///
@@ -1351,6 +1359,95 @@ lazy_static::lazy_static! {
                 .unwrap_or(usize::MAX),
         }
     };
+
+    /// Soft heap cap, in bytes, handed to the Go toolchain as `GOMEMLIMIT` when it
+    /// compiles a script. It is the only bound those subprocesses have: they run
+    /// with a cleared environment, so nothing configured on the worker reaches them
+    /// and a compilation grows until the cgroup OOM killer takes the worker process
+    /// down, every job colocated on it with it. `GOMEMLIMIT` is soft — the Go GC
+    /// works harder as the heap nears it instead of failing the allocation — so a
+    /// pathological build degrades into a slow one rather than a dead worker.
+    ///
+    /// `GO_BUILD_MEMLIMIT` overrides the derived value (`512MB`, `2GiB`, …), and
+    /// `0`/`off` disables the cap, as does a worker with no cgroup memory reading to
+    /// scale from. A `GOMEMLIMIT` set on the worker group wins over both.
+    pub static ref GO_BUILD_MEMLIMIT: Option<usize> = {
+        let limit = resolve_go_build_memlimit(
+            std::env::var("GO_BUILD_MEMLIMIT").ok().as_deref(),
+            windmill_common::worker::get_memory(),
+        );
+        // A slow compilation is the symptom of a cap that is too low, and nothing
+        // else would tell an operator one is in force or what it resolved to.
+        tracing::info!(
+            "Go compilation memory limit (GOMEMLIMIT): {}",
+            limit.map(format_byte_size).unwrap_or_else(|| "none".to_string())
+        );
+        limit
+    };
+}
+
+fn resolve_go_build_memlimit(
+    env_override: Option<&str>,
+    worker_memory: Option<i64>,
+) -> Option<usize> {
+    let derived = || {
+        worker_memory.filter(|bytes| *bytes > 0).map(|bytes| {
+            ((bytes as f64 * GO_BUILD_MEMLIMIT_FRACTION) as usize).max(MIN_GO_BUILD_MEMLIMIT)
+        })
+    };
+
+    match env_override.map(str::trim).filter(|v| !v.is_empty()) {
+        None => derived(),
+        Some(v) if v.eq_ignore_ascii_case("off") => None,
+        Some(v) => match parse_byte_size(v) {
+            // A zero cap would have the GC hold the heap at nothing, so it reads as
+            // "no cap" instead.
+            Some(0) => None,
+            Some(bytes) => Some(bytes),
+            None => {
+                // Falling back silently would leave the operator believing the limit
+                // they wrote is in force.
+                tracing::warn!(
+                    "GO_BUILD_MEMLIMIT={v:?} is not a byte size (e.g. 512MB, 2GiB); \
+                     falling back to the memory-derived limit"
+                );
+                derived()
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod go_build_memlimit_tests {
+    use super::{resolve_go_build_memlimit, MIN_GO_BUILD_MEMLIMIT};
+
+    const GIB: i64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn resolves_the_go_build_memlimit() {
+        assert_eq!(
+            resolve_go_build_memlimit(None, Some(4 * GIB)),
+            Some(3 * GIB as usize)
+        );
+        // Nothing to scale from leaves the toolchain uncapped, as it was before.
+        assert_eq!(resolve_go_build_memlimit(None, None), None);
+        // A worker too small to derive a workable cap from keeps the floor.
+        assert_eq!(
+            resolve_go_build_memlimit(None, Some(GIB / 8)),
+            Some(MIN_GO_BUILD_MEMLIMIT)
+        );
+        assert_eq!(
+            resolve_go_build_memlimit(Some("2GiB"), Some(4 * GIB)),
+            Some(2 * GIB as usize)
+        );
+        assert_eq!(resolve_go_build_memlimit(Some("off"), Some(4 * GIB)), None);
+        assert_eq!(resolve_go_build_memlimit(Some("0MB"), Some(4 * GIB)), None);
+        // An unparseable override falls back to the derived cap rather than uncapping.
+        assert_eq!(
+            resolve_go_build_memlimit(Some("lots"), Some(4 * GIB)),
+            Some(3 * GIB as usize)
+        );
+    }
 }
 
 /// The limit postgres collection is bounded by: the cloud product cap where one

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1402,8 +1402,8 @@ fn worker_vcpus() -> usize {
     effective_vcpus(
         windmill_common::worker::get_vcpus(),
         windmill_common::worker::get_cpu_period(),
-        std::thread::available_parallelism()
-            .map(|n| n.get())
+        windmill_common::worker::get_affinity_cpus()
+            .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
             .unwrap_or(1),
     )
 }
@@ -1415,15 +1415,17 @@ fn worker_vcpus() -> usize {
 /// it rounds up the way the Go runtime's own container-aware `GOMAXPROCS` does:
 /// flooring would call that worker single-core and serialize its builds.
 ///
-/// `host_cpus` is only the answer when there is no quota to read. It cannot also
-/// serve as a ceiling on one: `available_parallelism` already folds the quota in
-/// and floors it, so clamping to it would put back the rounding this exists to fix.
+/// `host_cpus` counts the CPUs the worker may run on, quota aside, and is both the
+/// answer when there is no quota and the floor under one: Go's own container-aware
+/// default never drops below two while the machine has two to give, since even a
+/// fraction of a CPU compiles two packages faster than it compiles them in series.
 fn effective_vcpus(quota_us: Option<i64>, period_us: Option<i64>, host_cpus: usize) -> usize {
     quota_us
         .zip(period_us)
         .filter(|(quota, period)| *quota > 0 && *period > 0)
         .map(|(quota, period)| ((quota + period - 1) / period) as usize)
         .unwrap_or(host_cpus)
+        .max(host_cpus.min(2))
         .max(1)
 }
 
@@ -1504,7 +1506,10 @@ mod go_build_limits_tests {
         // it would otherwise be clamped to has already floored it.
         assert_eq!(effective_vcpus(Some(4_000_000), Some(100_000), 4), 40);
         assert_eq!(effective_vcpus(None, None, 8), 8);
-        assert_eq!(effective_vcpus(Some(50_000), Some(100_000), 24), 1);
+        // Under a whole CPU the floor is two, as the Go runtime's own default is —
+        // but only where there are two to give.
+        assert_eq!(effective_vcpus(Some(50_000), Some(100_000), 24), 2);
+        assert_eq!(effective_vcpus(Some(50_000), Some(100_000), 1), 1);
     }
 
     #[test]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1279,11 +1279,18 @@ const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 // that an ordinary build never approaches it, so the only builds whose behavior
 // changes are those that were about to take the worker down.
 const GO_BUILD_MEMLIMIT_FRACTION: f64 = 0.75;
-// Least heap worth handing a Go compiler: under it the process spends more time
-// collecting than compiling, so the budget buys fewer of them instead. Measured on
-// a dependency-heavy build at a fixed budget: this share compiles it faster than
-// both more-and-smaller processes and fewer-and-larger ones, the latter steeply so.
-const MIN_GO_BUILD_MEMLIMIT: usize = 384 * 1024 * 1024;
+// Heap a Go compiler is comfortable in: cores are only put to work while the budget
+// still affords each of them this much.
+const GO_BUILD_TARGET_MEMLIMIT: usize = 384 * 1024 * 1024;
+// Driver plus the compilers below which a build stops overlapping and starts
+// waiting. Measured on a dependency-heavy build: at a budget too small to give this
+// many the target share, splitting it further still compiles faster than handing
+// fewer processes more — one compiler alone costs ~3x what five of them do on the
+// same budget — so the process count holds and the share absorbs the difference.
+const MIN_GO_BUILD_PROCESSES: usize = 6;
+// Floor under the share, past which dividing the budget again buys nothing: the
+// processes only trade compiling time for collecting time.
+const MIN_GO_BUILD_MEMLIMIT: usize = 128 * 1024 * 1024;
 
 /// `"512"`, `"512MB"`, `"2GiB"`, `"1.5GB"` -> bytes. Suffixes are case-insensitive
 /// and binary, so `MB` and `MiB` both mean 1024².
@@ -1371,24 +1378,11 @@ lazy_static::lazy_static! {
     /// `GO_BUILD_MEMLIMIT` overrides the budget (`512MB`, `2GiB`, …), and `0`/`off`
     /// disables the whole thing, as does a worker with no cgroup memory reading to
     /// scale from.
-    pub(crate) static ref GO_BUILD_LIMITS: Option<GoBuildLimits> = {
-        let limits = resolve_go_build_limits(
-            std::env::var("GO_BUILD_MEMLIMIT").ok().as_deref(),
-            windmill_common::worker::get_memory(),
-            worker_vcpus(),
-        );
-        // A slow compilation is the symptom of a budget that is too low, and nothing
-        // else would tell an operator one is in force or what it resolved to.
-        match limits {
-            Some(l) => tracing::info!(
-                "Go compilation limited to {} per process across {} compilers",
-                format_byte_size(l.memlimit),
-                l.parallelism
-            ),
-            None => tracing::info!("Go compilation memory is unlimited"),
-        }
-        limits
-    };
+    pub(crate) static ref GO_BUILD_LIMITS: Option<GoBuildLimits> = resolve_go_build_limits(
+        std::env::var("GO_BUILD_MEMLIMIT").ok().as_deref(),
+        windmill_common::worker::get_memory(),
+        worker_vcpus(),
+    );
 }
 
 /// How much memory the Go toolchain may hold while compiling a script, expressed
@@ -1446,10 +1440,13 @@ fn resolve_go_build_limits(
         },
     };
 
-    // The floor wins over the budget on a worker too small to honor both: a
-    // compiler squeezed under it makes no progress, so exceeding the budget is the
-    // lesser evil.
-    let processes = (budget / MIN_GO_BUILD_MEMLIMIT).clamp(2, vcpus.max(1) + 1);
+    // One compiler per core while the budget affords each the target share, never
+    // so few that the build stops overlapping, and never more than the cores can
+    // run. The floor is the last word: on a worker too small to honor both, the
+    // budget is the one that gives, since processes squeezed under it make no
+    // progress to bound.
+    let cap = vcpus.max(1) + 1;
+    let processes = (budget / GO_BUILD_TARGET_MEMLIMIT).clamp(MIN_GO_BUILD_PROCESSES.min(cap), cap);
     Some(GoBuildLimits {
         memlimit: (budget / processes).max(MIN_GO_BUILD_MEMLIMIT),
         parallelism: processes - 1,
@@ -1458,7 +1455,9 @@ fn resolve_go_build_limits(
 
 #[cfg(test)]
 mod go_build_limits_tests {
-    use super::{resolve_go_build_limits, GoBuildLimits, MIN_GO_BUILD_MEMLIMIT};
+    use super::{
+        resolve_go_build_limits, GoBuildLimits, GO_BUILD_TARGET_MEMLIMIT, MIN_GO_BUILD_MEMLIMIT,
+    };
 
     const GIB: i64 = 1024 * 1024 * 1024;
 
@@ -1468,22 +1467,30 @@ mod go_build_limits_tests {
 
     #[test]
     fn splits_the_budget_across_the_build_tree() {
-        // 3GiB of budget over a driver plus 4 compilers, none under the floor.
+        // Fewer cores than the budget could feed: every core gets a compiler, and
+        // they share 3GiB with the driver.
         assert_eq!(
             resolve_go_build_limits(None, Some(4 * GIB), 4),
             limits(3 * GIB as usize / 5, 4)
         );
-        // More cores than the budget can feed buys fewer compilers, not smaller ones.
+        // More cores than it can feed at the target share: the extra cores idle
+        // rather than shrink every compiler.
         assert_eq!(
             resolve_go_build_limits(None, Some(4 * GIB), 64),
-            limits(MIN_GO_BUILD_MEMLIMIT, 7)
+            limits(GO_BUILD_TARGET_MEMLIMIT, 7)
+        );
+        // Too small to give even the minimum process count the target share: the
+        // build keeps overlapping and the share absorbs it.
+        assert_eq!(
+            resolve_go_build_limits(None, Some(GIB), 64),
+            limits(3 * GIB as usize / 4 / 6, 5)
         );
         // Nothing to scale from leaves the toolchain unlimited, as it was before.
         assert_eq!(resolve_go_build_limits(None, None, 4), None);
-        // A worker too small for even one compiler still gets the floor.
+        // Under the floor the budget gives instead of the share.
         assert_eq!(
             resolve_go_build_limits(None, Some(GIB / 8), 4),
-            limits(MIN_GO_BUILD_MEMLIMIT, 1)
+            limits(MIN_GO_BUILD_MEMLIMIT, 4)
         );
         assert_eq!(
             resolve_go_build_limits(Some("2GiB"), Some(4 * GIB), 4),

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1510,6 +1510,9 @@ mod go_build_limits_tests {
         // but only where there are two to give.
         assert_eq!(effective_vcpus(Some(50_000), Some(100_000), 24), 2);
         assert_eq!(effective_vcpus(Some(50_000), Some(100_000), 1), 1);
+        // A one-CPU allowance stays one when that is all the worker may use, which
+        // is how the Windows 1CU cap reports itself.
+        assert_eq!(effective_vcpus(Some(100_000), Some(100_000), 1), 1);
     }
 
     #[test]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1275,12 +1275,12 @@ const SQL_RESULT_SIZE_FRACTION: f64 = 0.15;
 // only reject work that would have succeeded.
 const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 
-// Share of the worker's memory budget a Go compilation is told to keep its heap
-// under. Set high enough that an ordinary build never approaches it, so the only
-// builds whose behavior changes are those that were about to take the worker down.
+// Share of the worker's memory budget a Go compilation may hold. Set high enough
+// that an ordinary build never approaches it, so the only builds whose behavior
+// changes are those that were about to take the worker down.
 const GO_BUILD_MEMLIMIT_FRACTION: f64 = 0.75;
-// Below this the toolchain would spend more time collecting than compiling, and a
-// build confined to that little cannot threaten a worker anyway.
+// Least heap worth handing a Go compiler: under it the process spends more time
+// collecting than compiling, so the budget buys fewer of them instead.
 const MIN_GO_BUILD_MEMLIMIT: usize = 256 * 1024 * 1024;
 
 /// `"512"`, `"512MB"`, `"2GiB"`, `"1.5GB"` -> bytes. Suffixes are case-insensitive
@@ -1360,92 +1360,140 @@ lazy_static::lazy_static! {
         }
     };
 
-    /// Soft heap cap, in bytes, handed to the Go toolchain as `GOMEMLIMIT` when it
-    /// compiles a script. It is the only bound those subprocesses have: they run
-    /// with a cleared environment, so nothing configured on the worker reaches them
-    /// and a compilation grows until the cgroup OOM killer takes the worker process
-    /// down, every job colocated on it with it. `GOMEMLIMIT` is soft — the Go GC
-    /// works harder as the heap nears it instead of failing the allocation — so a
-    /// pathological build degrades into a slow one rather than a dead worker.
+    /// What a Go compilation is allowed to cost, derived from the worker's memory
+    /// budget. Nothing else bounds it: a compilation grows until the cgroup OOM
+    /// killer takes the worker process down, every job colocated on it with it.
+    /// `GOMEMLIMIT` is soft — the GC works harder as the heap nears it instead of
+    /// failing the allocation — so a pathological build turns into a slow one.
     ///
-    /// `GO_BUILD_MEMLIMIT` overrides the derived value (`512MB`, `2GiB`, …), and
-    /// `0`/`off` disables the cap, as does a worker with no cgroup memory reading to
-    /// scale from. A `GOMEMLIMIT` set on the worker group wins over both.
-    pub static ref GO_BUILD_MEMLIMIT: Option<usize> = {
-        let limit = resolve_go_build_memlimit(
+    /// `GO_BUILD_MEMLIMIT` overrides the budget (`512MB`, `2GiB`, …), and `0`/`off`
+    /// disables the whole thing, as does a worker with no cgroup memory reading to
+    /// scale from.
+    pub(crate) static ref GO_BUILD_LIMITS: Option<GoBuildLimits> = {
+        let limits = resolve_go_build_limits(
             std::env::var("GO_BUILD_MEMLIMIT").ok().as_deref(),
             windmill_common::worker::get_memory(),
+            worker_vcpus(),
         );
-        // A slow compilation is the symptom of a cap that is too low, and nothing
+        // A slow compilation is the symptom of a budget that is too low, and nothing
         // else would tell an operator one is in force or what it resolved to.
-        tracing::info!(
-            "Go compilation memory limit (GOMEMLIMIT): {}",
-            limit.map(format_byte_size).unwrap_or_else(|| "none".to_string())
-        );
-        limit
+        match limits {
+            Some(l) => tracing::info!(
+                "Go compilation limited to {} per process across {} compilers",
+                format_byte_size(l.memlimit),
+                l.parallelism
+            ),
+            None => tracing::info!("Go compilation memory is unlimited"),
+        }
+        limits
     };
 }
 
-fn resolve_go_build_memlimit(
+/// How much memory the Go toolchain may hold while compiling a script, expressed
+/// the only way the toolchain understands it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct GoBuildLimits {
+    /// `GOMEMLIMIT`, which caps one process rather than the build.
+    pub memlimit: usize,
+    /// `GOMAXPROCS`, which is also `go build`'s default `-p`: how many compilers it
+    /// runs at once.
+    pub parallelism: usize,
+}
+
+fn worker_vcpus() -> usize {
+    windmill_common::worker::get_vcpus()
+        // cgroup quota, in µs of CPU time per 100ms period.
+        .map(|quota| (quota / 100_000).max(1) as usize)
+        .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
+        .unwrap_or(1)
+}
+
+/// Split a build budget into the per-process cap and the parallelism it assumes.
+///
+/// `GOMEMLIMIT` bounds one process, and a build is a driver plus up to `-p`
+/// compilers that each inherit the same value, so the budget only holds if the
+/// number of processes sharing it is pinned alongside it.
+fn resolve_go_build_limits(
     env_override: Option<&str>,
     worker_memory: Option<i64>,
-) -> Option<usize> {
+    vcpus: usize,
+) -> Option<GoBuildLimits> {
     let derived = || {
-        worker_memory.filter(|bytes| *bytes > 0).map(|bytes| {
-            ((bytes as f64 * GO_BUILD_MEMLIMIT_FRACTION) as usize).max(MIN_GO_BUILD_MEMLIMIT)
-        })
+        worker_memory
+            .filter(|bytes| *bytes > 0)
+            .map(|bytes| (bytes as f64 * GO_BUILD_MEMLIMIT_FRACTION) as usize)
     };
 
-    match env_override.map(str::trim).filter(|v| !v.is_empty()) {
-        None => derived(),
-        Some(v) if v.eq_ignore_ascii_case("off") => None,
+    let budget = match env_override.map(str::trim).filter(|v| !v.is_empty()) {
+        None => derived()?,
+        Some(v) if v.eq_ignore_ascii_case("off") => return None,
         Some(v) => match parse_byte_size(v) {
-            // A zero cap would have the GC hold the heap at nothing, so it reads as
-            // "no cap" instead.
-            Some(0) => None,
-            Some(bytes) => Some(bytes),
+            // A zero budget would have the GC hold the heap at nothing, so it reads
+            // as "no limit" instead.
+            Some(0) => return None,
+            Some(bytes) => bytes,
             None => {
                 // Falling back silently would leave the operator believing the limit
                 // they wrote is in force.
                 tracing::warn!(
-                    "GO_BUILD_MEMLIMIT={v:?} is not a byte size (e.g. 512MB, 2GiB); \
-                     falling back to the memory-derived limit"
+                    "Go build memory budget {v:?} is not a byte size (e.g. 512MB, \
+                     2GiB); falling back to the worker's memory-derived budget"
                 );
-                derived()
+                derived()?
             }
         },
-    }
+    };
+
+    // The floor wins over the budget on a worker too small to honor both: a
+    // compiler squeezed under it makes no progress, so exceeding the budget is the
+    // lesser evil.
+    let processes = (budget / MIN_GO_BUILD_MEMLIMIT).clamp(2, vcpus.max(1) + 1);
+    Some(GoBuildLimits {
+        memlimit: (budget / processes).max(MIN_GO_BUILD_MEMLIMIT),
+        parallelism: processes - 1,
+    })
 }
 
 #[cfg(test)]
-mod go_build_memlimit_tests {
-    use super::{resolve_go_build_memlimit, MIN_GO_BUILD_MEMLIMIT};
+mod go_build_limits_tests {
+    use super::{resolve_go_build_limits, GoBuildLimits, MIN_GO_BUILD_MEMLIMIT};
 
     const GIB: i64 = 1024 * 1024 * 1024;
 
+    fn limits(memlimit: usize, parallelism: usize) -> Option<GoBuildLimits> {
+        Some(GoBuildLimits { memlimit, parallelism })
+    }
+
     #[test]
-    fn resolves_the_go_build_memlimit() {
+    fn splits_the_budget_across_the_build_tree() {
+        // 3GiB of budget over a driver plus 4 compilers, none under the floor.
         assert_eq!(
-            resolve_go_build_memlimit(None, Some(4 * GIB)),
-            Some(3 * GIB as usize)
+            resolve_go_build_limits(None, Some(4 * GIB), 4),
+            limits(3 * GIB as usize / 5, 4)
         );
-        // Nothing to scale from leaves the toolchain uncapped, as it was before.
-        assert_eq!(resolve_go_build_memlimit(None, None), None);
-        // A worker too small to derive a workable cap from keeps the floor.
+        // More cores than the budget can feed buys fewer compilers, not smaller ones.
         assert_eq!(
-            resolve_go_build_memlimit(None, Some(GIB / 8)),
-            Some(MIN_GO_BUILD_MEMLIMIT)
+            resolve_go_build_limits(None, Some(4 * GIB), 64),
+            limits(MIN_GO_BUILD_MEMLIMIT, 11)
+        );
+        // Nothing to scale from leaves the toolchain unlimited, as it was before.
+        assert_eq!(resolve_go_build_limits(None, None, 4), None);
+        // A worker too small for even one compiler still gets the floor.
+        assert_eq!(
+            resolve_go_build_limits(None, Some(GIB / 8), 4),
+            limits(MIN_GO_BUILD_MEMLIMIT, 1)
         );
         assert_eq!(
-            resolve_go_build_memlimit(Some("2GiB"), Some(4 * GIB)),
-            Some(2 * GIB as usize)
+            resolve_go_build_limits(Some("2GiB"), Some(4 * GIB), 4),
+            limits(2 * GIB as usize / 5, 4)
         );
-        assert_eq!(resolve_go_build_memlimit(Some("off"), Some(4 * GIB)), None);
-        assert_eq!(resolve_go_build_memlimit(Some("0MB"), Some(4 * GIB)), None);
-        // An unparseable override falls back to the derived cap rather than uncapping.
+        assert_eq!(resolve_go_build_limits(Some("off"), Some(4 * GIB), 4), None);
+        assert_eq!(resolve_go_build_limits(Some("0MB"), Some(4 * GIB), 4), None);
+        // An unparseable override falls back to the derived budget rather than
+        // lifting the limit.
         assert_eq!(
-            resolve_go_build_memlimit(Some("lots"), Some(4 * GIB)),
-            Some(3 * GIB as usize)
+            resolve_go_build_limits(Some("lots"), Some(4 * GIB), 4),
+            limits(3 * GIB as usize / 5, 4)
         );
     }
 }

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1389,7 +1389,9 @@ lazy_static::lazy_static! {
 /// the only way the toolchain understands it.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) struct GoBuildLimits {
-    /// `GOMEMLIMIT`.
+    /// What the whole build may hold, and so what a step that is one process gets.
+    pub budget: usize,
+    /// `GOMEMLIMIT` for one process of a build that fans out.
     pub memlimit: usize,
     /// `GOMAXPROCS`, which is also `go build`'s default `-p`: how many compilers it
     /// runs at once.
@@ -1448,6 +1450,7 @@ fn resolve_go_build_limits(
     let cap = vcpus.max(1) + 1;
     let processes = (budget / GO_BUILD_TARGET_MEMLIMIT).clamp(MIN_GO_BUILD_PROCESSES.min(cap), cap);
     Some(GoBuildLimits {
+        budget,
         memlimit: (budget / processes).max(MIN_GO_BUILD_MEMLIMIT),
         parallelism: processes - 1,
     })
@@ -1461,8 +1464,8 @@ mod go_build_limits_tests {
 
     const GIB: i64 = 1024 * 1024 * 1024;
 
-    fn limits(memlimit: usize, parallelism: usize) -> Option<GoBuildLimits> {
-        Some(GoBuildLimits { memlimit, parallelism })
+    fn limits(budget: usize, memlimit: usize, parallelism: usize) -> Option<GoBuildLimits> {
+        Some(GoBuildLimits { budget, memlimit, parallelism })
     }
 
     #[test]
@@ -1471,30 +1474,30 @@ mod go_build_limits_tests {
         // they share 3GiB with the driver.
         assert_eq!(
             resolve_go_build_limits(None, Some(4 * GIB), 4),
-            limits(3 * GIB as usize / 5, 4)
+            limits(3 * GIB as usize, 3 * GIB as usize / 5, 4)
         );
         // More cores than it can feed at the target share: the extra cores idle
         // rather than shrink every compiler.
         assert_eq!(
             resolve_go_build_limits(None, Some(4 * GIB), 64),
-            limits(GO_BUILD_TARGET_MEMLIMIT, 7)
+            limits(3 * GIB as usize, GO_BUILD_TARGET_MEMLIMIT, 7)
         );
         // Too small to give even the minimum process count the target share: the
         // build keeps overlapping and the share absorbs it.
         assert_eq!(
             resolve_go_build_limits(None, Some(GIB), 64),
-            limits(3 * GIB as usize / 4 / 6, 5)
+            limits(3 * GIB as usize / 4, 3 * GIB as usize / 4 / 6, 5)
         );
         // Nothing to scale from leaves the toolchain unlimited, as it was before.
         assert_eq!(resolve_go_build_limits(None, None, 4), None);
         // Under the floor the budget gives instead of the share.
         assert_eq!(
             resolve_go_build_limits(None, Some(GIB / 8), 4),
-            limits(MIN_GO_BUILD_MEMLIMIT, 4)
+            limits(3 * GIB as usize / 32, MIN_GO_BUILD_MEMLIMIT, 4)
         );
         assert_eq!(
             resolve_go_build_limits(Some("2GiB"), Some(4 * GIB), 4),
-            limits(2 * GIB as usize / 5, 4)
+            limits(2 * GIB as usize, 2 * GIB as usize / 5, 4)
         );
         assert_eq!(resolve_go_build_limits(Some("off"), Some(4 * GIB), 4), None);
         assert_eq!(resolve_go_build_limits(Some("0MB"), Some(4 * GIB), 4), None);
@@ -1502,7 +1505,7 @@ mod go_build_limits_tests {
         // lifting the limit.
         assert_eq!(
             resolve_go_build_limits(Some("lots"), Some(4 * GIB), 4),
-            limits(3 * GIB as usize / 5, 4)
+            limits(3 * GIB as usize, 3 * GIB as usize / 5, 4)
         );
     }
 }

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1399,11 +1399,32 @@ pub(crate) struct GoBuildLimits {
 }
 
 fn worker_vcpus() -> usize {
-    windmill_common::worker::get_vcpus()
-        // cgroup quota, in µs of CPU time per 100ms period.
-        .map(|quota| (quota / 100_000).max(1) as usize)
-        .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
-        .unwrap_or(1)
+    effective_vcpus(
+        windmill_common::worker::get_vcpus(),
+        windmill_common::worker::get_cpu_period(),
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1),
+    )
+}
+
+/// CPUs worth of work the worker can actually run at once.
+///
+/// The cgroup states its allowance as a quota over a period, and only their ratio
+/// is a number of CPUs — `1500m` is `150000/100000`. A fraction still runs work, so
+/// it rounds up the way the Go runtime's own container-aware `GOMAXPROCS` does:
+/// flooring would call that worker single-core and serialize its builds.
+///
+/// `host_cpus` is only the answer when there is no quota to read. It cannot also
+/// serve as a ceiling on one: `available_parallelism` already folds the quota in
+/// and floors it, so clamping to it would put back the rounding this exists to fix.
+fn effective_vcpus(quota_us: Option<i64>, period_us: Option<i64>, host_cpus: usize) -> usize {
+    quota_us
+        .zip(period_us)
+        .filter(|(quota, period)| *quota > 0 && *period > 0)
+        .map(|(quota, period)| ((quota + period - 1) / period) as usize)
+        .unwrap_or(host_cpus)
+        .max(1)
 }
 
 /// Split a build budget into the per-process cap and the parallelism it assumes.
@@ -1461,13 +1482,29 @@ fn resolve_go_build_limits(
 #[cfg(test)]
 mod go_build_limits_tests {
     use super::{
-        resolve_go_build_limits, GoBuildLimits, GO_BUILD_TARGET_MEMLIMIT, MIN_GO_BUILD_MEMLIMIT,
+        effective_vcpus, resolve_go_build_limits, GoBuildLimits, GO_BUILD_TARGET_MEMLIMIT,
+        MIN_GO_BUILD_MEMLIMIT,
     };
 
     const GIB: i64 = 1024 * 1024 * 1024;
 
     fn limits(budget: usize, memlimit: usize, parallelism: usize) -> Option<GoBuildLimits> {
         Some(GoBuildLimits { budget, memlimit, parallelism })
+    }
+
+    #[test]
+    fn reads_the_cgroup_allowance_as_cpus() {
+        // 1500m: a fraction of a CPU still runs work, so it is two compilers' worth
+        // of concurrency rather than one.
+        assert_eq!(effective_vcpus(Some(150_000), Some(100_000), 24), 2);
+        assert_eq!(effective_vcpus(Some(400_000), Some(100_000), 24), 4);
+        // The period is configurable, so only the ratio means anything.
+        assert_eq!(effective_vcpus(Some(400_000), Some(50_000), 24), 8);
+        // The quota is the answer whenever there is one to read, since the count
+        // it would otherwise be clamped to has already floored it.
+        assert_eq!(effective_vcpus(Some(4_000_000), Some(100_000), 4), 40);
+        assert_eq!(effective_vcpus(None, None, 8), 8);
+        assert_eq!(effective_vcpus(Some(50_000), Some(100_000), 24), 1);
     }
 
     #[test]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1280,8 +1280,10 @@ const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 // changes are those that were about to take the worker down.
 const GO_BUILD_MEMLIMIT_FRACTION: f64 = 0.75;
 // Least heap worth handing a Go compiler: under it the process spends more time
-// collecting than compiling, so the budget buys fewer of them instead.
-const MIN_GO_BUILD_MEMLIMIT: usize = 256 * 1024 * 1024;
+// collecting than compiling, so the budget buys fewer of them instead. Measured on
+// a dependency-heavy build at a fixed budget: this share compiles it faster than
+// both more-and-smaller processes and fewer-and-larger ones, the latter steeply so.
+const MIN_GO_BUILD_MEMLIMIT: usize = 384 * 1024 * 1024;
 
 /// `"512"`, `"512MB"`, `"2GiB"`, `"1.5GB"` -> bytes. Suffixes are case-insensitive
 /// and binary, so `MB` and `MiB` both mean 1024².
@@ -1393,7 +1395,7 @@ lazy_static::lazy_static! {
 /// the only way the toolchain understands it.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) struct GoBuildLimits {
-    /// `GOMEMLIMIT`, which caps one process rather than the build.
+    /// `GOMEMLIMIT`.
     pub memlimit: usize,
     /// `GOMAXPROCS`, which is also `go build`'s default `-p`: how many compilers it
     /// runs at once.
@@ -1474,7 +1476,7 @@ mod go_build_limits_tests {
         // More cores than the budget can feed buys fewer compilers, not smaller ones.
         assert_eq!(
             resolve_go_build_limits(None, Some(4 * GIB), 64),
-            limits(MIN_GO_BUILD_MEMLIMIT, 11)
+            limits(MIN_GO_BUILD_MEMLIMIT, 7)
         );
         // Nothing to scale from leaves the toolchain unlimited, as it was before.
         assert_eq!(resolve_go_build_limits(None, None, 4), None);

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1278,6 +1278,11 @@ const MIN_MAX_SQL_RESULT_SIZE: usize = 8 * 1024 * 1024;
 // Share of the worker's memory budget a Go compilation may hold. Set high enough
 // that an ordinary build never approaches it, so the only builds whose behavior
 // changes are those that were about to take the worker down.
+//
+// What the rest covers is not the worker process, which is tens of MB and would
+// argue for a constant: it is everything `GOMEMLIMIT` does not count and that grows
+// with the build — the toolchain's mmapped inputs and outputs, its non-Go
+// allocations, and the page cache its writes charge to the cgroup.
 const GO_BUILD_MEMLIMIT_FRACTION: f64 = 0.75;
 // Heap a Go compiler is comfortable in: cores are only put to work while the budget
 // still affords each of them this much.


### PR DESCRIPTION
## Summary

Go compilation had no memory bound. `go build` and `go mod init|tidy|download` are spawned with `env_clear()` and only receive `PATH`, `GOPATH`, `HOME`, `GOCACHE` and the proxy vars, so nothing configured on the worker reached them and the container memory limit was the only control. A compilation that outgrows the cgroup gets the worker process OOM-killed, taking every job colocated on it down with it.

This gives the toolchain a budget derived from the worker's own memory limit, and forwards the Go tuning knobs from the worker group config to the compilation step (previously they only reached the run step).

`GOMEMLIMIT` is a *soft* limit: the GC works harder as the heap approaches it rather than failing the allocation, so a pathological build turns into a slow build instead of a dead worker.

## Changes

- `GO_BUILD_LIMITS` (`windmill-worker/src/worker.rs`) resolves a build budget: `GO_BUILD_MEMLIMIT` (`512MB`, `2GiB`, … / `0` / `off`) if set, else 75% of the worker's memory reading. A worker with no reading to scale from stays unlimited.
- The budget is split into `GOMEMLIMIT` **and** `GOMAXPROCS`, applied as an atomic pair. `GOMEMLIMIT` caps one process, but a build is a driver plus up to `-p` (= `GOMAXPROCS`) compilers that each inherit it, so a per-process cap alone bounds nothing — half of the pair is no limit, whichever half is missing. Cores are put to work while the budget affords each compiler a comfortable share; below that the process count holds and the share absorbs the difference, down to an absolute floor.
- `GOMEMLIMIT`, `GOGC` and `GOMAXPROCS` set on the worker group are forwarded to all three toolchain spawn sites. The allowlist is deliberately narrow: the built binary is cached under a hash of the source and lockfile alone (and shared through the object store), so a var that alters codegen — `GOFLAGS`, build tags — would let two worker groups disagree about the contents of one cache entry. A worker group that pins either half of the pair owns both, and the derived pair steps aside entirely.
- Forwarded values are passed through verbatim, not normalized. Parsing `512MB` into bytes for the toolchain was considered and rejected: the run step already forwards the same variable verbatim, so a spelling the Go runtime rejects (it takes a bare byte count or `KiB`/`MiB`/`GiB` only) would compile fine and then abort on the binary it produced — confirmed by running it. Failing both steps identically is the clearer signal.
- `go build` passes `-p` explicitly. `GOMAXPROCS` only supplies its *default*, and a `GOFLAGS=-p=…` persisted in the toolchain's own env file outranks that — `env_clear()` does not disable it, since the command restores `HOME`. A flag on the command line is applied last, so the parallelism the aggregate assumes is the one the build gets. It is only passed when the installed value is a positive integer, so a worker group's typo stays as harmless as the Go runtime makes it.
- The `go mod init|tidy|download` steps get the whole budget instead of a compiler's share: they are a single process with nothing else running, and their fetch queue is sized from `GOMAXPROCS`, so pinning it would slow them without bounding anything.
- The limits actually handed to the toolchain are logged once per distinct setting, so an operator can tell what is in force — including when a worker group's own values are the ones installed.

Ordering note: the forwarded envs are applied *before* each command's explicit `.env` calls, so the worker's own `PATH`/`GOPATH`/`GOCACHE`/`HOME` still win — the same precedence the run step already has.

## Cost of the limit (measured)

The split was chosen by measurement. Cold build cache, dependency-heavy script (aws-sdk-go-v2 s3, 36 modules), 24-core host; within each table every row holds the same aggregate.

At a 2.25 GiB budget (a 3 GiB worker):

| split | wall | peak RSS |
|---|---|---|
| unlimited | 4.97s | ~650 MB |
| `GOMAXPROCS=8` alone | 5.25s | 611 MB |
| 256MB x 8 compilers | 7.46s | 411 MB |
| **384MB x 5 compilers** | **6.92s** | 450 MB |
| 768MB x 2 compilers | 10.38s | 643 MB |
| 1.1GB x 1 compiler | 23.93s | 612 MB |

At a 768 MiB budget (a 1 GiB worker):

| split | wall |
|---|---|
| 384MB x 1 compiler | 26.63s |
| 256MB x 2 | 14.37s |
| 192MB x 3 | 10.96s |
| **128MB x 5** | **9.20s** |
| 96MB x 7 | 9.38s |

Both budgets peak at the same *process count*, not the same share: what a build is sensitive to is how much of it overlaps, and pinning parallelism alone costs almost nothing (+5%). So the split puts one compiler on each core while the budget affords them a comfortable share, holds a minimum process count when it cannot, and only then lets the share fall to an absolute floor. Dropping to a single compiler — the naive way to give the serial link phase a real share — is ~3x worse.

What remains is ~40% on a cold, dependency-heavy build on a memory-tight worker, paid once per script version since the built binary is cached locally and in the object store. An ordinary build never approaches the cap.

## Test plan

Verified against a running worker (`cargo check` and unit tests do not exercise a spawn path), with the backend inside a 3 GiB cgroup via `systemd-run --user --scope -p MemoryMax=3G`:

- [x] Derived path (3 GiB cgroup, 24 cores): log reads `Go compilation limited to GOMEMLIMIT=402653184 GOMAXPROCS=5`, job compiles and runs
- [x] Small-worker budget (`GO_BUILD_MEMLIMIT=768MB`, what a 1 GiB worker derives): `GOMEMLIMIT=134217728 GOMAXPROCS=5` — five compilers, not one
- [x] `GO_BUILD_MEMLIMIT=300MiB` on the worker: resolves and applies, job compiles and runs
- [x] Worker group `GOMEMLIMIT=512MiB` + `GOGC=50`: honored, job compiles and runs
- [x] Worker group `GOMAXPROCS=3` alone: derived pair steps aside and the log says so (`Go compilation limited to GOMAXPROCS=3`), claiming no bound it does not install
- [x] Worker group `GOMEMLIMIT=bogus` / `512MB`: `go mod init` aborts with `malformed GOMEMLIMIT` — proves the value reaches the compilation subprocess, and matches how the same value already fails the run step
- [x] Worker group value takes precedence over `GO_BUILD_MEMLIMIT`
- [x] No memory reading available (plain host, `memory.max=max`): unlimited, job compiles and runs
- [x] Persisted `GOFLAGS=-p=0` in the worker's `HOME`: build succeeds with the derived `-p`, and fails with `go: -p must be a positive integer: 0` when no `-p` is asserted — the bypass is reachable, and the flag closes it
- [x] Per-step limits: `Go dependency resolution limited to GOMEMLIMIT=2415919104` alongside `Go compilation limited to GOMEMLIMIT=402653184 GOMAXPROCS=5`
- [x] Timing matrices above, on the real toolchain
- [x] `cargo check -p windmill-worker --all-targets`; unit tests pin the budget split (floor, `off`/`0`, unparseable fallback) and the env merge (either-half-pinned, whitespace, empty allowlist entry)

Not exercised: a build large enough to OOM a worker outright. The aggregate is arithmetic over `GOMEMLIMIT` × `GOMAXPROCS`, and non-Go allocations in the toolchain sit outside it, so the budget is a close bound rather than a hard one. Below ~1 GiB of worker memory the floor under the share wins and the aggregate exceeds the budget — deliberately, since every split that respects it there measured worse.

Fixes WIN-2354

