### PR TITLE
fix: check direct-deployment lock and superadmin in the deploy preflight

### DIFF
--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -304,9 +304,9 @@
 	let selectedItems = $state<string[]>([])
 	let deploying = $state(false)
 
-	// Whether the user may deploy drafts into this workspace — fills the
-	// `RestrictDeployToDeployers` (+ operator) gap via the shared util, same as the
-	// fork compare page and the session review drawer. Fail-open while resolving.
+	// Whether the user may deploy drafts into this workspace, via the shared util —
+	// same as the fork compare page and the session review drawer. Fail-open while
+	// resolving.
 	let deployPerm = $state<DeployPermission>({ ok: true })
 	$effect(() => {
 		const ws = currentWorkspaceId

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -22,7 +22,11 @@
 		discardDraft,
 		draftBaseIsStale
 	} from '$lib/utils_draft_deploy'
-	import { checkDeployPermission, type DeployPermission } from '$lib/utils_workspace_deploy'
+	import {
+		checkDeployPermission,
+		deployPermissionForKinds,
+		type DeployPermission
+	} from '$lib/utils_workspace_deploy'
 	import {
 		type DraftItem,
 		invalidateWorkspaceDrafts,
@@ -307,17 +311,27 @@
 	// Whether the user may deploy drafts into this workspace, via the shared util —
 	// same as the fork compare page and the session review drawer. Fail-open while
 	// resolving.
-	let deployPerm = $state<DeployPermission>({ ok: true })
+	let workspaceDeployPerm = $state<DeployPermission>({ ok: true })
 	$effect(() => {
 		const ws = currentWorkspaceId
 		// Reset to fail-open on workspace change, and drop a stale resolution —
 		// otherwise the previous workspace's verdict lingers (or lands last) and
 		// gates the wrong workspace.
-		deployPerm = { ok: true }
+		workspaceDeployPerm = { ok: true }
 		void checkDeployPermission(ws).then((p) => {
-			if (ws === currentWorkspaceId) deployPerm = p
+			if (ws === currentWorkspaceId) workspaceDeployPerm = p
 		})
 	})
+	// A direct-deployment lock never reaches trigger or schedule drafts server-side, so it must
+	// not disable a selection made only of those. One refused kind still blocks the whole action.
+	let deployPerm = $derived(
+		deployPermissionForKinds(
+			workspaceDeployPerm,
+			visibleItems
+				.filter((i) => selectedItems.includes(i.key) && isDeployable(i))
+				.map((i) => i.draftKind)
+		)
+	)
 	// Select all on the first non-empty load (acting on everything is the common
 	// intent); only once, so a refetch after a deploy doesn't re-select the
 	// leftovers.

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -41,6 +41,7 @@
 	import type { Kind } from '$lib/utils_deployable'
 	import {
 		checkDeployPermission,
+		deployPermissionForKinds,
 		deployItem,
 		deleteItemInWorkspace,
 		diffActionableInDirection,
@@ -984,7 +985,17 @@
 			void checkDeployPermission(ws).then((p) => (deployPerms = { ...deployPerms, [ws]: p }))
 		}
 	})
-	let deployPerm = $derived(deployPerms[deployTargetWorkspace] ?? { ok: true })
+	let workspaceDeployPerm = $derived(deployPerms[deployTargetWorkspace] ?? { ok: true })
+	// A direct-deployment lock never reaches schedules or triggers server-side, so it must not
+	// disable a selection made only of those. One refused kind still blocks the whole action.
+	let deployPerm = $derived(
+		deployPermissionForKinds(
+			workspaceDeployPerm,
+			(comparison?.diffs ?? [])
+				.filter((d) => selectedItems.includes(getItemKey(d)))
+				.map((d) => d.kind)
+		)
+	)
 
 	// Fetch summaries and on_behalf_of_email when comparison data loads
 	$effect(() => {

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -972,10 +972,9 @@
 		fetchPermissions()
 	})
 
