### PR TITLE
docs: make herdr the documented worktree manager

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,9 @@ they set disjoint environment variables, so check which one you are in:
 
 See `backend/AGENTS.md` to restart the backend with different cargo features. Under herdr, `herdr
 --skill` prints a full reference for inspecting and driving panes and agents, and the plugins that
-provision worktrees live in `windmill-labs/windmill-herdr` — clone it and run `./setup.sh` to
-install them and the keybindings they need. The commands below are for a plain checkout with
-nothing running.
+provision worktrees live in the private `windmill-labs/windmill-herdr` — clone it and run
+`./setup.sh` to install them and the keybindings they need. The commands below are for a plain
+checkout with nothing running.
 
 - **Backend**: `cargo run` from `backend/` (API at http://localhost:8000)
 - **Frontend**: `REMOTE=http://localhost:8000 npm run dev` from `frontend/` (port 3000+)
@@ -78,9 +78,8 @@ nothing running.
 ### Per-worktree ports and database
 
 **`.env.local` in the worktree root is the portable answer** — `BACKEND_PORT`,
-`FRONTEND_PORT`, `REMOTE`, `DATABASE_URL`, `CARGO_FEATURES`, `WM_DB_NAME`. Both managers write it
-through the same helper (`wm_write_env_local` in `scripts/worktree-common.sh`), so it is correct
-whichever one you are in, and it is readable despite the name.
+`FRONTEND_PORT`, `REMOTE`, `DATABASE_URL`, `CARGO_FEATURES`, `WM_DB_NAME`. Both managers write
+those fields, so it is correct whichever one you are in, and it is readable despite the name.
 
 webmux additionally writes `$(git rev-parse --git-dir)/webmux/runtime.env`, which every pane
 sources at startup and which carries the extras `.env.local` lacks: `WEBMUX_*`, `WM_CLONE_DB`,
@@ -98,11 +97,12 @@ opt-in via `WM_CLONE_DB` (in `.webmux.yaml` under webmux, or the `windmill.workt
 
 The database is named after the **worktree directory, not the branch** (`scripts/worktree-common.sh`):
 `windmill_` + the directory basename with `-` → `_`, which Postgres then truncates at 63
-characters. Branch `hugo/win-2340-ai-agent-evals-standalone-agent-runs-and-eval-datasets` sits in
-a worktree directory named `win-2340-…`, so its database is
-`windmill_win_2340_ai_agent_evals_standalone_agent_runs_and_eval` — no `hugo_`, and the tail
-chopped. Take `WM_DB_NAME` from `runtime.env` instead of reconstructing the name. Read those, or
-discover from what is already running:
+characters. The two managers lay worktrees out differently, so the same branch lands in different
+directories and therefore different databases: under webmux, branch
+`hugo/win-2340-ai-agent-evals-standalone-agent-runs-and-eval-datasets` sits in a directory named
+`win-2340-…`, so its database is `windmill_win_2340_ai_agent_evals_standalone_agent_runs_and_eval`
+— no `hugo_`, and the tail chopped. Take `WM_DB_NAME` from `.env.local` instead of reconstructing
+the name. Read that, or discover from what is already running:
 
 ```bash
 psql postgres://postgres:changeme@localhost:5432/postgres -tAc \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,9 @@ they set disjoint environment variables, so check which one you are in:
 
 See `backend/AGENTS.md` to restart the backend with different cargo features. Under herdr, `herdr
 --skill` prints a full reference for inspecting and driving panes and agents, and the plugins that
-provision worktrees live in `windmill-labs/windmill-herdr`. The commands below are for a plain
-checkout with nothing running.
+provision worktrees live in `windmill-labs/windmill-herdr` — clone it and run `./setup.sh` to
+install them and the keybindings they need. The commands below are for a plain checkout with
+nothing running.
 
 - **Backend**: `cargo run` from `backend/` (API at http://localhost:8000)
 - **Frontend**: `REMOTE=http://localhost:8000 npm run dev` from `frontend/` (port 3000+)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,9 @@ checkout with nothing running.
 
 **`.env.local` in the worktree root is the portable answer** — `BACKEND_PORT`,
 `FRONTEND_PORT`, `REMOTE`, `DATABASE_URL`, `CARGO_FEATURES`, `WM_DB_NAME`. Both managers write
-those fields, so it is correct whichever one you are in, and it is readable despite the name.
+those fields, so it is correct whichever one you are in. Read it with `cat .env.local` from a
+shell: the file-read tool denies every `.env.*` path, and `DATABASE_URL` is written with an
+`export` prefix that a `^DATABASE_URL=` grep misses.
 
 webmux additionally writes `$(git rev-parse --git-dir)/webmux/runtime.env`, which every pane
 sources at startup and which carries the extras `.env.local` lacks: `WEBMUX_*`, `WM_CLONE_DB`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,13 +51,21 @@ Open-source platform for internal tools, workflows, API integrations, background
 > defaults in this section apply only to a plain single checkout. **Discover the real
 > values before running anything** — see "Per-worktree ports and database" below.
 
-**Check whether they are already running before starting anything.** In a webmux worktree
-(`$WEBMUX_WORKTREE_PATH` is set) the backend and frontend are already up in sibling tmux panes —
-use those, don't spawn your own. `tmux list-panes -t "$(tmux display-message -p -t "$TMUX_PANE"
-'#{window_id}')" -F '#{pane_index} #{pane_current_command}'` shows what is running; read its log
-with `tmux capture-pane`, and see `backend/AGENTS.md` to restart it with different cargo features.
-A second server started in your own shell fights the first one for the port. The commands below
-are for a plain checkout with nothing running.
+**Check whether they are already running before starting anything.** In a managed worktree the
+backend and frontend are already up in sibling panes — use those, don't spawn your own. A second
+server started in your own shell fights the first one for the port. Two managers are in use, and
+they set disjoint environment variables, so check which one you are in:
+
+| | webmux | herdr |
+| --- | --- | --- |
+| marker | `$WEBMUX_WORKTREE_PATH` is set | `$HERDR_ENV=1` |
+| what is running | `tmux list-panes -t "$(tmux display-message -p -t "$TMUX_PANE" '#{window_id}')" -F '#{pane_index} #{pane_current_command}'` | `herdr pane list --workspace "$HERDR_WORKSPACE_ID"` |
+| read a pane's log | `tmux capture-pane -p -S -50` | `herdr pane read <pane_id> --source recent-unwrapped --lines 50` |
+
+See `backend/AGENTS.md` to restart the backend with different cargo features. Under herdr, `herdr
+--skill` prints a full reference for inspecting and driving panes and agents, and the plugins that
+provision worktrees live in `windmill-labs/windmill-herdr`. The commands below are for a plain
+checkout with nothing running.
 
 - **Backend**: `cargo run` from `backend/` (API at http://localhost:8000)
 - **Frontend**: `REMOTE=http://localhost:8000 npm run dev` from `frontend/` (port 3000+)
@@ -68,10 +76,14 @@ are for a plain checkout with nothing running.
 
 ### Per-worktree ports and database
 
-In a webmux worktree the authoritative values live in
-`$(git rev-parse --git-dir)/webmux/runtime.env` — `BACKEND_PORT`, `FRONTEND_PORT`,
-`DATABASE_URL`, `CARGO_FEATURES`, `WM_DB_NAME`. Every pane sources it at startup. Read that
-first: it is not a `.env*` file, so the repo's secret-file read rules don't stand in the way.
+**`.env.local` in the worktree root is the portable answer** — `BACKEND_PORT`,
+`FRONTEND_PORT`, `REMOTE`, `DATABASE_URL`, `CARGO_FEATURES`, `WM_DB_NAME`. Both managers write it
+through the same helper (`wm_write_env_local` in `scripts/worktree-common.sh`), so it is correct
+whichever one you are in, and it is readable despite the name.
+
+webmux additionally writes `$(git rev-parse --git-dir)/webmux/runtime.env`, which every pane
+sources at startup and which carries the extras `.env.local` lacks: `WEBMUX_*`, `WM_CLONE_DB`,
+`USE_RUST_PLUGIN`. herdr has no equivalent file; its plugin hooks read `.env.local`.
 
 In a plain checkout, fall back to `.env` / `.env.local` (repo root) and `backend/.env`.
 
@@ -80,7 +92,8 @@ hook. It is not a copy of the main dev instance: you get the `admins` workspace,
 `admin@windmill.dev` superadmin, the license key copied from the base database, and whatever the
 migrations seed — and none of your own workspaces, scripts, flows or apps. Create whatever a test
 needs. Cloning the base `windmill` database instead is
-opt-in per project via `WM_CLONE_DB` in `.webmux.yaml`; read the note there before turning it on.
+opt-in via `WM_CLONE_DB` (in `.webmux.yaml` under webmux, or the `windmill.worktree` plugin's
+`config.env` under herdr); read the note in `.webmux.yaml` before turning it on.
 
 The database is named after the **worktree directory, not the branch** (`scripts/worktree-common.sh`):
 `windmill_` + the directory basename with `-` → `_`, which Postgres then truncates at 63

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ they set disjoint environment variables, so check which one you are in:
 | --- | --- | --- |
 | marker | `$WEBMUX_WORKTREE_PATH` is set | `$HERDR_ENV=1` |
 | what is running | `tmux list-panes -t "$(tmux display-message -p -t "$TMUX_PANE" '#{window_id}')" -F '#{pane_index} #{pane_current_command}'` | `herdr pane list --workspace "$HERDR_WORKSPACE_ID"` |
-| read a pane's log | `tmux capture-pane -p -S -50` | `herdr pane read <pane_id> --source recent-unwrapped --lines 50` |
+| read a pane's log | `tmux capture-pane -t "$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}:#{window_name}').1" -p -S -50` (`.1` backend, `.2` frontend) | `herdr pane read <pane_id> --source recent-unwrapped --lines 50` |
 
 See `backend/AGENTS.md` to restart the backend with different cargo features. Under herdr, `herdr
 --skill` prints a full reference for inspecting and driving panes and agents, and the plugins that

--- a/scripts/post-create.sh
+++ b/scripts/post-create.sh
@@ -11,15 +11,5 @@ if [[ -z "$backend_port" || -z "$frontend_port" ]]; then
   exit 1
 fi
 
-cat > .env.local <<EOF
-BACKEND_PORT=$backend_port
-FRONTEND_PORT=$frontend_port
-REMOTE=http://localhost:$backend_port
-EOF
-
-if [[ -n "${CARGO_FEATURES:-}" ]]; then
-  echo "CARGO_FEATURES=$CARGO_FEATURES" >> .env.local
-fi
-
-echo "Created .env.local with ports: backend=$backend_port, frontend=$frontend_port"
+wm_write_env_local "$(pwd)" "$backend_port" "$frontend_port"
 wm_shared_post_create "$(pwd)"

--- a/scripts/worktree-common.sh
+++ b/scripts/worktree-common.sh
@@ -13,8 +13,7 @@ wm_main_repo_root() {
   cd "$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null)/.." && pwd
 }
 
-# Written by both worktree entry points — `worktree-env` by hand, `post-create.sh` from the
-# webmux hook — and read by agents to find their own ports, so the two must not drift.
+# These field names are documented in AGENTS.md as how an agent finds its own ports and database.
 wm_write_env_local() {
   local repo_root=$1
   local backend_port=$2

--- a/scripts/worktree-common.sh
+++ b/scripts/worktree-common.sh
@@ -13,46 +13,8 @@ wm_main_repo_root() {
   cd "$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null)/.." && pwd
 }
 
-wm_port_in_use() {
-  lsof -nP -iTCP:"$1" -sTCP:LISTEN &>/dev/null
-}
-
-# Prints "<backend_port> <frontend_port>" for the lowest free slot. Slots are read from
-# each worktree's .env.local rather than from position in `git worktree list`: removing a
-# worktree in the middle would otherwise hand its slot to a new one while a live
-# neighbour still listens on those ports. Slot 0 belongs to the main checkout.
-wm_assign_ports() {
-  local repo_root=$1
-  local slot=${WM_SLOT:-}
-  local used_slots=() wt_path backend_port frontend_port bp
-
-  if [[ -z "$slot" ]]; then
-    while IFS= read -r wt_path; do
-      [[ "$wt_path" == "$repo_root" ]] && continue
-      [[ -f "$wt_path/.env.local" ]] || continue
-      bp=$(grep '^BACKEND_PORT=' "$wt_path/.env.local" | cut -d= -f2 || true)
-      if [[ -n "$bp" && "$bp" -gt 8000 ]]; then
-        used_slots+=("$(( (bp - 8000) / 10 ))")
-      fi
-    done < <(git -C "$repo_root" worktree list --porcelain | sed -n 's/^worktree //p')
-
-    slot=1
-    while [[ " ${used_slots[*]:-} " == *" $slot "* ]]; do
-      ((slot++))
-    done
-    echo "Auto-assigned slot $slot (used: ${used_slots[*]:-none})" >&2
-  fi
-
-  backend_port=$((8000 + slot * 10))
-  frontend_port=$((3000 + slot * 10))
-
-  if wm_port_in_use "$backend_port" || wm_port_in_use "$frontend_port"; then
-    echo "WARNING: slot $slot ports ($backend_port/$frontend_port) already in use" >&2
-  fi
-
-  printf '%s %s\n' "$backend_port" "$frontend_port"
-}
-
+# Written by both worktree entry points — `worktree-env` by hand, `post-create.sh` from the
+# webmux hook — and read by agents to find their own ports, so the two must not drift.
 wm_write_env_local() {
   local repo_root=$1
   local backend_port=$2

--- a/scripts/worktree-common.sh
+++ b/scripts/worktree-common.sh
@@ -13,6 +13,65 @@ wm_main_repo_root() {
   cd "$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null)/.." && pwd
 }
 
+wm_port_in_use() {
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN &>/dev/null
+}
+
+# Prints "<backend_port> <frontend_port>" for the lowest free slot. Slots are read from
+# each worktree's .env.local rather than from position in `git worktree list`: removing a
+# worktree in the middle would otherwise hand its slot to a new one while a live
+# neighbour still listens on those ports. Slot 0 belongs to the main checkout.
+wm_assign_ports() {
+  local repo_root=$1
+  local slot=${WM_SLOT:-}
+  local used_slots=() wt_path backend_port frontend_port bp
+
+  if [[ -z "$slot" ]]; then
+    while IFS= read -r wt_path; do
+      [[ "$wt_path" == "$repo_root" ]] && continue
+      [[ -f "$wt_path/.env.local" ]] || continue
+      bp=$(grep '^BACKEND_PORT=' "$wt_path/.env.local" | cut -d= -f2 || true)
+      if [[ -n "$bp" && "$bp" -gt 8000 ]]; then
+        used_slots+=("$(( (bp - 8000) / 10 ))")
+      fi
+    done < <(git -C "$repo_root" worktree list --porcelain | sed -n 's/^worktree //p')
+
+    slot=1
+    while [[ " ${used_slots[*]:-} " == *" $slot "* ]]; do
+      ((slot++))
+    done
+    echo "Auto-assigned slot $slot (used: ${used_slots[*]:-none})" >&2
+  fi
+
+  backend_port=$((8000 + slot * 10))
+  frontend_port=$((3000 + slot * 10))
+
+  if wm_port_in_use "$backend_port" || wm_port_in_use "$frontend_port"; then
+    echo "WARNING: slot $slot ports ($backend_port/$frontend_port) already in use" >&2
+  fi
+
+  printf '%s %s\n' "$backend_port" "$frontend_port"
+}
+
+wm_write_env_local() {
+  local repo_root=$1
+  local backend_port=$2
+  local frontend_port=$3
+  local env_file="${repo_root}/.env.local"
+
+  cat > "$env_file" <<EOF
+BACKEND_PORT=$backend_port
+FRONTEND_PORT=$frontend_port
+REMOTE=http://localhost:$backend_port
+EOF
+
+  if [[ -n "${CARGO_FEATURES:-}" ]]; then
+    echo "CARGO_FEATURES=$CARGO_FEATURES" >> "$env_file"
+  fi
+
+  echo "Created .env.local with ports: backend=$backend_port, frontend=$frontend_port"
+}
+
 wm_setup_database() {
   local repo_root=$1
   local env_file=$2

--- a/scripts/worktree-env
+++ b/scripts/worktree-env
@@ -3,54 +3,6 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 
-port_in_use() {
-  lsof -nP -iTCP:"$1" -sTCP:LISTEN &>/dev/null
-}
-
-if [[ -z "${WM_SLOT:-}" ]]; then
-  # Scan .env.local files of existing worktrees to find which slots are claimed,
-  # then pick the lowest free slot. This avoids collisions when worktrees are
-  # removed and new ones created (position-based indexing would re-use slots
-  # still held by surviving worktrees).
-  used_slots=()
-  current_dir="$(pwd)"
-  while IFS= read -r wt_path; do
-    [[ "$wt_path" == "$current_dir" ]] && continue
-    if [[ -f "$wt_path/.env.local" ]]; then
-      bp=$(grep '^BACKEND_PORT=' "$wt_path/.env.local" | cut -d= -f2 || true)
-      if [[ -n "$bp" && "$bp" -gt 8000 ]]; then
-        used_slots+=("$(( (bp - 8000) / 10 ))")
-      fi
-    fi
-  done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
-
-  # Find lowest available slot (slot 0 = 8000/3000 is reserved for main)
-  WM_SLOT=1
-  while [[ " ${used_slots[*]:-} " == *" $WM_SLOT "* ]]; do
-    ((WM_SLOT++))
-  done
-  echo "Auto-assigned slot $WM_SLOT (used: ${used_slots[*]:-none})"
-fi
-
-# Slot-based: predictable ports for SSH forwarding
-# Slot 0 = 8000/3000, slot 1 = 8010/3010, slot 2 = 8020/3020, etc.
-backend_port=$((8000 + WM_SLOT * 10))
-frontend_port=$((3000 + WM_SLOT * 10))
-
-if port_in_use "$backend_port" || port_in_use "$frontend_port"; then
-  echo "WARNING: Slot $WM_SLOT ports ($backend_port/$frontend_port) already in use" >&2
-fi
-
-# Generate .env.local with port overrides
-cat > .env.local <<EOF
-BACKEND_PORT=$backend_port
-FRONTEND_PORT=$frontend_port
-REMOTE=http://localhost:$backend_port
-EOF
-
-if [[ -n "${CARGO_FEATURES:-}" ]]; then
-  echo "CARGO_FEATURES=$CARGO_FEATURES" >> .env.local
-fi
-
-echo "Created .env.local with ports: backend=$backend_port, frontend=$frontend_port"
+read -r backend_port frontend_port < <(wm_assign_ports "$(pwd)")
+wm_write_env_local "$(pwd)" "$backend_port" "$frontend_port"
 wm_shared_post_create "$(pwd)"

--- a/scripts/worktree-env
+++ b/scripts/worktree-env
@@ -3,6 +3,43 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 
-read -r backend_port frontend_port < <(wm_assign_ports "$(pwd)")
+port_in_use() {
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN &>/dev/null
+}
+
+if [[ -z "${WM_SLOT:-}" ]]; then
+  # Scan .env.local files of existing worktrees to find which slots are claimed,
+  # then pick the lowest free slot. This avoids collisions when worktrees are
+  # removed and new ones created (position-based indexing would re-use slots
+  # still held by surviving worktrees).
+  used_slots=()
+  current_dir="$(pwd)"
+  while IFS= read -r wt_path; do
+    [[ "$wt_path" == "$current_dir" ]] && continue
+    if [[ -f "$wt_path/.env.local" ]]; then
+      bp=$(grep '^BACKEND_PORT=' "$wt_path/.env.local" | cut -d= -f2 || true)
+      if [[ -n "$bp" && "$bp" -gt 8000 ]]; then
+        used_slots+=("$(( (bp - 8000) / 10 ))")
+      fi
+    fi
+  done < <(git worktree list --porcelain | sed -n 's/^worktree //p')
+
+  # Find lowest available slot (slot 0 = 8000/3000 is reserved for main)
+  WM_SLOT=1
+  while [[ " ${used_slots[*]:-} " == *" $WM_SLOT "* ]]; do
+    ((WM_SLOT++))
+  done
+  echo "Auto-assigned slot $WM_SLOT (used: ${used_slots[*]:-none})"
+fi
+
+# Slot-based: predictable ports for SSH forwarding
+# Slot 0 = 8000/3000, slot 1 = 8010/3010, slot 2 = 8020/3020, etc.
+backend_port=$((8000 + WM_SLOT * 10))
+frontend_port=$((3000 + WM_SLOT * 10))
+
+if port_in_use "$backend_port" || port_in_use "$frontend_port"; then
+  echo "WARNING: Slot $WM_SLOT ports ($backend_port/$frontend_port) already in use" >&2
+fi
+
 wm_write_env_local "$(pwd)" "$backend_port" "$frontend_port"
 wm_shared_post_create "$(pwd)"


### PR DESCRIPTION
## Summary

The `AGENTS.md` dev environment section still assumes webmux and tmux throughout, so an agent in a
herdr worktree goes looking for `$WEBMUX_WORKTREE_PATH` and `webmux/runtime.env`, finds neither,
and is left with no documented way to discover its own ports or database. Now that herdr is what
the team runs, this makes it the documented manager and keeps webmux as a short fallback for
whoever has not moved.

This PR was opened in August, when herdr was still being trialled alongside webmux, and documented
the two side by side. Reshaped: herdr leads, the symmetric table is gone, and the shell-script
refactor it also carried is dropped (both of its callers, `scripts/worktree-env` and
`scripts/post-create.sh`, are webmux-only paths — herdr's hook writes its own `.env.local` by
design). Docs only now.

## Changes

- `AGENTS.md`: herdr's markers and pane commands (`$HERDR_ENV`, `herdr pane list` / `pane read`,
  `herdr --skill`), with the webmux/tmux equivalents kept in one short paragraph
- `AGENTS.md`: `.env.local` is documented as where the per-worktree values actually live, read
  with `cat` rather than the file-read tool, which denies every `.env.*` path. `DATABASE_URL` is
  written with an `export` prefix that a `^DATABASE_URL=` grep misses
- `AGENTS.md`: the database-naming example uses the herdr layout, where the directory keeps the
  full branch name and the 63-character truncation cuts mid-word
- `AGENTS.md`: the fallback discovery snippet matched `git branch --show-current | tr - _`, which
  under herdr returns nothing for any branch with a `/` in it or any name past the truncation
  limit. It now matches the worktree directory, truncated the way Postgres truncates it
- `backend/AGENTS.md`: the restart recipe was pure `tmux send-keys`, so none of it worked under
  herdr; each step now gives the herdr command with the webmux one alongside
- `.agents/skills/pr/SKILL.md`: "webmux oneshot" is just "a one-shot run" now

## Test plan

- [x] Every herdr claim checked against the running CLI: `HERDR_ENV=1`, `HERDR_WORKSPACE_ID`,
      `herdr pane list --workspace`, `herdr pane read --source recent-unwrapped --lines`,
      `herdr pane process-info --pane`, `herdr pane send-keys`, `herdr pane run`, `herdr --skill`
- [x] `.env.local` in three live herdr worktrees carries all six documented fields
- [x] The new database-discovery snippet returns the right database in a herdr worktree; the old
      one returns nothing there
- [x] The vite `REMOTE` snippet still resolves in a herdr worktree
- [x] `WM_CLONE_DB` confirmed to come from the `windmill.worktree` plugin's `config.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)