### PR TITLE
fix: log the settings a failed read left unapplied

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -3235,6 +3235,10 @@ impl<'a> SettingsPass<'a> {
                 PassStep::Setting { name, apply, .. } => {
                     if let Some(value) = values.remove(name) {
                         apply(value).await
+                    } else {
+                        tracing::warn!(
+                            "Setting {name} could not be read, leaving its in-memory value unchanged"
+                        );
                     }
                 }
                 PassStep::Settings { names, apply, .. } => {
@@ -3244,6 +3248,17 @@ impl<'a> SettingsPass<'a> {
                         .collect();
                     if asked.len() == names.len() {
                         apply(asked).await
+                    } else {
+                        let missing = names
+                            .iter()
+                            .filter(|n| !asked.contains_key(*n))
+                            .copied()
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        tracing::warn!(
+                            "Settings {missing} could not be read, leaving the in-memory values of {} unchanged",
+                            names.join(", ")
+                        );
                     }
                 }
                 PassStep::Action(fut) => fut.await,


### PR DESCRIPTION
## Summary

#10698 replaced ~35 per-setting reads in `initial_load` with a single batched `SettingsPass`. A read that fails now causes its step's applier to be **skipped** — deliberately, since that is how a setting keeps its current in-memory value across a transient database error — but nothing said which settings were skipped. The batch error and the per-setting errors from the fallback tell you the read failed; neither tells you the consequence.

Both arms of the step loop now warn, naming the settings whose applier did not run.

## Changes

- `PassStep::Setting`: warn naming the setting when its value is missing from the batch result.
- `PassStep::Settings`: warn naming the settings that failed and the whole group left unapplied, since the step is atomic. Only one such step exists today (`oauths` + `base_url`) so both lists coincide, but they won't when one of the two reads fails and the other doesn't.

Wording is deliberately "leaving its in-memory value unchanged" rather than "leaving it as it was": on a reload tick the retained value is the configured one, but on the first `initial_load` there is no known-good state and the retained value is the compile-time default. The neutral phrasing is true in both cases.

No behavior change — both additions are `else` arms on branches that previously fell through silently.

## Test plan

Exercised on a running backend against the dev database, with a temporary env-gated failure injection in `fetch_settings_batch` / `fetch_settings_individually` (reverted; not part of this diff).

- [x] **Normal startup** — 0 skip warns, settings applied, `health check completed status="healthy"`. No false positives, including for the agent-worker case where an `http: false` setting is re-inserted as unset rather than left missing.
- [x] **Batch fails, per-setting fallback succeeds** — 0 skip warns, settings still applied:
  ```
  ERROR Could not load global settings: ...
  WARN  Falling back to per-setting reads for 60 settings
  INFO  Loaded setting custom_tags, common: ["chromium"], per-workspace: {}
  ```
- [x] **Batch fails and the fallback fails too** — one line per skipped step, all 60 declared reads accounted for, and the process still reaches `health check completed`:
  ```
  WARN Settings oauths, base_url could not be read, leaving the in-memory values of oauths, base_url unchanged
  WARN Setting critical_error_channels could not be read, leaving its in-memory value unchanged
  WARN Setting workspace_fairness_enabled could not be read, leaving its in-memory value unchanged
  WARN Setting jwt_secret could not be read, leaving its in-memory value unchanged
  ... (58 single-setting lines)
  ```

No test is shipped: asserting on log output for a message-only change is the ceremonial test AGENTS.md says to omit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when a settings read fails and its applier is skipped, so reviewers can see which settings were left unapplied. Previously these skips were silent; now we log the affected setting(s) without changing behavior.

- PassStep::Setting: warn when the value is missing, e.g., “Setting {name} could not be read, leaving its in-memory value unchanged.”
- PassStep::Settings: warn with the missing names and note the whole group was left unapplied.
- No behavior change; only new warn logs in the existing “else” paths.
- No migration required.

<sup>Written for commit b659cc98063a6bbab007f5b188521f61d18637e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

