### PR TITLE
fix: recover from a refused mcp read assertion, drop stale discovery

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/mcpTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/mcpTools.test.ts
@@ -127,6 +127,30 @@ describe('read/write split', () => {
 		expect(getTool('call_mcp_write_tool').requiresConfirmation).toBe(true)
 	})
 
+	// The rejection sends the model to the write tool, which classifies from the
+	// same cached listing: without dropping it, that retry is refused too and the
+	// model has nowhere to go until the entry expires.
+	it('reclassifies after the backend refuses the read-only assertion', async () => {
+		callMcpToolMock.mockRejectedValueOnce({
+			status: 400,
+			body: 'Bad request: MCP tool get_issue is not marked read-only by the server, it must be called as a tool that modifies data'
+		})
+		const refused = await run('call_mcp_read_tool', {
+			server: 'u/hugo/github_mcp',
+			tool: 'get_issue'
+		})
+		expect(refused.success).toBe(false)
+
+		// The server now reports the same name as mutating.
+		getMcpToolsMock.mockResolvedValue([{ ...TOOLS[0], annotations: { readOnlyHint: false } }])
+		callMcpToolMock.mockResolvedValue({ content: [] })
+		const retried = await run('call_mcp_write_tool', {
+			server: 'u/hugo/github_mcp',
+			tool: 'get_issue'
+		})
+		expect(retried.success).toBe(true)
+	})
+
 	// This classification comes from a listing that can predate a resource edited
 	// mid-turn, so the backend re-checks it against the server it is calling — but
 	// only knows to when the unconfirmed path says it assumed read-only.

