### PR TITLE
perf: cache resolved python interpreter path across worker restarts

### DIFF
--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -1,12 +1,15 @@
 use std::{
+    collections::HashMap,
     ops::{Deref, DerefMut},
     process::Stdio,
     str::FromStr,
     sync::Arc,
+    time::UNIX_EPOCH,
 };
 
 use chrono::{DateTime, Duration, Utc};
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::{fs::DirBuilder, process::Command, sync::RwLock};
 use uuid::Uuid;
@@ -465,7 +468,7 @@ impl PyV {
         w_id: &str,
         occupancy_metrics: &mut Option<&mut OccupancyMetrics>,
     ) -> error::Result<Option<String>> {
-        let py_path = self.find_python().await;
+        let py_path = self.find_python_cached().await;
 
         // Runtime is not installed
         if let Err(py_err) = py_path {
@@ -480,7 +483,7 @@ impl PyV {
                 return Err(err);
             } else {
                 // Try to find one more time
-                let py_path = self.find_python().await;
+                let py_path = self.find_python_cached().await;
 
                 if let Err(err) = py_path {
                     tracing::error!(
@@ -489,7 +492,6 @@ impl PyV {
                     return Err(err);
                 }
 
-                // TODO: Cache the result
                 py_path
             }
         } else {
@@ -600,7 +602,33 @@ impl PyV {
         .await?;
         Ok(())
     }
+    /// Same as [`Self::find_python`] but backed by [`PY_PATH_CACHE_FILE`], which outlives the
+    /// worker process. The subprocess is only spawned when there is nothing usable on disk.
+    async fn find_python_cached(&self) -> error::Result<Option<String>> {
+        let version = self.to_string();
+
+        if let Some(py_path) = read_python_path_cache()
+            .await
+            .and_then(|cache| cache.paths.get(&version).cloned())
+        {
+            // Serving a path that no longer exists is far worse than the spawn it saves, so
+            // the interpreter is checked instead of trusted (the install dir may have been
+            // wiped, or uv may have moved it).
+            if tokio::fs::try_exists(&py_path).await.unwrap_or(false) {
+                return Ok(Some(py_path));
+            }
+        }
+
+        let py_path = self.find_python().await;
+        if let Ok(Some(ref py_path)) = py_path {
+            write_python_path_cache(&version, py_path).await;
+        }
+        py_path
+    }
+
     async fn find_python(&self) -> error::Result<Option<String>> {
+        tracing::debug!("Resolving python {} with uv python find", self.to_string());
+
         #[cfg(windows)]
         let uv_cmd = "uv";
 
@@ -667,6 +695,65 @@ impl PyV {
                 String::from_utf8(output.stderr).expect("Failed to convert error output to String");
             return Err(error::Error::FindPythonError(stderr));
         }
+    }
+}
+
+lazy_static::lazy_static! {
+    /// Sits next to `PY_INSTALL_DIR` rather than inside it, so uv never sees it while scanning
+    /// that directory for managed interpreters.
+    static ref PY_PATH_CACHE_FILE: String = format!("{}_paths.json", *PY_INSTALL_DIR);
+}
+
+/// Interpreter paths resolved by `uv python find`, keyed by the requested version.
+#[derive(Serialize, Deserialize)]
+struct PythonPathCache {
+    /// Identity of the uv that produced the entries. An upgraded uv may pick a different
+    /// interpreter for the same request, so entries from another uv are dropped wholesale.
+    uv: String,
+    paths: HashMap<String, String>,
+}
+
+/// `None` disables the cache entirely: without an identity for uv, an upgrade would go unnoticed.
+fn uv_identity() -> Option<String> {
+    #[cfg(windows)]
+    let uv_cmd = "uv";
+
+    #[cfg(unix)]
+    let uv_cmd = UV_PATH.as_str();
+
+    let metadata = std::fs::metadata(uv_cmd).ok()?;
+    let mtime = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?;
+    Some(format!("{uv_cmd}:{}:{}", metadata.len(), mtime.as_secs()))
+}
+
+async fn read_python_path_cache() -> Option<PythonPathCache> {
+    let uv = uv_identity()?;
+    let content = tokio::fs::read(&*PY_PATH_CACHE_FILE).await.ok()?;
+    let cache = serde_json::from_slice::<PythonPathCache>(&content).ok()?;
+    (cache.uv == uv).then_some(cache)
+}
+
+async fn write_python_path_cache(version: &str, py_path: &str) {
+    let Some(uv) = uv_identity() else {
+        return;
+    };
+
+    let mut cache = read_python_path_cache()
+        .await
+        .unwrap_or_else(|| PythonPathCache { uv, paths: HashMap::new() });
+    cache.paths.insert(version.to_owned(), py_path.to_owned());
+
+    // Written aside and renamed so that a concurrent worker never reads a half-written cache.
+    let tmp_file = format!("{}.{}.tmp", *PY_PATH_CACHE_FILE, Uuid::new_v4());
+    let write = async {
+        tokio::fs::write(&tmp_file, serde_json::to_vec(&cache)?).await?;
+        tokio::fs::rename(&tmp_file, &*PY_PATH_CACHE_FILE).await?;
+        Ok::<_, anyhow::Error>(())
+    };
+
+    if let Err(e) = write.await {
+        tracing::warn!("Could not cache resolved python path ({py_path}): {e}");
+        let _ = tokio::fs::remove_file(&tmp_file).await;
     }
 }
 

--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -604,6 +604,9 @@ impl PyV {
     /// Same as [`Self::find_python`] but backed by [`PY_PATH_CACHE_DIR`], which outlives the
     /// worker process. The subprocess is only spawned when there is nothing usable on disk.
     async fn find_python_cached(&self) -> error::Result<Option<String>> {
+        // Keyed on the requested version, not on the resolved patch: uv answers a minor-only
+        // request with its own minor-version link, which it re-points when a newer patch is
+        // installed, so an entry follows patch upgrades without being invalidated.
         let version = self.to_string();
         // Without an identity for uv an upgrade would go unnoticed, so the cache is skipped.
         let uv = uv_identity().await;
@@ -727,12 +730,16 @@ struct CachedPythonPath {
 /// `None` disables the cache: an upgrade of a uv we cannot stat would go unnoticed.
 async fn uv_identity() -> Option<String> {
     #[cfg(unix)]
-    let uv_cmd = UV_PATH.as_str();
+    let uv_cmd = UV_PATH.clone();
 
+    // Initializing the static probes PATH synchronously, which must not happen on the runtime.
     #[cfg(windows)]
-    let uv_cmd = UV_PATH.as_deref()?;
+    let uv_cmd = tokio::task::spawn_blocking(|| UV_PATH.clone())
+        .await
+        .ok()
+        .flatten()?;
 
-    let metadata = tokio::fs::metadata(uv_cmd).await.ok()?;
+    let metadata = tokio::fs::metadata(&uv_cmd).await.ok()?;
     let mtime = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?;
     Some(format!("{uv_cmd}:{}:{}", metadata.len(), mtime.as_secs()))
 }

--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     ops::{Deref, DerefMut},
     process::Stdio,
     str::FromStr,
@@ -602,26 +601,27 @@ impl PyV {
         .await?;
         Ok(())
     }
-    /// Same as [`Self::find_python`] but backed by [`PY_PATH_CACHE_FILE`], which outlives the
+    /// Same as [`Self::find_python`] but backed by [`PY_PATH_CACHE_DIR`], which outlives the
     /// worker process. The subprocess is only spawned when there is nothing usable on disk.
     async fn find_python_cached(&self) -> error::Result<Option<String>> {
         let version = self.to_string();
+        // Without an identity for uv an upgrade would go unnoticed, so the cache is skipped.
+        let uv = uv_identity().await;
 
-        if let Some(py_path) = read_python_path_cache()
-            .await
-            .and_then(|cache| cache.paths.get(&version).cloned())
-        {
-            // Serving a path that no longer exists is far worse than the spawn it saves, so
-            // the interpreter is checked instead of trusted (the install dir may have been
-            // wiped, or uv may have moved it).
-            if tokio::fs::try_exists(&py_path).await.unwrap_or(false) {
-                return Ok(Some(py_path));
+        if let Some(ref uv) = uv {
+            if let Some(py_path) = read_cached_python_path(&PY_PATH_CACHE_DIR, uv, &version).await {
+                // Serving a path that no longer exists is far worse than the spawn it saves, so
+                // the interpreter is checked instead of trusted (the install dir may have been
+                // wiped, or uv may have moved it).
+                if tokio::fs::try_exists(&py_path).await.unwrap_or(false) {
+                    return Ok(Some(py_path));
+                }
             }
         }
 
         let py_path = self.find_python().await;
-        if let Ok(Some(ref py_path)) = py_path {
-            write_python_path_cache(&version, py_path).await;
+        if let (Some(uv), Ok(Some(py_path))) = (&uv, &py_path) {
+            write_cached_python_path(&PY_PATH_CACHE_DIR, uv, &version, py_path).await;
         }
         py_path
     }
@@ -699,55 +699,67 @@ impl PyV {
 }
 
 lazy_static::lazy_static! {
-    /// Sits next to `PY_INSTALL_DIR` rather than inside it, so uv never sees it while scanning
-    /// that directory for managed interpreters.
-    static ref PY_PATH_CACHE_FILE: String = format!("{}_paths.json", *PY_INSTALL_DIR);
+    /// Sits next to `PY_INSTALL_DIR` rather than inside it, so uv never sees these entries while
+    /// scanning that directory for managed interpreters.
+    static ref PY_PATH_CACHE_DIR: String = format!("{}_paths", *PY_INSTALL_DIR);
 }
 
-/// Interpreter paths resolved by `uv python find`, keyed by the requested version.
+#[cfg(windows)]
+lazy_static::lazy_static! {
+    /// uv is invoked as a bare `uv` on windows, hence resolved through PATH, which
+    /// [`tokio::fs::metadata`] does not search. PATH does not change under us, so the lookup is
+    /// done once.
+    static ref UV_PATH: Option<String> = std::env::split_paths(PATH_ENV.as_str())
+        .map(|dir| dir.join("uv.exe"))
+        .find(|path| path.is_file())
+        .map(|path| path.to_string_lossy().into_owned());
+}
+
+/// Interpreter path resolved by `uv python find` for one requested version.
 #[derive(Serialize, Deserialize)]
-struct PythonPathCache {
-    /// Identity of the uv that produced the entries. An upgraded uv may pick a different
-    /// interpreter for the same request, so entries from another uv are dropped wholesale.
+struct CachedPythonPath {
+    /// Identity of the uv that resolved `path`. An upgraded uv may pick a different interpreter
+    /// for the same request, so an entry left by another uv is ignored.
     uv: String,
-    paths: HashMap<String, String>,
+    path: String,
 }
 
-/// `None` disables the cache entirely: without an identity for uv, an upgrade would go unnoticed.
-fn uv_identity() -> Option<String> {
-    #[cfg(windows)]
-    let uv_cmd = "uv";
-
+/// `None` disables the cache: an upgrade of a uv we cannot stat would go unnoticed.
+async fn uv_identity() -> Option<String> {
     #[cfg(unix)]
     let uv_cmd = UV_PATH.as_str();
 
-    let metadata = std::fs::metadata(uv_cmd).ok()?;
+    #[cfg(windows)]
+    let uv_cmd = UV_PATH.as_deref()?;
+
+    let metadata = tokio::fs::metadata(uv_cmd).await.ok()?;
     let mtime = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?;
     Some(format!("{uv_cmd}:{}:{}", metadata.len(), mtime.as_secs()))
 }
 
-async fn read_python_path_cache() -> Option<PythonPathCache> {
-    let uv = uv_identity()?;
-    let content = tokio::fs::read(&*PY_PATH_CACHE_FILE).await.ok()?;
-    let cache = serde_json::from_slice::<PythonPathCache>(&content).ok()?;
-    (cache.uv == uv).then_some(cache)
+/// One file per version, so that workers resolving different versions concurrently cannot drop
+/// each other's entry the way a shared map would.
+fn cached_python_path_file(dir: &str, version: &str) -> String {
+    format!("{dir}/{version}.json")
 }
 
-async fn write_python_path_cache(version: &str, py_path: &str) {
-    let Some(uv) = uv_identity() else {
-        return;
-    };
-
-    let mut cache = read_python_path_cache()
+async fn read_cached_python_path(dir: &str, uv: &str, version: &str) -> Option<String> {
+    let content = tokio::fs::read(cached_python_path_file(dir, version))
         .await
-        .unwrap_or_else(|| PythonPathCache { uv, paths: HashMap::new() });
-    cache.paths.insert(version.to_owned(), py_path.to_owned());
+        .ok()?;
+    let cached = serde_json::from_slice::<CachedPythonPath>(&content).ok()?;
+    (cached.uv == uv).then_some(cached.path)
+}
 
-    // Written aside and renamed so that a concurrent worker never reads a half-written cache.
-    let tmp_file = format!("{}.{}.tmp", *PY_PATH_CACHE_FILE, Uuid::new_v4());
+async fn write_cached_python_path(dir: &str, uv: &str, version: &str, py_path: &str) {
+    let cached = CachedPythonPath { uv: uv.to_owned(), path: py_path.to_owned() };
+
+    // Written aside and renamed so that a concurrent worker never reads a half-written entry.
+    let tmp_file = format!("{dir}/{}.tmp", Uuid::new_v4());
     let write = async {
-        tokio::fs::write(&tmp_file, serde_json::to_vec(&cache)?).await?;
-        tokio::fs::rename(&tmp_file, &*PY_PATH_CACHE_FILE).await?;
+        tokio::fs::create_dir_all(dir).await?;
+        tokio::fs::write(&tmp_file, serde_json::to_vec(&cached)?).await?;
+        tokio::fs::rename(&tmp_file, cached_python_path_file(dir, version)).await?;
         Ok::<_, anyhow::Error>(())
     };
 
@@ -1051,5 +1063,26 @@ mod tests {
             pyv("2.3"),
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_cached_python_path_is_scoped_to_uv() {
+        let dir = std::env::temp_dir()
+            .join(format!("wm_py_path_cache_{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned();
+
+        write_cached_python_path(&dir, "uv-a", "3.12", "/py/3.12/bin/python3.12").await;
+        assert_eq!(
+            read_cached_python_path(&dir, "uv-a", "3.12")
+                .await
+                .as_deref(),
+            Some("/py/3.12/bin/python3.12")
+        );
+        // An upgraded uv may pick a different interpreter, so its entries cannot be reused
+        assert_eq!(read_cached_python_path(&dir, "uv-b", "3.12").await, None);
+        assert_eq!(read_cached_python_path(&dir, "uv-a", "3.13").await, None);
+
+        tokio::fs::remove_dir_all(&dir).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Every worker process start spawns two `uv python find` subprocesses (the pre-warm block in
`run_worker`, one for the gravitational version and one for `PyVAlias::default()`), and every
python job spawns one more, all to re-resolve an interpreter path that has not changed.
`get_python_inner` already carried a `// TODO: Cache the result`.

Under `EXIT_AFTER_N_JOBS` that startup cost is paid once per job, and the process often exits
before the pre-warm even finishes. The worker cache dirs under `/tmp/windmill` outlive the process
(that is the documented premise of `EXIT_AFTER_N_JOBS` — a container restart resets the process,
not the filesystem), so resolved paths are now memoized there.

## Changes

- `find_python_cached` wraps `find_python`: a cached path is served only when it is still on disk,
  otherwise the subprocess runs and the result is written back.
- Entries live in `{PY_INSTALL_DIR}_paths/<version>.json` — next to the uv install dir rather than
  inside it, so uv never sees them while scanning for managed interpreters. One file per requested
  version, so workers resolving different versions concurrently cannot drop each other's entry;
  each write goes through a temp file + rename so a concurrent reader never sees a partial entry.
- Invalidation, on top of the `exists()` check:
  - keyed by the requested version, so an `instance_python_version` change resolves under a
    different key rather than serving the old path;
  - each entry records the identity of the uv that produced it (path, size, mtime), so a uv
    upgrade falls through to a real `uv python find`. On windows uv is invoked as a bare `uv`,
    i.e. resolved through PATH, so the same lookup is done before stat'ing it.
- `find_python` logs a debug line, which is the observable marker that the subprocess ran.

Native mode still skips the pre-warm block entirely (unchanged).

## Measurements

`exec` → `listening for jobs` probe, CE debug build, counting `uv python find` executions via a
wrapper on `UV_PATH`:

| | uv spawns per worker start |
|---|---|
| before | 2 (every start) |
| after, cold cache | 1 |
| after, warm cache | 0 |

Each spawn is ~20-50 ms of wall time. The pre-warm is `tokio::spawn`ed so it never delayed
`listening for jobs` (~490 ms, unchanged); what it burned was CPU and two process spawns exactly
while the worker was starting its first job. Python jobs also no longer spawn uv to resolve the
interpreter.

## Test plan

Exercised on a local worker built with `--features quickjs,python`:

- [x] two consecutive worker starts: 1 `uv python find` on the first, 0 on the second and third
- [x] real python job runs and returns the cached interpreter
      (`/tmp/windmill/cache/py_runtime/cpython-3.12-linux-x86_64-gnu/bin/python3.12`)
- [x] `instance_python_version` set to 3.13 in `/#superadmin-settings`, worker restarted: falls
      through to `uv python find 3.13`, installs it, and the 3.12 pre-warm still hits its own entry
- [x] cached path pointed at a missing interpreter: falls through and repairs the entry
- [x] uv binary identity changed: entries are ignored and re-resolved under the new identity
- [x] `cargo test -p windmill-worker --features python python_versions` (16 passed)

The one unit test added covers the uv-identity scoping; the `exists()` fall-through and the
version keying need a real uv and were verified by hand as above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache resolved Python interpreter paths across worker restarts to avoid repeatedly running `uv python find`. Previously each worker start spawned two `uv` processes and each Python job spawned one more; now workers reuse a persisted path when valid, reducing CPU and process spawns (notably under `EXIT_AFTER_N_JOBS`).

- Adds `find_python_cached`, which wraps `find_python` and returns a cached path only if the interpreter still exists; otherwise runs `uv python find` and updates the cache.
- Stores one JSON file per requested version under `{PY_INSTALL_DIR}_paths/<version>.json`, outside the `uv` install dir so `uv` never scans it.
- Cache keys: requested version and `uv` identity (binary path, size, mtime). Minor-only version keys follow patch upgrades via `uv`’s minor-version link; different `uv` or version triggers a real resolution.
- Writes are atomic (temp file + rename); concurrent workers cannot read partial entries or clobber other versions.
- Skips the cache if `uv` cannot be stat’ed; on Windows, resolves `uv` through PATH once on a blocking thread before stat’ing to keep the async runtime unblocked.
- Emits a debug log when a real `uv python find` runs.
- Adds a unit test ensuring cache entries are scoped to the `uv` identity.

<sup>Written for commit 474c3d9d8bac16413349999ca43aa78015eae6ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

