### PR TITLE
fix: stream ansible playbook logs in real time

### DIFF
--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -175,3 +175,6 @@ envar: "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
 envar: "PYTHONPATH={ADDITIONAL_PYTHON_PATHS}"
 envar: "HOME=/tmp"
 envar: "ANSIBLE_CONFIG=/tmp/ansible.cfg"
+# Ansible never flushes its own stdout; on the pipe Windmill gives it, python block-buffers
+# and the job log arrives in bursts instead of as tasks run. Mirrors ansible_executor.rs.
+envar: "PYTHONUNBUFFERED=1"

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -56,6 +56,12 @@ const WINDMILL_ANSIBLE_PASSWORD_FILENAME: &str = ".windmill.ansible_vault_passwo
 
 const DELEGATE_GIT_REPO_TARGET: &str = "delegate_git_repository";
 
+/// Ansible's `Display` writes to `sys.stdout` and never flushes, relying on a terminal being
+/// line-buffered. Windmill hands it a pipe, where python block-buffers instead, so without this
+/// the job log arrives in bursts rather than as tasks run. No ansible.cfg knob covers it.
+/// The nsjail path sets the same var in `nsjail/run.ansible.config.proto`.
+const PYTHONUNBUFFERED_ENV: &str = "PYTHONUNBUFFERED";
+
 /// Usable bytes in `sockaddr_un.sun_path` (108 minus the NUL). An ABI constant, not a
 /// filesystem limit — which is why only the socket breaks while every regular file in the
 /// same job dir is fine.
