### PR TITLE
fix: compile resource types with no properties instead of throwing

### DIFF
--- a/cli/src/utils/resource_types.ts
+++ b/cli/src/utils/resource_types.ts
@@ -4,18 +4,29 @@ function quotePropName(name: string): string {
   return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
 }
 
-export function compileResourceTypeToTsType(schema: Schema) {
-  function rec(x: { [name: string]: SchemaProperty }, root = false) {
-    let res = "{\n";
+function isPropertyMap(x: unknown): x is { [name: string]: SchemaProperty } {
+  return typeof x === "object" && x !== null && !Array.isArray(x);
+}
+
+// Schemas are free-form jsonb: the column is nullable and hub types such as
+// `record` or `dbt_profile` carry `{}` / `{"type":"object"}` with no
+// `properties`. Anything that is not a property map compiles to `any`, since a
+// throw here aborts the whole rt.d.ts generation.
+export function compileResourceTypeToTsType(schema: Schema | undefined | null) {
+  function rec(x: unknown): string {
+    if (!isPropertyMap(x)) {
+      return "any";
+    }
     const entries = Object.entries(x);
     if (entries.length == 0) {
       return "any";
     }
+    let res = "{\n";
     let i = 0;
     for (let [name, prop] of entries) {
-      if (prop.type == "object") {
-        res += `  ${quotePropName(name)}: ${rec(prop.properties ?? {})}`;
-      } else if (prop.type == "array") {
+      if (prop?.type == "object") {
+        res += `  ${quotePropName(name)}: ${rec(prop.properties)}`;
+      } else if (prop?.type == "array") {
         res += `  ${quotePropName(name)}: ${prop?.items?.type ?? "any"}[]`;
       } else {
         let typ = prop?.type ?? "any";
@@ -33,5 +44,5 @@ export function compileResourceTypeToTsType(schema: Schema) {
     return res;
   }
 
-  return rec(schema.properties, true);
+  return rec(schema?.properties);
 }

--- a/cli/test/resource_types_unit.test.ts
+++ b/cli/test/resource_types_unit.test.ts
@@ -52,6 +52,26 @@ test("non-identifier property names are double-quoted", () => {
   expect(out).toContain('  "3leading": boolean');
 });
 
+// WIN-2392: hub types like `record` (schema `{}`) or `dbt_profile`
+// (`{"type":"object"}`) have no `properties`, and the schema column itself is
+// nullable. A type whose property map is missing must still compile, otherwise
+// it aborts the whole rt.d.ts generation.
+test("schemas without a usable property map compile to any", () => {
+  expect(compileResourceTypeToTsType(undefined)).toBe("any");
+  expect(compileResourceTypeToTsType(null)).toBe("any");
+  expect(compileResourceTypeToTsType({ type: "object" } as any)).toBe("any");
+  expect(compileResourceTypeToTsType({ properties: null } as any)).toBe("any");
+  expect(compileResourceTypeToTsType(schema({}))).toBe("any");
+});
+
+test("a null property compiles to any instead of throwing", () => {
+  const out = compileResourceTypeToTsType(
+    schema({ host: null, port: { type: "integer" } } as any)
+  );
+  expect(out).toContain("  host: any");
+  expect(out).toContain("  port: number");
+});
+
 test("nested object and array property names are quoted too", () => {
   const out = compileResourceTypeToTsType(
     schema({

--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -396,15 +396,15 @@
 	function compile(schema: Schema) {
 		function rec(x: { [name: string]: SchemaProperty }, root = false) {
 			let res = '{\n'
-			const entries = Object.entries(x)
+			const entries = Object.entries(x ?? {})
 			if (entries.length == 0) {
 				return 'any'
 			}
 			let i = 0
 			for (let [name, prop] of entries) {
-				if (prop.type == 'object') {
+				if (prop?.type == 'object') {
 					res += `${name}: ${rec(prop.properties ?? {})}`
-				} else if (prop.type == 'array') {
+				} else if (prop?.type == 'array') {
 					res += `${name}: ${prop?.items?.type ?? 'any'}[]`
 				} else {
 					let typ = prop?.type ?? 'any'
@@ -423,7 +423,7 @@
 			}
 			return res
 		}
-		return rec(schema.properties, true)
+		return rec(schema?.properties, true)
 	}
 
 	async function quicktypeJSONSchema(targetLanguage, typeName, jsonSchemaString, rendererOptions) {
@@ -484,22 +484,22 @@
 
 	function phpCompile(schema: Schema) {
 		let res = '  '
-		const entries = Object.entries(schema.properties)
+		const entries = Object.entries(schema?.properties ?? {})
 		if (entries.length === 0) {
-			return 'array'
+			return ''
 		}
 		let i = 0
 		for (let [name, prop] of entries) {
 			let typ = 'array'
-			if (prop.type === 'array') {
+			if (prop?.type === 'array') {
 				typ = 'array'
-			} else if (prop.type === 'string') {
+			} else if (prop?.type === 'string') {
 				typ = 'string'
-			} else if (prop.type === 'number') {
+			} else if (prop?.type === 'number') {
 				typ = 'float'
-			} else if (prop.type === 'integer') {
+			} else if (prop?.type === 'integer') {
 				typ = 'int'
-			} else if (prop.type === 'boolean') {
+			} else if (prop?.type === 'boolean') {
 				typ = 'bool'
 			}
 			res += `public ${typ} $${name};`
@@ -512,22 +512,23 @@
 	}
 	function pythonCompile(schema: Schema) {
 		let res = ''
-		const entries = Object.entries(schema.properties)
+		const entries = Object.entries(schema?.properties ?? {})
 		if (entries.length === 0) {
-			return 'dict'
+			// the result is inserted as a `class X(TypedDict):` body
+			return 'pass'
 		}
 		let i = 0
 		for (let [name, prop] of entries) {
 			let typ = 'dict'
-			if (prop.type === 'array') {
+			if (prop?.type === 'array') {
 				typ = 'list'
-			} else if (prop.type === 'string') {
+			} else if (prop?.type === 'string') {
 				typ = 'str'
-			} else if (prop.type === 'number') {
+			} else if (prop?.type === 'number') {
 				typ = 'float'
-			} else if (prop.type === 'integer') {
+			} else if (prop?.type === 'integer') {
 				typ = 'int'
-			} else if (prop.type === 'boolean') {
+			} else if (prop?.type === 'boolean') {
 				typ = 'bool'
 			}
 			res += `${name}: ${typ}`

--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -59,7 +59,7 @@
 		Settings,
 		Users
 	} from 'lucide-svelte'
-	import { capitalize, formatS3Object, toCamel, type Item } from '$lib/utils'
+	import { capitalize, formatS3Object, isObject, toCamel, type Item } from '$lib/utils'
 	import DropdownV2 from './DropdownV2.svelte'
 	import type { Schema, SchemaProperty, SupportedLanguage } from '$lib/common'
 	import ScriptVersionHistory from './ScriptVersionHistory.svelte'
@@ -394,16 +394,16 @@
 	const dispatch = createEventDispatcher()
 
 	function compile(schema: Schema) {
-		function rec(x: { [name: string]: SchemaProperty }, root = false) {
+		function rec(x: { [name: string]: SchemaProperty } | undefined, root = false) {
 			let res = '{\n'
-			const entries = Object.entries(x ?? {})
+			const entries = Object.entries(isObject(x) ? x : {})
 			if (entries.length == 0) {
 				return 'any'
 			}
 			let i = 0
 			for (let [name, prop] of entries) {
 				if (prop?.type == 'object') {
-					res += `${name}: ${rec(prop.properties ?? {})}`
+					res += `${name}: ${rec(prop.properties)}`
 				} else if (prop?.type == 'array') {
 					res += `${name}: ${prop?.items?.type ?? 'any'}[]`
 				} else {
@@ -484,7 +484,8 @@
 
 	function phpCompile(schema: Schema) {
 		let res = '  '
-		const entries = Object.entries(schema?.properties ?? {})
+		const properties = schema?.properties
+		const entries = Object.entries(isObject(properties) ? properties : {})
 		if (entries.length === 0) {
 			return ''
 		}
@@ -512,7 +513,8 @@
 	}
 	function pythonCompile(schema: Schema) {
 		let res = ''
-		const entries = Object.entries(schema?.properties ?? {})
+		const properties = schema?.properties
+		const entries = Object.entries(isObject(properties) ? properties : {})
 		if (entries.length === 0) {
 			// the result is inserted as a `class X(TypedDict):` body
 			return 'pass'

--- a/frontend/src/lib/components/copilot/chat/script/core.ts
+++ b/frontend/src/lib/components/copilot/chat/script/core.ts
@@ -1,6 +1,6 @@
 import { ResourceService, JobService } from '$lib/gen/services.gen'
 import type { AIProvider, AIProviderModel, ResourceType, ScriptLang } from '$lib/gen/types.gen'
-import { capitalize, isObject, toCamel } from '$lib/utils'
+import { capitalize, toCamel } from '$lib/utils'
 import { compile, phpCompile, pythonCompile } from '../../utils'
 import type {
 	ChatCompletionSystemMessageParam,
@@ -41,16 +41,13 @@ export function formatResourceTypes(
 	allResourceTypes: ResourceType[],
 	lang: 'python3' | 'php' | 'bun' | 'deno' | 'nativets' | 'bunnative'
 ) {
-	const resourceTypes = allResourceTypes.filter(
-		(rt) => isObject(rt.schema) && 'properties' in rt.schema && isObject(rt.schema.properties)
-	)
 	if (lang === 'python3') {
-		const result = resourceTypes.map((resourceType) => {
+		const result = allResourceTypes.map((resourceType) => {
 			return `class ${resourceType.name}(TypedDict):\n${pythonCompile(resourceType.schema as any)}`
 		})
 		return '\n**Make sure to rename conflicting imported modules**\n' + result.join('\n\n')
 	} else if (lang === 'php') {
-		const result = resourceTypes.map((resourceType) => {
+		const result = allResourceTypes.map((resourceType) => {
 			return `class ${toCamel(capitalize(resourceType.name))} {\n${phpCompile(
 				resourceType.schema as any
 			)}\n}`
@@ -58,7 +55,7 @@ export function formatResourceTypes(
 		return '\n' + result.join('\n\n')
 	} else {
 		let resultStr = 'namespace RT {\n'
-		const result = resourceTypes.map((resourceType) => {
+		const result = allResourceTypes.map((resourceType) => {
 			return `  type ${toCamel(capitalize(resourceType.name))} = ${compile(
 				resourceType.schema as any
 			).replaceAll('\n', '\n  ')}`

--- a/frontend/src/lib/components/copilot/utils.resourceTypes.test.ts
+++ b/frontend/src/lib/components/copilot/utils.resourceTypes.test.ts
@@ -4,15 +4,15 @@ import { formatResourceTypes } from './utils'
 // Hub resource types such as `record` (schema `{}`) or `dbt_profile`
 // (`{"type":"object"}`) carry no `properties`, and the schema column is
 // nullable, so any workspace can hold a type whose property map is missing.
-describe('formatResourceTypes tolerates resource types without a property map', () => {
-	const resourceTypes = [
-		{ name: 'record', schema: {} },
-		{ name: 'dbt_profile', schema: { type: 'object' } },
-		{ name: 'null_schema', schema: null },
-		{ name: 'null_properties', schema: { type: 'object', properties: null } },
-		{ name: 'ok', schema: { type: 'object', properties: { host: { type: 'string' } } } }
-	] as any
+const resourceTypes = [
+	{ name: 'record', schema: {} },
+	{ name: 'dbt_profile', schema: { type: 'object' } },
+	{ name: 'null_schema', schema: null },
+	{ name: 'null_properties', schema: { type: 'object', properties: null } },
+	{ name: 'ok', schema: { type: 'object', properties: { host: { type: 'string' } } } }
+] as any
 
+describe('formatResourceTypes tolerates resource types without a property map', () => {
 	it('emits `any` for typescript and keeps the valid types', () => {
 		const out = formatResourceTypes(resourceTypes, 'typescript')
 		expect(out).toContain('type Record = any')

--- a/frontend/src/lib/components/copilot/utils.resourceTypes.test.ts
+++ b/frontend/src/lib/components/copilot/utils.resourceTypes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { formatResourceTypes } from './utils'
+
+// Hub resource types such as `record` (schema `{}`) or `dbt_profile`
+// (`{"type":"object"}`) carry no `properties`, and the schema column is
+// nullable, so any workspace can hold a type whose property map is missing.
+describe('formatResourceTypes tolerates resource types without a property map', () => {
+	const resourceTypes = [
+		{ name: 'record', schema: {} },
+		{ name: 'dbt_profile', schema: { type: 'object' } },
+		{ name: 'null_schema', schema: null },
+		{ name: 'null_properties', schema: { type: 'object', properties: null } },
+		{ name: 'ok', schema: { type: 'object', properties: { host: { type: 'string' } } } }
+	] as any
+
+	it('emits `any` for typescript and keeps the valid types', () => {
+		const out = formatResourceTypes(resourceTypes, 'typescript')
+		expect(out).toContain('type Record = any')
+		expect(out).toContain('host: string')
+	})
+
+	it('emits an indented `pass` body for python', () => {
+		const out = formatResourceTypes(resourceTypes, 'python3')
+		expect(out).toContain('class record(TypedDict):\n    pass')
+		expect(out).toContain('host: str')
+	})
+
+	it('emits an empty class body for php', () => {
+		const out = formatResourceTypes(resourceTypes, 'php')
+		expect(out).toContain('class Record {\n\n}')
+		expect(out).toContain('public string $host;')
+	})
+})

--- a/frontend/src/lib/components/copilot/utils.ts
+++ b/frontend/src/lib/components/copilot/utils.ts
@@ -42,15 +42,15 @@ export const getCommentSymbol = (
 export function compile(schema: Schema) {
 	function rec(x: { [name: string]: SchemaProperty }, root = false) {
 		let res = '{\n'
-		const entries = Object.entries(x)
+		const entries = Object.entries(x ?? {})
 		if (entries.length == 0) {
 			return 'any'
 		}
 		let i = 0
 		for (let [name, prop] of entries) {
-			if (prop.type == 'object') {
+			if (prop?.type == 'object') {
 				res += `  ${name}: ${rec(prop.properties ?? {})}`
-			} else if (prop.type == 'array') {
+			} else if (prop?.type == 'array') {
 				res += `  ${name}: ${prop?.items?.type ?? 'any'}[]`
 			} else {
 				let typ = prop?.type ?? 'any'
@@ -68,27 +68,28 @@ export function compile(schema: Schema) {
 		return res
 	}
 
-	return rec(schema.properties, true)
+	return rec(schema?.properties, true)
 }
 
 export function pythonCompile(schema: Schema) {
 	let res = ''
-	const entries = Object.entries(schema.properties)
+	const entries = Object.entries(schema?.properties ?? {})
 	if (entries.length === 0) {
-		return 'dict'
+		// callers embed the result as a `class X(TypedDict):` body
+		return '    pass'
 	}
 	let i = 0
 	for (let [name, prop] of entries) {
 		let typ = 'dict'
-		if (prop.type === 'array') {
+		if (prop?.type === 'array') {
 			typ = 'list'
-		} else if (prop.type === 'string') {
+		} else if (prop?.type === 'string') {
 			typ = 'str'
-		} else if (prop.type === 'number') {
+		} else if (prop?.type === 'number') {
 			typ = 'float'
-		} else if (prop.type === 'integer') {
+		} else if (prop?.type === 'integer') {
 			typ = 'int'
-		} else if (prop.type === 'boolean') {
+		} else if (prop?.type === 'boolean') {
 			typ = 'bool'
 		}
 		res += `    ${name}: ${typ}`
@@ -102,22 +103,22 @@ export function pythonCompile(schema: Schema) {
 
 export function phpCompile(schema: Schema) {
 	let res = ''
-	const entries = Object.entries(schema.properties)
+	const entries = Object.entries(schema?.properties ?? {})
 	if (entries.length === 0) {
-		return 'array'
+		return ''
 	}
 	let i = 0
 	for (let [name, prop] of entries) {
 		let typ = 'array'
-		if (prop.type === 'array') {
+		if (prop?.type === 'array') {
 			typ = 'array'
-		} else if (prop.type === 'string') {
+		} else if (prop?.type === 'string') {
 			typ = 'string'
-		} else if (prop.type === 'number') {
+		} else if (prop?.type === 'number') {
 			typ = 'float'
-		} else if (prop.type === 'integer') {
+		} else if (prop?.type === 'integer') {
 			typ = 'int'
-		} else if (prop.type === 'boolean') {
+		} else if (prop?.type === 'boolean') {
 			typ = 'bool'
 		}
 		res += `  public ${typ} $${name};`

--- a/frontend/src/lib/components/copilot/utils.ts
+++ b/frontend/src/lib/components/copilot/utils.ts
@@ -2,7 +2,7 @@ import type { Schema, SchemaProperty } from '../../common'
 
 import type { ResourceType, ScriptLang } from '../../gen'
 
-import { capitalize, toCamel } from '$lib/utils'
+import { capitalize, isObject, toCamel } from '$lib/utils'
 import YAML from 'yaml'
 
 export const getCommentSymbol = (
@@ -40,16 +40,16 @@ export const getCommentSymbol = (
 }
 
 export function compile(schema: Schema) {
-	function rec(x: { [name: string]: SchemaProperty }, root = false) {
+	function rec(x: { [name: string]: SchemaProperty } | undefined, root = false) {
 		let res = '{\n'
-		const entries = Object.entries(x ?? {})
+		const entries = Object.entries(isObject(x) ? x : {})
 		if (entries.length == 0) {
 			return 'any'
 		}
 		let i = 0
 		for (let [name, prop] of entries) {
 			if (prop?.type == 'object') {
-				res += `  ${name}: ${rec(prop.properties ?? {})}`
+				res += `  ${name}: ${rec(prop.properties)}`
 			} else if (prop?.type == 'array') {
 				res += `  ${name}: ${prop?.items?.type ?? 'any'}[]`
 			} else {
@@ -73,7 +73,8 @@ export function compile(schema: Schema) {
 
 export function pythonCompile(schema: Schema) {
 	let res = ''
-	const entries = Object.entries(schema?.properties ?? {})
+	const properties = schema?.properties
+	const entries = Object.entries(isObject(properties) ? properties : {})
 	if (entries.length === 0) {
 		// callers embed the result as a `class X(TypedDict):` body
 		return '    pass'
@@ -103,7 +104,8 @@ export function pythonCompile(schema: Schema) {
 
 export function phpCompile(schema: Schema) {
 	let res = ''
-	const entries = Object.entries(schema?.properties ?? {})
+	const properties = schema?.properties
+	const entries = Object.entries(isObject(properties) ? properties : {})
 	if (entries.length === 0) {
 		return ''
 	}


### PR DESCRIPTION
## Summary

Fixes WIN-2392. `wmill init` (and `wmill resource-type generate-namespace`) aborted with

```
Could not pull resource types and generate TypeScript namespace: Cannot convert undefined or null to object
```

as soon as the workspace held a resource type whose schema has no property map. That is not an
edge case: the hub types `record`, `form_input` and `question_input` ship with schema `{}` and
`dbt_profile` with `{"type": "object"}`, and the `resource_type.schema` column is nullable, so
`Object.entries(schema.properties)` threw and one such type killed the whole `rt.d.ts`.

The same `compile`/`pythonCompile`/`phpCompile` helpers are duplicated in the frontend, where the
identical data made the copilot's resource-type context throw and made the script editor's "Add
resource type" silently insert nothing (unhandled rejection, no toast). Those copies are guarded
too, and their empty-schema output is now a valid class body (`pass` for Python, an empty body for
PHP) rather than a bare `dict` / `array` statement.

## Changes

- `cli/src/utils/resource_types.ts`: `compileResourceTypeToTsType` accepts a null/undefined schema
  and any non-property-map `properties`, compiling those to `any` instead of throwing.
- `frontend/src/lib/components/copilot/utils.ts`, `frontend/src/lib/components/EditorBar.svelte`:
  same tolerance in the duplicated compile helpers, plus valid empty Python/PHP class bodies.
- Regression tests: `cli/test/resource_types_unit.test.ts` and
  `frontend/src/lib/components/copilot/utils.resourceTypes.test.ts`.

## Test plan

- [x] `cd cli && UNIT_ONLY=1 bun run test:unit` — 1065 pass
- [x] `cd frontend && npm run check` — 0 errors
- [x] `npx vitest run src/lib/components/copilot/utils.resourceTypes.test.ts`
- [x] Planted resource types with `schema NULL`, `{"type":"object"}`, `properties: null` and a null
  property value in a workspace, then ran `wmill init` against it: before, the reported warning;
  after, `rt.d.ts` is written with `type RtNullSchema = any` etc. and `tsc --noEmit rt.d.ts` passes.
- [x] Script editor "Add resource type" on those types for TypeScript, Python and PHP: valid code
  inserted, no unhandled rejection (before: nothing inserted).

## Screenshots

TypeScript editor — a property-less resource type now inserts `type RtNoProperties = any`:

![win2392-insert-rt-no-properties](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2392-fix-typescript-namespace-generation-when-resource-types-are/1786985450-win2392-insert-rt-no-properties.png)

PHP editor — an empty, parseable class body instead of a bare `array` statement:

![win2392-php-insert](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2392-fix-typescript-namespace-generation-when-resource-types-are/1786985453-win2392-php-insert.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2392 by compiling resource types with missing or non-object `schema.properties` and keeping them in the editor/copilot RT namespace. Previously `wmill init`/`wmill resource-type generate-namespace` threw and the editor/copilot dropped those types; now TypeScript emits `any`, Python uses `pass`, and PHP emits an empty class body.

- CLI: `compileResourceTypeToTsType` tolerates `schema` being `null`/`undefined` and non-map `properties`, returning `any` with guarded property access.
- Frontend: `compile`, `pythonCompile`, and `phpCompile` accept missing `properties`; Python returns an indented `pass`, PHP returns an empty class body. RT namespace generation no longer filters out property-less types.
- Tests: Added/updated CLI and frontend tests to cover `null`/empty schemas and verify outputs (`any` in TS, `pass` in Python, empty body in PHP) and inclusion in the RT namespace.

<sup>Written for commit f51122b7278721f51494fb61c55704cdd35fc0b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

