### PR TITLE
fix: keep a resource's linked secret reference in sync while renaming

### DIFF
--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -154,12 +154,6 @@
 		)
 	})
 
-	let linkedVars = $derived(
-		Object.entries(current?.args ?? {})
-			.filter(([_, v]) => typeof v == 'string' && v == `$var:${initialPath}`)
-			.map(([k, _]) => k)
-	)
-
 	const dirtyWorkspaces = $derived(
 		Object.keys(states).filter((ws) => !draftValuesEqual(states[ws].draft, initialStates[ws]))
 	)
@@ -312,16 +306,18 @@
 			})
 	})
 
-	$effect(() => {
+	/** Sole writer of `current.path` — an arg still holding `$var:<the path being
+	 * replaced>` is the resource's own linked secret, which the backend renames
+	 * along with the resource, so the reference moves with it. An arg pointing at
+	 * any other variable was set by the user and is left alone. */
+	function setPath(npath: string): void {
 		if (!current) return
-		if (linkedVars.length > 0 && current.path) {
-			untrack(() => {
-				linkedVars.forEach((k) => {
-					current!.args[k] = `$var:${current!.path}`
-				})
-			})
+		const prev = current.path
+		for (const [k, v] of Object.entries(current.args)) {
+			if (v === `$var:${prev}`) current.args[k] = `$var:${npath}`
 		}
-	})
+		current.path = npath
+	}
 
 	export async function save(): Promise<void> {
 		const dirty = dirtyWorkspaces
@@ -388,7 +384,7 @@
 		{#if current}
 			{#key current}
 				<ResourceForm
-					bind:path={current.path}
+					bind:path={() => current!.path, setPath}
 					bind:labels={current.labels}
 					bind:description={current.description}
 					bind:args={current.args}

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -313,7 +313,8 @@
 	function setPath(npath: string): void {
 		if (!current) return
 		const prev = current.path
-		for (const [k, v] of Object.entries(current.args)) {
+		// `args` is whatever the raw JSON editor parsed — `null` included.
+		for (const [k, v] of Object.entries(current.args ?? {})) {
 			if (v === `$var:${prev}`) current.args[k] = `$var:${npath}`
 		}
 		current.path = npath


### PR DESCRIPTION
## Summary

Renaming a resource that owns a linked secret persisted a **truncated** `$var:` reference: renaming `demo_pg` to `demo_pg_renamed` saved `password: "$var:u/admin/d"`. The backend renames the linked variable to the full new path (`update_resource` in `backend/windmill-store/src/resources.rs`), so the resource was left pointing at a variable that no longer exists — the connection then fails at runtime. Not Postgres-specific: it hits any resource type whose value holds `$var:<its own path>` (anything created through the app-connect flow with a single linked secret).

Cause: the set of "linked" keys was `$derived` from the *live* args matching `` `$var:${initialPath}` ``. The first keystroke rewrote the arg, the predicate stopped matching, and every later keystroke was ignored — so whatever the path was after one character is what got saved.

## Changes

- `ResourceEditor.svelte`: replaced the self-invalidating `linkedVars` derived + its `$effect` with a `setPath` callback wired through a Svelte 5 function binding (`bind:path={() => current!.path, setPath}`).
- The rewrite now matches args against `` `$var:${the path being replaced}` ``, so it chains correctly across every keystroke, and args + path change in one synchronous mutation (previously a draft could autosave with the new path and the old args).
- An arg pointing at any *other* variable is left alone — that's a user-entered value, and the backend only renames the variable sitting at the resource's own path.
- `args` is guarded against `null`, which the raw JSON editor can produce (`JSON.parse("null")`).

## Screenshots

Renaming `u/admin/demo_pg` → `u/admin/demo_pg_renamed`, password field after typing the full new name:

Before — reference truncated at the first character:

![password-linked-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-resource-rename/1786696910-password-linked-before.png)

After — reference follows the full path:

![password-linked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-resource-rename/1786696912-password-linked.png)

## Test plan

- [x] Rename a postgres resource with a linked secret, save: resource value is `$var:<new path>` and the variable sits at `<new path>` (verified against the API, not just the UI)
- [x] Reopen and rename again: still syncs (the reference survives past the first save)
- [x] Resource whose password points at an unrelated variable: untouched by a rename
- [x] Same, but set in the *unsaved* draft via the As JSON editor: untouched by a subsequent rename
- [x] New resource: path field still auto-fills and types normally (creation writes `$var:` once at save, so it never went through this code path)
- [x] `npm run check:fast` (full, 1756 files) clean