@@ -662,6 +668,7 @@ async fn run_galaxy_install_from_requirements(
     galaxy_roles_cmd
         .current_dir(job_dir)
         .env_clear()
+        .env(PYTHONUNBUFFERED_ENV, "1")
         .envs(PROXY_ENVS.clone())
         .env("PATH", PATH_ENV.as_str())
         .env("TZ", TZ_ENV.as_str())
@@ -700,6 +707,7 @@ async fn run_galaxy_install_from_requirements(
     galaxy_collections_cmd
         .current_dir(job_dir)
         .env_clear()
+        .env(PYTHONUNBUFFERED_ENV, "1")
         .envs(PROXY_ENVS.clone())
         .env("PATH", PATH_ENV.as_str())
         .env("TZ", TZ_ENV.as_str())
@@ -1888,6 +1896,7 @@ fi
         ansible_cmd
             .current_dir(job_dir)
             .env_clear()
+            .env(PYTHONUNBUFFERED_ENV, "1")
             .envs(envs)
             .envs(reserved_variables)
             .env("PATH", PATH_ENV.as_str())


### PR DESCRIPTION
## Summary

Ansible job logs arrived in bursts aligned with task / `serial:` batch boundaries instead of streaming as the playbook ran. On a task with `retries`/`until`, the `TASK [...]` banner appeared and then nothing until the retry loop gave up; with `serial:`, a batch's per-host `changed:` lines all landed when the slowest host finished. That makes a stuck playbook indistinguishable from a slow one.

The cause is on the Ansible side, not in Windmill's log pipeline. `Display.display()` in ansible-core writes to `sys.stdout` and deliberately never flushes:

```python
            with self._lock:
                fileobj.write(msg2)

            # With locks, and the fact that we aren't printing from forks
            # just write, and let the system flush. Everything should come out peachy
            # ...
            # try:
            #     fileobj.flush()
```

"Let the system flush" only works on a terminal, where CPython line-buffers stdout. Windmill always hands the child a pipe, where CPython falls back to 8 KiB block buffering, so output surfaces only when the buffer fills or at process exit. Ansible's own `TaskQueueManager.cleanup` end-of-run flush is what made everything appear at once. There is no ansible.cfg knob for this, so the fix unbuffers the interpreter.

Note stderr was never affected (CPython line-buffers stderr even when piped), which is why `[WARNING]` lines did stream — a good hint at where the buffering lived.

## Changes

- `ansible_executor.rs`: set `PYTHONUNBUFFERED=1` on the spawned `ansible-playbook` process, and on both `ansible-galaxy` install processes (role + collection installs had the same defect, so a long download showed no progress).
- `nsjail/run.ansible.config.proto`: same var as an `envar` for the sandboxed path.

Placed directly after `.env_clear()` so an explicitly configured job env of the same name still wins.

## Evidence

Timings below are the wall-clock second at which each line first became readable through `GET /jobs_u/get/<id>` — i.e. what the UI shows. Repro A from the issue (a task with `retries: 4`, `delay: 4`), run as a real Ansible job on a worker:

**Before** (identical build, `PYTHONUNBUFFERED` stripped from the child):

```
t+006s | ok: [localhost] => { "msg": "MARKER B generated at 19:06:23" }
t+023s | TASK [Retry loop - 4 attempts, 4s apart] ***************************************
t+023s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (3 retries left).
t+023s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (2 retries left).
t+023s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (1 retries left).
t+023s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (0 retries left).
```

**After**:

```
t+006s | ok: [localhost] => { "msg": "MARKER B generated at 19:04:52" }
t+006s | TASK [Retry loop - 4 attempts, 4s apart] ***************************************
t+011s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (3 retries left).
t+017s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (2 retries left).
t+021s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (1 retries left).
t+023s | FAILED - RETRYING: [localhost]: Retry loop - 4 attempts, 4s apart (0 retries left).
```

Repro B (`serial: 4`, hosts sleeping 3/6/9/12s) after the fix — per-host results now land as each host reports instead of all at the batch boundary:

```
t+004s | TASK [Sleep staggered per host] ************************************************
t+007s | changed: [host-01]
t+010s | changed: [host-02]
t+015s | changed: [host-03]
t+015s | changed: [host-04]
```

The residual clumping at the tail is Windmill's own log-write batching in `handle_child` (500ms for the first 10s of a job, then 2.5s, then 5s), not Ansible buffering. That is a deliberate write-amplification tradeoff and is left alone.

Unbuffering costs one `write()` syscall per `Display` call, which is no more than the line-buffered syscall rate a terminal run already pays. It also removes a latent hazard: with buffering, a `fork()` copies unflushed bytes into the child, so a worker fork can duplicate output.

## Test plan

- [x] Repro A from the issue run as a real Ansible job on a worker: `FAILED - RETRYING` lines now appear ~4s apart, matching the `delay`, instead of all at once at the end (before/after timings above, same build, only the child env differs).
- [x] Repro B from the issue run as a real Ansible job: per-host `changed:` lines stream as each host reports.
- [x] Both repros also confirmed at the ansible-playbook level: piped output matches pty output only with `PYTHONUNBUFFERED=1`.
- [x] `ansible-galaxy` path: a job pinning four collection versions (forcing real downloads) streamed `Downloading …` / `… was installed successfully` at t+017s, t+020s and t+023s while the install was still running, instead of at completion. Lockfile generation is unaffected: `get_collection_locks` / `get_role_locks` use `.output()` rather than `handle_child`, so they are deliberately not part of this change.
- [x] Backend log clean after the runs (no panic, no worker death).
- [x] Sandboxed (nsjail) path: rendered the modified profile and ran `nsjail --config … -- /usr/bin/env`; the profile still parses and `PYTHONUNBUFFERED=1` reaches the jailed process alongside the existing `HOME` / `ANSIBLE_CONFIG` entries. A full playbook run under nsjail was not exercised (the devbox ansible install is not on a path that profile mounts).

No unit test: the change is an env var on a `Command` built inline inside `handle_ansible_job`, so any test would assert the literal it was just handed rather than the streaming behavior that actually matters. The behavior is only observable by running a playbook, which the test plan above covers.

Fixes GIT-960


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams Ansible job logs in real time by unbuffering Python stdout. Before, logs arrived in bursts at retry/`serial:` batch boundaries; now they stream as tasks and hosts progress.

- Set `PYTHONUNBUFFERED=1` for `ansible-playbook` and both `ansible-galaxy` installs in `ansible_executor.rs`, and as an `envar` in `nsjail/run.ansible.config.proto`.
- The env var is set after `.env_clear()` so a job’s explicit `PYTHONUNBUFFERED` can override.
- No change to lockfile generation paths (still use `.output()`), and Windmill’s own log batching remains unchanged.

<sup>Written for commit 4d849647aaf814f6d81006ac8a3d4b66a91f7f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

