### PR TITLE
fix: fall back to polling when a proxy mutes the job SSE stream

### DIFF
--- a/frontend/src/lib/components/JobLoader.svelte
+++ b/frontend/src/lib/components/JobLoader.svelte
@@ -893,7 +893,14 @@
 									`SSE error (1), retrying ...  attempt: ${attempt + 1}/${MAX_SSE_ATTEMPTS}`
 								)
 							}
-							setTimeout(() => loadTestJobWithSSE(id, attempt + 1, callbacks), delay)
+							// A no-logs restart is deliberate (the caller wants a stream with different
+							// query args), not a failure, so it must not consume the retry budget:
+							// toggling the flow graph tab would otherwise exhaust it in a few clicks
+							// and strand a healthy stream on polling.
+							setTimeout(
+								() => loadTestJobWithSSE(id, isNoLogsChange ? attempt : attempt + 1, callbacks),
+								delay
+							)
 						} else {
 							// Fall back to polling on error
 							setTimeout(() => syncer(id, callbacks), 1000)

--- a/frontend/src/lib/components/JobLoader.svelte
+++ b/frontend/src/lib/components/JobLoader.svelte
@@ -87,6 +87,7 @@
 	let finished: string[] = []
 	let ITERATIONS_BEFORE_SLOW_REFRESH = 10
 	let ITERATIONS_BEFORE_SUPER_SLOW_REFRESH = 100
+	const MAX_SSE_ATTEMPTS = 3
 
 	let lastStartedAt: number = Date.now()
 	let currentId: string | undefined = $state(undefined)
@@ -179,7 +180,7 @@
 			lastCompletedJobId = undefined
 			clearCurrentJob()
 			lastCallbacks = callbacks
-			noPingTimeout = undefined
+			clearNoPingTimeout()
 			const startedAt = Date.now()
 			const testId = await fn()
 
@@ -669,16 +670,30 @@
 		}
 	}
 
