### PR TITLE
fix(frontend): unbreak the shared-utils library build

### DIFF
--- a/frontend/sharedUtils/vite.sharedUtils.config.js
+++ b/frontend/sharedUtils/vite.sharedUtils.config.js
@@ -1,11 +1,12 @@
 import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { resolve } from 'path'
 import { writeFileSync } from 'fs'
 import { exec } from 'child_process'
 import { promisify } from 'util'
 
 const execAsync = promisify(exec)
-const VERSION = '1.0.12'
+const VERSION = '1.0.13'
 
 export default defineConfig({
 	build: {
@@ -24,6 +25,7 @@ export default defineConfig({
 		}
 	},
 	plugins: [
+		svelte(),
 		{
 			name: 'bundle-types',
 			async closeBundle() {

--- a/frontend/src/lib/svelte5Utils.svelte.ts
+++ b/frontend/src/lib/svelte5Utils.svelte.ts
@@ -18,8 +18,12 @@ export function createState<T>(initialValue: T): T {
 	return s
 }
 
-export function stateSnapshot<T>(state: T) {
-	return $state.snapshot(state)
+// Annotated: the inferred `Snapshot<T>` is a deep conditional type TS refuses to
+// serialize into a declaration file (TS7056), which breaks the shared-utils build.
+// `Snapshot<T>` is not exported from the `$state` namespace, and it only differs
+// from `T` for Date/Map/Set, which no caller snapshots.
+export function stateSnapshot<T>(state: T): T {
+	return $state.snapshot(state) as T
 }
 export function refreshStateStore<T>(store: StateStore<T>): void {
 	store.val = $state.snapshot(store.val) as any


### PR DESCRIPTION
## Summary

`npm run build:utils` (the `@windmill-labs/shared-utils` library build) has been failing, which is why the package has not been republished since February. Two independent failures:

1. **`tsc` declaration emit** — `svelte5Utils.svelte.ts:21`, TS7056: the inferred `Snapshot<T>` returned by `$state.snapshot` is a deep recursive conditional type TS refuses to serialize into a `.d.ts`. Fixed with an explicit return type. `Snapshot<T>` is not exported from the `$state` namespace, so the annotation is `T` plus a cast; the two only differ for `Date`/`Map`/`Set`, which no caller snapshots.

   This one also masked the second: `jsr.json` and `package.json` are written by the same `closeBundle` hook that runs `tsc`, so when it threw they were never emitted, and a follow-up `npx jsr publish` failed with "couldn't find a jsr.json" — which reads like a registry problem but isn't.

2. **The bundle** — with `tsc` passing, the build then failed with 1865 `PARSE_ERROR: Unexpected JSX expression` across every `.svelte` file it reached (`icons/BarsStaggered.svelte`, `lucide-svelte/Icon.svelte`, `@zerodevx/svelte-toast`, …). The lib config registers no Svelte plugin, and the entry's import graph has since grown to reach Svelte modules. Fixed by adding `svelte()` to the config's plugins, as the app's own `vite.config.js` does.

Also bumps `VERSION` to `1.0.13`, since a republish of `1.0.12` is rejected and the point of the fix is to make a publish possible.

## Effect

Before: build fails, no `lib.es.js`.
After: `✓ 4704 modules transformed`, and `dist/sharedUtils/` gets `lib.es.js`, `lib.d.ts`, `package.json`, `jsr.json`.

The published `1.0.12` is missing `sensitive_inputs`, `delete_after_secs` and inline-script `tag` in `updateRawAppPolicy` (added by #8975 / #9005 in April/May), and the `datatable` branch of the low-code `updatePolicy`. The rebuilt bundle carries all of them. Concretely, for raw apps pushed with `wmill app push` / git-sync, that means viewer inputs marked sensitive are currently stored in `v2_job.args` in plaintext instead of `$encrypted:`, job auto-deletion is ignored, and inline scripts lose their pinned worker tag (run mode reads the tag only from the policy).

## Worth a look before merging

Adding the Svelte plugin makes the bundle **compile the Svelte modules in** rather than fail on them: `lib.es.js` goes from 60 KB (published 1.0.12) to 149 KB, and now references `svelte-toast`. That is a real change in what this package is — a "shared utils" package that ships UI code. The alternative fix is to prune the export graph in `src/lib/sharedUtils.ts` back to plain TS so it stops reaching components at all, which is arguably what it should be, but that is a design change rather than a build fix. Flagging rather than deciding.

There is also no CI workflow that publishes this package (`jsr_on_release.yml` covers only `typescript-client`), so nothing caught the breakage. Worth adding one.

## Test plan

- [x] `npm run build:utils` succeeds and emits all four artifacts (it did not before).
- [x] The rebuilt `lib.es.js` contains `sensitive_inputs`, `delete_after_secs` and `tag`, which the published 1.0.12 does not.
- [x] `npm run check:fast` — 0 problems, so the `stateSnapshot` signature change does not ripple (it is used widely).
- [ ] Not done here: the actual `npx jsr publish` (needs credentials) and the `cli/package.json` pin bump to `^1.0.13`, which should follow the publish.

No screenshots: no UI change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `@windmill-labs/shared-utils` build so we can publish `1.0.13`. Before: `npm run build:utils` failed on TS declaration emit and Vite parse errors for `.svelte` imports; after: the build completes and emits `lib.es.js`, `lib.d.ts`, `package.json`, and `jsr.json`. The bundle now compiles Svelte modules by adding `@sveltejs/vite-plugin-svelte`, which increases output size and ships UI code.

- Annotates `stateSnapshot<T>` to return `T` and casts the snapshot to fix TS declaration emit.
- Adds `svelte()` to the shared-utils Vite config; bumps version to `1.0.13`.

**Review notes**
- Confirm that compiling Svelte components into `@windmill-labs/shared-utils` is acceptable; `lib.es.js` grows (~60 KB → ~149 KB) and now includes dependencies like `@zerodevx/svelte-toast`.
- The `stateSnapshot<T>` signature change is type-only; verify no unintended API/consumer impact.

**Rollout**
- Publish `@windmill-labs/shared-utils@1.0.13` to JSR and update `cli/package.json` to `^1.0.13`.

<sup>Written for commit 77c165e1a8f9e1f056b3864e06cac9b3bc96fba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

