### PR TITLE
fix(ci): use random delimiters for untrusted multiline workflow values

### DIFF
--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -167,8 +167,14 @@ jobs:
         env:
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
+          # prior-comments.md is PR comment text verbatim, and commenting needs no write access.
+          # With a fixed delimiter, a comment containing a bare `EOF` line closes the block early:
+          # the step dies, and whatever follows in that comment is read as further environment
+          # assignments for the rest of this job, which holds the review tokens. Hence a random
+          # delimiter, per GitHub's guidance for untrusted multiline values.
+          delimiter="REVIEW_PROMPT_EOF_$(openssl rand -hex 16)"
           {
-            echo 'REVIEW_PROMPT<<EOF'
+            echo "REVIEW_PROMPT<<$delimiter"
             cat REVIEW.md
             echo ''
             cat .claude/review-prompt.md
@@ -182,7 +188,7 @@ jobs:
               echo ''
               cat prior-comments.md
             fi
-            echo 'EOF'
+            echo "$delimiter"
           } >> "$GITHUB_ENV"
 
       - name: Automatic PR Review

--- a/.github/workflows/pr-review-commands.yml
+++ b/.github/workflows/pr-review-commands.yml
@@ -25,16 +25,20 @@ jobs:
               REMAINDER_FIRST_LINE=${FIRST_LINE#"$FIRST_WORD"}
               REMAINDER_FIRST_LINE=${REMAINDER_FIRST_LINE# }
               REST=$(printf '%s' "$BODY" | tail -n +2)
+              # The value is the comment body, which anyone can write. A fixed delimiter lets a
+              # comment close the block early and have the rest of itself read as further step
+              # outputs, so the delimiter has to be unguessable.
+              delimiter="EXTRA_EOF_$(openssl rand -hex 16)"
               {
                 echo "command=$COMMAND"
-                echo 'extra_prompt<<EXTRA_EOF'
+                echo "extra_prompt<<$delimiter"
                 if [ -n "$REMAINDER_FIRST_LINE" ]; then
                   printf '%s\n' "$REMAINDER_FIRST_LINE"
                 fi
                 if [ -n "$REST" ]; then
                   printf '%s\n' "$REST"
                 fi
-                echo 'EXTRA_EOF'
+                echo "$delimiter"
               } >> "$GITHUB_OUTPUT"
               ;;
             *)


### PR DESCRIPTION
## Summary

Two live workflows write untrusted text into `$GITHUB_ENV` / `$GITHUB_OUTPUT` under a fixed
heredoc delimiter. Commenting on a PR needs no write access, so a comment containing a line equal
to that delimiter closes the block early and has the rest of itself read as further assignments,
in jobs holding `CLAUDE_CODE_OAUTH_TOKEN` and `WINDMILL_EE_PRIVATE_ACCESS`.

- `pr-ready-review.yml` — the last 20 PR comments under `REVIEW_PROMPT<<EOF`
- `pr-review-commands.yml` — `github.event.comment.body` under `extra_prompt<<EXTRA_EOF`

Found by accident: the Claude reviewer posted nothing on all nine review rounds of #10703, while
Codex and Pi worked. That PR is about heredoc parsing, so its discussion is full of examples
ending in a bare `EOF` line, and each round died with
`Unable to process file command 'env' successfully. Invalid format '```'`.

## Impact

Reproduced locally against the exact shell from each workflow, with a parser mimicking the
runner's `GITHUB_ENV` / `GITHUB_OUTPUT` handling.

**`pr-ready-review.yml`** — a three-line comment body:

```
EOF
NODE_OPTIONS=--require=/tmp/payload.js
IGNORED<<EOF
```

sets `NODE_OPTIONS` for the rest of the job, while the trailing `IGNORED<<EOF` swallows the
workflow's own closing `EOF` so the file stays valid and **the step succeeds with nothing in the
log**. The action that follows is a JS action, so it runs under that value. `REVIEW_PROMPT` is
truncated at the same time, silently degrading the review. Drop the third line and the step fails
loudly instead, which is the variant that has been firing on #10703.

**`pr-review-commands.yml`** — a comment starting with `/review` and containing `EXTRA_EOF`
followed by `command=codex` overwrites the step output that selects which reviewer runs (last
write wins), again with no error. Verified: `command` comes out as `codex` instead of `review`,
and an arbitrary extra output is set.

## Changes

- Both sites generate `$(openssl rand -hex 16)` delimiters per run, per GitHub's guidance for
  untrusted multiline values.

## Test plan

- [x] Fixed-delimiter versions reproduce: the loud failure with CI's exact error string, the
      silent env injection, and the `command` output hijack
- [x] Random-delimiter versions: no parse error, nothing injected, `command` and the full prompt
      preserved
- [x] `yaml.safe_load` on both workflows

## Remaining fixed delimiter, deliberately not changed

`backend-test.yml:194` writes `TEST_NPMRC<<NPMRC_EOF`, but its content is a registry URL plus an
npm token the workflow itself just minted, so nothing there is attacker-controlled. Changing it
would be hygiene, not a fix.

## Noted, not changed

`linear-claude.yaml` interpolates `github.event.client_payload.*` directly into a `run:` block,
which is shell injection rather than env injection. It is gated behind `repository_dispatch`, so
firing it needs a token with repo access, and it looked stale enough (`claude-code-action@beta`,
`ANTHROPIC_API_KEY`) that I did not want to touch it blind.