### PR TITLE
test: stop stranding sqlx pool permits in run_in_isolated_thread

### DIFF
--- a/backend/tests/python_jobs.rs
+++ b/backend/tests/python_jobs.rs
@@ -1132,7 +1132,8 @@ async def main(item: str, qty: int, email: str):
             port,
         )
         .await;
-    });
+    })
+    .await;
     Ok(())
 }
 

--- a/backend/windmill-test-utils/src/lib.rs
+++ b/backend/windmill-test-utils/src/lib.rs
@@ -407,24 +407,41 @@ pub async fn in_test_worker<Fut: std::future::Future>(
 ///
 /// The chain contains `?Send` futures (trait objects), so `tokio::spawn`
 /// is not viable; `std::thread::spawn` sidesteps the shared-stack issue.
-pub fn run_in_isolated_thread<F, Fut, R>(f: F) -> R
+///
+/// Await the thread, never `join()` it: the caller's runtime owns the `sqlx`
+/// pool, and sqlx hands a connection's permit back from a task it spawns when
+/// the connection drops. Blocking that runtime holds those permits for as long
+/// as the body runs, so the body's own `push` dies on `PoolTimedOut`.
+///
+/// The thread is detached, so dropping this future leaves the body — including
+/// its worker and its pool handles — running past the end of the test. Don't
+/// wrap the call in `timeout`/`select!`.
+pub async fn run_in_isolated_thread<F, Fut, R>(f: F) -> R
 where
     F: FnOnce() -> Fut + Send + 'static,
     Fut: std::future::Future<Output = R>,
     R: Send + 'static,
 {
+    let (tx, rx) = tokio::sync::oneshot::channel();
     std::thread::Builder::new()
         .stack_size(8 * 1024 * 1024)
         .spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("build current-thread runtime");
-            rt.block_on(f())
+            let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build current-thread runtime");
+                rt.block_on(f())
+            }));
+            let _ = tx.send(res);
         })
-        .expect("spawn isolated test thread")
-        .join()
-        .expect("isolated test thread panicked")
+        .expect("spawn isolated test thread");
+
+    match rx.await {
+        Ok(Ok(res)) => res,
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(_) => panic!("isolated test thread died without returning"),
+    }
 }
 
 pub fn spawn_test_worker(


### PR DESCRIPTION
## Summary

`test_python_wac_v2_with_args` flakes in CI with:

```
thread '<unnamed>' panicked at windmill-test-utils/src/lib.rs:248:
push has to succeed: SqlErr { error: PoolTimedOut, location: "jobs.rs:5161:56" }
```

(`jobs.rs:5161` is `PushIsolationLevel::IsolatedRoot(db) => db.begin()`.)

`run_in_isolated_thread` — added to dodge a stack overflow in the deep
`in_test_worker -> run_until_complete -> push` chain — `join()`ed the OS thread it
spawned, which blocks the caller's tokio runtime for the whole test body. That runtime
owns the `#[sqlx::test]` pool, and sqlx hands a `PoolConnection`'s permit back from a task
it *spawns* on the runtime current at drop time (`PoolConnection::drop` ->
`rt::spawn(return_to_pool)`). Every connection released just before the block — the
`ApiServer::start` startup queries, the pool's 1s idle reaper — therefore kept its permit
until the body finished.

The test pool is `max_connections(5)` on a current-thread runtime, so a handful of
stranded permits is the entire pool: the body's first `push` burns the 30s acquire
timeout and panics. Whether a given run strands enough permits depends on what was
in flight at block time, which is what makes it a flake rather than a hard failure.

The helper is now `async` and hands its result back over a oneshot instead of blocking,
so the caller's runtime keeps draining while the body runs.

## Changes

- `run_in_isolated_thread` is `async`; it awaits a `oneshot` from the spawned thread
  instead of `join()`ing it, and documents why blocking the caller's runtime is wrong.
- Panics inside the body are caught and re-raised with `resume_unwind`, so the real
  message survives instead of the `isolated test thread panicked: Any { .. }` the old
  `.join().expect(...)` produced (visible in the CI log above).
- Updated the single call site in `tests/python_jobs.rs` to `.await`.

Side effect: the `ApiServer` these tests start is now actually driven during the body
instead of being frozen alongside the runtime.

## Test plan

- [x] Mechanism reproduced in isolation: standalone crate on the same sqlx 0.8.6 with the
      same pool options — `join()` variant returns `PoolTimedOut` after the full acquire
      timeout, awaited variant acquires in 167µs.
- [x] Reproduced on the real test path: temporary scaffolding that makes the timing window
      deterministic (5 acquire+drop tasks before entering the thread) fails under the old
      `join()` helper with the byte-identical CI error, and passes under the fix.
      Scaffolding removed before commit.
- [x] `cargo test --features python --test python_jobs -- --test-threads=10` — 18 passed,
      0 failed.
- [x] 20 sequential runs of `test_python_wac_v2_with_args` — 20/20 green, no
      `PoolTimedOut`, no hang at the new `rx.await`.
