### PR TITLE
fix: keep non traffic-serving processes out of coordinated restarts

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1691,7 +1691,8 @@ async fn process_notify_event(
         "restart_worker_group" => {
             if worker_mode && payload == *WORKER_GROUP {
                 tracing::info!("Restart requested for worker group '{payload}'");
-                spawn_graceful_killpill(tx, db, 30, "worker group restart requested").await;
+                spawn_graceful_killpill(tx, db, 30, "worker group restart requested", server_mode)
+                    .await;
             }
         }
         "notify_webhook_change" => {
@@ -1997,8 +1998,14 @@ async fn process_notify_event(
                     reload_otel_tracing_proxy_setting(conn).await;
                     if worker_mode {
                         tracing::info!("OTEL tracing proxy setting changed, restarting worker");
-                        spawn_graceful_killpill(tx, db, 30, "OTEL tracing proxy setting change")
-                            .await;
+                        spawn_graceful_killpill(
+                            tx,
+                            db,
+                            30,
+                            "OTEL tracing proxy setting change",
+                            server_mode,
+                        )
+                        .await;
                     }
                 }
                 REQUIRE_PREEXISTING_USER_FOR_OAUTH_SETTING => {
@@ -2009,12 +2016,20 @@ async fn process_notify_event(
                 }
                 EXPOSE_METRICS_SETTING => {
                     tracing::info!("Metrics setting changed, restarting");
-                    spawn_graceful_killpill(tx, db, 30, "metrics setting change").await;
+                    spawn_graceful_killpill(tx, db, 30, "metrics setting change", server_mode)
+                        .await;
                 }
                 EMAIL_DOMAIN_SETTING => {
                     tracing::info!("Email domain setting changed");
                     if server_mode {
-                        spawn_graceful_killpill(tx, db, 30, "email domain setting change").await;
+                        spawn_graceful_killpill(
+                            tx,
+                            db,
+                            30,
+                            "email domain setting change",
+                            server_mode,
+                        )
+                        .await;
                     }
                 }
                 EXPOSE_DEBUG_METRICS_SETTING => {
@@ -2050,19 +2065,26 @@ async fn process_notify_event(
                 }
                 OTEL_SETTING => {
                     tracing::info!("OTEL setting changed, restarting");
-                    spawn_graceful_killpill(tx, db, 30, "OTEL setting change").await;
+                    spawn_graceful_killpill(tx, db, 30, "OTEL setting change", server_mode).await;
                 }
                 REQUEST_SIZE_LIMIT_SETTING => {
                     if server_mode {
                         tracing::info!("Request limit size change detected, killing server expecting to be restarted");
-                        spawn_graceful_killpill(tx, db, 30, "request size limit change").await;
+                        spawn_graceful_killpill(
+                            tx,
+                            db,
+                            30,
+                            "request size limit change",
+                            server_mode,
+                        )
+                        .await;
                     }
                 }
                 SAML_METADATA_SETTING => {
                     tracing::info!(
                         "SAML metadata change detected, killing server expecting to be restarted"
                     );
-                    spawn_graceful_killpill(tx, db, 30, "SAML metadata change").await;
+                    spawn_graceful_killpill(tx, db, 30, "SAML metadata change", server_mode).await;
                 }
                 HUB_BASE_URL_SETTING => {
                     if let Err(e) = reload_hub_base_url_setting(conn, server_mode).await {
@@ -2286,16 +2308,25 @@ pub async fn run_workers(
 /// then the sleep+kill is spawned in the background so the notification handler is not blocked.
 ///
 /// Falls back to drain-only delay if DB coordination fails.
+///
+/// Only `server_mode` processes coordinate. A worker answers no request, and its group
+/// sitting empty for a moment costs queue latency rather than work: the queue rows are
+/// durable and the killpill is read between jobs, so the one in flight still finishes.
+/// Letting workers take part would also let one claim the `is_first` slot and leave every
+/// server holding its shutdown open for a peer that serves no traffic.
 async fn spawn_graceful_killpill(
     tx: &KillpillSender,
     db: &Pool<Postgres>,
     safety_margin_secs: u64,
     context: &str,
+    server_mode: bool,
 ) {
     // Minimum delay before any restart to let in-flight requests drain
     const DRAIN_DELAY_SECS: u64 = 3;
 
-    let (delay, is_first) =
+    let (delay, is_first) = if !server_mode {
+        (DRAIN_DELAY_SECS, true)
+    } else {
         match coordinate_restart_delay(db, safety_margin_secs, DRAIN_DELAY_SECS).await {
             Ok(r) => r,
             Err(e) => {
@@ -2305,7 +2336,8 @@ async fn spawn_graceful_killpill(
                 );
                 (DRAIN_DELAY_SECS, true)
             }
-        };
+        }
+    };
 
     tracing::info!(
         "Scheduling {context} graceful shutdown in {delay}s (first_to_restart={is_first})"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2309,11 +2309,12 @@ pub async fn run_workers(
 ///
 /// Falls back to drain-only delay if DB coordination fails.
 ///
-/// Only `server_mode` processes coordinate. A worker answers no request, and its group
-/// sitting empty for a moment costs queue latency rather than work: the queue rows are
-/// durable and the killpill is read between jobs, so the one in flight still finishes.
-/// Letting workers take part would also let one claim the `is_first` slot and leave every
-/// server holding its shutdown open for a peer that serves no traffic.
+/// Only `server_mode` processes coordinate; worker, indexer and MCP ones drain and go. None
+/// of them answers traffic that outlives the process, and an empty worker group costs queue
+/// latency rather than work: the queue rows are durable and the killpill is read between
+/// jobs, so the one in flight still finishes. Were they to take part, one could claim the
+/// `is_first` slot and leave every server holding its shutdown open for a peer that answers
+/// nothing.
 async fn spawn_graceful_killpill(
     tx: &KillpillSender,
     db: &Pool<Postgres>,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2309,12 +2309,10 @@ pub async fn run_workers(
 ///
 /// Falls back to drain-only delay if DB coordination fails.
 ///
-/// Only `server_mode` processes coordinate; worker, indexer and MCP ones drain and go. None
-/// of them answers traffic that outlives the process, and an empty worker group costs queue
-/// latency rather than work: the queue rows are durable and the killpill is read between
-/// jobs, so the one in flight still finishes. Were they to take part, one could claim the
-/// `is_first` slot and leave every server holding its shutdown open for a peer that answers
-/// nothing.
+/// Only `server_mode` processes coordinate, on the strength of the worker case: a worker
+/// group restarting costs queue latency rather than lost work, `v2_job_queue` being durable.
+/// Were workers to take part, one could claim the `is_first` slot and leave every server
+/// holding its shutdown open for a peer that serves no API traffic.
 async fn spawn_graceful_killpill(
     tx: &KillpillSender,
     db: &Pool<Postgres>,

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -1166,8 +1166,10 @@ pub async fn run_server(
     }
 
     // Announce this server is ready so coordinated restarts can detect a healthy peer.
-    if let Err(e) = announce_server_started(&db).await {
-        tracing::warn!("Failed to announce server started: {e:#}");
+    if server_mode {
+        if let Err(e) = announce_server_started(&db).await {
+            tracing::warn!("Failed to announce server started: {e:#}");
+        }
     }
 
     let server = server.with_graceful_shutdown(async move {
@@ -1314,17 +1316,17 @@ pub async fn wait_for_db_migrations(
 
 const SERVER_HEARTBEAT_TASK: &str = "server_heartbeat";
 
-/// Write a server-started heartbeat to `background_task_state` so that
-/// other instances waiting to restart can detect this process is healthy.
+/// Write a server-started heartbeat to `background_task_state` so that other
+/// traffic-serving instances waiting to restart can detect this one is healthy.
 ///
-/// Worker-mode processes announce too: `restart_worker_group` puts every worker of
-/// the group through `spawn_graceful_killpill`, which waits for a peer, and where no
-/// server is co-located workers are the only peers each other can detect.
+/// Only `server_mode` processes announce, since only they are peers worth waiting
+/// for: `spawn_graceful_killpill` holds a shutdown open to keep requests answered,
+/// which a worker neither does nor needs.
 ///
 /// The row is keyed per host and `owner` per process, and both halves carry weight.
 /// `INSTANCE_NAME` is random per start, so a row keyed on it never conflicts and
-/// accumulates one row per start, which is one per job under `EXIT_AFTER_N_JOBS`;
-/// `owner` is what tells a peer's start from its own when processes share a host.
+/// accumulates one row per start; `owner` is what tells a peer's start from its own
+/// when processes share a host.
 async fn announce_server_started(db: &DB) -> anyhow::Result<()> {
     use windmill_common::{utils::HOSTNAME, INSTANCE_NAME};
 

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -1315,24 +1315,37 @@ pub async fn wait_for_db_migrations(
 const SERVER_HEARTBEAT_TASK: &str = "server_heartbeat";
 
 /// Write a server-started heartbeat to `background_task_state` so that
-/// other instances waiting to restart can detect this server is healthy.
+/// other instances waiting to restart can detect this process is healthy.
+///
+/// Every process that reaches `run_server` announces, worker-mode ones included:
+/// a worker waits for a peer too (a `restart_worker_group` notification puts every
+/// worker of the group through `spawn_graceful_killpill`), so in a deployment with
+/// no co-located server, workers are the only peers each other can detect.
+///
+/// The row is keyed by hostname rather than by `INSTANCE_NAME`, which is random per
+/// process: keying on the latter means the upsert never conflicts, so every start
+/// leaves behind a row no later start reuses and only the sweep below removes, a
+/// week on. That is a row per job under `EXIT_AFTER_N_JOBS`.
+/// `owner` stays per-process so `check_any_server_started` can still tell a peer's
+/// start from its own when several processes share a host, and hence a row.
 async fn announce_server_started(db: &DB) -> anyhow::Result<()> {
-    use windmill_common::INSTANCE_NAME;
+    use windmill_common::{utils::HOSTNAME, INSTANCE_NAME};
 
     let instance = INSTANCE_NAME.as_str();
+    let host = HOSTNAME.as_str();
 
     sqlx::query(
         "INSERT INTO background_task_state (name, value, running, owner, started_at, updated_at)
          VALUES ($1, '\"started\"'::jsonb, true, $2, NOW(), NOW())
          ON CONFLICT (name)
-         DO UPDATE SET updated_at = NOW(), running = true, owner = $2",
+         DO UPDATE SET started_at = NOW(), updated_at = NOW(), running = true, owner = $2",
     )
-    .bind(format!("{SERVER_HEARTBEAT_TASK}:{instance}"))
+    .bind(format!("{SERVER_HEARTBEAT_TASK}:{host}"))
     .bind(instance)
     .execute(db)
     .await?;
 
-    tracing::info!("Announced server started for instance {instance}");
+    tracing::info!("Announced server started for instance {instance} on host {host}");
     Ok(())
 }
 
@@ -1362,10 +1375,10 @@ pub async fn check_any_server_started(db: &DB, not_before: chrono::DateTime<chro
 }
 
 /// Delete `server_heartbeat:*` rows that have not been refreshed in a long
-/// time. Each server startup generates a fresh random `INSTANCE_NAME` and
-/// inserts a new row keyed by `server_heartbeat:{instance}`; because that
-/// row is only written once (on startup) and never updated thereafter, the
-/// table grows by one row per server restart and is otherwise never pruned.
+/// time. A restart in place reuses its host's row (see
+/// `announce_server_started`), but a host that never comes back leaves one
+/// behind, and hosts are disposable wherever the hostname carries a generated
+/// pod or container id.
 ///
 /// The row is only consulted by `check_any_server_started`, which itself
 /// filters on `updated_at > not_before` (the moment a restart was initiated),

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -1319,9 +1319,9 @@ const SERVER_HEARTBEAT_TASK: &str = "server_heartbeat";
 /// Write a server-started heartbeat to `background_task_state` so that other
 /// traffic-serving instances waiting to restart can detect this one is healthy.
 ///
-/// Only `server_mode` processes announce, since only they are peers worth waiting
-/// for: `spawn_graceful_killpill` holds a shutdown open to keep requests answered,
-/// which a worker neither does nor needs.
+/// Only `server_mode` processes announce, since only they are peers worth waiting for:
+/// `spawn_graceful_killpill` holds a shutdown open to keep requests answered, and a
+/// worker, indexer or MCP process coming up is no evidence that anything is answering.
 ///
 /// The row is keyed per host and `owner` per process, and both halves carry weight.
 /// `INSTANCE_NAME` is random per start, so a row keyed on it never conflicts and

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -1320,8 +1320,8 @@ const SERVER_HEARTBEAT_TASK: &str = "server_heartbeat";
 /// traffic-serving instances waiting to restart can detect this one is healthy.
 ///
 /// Only `server_mode` processes announce, since only they are peers worth waiting for:
-/// `spawn_graceful_killpill` holds a shutdown open to keep requests answered, and a
-/// worker, indexer or MCP process coming up is no evidence that anything is answering.
+/// `spawn_graceful_killpill` holds a shutdown open to keep the API answered, and a worker,
+/// indexer or MCP process coming up is no evidence that it is.
 ///
 /// The row is keyed per host and `owner` per process, and both halves carry weight.
 /// `INSTANCE_NAME` is random per start, so a row keyed on it never conflicts and

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -1317,17 +1317,14 @@ const SERVER_HEARTBEAT_TASK: &str = "server_heartbeat";
 /// Write a server-started heartbeat to `background_task_state` so that
 /// other instances waiting to restart can detect this process is healthy.
 ///
-/// Every process that reaches `run_server` announces, worker-mode ones included:
-/// a worker waits for a peer too (a `restart_worker_group` notification puts every
-/// worker of the group through `spawn_graceful_killpill`), so in a deployment with
-/// no co-located server, workers are the only peers each other can detect.
+/// Worker-mode processes announce too: `restart_worker_group` puts every worker of
+/// the group through `spawn_graceful_killpill`, which waits for a peer, and where no
+/// server is co-located workers are the only peers each other can detect.
 ///
-/// The row is keyed by hostname rather than by `INSTANCE_NAME`, which is random per
-/// process: keying on the latter means the upsert never conflicts, so every start
-/// leaves behind a row no later start reuses and only the sweep below removes, a
-/// week on. That is a row per job under `EXIT_AFTER_N_JOBS`.
-/// `owner` stays per-process so `check_any_server_started` can still tell a peer's
-/// start from its own when several processes share a host, and hence a row.
+/// The row is keyed per host and `owner` per process, and both halves carry weight.
+/// `INSTANCE_NAME` is random per start, so a row keyed on it never conflicts and
+/// accumulates one row per start, which is one per job under `EXIT_AFTER_N_JOBS`;
+/// `owner` is what tells a peer's start from its own when processes share a host.
 async fn announce_server_started(db: &DB) -> anyhow::Result<()> {
     use windmill_common::{utils::HOSTNAME, INSTANCE_NAME};
 


### PR DESCRIPTION
## Summary

`announce_server_started` writes a `background_task_state` row keyed on `INSTANCE_NAME`, which is
`rd_string(5)`, a fresh random value per process. The `ON CONFLICT (name)` therefore never fires,
and every process start inserts a row nothing ever reuses.

`run_server` is reached by every non-agent process, worker-mode ones included, so this ran in
workers too. With `EXIT_AFTER_N_JOBS=1`, one process start per job, the table grows by a row per
job: roughly 700k rows steady state at 100k jobs/day, all of them scanned by
`check_any_server_started`'s `name LIKE 'server_heartbeat:%'`. The 7-day sweep is the only bound,
and it only runs in server mode.

The row exists so a coordinated restart can hold a shutdown open until a peer is confirmed
serving. That matters for an API server: if every replica is down at instant T, a request arriving
at T fails outright, with no queue and no retry. It does not matter for a worker, an indexer or an
MCP process, none of which answers traffic that outlives the process. A worker group sitting empty
for a moment costs queue latency rather than work: `v2_job_queue` rows are durable, and the
killpill is read between jobs (`windmill-worker/src/worker.rs:3222`) so the job in flight still
drains and persists its result.

So the fix is to keep those processes out of the mechanism entirely rather than to make their rows
cheaper, and to bound the remaining growth from server restarts on top.

Worth noting the old peer gate never staggered anything: non-first processes ignore their computed
`delay` and all release on the same first-peer poll, so `restart_worker_group` already restarted
the whole group together after the first worker returned. What changes for a worker group is a
window of roughly one second with no worker up, instead of one worker staying up while the rest
shut down.

## Changes

- `announce_server_started` is called only when `server_mode` (`Mode::Server` or
  `Mode::Standalone` with the server enabled). Worker, indexer and MCP processes no longer write
  a heartbeat row at all.
- `spawn_graceful_killpill` takes `server_mode`. Non-server processes skip
  `coordinate_restart_delay` and the peer wait and take the 3s drain delay. They no longer write
  `_restart_coordination` entries either, so a worker can no longer claim the `is_first` slot and
  leave every server waiting on a peer that answers nothing.
- The rows that servers do still write are keyed `server_heartbeat:{HOSTNAME}` instead of
  `server_heartbeat:{INSTANCE_NAME}`, so a restart in place reuses one row. `owner` stays the
  per-process `INSTANCE_NAME`, which is what lets `check_any_server_started` tell a peer's start
  from its own when several processes share a host and therefore a row.
- The `ON CONFLICT` branch also refreshes `started_at`. It never fired before, so there is no
  prior behaviour to preserve.

Pre-existing instance-keyed rows are left to the 7-day sweep. They cannot affect a restart
decision meanwhile, since `check_any_server_started` filters on `updated_at > not_before`.

## Test plan

Verified on a local instance, CE debug build. `_restart_coordination` was cleared between runs,
since its entries stay non-stale for 120s and otherwise make every process believe it is not
first.

- [x] **Workers write no row.** 5 consecutive `MODE=worker DISABLE_SERVER=true` starts: the
      `server_heartbeat:%` count stayed at 1 throughout, that one row belonging to the separate
      standalone dev backend. On main the same run went 1 to 6.
- [x] **`restart_worker_group` still works, without a peer.** Two supervised workers in one group
      on distinct hosts. Both logged `Scheduling worker group restart requested graceful shutdown
      in 3s (first_to_restart=true)`, both were listening for jobs again 4s after the
      notification, no heartbeat rows were written, and `_restart_coordination` was left empty.
- [x] **Servers still coordinate (regression check).** Two `MODE=server` processes plus an
      `expose_metrics` change. `srvhost1` took `first_to_restart=true` and was back up at `:49`;
      `srvhost2` logged `healthy peer detected after 5.0s` and restarted at `:53`, so the
      availability overlap held and it did not fall through to the 120s ceiling.
- [x] **Server rows are reused.** 3 restarts of the dev backend: `owner` went
      `YaulL`, `9d6Pj`, `6ABHp`, `ajo6y` with the total `server_heartbeat:%` count staying at 1.
- [x] **Shared host.** Two servers under one hostname, sharing a single row. The non-first still
      logged `healthy peer detected after 5.0s`, since the first one's restart rewrote `owner` to
      a new instance name. This is the case the per-process `owner` exists to protect.