### PR TITLE
fix(api): document cache_ignore_s3_path on the Script read schema

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -26372,6 +26372,8 @@ components:
           type: integer
         cache_ttl:
           type: number
+        cache_ignore_s3_path:
+          type: boolean
         dedicated_worker:
           type: boolean
         ws_error_handler_muted:


### PR DESCRIPTION
## Summary

`GET /scripts/get/p/{path}` returns `cache_ignore_s3_path` (the field is on the `Script` struct with the usual `skip_serializing_if`), but the OpenAPI `Script` schema never declared it, while `NewScript` did. Clients generated from the spec therefore accept the field on write and cannot see it on read, which forces casts like the `(remote as any)` in #10741 and hides the setting from anything typed against the spec.

## Changes

- `backend/windmill-api/openapi.yaml`: declare `cache_ignore_s3_path` on the `Script` schema, next to `cache_ttl`, matching the `NewScript` declaration.

The generated clients are not checked in (`cli/gen` and `frontend/src/lib/gen` are gitignored), so there is nothing else to commit. The embedded `openapi-deref.{yaml,json}` bundles are regenerated periodically rather than per-PR, so they are deliberately untouched here.

## Test plan

- [x] Regenerated both clients (`cli/gen_wm_client.sh`, `frontend: npm run generate-backend-client`); `cache_ignore_s3_path` now appears on the `Script` type as well as `NewScript`.
- [x] `npm run check:fast` in `frontend/`: no problems found.
- [x] Confirmed against a running instance that the API does return the field: a script created with `cache_ignore_s3_path: true` reads back with `cache_ignore_s3_path: true`.

Once this lands, the `(remote as any).cache_ignore_s3_path` cast added in #10741 can become a plain property access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents `cache_ignore_s3_path` on the `Script` read schema so generated clients can read it. Previously the API returned this field but the OpenAPI `Script` schema omitted it; now it is declared as a boolean, matching `NewScript`.

- Change is limited to `backend/windmill-api/openapi.yaml`: add `cache_ignore_s3_path: boolean` to `components.schemas.Script.properties` next to `cache_ttl`. No server behavior changes.
- Regenerate API clients to adopt the new typing, then replace any casts accessing `cache_ignore_s3_path` with plain property access.
- `openapi-deref` bundles are not updated in this PR and will be refreshed through the usual process.

<sup>Written for commit b6afd2a770e082d79acb31c3c269efd6a78683c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

