### PR TITLE
style: use subtle Button for raw app preview toolbar actions

### DIFF
--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -7,6 +7,7 @@
 	import RawAppYamlEditor, { type RawAppYamlUpdate } from './RawAppYamlEditor.svelte'
 	import type Drawer from '../common/drawer/Drawer.svelte'
 	import Alert from '../common/alert/Alert.svelte'
+	import { Button } from '../common'
 	import { AppService, type Policy, WorkspaceService } from '$lib/gen'
 	import DiffDrawer from '../DiffDrawer.svelte'
 	import { deepEqual } from 'fast-equals'
@@ -2357,19 +2358,19 @@
 								>
 									{#snippet trailing()}
 										<div class="flex items-center gap-1 px-2">
-											<button
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												iconOnly
+												startIcon={{ icon: Columns2 }}
+												selected={splitWithPreview}
 												title={splitWithPreview
 													? 'Move preview back into a tab'
 													: 'Pin preview to the right'}
 												aria-label="Toggle split with preview"
 												aria-pressed={splitWithPreview}
-												class={splitWithPreview
-													? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-													: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-												onclick={toggleSplit}
-											>
-												<Columns2 size={14} />
-											</button>
+												onClick={toggleSplit}
+											/>
 										</div>
 									{/snippet}
 								</DraggableTabs>
@@ -2442,27 +2443,32 @@
 								>
 									{#snippet trailing()}
 										<div class="flex items-center gap-1 px-2">
-											<button
-												class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
 												title="Switch bundler"
-												onclick={() => {
+												onClick={() => {
 													const next = bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
 													bundlerType = next
 													iframe?.contentWindow?.postMessage(
 														{ type: 'setBundlerType', bundlerType: next },
 														'*'
 													)
-												}}>{bundlerType}</button
+												}}
 											>
-											<button
+												{bundlerType}
+											</Button>
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												iconOnly
+												startIcon={{ icon: MousePointerSquareDashed }}
+												selected={inspectorEnabled}
 												title={inspectorEnabled
 													? 'Click to disable element inspector'
 													: 'Click to enable element inspector'}
-												class={inspectorEnabled
-													? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-													: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
 												aria-label="Toggle element inspector"
-												onclick={() => {
+												onClick={() => {
 													if (inspectorEnabled) {
 														// Turning off is a full exit: stop picking and clear the
 														// selection + inline prompt (mirrors Escape).
@@ -2475,42 +2481,42 @@
 														)
 													}
 												}}
-											>
-												<MousePointerSquareDashed size={14} />
-											</button>
-											<button
-												class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+											/>
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												iconOnly
+												startIcon={{ icon: RefreshCw }}
 												title="Replay the last build into the preview"
 												aria-label="Rebuild"
-												onclick={() => {
+												onClick={() => {
 													if (lastBuild) {
 														feedPreviewIframe(lastBuild)
 													}
 												}}
-											>
-												<RefreshCw size={14} />
-											</button>
-											<button
-												class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+											/>
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												iconOnly
+												startIcon={{ icon: SquareArrowOutUpRight }}
 												title="Open preview in a separate window"
 												aria-label="Open preview in a separate window"
-												onclick={openExternalPreview}
-											>
-												<SquareArrowOutUpRight size={14} />
-											</button>
-											<button
+												onClick={openExternalPreview}
+											/>
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												iconOnly
+												startIcon={{ icon: Columns2 }}
+												selected={splitWithPreview}
 												title={splitWithPreview
 													? 'Move preview back into a tab'
 													: 'Pin preview to the right'}
 												aria-label="Toggle split with preview"
 												aria-pressed={splitWithPreview}
-												class={splitWithPreview
-													? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-													: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-												onclick={toggleSplit}
-											>
-												<Columns2 size={14} />
-											</button>
+												onClick={toggleSplit}
+											/>
 										</div>
 									{/snippet}
 								</DraggableTabs>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -2468,6 +2468,7 @@
 													? 'Click to disable element inspector'
 													: 'Click to enable element inspector'}
 												aria-label="Toggle element inspector"
+												aria-pressed={inspectorEnabled}
 												onClick={() => {
 													if (inspectorEnabled) {
 														// Turning off is a full exit: stop picking and clear the


### PR DESCRIPTION
## Summary

The preview tab bar in the raw app editor carried five hand-rolled `<button>` elements with the design system's *default* variant baked in as literal Tailwind classes. They read heavier than the tab bar they sit in, and the ES build label rendered bold because the raw button set no font weight and inherited one from the tab bar.

They now use the shared `Button` with `variant="subtle"`.

## Changes

- `RawAppEditor.svelte`: the bundler switch, element inspector, rebuild, open-in-new-window and split-view buttons are `<Button variant="subtle" unifiedSize="sm">`. The split-view toggle appears on both pane tab bars, so six call sites in total.
- `unifiedSize="sm"` keeps the previous 28px height and `text-xs`, and adds `font-normal` — that is what un-bolds the ES build label.
- Icon buttons use `iconOnly` + `startIcon`, so the icon size comes from the size scale (13px, was a hardcoded 14px).
- The two toggles (inspector, split view) use the `selected` prop instead of a hand-written `bg-surface-accent-selected text-accent border-border-selected` branch.
- `title`, `aria-label` and `aria-pressed` carry over unchanged.

## Screenshots

Before — bordered, bold `esbuild` label:

![toolbar-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-subtle-buttons/1787045940-toolbar-before.png)

After — subtle, regular weight:

![toolbar-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-subtle-buttons/1787045942-toolbar-after.png)

Selected state still reads (split view pinned):

![toolbar-after-selected](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-subtle-buttons/1787045943-toolbar-after-selected.png)

In context:

![rawapp-after-full](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-subtle-buttons/1787045944-rawapp-after-full.png)

## Test plan

- [x] `svelte-check` — 0 errors
- [x] Open a raw app editor, confirm all five toolbar buttons render borderless at the same size and position as before
- [x] Toggle split view and confirm the button takes the accent-selected state
- [x] Click the bundler switch and confirm it flips esbuild ⇄ rolldown