### PR TITLE
perf: unblock workers before the API router is built

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1629,6 +1629,10 @@ Windmill Community Edition {GIT_VERSION}
             }
         }
 
+        // `workers_f` must stay ahead of `server_f`: these are polled on one task in
+        // declaration order, and `run_server` yields once after handing over the base
+        // internal url so the workers get past that oneshot before it builds its router.
+        // Ordering `server_f` first makes them wait out the whole build instead.
         if mcp_mode {
             futures::try_join!(workers_f, server_f)?;
         } else {

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -584,6 +584,16 @@ pub async fn run_server(
         (Router::new(), Router::new(), Option::<()>::None)
     };
 
+    // Workers block on this before pulling their first job, so it is released ahead of
+    // the router tree below. `try_join!` polls this future and `workers_f` on one task,
+    // so the yield is what lets them proceed; without it they wait out the whole
+    // synchronous build. A request arriving first queues in the bound listener's backlog.
+    if let Err(e) = port_tx.send(format!("http://localhost:{}", port)) {
+        tracing::error!("Failed to send port: {e:#}");
+        return Err(anyhow::anyhow!("Failed to send port, exiting early: {e:#}"));
+    }
+    tokio::task::yield_now().await;
+
     let mcp_list_tools_service = {
         #[cfg(feature = "mcp")]
         {
@@ -1180,11 +1190,6 @@ pub async fn run_server(
         ip,
         name.map(|x| format!("name={x}")).unwrap_or_default()
     );
-
-    if let Err(e) = port_tx.send(format!("http://localhost:{}", port)) {
-        tracing::error!("Failed to send port: {e:#}");
-        return Err(anyhow::anyhow!("Failed to send port, exiting early: {e:#}"));
-    }
 
     // Announce this server is ready so coordinated restarts can detect a healthy peer.
     if server_mode {


### PR DESCRIPTION
## Summary

A worker takes its `BASE_INTERNAL_URL` from a oneshot that `run_server` fills, and cannot pull its first job until it arrives. That send sat at the very end of `run_server`, so every worker process waited for the entire API router tree to be constructed before pulling anything — work a worker does not need in order to start.

Measured on production worker pods (v1.790.0), that wait is the two largest remaining slices of a ~176 ms startup: ~57 ms loading the HTTP trigger routers and ~20 ms building the router tree.

## Changes

- Move `port_tx.send(...)` in `run_server` from just before `axum::serve` to immediately after the MCP setup, ahead of the router tree.
- Add `tokio::task::yield_now().await` after the send. This is load-bearing: `futures::try_join!` polls `workers_f` and `server_f` **on one task**, so completing the oneshot cannot preempt `server_f`'s synchronous router construction. Without the yield the move is a no-op and workers unblock at exactly the same moment as before.
- Record the ordering invariant at the `try_join!` sites in `main.rs` — `workers_f` must stay ahead of `server_f`, or the yield hands control back to the router build instead and the change silently reverts.

The send stays **below** `setup_mcp_server(...).await?`, the one fallible call in this span, so the port signal still means "`run_server` survived its fallible setup" — which `windmill-test-utils` relies on as its readiness gate.

Correctness does not depend on the server being ready, but on the listener being bound, which happens in `main.rs` before `run_server` is called. A request arriving in the window queues in the kernel accept backlog rather than being refused. That window already existed on main: the old send site still preceded `server.await`.

## Test plan

- [x] `cargo check --features quickjs` clean
- [x] Standalone backend: log order inverts from `server started on port` → `Starting N workers` to `Starting 1 workers` / `listening for jobs` ~16 ms **before** `server started on port` (local build has no `http_trigger`, so the gap is small here; in production it is the 57 ms + 20 ms above)
- [x] Real bash job run end to end; its call to `$BASE_INTERNAL_URL/api/version` returned 200
- [x] Accept-backlog behaviour verified directly: a request sent 1.5 s before `accept()` is not refused, it waits and succeeds
- [ ] Backend integration suite (every test gates on `port_rx`, so this is the relevant regression check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks workers before the API router is built by sending the base internal URL earlier in `run_server` and yielding once. Previously, workers waited for router construction; now they start pulling jobs immediately after MCP setup, cutting worker startup latency by ~77 ms in production. Requests arriving during the build queue in the listener backlog.

- The port signal remains after the fallible MCP setup, preserving readiness semantics used by `windmill-test-utils`.
- Adds `tokio::task::yield_now()` after the send to let workers advance; without it, `futures::try_join!` keeps them blocked during the synchronous router build.
- Documents and enforces the invariant that `workers_f` must be declared before `server_f`; reversing them silently restores the old delay.
- Listener binding occurs before `run_server`; no change to external correctness.

<sup>Written for commit fdac5209dead99866cdf6cc70d48ea6bc3b47998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## "How do we know the server is accepting when the first job starts?"

We don't, and the change does not need it to be. Let `W` be the window between the send and `axum::serve`:

- **Before:** worker unblocks at `T+W`, pulls a job, issues its first API call, answered at ~`T+W`.
- **After:** worker unblocks at `T+0`, pulls a job, its first API call queues in the listener backlog, answered at `T+W`.

The response lands at `T+W` either way, so the first job is never slower end to end — and the worker's own setup now overlaps the build.

What does change is that the client's timeout clock starts `W` earlier. Measured over 632 real worker starts across all four production clusters (last 3 days), `W` is p50 79 ms, p90 113 ms, p99 343 ms, max 2207 ms. Internal clients use `timeout(20s)` / `connect_timeout(10s)` (`windmill-common/src/utils.rs:63-64`); the connect timeout is never at risk because connect succeeds immediately off the backlog. So at the worst observed window a request would need to consume more than 17.8 s of server time to newly time out.

`W` scales with an instance's `http_trigger` count, since the router load is O(routes). Not loading those routers on non-server processes at all would remove the window rather than bound it, and is the natural follow-up.
