### PR TITLE
feat(copilot): let plan mode draw, but never write the plan

### DIFF
--- a/ai_evals/adapters/frontend/core/global/evalArtifactHelpers.test.ts
+++ b/ai_evals/adapters/frontend/core/global/evalArtifactHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { createEvalArtifactHelpers } from "./evalArtifactStore";
+import { planArtifactId } from "../../../../../frontend/src/lib/components/copilot/chat/artifacts/planIdentity";
 
 // A hand-written stand-in for SessionArtifactsStore (bun has no IndexedDB), so nothing
 // makes it follow that class. A method missing from it surfaces as a tool throwing
@@ -18,5 +19,21 @@ describe("eval artifact store", () => {
     ]) {
       expect(typeof (helpers.artifacts as any)[method]).toBe("function");
     }
+  });
+
+  it("files a plan under the id production derives, seeded or created", async () => {
+    const { helpers, sessionId } = createEvalArtifactHelpers([
+      { name: "Seeded plan", role: "plan", versions: [{ content: "v1" }] },
+    ]);
+    const seeded = await helpers.artifacts.listForSession(sessionId);
+    expect(seeded.map((a: any) => a.id)).toEqual([planArtifactId(sessionId)]);
+
+    const other = createEvalArtifactHelpers();
+    const created = await other.helpers.artifacts.create(other.sessionId, {
+      name: "Plan",
+      content: "v1",
+      role: "plan",
+    });
+    expect(created.id).toBe(planArtifactId(other.sessionId));
   });
 });

--- a/ai_evals/adapters/frontend/core/global/evalArtifactStore.ts
+++ b/ai_evals/adapters/frontend/core/global/evalArtifactStore.ts
@@ -1,3 +1,5 @@
+import { planArtifactId } from "../../../../../frontend/src/lib/components/copilot/chat/artifacts/planIdentity";
+
 // SessionArtifactsStore can't run here (bun has no IndexedDB, nor the compiled $state runes),
 // so mirror only the shape the artifact tools call, not its scoping or race handling.
 // Cases run concurrently in one process and the preview handlers are registered