-	function setNoPingTimeout(id: string, attempt: number, callbacks?: Callbacks) {
+	function clearNoPingTimeout() {
 		if (noPingTimeout) {
 			clearTimeout(noPingTimeout)
+			noPingTimeout = undefined
 		}
+	}
+
+	function setNoPingTimeout(id: string, attempt: number, callbacks?: Callbacks) {
+		clearNoPingTimeout()
 		if (isCurrentJob(id)) {
 			noPingTimeout = setTimeout(() => {
+				noPingTimeout = undefined
 				if (isCurrentJob(id)) {
 					currentEventSource?.close()
 					currentEventSource = undefined
-					loadTestJobWithSSE(id, attempt + 1, callbacks)
+					// A proxy that buffers the response rather than cutting it keeps the
+					// connection open and error-free, so this watchdog is the only signal that
+					// no event is getting through. It has to share the retry budget: otherwise
+					// it reopens an equally mute stream forever and polling is never reached.
+					if (attempt < MAX_SSE_ATTEMPTS) {
+						loadTestJobWithSSE(id, attempt + 1, callbacks)
+					} else {
+						syncer(id, callbacks)
+					}
 				}
 			}, 10000)
 		}
@@ -841,10 +856,7 @@
 							if (previewJobUpdates.completed) {
 								currentEventSource?.close()
 								currentEventSource = undefined
-								if (noPingTimeout) {
-									clearTimeout(noPingTimeout)
-									noPingTimeout = undefined
-								}
+								clearNoPingTimeout()
 								isCompleted = true
 								if (onlyResult) {
 									callbacks?.doneResult?.({
@@ -869,14 +881,17 @@
 						console.warn('SSE error:', error)
 						currentEventSource?.close()
 						currentEventSource = undefined
+						clearNoPingTimeout()
 						let delay = 1000
 						let isNoLogsChange = error.type == noLogsChangeRestartEvent
 						if (isNoLogsChange) {
 							delay = 0
 						}
-						if (attempt < 3 || isNoLogsChange) {
+						if (attempt < MAX_SSE_ATTEMPTS || isNoLogsChange) {
 							if (!isNoLogsChange) {
-								console.log(`SSE error (1), retrying ...  attempt: ${attempt + 1}/3`)
+								console.log(
+									`SSE error (1), retrying ...  attempt: ${attempt + 1}/${MAX_SSE_ATTEMPTS}`
+								)
 							}
 							setTimeout(() => loadTestJobWithSSE(id, attempt + 1, callbacks), delay)
 						} else {
@@ -901,9 +916,10 @@
 				// Fall back to polling on error
 				currentEventSource?.close()
 				currentEventSource = undefined
+				clearNoPingTimeout()
 
-				if (attempt < 3) {
-					console.log(`SSE error (2), retrying ... attempt: ${attempt}/3`)
+				if (attempt < MAX_SSE_ATTEMPTS) {
+					console.log(`SSE error (2), retrying ... attempt: ${attempt}/${MAX_SSE_ATTEMPTS}`)
 					attempt++
 					loadTestJobWithSSE(id, attempt, callbacks)
 				} else {
@@ -942,6 +958,7 @@
 		clearCurrentId()
 		currentEventSource?.close()
 		currentEventSource = undefined
+		clearNoPingTimeout()
 		replayTimeouts.forEach(clearTimeout)
 		replayTimeouts = []
 	})


### PR DESCRIPTION
## Summary

A proxy that **buffers** an SSE response rather than cutting it defeats every recovery layer in `JobLoader`: the connection stays open, `onerror` never fires, and the only signal left is the 10s no-ping watchdog. That watchdog restarted the stream unconditionally, so it reopened an equally mute stream every 10s forever and the `attempt >= 3 -> syncer()` polling fallback (which lives inside `onerror`) was never reachable.

The result is a run page frozen at its initial state for the entire job: no logs, no status change, "live" only after a manual refresh or once the stream ends and the proxy flushes.

Cutting proxies were already handled (`onerror` -> 3 retries -> polling). Only the buffering case was not.

## Changes

- The no-ping watchdog now shares the SSE retry budget: after `MAX_SSE_ATTEMPTS` mute restarts it hands off to `syncer()` polling instead of reopening the stream indefinitely.
- Every stream teardown path clears the pending watchdog timer (`clearNoPingTimeout()`). Previously `onerror`'s hand-off to polling left a watchdog armed that fired up to 10s later and started a **second** concurrent polling loop.
- The literal `3` is now the named `MAX_SSE_ATTEMPTS`, shared by all three retry branches so the budget cannot drift apart.

## Test plan

- [x] Simulated a buffering proxy (every `getupdate_sse` request hangs: no headers, no data, no error) and watched a running job: 4 SSE attempts, then continuous `getupdate` polls with `log_offset` advancing, logs streaming live in the UI.
- [x] Same scenario on `main`: endless 10s SSE restarts, zero polls, UI frozen on "Queue position: 1 (Waiting for an available worker)" and an empty log panel while the API showed the job running with 23 log lines.
- [x] Happy path with no interception: `SSE connection opened for job: …`, logs streamed over SSE, job ended `Success` with its result, no polling fallback triggered.
- [x] `npm run check:fast` clean.

No automated test: the failure is in timer/EventSource lifecycle wiring, which the pure-logic unit tests in this directory cannot reach, and a test over the extracted `attempt < MAX` comparison would be ceremonial.

## Screenshots

Both taken ~75s into an identical running job, with SSE hung in the same way.

**Before — frozen, no logs, still reported as queued:**

![before-frozen-logs](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/i-don-t-see-a-conversation-about-sse-in/1786917748-before-frozen-logs.png)

**After — polling fallback engaged, logs streaming live:**

![after-live-via-polling](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/i-don-t-see-a-conversation-about-sse-in/1786917751-after-live-via-polling.png)

## Note for deployments hitting this

The fix makes the UI degrade gracefully; it does not make SSE work through a buffering proxy. We do send `X-Accel-Buffering: no`, but that is an nginx/Cloudflare convention and Azure Application Gateway ignores it, so response buffering still has to be disabled at the gateway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run page now falls back to polling when a proxy buffers the job SSE stream. Previously the SSE stayed open and the 10s watchdog restarted it forever, so polling never started and the UI froze.

- Introduces `MAX_SSE_ATTEMPTS` and applies it to all SSE retry paths, replacing the literal 3.
- On no-ping: close the `EventSource`; retry SSE until the budget, then hand off to `syncer()` polling.
- Do not charge deliberate “no-logs” SSE restarts to the retry budget; keep the same attempt and retry immediately.
- Adds `clearNoPingTimeout()` and calls it on every teardown (completion, errors, destroy) to prevent concurrent polling loops.
- Updates retry log messages to reflect the shared budget.

<sup>Written for commit ce316d7fe7e93562499fff2db9a011f5a2d63324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

