### PR TITLE
fix: drop sampling params on Claude models that reject them

### DIFF
--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -1,3 +1,4 @@
+use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use crate::{
     ai_google::parse_data_url,
     ai_providers::{AIPlatform, AIProvider},
@@ -12,7 +13,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use http::Method;
-use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use windmill_common::{client::AuthedClient, error::Error};

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use http::Method;
-use super::REASONING_OFF_SENTINEL;
+use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use windmill_common::{client::AuthedClient, error::Error};
@@ -165,10 +165,10 @@ pub struct AnthropicOutputConfig {
 }
 
 /// Resolve the thinking config, effort and sampling params for a reasoning
-/// selection. Adaptive thinking rejects sampling params, so temperature only
-/// survives when thinking is off or explicitly disabled (Anthropic returns a
-/// hard 400 otherwise).
+/// selection. Temperature is dropped both under adaptive thinking, which
+/// rejects it, and on the models that removed the sampling params outright.
 fn anthropic_thinking_config(
+    model: &str,
     reasoning_effort: Option<&str>,
     temperature: Option<f32>,
 ) -> (
@@ -176,6 +176,9 @@ fn anthropic_thinking_config(
     Option<AnthropicOutputConfig>,
     Option<f32>,
 ) {
+    let temperature = (!anthropic_model_rejects_sampling_params(model))
+        .then_some(temperature)
+        .flatten();
     match reasoning_effort {
         // The disable sentinel is not an effort token — Anthropic's vocabulary
         // is low..max and rejects it. The disable carries no effort either:
@@ -688,7 +691,7 @@ impl AnthropicQueryBuilder {
         }
 
         let (thinking, output_config, temperature) =
-            anthropic_thinking_config(args.reasoning_effort, args.temperature);
+            anthropic_thinking_config(args.model, args.reasoning_effort, args.temperature);
 
         // Build request based on platform
         if self.is_vertex() {
@@ -1128,22 +1131,48 @@ mod tests {
     /// forwarded as an effort token Anthropic would reject.
     #[test]
     fn anthropic_thinking_config_translates_the_off_sentinel() {
-        let (thinking, output_config, temperature) =
-            anthropic_thinking_config(Some("none"), Some(0.5));
+        let (thinking, output_config, _) =
+            anthropic_thinking_config("claude-sonnet-4-6", Some("none"), Some(0.5));
         assert_eq!(thinking.as_ref().map(|t| t.r#type), Some("disabled"));
         assert!(output_config.is_none());
-        // Sampling params are only rejected alongside adaptive thinking.
-        assert_eq!(temperature, Some(0.5));
 
         let (thinking, output_config, temperature) =
-            anthropic_thinking_config(Some("xhigh"), Some(0.5));
+            anthropic_thinking_config("claude-sonnet-4-6", Some("xhigh"), Some(0.5));
         assert_eq!(thinking.as_ref().map(|t| t.r#type), Some("adaptive"));
         assert_eq!(output_config.map(|c| c.effort), Some("xhigh".to_string()));
+        // Adaptive thinking rejects sampling params on every model.
         assert!(temperature.is_none());
 
-        let (thinking, output_config, temperature) = anthropic_thinking_config(None, Some(0.5));
+        let (thinking, output_config, temperature) =
+            anthropic_thinking_config("claude-sonnet-4-6", None, Some(0.5));
         assert!(thinking.is_none());
         assert!(output_config.is_none());
+        assert_eq!(temperature, Some(0.5));
+    }
+
+    /// Live-verified: Opus 4.8 and the 5 family 400 with `temperature is
+    /// deprecated for this model` whatever the thinking mode, so the disable and
+    /// no-reasoning paths have to drop it too.
+    #[test]
+    fn anthropic_thinking_config_drops_sampling_params_on_models_that_reject_them() {
+        for model in [
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+            "anthropic/claude-opus-4.7",
+            "claude-fable-5",
+        ] {
+            for effort in [Some("none"), None] {
+                let (_, _, temperature) = anthropic_thinking_config(model, effort, Some(0.5));
+                assert!(
+                    temperature.is_none(),
+                    "{model} must not carry temperature (effort {effort:?})"
+                );
+            }
+        }
+        // Sonnet 4.6 still accepts them, so an off selection keeps temperature.
+        let (_, _, temperature) =
+            anthropic_thinking_config("claude-sonnet-4-6", Some("none"), Some(0.5));
         assert_eq!(temperature, Some(0.5));
     }
 

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -1178,15 +1178,17 @@ mod tests {
 
     #[test]
     fn anthropic_request_serializes_the_off_sentinel_as_a_thinking_disable() {
+        let (thinking, output_config, temperature) =
+            anthropic_thinking_config("claude-opus-5", Some("none"), Some(0.5));
         let request = AnthropicRequest {
             model: "claude-opus-5",
             system: None,
             messages: vec![],
             tools: None,
             tool_choice: None,
-            temperature: Some(0.5),
-            thinking: Some(AnthropicThinking::disabled()),
-            output_config: None,
+            temperature,
+            thinking,
+            output_config,
             max_tokens: Some(64000),
             stream: true,
         };
@@ -1198,8 +1200,7 @@ mod tests {
         // only applies to a thinking mode that actually runs.
         assert!(body["thinking"].get("display").is_none());
         assert!(body.get("output_config").is_none());
-        // Sampling params are only rejected alongside adaptive thinking.
-        assert_eq!(body["temperature"], 0.5);
+        assert!(body.get("temperature").is_none());
     }
 
     #[test]

--- a/backend/windmill-ai/src/providers/bedrock.rs
+++ b/backend/windmill-ai/src/providers/bedrock.rs
@@ -25,7 +25,7 @@ use crate::{
     query_builder::{ParsedResponse, StreamEventSink},
     types::{OpenAIMessage, StreamingEvent, TokenUsage, ToolDef},
 };
-use super::REASONING_OFF_SENTINEL;
+use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
 use http::{HeaderMap, Method, StatusCode};
@@ -359,9 +359,11 @@ async fn handle_bedrock_sdk_streaming(
     let (bedrock_messages, system_prompts) =
         openai_messages_to_bedrock(&openai_req.messages, enable_prompt_caching)?;
     // Adaptive thinking rejects sampling params; drop temperature when reasoning is on.
-    let temperature = (!effort_enables_thinking(openai_req.reasoning_effort.as_deref()))
-        .then_some(openai_req.temperature)
-        .flatten();
+    let temperature = bedrock_temperature(
+        model,
+        openai_req.reasoning_effort.as_deref(),
+        openai_req.temperature,
+    );
     let inference_config = create_inference_config(temperature, openai_req.max_tokens);
     let tool_config = build_tool_config_from_request(
         openai_req.tools.as_deref(),
@@ -410,9 +412,23 @@ async fn handle_bedrock_sdk_streaming(
 }
 
 /// Whether an effort token turns adaptive thinking on. `"none"` is the disable
-/// sentinel rather than a level, and sampling params stay usable alongside it.
+/// sentinel rather than a level.
 fn effort_enables_thinking(effort: Option<&str>) -> bool {
     matches!(effort, Some(effort) if effort != REASONING_OFF_SENTINEL)
+}
+
+/// Temperature survives only when thinking is not adaptive — which rejects
+/// sampling params — and the model still accepts them at all. Non-Anthropic
+/// Bedrock models (Nova, Llama) are unaffected by the second check.
+fn bedrock_temperature(
+    model: &str,
+    effort: Option<&str>,
+    temperature: Option<f32>,
+) -> Option<f32> {
+    if effort_enables_thinking(effort) || anthropic_model_rejects_sampling_params(model) {
+        return None;
+    }
+    temperature
 }
 
 /// Build the Converse `additionalModelRequestFields` carrying Claude's thinking
@@ -677,9 +693,11 @@ async fn handle_bedrock_sdk_non_streaming(
     let (bedrock_messages, system_prompts) =
         openai_messages_to_bedrock(&openai_req.messages, enable_prompt_caching)?;
     // Adaptive thinking rejects sampling params; drop temperature when reasoning is on.
-    let temperature = (!effort_enables_thinking(openai_req.reasoning_effort.as_deref()))
-        .then_some(openai_req.temperature)
-        .flatten();
+    let temperature = bedrock_temperature(
+        model,
+        openai_req.reasoning_effort.as_deref(),
+        openai_req.temperature,
+    );
     let inference_config = create_inference_config(temperature, openai_req.max_tokens);
     let tool_config = build_tool_config_from_request(
         openai_req.tools.as_deref(),
@@ -946,8 +964,7 @@ impl BedrockQueryBuilder {
             openai_messages_to_bedrock(&prepared_messages, enable_prompt_caching)?;
 
         // Adaptive thinking rejects sampling params; drop temperature when reasoning is on.
-        let temperature =
-            (!effort_enables_thinking(reasoning_effort)).then_some(temperature).flatten();
+        let temperature = bedrock_temperature(model, reasoning_effort, temperature);
 
         // Build inference configuration using shared helper
         let inference_config = create_inference_config(temperature, max_tokens.map(|t| t as i32));
@@ -1307,6 +1324,17 @@ mod tests {
         assert!(effort_enables_thinking(Some("xhigh")));
         assert!(!effort_enables_thinking(Some("none")));
         assert!(!effort_enables_thinking(None));
+        // Adaptive thinking drops sampling params; so do the models that
+        // removed them, on every thinking mode.
+        assert!(bedrock_temperature("anthropic.claude-sonnet-4-6", Some("xhigh"), Some(0.5)).is_none());
+        assert_eq!(
+            bedrock_temperature("anthropic.claude-sonnet-4-6", Some("none"), Some(0.5)),
+            Some(0.5)
+        );
+        assert!(bedrock_temperature("global.anthropic.claude-opus-5", Some("none"), Some(0.5)).is_none());
+        assert!(bedrock_temperature("anthropic.claude-opus-4-8", None, Some(0.5)).is_none());
+        // A non-Anthropic Bedrock model keeps its sampling params.
+        assert_eq!(bedrock_temperature("amazon.nova-pro-v1:0", None, Some(0.5)), Some(0.5));
     }
 
     #[test]

--- a/backend/windmill-ai/src/providers/bedrock.rs
+++ b/backend/windmill-ai/src/providers/bedrock.rs
@@ -6,6 +6,7 @@
 //! - Stream event parsing
 //! - Helper utilities
 
+use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use crate::{
     ai_bedrock::{
         bedrock_model_supports_prompt_caching, bedrock_stream_event_is_block_stop,
@@ -25,7 +26,6 @@ use crate::{
     query_builder::{ParsedResponse, StreamEventSink},
     types::{OpenAIMessage, StreamingEvent, TokenUsage, ToolDef},
 };
-use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use bytes::Bytes;
 use futures::{stream::BoxStream, StreamExt};
 use http::{HeaderMap, Method, StatusCode};
@@ -358,7 +358,8 @@ async fn handle_bedrock_sdk_streaming(
     let enable_prompt_caching = bedrock_model_supports_prompt_caching(model);
     let (bedrock_messages, system_prompts) =
         openai_messages_to_bedrock(&openai_req.messages, enable_prompt_caching)?;
-    // Adaptive thinking rejects sampling params; drop temperature when reasoning is on.
+    // Sampling params are dropped under adaptive thinking and on the models
+    // that removed them outright — see `bedrock_temperature`.
     let temperature = bedrock_temperature(
         model,
         openai_req.reasoning_effort.as_deref(),
@@ -420,11 +421,7 @@ fn effort_enables_thinking(effort: Option<&str>) -> bool {
 /// Temperature survives only when thinking is not adaptive — which rejects
 /// sampling params — and the model still accepts them at all. Non-Anthropic
 /// Bedrock models (Nova, Llama) are unaffected by the second check.
-fn bedrock_temperature(
-    model: &str,
-    effort: Option<&str>,
-    temperature: Option<f32>,
-) -> Option<f32> {
+fn bedrock_temperature(model: &str, effort: Option<&str>, temperature: Option<f32>) -> Option<f32> {
     if effort_enables_thinking(effort) || anthropic_model_rejects_sampling_params(model) {
         return None;
     }
@@ -692,7 +689,8 @@ async fn handle_bedrock_sdk_non_streaming(
     let enable_prompt_caching = bedrock_model_supports_prompt_caching(model);
     let (bedrock_messages, system_prompts) =
         openai_messages_to_bedrock(&openai_req.messages, enable_prompt_caching)?;
-    // Adaptive thinking rejects sampling params; drop temperature when reasoning is on.
+    // Sampling params are dropped under adaptive thinking and on the models
+    // that removed them outright — see `bedrock_temperature`.
     let temperature = bedrock_temperature(
         model,
         openai_req.reasoning_effort.as_deref(),
@@ -963,7 +961,8 @@ impl BedrockQueryBuilder {
         let (bedrock_messages, system_prompts) =
             openai_messages_to_bedrock(&prepared_messages, enable_prompt_caching)?;
 
-        // Adaptive thinking rejects sampling params; drop temperature when reasoning is on.
+        // Sampling params are dropped under adaptive thinking and on the models
+        // that removed them outright — see `bedrock_temperature`.
         let temperature = bedrock_temperature(model, reasoning_effort, temperature);
 
         // Build inference configuration using shared helper
@@ -1320,21 +1319,29 @@ mod tests {
         assert_eq!(fields["thinking"]["type"], "disabled");
         // An effort alongside the disable is a 400 on Opus 5.
         assert!(fields.get("output_config").is_none());
-        // Sampling params survive a disable, unlike adaptive thinking.
         assert!(effort_enables_thinking(Some("xhigh")));
         assert!(!effort_enables_thinking(Some("none")));
         assert!(!effort_enables_thinking(None));
-        // Adaptive thinking drops sampling params; so do the models that
-        // removed them, on every thinking mode.
-        assert!(bedrock_temperature("anthropic.claude-sonnet-4-6", Some("xhigh"), Some(0.5)).is_none());
-        assert_eq!(
-            bedrock_temperature("anthropic.claude-sonnet-4-6", Some("none"), Some(0.5)),
-            Some(0.5)
-        );
-        assert!(bedrock_temperature("global.anthropic.claude-opus-5", Some("none"), Some(0.5)).is_none());
-        assert!(bedrock_temperature("anthropic.claude-opus-4-8", None, Some(0.5)).is_none());
+    }
+
+    #[test]
+    fn bedrock_temperature_drops_sampling_params_per_thinking_mode_and_model() {
+        // Adaptive thinking rejects sampling params on every model...
+        let adaptive = bedrock_temperature("anthropic.claude-sonnet-4-6", Some("xhigh"), Some(0.5));
+        assert!(adaptive.is_none());
+        // ...while a model that still accepts them keeps them when off.
+        let off = bedrock_temperature("anthropic.claude-sonnet-4-6", Some("none"), Some(0.5));
+        assert_eq!(off, Some(0.5));
+        // The models that removed them drop them on every mode.
+        for (model, effort) in [
+            ("global.anthropic.claude-opus-5", Some("none")),
+            ("anthropic.claude-opus-4-8", None),
+        ] {
+            assert!(bedrock_temperature(model, effort, Some(0.5)).is_none());
+        }
         // A non-Anthropic Bedrock model keeps its sampling params.
-        assert_eq!(bedrock_temperature("amazon.nova-pro-v1:0", None, Some(0.5)), Some(0.5));
+        let nova = bedrock_temperature("amazon.nova-pro-v1:0", None, Some(0.5));
+        assert_eq!(nova, Some(0.5));
     }
 
     #[test]

--- a/backend/windmill-ai/src/providers/bedrock.rs
+++ b/backend/windmill-ai/src/providers/bedrock.rs
@@ -358,8 +358,6 @@ async fn handle_bedrock_sdk_streaming(
     let enable_prompt_caching = bedrock_model_supports_prompt_caching(model);
     let (bedrock_messages, system_prompts) =
         openai_messages_to_bedrock(&openai_req.messages, enable_prompt_caching)?;
-    // Sampling params are dropped under adaptive thinking and on the models
-    // that removed them outright — see `bedrock_temperature`.
     let temperature = bedrock_temperature(
         model,
         openai_req.reasoning_effort.as_deref(),
@@ -689,8 +687,6 @@ async fn handle_bedrock_sdk_non_streaming(
     let enable_prompt_caching = bedrock_model_supports_prompt_caching(model);
     let (bedrock_messages, system_prompts) =
         openai_messages_to_bedrock(&openai_req.messages, enable_prompt_caching)?;
-    // Sampling params are dropped under adaptive thinking and on the models
-    // that removed them outright — see `bedrock_temperature`.
     let temperature = bedrock_temperature(
         model,
         openai_req.reasoning_effort.as_deref(),
@@ -961,8 +957,6 @@ impl BedrockQueryBuilder {
         let (bedrock_messages, system_prompts) =
             openai_messages_to_bedrock(&prepared_messages, enable_prompt_caching)?;
 
-        // Sampling params are dropped under adaptive thinking and on the models
-        // that removed them outright — see `bedrock_temperature`.
         let temperature = bedrock_temperature(model, reasoning_effort, temperature);
 
         // Build inference configuration using shared helper

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -18,8 +18,18 @@ pub(crate) const REASONING_OFF_SENTINEL: &str = "none";
 /// `top_k`). On these, any value is a hard 400 — `temperature is deprecated for
 /// this model` — whatever the thinking mode, so the param has to be dropped on
 /// the reasoning-off and no-reasoning paths too, not only under adaptive
-/// thinking. Live-verified against the Messages API: Opus 4.8 and the 5 family
-/// reject them, Sonnet 4.6 still accepts them.
+/// thinking.
+///
+/// Probed against the Messages API: `claude-opus-5`, `claude-sonnet-5` and
+/// `claude-opus-4-8` reject them; `claude-sonnet-4-6` still accepts them. Opus
+/// 4.7, Fable and Mythos are included from Anthropic's migration guide, which
+/// documents the same removal, rather than from a probe.
+///
+/// Matching is on the model name, so a Bedrock *application* inference profile —
+/// whose id is opaque (`k1c3lwu20lem`) rather than derived from the model —
+/// cannot be classified and keeps its sampling params. Resolving the backing
+/// model would need a per-request AWS lookup; `bedrock_model_supports_prompt_caching`
+/// degrades on the same ids for the same reason.
 pub(crate) fn anthropic_model_rejects_sampling_params(model: &str) -> bool {
     let model = model.to_lowercase().replace('.', "-");
     model.contains("claude-opus-4-7")

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -14,6 +14,22 @@ use std::time::{Duration, Instant};
 /// its `thinking` param, Gemini to a zero budget or the model's floor).
 pub(crate) const REASONING_OFF_SENTINEL: &str = "none";
 
+/// Whether a Claude model removed the sampling params (`temperature`, `top_p`,
+/// `top_k`). On these, any value is a hard 400 — `temperature is deprecated for
+/// this model` — whatever the thinking mode, so the param has to be dropped on
+/// the reasoning-off and no-reasoning paths too, not only under adaptive
+/// thinking. Live-verified against the Messages API: Opus 4.8 and the 5 family
+/// reject them, Sonnet 4.6 still accepts them.
+pub(crate) fn anthropic_model_rejects_sampling_params(model: &str) -> bool {
+    let model = model.to_lowercase().replace('.', "-");
+    model.contains("claude-opus-4-7")
+        || model.contains("claude-opus-4-8")
+        || model.contains("claude-opus-5")
+        || model.contains("claude-sonnet-5")
+        || model.contains("claude-fable")
+        || model.contains("claude-mythos")
+}
+
 use windmill_common::cache::Cache;
 
 use crate::{

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -87,7 +87,7 @@ export const AI_PROVIDERS: Record<AIProvider, AIProviderDetails> = {
 		defaultModels: [
 			'gemini-3.6-flash',
 			'gemini-3.5-flash',
-			'gemini-3.1-pro',
+			'gemini-3.1-pro-preview',
 			'gemini-3.5-flash-lite',
 			'gemini-3.1-flash-lite',
 			'gemini-2.5-pro',

--- a/frontend/src/lib/components/copilot/reasoningRegistry.test.ts
+++ b/frontend/src/lib/components/copilot/reasoningRegistry.test.ts
@@ -75,7 +75,8 @@ describe('supportsReasoning (static registry)', () => {
 				resolveRequestReasoning({ provider: 'anthropic', model, reasoning: REASONING_OFF })
 			).toBe('none')
 		}
-		// Bedrock translates the same sentinel on its Converse path.
+		// Bedrock translates the same sentinel on its Converse path, but only for
+		// Opus 5 — AWS documents Bedrock's Sonnet 5 as always thinking.
 		expect(
 			getReasoningCapability('aws_bedrock', 'global.anthropic.claude-opus-5').canDisable
 		).toBe(true)
@@ -86,6 +87,11 @@ describe('supportsReasoning (static registry)', () => {
 				reasoning: REASONING_OFF
 			})
 		).toBe('none')
+		expect(
+			getReasoningCapability('aws_bedrock', 'global.anthropic.claude-sonnet-5').canDisable
+		).toBe(false)
+		// ...while the same model on the native provider does accept a disable.
+		expect(getReasoningCapability('anthropic', 'claude-sonnet-5').canDisable).toBe(true)
 	})
 	it('flags Claude models served through Bedrock, with the Anthropic ladder', () => {
 		expect(supportsReasoning('aws_bedrock', 'us.anthropic.claude-opus-4-6-v1')).toBe(true)

--- a/frontend/src/lib/components/copilot/reasoningRegistry.ts
+++ b/frontend/src/lib/components/copilot/reasoningRegistry.ts
@@ -265,11 +265,14 @@ function canDisableReasoning(provider: AIProvider, model: string): boolean {
 	const base = baseModelId(model)
 	switch (reasoningProviderFamily(provider, model)) {
 		case 'anthropic':
-		case 'aws_bedrock':
 			// Every Claude but Fable and Mythos can stop thinking: 4.6-4.8 by
 			// omission, and the 5 family through the explicit disable that
-			// `explicitOffToken` sends (both routes translate it).
+			// `explicitOffToken` sends.
 			return !ANTHROPIC_ALWAYS_THINKING.test(m)
+		case 'aws_bedrock':
+			// Same models, different answer: AWS documents Sonnet 5 on Bedrock as
+			// always thinking, where the native API accepts a disable for it.
+			return !(ANTHROPIC_ALWAYS_THINKING.test(m) || m.includes('claude-sonnet-5'))
 		case 'googleai':
 			return geminiCanDisable(model)
 		case 'openai':
@@ -355,12 +358,17 @@ const ANTHROPIC_ALWAYS_THINKING = /fable|mythos/
 export function explicitOffToken(provider: AIProvider, model: string): ReasoningEffort | undefined {
 	switch (reasoningProviderFamily(provider, model)) {
 		case 'anthropic':
-		case 'aws_bedrock':
 			// Claude 4.6-4.8 only think when asked, so omission is already a
 			// real off there and stays the wire form. Only the 5 family, which
 			// thinks when the field is absent, needs the explicit disable —
 			// Fable and Mythos reject it outright and get no off token at all.
 			return /claude-(opus|sonnet)-5/.test(model.toLowerCase())
+				? ANTHROPIC_OFF_SENTINEL
+				: undefined
+		case 'aws_bedrock':
+			// Bedrock's Sonnet 5 cannot be disabled at all, so only Opus 5 gets
+			// the sentinel; the rest keep omission.
+			return model.toLowerCase().includes('claude-opus-5')
 				? ANTHROPIC_OFF_SENTINEL
 				: undefined
 		case 'googleai':


### PR DESCRIPTION
## Summary

Follow-up to #10690, verified against the live Anthropic Messages API.

Claude Opus 4.7/4.8 and the 5 family removed the sampling params: any
`temperature` is a hard 400 — `` `temperature` is deprecated for this model `` —
**whatever the thinking mode**. Both provider paths only dropped it under
adaptive thinking, so two request shapes 400 today.

## The two failure modes

Probed against `api.anthropic.com` (bodies emitted by the code itself, then POSTed):

| Request | Result on merged main |
|---|---|
| `claude-opus-5`, reasoning off, `temperature` set | `400 temperature is deprecated for this model` |
| `claude-opus-4-8`, no reasoning at all, `temperature` set | `400 temperature is deprecated for this model` |

The first is a regression from #10690: the off sentinel added
`thinking: {type: "disabled"}` and kept `temperature`, on the mistaken premise
that sampling params are only rejected alongside *adaptive* thinking. They are
rejected by the *model*.

The second predates #10690 (the default `None` arm passed `temperature`
straight through) and hits any agent step on Opus 4.7/4.8 that sets a
temperature and leaves reasoning unset.

## Changes

- `providers/mod.rs`: `anthropic_model_rejects_sampling_params(model)` — one
  home for the model list (Opus 4.7/4.8, Opus 5, Sonnet 5, Fable, Mythos).
- `providers/anthropic.rs`: `anthropic_thinking_config` takes the model and
  drops `temperature` for those models on every arm, not just adaptive.
- `providers/bedrock.rs`: same rule via `bedrock_temperature`, applied at all
  three Converse call sites. Non-Anthropic Bedrock models (Nova, Llama) keep
  their sampling params.

## Verification

Bodies were emitted by the real code path and POSTed to the live API:

| Body the code builds | Live result |
|---|---|
| `opus-5` `thinking=disabled`, no effort, no temp | **OK** |
| `opus-5` `thinking=adaptive` `effort=xhigh`, no temp | **OK** |
| `opus-4-8` no thinking, no temp | **OK** |
| `sonnet-4-6` `thinking=disabled`, `temperature=0.5` | **OK** (4.6 still accepts sampling) |

Same probe also confirmed two things #10690 asserted from documentation only:
- `thinking: {type: "disabled"}` is accepted on Opus 5 and Sonnet 5, and returns
  no thinking block — the off switch works.
- `output_config.effort: "none"` is rejected (`Input should be 'low', 'medium',
  'high', 'xhigh' or 'max'`), and a disable paired with `xhigh` is rejected
  (`Use effort 'high' or below, or enable thinking`) — the sentinel translation
  and the no-effort-with-disable rule were both necessary.

## Test plan
- [x] `cargo test -p windmill-ai --features bedrock` — 131 passing, including
      per-model sampling coverage on both paths and a non-Anthropic Bedrock case
- [x] Live probe against `api.anthropic.com` (table above)
- [ ] Bedrock leg of the sampling rule is inferred from the shared model, not
      probed — no AWS credentials here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `temperature` on Claude models that removed sampling params across Anthropic and Bedrock to prevent 400s when reasoning is off or unset. Also aligns Bedrock behavior: Sonnet 5 cannot disable thinking on Bedrock, unlike the native Anthropic API.

- Centralizes detection in `anthropic_model_rejects_sampling_params` (Opus 4.7/4.8, Opus 5, Sonnet 5, Fable, Mythos). Bedrock application inference profiles with opaque IDs keep `temperature`.
- Anthropic: `anthropic_thinking_config` now takes the model and drops `temperature` on rejecting models on every path; adaptive thinking still drops it on all models.
- Bedrock: `bedrock_temperature` applies the same drop rule in streaming, non‑streaming, and builder paths. Non‑Anthropic Bedrock models (e.g., `amazon.nova-pro-v1:0`) keep `temperature`; Sonnet 4.6 still accepts it. Sonnet 5 cannot be disabled on Bedrock; the native provider still supports disable.
- Verification: live probes cover `claude-opus-5` (disabled/adaptive) and `claude-opus-4-8`; tests exercise both providers, a non‑Anthropic case, per‑model temperature behavior, and build the disable request via the resolver.
- UI: updates Gemini default model id to `gemini-3.1-pro-preview` and reflects the Bedrock Sonnet 5 disable rule in the reasoning registry.

<sup>Written for commit 940a80d8255cc8500840c251afa57d0a44250b20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

