### PR TITLE
fix: type s3-streamed columns that are all-null in the inference sample

### DIFF
--- a/backend/windmill-object-store/src/lib.rs
+++ b/backend/windmill-object-store/src/lib.rs
@@ -1214,6 +1214,45 @@ impl RecordBatchWriter for RecordBatchWriterEnum {
     }
 }
 
+/// Infer the Arrow schema of a newline-delimited JSON file.
+///
+/// Inference only looks at the first `DEFAULT_SCHEMA_INFER_MAX_RECORD` rows, and a column
+/// that holds nothing but JSON `null` across that sample is typed `DataType::Null`, which
+/// makes the reader reject the first real value further down the file. When a longer file
+/// leaves such a column behind, re-infer over all of it so the column's type comes from
+/// wherever its first non-null value is.
+#[cfg(feature = "parquet")]
+fn infer_ndjson_schema(
+    path: &std::path::Path,
+    row_count: u64,
+) -> anyhow::Result<datafusion::arrow::datatypes::Schema> {
+    use datafusion::arrow::datatypes::{DataType, Schema};
+    use datafusion::arrow::json::reader::infer_json_schema;
+    use datafusion::datasource::file_format::DEFAULT_SCHEMA_INFER_MAX_RECORD;
+
+    fn is_untyped(data_type: &DataType) -> bool {
+        match data_type {
+            DataType::Null => true,
+            DataType::Struct(fields) => fields.iter().any(|f| is_untyped(f.data_type())),
+            DataType::List(field) | DataType::LargeList(field) => is_untyped(field.data_type()),
+            _ => false,
+        }
+    }
+
+    let infer = |max_records: Option<usize>| -> anyhow::Result<Schema> {
+        let reader = std::io::BufReader::new(std::fs::File::open(path)?);
+        Ok(infer_json_schema(reader, max_records).map_err(to_anyhow)?.0)
+    };
+
+    let schema = infer(Some(DEFAULT_SCHEMA_INFER_MAX_RECORD))?;
+    if row_count > DEFAULT_SCHEMA_INFER_MAX_RECORD as u64
+        && schema.fields().iter().any(|f| is_untyped(f.data_type()))
+    {
+        return infer(None);
+    }
+    Ok(schema)
+}
+
 #[cfg(feature = "parquet")]
 struct ChannelWriter {
     sender: tokio::sync::mpsc::Sender<anyhow::Result<Bytes>>,
@@ -1380,10 +1419,21 @@ where
         ingest_start.elapsed(),
     );
 
+    let inferred_schema = {
+        let path = path.clone();
+        task::spawn_blocking(move || infer_ndjson_schema(&path, row_count))
+            .await
+            .map_err(to_anyhow)??
+    };
+
     let ctx = SessionContext::new();
-    ctx.register_json("my_table", path_str, NdJsonReadOptions::default())
-        .await
-        .map_err(to_anyhow)?;
+    ctx.register_json(
+        "my_table",
+        path_str,
+        NdJsonReadOptions::default().schema(&inferred_schema),
+    )
+    .await
+    .map_err(to_anyhow)?;
 
     let df = ctx.sql("SELECT * FROM my_table").await.map_err(to_anyhow)?;
     let schema = df.schema().clone().into();