--- a/frontend/src/lib/components/copilot/chat/global/mcpTools.ts
+++ b/frontend/src/lib/components/copilot/chat/global/mcpTools.ts
@@ -222,10 +222,17 @@ async function executeTool(
 		})
 	} catch (e: any) {
 		const status = e?.status
+		const error = errorMessage(e)
+		// The server disagrees with the listing this call was classified from, so the
+		// write tool the model is sent to must not be handed the same answer. Matching
+		// loosely is safe: the worst a false positive costs is one extra listing.
+		if (skippedConfirmation && status === 400 && /read-only/i.test(error)) {
+			forgetServerTools(workspace, server.path)
+		}
 		return bounded({
 			success: false,
 			...(status ? { status } : {}),
-			error: errorMessage(e),
+			error,
 			// Wrong arguments are the common failure: echo the schema so the model
 			// can self-correct on the next call without a separate schema tool.
 			...(status >= 400 && status < 500 ? { schema: tool.inputSchema } : {})
@@ -373,14 +380,7 @@ function createCallTool(servers: McpServer[], mode: 'read' | 'write'): Tool<{}> 
 				parsed.arguments ?? {},
 				isRead
 			)
-			const payload = JSON.parse(result)
-			const ok = payload.success === true
-			// The server disagrees with the listing this call was classified from, so
-			// the retry has to reclassify. Matching loosely is safe: the worst a false
-			// positive costs is one extra listing.
-			if (isRead && payload.status === 400 && /read-only/i.test(payload.error ?? '')) {
-				forgetServerTools(workspace, resolved.server.path)
-			}
+			const ok = JSON.parse(result).success === true
 			toolCallbacks.setToolStatus(toolId, {
 				content: ok ? `Called ${parsed.tool}` : `Call to ${parsed.tool} failed`,
 				result,

--- a/frontend/src/lib/components/copilot/chat/global/mcpTools.ts
+++ b/frontend/src/lib/components/copilot/chat/global/mcpTools.ts
@@ -67,6 +67,20 @@ export function clearMcpToolsCache() {
 }
 
 /**
+ * Drop one server's listing after the backend refused the read-only assertion it
+ * produced. Without this the write call the model is being sent to would be
+ * rejected by the same stale `readOnlyHint`, leaving it with nowhere to go until
+ * the entry expires.
+ */
+function forgetServerTools(workspace: string, path: string) {
+	cacheGeneration++
+	const prefix = `${workspace}:${path}:`
+	for (const key of Object.keys(toolsCache)) {
+		if (key.startsWith(prefix)) delete toolsCache[key]
+	}
+}
+
+/**
  * The `mcp` resources the user turned on for this workspace. Readable is not
  * enough: a shared resource would otherwise put a server the user never chose
  * into every one of their sessions.
@@ -359,7 +373,14 @@ function createCallTool(servers: McpServer[], mode: 'read' | 'write'): Tool<{}> 
 				parsed.arguments ?? {},
 				isRead
 			)
-			const ok = JSON.parse(result).success === true
+			const payload = JSON.parse(result)
+			const ok = payload.success === true
+			// The server disagrees with the listing this call was classified from, so
+			// the retry has to reclassify. Matching loosely is safe: the worst a false
+			// positive costs is one extra listing.
+			if (isRead && payload.status === 400 && /read-only/i.test(payload.error ?? '')) {
+				forgetServerTools(workspace, resolved.server.path)
+			}
 			toolCallbacks.setToolStatus(toolId, {
 				content: ok ? `Called ${parsed.tool}` : `Call to ${parsed.tool} failed`,
 				result,

--- a/frontend/src/lib/components/mcp/McpServerOAuthConnect.svelte
+++ b/frontend/src/lib/components/mcp/McpServerOAuthConnect.svelte
@@ -38,6 +38,7 @@
 	let noOAuth = $state(false)
 	let pending: { workspace: string; path: string; serverUrl: string } | undefined = undefined
 	let popup: Window | null = null
+	let destroyed = false
 
 	async function discoverOAuth() {
 		status = 'discovering'
@@ -46,11 +47,17 @@
 			discoveryResult = await McpOauthService.discoverMcpOauth({
 				requestBody: { mcp_server_url: serverUrl }
 			})
+			// The caller keys this component on the url, so editing it replaces this
+			// instance while its request is still in flight. Reporting the answer then
+			// would describe the previous server: a slow failure would take the new
+			// connector down with it.
+			if (destroyed) return
 			selectedScopes = discoveryResult?.scopes_supported ?? []
 			noOAuth = false
 			status = 'discovered'
 			onDiscovered?.(true)
 		} catch (e) {
+			if (destroyed) return
 			console.error('Error discovering OAuth settings', e)
 			noOAuth = true
 			status = 'idle'
@@ -187,7 +194,10 @@
 
 	onMount(discoverOAuth)
 
-	onDestroy(cleanup)
+	onDestroy(() => {
+		destroyed = true
+		cleanup()
+	})
 </script>
 
 <div class="flex flex-col gap-4">


### PR DESCRIPTION
## Summary

Two follow-ups to #10656, both raised by the review round that ran on its final head and could not post (the PR conversation was locked by then, so the verdict only exists in the workflow log — "Mergeable, but should ideally address nits", two P2s).

The first one matters most: the read-only gate that shipped in #10656 refuses a stale read call and tells the model to use the write tool, but the write facade classifies from the same cached listing and refuses it right back. In exactly the situation the gate exists for, the chat had nowhere to go until the 60s cache entry expired.

## Changes

- `mcpTools.ts`: when the backend refuses the read-only assertion, drop that server's cached listing so the write retry re-lists and reclassifies. Matching the rejection is deliberately loose — a false positive costs one extra listing, nothing more.
- `McpServerOAuthConnect.svelte`: ignore a discovery result that arrives after the component was destroyed. The connector is keyed on the url, so editing it replaces the instance while its request is in flight; a slow failure from the previous server would otherwise force the new one into token-only mode.
- One regression test: the write retry succeeds after the read call is refused (it fails without the cache drop).

## Test plan

- [x] `npm run check` — 0 errors; `mcpTools.test.ts` 23 passed
- [x] Recovery loop end to end against a local stub MCP server, driven by the real chat: listing cached with `readOnlyHint: true` → tool flipped to mutating on the server → read call refused with 400 → **a fresh `GET mcp_tools`** (the cache drop) → confirmed write call succeeds. Without the fix there is no second listing and the write facade refuses from cache.
- [x] Discovery race in the browser: server A discovers slowly and fails, switch to server B which discovers fast and advertises OAuth; when A's failure lands ~60s later the card still shows B's OAuth scopes and sign-in button, with no token fallback.

## Screenshots

No visible UI change: the connect card renders identically, and both fixes are behavioral (a cache drop, and a late callback being ignored). The observable difference is in the request sequence, described in the test plan above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover from refused MCP read-only assertions and ignore stale OAuth discovery callbacks. Previously, a refused read call sent the model to write, but the write retry reused the same cached listing and was also refused; a late discovery from a replaced connector could force the new one into token-only mode.

- In `mcpTools.ts`, when a read call returns 400 and the raw backend error mentions "read-only", drop that server’s cached listing for the workspace so the write retry re-lists and reclassifies. Matching is loose and done against the raw error (not the bounded payload); worst case is one extra listing. Adds `forgetServerTools(workspace, path)` and a regression test.
- In `McpServerOAuthConnect.svelte`, track `destroyed` and bail if a discovery result arrives after unmount. Prevents a slow failure from a previous server from overriding the new server’s OAuth state. No UI changes.

<sup>Written for commit 901a18122f3b1a57a0e0d94efd4be2d22eaba1f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

