### PR TITLE
fix: send sage_intacct oauth client credentials in the request body

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -159,7 +159,8 @@
   "sage_intacct": {
     "auth_url": "https://api.intacct.com/ia/api/v1/oauth2/authorize",
     "token_url": "https://api.intacct.com/ia/api/v1/oauth2/token",
-    "scopes": ["offline_access"]
+    "scopes": ["offline_access"],
+    "req_body_auth": true
   },
   "spotify": {
     "auth_url": "https://accounts.spotify.com/authorize",

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -1179,6 +1179,18 @@ mod tests {
         assert!(verifier.verify("123", "body", "wrong_sig").is_err());
     }
 
+    // Sage Intacct's token endpoint rejects HTTP Basic client authentication on the
+    // refresh_token grant (`invalid_client`), so its credentials must go in the form body.
+    #[test]
+    fn sage_intacct_registry_entry_uses_request_body_client_auth() {
+        let registry: HashMap<String, OAuthConfig> =
+            serde_json::from_str(include_str!("../../oauth_connect.json")).unwrap();
+        assert_eq!(
+            registry.get("sage_intacct").unwrap().req_body_auth,
+            Some(true)
+        );
+    }
+
     #[test]
     fn canonical_provider_name_strips_sandbox_suffix() {
         assert_eq!(canonical_provider_name("docusign_sandbox"), "docusign");


### PR DESCRIPTION
## Summary

The built-in `sage_intacct` OAuth connector authorized fine but every token refresh
failed with `400 invalid_client: Client authentication failed`, flipping the resource to
`is_expired: true`.

Its registry entry in `backend/oauth_connect.json` did not set `req_body_auth`, so
`build_basic_client` left the client on the default `AuthType::BasicAuth` and sent the
client credentials in an HTTP `Authorization: Basic` header. Sage Intacct's token
endpoint tolerates that on the `authorization_code` exchange but requires `client_id` /
`client_secret` as `x-www-form-urlencoded` body parameters on the `refresh_token` grant —
which is why a connect-and-call smoke test passes and only the first refresh (Sage access
tokens last 12 hours) surfaces the failure. An equivalent custom connector pointed at the
same endpoints with "payload in body" refreshes successfully.

Setting `req_body_auth: true` switches both grants to `AuthType::RequestBody`, matching
the working custom-connector configuration.

Existing `sage_intacct` accounts recover on upgrade without re-authorizing, as long as
their stored refresh token is still valid — the registry config is read on every refresh.

Fixes GIT-962

## Changes

- `backend/oauth_connect.json`: add `"req_body_auth": true` to the `sage_intacct` entry.
- `backend/windmill-oauth/src/lib.rs`: unit test pinning that entry to body auth (it also
  covers that the whole registry still deserializes into `HashMap<String, OAuthConfig>`,
  which is otherwise only checked at runtime).

## Validation

`cargo test -p windmill-oauth` — 19 passed.

The wire format was verified end-to-end with a throwaway integration test (not committed)
that builds the client from the shipped registry entry with the token URL pointed at a
local socket, then runs `exchange_token(..., "authorization_code", ...)` and dumps the raw
request.

Before (`req_body_auth` absent — credentials only in the header, which Sage rejects on
this grant):

```
POST /token HTTP/1.1
accept: application/json
authorization: Basic dGhlLWNsaWVudC1pZDp0aGUtY2xpZW50LXNlY3JldA==
content-type: application/x-www-form-urlencoded

grant_type=refresh_token&refresh_token=the-refresh-token&redirect_uri=...
```

After (`req_body_auth: true` — credentials in the form body, no `Authorization` header):

```
POST /token HTTP/1.1
accept: application/json
content-type: application/x-www-form-urlencoded

client_id=the-client-id&client_secret=the-client-secret&grant_type=refresh_token&refresh_token=the-refresh-token&redirect_uri=...
```

No frontend changes, so no screenshots.

## Test plan

- [ ] Configure `sage_intacct` in instance settings with a real Sage Intacct API client
      (redirect URI `<instance>/oauth/callback/sage_intacct`).
- [ ] Add a `sage_intacct` resource via Connect and confirm the browser sign-in still
      completes and the resource is created (the code exchange now also uses body auth).
- [ ] Click refresh on the resource: it returns a new access token, `refresh_error` stays
      null and `is_expired` stays false.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sage_intacct` OAuth refresh by sending client credentials in the form body. Previously we used HTTP Basic, which Sage rejects on refresh, causing 400 invalid_client and flipping resources to is_expired. Fixes GIT-962.

- Adds `"req_body_auth": true` to `sage_intacct` in `backend/oauth_connect.json`, switching both authorization_code and refresh_token grants to body auth.
- Adds a unit test to pin the registry entry to request-body client auth and validate registry deserialization.

**Rollout**
- No action required. Existing `sage_intacct` connections recover on next refresh if the stored refresh token is still valid; otherwise re-authorize.

<sup>Written for commit 8dd6d0ae44436bc067fa4bafc88ee9c0ee9ca4e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

