### PR TITLE
docs: announce we are not seeking outside contribution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,12 +3,12 @@ We are not seeking outside contribution at this time. Small, trivially-verified 
 problem are still welcome; low-value PRs (e.g. typo fixes) and PRs longer than a dozen or so lines
 will be closed with a reference to CONTRIBUTING.md.
 
-For a bigger idea, please open a discussion instead:
-https://github.com/windmill-labs/windmill/discussions
+For a bigger idea, please open a feature request instead:
+https://github.com/windmill-labs/windmill/issues/new?template=feature_request.md
 
 Read https://github.com/windmill-labs/windmill/blob/main/CONTRIBUTING.md before submitting.
 -->
 
 ## What does this PR do?
 
-## Related issue or discussion
+## Related issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!--
+We are not seeking outside contribution at this time. Small, trivially-verified PRs that fix a
+problem are still welcome; low-value PRs (e.g. typo fixes) and PRs longer than a dozen or so lines
+will be closed with a reference to CONTRIBUTING.md.
+
+For a bigger idea, please open a discussion instead:
+https://github.com/windmill-labs/windmill/discussions
+
+Read https://github.com/windmill-labs/windmill/blob/main/CONTRIBUTING.md before submitting.
+-->
+
+## What does this PR do?
+
+## Related issue or discussion

--- a/.github/workflows/sign-cla.yml
+++ b/.github/workflows/sign-cla.yml
@@ -27,7 +27,7 @@ jobs:
           custom-notsigned-prcomment: |
             Thank you for taking the time to open this PR.
 
