### PR TITLE
fix: include delete_after_secs in script deploy payload

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -700,6 +700,7 @@
 					ws_error_handler_muted: script.ws_error_handler_muted,
 					priority: script.priority,
 					restart_unless_cancelled: script.restart_unless_cancelled,
+					delete_after_secs: script.delete_after_secs,
 					timeout: script.timeout,
 					concurrency_key: emptyString(script.concurrency_key) ? undefined : script.concurrency_key,
 					visible_to_runner_only: script.visible_to_runner_only,


### PR DESCRIPTION
## Summary

Fixes WIN-2393.

The script editor builds its `createScript` request body by listing each field explicitly, and `delete_after_secs` was missing from that list. The "Delete logs, arguments and results after completion" toggle set the value on the local script object (and the diff viewer showed it), but the value was never sent, so every deploy persisted `NULL` — the toggle came back off on the next edit load, and redeploying a script that already had the setting silently cleared it.

The field was dropped when `delete_after_use` was replaced by `delete_after_secs` in #8753: the old key was removed from the payload and the new one never added. The backend has always accepted it (`NewScript.delete_after_secs`), and every other `createScript` caller spreads the whole script object, so the editor was the only path losing it.

## Changes

- `frontend/src/lib/components/ScriptBuilder.svelte`: add `delete_after_secs: script.delete_after_secs` to the `createScript` request body in `editScript`.

## Test plan

Verified against the local dev instance (CE build, so the EE-gated toggle was temporarily un-gated in the working tree only to drive it; the committed diff is the single line above).

- [x] New script, toggle on, set 1h30m, deploy → `script.delete_after_secs = 5400` in the DB.
- [x] Reopen the editor for that script → toggle on, "Deleted 5400s after completion".
- [x] Negative control: with the one line removed, redeploying that same script (setting still shown in the UI) wrote `delete_after_secs = NULL`.
- [x] With the committed code and the EE gate restored: planted `delete_after_secs = 900` on the deployed row, opened the editor, hit Deploy → new version still carries `900` instead of dropping to `NULL`.
- [x] Immediate-deletion edge case: planted `delete_after_secs = 0`, editor showed "Deleted immediately after completion", redeploy kept `0` rather than collapsing the falsy value to `NULL`.
- [x] `npm run check` — 0 errors.

## Screenshots

Script editor → Settings → Runtime, after redeploying a script whose `delete_after_secs` is 900: the setting survives the round-trip (the toggle renders greyed because this dev instance is a CE build, where the setting is EE-gated).

![delete-after-secs-persisted](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2393-fix-include-delete_after_secs-in-script-deploy-payload/1786987092-delete-after-secs-persisted.png)
