### PR TITLE
fix: stop websockets resurrecting a reclaimed dev server

### DIFF
--- a/frontend/scripts/dev-supervisor.mjs
+++ b/frontend/scripts/dev-supervisor.mjs
@@ -297,28 +297,27 @@ class Target {
 	}
 
 	#dispatch(client, first) {
-		// Three kinds of connection, told apart by the subprotocol vite gives its own
-		// sockets. Vite's must not restart a reclaimed server, because its reconnect probe
-		// (`vite-ping`) would resurrect every one we stop. The app's `/ws/*` language-server
-		// and multiplayer sockets must, or a parked script editor loses its smart assistant
-		// until reload. Neither counts as activity: a tab nobody is looking at still
-		// heartbeats, and treating that as use is what pinned servers forever.
+		// No websocket may start a stopped server, and none counts as activity. Every
+		// websocket client on this port reconnects on an unconditional timer — vite's own
+		// restart probe, y-websocket at a 2.5s ceiling, the language-server retry — so
+		// starting on one means a reclaimed server is back within seconds and stays
+		// resident for as long as any tab is open. Recovery is the client's job instead:
+		// `devPollingDormancy` warms the server over HTTP the moment someone returns, and
+		// these sockets reconnect into it on their own retries.
 		const head = first.toString('latin1', 0, Math.min(first.length, MAX_HEAD_BYTES))
 		const isWebsocket = /\r\nupgrade:\s*websocket/i.test(head)
