### PR TITLE
refactor(frontend): keep the shared-utils bundle free of UI code

### DIFF
--- a/frontend/sharedUtils/vite.sharedUtils.config.js
+++ b/frontend/sharedUtils/vite.sharedUtils.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vite'
-import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { resolve } from 'path'
 import { writeFileSync } from 'fs'
 import { exec } from 'child_process'
@@ -25,7 +24,6 @@ export default defineConfig({
 		}
 	},
 	plugins: [
-		svelte(),
 		{
 			name: 'bundle-types',
 			async closeBundle() {

--- a/frontend/src/lib/components/raw_apps/utils.ts
+++ b/frontend/src/lib/components/raw_apps/utils.ts
@@ -3,7 +3,7 @@ import type { Schema } from '../../common'
 import { schemaToTsType } from '../../schema'
 import { isRunnableByName, isRunnableByPath, type RunnableWithFields } from '../apps/inputType'
 import type { InlineScript } from '../apps/sharedTypes'
-import { stateSnapshot } from '$lib/svelte5Utils.svelte'
+import { stateSnapshot } from '$lib/stateSnapshot.svelte'
 import { appSourceToDraftValue, normalizeRawAppData } from './rawAppDraftValue'
 
 // export type RunnableWithFields = any

--- a/frontend/src/lib/stateSnapshot.svelte.ts
+++ b/frontend/src/lib/stateSnapshot.svelte.ts
@@ -1,0 +1,15 @@
+/** Deep-clones reactive state into plain values.
+ *
+ * A leaf on purpose: `$lib/svelte5Utils.svelte` re-exports this but also reaches
+ * `$lib/utils`, and through it the icon and store modules. Anything that only
+ * needs a snapshot (the `sharedUtils` entry point, most of all) imports it from
+ * here so it doesn't drag the UI graph along.
+ *
+ * Return type annotated because the inferred `Snapshot<T>` is a deep conditional
+ * type TS refuses to serialize into a declaration file (TS7056). It is not
+ * exported from the `$state` namespace, and only differs from `T` for
+ * Date/Map/Set, which no caller snapshots.
+ */
+export function stateSnapshot<T>(state: T): T {
+	return $state.snapshot(state) as T
+}

--- a/frontend/src/lib/svelte5Utils.svelte.ts
+++ b/frontend/src/lib/svelte5Utils.svelte.ts
@@ -18,13 +18,7 @@ export function createState<T>(initialValue: T): T {
 	return s
 }
 
-// Annotated: the inferred `Snapshot<T>` is a deep conditional type TS refuses to
-// serialize into a declaration file (TS7056), which breaks the shared-utils build.
-// `Snapshot<T>` is not exported from the `$state` namespace, and it only differs
-// from `T` for Date/Map/Set, which no caller snapshots.
-export function stateSnapshot<T>(state: T): T {
-	return $state.snapshot(state) as T
-}
+export { stateSnapshot } from './stateSnapshot.svelte'
 export function refreshStateStore<T>(store: StateStore<T>): void {
 	store.val = $state.snapshot(store.val) as any
 }


### PR DESCRIPTION
## Summary

Follow-up to #10734. That PR unbroke the `@windmill-labs/shared-utils` build by adding the Svelte plugin, which made the bundle *compile the UI modules in* rather than fail on them: 60 KB → 149 KB, now carrying icons and `svelte-toast`. This removes the reason they were ever in the graph, so the plugin isn't needed and the bundle gets smaller than it was before.

**One import was the entire cause.** Traced with esbuild's metafile from the `src/lib/sharedUtils.ts` entry:

```
sharedUtils.ts
  -> components/raw_apps/utils.ts          (genWmillTs)
  -> $lib/svelte5Utils.svelte              (for stateSnapshot)
  -> $lib/utils.ts                         (for readFieldsRecursively)
  -> components/icons/index.ts             -> AirtableIcon.svelte, ...
  -> stores.ts -> hub.ts -> toast.ts       -> Toast.svelte, @zerodevx/svelte-toast
```

`raw_apps/utils.ts` needs exactly one thing from `svelte5Utils.svelte`: `stateSnapshot`, used on a single line to strip Svelte proxies before a `structuredClone`. That function is a one-liner with no dependencies of its own, but the module it lives in imports `$lib/utils.ts`, and that is the kitchen sink that reaches the icon and store modules.

So `stateSnapshot` moves to its own leaf module. `svelte5Utils.svelte` re-exports it, so every existing importer is untouched.

## Effect

| | modules | UI modules | `lib.es.js` |
|---|---|---|---|
| published 1.0.12 | — | — | 60 KB |
| main today (#10734, svelte plugin) | 4704 | 232 | 149 KB |
| this PR | 158 | **0** | **39 KB** |

The Svelte plugin added by #10734 is reverted here — with no `.svelte` in the graph there is nothing for it to do, and the build passes without it. The package goes back to being what its name says.

## Changes

- `frontend/src/lib/stateSnapshot.svelte.ts` (new): `stateSnapshot`, deliberately dependency-free.
- `svelte5Utils.svelte.ts` re-exports it instead of defining it, so no call site changes.
- `raw_apps/utils.ts` imports from the leaf.
- Reverts `svelte()` from `sharedUtils/vite.sharedUtils.config.js`.

## Test plan

- [x] `npm run build:utils` succeeds without the Svelte plugin: `✓ 158 modules transformed`, all four artifacts emitted.
- [x] esbuild metafile over the entry graph reports 0 `.svelte` / `lucide-svelte` / `svelte-toast` modules (232 before).
- [x] The bundle still contains `sensitive_inputs`, `delete_after_secs`, `rawscript`, `hubscript` and `datatable`, i.e. everything the stale published 1.0.12 is missing.
- [x] `npm run check:fast` — 0 errors, so re-exporting `stateSnapshot` doesn't ripple (it is imported widely).

No screenshots: no UI change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes UI dependencies from `@windmill-labs/shared-utils` by isolating `stateSnapshot` in a leaf module and dropping the Svelte Vite plugin, restoring a UI-free build and shrinking the bundle. Previously the build pulled `.svelte` modules and required `@sveltejs/vite-plugin-svelte` (~149 KB); now there are no UI modules or Svelte plugin (~39 KB). No runtime behavior changes; existing imports continue to work via re-export.

**Key changes**
- Adds `frontend/src/lib/stateSnapshot.svelte.ts` with a dependency-free `stateSnapshot<T>` (annotated to keep d.ts generation working).
- `frontend/src/lib/svelte5Utils.svelte.ts` re-exports `stateSnapshot`.
- Switches `raw_apps/utils.ts` to import from `stateSnapshot.svelte`.
- Removes `svelte()` from `frontend/sharedUtils/vite.sharedUtils.config.js` since no `.svelte` files enter the graph.

**Review and rollout**
- Verify `npm run build:utils` succeeds without `@sveltejs/vite-plugin-svelte` and the metafile shows 0 `.svelte`/UI modules.
- No migration required for consumers; internal import paths remain valid via re-export.

<sup>Written for commit 9e84f573b9bdc7dea984abe6acac23afc91cddc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

