### PR TITLE
test(agents): make the hook decision table pass from a linked worktree

### DIFF
--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -14,6 +14,16 @@ CWD="$(git -C "$H" rev-parse --show-toplevel)"
 OUT="$HOME/not-a-git-tree"   # never written to; only the guards' path checks look at it
 fails=0
 
+# A tree's own root is auto-allowable only when it is a LINKED worktree, whose `.git` is a
+# pointer file so the history lives in the main repo and survives; a primary checkout's `.git`
+# is the history itself. The suite runs from either kind, so the rows that name the root follow
+# the one it is run in — which is also what pins both halves of that rule.
+if [ -f "$CWD/.git" ]; then
+  ROOT_SOLO=allow ROOT_CHAINED=none      # linked worktree
+else
+  ROOT_SOLO=ask ROOT_CHAINED=ask         # primary checkout
+fi
+
 run() { # run <hook> <allow|ask|none> <command>
   local hook="$1" want="$2" cmd="$3" out got
   out=$(jq -nc --arg c "$cmd" --arg w "$CWD" \
@@ -45,7 +55,7 @@ run $G ask   "rm $CWD/.claude/settings.json"
 run $G ask   "rm $CWD/.claude/settings.local.json"
 run $G ask   "rm -rf $CWD/backend/.env"
 run $G ask   "rm -rf $CWD/.env.local"
-run $G ask   "rm -rf $CWD"
+run $G $ROOT_SOLO "rm -rf $CWD"
 run $G ask   "rm -rf $CWD/*"
 run $G ask   "rm -rf /etc/passwd"
 run $G ask   'rm -rf "$HOME/x"'
@@ -148,7 +158,7 @@ run $A allow "cp -r /tmp/a /tmp/b"
 run $A allow "tar -xzf /tmp/a.tar.gz -C /tmp/out"
 run $A ask   "mv /tmp/a $OUT"
 run $A ask   "mv $CWD/AGENTS.md /tmp/a"
-run $A ask   "chmod -R 777 $CWD"
+run $A $ROOT_SOLO "chmod -R 777 $CWD"
 run $A none  "ls && mv /tmp/a /tmp/b"     # proved move, unexamined neighbour
 run $A ask   'echo $(mv /tmp/a /etc)'
 run $A ask   "timeout --signal KILL 5 mv /tmp/a /etc"
@@ -164,7 +174,7 @@ run $A none  "cargo build"
 run $A none  "mkdir -p /tmp/x; mv /tmp/a /tmp/x; chmod 755 /tmp/x"   # one write per line
 run $A none  "$(printf 'mv /tmp/a /tmp/b\nchmod 755 /tmp/b')"
 run $A ask   "ls && mv /tmp/a /etc"
-run $A ask   "$(printf 'mkdir -p /tmp/x\nchmod -R 777 %s' "$CWD")"
+run $A $ROOT_CHAINED "$(printf 'mkdir -p /tmp/x\nchmod -R 777 %s' "$CWD")"
 run $A allow "cd /tmp/x && tar -xzf /tmp/a.tar.gz -C /tmp/out"
 # The checkout is a root of its own, so an in-repo move or chmod is as auto-allowable as the
 # in-repo delete already was — but one operation may not straddle it and /tmp.


### PR DESCRIPTION
## Summary

Follow-up to #10744, which merged a few minutes before this commit reached the branch.

Three rows in `.claude/hooks/test-hooks.sh` hardcoded the primary-checkout expectation for a tree's own root, so the suite reports `3 FAILURES` when run from a linked worktree — which is where much of the team works, and which #10744's own test plan asks people to use.

It is a test bug, not a guard bug. `path_class` behaves as designed in both cases: a linked worktree's root **is** auto-allowable, because its `.git` is a pointer file and the history lives in the main repo where it survives; a primary checkout's root is not, because its `.git` is the history itself. That rule predates #10744.

## Changes

- `rm -rf $CWD`, `chmod -R 777 $CWD` and the chained `chmod` variant now take their expected verdict from `[ -f "$CWD/.git" ]`, i.e. from the kind of checkout the suite runs in.
- That also pins the linked-worktree half of the root rule, which no row covered before.

## Test plan

- [x] `bash .claude/hooks/test-hooks.sh` from the primary checkout — ALL PASS
- [x] Same suite from a linked worktree (`git worktree add --detach`) — ALL PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hook decision table tests so they pass from a linked worktree. Previously, three root-targeting rows assumed a primary checkout and produced 3 failures in a linked worktree; now expected verdicts derive from the checkout kind. No guard behavior changes.

- Detects checkout kind via `[ -f "$CWD/.git" ]` and sets `ROOT_SOLO`/`ROOT_CHAINED` accordingly.
- Updates expected outcomes for `rm -rf $CWD`, `chmod -R 777 $CWD`, and the chained `mkdir …; chmod -R 777 $CWD`.
- Pins the linked-worktree half of the root rule. Only `.claude/hooks/test-hooks.sh` is modified.

<sup>Written for commit 67efefbf53ad81a5bd8b0afb30b44231be5194fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

