### PR TITLE
chore: pin git-sync scripts to hub 28903/28904 (cli 1.787.0)

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -175,7 +175,7 @@ pub enum ObjectType {
     DatatableMigration,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28871/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28904/sync-script-to-git-repo-windmill";
 
 /// Hub script that applies a repository's state back into a workspace
 /// (the repo → Windmill / "pull" direction). Same script the UI runs from
@@ -183,7 +183,7 @@ pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28871/sync-script-to-git-repo
 /// ignores the slug, so the slug is kept free of characters that would be
 /// percent-encoded into the run URL (a `:` becomes `%3A`, which some hardened
 /// reverse proxies reject as double-encoding when the client re-encodes it).
-pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28890/git-sync-init-repository-windmill";
+pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28903/git-sync-init-repository-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,6 +1,6 @@
 {
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28890/git-sync-init-repository-windmill",
+	"gitInitRepo": "hub/28903/git-sync-init-repository-windmill",
 	"slackErrorHandler": "hub/28794/workspace-or-schedule-error-handler-slack",
 	"emailErrorHandler": "hub/19795/workspace-or-error-handler-email",
 	"slackRecoveryHandler": "hub/28791/slack/schedule-recovery-handler-slack",


### PR DESCRIPTION
## Summary

Point the git-sync hub script paths at the versions published by
windmill-labs/windmill-integrations#175, which bump the CLI those scripts bundle from
`1.777.2-gitsync.0` to `1.787.0`.

The old pin predates #10639, so deleting a resource from a tracked repo aborted
"Pull from repo" with `Sync push failed: Not Found`. That CLI derived the server path
with `removeSuffix(target, ".resource.json")` — a fixed 14-character slice, correct for
`.resource.yaml`/`.resource.json` but too short for the `.resource.file.<ext>` file a
resource type with a `format_extension` produces. `f/x/myfile.resource.file.yaml` became
`f/x/myfile.reso` and the delete 404'd.

The fix has been in the CLI since 1.785.0, but git-sync does not run the instance's CLI —
it runs a hub script with its own pinned copy. Hub version ids are immutable, so the fix
only reaches instances once these constants move.

Fixes #10679. Linear: GIT-961.

## Changes

- `backend/windmill-common/src/workspaces.rs`: `GIT_SYNC_PULL_SCRIPT_PATH` 28890 → 28903
  (repo → Windmill) and `LATEST_GIT_SYNC_SCRIPT_PATH` 28871 → 28904 (Windmill → repo).
- `frontend/src/lib/hubPaths.json`: `gitInitRepo` 28890 → 28903.

## Test plan

- [x] Confirmed both new hub ids serve the bumped scripts:
      `GET hub.windmill.dev/raw/28903` and `/raw/28904` both import
      `windmill-cli@1.787.0`, with import shapes matching the init and sync scripts
      respectively.
- [x] Reproduced the bug with the previously pinned bundle
      (`npm pack windmill-cli@1.777.2-gitsync.0`) against a local backend: created a
      resource type with `format_extension: yaml` plus a resource of that type,
      `sync pull`, deleted both files, `sync push`:

      Deleting resource f/test961/myfile.resource.file.yaml
      Server failed. Not Found: Not found: Resource not found at name f/test961/myfile.reso
      ApiError: Not Found
           url: ".../api/w/git961/resources/delete/f/test961/myfile.reso", status: 404

- [x] Same scenario against the published `windmill-cli@1.787.0` tarball, the exact
      artifact these scripts now install: both deletes resolve to `f/test961/myfile`,
      the push completes, and `GET /resources/list` returns `[]`.
- [x] `cargo check -p windmill-common`, `npm run check:fast` — both clean.
- [ ] `Git Sync Integration Tests` (triggered by the `workspaces.rs` change), which
      exercise the new hub scripts end-to-end against a real gitea.

## Not covered

The git-sync e2e suite drives the real hub script, so it does cover this pin — but only
along paths it already tests. Its one repo → Windmill test
(`test_polling_applies_remote_commit`) configures `include_type=["script"]` and asserts
on a script edit; nothing in the suite deletes a repo-side file or involves a resource.
So the suite guards the version jump generally, and would not have caught this bug.

A regression test for it belongs in `integration_tests/test/git_sync_test.py` — seed a
resource whose type has a `format_extension`, delete both files in the repo, assert the
resource leaves the workspace. Left out of this PR to keep the fix shippable; it is
worth adding before the next pin bump.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins git-sync hub script paths to `hub/28903` (init) and `hub/28904` (sync) to pick up `windmill-cli@1.787.0`. Previously, deleting `.resource.file.<ext>` from a tracked repo truncated the server path and 404’d during “Pull from repo”/“sync push”; now deletes resolve correctly. Fixes #10679 (Linear: GIT-961).

**Review notes**
- Backend: `GIT_SYNC_PULL_SCRIPT_PATH` → `hub/28903`, `LATEST_GIT_SYNC_SCRIPT_PATH` → `hub/28904`. Frontend: `gitInitRepo` → `hub/28903`.
- Behavior: deletes from repo now remove the resource in Windmill; before, they failed with Not Found due to fixed-suffix path derivation. No API or config changes.
- Rollout: instances pick this up only via these hub ids (hub versions are immutable). No migration actions; optional verification: delete a resource with a `format_extension` and push—expect success.

<sup>Written for commit 06ea43b25b764fc10c7ee0c655a1c6c2ffec481b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