-            Please note that **we are not seeking outside contribution at this time**. Small, trivially-verified PRs that fix a problem are still accepted, but low-value PRs (e.g. typo fixes) and PRs longer than a dozen or so lines will be closed. If you have a bigger idea, please open a [discussion](https://github.com/windmill-labs/windmill/discussions) instead. See [CONTRIBUTING.md](https://github.com/windmill-labs/windmill/blob/main/CONTRIBUTING.md) for the full policy.
+            Please note that **we are not seeking outside contribution at this time**. Small, trivially-verified PRs that fix a problem are still accepted, but low-value PRs (e.g. typo fixes) and PRs longer than a dozen or so lines will be closed. If you have a bigger idea, please open a [feature request](https://github.com/windmill-labs/windmill/issues/new?template=feature_request.md) instead. See [CONTRIBUTING.md](https://github.com/windmill-labs/windmill/blob/main/CONTRIBUTING.md) for the full policy.
 
             If your PR falls within that scope, we ask that you sign our [Contributor License Agreement](https://github.com/windmill-labs/windmill/blob/main/CLA.md) before we can accept it. You can sign the CLA by just posting a Pull Request Comment same as the below format.
 

--- a/.github/workflows/sign-cla.yml
+++ b/.github/workflows/sign-cla.yml
@@ -21,9 +21,15 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
         with:
           path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/windmill-labs/windmill/blob/master/CLA.md"
+          path-to-document: "https://github.com/windmill-labs/windmill/blob/main/CLA.md"
           branch: "signatures"
           allowlist: rubenfiszel,bot*
+          custom-notsigned-prcomment: |
+            Thank you for taking the time to open this PR.
+
+            Please note that **we are not seeking outside contribution at this time**. Small, trivially-verified PRs that fix a problem are still accepted, but low-value PRs (e.g. typo fixes) and PRs longer than a dozen or so lines will be closed. If you have a bigger idea, please open a [discussion](https://github.com/windmill-labs/windmill/discussions) instead. See [CONTRIBUTING.md](https://github.com/windmill-labs/windmill/blob/main/CONTRIBUTING.md) for the full policy.
+
+            If your PR falls within that scope, we ask that you sign our [Contributor License Agreement](https://github.com/windmill-labs/windmill/blob/main/CLA.md) before we can accept it. You can sign the CLA by just posting a Pull Request Comment same as the below format.
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Windmill
+
+At this time, we are not seeking outside contribution.
+
+AI has made writing code easy. The hard part, today, is not writing the code, but reviewing it,
+making sure quality stays high, and keeping the product coherent. In that light, unfortunately,
+external code contributions are "donating" the easy part of the job, while creating more of the
+hard work.
+
+With that said, we are happy to accept small, trivially-verified PRs that fix a problem. However,
+we ask that you refrain from submitting low-value PRs (e.g. typo fixes) or PRs that are more than a
+dozen or so lines. Such PRs will be closed with a reference to this guideline.
+
+If you have a big idea you'd like us to consider, feel free to open a
+[discussion](https://github.com/windmill-labs/windmill/discussions) about it.
+
+This policy may change in the future as the project matures. Until then, thank you for your
+understanding.
+
+## What is still very welcome
+
+- [Bug reports](https://github.com/windmill-labs/windmill/issues/new/choose), with clear
+  reproduction steps.
+- [Feature requests](https://github.com/windmill-labs/windmill/issues/new/choose) and
+  [discussions](https://github.com/windmill-labs/windmill/discussions).
+- Questions and feedback on [Discord](https://discord.gg/V7PM2YHsPB).
+- Contributions to the [Windmill Hub](https://hub.windmill.dev), where scripts, flows and apps are
+  shared with the community.
+
+## If you do open a PR
+
+Small, self-contained fixes are still accepted. They require signing the
+[CLA](./CLA.md), which the CLA bot will prompt for on your first PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,17 +12,18 @@ we ask that you refrain from submitting low-value PRs (e.g. typo fixes) or PRs t
 dozen or so lines. Such PRs will be closed with a reference to this guideline.
 
 If you have a big idea you'd like us to consider, feel free to open a
-[discussion](https://github.com/windmill-labs/windmill/discussions) about it.
+[feature request](https://github.com/windmill-labs/windmill/issues/new?template=feature_request.md)
+about it.
 
 This policy may change in the future as the project matures. Until then, thank you for your
 understanding.
 
 ## What is still very welcome
 
-- [Bug reports](https://github.com/windmill-labs/windmill/issues/new/choose), with clear
-  reproduction steps.
-- [Feature requests](https://github.com/windmill-labs/windmill/issues/new/choose) and
-  [discussions](https://github.com/windmill-labs/windmill/discussions).
+- [Bug reports](https://github.com/windmill-labs/windmill/issues/new?template=bug_report.yml), with
+  clear reproduction steps.
+- [Feature requests](https://github.com/windmill-labs/windmill/issues/new?template=feature_request.md),
+  including for ideas too big to be a PR.
 - Questions and feedback on [Discord](https://discord.gg/V7PM2YHsPB).
 - Contributions to the [Windmill Hub](https://hub.windmill.dev), where scripts, flows and apps are
   shared with the community.

--- a/README.md
+++ b/README.md
@@ -332,9 +332,9 @@ running options.
 
 ## Contributing
 
-At this time, we are not seeking outside contribution. Bug reports, feature requests and
-discussions remain very welcome, and small, trivially-verified PRs that fix a problem are still
-accepted. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full policy.
+At this time, we are not seeking outside contribution. Bug reports and feature requests remain very
+welcome, and small, trivially-verified PRs that fix a problem are still accepted. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for the full policy.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Scripts are turned into sharable UIs automatically, and can be composed together
 </p>
 
 <p align="center">
-  <a href="https://app.windmill.dev">Try it</a> - <a href="https://www.windmill.dev/">Website</a> - <a href="https://www.windmill.dev/docs/intro/">Docs</a> - <a href="https://discord.gg/V7PM2YHsPB">Discord</a> - <a href="https://hub.windmill.dev">Hub</a> - <a href="https://www.windmill.dev/docs/misc/contributing">Contributor's guide</a>
+  <a href="https://app.windmill.dev">Try it</a> - <a href="https://www.windmill.dev/">Website</a> - <a href="https://www.windmill.dev/docs/intro/">Docs</a> - <a href="https://discord.gg/V7PM2YHsPB">Discord</a> - <a href="https://hub.windmill.dev">Hub</a> - <a href="./CONTRIBUTING.md">Contributing</a>
 </p>
 
 # Windmill - Developer platform for APIs, background jobs, workflows and UIs
@@ -62,6 +62,7 @@ https://github.com/user-attachments/assets/d80de1d9-64de-4d89-aacd-6df23fa81fc4
   - [Run a local dev setup](#run-a-local-dev-setup)
     - [Frontend only](#frontend-only)
     - [Backend + Frontend](#backend--frontend)
+  - [Contributing](#contributing)
   - [Contributors](#contributors)
   - [Copyright](#copyright)
 
@@ -328,6 +329,12 @@ running options.
    1. `env DATABASE_URL=<YOUR_DATABASE_URL> RUST_LOG=info cargo run`
    2. You can specify any feature flag you want to enable, for example `cargo run --features python` to enable the python executor.
 7. Windmill should be available at `http://localhost:3000`
+
+## Contributing
+
+At this time, we are not seeking outside contribution. Bug reports, feature requests and
+discussions remain very welcome, and small, trivially-verified PRs that fix a problem are still
+accepted. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full policy.
 
 ## Contributors
 


### PR DESCRIPTION
## Summary

Announces that Windmill is not seeking outside code contribution at this time, and makes that policy visible on the surfaces where someone is about to open a PR.

Small, trivially-verified PRs that fix a problem are still accepted. Bug reports, feature requests, Discord and Hub submissions are unaffected and explicitly called out as still welcome; bigger ideas are pointed at the feature request issue template rather than at a PR.

## Changes

- `CONTRIBUTING.md` (new): the policy, plus a short list of what is still welcome and a note that accepted PRs still need the CLA. GitHub surfaces this file in the issue/PR creation flow and in the repo sidebar.
- `.github/PULL_REQUEST_TEMPLATE.md` (new): the repo had none. States the policy in an HTML comment at the moment someone writes a PR description, plus two minimal fields.
- `.github/workflows/sign-cla.yml`: sets `custom-notsigned-prcomment` so the CLA bot's first-PR comment leads with the policy instead of a plain invitation to sign. Also repoints `path-to-document` from `blob/master` to `blob/main` (it only worked through GitHub's default-branch redirect).
- `README.md`: header link now points at `CONTRIBUTING.md` instead of the docs site; adds a short `## Contributing` section and its TOC entry.

Docs-site counterpart: windmill-labs/windmilldocs#1683 (updates `/docs/misc/contributing`).

## Test plan

- [x] `.github/workflows/sign-cla.yml` parses and `custom-notsigned-prcomment` resolves to the intended markdown
- [x] Checked against `cla-assistant/github-action`'s `pullRequestCommentContent.ts`: the input replaces only the introductory line, so the comment still ends with the "post a PR comment in the below format" instruction followed by the signature block
- [ ] The CLA bot comment on the next external PR shows the new text (only observable once merged, since `pull_request_target` runs the workflow from the base branch)
- [ ] `CONTRIBUTING.md` shows up in GitHub's "New pull request" sidebar

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announces that Windmill is not seeking outside code contributions and surfaces the policy where PRs start. Small, trivially verified fixes remain accepted; bigger ideas are redirected to the feature request template.

- `.github/PULL_REQUEST_TEMPLATE.md` adds an HTML comment with the policy and a link to the feature request template.
- `.github/workflows/sign-cla.yml` repoints `path-to-document` to `main` and sets `custom-notsigned-prcomment` to explain the policy and link to the feature request template before the signature block; visible only after merge due to `pull_request_target`.
- `CONTRIBUTING.md` documents the policy, what is welcome, and the CLA requirement for accepted small fixes, with a link to the feature request template.
- `README.md` links to `CONTRIBUTING.md` and adds a short Contributing section.
- No product or runtime changes; low-value or longer external PRs may be closed with a link to the policy.

<sup>Written for commit 605a97abfb7d670ac38fb96a000106bf1894e9c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

