### PR TITLE
fix(flow): pass the flow's worker tag when testing a loop iteration

### DIFF
--- a/frontend/src/lib/components/FlowLoopIterationPreview.svelte
+++ b/frontend/src/lib/components/FlowLoopIterationPreview.svelte
@@ -89,7 +89,7 @@
 		runPreview(previewArgs, undefined)
 	}
 
-	const { flowStateStore, pathStore, opWorkspace } =
+	const { flowStateStore, flowStore, pathStore, opWorkspace } =
 		getContext<FlowEditorContext>('FlowEditorContext')
 	const dispatch = createEventDispatcher()
 
@@ -98,7 +98,9 @@
 		restartedFrom: RestartedFrom | undefined
 	) {
 		progressBar?.reset()
-		const newFlow = { value: { modules }, summary: '' }
+		// The preview flow holds only the loop body, so it inherits none of the flow's settings:
+		// carry the tag over so the iteration lands on the worker group the flow runs on.
+		const newFlow = { value: { modules }, summary: '', tag: flowStore.val.tag }
 		jobId = await runFlowPreview(
 			whileLoop ? withWhileLoopIter(args) : args,
 			newFlow,


### PR DESCRIPTION
## Summary

'Test an iteration' on a for/while loop built its preview flow as `{ value: { modules }, summary: '' }`, dropping the flow's worker group tag, so the iteration always ran on the default `flow` worker group instead of the group the flow itself runs on. 'Test flow' does not have this problem: it passes the whole `flowStore.val`, tag included.

Fixes WIN-2358

## Changes

- `FlowLoopIterationPreview.svelte`: destructure `flowStore` from `FlowEditorContext` and carry `flowStore.val.tag` onto the preview flow, so the iteration job is queued on the flow's worker group. Covers both loop kinds, since `FlowLoop` and `FlowWhileLoop` share this component.

## Test plan

- [x] `npm run check` — 0 errors (70 pre-existing warnings, none in the touched file)
- [x] For loop: flow `f/test/loop_tag` tagged `bun`, 'Test an iteration' → preview job runs with `Tag: bun`
- [x] While loop: flow `f/test/while_tag` tagged `bun`, 'Test an iteration' → preview job runs with `Tag: bun`
- [x] Pre-fix behavior reproduced by posting the same `preview_flow` payload without a tag → job runs with `Tag: flow`

## Screenshots

Iteration preview of a flow tagged `bun`, **before** (payload without `tag`, the old behavior) — job lands on the default `flow` group:

![win2358-run-tag-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2358-pass-flow-worker-group-tag-when-testing-a-loop-iteration/1786609642-win2358-run-tag-before.png)

**After** — the same 'Test an iteration' click now queues the preview on the flow's `bun` group:

![win2358-run-tag](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2358-pass-flow-worker-group-tag-when-testing-a-loop-iteration/1786609644-win2358-run-tag.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures “Test an iteration” queues the preview job on the flow’s configured worker group. Previously, iteration previews omitted the `tag` and ran on the default `flow` group; now they inherit `flowStore.val.tag`, matching “Test flow.”

**Review notes**
- Update `frontend/src/lib/components/FlowLoopIterationPreview.svelte` to read `flowStore` from `FlowEditorContext` and include `tag` in the `newFlow` preview payload.
- Applies to both `for` and `while` loops via the shared component.
- No migrations or config changes. Satisfies WIN-2358 (iteration preview runs on the same worker group as the flow).

<sup>Written for commit 92086d2f14084828e4739f1262ca493a93ed48b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

