### PR TITLE
feat(frontend): record the outcome of every AI chat tool call

### DIFF
--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -7,6 +7,11 @@ vi.mock('monaco-editor', () => ({
 	editor: {}
 }))
 
+vi.mock('$lib/utils/featureUsage', () => ({
+	logFeatureUsage: vi.fn(),
+	logHubScriptPick: vi.fn()
+}))
+
 const userHolder = vi.hoisted(() => ({
 	current: { is_super_admin: true } as { is_super_admin: boolean }
 }))
@@ -901,6 +906,48 @@ describe('processToolCall', () => {
 				error: 'An error occurred while calling the tool'
 			})
 		)
+	})
+
+	// The counter is silently dropped by the backend when the key is malformed, so nothing
+	// here fails loudly if a path stops logging or logs the wrong status.
+	it('logs one feature-usage outcome per tool call, keyed <tool>:<status>', async () => {
+		const { createToolDef } = await import('./shared')
+		const { logFeatureUsage } = await import('$lib/utils/featureUsage')
+
+		const outcomeKeys = async (
+			tool: Partial<import('./shared').Tool<any>> = {},
+			toolCallbacks: Partial<import('./shared').ToolCallbacks> = {}
+		) => {
+			vi.mocked(logFeatureUsage).mockClear()
+			await runToolCall(
+				{
+					def: createToolDef(z.object({}), 'run_script', 'Run script'),
+					fn: vi.fn().mockResolvedValue('done'),
+					...tool
+				},
+				toolCallbacks
+			)
+			return vi
+				.mocked(logFeatureUsage)
+				.mock.calls.map(([feature, kind, opts]) => [feature, kind, opts?.key])
+		}
+
+		expect(await outcomeKeys()).toEqual([['ai_chat', 'tool', 'run_script:ok']])
+		expect(await outcomeKeys({ fn: vi.fn().mockRejectedValue(new Error('boom')) })).toEqual([
+			['ai_chat', 'tool', 'run_script:error']
+		])
+		expect(await outcomeKeys({ validateBeforeConfirmation: () => 'not deployed' })).toEqual([
+			['ai_chat', 'tool', 'run_script:rejected']
+		])
+		expect(
+			await outcomeKeys(
+				{ requiresConfirmation: true },
+				{ requestConfirmation: vi.fn().mockResolvedValue(false) }
+			)
+		).toEqual([['ai_chat', 'tool', 'run_script:declined']])
+		expect(await outcomeKeys({}, { isPlanModeActive: () => true })).toEqual([
+			['ai_chat', 'tool', 'run_script:blocked_plan_mode']
+		])
 	})
 })
 

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -911,7 +911,7 @@ describe('processToolCall', () => {
 	// The counter is silently dropped by the backend when the key is malformed, so nothing
 	// here fails loudly if a path stops logging or logs the wrong status.
 	it('logs one feature-usage outcome per tool call, keyed <tool>:<status>', async () => {
-		const { createToolDef } = await import('./shared')
+		const { createToolDef, processToolCall } = await import('./shared')
 		const { logFeatureUsage } = await import('$lib/utils/featureUsage')
 
 		const outcomeKeys = async (
@@ -948,6 +948,21 @@ describe('processToolCall', () => {
 		expect(await outcomeKeys({}, { isPlanModeActive: () => true })).toEqual([
 			['ai_chat', 'tool', 'run_script:blocked_plan_mode']
 		])
+
+		// A name the model invented resolves to no tool, and must never reach telemetry.
+		vi.mocked(logFeatureUsage).mockClear()
+		await processToolCall({
+			tools: [{ def: createToolDef(z.object({}), 'run_script', 'Run script'), fn: vi.fn() }],
+			toolCall: {
+				id: 'call_ghost',
+				type: 'function',
+				function: { name: 'hallucinated_tool', arguments: '{}' }
+			},
+			helpers: {},
+			workspace: 'test-workspace',
+			toolCallbacks: { setToolStatus: vi.fn(), removeToolStatus: vi.fn() }
+		})
+		expect(logFeatureUsage).not.toHaveBeenCalled()
 	})
 })
 

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -797,7 +797,13 @@ function stringifyErrorBody(body: unknown): string {
 	}
 }
 
-/** Closed vocabulary for the `ai_chat`/`tool` counter's `<name>:<status>` key. */
+/**
+ * Closed vocabulary for the `ai_chat`/`tool` counter's `<name>:<status>` key.
+ * `ok` means the tool function resolved — tools that report failure by returning an
+ * error string instead of throwing land there too. A call abandoned mid-execution
+ * (tab closed while a tool polls) logs nothing, so the statuses sum to the calls that
+ * finished, not to the calls made.
+ */
 type ToolCallStatus = 'ok' | 'error' | 'declined' | 'rejected' | 'blocked_plan_mode'
 
 export async function processToolCall<T>({

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -797,6 +797,9 @@ function stringifyErrorBody(body: unknown): string {
 	}
 }
 
+/** Closed vocabulary for the `ai_chat`/`tool` counter's `<name>:<status>` key. */
+type ToolCallStatus = 'ok' | 'error' | 'declined' | 'rejected' | 'blocked_plan_mode'
+
 export async function processToolCall<T>({
 	tools,
 	toolCall,
@@ -810,10 +813,24 @@ export async function processToolCall<T>({
 	toolCallbacks: ToolCallbacks
 	workspace?: string
 }): Promise<ChatCompletionMessageParam> {
+	const tool = tools.find((t) => t.def.function.name === toolCall.function.name)
+	const workspaceId = workspace ?? get(workspaceStore) ?? ''
+
+	// Exactly once per call, on whichever path ends it. Keyed by the resolved tool's
+	// declared name, not the model-provided string, so hallucinated tool names never
+	// enter telemetry — an unresolved name is counted nowhere.
+	let outcomeLogged = false
+	const logToolOutcome = (status: ToolCallStatus) => {
+		if (!tool || outcomeLogged) return
+		outcomeLogged = true
+		logFeatureUsage('ai_chat', 'tool', {
+			key: `${tool.def.function.name}:${status}`,
+			workspace: workspaceId
+		})
+	}
+
 	try {
 		const args = JSON.parse(toolCall.function.arguments || '{}')
-		const tool = tools.find((t) => t.def.function.name === toolCall.function.name)
-		const workspaceId = workspace ?? get(workspaceStore) ?? ''
 
 		// Fails closed: untagged is blocked, only the safety tag exempt. Runs before anything
 		// belonging to the tool, so a validator cannot probe while planning — and again after
@@ -830,6 +847,7 @@ export async function processToolCall<T>({
 					: { label: PLAN_MODE_MESSAGES.blockedLabel, result: PLAN_MODE_MESSAGES.blockedResult }
 			if (!refusal) return undefined
 			toolCallbacks.onToolBlockedByPlanMode?.()
+			logToolOutcome('blocked_plan_mode')
 			toolCallbacks.setToolStatus(toolCall.id, {
 				content: refusal.label,
 				parameters: args,
@@ -858,6 +876,7 @@ export async function processToolCall<T>({
 			await tool?.validateBeforeConfirmation?.({ args, workspace: workspaceId, helpers })
 		)
 		if (rejection) {
+			logToolOutcome('rejected')
 			toolCallbacks.setToolStatus(toolCall.id, {
 				content: rejection.label,
 				parameters: args,
@@ -912,6 +931,7 @@ export async function processToolCall<T>({
 			const confirmed = await toolCallbacks.requestConfirmation(toolCall.id, toolCall.function.name)
 
 			if (!confirmed) {
+				logToolOutcome('declined')
 				toolCallbacks.setToolStatus(toolCall.id, {
 					content: 'Cancelled by user',
 					isLoading: false,
@@ -940,11 +960,6 @@ export async function processToolCall<T>({
 		}
 
 		let result = ''
-		// Key by the resolved tool's declared name, not the model-provided string,
-		// so hallucinated tool names never enter telemetry.
-		if (tool) {
-			logFeatureUsage('ai_chat', 'tool', { key: tool.def.function.name, workspace: workspaceId })
-		}
 		try {
 			result = await callTool({
 				tools,
@@ -955,12 +970,14 @@ export async function processToolCall<T>({
 				toolCallbacks,
 				toolId: toolCall.id
 			})
+			logToolOutcome('ok')
 			toolCallbacks.setToolStatus(toolCall.id, {
 				isLoading: false,
 				isStreamingArguments: false
 			})
 		} catch (err) {
 			console.error(err)
+			logToolOutcome('error')
 			const errorMessage = formatToolError(err)
 			toolCallbacks.setToolStatus(toolCall.id, {
 				isLoading: false,
@@ -977,6 +994,7 @@ export async function processToolCall<T>({
 		return toAdd
 	} catch (err) {
 		console.error(err)
+		logToolOutcome('error')
 		const errorMessage = formatToolError(err)
 		toolCallbacks.setToolStatus(toolCall.id, {
 			isLoading: false,


### PR DESCRIPTION
## Summary

The `ai_chat`/`tool` feature-usage counter fired *before* the tool ran, so it recorded which tools the model reached for but never whether the call worked. The three paths that refuse a call before it runs — a plan-mode block, a `validateBeforeConfirmation` rejection, a user declining the confirmation card — returned before the log site and recorded nothing at all.

`processToolCall` now logs once on whichever path ends the call, keyed `<tool_name>:<status>`.

## Changes

- `processToolCall` logs `ai_chat`/`tool` after the outcome is known, keyed `<tool_name>:<status>` over `ok`, `error`, `declined`, `rejected`, `blocked_plan_mode`.
- Tool resolution moved above the outer `try` so the outer `catch` can log `error` too; a `logToolOutcome` closure logs at most once per call and stays silent for a tool name the model invented, as before.
- Test covering all five statuses through the real code paths, plus the hallucinated-name case.

No EE change: `('ai_chat', 'tool')` is already in `FEATURE_USAGE_KINDS`, and `:` is an allowed key character, so `is_recordable_event` accepts the new shape. The `InstanceSettings` disclosure already covers this counter and gains no new data category — the key stays an anonymous count with no path, prompt, or identifier in it.

### Downstream note

`ai_chat`/`tool` keys change from `<tool_name>` to `<tool_name>:<status>`. A per-tool total now needs `split_part(key, ':', 1)`. Rows keyed by the bare tool name coexist for up to 60 days (30-day aggregation window, 60-day prune).

Two things the statuses deliberately do not capture, recorded in a comment on `ToolCallStatus`: `ok` means the tool function resolved, so tools that report failure by returning an error string rather than throwing count as `ok`; and a call abandoned mid-execution logs nothing, so the statuses sum to calls that finished, not calls made.

## Screenshots

None — telemetry only, no visible UI effect.

## Test plan

- [x] `npx vitest run src/lib/components/copilot/chat/shared.test.ts` — 64 pass
- [x] `npm run check:fast` clean
- [x] Exercised on a running EE instance (`--features enterprise,private`): drove a real AI session, which produced `open_page:ok` and `write_variable:ok` rows in `feature_usage`
- [x] POSTed `run_script:blocked_plan_mode` to `/api/w/{workspace}/workspaces/log_feature_usage` to confirm the longest key shape survives `is_recordable_event`
- [x] Downstream consumer tracked in WIN-2401 — updates the AI Dashboard in the `windmill-prod` workspace for the `<tool>:<status>` key. Nothing in this repo or `windmill-ee-private` parses `key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