-	// Can the user actually deploy into the target workspace? Fills the frontend
-	// gap for the `RestrictDeployToDeployers` rule (+ operator), shared with the
-	// session review drawer via the same checkDeployPermission util. Cached per
-	// workspace; `deployPerm` tracks whichever side the current direction targets.
+	// Can the user actually deploy into the target workspace? Shared with the session
+	// review drawer via the same checkDeployPermission util. Cached per workspace;
+	// `deployPerm` tracks whichever side the current direction targets.
 	let deployPerms = $state<Record<string, DeployPermission>>({})
 	const deployPermFetched = new Set<string>()
 	$effect(() => {

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -951,21 +951,28 @@
 		toggleDeploymentDirection(v)
 	}
 
-	// Fetch user permissions for both workspaces
+	// Fetch user permissions for both workspaces. The server's `can_preserve_on_behalf_of` reads
+	// the merged `is_admin || super_admin`, which `whoami` reports as two fields.
 	$effect(() => {
 		;[currentWorkspaceId, parentWorkspaceId]
 		async function fetchPermissions() {
 			try {
 				const parentUser = await UserService.whoami({ workspace: parentWorkspaceId })
 				canPreserveInParent =
-					parentUser.is_admin || parentUser.groups?.includes('wm_deployers') || false
+					parentUser.is_admin ||
+					parentUser.is_super_admin ||
+					parentUser.groups?.includes('wm_deployers') ||
+					false
 			} catch {
 				canPreserveInParent = false
 			}
 			try {
 				const currentUser = await UserService.whoami({ workspace: currentWorkspaceId })
 				canPreserveInCurrent =
-					currentUser.is_admin || currentUser.groups?.includes('wm_deployers') || false
+					currentUser.is_admin ||
+					currentUser.is_super_admin ||
+					currentUser.groups?.includes('wm_deployers') ||
+					false
 			} catch {
 				canPreserveInCurrent = false
 			}

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -982,7 +982,7 @@
 
 	// Can the user actually deploy into the target workspace? Shared with the session
 	// review drawer via the same checkDeployPermission util. Cached per workspace;
-	// `deployPerm` tracks whichever side the current direction targets.
+	// `workspaceDeployPerm` tracks whichever side the current direction targets.
 	let deployPerms = $state<Record<string, DeployPermission>>({})
 	const deployPermFetched = new Set<string>()
 	$effect(() => {

--- a/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
@@ -1072,15 +1072,15 @@
 															disabled={model.deploying ||
 																!!staged[d.key] ||
 																!view.canWrite ||
-																!model.deployPermission.ok}
+																!model.deployPermissionForKind(d.deployKind).ok}
 															startIcon={status?.status === 'loading'
 																? { icon: Loader2, classes: 'animate-spin' }
 																: { icon: Save }}
 															title={!view.canWrite
 																? "You don't have write permission on this path"
-																: model.deployPermission.ok
+																: model.deployPermissionForKind(d.deployKind).ok
 																	? undefined
-																	: model.deployPermission.reason}
+																	: model.deployPermissionForKind(d.deployKind).reason}
 															onclick={() => deployStaged(d)}
 														>
 															{action.label}

--- a/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
@@ -268,9 +268,9 @@ export function useSessionDeployModel(getArgs: () => SessionDeployModelArgs) {
 		// Snapshot before the await: the user may switch sessions while the
 		// deploy runs, and the event belongs to the initiating session.
 		const initiatingSessionId = sessionState.currentSessionId
-		// Don't attempt a deploy we know the user can't make (no write permission
-		// on the path, or blocked by the operator / deployer rule) — the UI
-		// disables it too; this is the guard behind that.
+		// Don't attempt a deploy we know the user can't make (no write permission on
+		// the path, or refused by the preflight for this kind) — the UI disables it
+		// too; this is the guard behind that.
 		if (!discard && (!item.canWrite || !deployPermissionForKind(deployPerm, item.deployKind).ok))
 			return false
 		setStatus(item.key, { status: 'loading' })

--- a/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
@@ -352,10 +352,10 @@ export function useSessionDeployModel(getArgs: () => SessionDeployModelArgs) {
 		staleOf(key: string): boolean {
 			return staleKeys.has(key)
 		},
-		/** Whether the user may deploy into the session workspace. */
 		/**
-		 * Per-kind, because a direct-deployment lock never reaches schedules or triggers
-		 * server-side — a row of that kind stays deployable while a script row does not.
+		 * Whether the user may deploy into the session workspace. Per-kind, because a
+		 * direct-deployment lock never reaches schedules or triggers server-side — a row of
+		 * that kind stays deployable while a script row does not.
 		 */
 		deployPermissionForKind(kind: Kind): DeployPermission {
 			return deployPermissionForKind(deployPerm, kind)

--- a/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
@@ -2,10 +2,12 @@ import { getDraftItems, type DraftItem } from '$lib/workspaceDrafts.svelte'
 import {
 	checkDeployPermission,
 	checkItemExists,
+	deployPermissionForKind,
 	getItemValue,
 	type DeployPermission,
 	type DeployResult
 } from '$lib/utils_workspace_deploy'
+import type { Kind } from '$lib/utils_deployable'
 import {
 	deployDraft,
 	discardDraft,
@@ -269,7 +271,8 @@ export function useSessionDeployModel(getArgs: () => SessionDeployModelArgs) {
 		// Don't attempt a deploy we know the user can't make (no write permission
 		// on the path, or blocked by the operator / deployer rule) — the UI
 		// disables it too; this is the guard behind that.
-		if (!discard && (!item.canWrite || !deployPerm.ok)) return false
+		if (!discard && (!item.canWrite || !deployPermissionForKind(deployPerm, item.deployKind).ok))
+			return false
 		setStatus(item.key, { status: 'loading' })
 		deploying = true
 		try {
@@ -350,8 +353,12 @@ export function useSessionDeployModel(getArgs: () => SessionDeployModelArgs) {
 			return staleKeys.has(key)
 		},
 		/** Whether the user may deploy into the session workspace. */
-		get deployPermission(): DeployPermission {
-			return deployPerm
+		/**
+		 * Per-kind, because a direct-deployment lock never reaches schedules or triggers
+		 * server-side — a row of that kind stays deployable while a script row does not.
+		 */
+		deployPermissionForKind(kind: Kind): DeployPermission {
+			return deployPermissionForKind(deployPerm, kind)
 		},
 		deployRow,
 		discardRow

--- a/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionDeployModel.svelte.ts
@@ -208,9 +208,9 @@ export function useSessionDeployModel(getArgs: () => SessionDeployModelArgs) {
 	})
 
 	// ── Deploy permission ────────────────────────────────────────────────────
-	// Preflight the shared checkDeployPermission (operator / RestrictDeployToDeployers)
-	// for the session workspace so the button disables with a reason instead of
-	// failing on click. `ok` defaults true while resolving (fail-open).
+	// Preflight the shared checkDeployPermission for the session workspace so the
+	// button disables with a reason instead of failing on click. `ok` defaults
+	// true while resolving (fail-open).
 	let deployPerm = $state<DeployPermission>({ ok: true })
 	let deployPermFetchedFor = ''
 	$effect(() => {

--- a/frontend/src/lib/utils_workspace_deploy.test.ts
+++ b/frontend/src/lib/utils_workspace_deploy.test.ts
@@ -171,6 +171,16 @@ describe('workspace-level deploy permission', () => {
 		expect(res.reason).toContain('prod')
 	})
 
+	// The reserved dev-workspace lock sets DisableWorkspaceForking alongside, so the advice would
+	// otherwise send the user at a second blocked action.
+	it('drops the fork advice when forking is blocked too', async () => {
+		const res = await permission(member, [
+			ruleset('lock', ['DisableDirectDeployment', 'DisableWorkspaceForking'])
+		])
+		expect(res.reason).not.toContain('fork')
+		expect(res.reason).toContain('locally')
+	})
+
 	// wm_deployers is an implicit pass on RestrictDeployToDeployers only. Letting it
 	// short-circuit the whole check — as an "is this user a deployer?" early return would —
 	// walks a deployer straight through a deploy-locked workspace.
@@ -257,6 +267,13 @@ describe('scoping a refusal to the kinds the server gates', () => {
 	it('leaves the deployers-only refusal applying to every kind', () => {
 		expect(deployPermissionForKind(deployersOnly, 'script').ok).toBe(false)
 		expect(deployPermissionForKind(deployersOnly, 'schedule').ok).toBe(false)
+	})
+
+	// `[].some()` is false, so an unguarded fold reports the empty selection as deployable and
+	// drops the only message saying why the action is unavailable.
+	it('keeps the refusal when nothing is selected', () => {
+		expect(deployPermissionForKinds(locked, []).ok).toBe(false)
+		expect(deployPermissionForKinds(deployersOnly, []).ok).toBe(false)
 	})
 
 	it('blocks a mixed selection but frees an all-ungated one', () => {

--- a/frontend/src/lib/utils_workspace_deploy.test.ts
+++ b/frontend/src/lib/utils_workspace_deploy.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { ProtectionRuleset, ProtectionRuleKind, User } from './gen'
+import type { DeployPermission } from './utils_workspace_deploy'
 import {
 	checkDeployPermission,
+	deployPermissionForKind,
+	deployPermissionForKinds,
+	kindGatedByDeployRules,
 	checkPathWritePermission,
 	diffActionableInDirection,
 	diffCreatesInTarget,
@@ -193,5 +197,63 @@ describe('workspace-level deploy permission', () => {
 		const res = await permission({ ...member, operator: true, is_super_admin: true }, [])
 		expect(res.ok).toBe(false)
 		expect(res.reason).toContain('operator')
+	})
+})
+
+describe('scoping a refusal to the kinds the server gates', () => {
+	const locked: DeployPermission = {
+		ok: false,
+		reason: 'Direct deployment to prod is disabled',
+		refusedBy: 'DisableDirectDeployment'
+	}
+	const deployersOnly: DeployPermission = {
+		ok: false,
+		reason: 'Only workspace admins and members of wm_deployers can deploy to prod',
+		refusedBy: 'RestrictDeployToDeployers'
+	}
+
+	// The kinds whose handlers call check_deploy_rules, against those that reach no gate.
+	it('gates the item kinds the server gates, and no others', () => {
+		for (const k of [
+			'script',
+			'flow',
+			'app',
+			'raw_app',
+			'resource',
+			'resource_type',
+			'variable',
+			'folder'
+		] as const) {
+			expect(kindGatedByDeployRules(k)).toBe(true)
+		}
+		for (const k of ['schedule', 'http_trigger', 'email_trigger', 'data_pipeline'] as const) {
+			expect(kindGatedByDeployRules(k)).toBe(false)
+		}
+	})
+
+	// Draft rows speak UserDraftItemKind; the gated names coincide, the ungated ones don't.
+	it('reads draft kinds with the same lookup', () => {
+		expect(kindGatedByDeployRules('variable')).toBe(true)
+		expect(kindGatedByDeployRules('trigger_schedule')).toBe(false)
+		expect(kindGatedByDeployRules('trigger_http')).toBe(false)
+	})
+
+	it('keeps a direct-deployment refusal off the kinds the server never gates', () => {
+		expect(deployPermissionForKind(locked, 'script').ok).toBe(false)
+		expect(deployPermissionForKind(locked, 'schedule').ok).toBe(true)
+		expect(deployPermissionForKind(locked, 'trigger_schedule').ok).toBe(true)
+	})
+
+	// The deployers-only term over-reaches the same way, but it does so on main too. Narrowing it
+	// would loosen the UI beyond mirroring the new rule, so it stays workspace-wide.
+	it('leaves the deployers-only refusal applying to every kind', () => {
+		expect(deployPermissionForKind(deployersOnly, 'script').ok).toBe(false)
+		expect(deployPermissionForKind(deployersOnly, 'schedule').ok).toBe(false)
+	})
+
+	it('blocks a mixed selection but frees an all-ungated one', () => {
+		expect(deployPermissionForKinds(locked, ['schedule', 'script']).ok).toBe(false)
+		expect(deployPermissionForKinds(locked, ['schedule', 'http_trigger']).ok).toBe(true)
+		expect(deployPermissionForKinds(deployersOnly, ['schedule']).ok).toBe(false)
 	})
 })

--- a/frontend/src/lib/utils_workspace_deploy.test.ts
+++ b/frontend/src/lib/utils_workspace_deploy.test.ts
@@ -85,13 +85,13 @@ describe('deploy direction of a one-sided diff row', () => {
 })
 
 describe('per-item write permission in the deploy target', () => {
-	const member = { is_admin: false, username: 'alice', folders: ['shared'] }
+	const member = { is_admin: false, is_super_admin: false, username: 'alice', folders: ['shared'] }
 	const never = async () => {
 		throw new Error('folder probe should not run')
 	}
 
 	it('lets a workspace admin write anywhere', async () => {
-		const admin = { is_admin: true, username: 'root', folders: [] }
+		const admin = { is_admin: true, is_super_admin: false, username: 'root', folders: [] }
 		expect(await checkPathWritePermission('dev', 'u/someone/x', admin, never)).toEqual({ ok: true })
 		expect(await checkPathWritePermission('dev', 'f/locked/x', admin, never)).toEqual({ ok: true })
 	})
@@ -101,6 +101,14 @@ describe('per-item write permission in the deploy target', () => {
 		const refused = await checkPathWritePermission('dev', 'u/bob/x', member, never)
 		expect(refused.ok).toBe(false)
 		expect(refused.reason).toContain('u/bob')
+	})
+
+	// The server's `is_owner` reads the merged `is_admin || super_admin`, so a superadmin who is a
+	// plain member owns every path — refusing them here would block a write the server accepts.
+	it('lets a superadmin who is a plain member write anywhere', async () => {
+		const su = { is_admin: false, is_super_admin: true, username: 'root', folders: [] }
+		expect(await checkPathWritePermission('dev', 'f/locked/x', su, never)).toEqual({ ok: true })
+		expect(await checkPathWritePermission('dev', 'u/someone/x', su, never)).toEqual({ ok: true })
 	})
 
 	it('allows a folder in the write set without probing for it', async () => {

--- a/frontend/src/lib/utils_workspace_deploy.test.ts
+++ b/frontend/src/lib/utils_workspace_deploy.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import type { ProtectionRuleset, ProtectionRuleKind, User } from './gen'
 import {
+	checkDeployPermission,
 	checkPathWritePermission,
 	diffActionableInDirection,
 	diffCreatesInTarget,
 	diffRemovesInTarget
 } from './utils_workspace_deploy'
+
+// Only the rules fetch is stubbed: the bypass logic it feeds is the code under test here,
+// so it has to stay real.
+let rulesets: ProtectionRuleset[] = []
+vi.mock('$lib/workspaceProtectionRules.svelte', async (importOriginal) => ({
+	...((await importOriginal()) as object),
+	fetchProtectionRulesForWorkspace: async () => rulesets
+}))
 
 /** The row shape the fork comparison returns for an item the parent has and the
  * fork does not: one write on the fork side, whatever that write was. */
@@ -114,5 +124,74 @@ describe('per-item write permission in the deploy target', () => {
 		expect(await checkPathWritePermission('dev', 'f/locked/x', member, probeFailed)).toEqual({
 			ok: true
 		})
+	})
+})
+
+describe('workspace-level deploy permission', () => {
+	const ruleset = (name: string, rules: ProtectionRuleKind[]): ProtectionRuleset => ({
+		name,
+		rules,
+		bypass_users: [],
+		bypass_groups: []
+	})
+	const member: User = {
+		email: 'alice@windmill.dev',
+		username: 'alice',
+		is_admin: false,
+		is_super_admin: false,
+		operator: false,
+		disabled: false,
+		created_at: '2024-01-01T00:00:00Z',
+		groups: [],
+		folders: [],
+		folders_read: [],
+		folders_owners: []
+	}
+
+	const permission = (me: User, rules: ProtectionRuleset[]) => {
+		rulesets = rules
+		return checkDeployPermission('prod', me)
+	}
+
+	it('refuses a member when direct deployment is disabled', async () => {
+		const res = await permission(member, [ruleset('lock', ['DisableDirectDeployment'])])
+		expect(res.ok).toBe(false)
+		expect(res.reason).toContain('prod')
+	})
+
+	// wm_deployers is an implicit pass on RestrictDeployToDeployers only. Letting it
+	// short-circuit the whole check — as an "is this user a deployer?" early return would —
+	// walks a deployer straight through a deploy-locked workspace.
+	it('still refuses a wm_deployers member when direct deployment is disabled', async () => {
+		const deployer = { ...member, groups: ['wm_deployers'] }
+		expect((await permission(deployer, [ruleset('lock', ['DisableDirectDeployment'])])).ok).toBe(
+			false
+		)
+		expect((await permission(deployer, [ruleset('gate', ['RestrictDeployToDeployers'])])).ok).toBe(
+			true
+		)
+	})
+
+	// whoami reports is_admin and is_super_admin separately; the server sees them merged.
+	it('lets a superadmin who is a plain member deploy', async () => {
+		const su = { ...member, is_super_admin: true }
+		expect((await permission(su, [ruleset('lock', ['DisableDirectDeployment'])])).ok).toBe(true)
+	})
+
+	it('reports the direct-deployment refusal when both rules block', async () => {
+		const res = await permission(member, [
+			ruleset('lock', ['DisableDirectDeployment', 'RestrictDeployToDeployers'])
+		])
+		expect(res.reason).toContain('Direct deployment')
+	})
+
+	// The server refuses an operator in the item handler regardless of their global role: a
+	// superadmin who is an operator in the workspace still gets 401 creating a script. So the
+	// operator term has to stay above the admin/superadmin short-circuit — hoisting the admin
+	// checks would offer a deploy the server refuses.
+	it('refuses an operator who is also a superadmin', async () => {
+		const res = await permission({ ...member, operator: true, is_super_admin: true }, [])
+		expect(res.ok).toBe(false)
+		expect(res.reason).toContain('operator')
 	})
 })

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -855,11 +855,13 @@ export async function checkDeployPermission(
 export async function checkPathWritePermission(
 	workspace: string,
 	path: string,
-	me: Pick<User, 'is_admin' | 'username' | 'folders'>,
+	me: Pick<User, 'is_admin' | 'is_super_admin' | 'username' | 'folders'>,
 	folderExists: (folderPath: string) => Promise<boolean> = (folderPath) =>
 		checkItemExists('folder', folderPath, workspace)
 ): Promise<DeployPermission> {
-	if (me.is_admin) return { ok: true }
+	// The server's `is_owner` reads `ApiAuthed.is_admin`, the merged `is_admin || super_admin`,
+	// so a superadmin owns every path here whether or not they own the folder.
+	if (me.is_admin || me.is_super_admin) return { ok: true }
 	const owner = path.match(/^u\/([^/]+)\//)?.[1]
 	if (owner) {
 		return owner === me.username
@@ -910,7 +912,8 @@ export async function checkItemDeployAccess(
 		permission: workspaceLevel.ok
 			? await checkPathWritePermission(workspace, path, me)
 			: workspaceLevel,
-		canPreserveOnBehalfOf: me.is_admin || (me.groups ?? []).includes('wm_deployers'),
+		canPreserveOnBehalfOf:
+			me.is_admin || me.is_super_admin || (me.groups ?? []).includes('wm_deployers'),
 		me: { email: me.email, permissionedAs: `u/${me.username}` }
 	}
 }

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -706,13 +706,16 @@ export async function createFolderIfAbsent(
 export type DeployPermission = { ok: boolean; reason?: string }
 
 /**
- * Whether the current user may deploy into `workspace`. Mirrors the server-side
- * deploy authorization (`check_user_against_rule` in windmill-common) so the UI
- * can disable the action with a reason instead of letting the click 403:
- *  - operators can never deploy;
- *  - when the `RestrictDeployToDeployers` protection rule is active, only
- *    admins, `wm_deployers` members (implicitly), and per-ruleset bypass
- *    users/groups may deploy.
+ * Whether the current user may deploy into `workspace`. Mirrors `check_deploy_rules` in
+ * windmill-common so the UI can disable the action with a reason instead of letting the
+ * click 403: `DisableDirectDeployment` is evaluated before `RestrictDeployToDeployers`, so
+ * the same message wins here as on the server when both block; admins and superadmins bypass
+ * both rules, while `wm_deployers` members bypass only the latter.
+ *
+ * The operator refusal is not part of that mirror. The server refuses operators in the item
+ * handlers instead, and for fewer kinds, so refusing them for everything here is deliberately
+ * stricter than the server rather than a faithful copy of it.
+ *
  * Fails open on any error — the server still enforces on the actual deploy.
  * Shared by the session dock and the compare page so both gate identically.
  */
@@ -726,17 +729,32 @@ export async function checkDeployPermission(
 		if (me.operator) {
 			return { ok: false, reason: "You're an operator in this workspace — operators can't deploy" }
 		}
-		// Admins and wm_deployers members always satisfy RestrictDeployToDeployers
-		// (the backend allows wm_deployers implicitly, so check it before the
-		// per-ruleset bypass_users/bypass_groups fallback).
-		const isDeployer = me.is_admin || (me.groups ?? []).includes('wm_deployers')
-		if (!isDeployer) {
+		const userInfo = {
+			is_admin: !!me.is_admin,
+			is_super_admin: !!me.is_super_admin,
+			username: me.username,
+			groups: me.groups ?? []
+		}
+		// A superadmin who is only a plain member of the workspace still bypasses every rule,
+		// so dropping either term here refuses a deploy the server accepts.
+		if (!userInfo.is_admin && !userInfo.is_super_admin) {
 			const rulesets = await fetchProtectionRulesForWorkspace(workspace)
-			const userInfo = { is_admin: !!me.is_admin, username: me.username, groups: me.groups ?? [] }
-			if (!canUserBypassRuleKindInRulesets(rulesets, 'RestrictDeployToDeployers', userInfo)) {
+			if (!canUserBypassRuleKindInRulesets(rulesets, 'DisableDirectDeployment', userInfo)) {
 				return {
 					ok: false,
-					reason: 'Only workspace admins and members of wm_deployers can deploy here'
+					reason: `Direct deployment to ${workspace} is disabled — fork the workspace or open a pull request`
+				}
+			}
+			// `wm_deployers` membership is an implicit pass on this rule only, so it cannot
+			// short-circuit the fetch above the way admin does.
+			const isDeployer = userInfo.groups.includes('wm_deployers')
+			if (
+				!isDeployer &&
+				!canUserBypassRuleKindInRulesets(rulesets, 'RestrictDeployToDeployers', userInfo)
+			) {
+				return {
+					ok: false,
+					reason: `Only workspace admins and members of wm_deployers can deploy to ${workspace}`
 				}
 			}
 		}

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -21,6 +21,7 @@ import {
 	WorkspaceService,
 	type User
 } from '$lib/gen'
+import type { UserDraftItemKind } from '$lib/gen'
 import {
 	fetchProtectionRulesForWorkspace,
 	canUserBypassRuleKindInRulesets
@@ -703,7 +704,79 @@ export async function createFolderIfAbsent(
 	}
 }
 
-export type DeployPermission = { ok: boolean; reason?: string }
+/** Which term refused, so a caller can scope a refusal the server applies to only some kinds. */
+export type DeployRefusal = 'operator' | 'DisableDirectDeployment' | 'RestrictDeployToDeployers'
+
+export type DeployPermission = { ok: boolean; reason?: string; refusedBy?: DeployRefusal }
+
+// The server reaches `check_deploy_rules` from the item handlers, and only these kinds call it
+// (windmill-api-{scripts,flows,groups}, windmill-api/src/apps.rs, windmill-store/src/{resources,
+// variables}.rs). Schedules and triggers hit no gate at all, so a protection rule must not
+// disable them here. Exhaustive by construction: a new `Kind` fails to compile without a verdict.
+const KIND_GATED_BY_DEPLOY_RULES: Record<Kind, boolean> = {
+	script: true,
+	flow: true,
+	app: true,
+	raw_app: true,
+	resource: true,
+	resource_type: true,
+	variable: true,
+	folder: true,
+	schedule: false,
+	http_trigger: false,
+	websocket_trigger: false,
+	kafka_trigger: false,
+	nats_trigger: false,
+	postgres_trigger: false,
+	mqtt_trigger: false,
+	amqp_trigger: false,
+	sqs_trigger: false,
+	gcp_trigger: false,
+	azure_trigger: false,
+	email_trigger: false,
+	datatable_migration: false,
+	trigger: false,
+	data_pipeline: false
+}
+
+// Every gated kind is spelled identically in `Kind` and `UserDraftItemKind`, so one lookup serves
+// both taxonomies and the drafts surface needs no bridge. The kinds whose spellings diverge
+// (`trigger_http` vs `http_trigger`) are exactly the ungated ones — so if a trigger kind ever
+// becomes gated server-side, it needs its draft spelling added here too.
+const GATED_KIND_NAMES = new Set(
+	Object.entries(KIND_GATED_BY_DEPLOY_RULES)
+		.filter(([, gated]) => gated)
+		.map(([kind]) => kind)
+)
+
+export function kindGatedByDeployRules(kind: Kind | UserDraftItemKind): boolean {
+	return GATED_KIND_NAMES.has(kind)
+}
+
+/**
+ * Narrow a workspace-level refusal to one item kind. Only the direct-deployment term is scoped:
+ * the deployers-only term over-reaches the same way, but it does so on `main` too, and loosening
+ * it here would change behaviour beyond mirroring the server.
+ */
+export function deployPermissionForKind(
+	perm: DeployPermission,
+	kind: Kind | UserDraftItemKind
+): DeployPermission {
+	if (perm.ok) return perm
+	if (perm.refusedBy === 'DisableDirectDeployment' && !kindGatedByDeployRules(kind)) {
+		return { ok: true }
+	}
+	return perm
+}
+
+/** The refusal a bulk action carries: it applies as soon as one selected kind is still refused. */
+export function deployPermissionForKinds(
+	perm: DeployPermission,
+	kinds: (Kind | UserDraftItemKind)[]
+): DeployPermission {
+	if (perm.ok) return perm
+	return kinds.some((k) => !deployPermissionForKind(perm, k).ok) ? perm : { ok: true }
+}
 
 /**
  * Whether the current user may deploy into `workspace`. Mirrors `check_deploy_rules` in
@@ -727,7 +800,11 @@ export async function checkDeployPermission(
 	try {
 		const me = whoami ?? (await UserService.whoami({ workspace }))
 		if (me.operator) {
-			return { ok: false, reason: "You're an operator in this workspace — operators can't deploy" }
+			return {
+				ok: false,
+				reason: "You're an operator in this workspace — operators can't deploy",
+				refusedBy: 'operator'
+			}
 		}
 		const userInfo = {
 			is_admin: !!me.is_admin,
@@ -742,7 +819,8 @@ export async function checkDeployPermission(
 			if (!canUserBypassRuleKindInRulesets(rulesets, 'DisableDirectDeployment', userInfo)) {
 				return {
 					ok: false,
-					reason: `Direct deployment to ${workspace} is disabled — fork the workspace or open a pull request`
+					reason: `Direct deployment to ${workspace} is disabled — fork the workspace or open a pull request`,
+					refusedBy: 'DisableDirectDeployment'
 				}
 			}
 			// `wm_deployers` membership is an implicit pass on this rule only, so it cannot
@@ -754,7 +832,8 @@ export async function checkDeployPermission(
 			) {
 				return {
 					ok: false,
-					reason: `Only workspace admins and members of wm_deployers can deploy to ${workspace}`
+					reason: `Only workspace admins and members of wm_deployers can deploy to ${workspace}`,
+					refusedBy: 'RestrictDeployToDeployers'
 				}
 			}
 		}

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -775,6 +775,9 @@ export function deployPermissionForKinds(
 	kinds: (Kind | UserDraftItemKind)[]
 ): DeployPermission {
 	if (perm.ok) return perm
+	// An empty selection keeps the workspace-level refusal, which is then the only thing left
+	// to say why the action is unavailable.
+	if (kinds.length === 0) return perm
 	return kinds.some((k) => !deployPermissionForKind(perm, k).ok) ? perm : { ok: true }
 }
 
@@ -817,9 +820,19 @@ export async function checkDeployPermission(
 		if (!userInfo.is_admin && !userInfo.is_super_admin) {
 			const rulesets = await fetchProtectionRulesForWorkspace(workspace)
 			if (!canUserBypassRuleKindInRulesets(rulesets, 'DisableDirectDeployment', userInfo)) {
+				// The reserved dev-workspace lock carries DisableWorkspaceForking alongside this rule,
+				// so suggesting a fork unconditionally would point at a second blocked action.
+				const canFork = canUserBypassRuleKindInRulesets(
+					rulesets,
+					'DisableWorkspaceForking',
+					userInfo
+				)
+				const advice = canFork
+					? 'fork the workspace or open a pull request'
+					: 'make your changes locally and open a pull request'
 				return {
 					ok: false,
-					reason: `Direct deployment to ${workspace} is disabled — fork the workspace or open a pull request`,
+					reason: `Direct deployment to ${workspace} is disabled — ${advice}`,
 					refusedBy: 'DisableDirectDeployment'
 				}
 			}

--- a/frontend/src/lib/workspaceProtectionRules.svelte.ts
+++ b/frontend/src/lib/workspaceProtectionRules.svelte.ts
@@ -4,7 +4,7 @@ import type { UserExt } from './stores'
 // The slice of the user identity the bypass checks read — structural, so
 // callers can pass a whoami response (normalised groups) as well as the
 // UserExt store value.
-export type RuleBypassUser = Pick<UserExt, 'is_admin' | 'username' | 'groups'>
+export type RuleBypassUser = Pick<UserExt, 'is_admin' | 'is_super_admin' | 'username' | 'groups'>
 
 // Mirrors DEV_WORKSPACE_LOCK_RULE_NAME in windmill-common. The pairing owns this rule by name:
 // attaching a dev workspace creates it, detaching deletes it. The API refuses to create or delete
@@ -102,11 +102,12 @@ export async function fetchProtectionRulesForWorkspace(
  * Checks if a user can bypass a specific ruleset
  * @param ruleset The protection ruleset to check
  * @param userInfo The user information
- * @returns true if user can bypass (is admin, in bypass_users, or has group in bypass_groups)
+ * @returns true if user can bypass (is admin or superadmin, in bypass_users, or has group in bypass_groups)
  */
 export function canUserBypassRule(ruleset: ProtectionRuleset, userInfo: RuleBypassUser): boolean {
-	// Admin always bypasses
-	if (userInfo.is_admin) {
+	// The server bypasses on `ApiAuthed.is_admin`, which it builds as `usr.is_admin ||
+	// super_admin`, so testing `is_admin` alone understates a superadmin who is a plain member.
+	if (userInfo.is_admin || userInfo.is_super_admin) {
 		return true
 	}
 

--- a/frontend/src/routes/kitchen_sink/deploy_animation/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/deploy_animation/+page.svelte
@@ -108,7 +108,7 @@
 			// Only non-draft_only rows carry a base pointer in production.
 			return staleDrafts && !items.find((it) => it.key === key)?.draftOnly
 		},
-		get deployPermission() {
+		deployPermissionForKind() {
 			return permOk
 				? { ok: true as const }
 				: { ok: false as const, reason: 'Deploy disabled by the playground toggle' }


### PR DESCRIPTION
## Problem

`checkDeployPermission` (`frontend/src/lib/utils_workspace_deploy.ts`) is the preflight that lets
the deploy UI disable an action with a reason instead of letting the click come back 403. It
mirrored only one of the terms the server's `check_deploy_rules`
(`backend/windmill-common/src/workspaces.rs`) evaluates:

- **`DisableDirectDeployment` was never checked.** In a workspace carrying only that rule the
  preflight allowed the deploy, and the request 403'd.
- **Superadmin was missing.** The server bypasses on `ApiAuthed.is_admin`, which is
  `usr.is_admin || super_admin`, while `whoami` reports the two separately. A superadmin who is a
  plain member of the workspace was refused a deploy the server allows.

## Change

Evaluate `DisableDirectDeployment` before `RestrictDeployToDeployers`, as the server does, so the
same message wins when both rules block, and add the superadmin term to the shared ruleset bypass
helper (`canUserBypassRule`).

One subtlety worth a reviewer's eye: `wm_deployers` membership is an implicit pass on
`RestrictDeployToDeployers` **only**, so it can no longer short-circuit the rules fetch the way
admin does — a deployer is still bound by a direct-deployment lock. There is a test pinning that.

The refusal is scoped to the kinds the server actually gates. `check_deploy_rules` runs from the
item handlers, and only scripts, flows, apps, resources, resource types, variables and folders
reach it — schedules and triggers hit no gate at all. Since the preflight answers per workspace
and that one answer drives the deploy action for every row, applying the new term workspace-wide
would have disabled schedule and trigger deploys the server accepts. Each refusal now carries the
term that produced it, and callers narrow a direct-deployment refusal to the gated kinds; a
selection still blocks as soon as one gated kind is in it. An empty selection keeps the
workspace-level refusal, so the reason a locked workspace offers no deploy is still stated before
the user picks a row.

The refusal text adapts to the workspace's other rules: the reserved dev-workspace lock carries
`DisableWorkspaceForking` alongside `DisableDirectDeployment`, so suggesting a fork unconditionally
would have pointed at a second blocked action. When forking is blocked the message asks for a local
change and a PR instead, matching what `NoDirectDeployAlert` already does.

`RestrictDeployToDeployers` deliberately keeps applying to every kind. It over-reaches in exactly
the same way, but it does so on `main` too, and narrowing it would loosen the UI beyond mirroring
the new rule. **No existing behaviour changes in this PR** — see the table below.

The blanket "operators can never deploy" term is likewise left exactly as it was. It is stricter
than the server, but tightening the frontend is safe and out of scope here; see **Not in scope**.

## Verification

Fixture: workspace `prod` carries ruleset `lock_prod` = `DisableDirectDeployment`; `dev` is a
non-admin member; `su` is a global superadmin who is a plain non-admin member.

Server ground truth for the action the button triggers:

```
POST /w/prod/scripts/create  as dev
403  Ruleset lock_prod of prod blocked this action:
     Cannot directly deploy in this workspace. Fork or Pull request required.

POST /w/prod/scripts/create  as su   (superadmin, not workspace admin)
201
```

Compare & deploy page, same fixture:

| user | `main` | this branch |
|---|---|---|
| `dev` (plain member) | enabled, no reason → click → 403 | disabled, reason shown |
| `su` (superadmin member) | enabled | enabled — matches the 201 above |

The superadmin case was mutation-tested: removing the new superadmin term flips that button to
disabled, so the term is what keeps it enabled rather than something incidental.

Which kinds the server gates, measured against `prod` as a plain member:

```
script 403 · variable 403 · resource 403 · resource_type 403 · folder 403   gated
schedule 200                                                               not gated
```

Same question against `stg` (which carries only `RestrictDeployToDeployers`): `script` 403,
`schedule` 200 — so that term over-reaches on `main` as well. Left alone here on purpose.

Deploy button for a lone **schedule** draft in the locked workspace, observed in the browser:

| | `main` | before this scoping | with it |
|---|---|---|---|
| schedule-only selection in `prod` | enabled | disabled ❌ | **enabled** ✅ |
| selection containing a script | enabled → 403 | disabled | **disabled** ✅ |
| any selection in `stg` | disabled | disabled | **disabled** (unchanged) |
| nothing selected in `prod` | disabled, reason shown | disabled, **reason lost** ❌ | disabled, reason shown ✅ |

Both wordings were exercised on the same fixture by toggling the second rule on `lock_prod`:

```
lock_prod = DisableDirectDeployment
  Direct deployment to prod is disabled — fork the workspace or open a pull request
lock_prod = DisableDirectDeployment + DisableWorkspaceForking
  Direct deployment to prod is disabled — make your changes locally and open a pull request
```

The `wm_deployers` subtlety was confirmed by hand in the browser: adding `dev` to the
`wm_deployers` group of both workspaces leaves the deploy button disabled on the
`DisableDirectDeployment` workspace and enables it on the `RestrictDeployToDeployers` one. The
implicit pass applies to the latter rule only, which is what the unit test pins.

The same superadmin merge was missing from the two per-item checks in this file.
`checkPathWritePermission` and `canPreserveOnBehalfOf` tested `is_admin` alone, while the server
reads the merged flag in `is_owner` and `can_preserve_on_behalf_of`. Verified: a superadmin who is
a plain non-admin member creating a script inside a folder owned only by `u/admin` gets `201`.

The compare page carries its own copy of that on-behalf-of expression in `canPreserveInParent` /
`canPreserveInCurrent`, which fed `OnBehalfOfSelector` and had the same gap. Exercised on the fork
comparison as a superadmin plain member, toggling only that user's `super_admin` flag:

| `super_admin` | "(target)" option | "Pick from workspace…" |
|---|---|---|
| `false` | disabled | disabled |
| `true` | **enabled**, preselected | enabled |

`canUserBypassRule` is shared with rule kinds beyond the two deploy ones, so the superadmin term
widens those too. That direction matches the server: every `check_user_against_rule` call site
passes `authed.is_admin`, which is built as `is_admin || super_admin`. Checked on a non-deploy
rule as well — with `RestrictPublicRunSharing` active, sharing a run publicly gives `403` for a
plain member and `200` for a superadmin who is a plain member:

```
GET /w/prod/jobs/job_public_view_token/{id}  as dev  403  Ruleset lock_prod of prod blocked
                                                          this action: Sharing a run publicly ...
GET /w/prod/jobs/job_public_view_token/{id}  as su   200
```

## Screenshots

**Before (`main`)** — the deploy button is enabled even though the server will refuse it:

![before_prod](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ah/win-2389-checkdeploypermission-is-an-incomplete-mirror-of-the-backend/1787064186-before_prod.png)

**After** — disabled, with the reason:

![after_prod](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ah/win-2389-checkdeploypermission-is-an-incomplete-mirror-of-the-backend/1787064188-after_prod.png)

## Tests

25 cases in `utils_workspace_deploy.test.ts`. The ones this branch adds each pin something it
introduces: the kind map and its two taxonomies, a direct-deployment refusal staying off ungated
kinds, the deployers-only refusal still applying to all of them, mixed-selection behaviour, the
empty selection keeping its refusal (`[].some()` is `false`, so the unguarded fold silently
reported it deployable), the advice dropping the fork suggestion when forking is blocked, the
superadmin path-write bypass, and:
the direct-deployment refusal, a `wm_deployers` member still refused by it, the superadmin bypass,
the message ordering when both rules block, and the precedence between the operator term and the
new superadmin bypass.

That last one is worth explaining. The server refuses an operator in the item handler regardless
of their global role — a superadmin who is an operator in the workspace still gets `401` creating
a script (verified). So the operator term has to stay above the admin/superadmin short-circuit; a
plausible "admins skip the whole gate" refactor would offer that user a deploy the server refuses.
Asserting it for an operator who is *also* a superadmin fails on that reordering, where asserting
it for a plain operator does not.

## Not in scope

Two gaps, both pre-existing:

**1. Two over-reaching terms remain, both pre-existing and neither made worse here.**

- `RestrictDeployToDeployers` still applies to every kind, so a schedule stays un-deployable from
  the compare page in a deployers-only workspace even though the server returns `200`. Fixing it
  is a one-line change to the map's consumer, but it *loosens* the UI relative to `main`, which
  this PR deliberately does not do.
- The operator refusal likewise applies to every kind, where the server refuses operators in the
  item handlers only, for fewer kinds. Correcting that needs per-kind behavioural evidence and
  per-row UI states.

Both point the same way — the UI refuses more than the server does, which is fail-closed. The
machinery to fix them now exists (`kindGatedByDeployRules`), so the follow-up ticket is mostly a
matter of deciding how far to loosen and verifying each kind.

**2. A duplicated message on the compare page.** When merging into a parent that carries
`DisableDirectDeployment`, `ParentWorkspaceProtectionAlert` and the preflight's own yellow reason
can both render, saying much the same thing. Flagged by review; I could not reproduce it on the
dev instance (the fixture's workspaces have no real fork lineage, so the fork comparison renders
no rows), so I have left it rather than change UI against an unreproduced hypothesis.

**3. Item editors have no preflight at all.** `checkDeployPermission` gates the deploy/compare
surfaces; the script, flow and variable editors call save directly and surface the server's 403
instead. That is a consistent-but-different UX, not a regression.




