### PR TITLE
chore(cli): pick up shared-utils 1.0.13

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -9,7 +9,7 @@
         "@cliffy/command": "npm:@jsr/cliffy__command@1.0.0",
         "@cliffy/prompt": "npm:@jsr/cliffy__prompt@1.0.0",
         "@cliffy/table": "npm:@jsr/cliffy__table@1.0.0",
-        "@windmill-labs/shared-utils": "^1.0.12",
+        "@windmill-labs/shared-utils": "^1.0.13",
         "diff": "^5.2.0",
         "esbuild": "0.28.0",
         "get-port": "7.1.0",
@@ -175,7 +175,7 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@windmill-labs/shared-utils": ["@jsr/windmill-labs__shared-utils@1.0.12", "https://npm.jsr.io/~/11/@jsr/windmill-labs__shared-utils/1.0.12.tgz", {}, "sha512-bJOacyfxxNPwNTzA4AxCB5iGFop0h3mCgs+E9j3ZaJYDo1soblY16CebnQ56EPy/M3V344X/QoOFBORyRo1Mnw=="],
+    "@windmill-labs/shared-utils": ["@windmill-labs/shared-utils@1.0.13", "", {}, "sha512-LB3bFq8i0bS2fwM8EqGRODrR1CXLXXyiNa766By1ZbSJYCmTzK8NVXqcluJP1ne7is80LRVZdOgWTw6YX+61Dg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -20,7 +20,7 @@
     "@cliffy/command": "npm:@jsr/cliffy__command@1.0.0",
     "@cliffy/prompt": "npm:@jsr/cliffy__prompt@1.0.0",
     "@cliffy/table": "npm:@jsr/cliffy__table@1.0.0",
-    "@windmill-labs/shared-utils": "^1.0.12",
+    "@windmill-labs/shared-utils": "^1.0.13",
     "diff": "^5.2.0",
     "esbuild": "0.28.0",
     "get-port": "7.1.0",


### PR DESCRIPTION
## Summary

Points the CLI at the freshly published `@windmill-labs/shared-utils@1.0.13`. This is the step that actually delivers the fix from #10734 / #10735 to users: the CLI bundles this package, so until the pin moves, `wmill app push` and git-sync keep deriving app policies with the four-month-old 1.0.12 copy.

**What 1.0.12 was getting wrong.** Its `updateRawAppPolicy` predates #8975 (2026-04-29) and #9005 (2026-05-01), so for raw apps it dropped:

- `sensitive_inputs` — the server encrypts these args to `$encrypted:` before pushing the job. Without the field, a viewer input the author marked sensitive is stored in `v2_job.args` in **plaintext**, readable by anyone who can see the run.
- `delete_after_secs` — job auto-deletion silently ignored.
- inline-script `tag` — in run mode the worker tag comes *only* from the policy (the client-supplied one is deliberately ignored), so a runnable pinned to a worker group silently ran on the default tag.

Its low-code `updatePolicy` also predates the `datatable` DB-explorer branch, so those components got no grants and were refused at run time.

The build had been failing since February, which is why none of it shipped; #10734 and #10735 fixed that.

## Note for review

`bun update` re-resolved this dependency from **npm** rather than the JSR npm-compat registry — the lockfile entry goes from `@jsr/windmill-labs__shared-utils@1.0.12` via `npm.jsr.io` to plain `@windmill-labs/shared-utils@1.0.13`. The package is published to both registries with identical content (the build emits both `package.json` and `jsr.json`), and `cli/.npmrc` only maps the `@jsr:` scope, so npm is the natural resolution for this specifier. Flagging it because it is a registry change, not just a version change.

Worth adding a publish workflow for this package: nothing in `.github/workflows` publishes it, which is how the build stayed broken for four months, and it needs *both* `npm publish` and `npx jsr publish` or the two registries drift (they had, at 1.0.12 vs 1.0.13, until both were pushed).

## Test plan

- [x] `bun update @windmill-labs/shared-utils` resolves 1.0.13.
- [x] Installed package is the fixed one: 39 KB (1.0.12 was 60 KB), contains `sensitive_inputs`, `delete_after_secs` and `datatable`, and 0 references to `svelte-toast`/`lucide` — i.e. it carries #10735's UI-free graph.
- [x] `UNIT_ONLY=1 bun test test/*_unit*` — 1065 pass, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the CLI to use `@windmill-labs/shared-utils@1.0.13` so policy derivation is current. Previously the bundled 1.0.12 omitted `sensitive_inputs`, `delete_after_secs`, inline-script `tag`, and `datatable` grants; now these are included, preventing plaintext sensitive args, honoring auto-deletion, routing to the correct worker tag, and enabling datatable components for `wmill app push` and git-sync.

- **Review notes**
  - The dependency now resolves from npm rather than the JSR npm-compat registry; the lockfile reflects this switch and package contents are identical across registries.
  - Only `package.json` and `bun.lock` changed; no migration or configuration changes required.

<sup>Written for commit 11f0e0f3449763b8b806d3e883a221a93c961745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