@@ -25,7 +27,12 @@ export function createEvalArtifactHelpers(seed: SeededArtifact[] = []) {
   const seededIds = new Map<string, string>();
   let seq = 0;
   for (const entry of seed) {
-    const id = `eval-artifact-${seq++}`;
+    // Derived, not minted: the tools that must not touch the plan recognise it by this id, so
+    // an id of the harness's own would pass a case the real gate refuses. The counter advances
+    // either way, or seeding a plan would renumber the rows around it and collapse the update
+    // order they are sorted on.
+    const n = seq++;
+    const id = entry.role === "plan" ? planArtifactId(sessionId) : `eval-artifact-${n}`;
     const current = entry.versions.at(-1);
     if (!current) continue;
     // A preview tab names the artifact it shows, so a shared name would open whichever
@@ -89,7 +96,10 @@ export function createEvalArtifactHelpers(seed: SeededArtifact[] = []) {
       }
       const now = seq++;
       const artifact = {
-        id: `eval-artifact-${now}`,
+        id:
+          input.role === "plan"
+            ? planArtifactId(sessionId)
+            : `eval-artifact-${now}`,
         sessionId,
         chatId: input.chatId,
         kind: input.kind ?? "md",

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1809,6 +1809,29 @@
     - the plan covers classifying an incoming email by urgency, routing it to a team, and posting urgent ones to Slack
     - the plan is specific about what would be built in Windmill (a flow and its steps, or the scripts involved)
 
+- id: global-planmode2-sketches-while-planning
+  prompt: |-
+    We're moving our nightly CSV export off a schedule and onto a webhook the vendor calls
+    when their file is ready. Work out how you'd rebuild it in Windmill — and draw me the
+    shape of it before you write anything, I find that easier to react to than prose.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json
+  runtime:
+    maxTurns: 10
+    sessionChat: true
+    planMode: true
+  # Both tools, because either alone is a different behaviour: create_artifact without
+  # exit_plan_mode means the model filed the plan as the drawing, and exit_plan_mode without
+  # create_artifact means the posture blocked the drawing it was asked for.
+  toolExpect:
+    requiredToolsUsed:
+      - create_artifact
+      - exit_plan_mode
+  judgeChecklist:
+    - saves a diagram of the proposed design as an artifact rather than only describing it in chat
+    - the diagram covers the webhook that starts the run and the steps that replace the nightly schedule
+    - hands the plan over with exit_plan_mode instead of leaving it in the artifact
+    - does not register the diagram as the session's plan document
+
 - id: global-npm1-script-search-package
   prompt: |-
     Find a good npm package for parsing RSS/Atom feeds and use it to create a draft Bun script

--- a/ai_evals/core/types.ts
+++ b/ai_evals/core/types.ts
@@ -33,8 +33,8 @@ export interface EvalCaseRuntimeSpec {
   appContext?: EvalCaseRuntimeAppContextSpec;
   // Global mode: run as a session chat (preview tools + session prompt) vs the standalone chat.
   sessionChat?: boolean;
-  // Global session chats: start the case in plan mode, so mutating tools are refused until
-  // the model hands over a plan with exit_plan_mode.
+  // Global session chats: start the case in plan mode, so the workspace-changing tools are
+  // refused until the model hands over a plan with exit_plan_mode.
   planMode?: boolean;
 }
 

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1511,7 +1511,7 @@ export class AIChatManager {
 		}
 	}
 
-	/** enter_plan_mode never qualifies: YOLO means "stop asking and run it", and a read-only
+	/** enter_plan_mode never qualifies: YOLO means "stop asking and run it", and a research
 	 * posture inverts that. Every accept path asks here rather than carrying its own copy. */
 	private autoAcceptsTool = (toolName: string | undefined) => toolName !== ENTER_PLAN_MODE_TOOL
 

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.test.ts
@@ -48,15 +48,22 @@ async function fresh(sessionId: string | undefined) {
 		string,
 		Tool<{}>
 	>
-	const call = (name: string, args: any) =>
+	// planModeActive drives the store-side policy only: the gate that consults
+	// refuseInPlanMode lives in the real ../shared, which is mocked out here.
+	const call = (name: string, args: any, planModeActive = false) =>
 		byName[name].fn({
 			args,
 			workspace: 'w',
 			helpers,
 			toolId: 't',
-			toolCallbacks: { setToolStatus: (_id: string, m: any) => statuses.push(m) } as any
+			toolCallbacks: {
+				setToolStatus: (_id: string, m: any) => statuses.push(m),
+				isPlanModeActive: () => planModeActive
+			} as any
 		})
-	return { call, store, dbMod, statuses, opened }
+	const refusal = (name: string, args: any) =>
+		byName[name].refuseInPlanMode?.({ args, helpers: helpers as any })
+	return { call, refusal, store, dbMod, statuses, opened }
 }
 
 let ctx: Awaited<ReturnType<typeof fresh>>
@@ -174,6 +181,54 @@ describe('artifact tools', () => {
 		)
 		expect(res.success).toBe(true)
 		expect((await ctx.dbMod.getArtifact(a.id))?.content).toBe('v2')
+	})
+
+	it('refuses in plan mode only what would write the plan, by either of its marks', async () => {
+		const plan = await ctx.store.savePlan('s1', { name: 'Plan', content: 'v1', note: 'n' }, 'c1')
+		const doc = JSON.parse(await ctx.call('create_artifact', { name: 'Doc', content: 'x' }))
+		// A row claiming the role without the derived id: no writer here mints one, and the
+		// refusal must not depend on that staying true.
+		await ctx.dbMod.putArtifact({
+			id: 'odd',
+			sessionId: 's1',
+			kind: 'md',
+			role: 'plan',
+			name: 'Odd',
+			content: 'x',
+			createdAt: 0,
+			updatedAt: 0,
+			version: 1
+		})
+		await ctx.store.setSession(undefined)
+		await ctx.store.setSession('s1')
+
+		expect(ctx.refusal('create_artifact', { name: 'P', content: 'x', role: 'plan' })).toBeDefined()
+		expect(ctx.refusal('create_artifact', { name: 'D', content: 'x' })).toBeUndefined()
+		expect(ctx.refusal('update_artifact', { id: plan.id, content: 'x' })).toBeDefined()
+		expect(ctx.refusal('update_artifact', { id: 'odd', content: 'x' })).toBeDefined()
+		expect(ctx.refusal('update_artifact', { id: doc.id, content: 'x' })).toBeUndefined()
+	})
+
+	it('refuses a plan write the posture only turned down mid-flight', async () => {
+		const plan = await ctx.store.savePlan('s1', { name: 'Plan', content: 'v1', note: 'n' }, 'c1')
+
+		const updated = JSON.parse(
+			await ctx.call(
+				'update_artifact',
+				{ id: plan.id, content: 'rewritten', change_note: 'x' },
+				true
+			)
+		)
+		expect(updated.success).toBe(false)
+		expect(updated.error).toMatch(/not writable in plan mode/)
+		expect((await ctx.dbMod.getArtifact(plan.id))?.content).toBe('v1')
+		expect(ctx.statuses.at(-1)).toMatchObject({ blockedByPlanMode: true })
+
+		const created = JSON.parse(
+			await ctx.call('create_artifact', { name: 'P', content: 'x', role: 'plan' }, true)
+		)
+		expect(created.success).toBe(false)
+		expect(created.error).toMatch(/not writable in plan mode/)
 	})
 
 	it('update_artifact reports a missing id', async () => {

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactTools.ts
@@ -1,9 +1,19 @@
 import { z } from 'zod'
-import { createToolDef, type Tool } from '../shared'
+import { createToolDef, type Tool, type ToolCallbacks } from '../shared'
 import { artifactOverflowBytes, MAX_ARTIFACT_BYTES, normalizeChangeNote } from './artifactLimits'
-import { currentVersion, type ArtifactVersion, type PersistedArtifact } from './artifactsDB'
+import {
+	currentVersion,
+	isPlanArtifact,
+	type ArtifactVersion,
+	type PersistedArtifact
+} from './artifactsDB'
 import type { ArtifactVersionTarget } from '$lib/components/sessions/previewRouter'
-import { PlanSlotTakenError, type SessionArtifactsStore } from './artifactsState.svelte'
+import {
+	PlanSlotTakenError,
+	PlanWriteRefusedError,
+	type SessionArtifactsStore
+} from './artifactsState.svelte'
+import { PLAN_MODE_MESSAGES } from '../planModeMessages'
 
 // The subset of GlobalToolHelpers these tools read. Kept local (not imported from
 // global/core) so the tools don't pull the whole global tool module — which would be a
@@ -59,6 +69,35 @@ function tooLarge(content: string): string | undefined {
 
 const UNAVAILABLE = 'Artifacts are only available inside an AI session.'
 
+const PLAN_WRITE_REFUSED = {
+	label: PLAN_MODE_MESSAGES.planWriteRefusedLabel,
+	result: PLAN_MODE_MESSAGES.planWriteRefused
+} as const
+
+/** Report a plan write the store refused after the gate had already admitted the call. Says
+ * what the gate says, so the same refusal cannot read as two different events: a lock row
+ * rather than an error card, and one more block against the retry escalation. */
+function reportPlanWriteRefused(toolCallbacks: ToolCallbacks, toolId: string): string {
+	toolCallbacks.onToolBlockedByPlanMode?.()
+	toolCallbacks.setToolStatus(toolId, {
+		content: PLAN_WRITE_REFUSED.label,
+		error: PLAN_WRITE_REFUSED.result,
+		blockedByPlanMode: true
+	})
+	return JSON.stringify({ success: false, error: PLAN_WRITE_REFUSED.result })
+}
+
+/** Whether this call would write the session's plan. Synchronous because the gate is: it answers
+ * from the arguments and the store's already-loaded list, never an awaited read of the database. */
+function targetsPlan(args: unknown, h: ArtifactToolHelpers): boolean {
+	const id = (args as { id?: unknown } | null | undefined)?.id
+	if (!h.sessionId || typeof id !== 'string') return false
+	return isPlanArtifact(
+		{ id, role: h.artifacts?.artifacts?.find((a) => a.id === id)?.role },
+		h.sessionId
+	)
+}
+
 export const artifactTools: Tool<{}>[] = [
 	{
 		def: createToolDef(
@@ -67,6 +106,13 @@ export const artifactTools: Tool<{}>[] = [
 			'Create a markdown artifact in the current session.'
 		),
 		showDetails: true,
+		// Writes nothing outside the browser, so a research posture can keep notes and diagrams
+		// here — except the one document that posture exists to put up for approval.
+		planModeSafe: true,
+		refuseInPlanMode: ({ args }) =>
+			(args as { role?: unknown } | null | undefined)?.role === 'plan'
+				? PLAN_WRITE_REFUSED
+				: undefined,
 		fn: async ({ args, toolId, toolCallbacks, helpers }) => {
 			const parsed = createArtifactSchema.parse(args)
 			const h = helpers as ArtifactToolHelpers
@@ -82,18 +128,23 @@ export const artifactTools: Tool<{}>[] = [
 			}
 			let artifact: PersistedArtifact
 			try {
-				artifact = await h.artifacts.create(sessionId, {
-					name: parsed.name,
-					content: parsed.content,
-					kind: 'md',
-					chatId: h.getChatId?.(),
-					role: parsed.role
-					// No approvedVersion: this tool asks for no confirmation, so a plan written here
-					// stands as a draft until a card decides it. exit_plan_mode alone confers it.
-				})
+				artifact = await h.artifacts.create(
+					sessionId,
+					{
+						name: parsed.name,
+						content: parsed.content,
+						kind: 'md',
+						chatId: h.getChatId?.(),
+						role: parsed.role
+						// No approvedVersion: this tool asks for no confirmation, so a plan written here
+						// stands as a draft until a card decides it. exit_plan_mode alone confers it.
+					},
+					{ canWritePlan: () => toolCallbacks.isPlanModeActive?.() !== true }
+				)
 			} catch (e) {
-				// The store checks the slot inside the write transaction, so another tab cannot
-				// take it in between.
+				// The store checks both inside the write transaction, so neither a posture entered
+				// mid-write nor another tab taking the slot can slip past in between.
+				if (e instanceof PlanWriteRefusedError) return reportPlanWriteRefused(toolCallbacks, toolId)
 				if (!(e instanceof PlanSlotTakenError)) throw e
 				const error = `This session's plan is already "${e.plan.name}" (id ${e.plan.id}). Rewrite that document with update_artifact — a session holds one plan.`
 				toolCallbacks.setToolStatus(toolId, { content: error, error })
@@ -111,6 +162,9 @@ export const artifactTools: Tool<{}>[] = [
 			'Overwrite an existing markdown artifact by id.'
 		),
 		showDetails: true,
+		planModeSafe: true,
+		refuseInPlanMode: ({ args, helpers }) =>
+			targetsPlan(args, helpers as ArtifactToolHelpers) ? PLAN_WRITE_REFUSED : undefined,
 		fn: async ({ args, toolId, toolCallbacks, helpers }) => {
 			const parsed = updateArtifactSchema.parse(args)
 			const h = helpers as ArtifactToolHelpers
@@ -124,18 +178,25 @@ export const artifactTools: Tool<{}>[] = [
 				toolCallbacks.setToolStatus(toolId, { content: sizeError, error: sizeError })
 				return JSON.stringify({ success: false, error: sizeError })
 			}
-			const updated = await h.artifacts.update(
-				parsed.id,
-				{
-					content: parsed.content,
-					name: parsed.name,
-					note: normalizeChangeNote(parsed.change_note),
-					// An agreed plan revised here is still agreed: this tool is blocked in plan mode,
-					// so every call is one the posture already trusts. A draft stays a draft.
-					keepApproved: true
-				},
-				{ sessionId }
-			)
+			let updated: PersistedArtifact | undefined
+			try {
+				updated = await h.artifacts.update(
+					parsed.id,
+					{
+						content: parsed.content,
+						name: parsed.name,
+						note: normalizeChangeNote(parsed.change_note),
+						// An agreed plan revised here is still agreed: this tool cannot reach the plan
+						// document while plan mode is active, so any call that reaches it is one the
+						// user's posture already trusts. A draft stays a draft.
+						keepApproved: true
+					},
+					{ sessionId, canWritePlan: () => toolCallbacks.isPlanModeActive?.() !== true }
+				)
+			} catch (e) {
+				if (!(e instanceof PlanWriteRefusedError)) throw e
+				return reportPlanWriteRefused(toolCallbacks, toolId)
+			}
 			if (!updated) {
 				const error = `No artifact found with id "${parsed.id}".`
 				toolCallbacks.setToolStatus(toolId, { content: error, error })

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsDB.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsDB.ts
@@ -60,11 +60,9 @@ export function currentVersion(a: Pick<PersistedArtifact, 'version'>): number {
 	return a.version ?? 1
 }
 
-/** A session holds one plan, so its id is the session's — the primary key is the constraint,
- * and no two writers can mint a second row for the same session. */
-export function planArtifactId(sessionId: string): string {
-	return `plan:${sessionId}`
-}
+// Re-exported so the artifact modules keep asking one module about storage; the definitions sit
+// in planIdentity because that module has to stay import-free, and this one cannot.
+export { isPlanArtifact, planArtifactId } from './planIdentity'
 
 export function versionKey(artifactId: string, version: number): string {
 	return `${artifactId}:${version}`
@@ -192,7 +190,12 @@ export interface ArtifactWrite {
  */
 export async function mutateArtifact(
 	id: string,
-	mutate: (existing: PersistedArtifact | undefined) => ArtifactEdit | undefined
+	mutate: (
+		existing: PersistedArtifact | undefined,
+		/** The snapshot `opts.readVersion` named, when it was asked for and is still stored. */
+		snapshot?: ArtifactVersion
+	) => ArtifactEdit | undefined,
+	opts?: { readVersion?: number }
 ): Promise<ArtifactWrite> {
 	const db = await getDB()
 	// `transaction()` throws on a connection closed since `getDB()` answered — another tab
@@ -226,10 +229,16 @@ export async function mutateArtifact(
 	const items = tx.objectStore('items')
 	const versions = tx.objectStore('versions')
 	let existing: PersistedArtifact | undefined
+	let snapshot: ArtifactVersion | undefined
 	try {
 		// Read outside this transaction, two tabs both see version N, both stamp N+1, and the
 		// later write silently replaces the earlier one — content and snapshot alike.
 		existing = await items.get(id)
+		// In the same transaction for the same reason: an edit conditioned on a version still
+		// being readable must not weigh it against one another tab pruned in between.
+		if (opts?.readVersion !== undefined) {
+			snapshot = await versions.get(versionKey(id, opts.readVersion))
+		}
 	} catch (err) {
 		console.error('Could not read the artifact being written', err)
 		reportFailure = false
@@ -240,7 +249,7 @@ export async function mutateArtifact(
 	// failing, so its error is neither reported as one nor swallowed.
 	let edit: ArtifactEdit | undefined
 	try {
-		edit = mutate(existing)
+		edit = mutate(existing, snapshot)
 	} catch (err) {
 		reportFailure = false
 		abort()

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.svelte.ts
@@ -4,6 +4,7 @@ import {
 	deleteArtifact,
 	getArtifact,
 	getArtifactVersion,
+	isPlanArtifact,
 	listArtifactVersions,
 	listArtifactsForSession,
 	mutateArtifact,
@@ -220,8 +221,21 @@ export class SessionArtifactsStore {
 	 * patched in one transaction, it can only ever move the pointer.
 	 */
 	async approve(id: string, version: number): Promise<boolean> {
-		const { outcome, artifact } = await mutateArtifact(id, (existing) =>
-			existing ? { artifact: { ...existing, approvedVersion: version }, snapshots: [] } : undefined
+		// No version number this could name, and a stamped NaN would leave a pointer that no
+		// comparison in planVersionView can ever match.
+		if (!Number.isSafeInteger(version) || version < 1) return false
+		const { outcome, artifact } = await mutateArtifact(
+			id,
+			(existing, snapshot) => {
+				if (!existing) return undefined
+				// Only a plan carries an approval, and only a version still readable is worth
+				// pointing at: the bar offering "view the plan you approved" has to land somewhere.
+				// The current version needs no snapshot — one written before history existed has none.
+				if (!isPlanArtifact(existing, existing.sessionId)) return undefined
+				if (version !== currentVersion(existing) && !snapshot) return undefined
+				return { artifact: { ...existing, approvedVersion: version }, snapshots: [] }
+			},
+			{ readVersion: version }
 		)
 		// Reflected only once it is stored, unlike an ordinary edit, which degrades unpersisted:
 		// content the store lost is still content, but an approval the store lost never happened,

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.svelte.ts
@@ -46,6 +46,20 @@ export class PlanSlotTakenError extends Error {
 	}
 }
 
+/**
+ * A write that would have touched the session's plan, refused by the policy its caller passed.
+ *
+ * Thrown rather than returned as `undefined`, which already means "no such artifact here": a
+ * caller that conflates the two answers a bad id with "the plan is read-only" and sends the
+ * model to fix a problem it does not have.
+ */
+export class PlanWriteRefusedError extends Error {
+	constructor() {
+		super('The session plan document may not be written here')
+		this.name = 'PlanWriteRefusedError'
+	}
+}
+
 export class ArtifactPersistenceError extends Error {
 	constructor() {
 		super('The plan document could not be saved')
@@ -117,8 +131,17 @@ export class SessionArtifactsStore {
 		return sortByUpdatedDesc(await listArtifactsForSession(sessionId))
 	}
 
-	/** Persist a new artifact for `sessionId` and reflect it in the list if that session is loaded. */
-	async create(sessionId: string, input: CreateArtifactInput): Promise<PersistedArtifact> {
+	/**
+	 * Persist a new artifact for `sessionId` and reflect it in the list if that session is loaded.
+	 *
+	 * `opts.canWritePlan` is asked at the mutation point rather than sampled by the caller: a
+	 * posture entered while this write was waiting on the store still gets to decide it.
+	 */
+	async create(
+		sessionId: string,
+		input: CreateArtifactInput,
+		opts?: { canWritePlan?: () => boolean }
+	): Promise<PersistedArtifact> {
 		const now = Date.now()
 		const draft = (id: string): PersistedArtifact => ({
 			id,
@@ -137,6 +160,11 @@ export class SessionArtifactsStore {
 		// on the row this write is about to replace, inside the transaction that replaces it.
 		const id = input.role === 'plan' ? planArtifactId(sessionId) : randomUUID()
 		const { outcome, artifact } = await mutateArtifact(id, (existing) => {
+			// Before the slot check: a posture that may not mint a plan at all is the more useful
+			// thing to say, and it holds whether or not the session already has one.
+			if (input.role === 'plan' && opts?.canWritePlan?.() === false) {
+				throw new PlanWriteRefusedError()
+			}
 			if (existing) throw new PlanSlotTakenError(existing)
 			const created = draft(id)
 			return { artifact: created, snapshots: [snapshotOf(created, 1)] }
@@ -156,18 +184,24 @@ export class SessionArtifactsStore {
 	async update(
 		id: string,
 		input: UpdateArtifactInput,
-		opts?: { sessionId?: string }
+		opts?: { sessionId?: string; canWritePlan?: () => boolean }
 	): Promise<PersistedArtifact | undefined> {
 		let refused = false
 		const { outcome, artifact } = await mutateArtifact(id, (stored) => {
 			// Read inside the mutator: hoisted out, it would weigh a stale copy against a fresh one.
-			const existing = furtherAlong(
-				stored,
-				this.artifacts.find((a) => a.id === id)
-			)
+			const held = this.artifacts.find((a) => a.id === id)
+			const existing = furtherAlong(stored, held)
 			if (!existing || (opts?.sessionId !== undefined && existing.sessionId !== opts.sessionId)) {
 				refused = true
 				return undefined
+			}
+			// A plan mark on *either* candidate is enough: furtherAlong can settle on a copy whose
+			// role is unset, and rows whose marks disagree are what this guards.
+			if (
+				opts?.canWritePlan?.() === false &&
+				[stored, held].some((a) => a !== undefined && isPlanArtifact(a, a.sessionId))
+			) {
+				throw new PlanWriteRefusedError()
 			}
 			return reviseInto(existing, input)
 		})

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.test.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.test.ts
@@ -25,14 +25,17 @@ async function fresh() {
 	;(globalThis as any).indexedDB = new IDBFactory()
 	;(await import('$lib/stores')).userStore.set({ email: 'a@x.com' } as never)
 	const dbMod = await import('./artifactsDB')
-	const { SessionArtifactsStore: Store } = await import('./artifactsState.svelte')
-	return { dbMod, store: new Store() }
+	// The re-imported module, not the file's static import: resetModules gives the store a fresh
+	// copy, and an error class from the stale one would never match what it throws.
+	const stateMod = await import('./artifactsState.svelte')
+	return { dbMod, stateMod, store: new stateMod.SessionArtifactsStore() }
 }
 
 let store: SessionArtifactsStore
 let dbMod: typeof db
+let stateMod: typeof import('./artifactsState.svelte')
 beforeEach(async () => {
-	;({ store, dbMod } = await fresh())
+	;({ store, dbMod, stateMod } = await fresh())
 })
 
 describe('SessionArtifactsStore', () => {
@@ -426,6 +429,31 @@ describe('SessionArtifactsStore', () => {
 
 		const row = await dbMod.getArtifact(plan.id)
 		expect(row).toMatchObject({ content: 'v2 from the other tab', version: 2, approvedVersion: 1 })
+	})
+
+	it('leaves the plan alone for a caller whose policy refuses it, and only that caller', async () => {
+		await store.setSession('s1')
+		const plan = await store.savePlan(
+			's1',
+			{ name: 'Plan', content: 'v1', note: 'first' },
+			undefined
+		)
+		const doc = await store.create('s1', { name: 'Doc', content: 'x' })
+		const no = { canWritePlan: () => false }
+
+		await expect(store.update(plan.id, { content: 'rewritten' }, no)).rejects.toThrow(
+			stateMod.PlanWriteRefusedError
+		)
+		await expect(
+			store.create('s2', { name: 'Plan', content: 'x', role: 'plan' }, no)
+		).rejects.toThrow(stateMod.PlanWriteRefusedError)
+		// The policy is about the plan, not about writing: everything else is untouched by it.
+		await expect(store.update(doc.id, { content: 'y' }, no)).resolves.toMatchObject({
+			content: 'y'
+		})
+		// And a caller that states no policy keeps every posture's plan writes exactly as they were.
+		await expect(store.update(plan.id, { content: 'v2' })).resolves.toMatchObject({ version: 2 })
+		expect((await dbMod.getArtifact(plan.id))?.content).toBe('v2')
 	})
 
 	it('refuses an approval naming no readable version, or no plan at all', async () => {

--- a/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.test.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/artifactsState.test.ts
@@ -428,6 +428,41 @@ describe('SessionArtifactsStore', () => {
 		expect(row).toMatchObject({ content: 'v2 from the other tab', version: 2, approvedVersion: 1 })
 	})
 
+	it('refuses an approval naming no readable version, or no plan at all', async () => {
+		await store.setSession('s1')
+		const plan = await store.savePlan(
+			's1',
+			{ name: 'Plan', content: 'v1', note: 'first' },
+			undefined
+		)
+		const doc = await store.create('s1', { name: 'Doc', content: 'x' })
+
+		await expect(store.approve(plan.id, 2)).resolves.toBe(false)
+		await expect(store.approve(plan.id, 0)).resolves.toBe(false)
+		await expect(store.approve(plan.id, 1.5)).resolves.toBe(false)
+		await expect(store.approve(plan.id, NaN)).resolves.toBe(false)
+		await expect(store.approve(doc.id, 1)).resolves.toBe(false)
+		expect((await dbMod.getArtifact(plan.id))?.approvedVersion).toBeUndefined()
+
+		await expect(store.approve(plan.id, 1)).resolves.toBe(true)
+	})
+
+	it('approves a retained older version after history has moved on', async () => {
+		// The approval a card proposed lands late, and the versions between it and the head are
+		// still stored — the pointer belongs on the version the user read, not on the newest.
+		await store.setSession('s1')
+		const plan = await store.savePlan(
+			's1',
+			{ name: 'Plan', content: 'v1', note: 'first' },
+			undefined
+		)
+		await store.savePlan('s1', { name: 'Plan', content: 'v2', note: 'second' }, undefined)
+		await store.savePlan('s1', { name: 'Plan', content: 'v3', note: 'third' }, undefined)
+
+		await expect(store.approve(plan.id, 1)).resolves.toBe(true)
+		expect(await dbMod.getArtifact(plan.id)).toMatchObject({ version: 3, approvedVersion: 1 })
+	})
+
 	it('does not move the approval when a write produces no new version', async () => {
 		// A plan approved at v1 and revised into a proposal the user turned down. Renaming it,
 		// or rewriting it with the text already there, adds no version — so there is nothing

--- a/frontend/src/lib/components/copilot/chat/artifacts/planIdentity.ts
+++ b/frontend/src/lib/components/copilot/chat/artifacts/planIdentity.ts
@@ -1,0 +1,20 @@
+// What makes an artifact the session's plan, in one place. Import-free on purpose, like
+// artifactLimits: the eval harness asks the same question from bun, where artifactsDB's `idb`
+// and `$lib` imports cannot be resolved.
+
+/** A session holds one plan, so its id is the session's — the primary key is the constraint,
+ * and no two writers can mint a second row for the same session. */
+export function planArtifactId(sessionId: string): string {
+	return `plan:${sessionId}`
+}
+
+/**
+ * Either mark is enough, so a row carrying only one of them still reads as the plan — the
+ * fail-closed answer for callers that must not touch it by accident.
+ *
+ * Structurally typed rather than taking a PersistedArtifact, which would cost the import this
+ * module exists to avoid.
+ */
+export function isPlanArtifact(a: { id: string; role?: 'plan' }, sessionId: string): boolean {
+	return a.role === 'plan' || a.id === planArtifactId(sessionId)
+}

--- a/frontend/src/lib/components/copilot/chat/planMode.ts
+++ b/frontend/src/lib/components/copilot/chat/planMode.ts
@@ -8,8 +8,9 @@ const ESCALATE_AFTER_BLOCKS = 3
 
 const PLAN_MODE_INSTRUCTIONS = `# Plan mode active
 
-This is a read-only research posture. Use only inspection tools; writes, execution, and deployment stay blocked until approval.
+This is a research posture. Inspect freely; changes to the workspace, execution, and deployment stay blocked until approval.
 
+- You may create and revise ordinary session artifacts here — a diagram (\`\`\`mermaid fences render), a design sketch, a comparison of options — for work the plan should point at rather than swallow. The plan document is not one of them: while plan mode is active, \`create_artifact\` with \`role: "plan"\` and \`update_artifact\` on the plan are both refused, whatever the general artifact guidance says about revising a plan. \`exit_plan_mode\` is what writes it.
 - When the plan is complete, call \`exit_plan_mode\` with the full, self-contained markdown plan. It persists and opens the document for approval, so do not create a separate plan artifact or repeat it in chat.
 - The summary replaces the whole document. For revisions, first find the session's \`role: "plan"\` artifact, read its current text, and merge the new work into the complete replacement.
 - If \`approvedVersion\` is behind the current version, the current text is an unapproved draft. Revise that draft; read the numbered approved version only when recovering what the user accepted. Missing \`approvedVersion\` means nothing was approved.
@@ -152,9 +153,9 @@ export const planSummaryOf = (args: unknown) => stringArg(args, 'summary')
 export const planChangeNoteOf = (args: unknown) => stringArg(args, 'change_note')
 export const planReasonOf = (args: unknown) => stringArg(args, 'reason')
 
-export const ENTER_PLAN_MODE_TOOL_DESCRIPTION = `Call this before starting a non-trivial change to research first and get the user's sign-off on your approach. Prefer it when the task adds meaningful new functionality, has several valid approaches, requires an architectural decision, will touch more than a couple of files, or is unclear enough that you need to explore before you understand the scope. Do NOT use it for small, well-specified edits (a typo, one obvious bug, a single function with clear requirements) or pure questions. On approval you enter a read-only posture; investigate, then call \`exit_plan_mode\` with your plan.`
+export const ENTER_PLAN_MODE_TOOL_DESCRIPTION = `Call this before starting a non-trivial change to research first and get the user's sign-off on your approach. Prefer it when the task adds meaningful new functionality, has several valid approaches, requires an architectural decision, will touch more than a couple of files, or is unclear enough that you need to explore before you understand the scope. Do NOT use it for small, well-specified edits (a typo, one obvious bug, a single function with clear requirements) or pure questions. On approval you enter a research posture where nothing in the workspace changes; investigate, then call \`exit_plan_mode\` with your plan.`
 
-export const EXIT_PLAN_MODE_TOOL_DESCRIPTION = `Call once your plan is ready and you want to start executing it. Shows the plan to the user for approval; only on approval are mutating tools unblocked. Do not call it to ask a question — use it only to hand over a complete plan. Valid only while plan mode is active: once the plan is approved there is nothing left to approve, and a revision goes into the plan document with \`update_artifact\`.`
+export const EXIT_PLAN_MODE_TOOL_DESCRIPTION = `Call once your plan is ready and you want to start executing it. Shows the plan to the user for approval; only on approval are the workspace-changing tools unblocked. Do not call it to ask a question — use it only to hand over a complete plan. Valid only while plan mode is active: once the plan is approved there is nothing left to approve, and a revision goes into the plan document with \`update_artifact\`.`
 
 /** Exported because the autonomy picker resolves pending cards by name, far from the
  * `createToolDef` calls — a rename missing one site would go silently inert. */

--- a/frontend/src/lib/components/copilot/chat/planModeController.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/planModeController.svelte.ts
@@ -150,7 +150,7 @@ export class PlanModeController {
 				return PLAN_MODE_MESSAGES.persistenceFailed
 			}
 			// Only to the round this approval belongs to: ending a re-entered round would drop the
-			// user out of a read-only posture they just chose.
+			// user out of a planning posture they just chose.
 			if (this.#host.active && epoch === this.#epoch) this.#host.restore()
 			return PLAN_MODE_MESSAGES.approvedWithDoc
 		}

--- a/frontend/src/lib/components/copilot/chat/planModeMessages.ts
+++ b/frontend/src/lib/components/copilot/chat/planModeMessages.ts
@@ -12,6 +12,14 @@ export const PLAN_MODE_MESSAGES = {
 	/** Sits beside the autonomy picker while plan mode holds. The picker's tooltip carries
 	 * the rest, so this states only the constraint. */
 	modeNote: 'Read-only',
+	// One pair for both artifact tools: the fact and the way forward are the same whether the
+	// model tried to mint the plan or to rewrite it, and the generic refusal above ("put this
+	// change in your plan") reads as nonsense for a call that writes a document.
+	planWriteRefusedLabel: 'Plan document is read-only while planning',
+	planWriteRefused:
+		'The session plan document is not writable in plan mode — exit_plan_mode is what writes it. ' +
+		'Keep researching, then hand the finished plan over with exit_plan_mode. Other artifacts ' +
+		'(diagrams, design sketches, comparisons) are yours to create and revise here.',
 	entered: 'Plan mode active.',
 	approvedWithDoc: 'Plan approved and saved as a document. You may now execute it.',
 	persistenceFailed:

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -1068,6 +1068,62 @@ describe('processToolCall plan-mode gate', () => {
 		expect(fn).not.toHaveBeenCalled()
 		expect(result.content).toContain('plan mode is active')
 	})
+
+	it('refuses only the arguments a tagged tool names, in its own words', async () => {
+		const { createToolDef } = await import('./shared')
+		const fn = vi.fn().mockResolvedValue('ran')
+		const setToolStatus = vi.fn()
+		const tool = {
+			def: createToolDef(z.object({ id: z.string() }), 'update_doc', 'Update a doc'),
+			planModeSafe: true,
+			refuseInPlanMode: ({ args }: { args: any }) =>
+				args.id === 'the-plan'
+					? { label: 'Not that one', result: 'Write anything but the plan.' }
+					: undefined,
+			fn
+		}
+
+		const refused = await runToolCall(
+			tool,
+			{ isPlanModeActive: () => true, setToolStatus },
+			{
+				id: 'the-plan'
+			}
+		)
+		expect(fn).not.toHaveBeenCalled()
+		expect(refused.content).toBe('Write anything but the plan.')
+		expect(setToolStatus).toHaveBeenCalledWith(
+			'call_plan',
+			expect.objectContaining({ content: 'Not that one', blockedByPlanMode: true })
+		)
+
+		const allowed = await runToolCall(tool, { isPlanModeActive: () => true }, { id: 'a-note' })
+		expect(fn).toHaveBeenCalled()
+		expect(allowed.content).toBe('ran')
+	})
+
+	it('never asks a tool which arguments it refuses once plan mode is over', async () => {
+		// The posture is the only thing that makes this hook relevant: consulted outside it, a
+		// tool that narrows itself for planning would narrow itself for every other mode too.
+		const { createToolDef } = await import('./shared')
+		const fn = vi.fn().mockResolvedValue('ran')
+		const refuseInPlanMode = vi.fn().mockReturnValue('refused')
+
+		const result = await runToolCall(
+			{
+				def: createToolDef(z.object({ id: z.string() }), 'update_doc', 'Update a doc'),
+				planModeSafe: true,
+				refuseInPlanMode,
+				fn
+			},
+			{ isPlanModeActive: () => false },
+			{ id: 'the-plan' }
+		)
+
+		expect(refuseInPlanMode).not.toHaveBeenCalled()
+		expect(fn).toHaveBeenCalled()
+		expect(result.content).toBe('ran')
+	})
 })
 
 describe('isActiveUserQuestion', () => {

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -818,27 +818,34 @@ export async function processToolCall<T>({
 		// Fails closed: untagged is blocked, only the safety tag exempt. Runs before anything
 		// belonging to the tool, so a validator cannot probe while planning — and again after
 		// the confirmation wait, since plan mode can be entered while a card is pending.
+		// An unresolved name is left alone, so it still reads as the unknown tool it is.
 		const planModeBlock = (): ChatCompletionMessageParam | undefined => {
-			if (!toolCallbacks.isPlanModeActive?.() || !tool || tool.planModeSafe === true) {
-				return undefined
-			}
+			if (!toolCallbacks.isPlanModeActive?.() || !tool) return undefined
+			// A tagged tool may still name arguments it refuses: the tag says the tool is usable
+			// while planning, not that every call of it is. Asked only once the tag has passed, so
+			// it can narrow what the gate admits and never widen it.
+			const refusal =
+				tool.planModeSafe === true
+					? normalizeToolRejection(tool.refuseInPlanMode?.({ args, helpers }))
+					: { label: PLAN_MODE_MESSAGES.blockedLabel, result: PLAN_MODE_MESSAGES.blockedResult }
+			if (!refusal) return undefined
 			toolCallbacks.onToolBlockedByPlanMode?.()
 			toolCallbacks.setToolStatus(toolCall.id, {
-				content: PLAN_MODE_MESSAGES.blockedLabel,
+				content: refusal.label,
 				parameters: args,
 				isLoading: false,
 				isQueued: false,
 				isStreamingArguments: false,
-				error: PLAN_MODE_MESSAGES.blockedResult,
+				error: refusal.result,
 				blockedByPlanMode: true,
 				needsConfirmation: false,
-				showDetails: tool?.showDetails,
-				autoCollapseDetails: tool?.autoCollapseDetails
+				showDetails: tool.showDetails,
+				autoCollapseDetails: tool.autoCollapseDetails
 			})
 			return {
 				role: 'tool' as const,
 				tool_call_id: toolCall.id,
-				content: PLAN_MODE_MESSAGES.blockedResult
+				content: refusal.result
 			}
 		}
 
@@ -1032,6 +1039,10 @@ export interface Tool<T> {
 	setSchema?: (helpers: any) => Promise<void>
 	/** Safe to run while plan mode is active. Absence fails closed. */
 	planModeSafe?: boolean
+	/** The arguments a plan-mode-safe tool still refuses while the posture holds — for a tool
+	 * that is admissible in general but not on every target. Consulted only once `planModeSafe`
+	 * is true. */
+	refuseInPlanMode?: (p: { args: any; helpers: T }) => ToolRejection | undefined
 	requiresConfirmation?: boolean
 	/** Header shown on the confirmation card before the tool runs. Pass a function
 	 * to derive it from the parsed arguments (e.g. name the script being tested). */


### PR DESCRIPTION
Fixes WIN-2377

## Summary

Plan mode is a research posture, but it blocked every artifact tool — so the assistant could not
draw a diagram, sketch a design, or lay two options side by side while working out what to
propose. It had to describe the shape in prose and hope the plan carried it.

This lets plan mode create and revise ordinary session artifacts, while keeping the one document
it must not touch out of reach: the session's **plan document**. Only `exit_plan_mode` writes
that, because only `exit_plan_mode` puts it in front of the user for approval. Every other
autonomy mode keeps writing the plan with `update_artifact` exactly as before — the refusal is
scoped strictly to plan mode, and is not a new restriction on anything else.

## Changes

**A tool can now narrow itself while planning.** `Tool<T>` gains an optional `refuseInPlanMode`
hook. The plan-mode gate consults it *only* when `planModeSafe === true`, so a tool can refuse
some of its own arguments but can never widen what the gate admits. The gate keeps failing closed
for everything untagged.

**Both artifact tools are tagged and declare their own refusal.** `create_artifact` refuses
`role: 'plan'`; `update_artifact` refuses a call whose target is the plan, recognised by the
canonical id or by the row's `role`.

**A store-side backstop closes the mode-transition race.** The gate reads the posture when the
call starts; the write then waits on IndexedDB, and the user can pick Plan in between.
`SessionArtifactsStore.create`/`update` take an optional `canWritePlan` callback evaluated *inside*
the write mutator, so the posture that is live when the row settles is the one that decides. The
option is optional with a permissive default — callers that pass nothing are unaffected, which is
what keeps the other modes unrestricted.

**Both refusals report themselves the same way.** The gate marks a blocked call
`blockedByPlanMode`, which renders as a flat lock row rather than a red error card, and counts
toward the retry escalation that tells the model to stop retrying and finalize. The store-side
refusal does both too, so the same event cannot read as two different failures depending on which
layer caught it.

**`approve()` validates the version it stamps.** It now refuses a non-integer, a version below 1,
a target that is not a plan, and a version whose snapshot has been pruned — the "view the plan you
approved" affordance has to land on text that is still there. `mutateArtifact` gained a
`readVersion` option so that snapshot is read in the same transaction as the row, and cannot race
a concurrent prune.

**Plan-mode prose reworded.** The posture is described as research rather than read-only, and the
instructions say plainly that diagrams and sketches are welcome but the plan document is written
by `exit_plan_mode` — countermanding the general artifact guidance that tells the model to revise
a plan with `update_artifact`.

**Plan identity moved to an import-free leaf.** `planArtifactId` / `isPlanArtifact` now live in
`planIdentity.ts` (re-exported from `artifactsDB`), because the eval harness needs the same
predicate from bun, where `artifactsDB`'s `idb` and `$lib` imports do not resolve. Same convention
as `artifactLimits`.

## Screenshots

Plan mode saves a mermaid diagram and renders it, with the composer still showing `Plan · Read-only`:

![state3](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ah-plan-mode-artifacts/1786974521-state3.png)

Ordered to rewrite the plan document with `update_artifact`, the call is refused — a lock row, not
an error card — and the plan is untouched:

![state6](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ah-plan-mode-artifacts/1786974524-state6.png)

## Test plan

- [x] In plan mode, ask for a design drawing — `create_artifact` succeeds and the diagram renders
      in the preview panel
- [x] In plan mode, order a plan write both ways (`create_artifact` with `role: plan`,
      `update_artifact` on the plan) — both refused, plan content and version unchanged
- [x] The refusal is discriminating: `update_artifact` with an unknown id while in plan mode still
      answers "No artifact found with id", not the plan refusal
- [x] Leave plan mode and rewrite the plan with `update_artifact` in **Ask permission** and in
      **Yolo** — goes through with no confirmation card and no restriction
- [x] Store-side backstop driven directly in the browser against real IndexedDB and the real
      module graph: both writers refused when the posture flips mid-write, the same call accepted
      with the posture off
- [x] `npm run check:fast` clean; artifact + shared + planMode suites green; eval adapter bun tests
      green
- [x] Driven by hand in the browser against a real model session, independently of the scripted
      run above

Note: auto-accept edits is not reachable in a session chat (`AUTO_ACCEPT_EDIT_MODES` is
`{SCRIPT, FLOW}`), so the picker offers only Plan / Ask permission / Yolo — the two reachable
non-plan postures are the ones exercised.

Adds the eval case `global-planmode2-sketches-while-planning`, which requires *both*
`create_artifact` and `exit_plan_mode`: either alone is a different behaviour — the plan filed as
the drawing, or the posture blocking the drawing.
