### PR TITLE
fix: make the listScripts parent_hash filter valid SQL

### DIFF
--- a/backend/tests/list_scripts_parent_hash.rs
+++ b/backend/tests/list_scripts_parent_hash.rs
@@ -1,0 +1,118 @@
+//! Pins the `parent_hash` filter of `GET /w/{workspace}/scripts/list`: the
+//! request must succeed and return exactly the scripts whose `parent_hashes`
+//! array contains the given hash. The filter is assembled into a raw SQL string,
+//! so a malformed predicate is only caught by executing the query.
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+fn new_script(path: &str, content: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": "",
+        "description": "",
+        "content": content,
+        "language": "deno",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    })
+}
+
+async fn create(port: u16, script: serde_json::Value) -> anyhow::Result<String> {
+    let resp = authed(
+        client().post(format!(
+            "http://localhost:{port}/api/w/test-workspace/scripts/create"
+        )),
+        "SECRET_TOKEN",
+    )
+    .json(&script)
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(status, 201, "script create should succeed: {body}");
+    Ok(body)
+}
+
+/// Paths returned by `scripts/list` for the given query string.
+async fn list_paths(port: u16, query: &str) -> anyhow::Result<Vec<String>> {
+    let resp = authed(
+        client().get(format!(
+            "http://localhost:{port}/api/w/test-workspace/scripts/list?{query}"
+        )),
+        "SECRET_TOKEN",
+    )
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(status, 200, "scripts/list?{query} should succeed: {body}");
+    let items: Vec<serde_json::Value> = serde_json::from_str(&body)?;
+    Ok(items
+        .iter()
+        .map(|it| it["path"].as_str().unwrap().to_string())
+        .collect())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_list_scripts_parent_hash_filter(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let lineage_path = "u/test-user/parent_hash_lineage";
+    let unrelated_path = "u/test-user/parent_hash_unrelated";
+
+    // A two-version lineage: v2's `parent_hashes` contains v1's hash.
+    let v1 = create(
+        port,
+        new_script(lineage_path, "export async function main() { return 1; }"),
+    )
+    .await?;
+    let mut v2_body = new_script(lineage_path, "export async function main() { return 2; }");
+    v2_body["parent_hash"] = json!(v1);
+    let v2 = create(port, v2_body).await?;
+
+    // ...plus a script with no lineage at all, which must never match.
+    create(
+        port,
+        new_script(unrelated_path, "export async function main() { return 3; }"),
+    )
+    .await?;
+
+    let all = list_paths(port, "").await?;
+    assert!(
+        all.contains(&lineage_path.to_string()) && all.contains(&unrelated_path.to_string()),
+        "unfiltered listing should return both scripts, got {all:?}"
+    );
+
+    let descendants = list_paths(port, &format!("parent_hash={v1}")).await?;
+    assert_eq!(
+        descendants,
+        vec![lineage_path.to_string()],
+        "parent_hash should return only the scripts descending from that hash"
+    );
+
+    // v2 is the head, so nothing descends from it.
+    let none = list_paths(port, &format!("parent_hash={v2}")).await?;
+    assert!(
+        none.is_empty(),
+        "no script descends from the head version, got {none:?}"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -289,7 +289,9 @@ async fn list_scripts(
         sqlb.and_where_eq("parent_hashes[array_upper(parent_hashes, 1)]", &ph.0);
     }
     if let Some(ph) = &lq.parent_hash {
-        sqlb.and_where_eq("any(parent_hashes)", &ph.0);
+        // ANY() only ever sits on the right of the comparison; `and_where_eq` would
+        // emit it on the left and Postgres rejects that as a syntax error.
+        sqlb.and_where("? = ANY(parent_hashes)".bind(&ph.0));
     }
     if let Some(it) = &lq.is_template {
         sqlb.and_where_eq("is_template", it);


### PR DESCRIPTION
## Summary

`GET /w/{workspace}/scripts/list` returned a 400 with `syntax error at or near "any"` whenever the optional `parent_hash` filter was supplied. The filter was built as `and_where_eq("any(parent_hashes)", hash)`, which emits `any(parent_hashes) = <hash>` — `ANY()` is only valid on the right-hand side of a comparison in PostgreSQL, so the endpoint could never serve the parameter it documents.

Fixes GIT-969

## Changes

- `backend/windmill-api-scripts/src/scripts.rs`: build the `parent_hash` predicate as `<hash> = ANY(parent_hashes)` via `and_where` + `bind`, matching the surrounding SQL-builder conventions. The hash is an `i64` newtype, so `bind` interpolates a bare integer literal.
- `backend/tests/list_scripts_parent_hash.rs`: new regression test driving the endpoint over HTTP — builds a two-version lineage plus an unrelated script, then asserts the filter returns the descendants of a hash, returns nothing for the head version, and that the unfiltered listing is unaffected.

No API-surface change: the `parent_hash` query parameter and its OpenAPI description already existed, and hash parsing and authorization are untouched.

## Test plan

- [x] `cargo test --features quickjs --test list_scripts_parent_hash` passes; reverting the one-line fix makes it fail with the exact `syntax error at or near "any"` from the report.
- [x] `--test script_auto_parent_archived --test runnables_list_pagination` still pass (the neighbouring script-listing coverage).
- [x] Exercised on a running dev instance: `scripts/list?parent_hash=<v1>` returns the v2 script, `parent_hash=<head>` returns `[]`, an unfiltered list is unchanged, and combinations with `show_archived`, `first_parent_hash` and `path_start` all return 200. A hash whose `i64` value is negative (`ffffffffffffffff`) also returns 200, confirming the bare integer literal is parenthesised safely by the builder.

## Note on reach

Creating a new version archives the parent row and `scripts/list` defaults to `archived = false`, so `parent_hash=<old hash>` surfaces the still-active descendant rather than every intermediate version; `show_archived=true` narrows to the newest row per path and so does not recover them either. Both are pre-existing properties of the surrounding filters, not introduced here — recorded so nobody expects this parameter to walk full version history.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid SQL in GET /w/{workspace}/scripts/list when the optional parent_hash filter is used, so the endpoint now returns scripts whose parent_hashes contain the given hash. Previously it emitted ANY(parent_hashes) = <hash> and returned 400; now it builds <hash> = ANY(parent_hashes). Fixes GIT-969.

- Builds the predicate via the SQL builder with a bound value: "? = ANY(parent_hashes)".
- Adds an HTTP regression test that creates a two-version lineage and verifies: descendants of v1 are returned, head has no descendants, and unfiltered results are unchanged.
- No API changes or migrations. Existing list semantics remain: with defaults, only active descendants are shown; show_archived does not traverse full history.

<sup>Written for commit bab0154f4406fca4b6725c7958ed05fd731c9d39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