-		const isViteSocket =
-			isWebsocket && /\r\nsec-websocket-protocol:[^\r\n]*vite-(hmr|ping)/i.test(head)
-		if (isViteSocket && !this.child) {
+		if (isWebsocket && !this.child) {
 			client.destroy()
 			return
 		}
-		if (!isWebsocket) this.lastActivity = Date.now()
-		if (!isViteSocket) {
-			this.liveSockets.add(client)
-			// Registered at insertion, not after the upstream connects: a client that gives
-			// up during a cold start would otherwise stay in the set forever and silently
-			// wedge the idle reaper for the life of the process.
-			client.once('close', () => this.liveSockets.delete(client))
+		if (!isWebsocket) {
+			this.lastActivity = Date.now()
 		}
+		this.liveSockets.add(client)
+		// Registered at insertion, not after the upstream connects: a client that gives up
+		// during a cold start would otherwise stay in the set forever and silently wedge the
+		// idle reaper for the life of the process.
+		client.once('close', () => this.liveSockets.delete(client))
 
 		this.ensureStarted().then(
 			(port) => {

--- a/frontend/scripts/dev-supervisor.mjs
+++ b/frontend/scripts/dev-supervisor.mjs
@@ -297,13 +297,10 @@ class Target {
 	}
 
 	#dispatch(client, first) {
-		// No websocket may start a stopped server, and none counts as activity. Every
-		// websocket client on this port reconnects on an unconditional timer — vite's own
-		// restart probe, y-websocket at a 2.5s ceiling, the language-server retry — so
-		// starting on one means a reclaimed server is back within seconds and stays
-		// resident for as long as any tab is open. Recovery is the client's job instead:
-		// `devPollingDormancy` warms the server over HTTP the moment someone returns, and
-		// these sockets reconnect into it on their own retries.
+		// No websocket may start a stopped server, nor count as activity: every websocket
+		// client here reconnects on an unconditional timer (y-websocket at a 2.5s ceiling),
+		// so starting on one keeps a reclaimed server alive for as long as a tab is open.
+		// `devPollingDormancy` warms it over HTTP on return instead, before they retry.
 		const head = first.toString('latin1', 0, Math.min(first.length, MAX_HEAD_BYTES))
 		const isWebsocket = /\r\nupgrade:\s*websocket/i.test(head)
 		if (isWebsocket && !this.child) {

--- a/frontend/scripts/dev-supervisor.mjs
+++ b/frontend/scripts/dev-supervisor.mjs
@@ -57,6 +57,9 @@ function parseArgs(argv) {
 	// Loopback by default: the supervised port fronts the /api proxy to a local backend
 	// and serves source over /@fs, and `server.allowedHosts` does not stop a non-browser
 	// client from sending whatever Host header it likes. Widening is opt-in.
+	// Keep `--idle` above the app's 5-minute background poll. Below it, a tab that never
+	// went dormant can have its server reclaimed with no way back: websockets cannot start
+	// one, and the dormancy warm-up only fires on a dormant-to-awake transition.
 	const opts = { targets: [], idleMs: parseDuration('15m'), bind: '127.0.0.1', stats: null }
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i]
@@ -303,7 +306,10 @@ class Target {
 		// `devPollingDormancy` warms it over HTTP on return instead, before they retry.
 		const head = first.toString('latin1', 0, Math.min(first.length, MAX_HEAD_BYTES))
 		const isWebsocket = /\r\nupgrade:\s*websocket/i.test(head)
-		if (isWebsocket && !this.child) {
+		// `starting` too, not just `child`: a start is in flight before the child exists, and
+		// the warm-up opens exactly that window for the sockets retrying alongside it. A
+		// socket may join a start someone else asked for; it still never initiates one.
+		if (isWebsocket && !this.child && !this.starting) {
 			client.destroy()
 			return
 		}

--- a/frontend/src/lib/utils/devPollingDormancy.dom.test.ts
+++ b/frontend/src/lib/utils/devPollingDormancy.dom.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Freshly imported per case: install is idempotent by design, so a shared module instance
 // would make the second case a no-op against a restored `window.setInterval`.
@@ -12,6 +12,15 @@ async function install() {
 // only thing standing between a forgotten tab and a dev server that never gets reclaimed.
 describe('devPollingDormancy', () => {
 	const original = { setInterval: window.setInterval, clearInterval: window.clearInterval }
+	let fetchSpy: ReturnType<typeof vi.fn>
+
+	// Stubbed for every case, not just the one that asserts on it: waking issues a real
+	// request otherwise, and jsdom's default origin is localhost:3000 — the frontend port
+	// of the first worktree, whose dev server the suite would then resurrect.
+	beforeEach(() => {
+		fetchSpy = vi.fn(() => Promise.resolve(new Response()))
+		vi.stubGlobal('fetch', fetchSpy)
+	})
 
 	afterEach(() => {
 		window.setInterval = original.setInterval
@@ -20,6 +29,8 @@ describe('devPollingDormancy', () => {
 		delete (window as unknown as Record<string, boolean>).__wmDevPollingDormancyInstalled
 		vi.useRealTimers()
 		vi.unstubAllEnvs()
+		// restoreAllMocks does not undo stubGlobal, and the config sets no unstubGlobals.
+		vi.unstubAllGlobals()
 		vi.restoreAllMocks()
 	})
 
@@ -63,8 +74,6 @@ describe('devPollingDormancy', () => {
 		vi.stubEnv('VITE_DEV_DORMANT_MS', '1000')
 		vi.spyOn(document, 'hasFocus').mockReturnValue(true)
 		setHidden(false)
-		const fetchSpy = vi.fn(() => Promise.resolve(new Response()))
-		vi.stubGlobal('fetch', fetchSpy)
 
 		await install()
 
@@ -74,6 +83,8 @@ describe('devPollingDormancy', () => {
 
 		setHidden(false)
 		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		// The origin is the load-bearing half: it has to reach the supervised port.
+		expect(fetchSpy.mock.calls[0][0]).toBe(`${location.origin}/`)
 		expect(fetchSpy.mock.calls[0][1]).toMatchObject({ method: 'HEAD' })
 	})
 

--- a/frontend/src/lib/utils/devPollingDormancy.dom.test.ts
+++ b/frontend/src/lib/utils/devPollingDormancy.dom.test.ts
@@ -58,6 +58,25 @@ describe('devPollingDormancy', () => {
 		expect(tick).not.toHaveBeenCalled()
 	})
 
+	it('warms the dev server on wake, since websockets cannot restart it', async () => {
+		vi.useFakeTimers()
+		vi.stubEnv('VITE_DEV_DORMANT_MS', '1000')
+		vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+		setHidden(false)
+		const fetchSpy = vi.fn(() => Promise.resolve(new Response()))
+		vi.stubGlobal('fetch', fetchSpy)
+
+		await install()
+
+		setHidden(true)
+		vi.advanceTimersByTime(1000)
+		expect(fetchSpy).not.toHaveBeenCalled()
+
+		setHidden(false)
+		expect(fetchSpy).toHaveBeenCalledTimes(1)
+		expect(fetchSpy.mock.calls[0][1]).toMatchObject({ method: 'HEAD' })
+	})
+
 	it('does not re-patch when the module itself is hot-replaced', async () => {
 		vi.useFakeTimers()
 		vi.spyOn(document, 'hasFocus').mockReturnValue(true)

--- a/frontend/src/lib/utils/devPollingDormancy.ts
+++ b/frontend/src/lib/utils/devPollingDormancy.ts
@@ -92,6 +92,11 @@ export function installDevPollingDormancy(): void {
 		}
 		if (!dormant) return
 		dormant = false
+		// The dev supervisor may have reclaimed the server while we were quiet, and it only
+		// restarts on HTTP: websockets deliberately cannot wake it, or their unconditional
+		// reconnect timers would keep every reclaimed server alive. So put the server back
+		// up front, before the language-server and multiplayer sockets retry into it.
+		void fetch(`${location.origin}/`, { method: 'HEAD', cache: 'no-store' }).catch(() => {})
 		for (const registration of registrations.values()) {
 			registration.native = nativeSetInterval(
 				registration.handler,

--- a/frontend/src/lib/utils/devPollingDormancy.ts
+++ b/frontend/src/lib/utils/devPollingDormancy.ts
@@ -92,10 +92,8 @@ export function installDevPollingDormancy(): void {
 		}
 		if (!dormant) return
 		dormant = false
-		// The dev supervisor may have reclaimed the server while we were quiet, and it only
-		// restarts on HTTP: websockets deliberately cannot wake it, or their unconditional
-		// reconnect timers would keep every reclaimed server alive. So put the server back
-		// up front, before the language-server and multiplayer sockets retry into it.
+		// The dev supervisor may have reclaimed the server while we were quiet, and only HTTP
+		// restarts it, so put it back up before the app's sockets retry into it.
 		void fetch(`${location.origin}/`, { method: 'HEAD', cache: 'no-store' }).catch(() => {})
 		for (const registration of registrations.values()) {
 			registration.native = nativeSetInterval(


### PR DESCRIPTION
## Summary

Follow-up to #10672. That PR's last commit (`4cb8fde`, merged without a completed review
round) let the app's own websockets start a stopped dev server, so a parked script editor
could get its language server back. That was wrong, and it defeated the tool.

Every websocket client on the supervised port reconnects on an unconditional timer:
`y-websocket` retries forever with a 2.5s ceiling via `setTimeout` and no visibility check
(`y-websocket/src/y-websocket.js:172`), and `MultiplayerMenu` connects whenever
`$enterpriseLicense && $workspaceStore` from the sidebar of every authenticated page. So a
reclaimed server came back within 2.5s and stayed resident for as long as any tab was
open — strictly worse than before, which at least reclaimed the memory.

Bounding the resurrect with a short grace window does not converge: the loop reconnects
immediately after each reclaim, so the server just cycles up-60s/down-2.5s, resident ~96%
of the time and restarting vite every minute. The fix is to take recovery off the socket
path entirely.

## Changes

- `dev-supervisor.mjs`: no websocket may start a stopped server (none counted as activity
  before, and none does now). Reclaim is reliable again.
- `devPollingDormancy.wake()`: issues one `HEAD /`, so the server is warm the moment
  someone returns, *before* the language-server and multiplayer sockets retry into it.
  This preserves what `4cb8fde` was trying to buy. It works because LSP retries are gated
  on `visibilityState` and spaced 60s apart (`Editor.svelte:1334`), so a hidden tab never
  burns its two attempts and the warm-up beats the next one.
- `devPollingDormancy.dom.test.ts`: a case pinning both halves of the client contract (no
  warm-up while going dormant, exactly one on return, at the right origin), plus a
  suite-wide `fetch` stub and `vi.unstubAllGlobals()`.

The stub is not tidiness. jsdom's default origin is `http://localhost:3000`, which under
`.webmux.yaml` (`portStart: 3000`) is slot 0's worktree port, so an unstubbed wake made
`npm run test` fire a real `HEAD /` at a supervised port and resurrect a 1.1-1.7 GB vite
nobody was looking at. Reproduced with a listener on :3000 (`HIT HEAD /`), and confirmed
silent after the fix.

## Screenshots

No visible UI change: the supervisor is a script and the dormancy module is dev-only with
no rendered surface.

## Test plan

- [x] With a listener bound to :3000, `npx vitest run --project dom` sends it nothing
      (before this branch it sent `HEAD /`)
- [x] 24 y-websocket-style reconnects over 60s against a reclaimed target start nothing:
      supervisor keeps zero children, one `starting dev server` in the log
- [x] The exact `HEAD /` that `wake()` issues restarts the target
- [x] Idle reclaim still fires and kills the child (`reclaiming 355 MB`)
- [x] `npx vitest run --project dom` green (23 tests); `--project server` matches main
      (4 failed files / 8 tests, all pre-existing and unrelated)
- [ ] Manual: park a logged-in EE tab with a script editor past `--idle`; the supervisor
      log must go quiet after `stopping dev server` instead of restarting within seconds,
      and returning to the tab must restore the language server and multiplayer presence
      without a reload

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops websockets from resurrecting a reclaimed dev server; warms the server over HTTP on tab wake so language server and multiplayer still recover. Previously app websockets (e.g., `y-websocket`) could start a stopped server via retries; now they cannot initiate a start, but can join an in-flight start.

- In `frontend/scripts/dev-supervisor.mjs`, treat all websockets as non-activity and non-starting; destroy websocket handshakes when the server is stopped and no start is in progress; track all sockets in `liveSockets` with cleanup.
- In `frontend/src/lib/utils/devPollingDormancy.ts`, on wake issue `HEAD ${location.origin}/` with `cache: 'no-store'` to warm the server before socket retries.
- In `frontend/src/lib/utils/devPollingDormancy.dom.test.ts`, stub `fetch` suite-wide, verify one warm-up on wake at the correct origin, and restore globals to avoid hitting a real dev server.

<sup>Written for commit ce81abdd5fa5db64eb0f43df5444f868133529e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