@@ -2328,5 +2378,35 @@ mod tests {
         // file_index is None → returns None
         let result = get_logs_from_store(1, "logs", &None).await;
         assert!(result.is_none());
+    }
+
+    #[cfg(feature = "parquet")]
+    #[tokio::test]
+    async fn test_convert_json_line_stream_value_after_null_only_sample() {
+        use datafusion::datasource::file_format::DEFAULT_SCHEMA_INFER_MAX_RECORD as SAMPLE;
+        use futures::StreamExt;
+
+        // One more all-null row than the inference sample can see, so the column's type has
+        // to come from the row that follows it.
+        let total = SAMPLE + 1;
+        let rows = (0..total).map(|i| {
+            Ok::<_, anyhow::Error>(serde_json::json!({
+                "col": if i < SAMPLE { serde_json::Value::Null } else { serde_json::json!("2023-11-30") }
+            }))
+        });
+
+        let (mut out, stats) =
+            convert_json_line_stream(futures::stream::iter(rows), S3ModeFormat::Json, None)
+                .await
+                .unwrap();
+        assert_eq!(stats.rows, total as u64);
+
+        let mut bytes = Vec::new();
+        while let Some(chunk) = out.next().await {
+            bytes.extend_from_slice(&chunk.expect("row after the null-only sample must decode"));
+        }
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.len(), total);
+        assert_eq!(parsed[total - 1]["col"], serde_json::json!("2023-11-30"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes GIT-965.

A SQL script that streams its result set to S3 (`-- s3 prefix=... format=...`) failed when a
nullable column happened to be all-`NULL` over the first rows of the result set and held a real
value further down:

```
Arrow error: Json error: whilst decoding field '<col>': expected null got "2023-11-30"
```

The report is against MSSQL, but the cause is in the shared streaming helper, so every executor
with an `-- s3` mode (MSSQL, PostgreSQL, MySQL, Snowflake, BigQuery, OracleDB) and all three
output formats (`json`, `parquet`, `csv`) are affected the same way.

Rows are written to a temp NDJSON file and then read back through DataFusion, which infers the
Arrow schema from the first `DEFAULT_SCHEMA_INFER_MAX_RECORD` (1000) rows only. A column that is
JSON `null` across that whole sample is typed `DataType::Null`, and the arrow JSON reader then
rejects the first real value it meets, failing the upload and the job. Which rows land in the
sample is a property of row ordering, which is why the failures looked intermittent.

The schema is now inferred by us instead of by DataFusion's default: same 1000-row sample, but if
a longer file still has a column left untyped (`Null`, including nested struct/list fields), the
inference is redone over the whole file so the column's type comes from wherever its first
non-null value is. Files at or below the sample size, and files with no untyped column, read
exactly one sample's worth of rows as before, so the common path costs the same as today. The
extra full pass is paid only by result sets that fail outright today.

## Changes

- `backend/windmill-object-store/src/lib.rs`: add `infer_ndjson_schema`, run it on a blocking
  thread, and pass the result to `register_json` via `NdJsonReadOptions::schema` so DataFusion
  skips its own sample-only inference.
- Regression test on `convert_json_line_stream`: a column that is null across the entire
  inference sample and valued on the next row must decode.

## Test plan

- [x] `cargo test -p windmill-object-store --features parquet` (41 passed). The new test fails
      with the exact reported error on the pre-fix code and passes after.
- [x] End to end against a real SQL Server 2022 container, running repros 1, 4 and 5 from the
      issue verbatim (`format=json` / `parquet` / `csv`, 1500 NULL dates then 1500 real ones):
      all three jobs succeed and the uploaded objects hold 3000 rows, 1500 null + 1500
      `2023-11-30`.
- [x] Same repro through the PostgreSQL executor on the pre-fix build as a control: fails with
      `expected null got "2023-11-30" @pg_executor.rs:561`, and passes after the fix.
- [x] Edge cases through the PostgreSQL executor: a column that is null in every row still
      streams fine, and int / float / bool / nested-JSON columns that stay null for 2000 rows
      all resolve to their real type.

## Design note

The second pass is deliberately uncapped. A cap (stop re-inferring after N rows and keep the
sample's `Null`) would reintroduce exactly the failure this PR fixes, only at a higher row count,
and the failure mode is a hard job error rather than a slowdown. The cost is bounded and only
paid by result sets that today either fail outright (a value appears after the sample) or hold a
column that is null in every row; it is one sequential read of a local temp file that was just
written, against a function that is about to decode, re-encode and upload that same file.
