### PR TITLE
fix(github-app): complete the self-managed setup instructions, render the page header

### DIFF
--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -1144,10 +1144,11 @@
 				description="Configure where secrets (secret variables) are stored."
 				link="https://www.windmill.dev/docs/core_concepts/workspace_secret_encryption"
 			/>
-		{:else if category == 'GitHub Enterprise App'}
+		{:else if category == 'GitHub App'}
 			<SettingsPageHeader
-				title="GitHub Enterprise App"
-				description="Configure a self-managed GitHub App for GitHub Enterprise Server git sync."
+				title="GitHub App"
+				description="Configure a self-managed GitHub App for git sync on GitHub.com, GHE Cloud or GitHub Enterprise Server."
+				link="https://www.windmill.dev/docs/integrations/git_repository#self-managed-github-app"
 			/>
 		{:else if category == 'DB Health'}
 			<SettingsPageHeader

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -1005,9 +1005,11 @@ export const settings: Record<string, Setting[]> = {
 	],
 	'GitHub App': [
 		{
-			label: 'GitHub App',
+			// The category header above already names the section; this labels the
+			// card that holds the app credentials, next to the webhook base url one.
+			label: 'App configuration',
 			description:
-				'Configure a self-managed GitHub App to enable git sync without stats.windmill.dev.',
+				'Use your own GitHub App instead of the Windmill-managed one on stats.windmill.dev.',
 			key: 'github_enterprise_app',
 			fieldType: 'github_enterprise_app',
 			storage: 'setting',

--- a/frontend/src/lib/components/instanceSettings/GhesAppSettings.svelte
+++ b/frontend/src/lib/components/instanceSettings/GhesAppSettings.svelte
@@ -194,12 +194,33 @@
 					<li>
 						<strong>Callback URL</strong>: <code>&lt;your-windmill-url&gt;/gh_success</code>
 					</li>
-					<li>Uncheck <strong>Active</strong> under Webhook (not needed)</li>
+					<li>
+						Uncheck <strong>Active</strong> under Webhook. Windmill registers the webhooks it
+						needs per repository, so the app-level webhook stays unused.
+					</li>
 				</ul>
 				<p><strong>3.</strong> Set repository permissions:</p>
 				<ul class="list-disc ml-4 space-y-1">
 					<li><strong>Contents</strong>: Read &amp; write</li>
 					<li><strong>Metadata</strong>: Read-only</li>
+				</ul>
+				<p>
+					Those two are the minimum, for the push direction (Windmill &rarr; git). Add these for
+					the pull direction (git &rarr; Windmill), all read &amp; write:
+				</p>
+				<ul class="list-disc ml-4 space-y-1">
+					<li>
+						<strong>Repository webhooks</strong>: deploy commits within seconds instead of
+						polling the repository
+					</li>
+					<li>
+						<strong>Pull requests</strong>: open pull requests for the branches Windmill pushes,
+						and maintain the deploy-preview comment
+					</li>
+					<li>
+						<strong>Checks</strong>: post the "Windmill diff" and deploy status checks on commits
+						and pull requests
+					</li>
 				</ul>
 				<p>
 					<strong>4.</strong> Under "Where can this GitHub App be installed?", choose
@@ -219,7 +240,18 @@
 				</p>
 				<p>
 					<strong>8.</strong> The <strong>Base URL</strong> is your GitHub instance root (e.g.
-					<code>https://github.com</code> or <code>https://github.mycompany.com</code>).
+					<code>https://github.com</code>, <code>https://mycompany.ghe.com</code> or
+					<code>https://github.mycompany.com</code>). On GHE Cloud (<code>*.ghe.com</code>), also
+					set <strong>App owner</strong> to the organization or user that owns the app: its
+					installation urls carry the owner.
+				</p>
+				<p>
+					Full setup guide: <a
+						href="https://www.windmill.dev/docs/integrations/git_repository#self-managed-github-app"
+						target="_blank"
+						rel="noreferrer"
+						class="underline">Self-managed GitHub App</a
+					>.
 				</p>
 			</div>
 		</details>


### PR DESCRIPTION
The in-product "How to create a GitHub App" panel had drifted from what a self-managed app actually needs, and the settings page rendered without a header.

## Setup instructions

- Permissions: the panel listed only Contents and Metadata, which covers the push direction of git sync. Repository webhooks, pull requests and checks are what the git → Windmill direction needs (webhook delivery, in-app PR creation, the "Windmill diff" and deploy status checks), so they are now listed with what each one enables.
- Webhook: says why Active stays unchecked (Windmill registers a webhook per repository itself) instead of just "not needed".
- App owner: a GHE Cloud (`*.ghe.com`) app needs it, since its installation urls carry the owner. The field hint below the input was the only place saying so; the Base URL step now mentions it and lists a `*.ghe.com` example.
- Links to the [Self-managed GitHub App](https://www.windmill.dev/docs/integrations/git_repository#self-managed-github-app) docs.

## Page header

`InstanceSettings.svelte` still tested `category == 'GitHub Enterprise App'`, the pre-rename name, so the GitHub App page rendered with no `SettingsPageHeader` at all. Fixed to the current category name, with the docs link.

Titling that header "GitHub App" duplicated the card right below it, which carried the same name, so the card is now labelled "App configuration" for what it holds, next to the "Webhook base url" card. The description on it keeps the searchable `stats.windmill.dev` keyword.

The matching docs changes are in windmilldocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the self‑managed GitHub App setup instructions and restores the GitHub App settings page header. Previously the page showed no header and the panel missed pull‑direction permissions and GHE Cloud owner guidance; now the header renders and guidance covers both sync directions.

- Render the Settings page header for the `GitHub App` category with an updated description and docs link.
- Relabel the credentials card to "App configuration" and clarify it replaces the Windmill‑managed app on stats.windmill.dev.
- Expand the in‑product setup panel: explain keeping Webhook “Active” unchecked; list required repository permissions for both directions (Contents, Metadata, plus Repository webhooks, Pull requests, Checks); add Base URL examples; call out the required App owner on `*.ghe.com`; link to the Self‑managed GitHub App docs.
- No data or key changes (`github_enterprise_app`); no migration required.

<sup>Written for commit fdc1ffafbd42e0b18dc98985f530386f1cec52cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

