### PR TITLE
feat: rework the resource type list in the add-resource drawer

### DIFF
--- a/frontend/src/lib/components/AppConnectDrawer.svelte
+++ b/frontend/src/lib/components/AppConnectDrawer.svelte
@@ -57,7 +57,7 @@
 		step = 1
 		dispatch('close')
 	}}
-	size="800px"
+	size="700px"
 	{disableChatOffset}
 >
 	<DrawerContent

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -4,7 +4,13 @@
 	import { userStore, workspaceStore } from '$lib/stores'
 	import LabelsInput from './LabelsInput.svelte'
 	import IconedResourceType from './IconedResourceType.svelte'
-	import { resourceTypeSearchText, sortResourceTypesByMatch } from './resourceTypeDisplay'
+	import {
+		isCustomResourceTypeName,
+		resourceTypeDisplayName,
+		resourceTypeMatchRank,
+		resourceTypeSearchText,
+		sortResourceTypesByMatch
+	} from './resourceTypeDisplay'
 	import {
 		OauthService,
 		ResourceService,
@@ -15,7 +21,7 @@
 	} from '$lib/gen'
 	import { emptyString, truncateRev, urlize } from '$lib/utils'
 	import oauthConnectRegistry from '$oauth_connect_registry'
-	import { createEventDispatcher, onDestroy } from 'svelte'
+	import { createEventDispatcher, onDestroy, tick, untrack } from 'svelte'
 	import Path from './Path.svelte'
 	import { Button, RadioCard, Skeleton } from './common'
 	import ApiConnectForm from './ApiConnectForm.svelte'
@@ -36,6 +42,7 @@
 	import SyncResourceTypes from './SyncResourceTypes.svelte'
 	import Label from './Label.svelte'
 	import ResourcePathHint from './ResourcePathHint.svelte'
+	import { twMerge } from 'tailwind-merge'
 
 	interface Props {
 		step?: number
@@ -71,6 +78,9 @@
 		'oracledb'
 	]
 
+	const SEARCH_INPUT_ID = 'search-resource-type'
+	let searchInput: { focus: () => void } | undefined = $state(undefined)
+
 	let filter = $state('')
 	let value: string = $state('')
 	let valueToken: TokenResponse | undefined = undefined
@@ -100,6 +110,19 @@
 	let connectsManual: { key: string; img?: string; instructions: string[] }[] | undefined =
 		$state(undefined)
 	let resourceTypeDescriptions: Record<string, string> = $state({})
+	// The hub sync writes into the `admins` workspace, where every workspace reads them from;
+	// a type sitting in this workspace was defined here. `created_by` looks like the same
+	// signal but isn't: seeded hub types carry a username too.
+	let customResourceTypes: Set<string> = $state(new Set())
+
+	// Hub descriptions are markdown; a row shows one line of it, where fenced blocks and
+	// backticks read as noise.
+	const plainDescription = (d: string) =>
+		d
+			.replace(/```[\s\S]*?```/g, '')
+			.replace(/`/g, '')
+			.replace(/\s+/g, ' ')
+			.trim()
 	let args: any = $state({})
 	let renderDescription = $state(true)
 
@@ -276,6 +299,14 @@
 	 * credentials form with the user's own credentials — even when the instance
 	 * has shared ones (the "Instance-configured OAuth APIs" section is the entry
 	 * point for those). Every other type opens the raw manual form. */
+	function connectOauth(key: string) {
+		manual = false
+		connectClient = key
+		resourceType = stripSandboxSuffix(key)
+		resetClientCredentialsState()
+		next()
+	}
+
 	function selectFromOthers(key: string) {
 		connectClient = key
 		resourceType = key
@@ -300,6 +331,8 @@
 			loadResourceTypes()
 		}
 		step = 1 //express && !manual ? 3 : 1
+		// The list is keyboard-driven from the search field, so it takes focus on open.
+		tick().then(() => searchInput?.focus())
 		value = ''
 		description = ''
 		labels = undefined
@@ -358,9 +391,13 @@
 		}
 	}
 
+	// Google's terms require its own button on the control that starts the sign-in, which is
+	// the step-2 Connect: step 1 only picks a type, and a manual step 2 saves a resource
+	// without ever reaching Google.
 	run(() => {
 		isGoogleSignin =
-			step == 1 &&
+			step == 2 &&
+			!manual &&
 			(resourceType == 'google' ||
 				resourceType == 'gmail' ||
 				resourceType == 'gcal' ||
@@ -408,6 +445,14 @@
 			.then((types) => {
 				resourceTypeDescriptions = Object.fromEntries(
 					types.filter((t) => t.description).map((t) => [t.name, t.description!])
+				)
+				customResourceTypes = new Set(
+					types
+						.filter(
+							(t) =>
+								isCustomResourceTypeName(t.name) || (t.workspace_id && t.workspace_id !== 'admins')
+						)
+						.map((t) => t.name)
 				)
 			})
 			.catch(() => {})
@@ -902,6 +947,94 @@
 		rank(filteredConnectsManual) as typeof filteredConnectsManual | undefined
 	)
 
+	// Browsing, the "Others" list leads with the native database types. Searching, that
+	// grouping would outrank the search itself — `ms_sql_server` sorting under `mysql` on
+	// "sql" — so the ranked order stands on its own.
+	let manualOrderedKeys = $derived(
+		filter === ''
+			? [
+					...(rankedConnectsManual ?? [])
+						.filter((x) => nativeLanguagesCategory.includes(x.key))
+						.map((x) => x.key),
+					...(rankedConnectsManual ?? [])
+						.filter((x) => !nativeLanguagesCategory.includes(x.key))
+						.map((x) => x.key)
+				]
+			: (rankedConnectsManual ?? []).map((x) => x.key)
+	)
+
+	let customKeys = $derived(manualOrderedKeys.filter((key) => customResourceTypes.has(key)))
+	let otherKeys = $derived(manualOrderedKeys.filter((key) => !customResourceTypes.has(key)))
+
+	// Every row in the order it is rendered, so arrow keys walk the sections as one list.
+	// A provider appears in more than one, so rows are addressed by index, not by name.
+	let navItems = $derived([
+		...customKeys.map((key) => ({ key, oauth: false })),
+		...(rankedConnects ?? []).map((x) => ({ key: x.key, oauth: true })),
+		...otherKeys.map((key) => ({ key, oauth: false }))
+	])
+	let highlightedIndex = $state(-1)
+	const rowDomId = (index: number) => `resource-type-row-${index}`
+
+	// Set at hover time rather than up front, so only the descriptions the row actually cut
+	// off carry a tooltip.
+	function titleIfTruncated(e: MouseEvent & { currentTarget: HTMLElement }) {
+		const el = e.currentTarget
+		el.title = el.scrollWidth > el.clientWidth ? (el.textContent?.trim() ?? '') : ''
+	}
+	const oauthRowOffset = $derived(customKeys.length)
+	const otherRowOffset = $derived(customKeys.length + (rankedConnects?.length ?? 0))
+
+	// Sections are rendered in a fixed order, so the best match is not necessarily the first
+	// row: rank the rows against the query to find it.
+	function bestMatchIndex(): number {
+		let best = navItems.length > 0 ? 0 : -1
+		let bestRank = Infinity
+		navItems.forEach((item, index) => {
+			const rank = resourceTypeMatchRank(item.key, resourceTypeDescriptions[item.key], filter)
+			if (rank < bestRank) {
+				bestRank = rank
+				best = index
+			}
+		})
+		return best
+	}
+
+	// Filtering reshuffles the rows under the highlight: point it at the best match so Enter
+	// takes the top hit, and drop it entirely once the filter is cleared.
+	$effect(() => {
+		navItems
+		filter
+		untrack(() => (highlightedIndex = filter === '' ? -1 : bestMatchIndex()))
+	})
+
+	function moveHighlight(delta: number) {
+		const count = navItems.length
+		if (count === 0) return
+		highlightedIndex =
+			highlightedIndex < 0
+				? delta > 0
+					? 0
+					: count - 1
+				: (highlightedIndex + delta + count) % count
+		document.getElementById(rowDomId(highlightedIndex))?.scrollIntoView({ block: 'nearest' })
+	}
+
+	function onListKeydown(e: KeyboardEvent) {
+		if (step !== 1) return
+		if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+			e.preventDefault()
+			moveHighlight(e.key === 'ArrowDown' ? 1 : -1)
+		} else if (e.key === 'Enter' && (e.target as HTMLElement)?.id === SEARCH_INPUT_ID) {
+			// Rows are buttons, so Enter on a focused row already activates it; this only
+			// covers Enter typed in the search field.
+			const item = navItems[highlightedIndex]
+			if (!item) return
+			e.preventDefault()
+			item.oauth ? connectOauth(item.key) : selectFromOthers(item.key)
+		}
+	}
+
 	let editScopes = $state(false)
 </script>
 
@@ -923,105 +1056,135 @@
 		f={(x) => resourceTypeSearchText(x.key, resourceTypeDescriptions[x.key])}
 	/>
 	{#if step == 1}
-		<div class="pb-2 my-1">
-			<div class="relative w-full">
-				<Search class="absolute left-2 top-1/2 -translate-y-1/2 text-tertiary" size={14} />
-				<TextInput
-					inputProps={{ placeholder: 'Search resource type', id: 'search-resource-type' }}
-					bind:value={filter}
-					class="pl-7 text-xs w-full"
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<!-- Arrow keys and Enter are caught here so they work whether the search field or a row
+		     holds focus. -->
+		<div onkeydown={onListKeydown}>
+			<!-- The list runs to a few hundred rows, so the search stays reachable while scrolling.
+			     `before` paints the scroll container's own top padding, which rows would otherwise
+			     scroll through above the bar; a negative top margin would drag the whole list up
+			     under it instead. -->
+			<div
+				class="sticky top-0 z-10 -mx-4 px-4 pb-4 bg-surface before:content-[''] before:absolute
+				before:inset-x-0 before:bottom-full before:h-4 before:bg-surface"
+			>
+				<div class="relative w-full">
+					<Search class="absolute left-2 top-1/2 -translate-y-1/2 text-tertiary" size={14} />
+					<TextInput
+						bind:this={searchInput}
+						inputProps={{ placeholder: 'Search resource type', id: SEARCH_INPUT_ID }}
+						bind:value={filter}
+						class="pl-7 text-xs w-full"
+					/>
+				</div>
+			</div>
+
+			{#snippet resourceRow(key: string)}
+				<div class="flex flex-row items-center gap-4 w-full min-w-0 text-left">
+					<div class="shrink-0">
+						<IconedResourceType name={key} silent width="20px" height="20px" />
+					</div>
+					<div class="flex flex-col gap-1 min-w-0">
+						<div class="flex flex-row items-baseline gap-2 min-w-0">
+							<span class="truncate leading-5">{resourceTypeDisplayName(key)}</span>
+							<span class="shrink-0 font-mono text-2xs font-normal text-hint">{key}</span>
+						</div>
+						{#if resourceTypeDescriptions[key]}
+							<span
+								class="truncate text-xs font-normal leading-4 text-secondary"
+								onmouseenter={titleIfTruncated}
+							>
+								{plainDescription(resourceTypeDescriptions[key])}
+							</span>
+						{/if}
+					</div>
+				</div>
+			{/snippet}
+
+			{#snippet resourceButton(key: string, index: number, oauth: boolean)}
+				<Button
+					id={rowDomId(index)}
+					aiId={`app-connect-inner-${key}`}
+					aiDescription={`Connect to ${key}`}
+					unifiedSize="md"
+					variant="subtle"
+					btnClasses={twMerge(
+						'justify-start px-3 h-auto py-3 scroll-mt-14 scroll-mb-2',
+						// The pointer moves the same highlight the arrow keys move, so the variant's
+						// own hover is off: two lit rows at once would be ambiguous.
+						'hover:bg-transparent',
+						// `!` so the highlight also wins on the row the pointer is over, whose own
+						// hover was turned off just above.
+						index === highlightedIndex ? '!bg-surface-hover' : ''
+					)}
+					on:mouseenter={() => (highlightedIndex = index)}
+					on:click={() => (oauth ? connectOauth(key) : selectFromOthers(key))}
+				>
+					{@render resourceRow(key)}
+				</Button>
+			{/snippet}
+
+			{#if customKeys.length > 0}
+				<h2 class="mb-3 text-2xs font-normal uppercase text-secondary">Custom resource types</h2>
+				<div class="flex flex-col gap-1 mb-10">
+					{#each customKeys as key, i}
+						{@render resourceButton(key, i, false)}
+					{/each}
+				</div>
+			{/if}
+
+			<h2 class="mb-4 text-2xs font-normal uppercase text-secondary">
+				Instance-configured OAuth APIs
+			</h2>
+			<div class="flex flex-col gap-1">
+				{#if rankedConnects}
+					{#each rankedConnects as { key }, i}
+						{@render resourceButton(key, oauthRowOffset + i, true)}
+					{/each}
+				{:else}
+					{#each new Array(3) as _}
+						<Skeleton layout={[[2]]} />
+					{/each}
+				{/if}
+			</div>
+			{#if connects && connects.filter(isSharedConnect).length == 0}
+				<div class="text-secondary text-xs w-full"
+					>No OAuth APIs have been set up on this instance. To add OAuth APIs, first sync the
+					resource types with the hub, then add OAuth configuration. See <a
+						href="https://www.windmill.dev/docs/misc/setup_oauth">documentation</a
+					>
+				</div>
+			{/if}
+
+			<h2 class="mt-10 mb-3 text-2xs font-normal uppercase text-secondary">Others</h2>
+
+			{#if connectsManual && connectsManual?.length < 10}
+				<div class="text-secondary text-xs p-2">
+					Resource types have not been synced with the hub
+				</div>
+			{/if}
+
+			<div class="flex flex-col gap-1 mb-2">
+				{#if rankedConnectsManual}
+					{#each otherKeys as key, i}
+						{@render resourceButton(key, otherRowOffset + i, false)}
+					{/each}
+				{:else}
+					{#each new Array(9) as _}
+						<Skeleton layout={[[2]]} />
+					{/each}
+				{/if}
+			</div>
+			<div class="mt-6">
+				<SyncResourceTypes
+					onSynced={async () => {
+						connectsManual = undefined
+						await loadResourceTypes()
+						connects = undefined
+						await loadConnects()
+					}}
 				/>
 			</div>
-		</div>
-
-		<h2 class="mb-4 text-sm font-semibold text-emphasis">Instance-configured OAuth APIs</h2>
-		<div class="grid sm:grid-cols-2 md:grid-cols-3 gap-x-2 gap-y-1 items-center">
-			{#if rankedConnects}
-				{#each rankedConnects as { key }}
-					<Button
-						unifiedSize="md"
-						variant="default"
-						selected={key === connectClient}
-						on:click={() => {
-							manual = false
-							connectClient = key
-							resourceType = stripSandboxSuffix(key)
-							resetClientCredentialsState()
-							next()
-						}}
-					>
-						<IconedResourceType name={key} after={true} width="20px" height="20px" />
-					</Button>
-				{/each}
-			{:else}
-				{#each new Array(3) as _}
-					<Skeleton layout={[[2]]} />
-				{/each}
-			{/if}
-		</div>
-		{#if connects && connects.filter(isSharedConnect).length == 0}
-			<div class="text-secondary text-xs w-full"
-				>No OAuth APIs have been set up on this instance. To add OAuth APIs, first sync the resource
-				types with the hub, then add OAuth configuration. See <a
-					href="https://www.windmill.dev/docs/misc/setup_oauth">documentation</a
-				>
-			</div>
-		{/if}
-
-		<h2 class="mt-8 mb-2 text-sm font-semibold text-emphasis">Others</h2>
-
-		{#if connectsManual && connectsManual?.length < 10}
-			<div class="text-secondary text-xs p-2">
-				Resource types have not been synced with the hub
-			</div>
-		{/if}
-
-		<div class="grid sm:grid-cols-2 md:grid-cols-3 gap-x-2 gap-y-1 items-center mb-2">
-			{#if rankedConnectsManual}
-				{#each rankedConnectsManual as { key }}
-					{#if nativeLanguagesCategory.includes(key)}
-						<Button
-							unifiedSize="md"
-							variant="default"
-							selected={key === resourceType}
-							on:click={() => selectFromOthers(key)}
-						>
-							<IconedResourceType name={key} after={true} width="20px" height="20px" />
-						</Button>
-					{/if}
-				{/each}
-			{/if}
-			{#if rankedConnectsManual}
-				{#each rankedConnectsManual as { key }}
-					{#if !nativeLanguagesCategory.includes(key)}
-						<!-- Exclude specific items -->
-						<Button
-							aiId={`app-connect-inner-${key}`}
-							aiDescription={`Connect to ${key}`}
-							unifiedSize="md"
-							variant="default"
-							selected={key === resourceType}
-							on:click={() => selectFromOthers(key)}
-						>
-							<IconedResourceType name={key} after={true} width="20px" height="20px" />
-						</Button>
-					{/if}
-				{/each}
-			{:else}
-				{#each new Array(9) as _}
-					<Skeleton layout={[[2]]} />
-				{/each}
-			{/if}
-		</div>
-		<div class="mt-6">
-			<SyncResourceTypes
-				onSynced={async () => {
-					connectsManual = undefined
-					await loadResourceTypes()
-					connects = undefined
-					await loadConnects()
-				}}
-			/>
 		</div>
 	{:else if step == 2 && manual}
 		<div class="flex flex-col gap-8">

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -950,11 +950,13 @@
 		rank(filteredConnectsManual) as typeof filteredConnectsManual | undefined
 	)
 
+	let searching = $derived(filter.trim() !== '')
+
 	// Browsing, the "Others" list leads with the native database types. Searching, that
 	// grouping would outrank the search itself — `ms_sql_server` sorting under `mysql` on
 	// "sql" — so the ranked order stands on its own.
 	let manualOrderedKeys = $derived(
-		filter === ''
+		!searching
 			? [
 					...(rankedConnectsManual ?? [])
 						.filter((x) => nativeLanguagesCategory.includes(x.key))
@@ -976,7 +978,6 @@
 		...(rankedConnects ?? []).map((x) => ({ key: x.key, oauth: true })),
 		...otherKeys.map((key) => ({ key, oauth: false }))
 	])
-	let searching = $derived(filter.trim() !== '')
 	// Both lists start undefined and render skeletons; "nothing found" only means something
 	// once they have landed.
 	let listsLoaded = $derived(rankedConnectsManual !== undefined && rankedConnects !== undefined)
@@ -1012,7 +1013,7 @@
 	$effect(() => {
 		navItems
 		filter
-		untrack(() => (highlightedIndex = filter === '' ? -1 : bestMatchIndex()))
+		untrack(() => (highlightedIndex = searching ? bestMatchIndex() : -1))
 	})
 
 	// Scrolling rows under a resting pointer makes the browser fire `mouseenter` on each one,

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -110,9 +110,10 @@
 	let connectsManual: { key: string; img?: string; instructions: string[] }[] | undefined =
 		$state(undefined)
 	let resourceTypeDescriptions: Record<string, string> = $state({})
-	// The hub sync writes into the `admins` workspace, where every workspace reads them from;
-	// a type sitting in this workspace was defined here. `created_by` looks like the same
-	// signal but isn't: seeded hub types carry a username too.
+	// Types made in this workspace, by the `c_` prefix the resources page adds or by the
+	// workspace they live in — the hub sync writes its own into `admins`, which every
+	// workspace reads from. `created_by` looks like the same signal but isn't: seeded hub
+	// types carry a username too.
 	let customResourceTypes: Set<string> = $state(new Set())
 
 	// Hub descriptions are markdown; a row shows one line of it, where fenced blocks and
@@ -434,6 +435,9 @@
 		const availableRts = await ResourceService.listResourceTypeNames({
 			workspace: effectiveWorkspace
 		})
+		// The prefix alone identifies a workspace-made type, and it rides on the names call the
+		// list already needs — so the custom section survives the full list below 403ing.
+		customResourceTypes = new Set(availableRts.filter(isCustomResourceTypeName))
 
 		// Descriptions only feed search, so they are fetched off the critical path and
 		// allowed to fail: `resources/type/list` is not on the public app domain's route
@@ -446,14 +450,13 @@
 				resourceTypeDescriptions = Object.fromEntries(
 					types.filter((t) => t.description).map((t) => [t.name, t.description!])
 				)
-				customResourceTypes = new Set(
-					types
-						.filter(
-							(t) =>
-								isCustomResourceTypeName(t.name) || (t.workspace_id && t.workspace_id !== 'admins')
-						)
-						.map((t) => t.name)
-				)
+				// A type sitting in this workspace was made here too, but only the full list carries
+				// `workspace_id`. Inside `admins` the two are indistinguishable — every type lives
+				// there — so the prefix is all there is to go on.
+				customResourceTypes = new Set([
+					...customResourceTypes,
+					...types.filter((t) => t.workspace_id && t.workspace_id !== 'admins').map((t) => t.name)
+				])
 			})
 			.catch(() => {})
 
@@ -1008,16 +1011,31 @@
 		untrack(() => (highlightedIndex = filter === '' ? -1 : bestMatchIndex()))
 	})
 
+	// Scrolling rows under a resting pointer makes the browser fire `mouseenter` on each one,
+	// which would drag the highlight back under the cursor as the arrow keys move it. Only a
+	// real pointer move hands the highlight back to the mouse.
+	let pointerOwnsHighlight = $state(true)
+
+	function highlightHovered(index: number) {
+		if (pointerOwnsHighlight) highlightedIndex = index
+	}
+
 	function moveHighlight(delta: number) {
 		const count = navItems.length
 		if (count === 0) return
+		pointerOwnsHighlight = false
+		// Rows are tabbable buttons, so focus can sit on one. Enter then activates whatever is
+		// focused, which has to stay the highlighted row.
+		const rowWasFocused = document.activeElement?.id?.startsWith('resource-type-row-') ?? false
 		highlightedIndex =
 			highlightedIndex < 0
 				? delta > 0
 					? 0
 					: count - 1
 				: (highlightedIndex + delta + count) % count
-		document.getElementById(rowDomId(highlightedIndex))?.scrollIntoView({ block: 'nearest' })
+		const row = document.getElementById(rowDomId(highlightedIndex))
+		row?.scrollIntoView({ block: 'nearest' })
+		if (rowWasFocused) row?.focus()
 	}
 
 	function onListKeydown(e: KeyboardEvent) {
@@ -1026,8 +1044,7 @@
 			e.preventDefault()
 			moveHighlight(e.key === 'ArrowDown' ? 1 : -1)
 		} else if (e.key === 'Enter' && (e.target as HTMLElement)?.id === SEARCH_INPUT_ID) {
-			// Rows are buttons, so Enter on a focused row already activates it; this only
-			// covers Enter typed in the search field.
+			// A focused row activates itself on Enter; this covers Enter typed in the search field.
 			const item = navItems[highlightedIndex]
 			if (!item) return
 			e.preventDefault()
@@ -1059,7 +1076,7 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<!-- Arrow keys and Enter are caught here so they work whether the search field or a row
 		     holds focus. -->
-		<div onkeydown={onListKeydown}>
+		<div onkeydown={onListKeydown} onpointermove={() => (pointerOwnsHighlight = true)}>
 			<!-- The list runs to a few hundred rows, so the search stays reachable while scrolling.
 			     `before` paints the scroll container's own top padding, which rows would otherwise
 			     scroll through above the bar; a negative top margin would drag the whole list up
@@ -1104,8 +1121,8 @@
 			{#snippet resourceButton(key: string, index: number, oauth: boolean)}
 				<Button
 					id={rowDomId(index)}
-					aiId={`app-connect-inner-${key}`}
-					aiDescription={`Connect to ${key}`}
+					aiId={`app-connect-inner-${oauth ? 'oauth-' : ''}${key}`}
+					aiDescription={`Connect to ${key}${oauth ? ' with the instance OAuth client' : ''}`}
 					unifiedSize="md"
 					variant="subtle"
 					btnClasses={twMerge(
@@ -1117,7 +1134,7 @@
 						// hover was turned off just above.
 						index === highlightedIndex ? '!bg-surface-hover' : ''
 					)}
-					on:mouseenter={() => (highlightedIndex = index)}
+					on:mouseenter={() => highlightHovered(index)}
 					on:click={() => (oauth ? connectOauth(key) : selectFromOthers(key))}
 				>
 					{@render resourceRow(key)}

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -976,6 +976,10 @@
 		...(rankedConnects ?? []).map((x) => ({ key: x.key, oauth: true })),
 		...otherKeys.map((key) => ({ key, oauth: false }))
 	])
+	let searching = $derived(filter.trim() !== '')
+	// Both lists start undefined and render skeletons; "nothing found" only means something
+	// once they have landed.
+	let listsLoaded = $derived(rankedConnectsManual !== undefined && rankedConnects !== undefined)
 	let highlightedIndex = $state(-1)
 	const rowDomId = (index: number) => `resource-type-row-${index}`
 
@@ -1076,15 +1080,14 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<!-- Arrow keys and Enter are caught here so they work whether the search field or a row
 		     holds focus. -->
-		<div onkeydown={onListKeydown} onpointermove={() => (pointerOwnsHighlight = true)}>
-			<!-- The list runs to a few hundred rows, so the search stays reachable while scrolling.
-			     `before` paints the scroll container's own top padding, which rows would otherwise
-			     scroll through above the bar; a negative top margin would drag the whole list up
-			     under it instead. -->
-			<div
-				class="sticky top-0 z-10 -mx-4 px-4 pb-4 bg-surface before:content-[''] before:absolute
-				before:inset-x-0 before:bottom-full before:h-4 before:bg-surface"
-			>
+		<!-- Full height so the rows scroll inside their own box: the search field and the sync
+		     button stay put, and the drawer itself never scrolls. -->
+		<div
+			class="flex flex-col h-full min-h-0"
+			onkeydown={onListKeydown}
+			onpointermove={() => (pointerOwnsHighlight = true)}
+		>
+			<div class="shrink-0 pb-4">
 				<div class="relative w-full">
 					<Search class="absolute left-2 top-1/2 -translate-y-1/2 text-tertiary" size={14} />
 					<TextInput
@@ -1118,6 +1121,12 @@
 				</div>
 			{/snippet}
 
+			{#snippet sectionHeading(title: string, count: number)}
+				<h2 class="mb-3 text-2xs font-normal uppercase text-secondary">
+					{title}{#if searching}<span class="ml-2 text-hint">{count}</span>{/if}
+				</h2>
+			{/snippet}
+
 			{#snippet resourceButton(key: string, index: number, oauth: boolean)}
 				<Button
 					id={rowDomId(index)}
@@ -1126,7 +1135,7 @@
 					unifiedSize="md"
 					variant="subtle"
 					btnClasses={twMerge(
-						'justify-start px-3 h-auto py-3 scroll-mt-14 scroll-mb-2',
+						'justify-start px-3 h-auto py-3 scroll-my-2',
 						// The pointer moves the same highlight the arrow keys move, so the variant's
 						// own hover is off: two lit rows at once would be ambiguous.
 						'hover:bg-transparent',
@@ -1141,58 +1150,85 @@
 				</Button>
 			{/snippet}
 
-			{#if customKeys.length > 0}
-				<h2 class="mb-3 text-2xs font-normal uppercase text-secondary">Custom resource types</h2>
-				<div class="flex flex-col gap-1 mb-10">
-					{#each customKeys as key, i}
-						{@render resourceButton(key, i, false)}
-					{/each}
-				</div>
-			{/if}
-
-			<h2 class="mb-4 text-2xs font-normal uppercase text-secondary">
-				Instance-configured OAuth APIs
-			</h2>
-			<div class="flex flex-col gap-1">
-				{#if rankedConnects}
-					{#each rankedConnects as { key }, i}
-						{@render resourceButton(key, oauthRowOffset + i, true)}
-					{/each}
+			<div class="flex-1 min-h-0 overflow-y-auto">
+				{#if searching && listsLoaded && navItems.length === 0}
+					<div class="flex flex-col items-center gap-1 py-16 text-center">
+						<span class="text-sm text-primary">No resource type matches “{filter.trim()}”</span>
+						<span class="text-xs text-secondary">
+							Search on the name, the product or what the resource holds — or sync resource types
+							with the hub for more.
+						</span>
+					</div>
 				{:else}
-					{#each new Array(3) as _}
-						<Skeleton layout={[[2]]} />
-					{/each}
+					<!-- One gap between sections, owned by the column: a section that a search empties
+					     out then takes its spacing with it. -->
+					<div class="flex flex-col gap-10">
+						{#if customKeys.length > 0}
+							<section>
+								{@render sectionHeading('Custom resource types', customKeys.length)}
+								<div class="flex flex-col gap-1">
+									{#each customKeys as key, i}
+										{@render resourceButton(key, i, false)}
+									{/each}
+								</div>
+							</section>
+						{/if}
+
+						{#if !searching || (rankedConnects?.length ?? 0) > 0}
+							<section>
+								{@render sectionHeading(
+									'Instance-configured OAuth APIs',
+									rankedConnects?.length ?? 0
+								)}
+								<div class="flex flex-col gap-1">
+									{#if rankedConnects}
+										{#each rankedConnects as { key }, i}
+											{@render resourceButton(key, oauthRowOffset + i, true)}
+										{/each}
+									{:else}
+										{#each new Array(3) as _}
+											<Skeleton layout={[[2]]} />
+										{/each}
+									{/if}
+								</div>
+								{#if !searching && connects && connects.filter(isSharedConnect).length == 0}
+									<div class="text-secondary text-xs w-full"
+										>No OAuth APIs have been set up on this instance. To add OAuth APIs, first sync
+										the resource types with the hub, then add OAuth configuration. See <a
+											href="https://www.windmill.dev/docs/misc/setup_oauth">documentation</a
+										>
+									</div>
+								{/if}
+							</section>
+						{/if}
+
+						{#if !searching || otherKeys.length > 0}
+							<section>
+								{@render sectionHeading('Others', otherKeys.length)}
+
+								{#if !searching && connectsManual && connectsManual?.length < 10}
+									<div class="text-secondary text-xs p-2">
+										Resource types have not been synced with the hub
+									</div>
+								{/if}
+
+								<div class="flex flex-col gap-1">
+									{#if rankedConnectsManual}
+										{#each otherKeys as key, i}
+											{@render resourceButton(key, otherRowOffset + i, false)}
+										{/each}
+									{:else}
+										{#each new Array(9) as _}
+											<Skeleton layout={[[2]]} />
+										{/each}
+									{/if}
+								</div>
+							</section>
+						{/if}
+					</div>
 				{/if}
 			</div>
-			{#if connects && connects.filter(isSharedConnect).length == 0}
-				<div class="text-secondary text-xs w-full"
-					>No OAuth APIs have been set up on this instance. To add OAuth APIs, first sync the
-					resource types with the hub, then add OAuth configuration. See <a
-						href="https://www.windmill.dev/docs/misc/setup_oauth">documentation</a
-					>
-				</div>
-			{/if}
-
-			<h2 class="mt-10 mb-3 text-2xs font-normal uppercase text-secondary">Others</h2>
-
-			{#if connectsManual && connectsManual?.length < 10}
-				<div class="text-secondary text-xs p-2">
-					Resource types have not been synced with the hub
-				</div>
-			{/if}
-
-			<div class="flex flex-col gap-1 mb-2">
-				{#if rankedConnectsManual}
-					{#each otherKeys as key, i}
-						{@render resourceButton(key, otherRowOffset + i, false)}
-					{/each}
-				{:else}
-					{#each new Array(9) as _}
-						<Skeleton layout={[[2]]} />
-					{/each}
-				{/if}
-			</div>
-			<div class="mt-6">
+			<div class="shrink-0 pt-4">
 				<SyncResourceTypes
 					onSynced={async () => {
 						connectsManual = undefined

--- a/frontend/src/lib/components/AppConnectLightweightResourcePicker.svelte
+++ b/frontend/src/lib/components/AppConnectLightweightResourcePicker.svelte
@@ -34,9 +34,11 @@
 
 <DarkModeObserver bind:darkMode />
 
-<div>
+<!-- Column so the step-1 list, which fills its parent to scroll its rows on its own, has a
+     height to fill here too. -->
+<div class="flex flex-col h-full min-h-0">
 	{#if !express}
-		<div class="flex flex-row-reverse w-full pb-2">
+		<div class="flex flex-row-reverse w-full pb-2 shrink-0">
 			<div class="flex gap-2">
 				{#if step > 2}
 					<Button variant="default" on:click={appConnect?.back ?? (() => {})}>Back</Button>
@@ -54,14 +56,16 @@
 			</div>
 		</div>
 	{/if}
-	<AppConnectInner
-		{express}
-		bind:this={appConnect}
-		bind:step
-		bind:resourceType
-		bind:disabled
-		bind:manual
-		on:error
-		on:refresh
-	/>
+	<div class="flex-1 min-h-0">
+		<AppConnectInner
+			{express}
+			bind:this={appConnect}
+			bind:step
+			bind:resourceType
+			bind:disabled
+			bind:manual
+			on:error
+			on:refresh
+		/>
+	</div>
 </div>

--- a/frontend/src/lib/components/ResourceTypePicker.svelte
+++ b/frontend/src/lib/components/ResourceTypePicker.svelte
@@ -77,7 +77,7 @@
 					{@const isPicked = value === undefined}
 					<Button
 						size="sm"
-						variant="default"
+						variant="subtle"
 						selected={isPicked}
 						disabled={notPickable}
 						on:click={() => {
@@ -92,7 +92,8 @@
 					{@const isPicked = value === r.name}
 					<Button
 						size="sm"
-						variant="default"
+						variant="subtle"
+						btnClasses="justify-start"
 						selected={isPicked}
 						disabled={notPickable}
 						on:click={() => {

--- a/frontend/src/lib/components/resourceTypeDisplay.ts
+++ b/frontend/src/lib/components/resourceTypeDisplay.ts
@@ -219,12 +219,16 @@ export function resourceTypeDisplayName(name: string): string {
 		.join(' ')
 }
 
+/** All-caps names said as a word rather than letter by letter ("a NATS resource"). */
+const SPOKEN_AS_WORD = new Set(['NATS'])
+
 /**
  * "Add **a** Supabase resource" / "Add **an** Airtable resource". Takes the display label, so
  * a leading acronym is read out letter by letter: "an S3 resource", "an MCP resource".
  */
 export function resourceTypeArticle(label: string): string {
-	const spokenAsVowel = /^[AEFHILMNORSX]([A-Z0-9]|$)/.test(label)
+	const firstWord = label.split(' ')[0] ?? ''
+	const spokenAsVowel = !SPOKEN_AS_WORD.has(firstWord) && /^[AEFHILMNORSX]([A-Z0-9]|$)/.test(label)
 	return spokenAsVowel || /^[aeiou]/i.test(label) ? 'an' : 'a'
 }
 

--- a/frontend/src/lib/components/resourceTypeDisplay.ts
+++ b/frontend/src/lib/components/resourceTypeDisplay.ts
@@ -4,7 +4,9 @@
  * name alone means searching "google" finds none of the Google integrations.
  */
 export function resourceTypeSearchText(name: string, description?: string): string {
-	return description ? `${name} ${description}` : name
+	const label = resourceTypeDisplayName(name)
+	const named = label.toLowerCase() === name ? name : `${name} ${label}`
+	return description ? `${named} ${description}` : named
 }
 
 function isWordStart(haystack: string, at: number): boolean {
@@ -14,15 +16,15 @@ function isWordStart(haystack: string, at: number): boolean {
 /**
  * Sort key for one resource type against a search query, lowest first.
  *
- * Searching the description makes a query like "google" match a dozen types, most of which
- * only mention the product in passing — so the ranking has to put a match on the type's own
- * name above any description match, otherwise `googleai` lands below `anthropic`.
- * Ties break on where the match starts: a description opening with the query describes the
- * product, one mentioning it halfway through is an aside.
+ * Three fields can match, and they are not worth the same: the name someone types to get
+ * this exact type, the product name it is displayed under, and the description — which
+ * mentions a dozen products in passing, so `googleai` has to outrank `anthropic` on
+ * "google". Hence the tiers: name, then display name, then description.
+ * Within a field, ties break on where the match starts: a field opening with the query is
+ * about the query, one mentioning it halfway through is an aside.
  *
- * Returns Number.MAX_SAFE_INTEGER when the query appears in neither field, so a caller
- * matching more loosely than a substring (uFuzzy) keeps those results last instead of
- * dropping them.
+ * Returns Number.MAX_SAFE_INTEGER when the query appears in no field, so a caller matching
+ * more loosely than a substring (uFuzzy) keeps those results last instead of dropping them.
  */
 export function resourceTypeMatchRank(
 	name: string,
@@ -35,18 +37,20 @@ export function resourceTypeMatchRank(
 	const n = name.toLowerCase()
 	if (n === q) return 0
 
-	const inName = n.indexOf(q)
-	if (inName >= 0) {
-		const tier = inName === 0 ? 1 : isWordStart(n, inName) ? 2 : 3
-		return tier * 1e4 + Math.min(inName, 9999)
+	const fields: [string, number][] = [
+		[n, 1],
+		[resourceTypeDisplayName(name).toLowerCase(), 4],
+		[(description ?? '').toLowerCase(), 7]
+	]
+
+	for (const [haystack, baseTier] of fields) {
+		const at = haystack.indexOf(q)
+		if (at < 0) continue
+		const tier = at === 0 ? baseTier : isWordStart(haystack, at) ? baseTier + 1 : baseTier + 2
+		return tier * 1e4 + Math.min(at, 9999)
 	}
 
-	const d = (description ?? '').toLowerCase()
-	const inDescription = d.indexOf(q)
-	if (inDescription < 0) return Number.MAX_SAFE_INTEGER
-
-	const tier = isWordStart(d, inDescription) ? 4 : 5
-	return tier * 1e4 + Math.min(inDescription, 9999)
+	return Number.MAX_SAFE_INTEGER
 }
 
 /**
@@ -76,6 +80,151 @@ export function resourceTypeLabel(name: string): string {
 	return spaced.charAt(0).toUpperCase() + spaced.slice(1)
 }
 
+/**
+ * Casing for name parts that capitalizing the first letter gets wrong — acronyms, and brands
+ * that carry a capital inside the word. Anything absent is capitalized, which is right for
+ * the great majority of types (`stripe` -> `Stripe`).
+ */
+const RESOURCE_TYPE_WORDS: Record<string, string> = {
+	ai: 'AI',
+	ai21: 'AI21',
+	amqp: 'AMQP',
+	api: 'API',
+	aws: 'AWS',
+	cms: 'CMS',
+	crm: 'CRM',
+	db: 'DB',
+	ftp: 'FTP',
+	gcp: 'GCP',
+	gpg: 'GPG',
+	hr: 'HR',
+	http: 'HTTP',
+	id: 'ID',
+	ifs: 'IFS',
+	json: 'JSON',
+	jwt: 'JWT',
+	ldap: 'LDAP',
+	mcp: 'MCP',
+	mqtt: 'MQTT',
+	ms: 'Microsoft',
+	nats: 'NATS',
+	oauth: 'OAuth',
+	odk: 'ODK',
+	oidc: 'OIDC',
+	rss: 'RSS',
+	s3: 'S3',
+	sdk: 'SDK',
+	smtp: 'SMTP',
+	sql: 'SQL',
+	ssh: 'SSH',
+	url: 'URL',
+	ynab: 'YNAB',
+	abstractapi: 'AbstractAPI',
+	arcgis: 'ArcGIS',
+	assemblyai: 'AssemblyAI',
+	bigquery: 'BigQuery',
+	chromadb: 'ChromaDB',
+	circleci: 'CircleCI',
+	clickhouse: 'ClickHouse',
+	clickup: 'ClickUp',
+	cockroachdb: 'CockroachDB',
+	comapeo: 'CoMapeo',
+	convertkit: 'ConvertKit',
+	currencyapi: 'CurrencyAPI',
+	customai: 'CustomAI',
+	datocms: 'DatoCMS',
+	dbt: 'dbt',
+	deepl: 'DeepL',
+	deepseek: 'DeepSeek',
+	digitalocean: 'DigitalOcean',
+	docspring: 'DocSpring',
+	docusign: 'DocuSign',
+	edgedb: 'EdgeDB',
+	faunadb: 'FaunaDB',
+	gcloud: 'Google Cloud',
+	ghostcms: 'Ghost CMS',
+	gitbook: 'GitBook',
+	github: 'GitHub',
+	gitlab: 'GitLab',
+	googleai: 'GoogleAI',
+	graphql: 'GraphQL',
+	groqai: 'GroqAI',
+	hubspot: 'HubSpot',
+	ipinfo: 'IPinfo',
+	kobotoolbox: 'KoboToolbox',
+	leonardoai: 'LeonardoAI',
+	linkedin: 'LinkedIn',
+	lumaai: 'LumaAI',
+	mailerlite: 'MailerLite',
+	mongodb: 'MongoDB',
+	mysql: 'MySQL',
+	netbox: 'NetBox',
+	netsuite: 'NetSuite',
+	newsapi: 'NewsAPI',
+	neondb: 'NeonDB',
+	nocodb: 'NocoDB',
+	openai: 'OpenAI',
+	openrouter: 'OpenRouter',
+	oracledb: 'OracleDB',
+	pagerduty: 'PagerDuty',
+	pandadoc: 'PandaDoc',
+	paypal: 'PayPal',
+	planetscale: 'PlanetScale',
+	postgresql: 'PostgreSQL',
+	readme: 'ReadMe',
+	rest: 'REST',
+	quickbooks: 'QuickBooks',
+	sendgrid: 'SendGrid',
+	servicenow: 'ServiceNow',
+	signoz: 'SigNoz',
+	surrealdb: 'SurrealDB',
+	togetherai: 'TogetherAI',
+	webscrapingai: 'WebScrapingAI',
+	weatherapi: 'WeatherAPI',
+	whatsapp: 'WhatsApp',
+	woocommerce: 'WooCommerce'
+}
+
+/** Types whose label is not their name with the parts re-cased. */
+const RESOURCE_TYPE_NAMES: Record<string, string> = {
+	adobe_acrobat_sign: 'Adobe Acrobat Sign',
+	bamboo_hr: 'BambooHR',
+	cacertificate: 'CA certificate',
+	deep_infra: 'DeepInfra',
+	gcal: 'Google Calendar',
+	gdocs: 'Google Docs',
+	gdrive: 'Google Drive',
+	gforms: 'Google Forms',
+	gsheets: 'Google Sheets',
+	gworkspace: 'Google Workspace',
+	ms_sql_server: 'Microsoft SQL Server',
+	sage_intacct: 'Sage Intacct',
+	sensortower: 'Sensor Tower',
+	their_stack: 'TheirStack'
+}
+
+/** The prefix the resources page puts on a type created in a workspace. */
+const CUSTOM_TYPE_PREFIX = 'c_'
+
+export function isCustomResourceTypeName(name: string): boolean {
+	return name.startsWith(CUSTOM_TYPE_PREFIX)
+}
+
+/**
+ * Display name for a resource type: `adobe_acrobat_sign` -> `Adobe Acrobat Sign`, `mysql` ->
+ * `MySQL`, `c_acme_api` -> `Acme API`. Inferred from the name, since nothing in the type
+ * carries a product name — the two tables above only cover what the inference gets wrong.
+ */
+export function resourceTypeDisplayName(name: string): string {
+	const exact = RESOURCE_TYPE_NAMES[name]
+	if (exact) return exact
+	const stripped = isCustomResourceTypeName(name) ? name.slice(CUSTOM_TYPE_PREFIX.length) : name
+	return stripped
+		.split('_')
+		.map((word) => RESOURCE_TYPE_WORDS[word] ?? word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ')
+}
+
 /** "Add **a** Supabase resource" / "Add **an** Airtable resource". */
 export function resourceTypeArticle(name: string): string {
 	return /^[aeiou]/i.test(name) ? 'an' : 'a'
@@ -83,7 +232,7 @@ export function resourceTypeArticle(name: string): string {
 
 /** Drawer title for creating a resource, named after its type once one is picked. */
 export function addResourceTitle(resourceType: string | undefined): string {
-	return resourceType
-		? `Add ${resourceTypeArticle(resourceType)} ${resourceTypeLabel(resourceType)} resource`
-		: 'Add a resource'
+	if (!resourceType) return 'Add a resource'
+	const label = resourceTypeDisplayName(resourceType)
+	return `Add ${resourceTypeArticle(label)} ${label} resource`
 }

--- a/frontend/src/lib/components/resourceTypeDisplay.ts
+++ b/frontend/src/lib/components/resourceTypeDisplay.ts
@@ -219,22 +219,13 @@ export function resourceTypeDisplayName(name: string): string {
 		.join(' ')
 }
 
-/** All-caps names said as a word rather than letter by letter ("a NATS resource"). */
-const SPOKEN_AS_WORD = new Set(['NATS'])
-
 /**
- * "Add **a** Supabase resource" / "Add **an** Airtable resource". Takes the display label, so
- * a leading acronym is read out letter by letter: "an S3 resource", "an MCP resource".
+ * Drawer title for creating a resource, named after its type once one is picked.
+ *
+ * Article-free on purpose: whether a label takes "a" or "an" follows how it is said, which
+ * the spelling does not carry — "an S3" but "a NATS", "an MCP" but "a REST" — so every rule
+ * over the type name gets a class of them wrong.
  */
-export function resourceTypeArticle(label: string): string {
-	const firstWord = label.split(' ')[0] ?? ''
-	const spokenAsVowel = !SPOKEN_AS_WORD.has(firstWord) && /^[AEFHILMNORSX]([A-Z0-9]|$)/.test(label)
-	return spokenAsVowel || /^[aeiou]/i.test(label) ? 'an' : 'a'
-}
-
-/** Drawer title for creating a resource, named after its type once one is picked. */
 export function addResourceTitle(resourceType: string | undefined): string {
-	if (!resourceType) return 'Add a resource'
-	const label = resourceTypeDisplayName(resourceType)
-	return `Add ${resourceTypeArticle(label)} ${label} resource`
+	return resourceType ? `Add ${resourceTypeDisplayName(resourceType)} resource` : 'Add a resource'
 }

--- a/frontend/src/lib/components/resourceTypeDisplay.ts
+++ b/frontend/src/lib/components/resourceTypeDisplay.ts
@@ -74,12 +74,6 @@ export function sortResourceTypesByMatch<T>(
 		.map((entry) => entry.item)
 }
 
-/** Human-facing label for a resource type: `git_repository` -> `Git repository`. */
-export function resourceTypeLabel(name: string): string {
-	const spaced = name.replace(/_/g, ' ')
-	return spaced.charAt(0).toUpperCase() + spaced.slice(1)
-}
-
 /**
  * Casing for name parts that capitalizing the first letter gets wrong — acronyms, and brands
  * that carry a capital inside the word. Anything absent is capitalized, which is right for
@@ -225,9 +219,13 @@ export function resourceTypeDisplayName(name: string): string {
 		.join(' ')
 }
 
-/** "Add **a** Supabase resource" / "Add **an** Airtable resource". */
-export function resourceTypeArticle(name: string): string {
-	return /^[aeiou]/i.test(name) ? 'an' : 'a'
+/**
+ * "Add **a** Supabase resource" / "Add **an** Airtable resource". Takes the display label, so
+ * a leading acronym is read out letter by letter: "an S3 resource", "an MCP resource".
+ */
+export function resourceTypeArticle(label: string): string {
+	const spokenAsVowel = /^[AEFHILMNORSX]([A-Z0-9]|$)/.test(label)
+	return spokenAsVowel || /^[aeiou]/i.test(label) ? 'an' : 'a'
 }
 
 /** Drawer title for creating a resource, named after its type once one is picked. */

--- a/frontend/src/lib/components/resourceTypeMatchRank.test.ts
+++ b/frontend/src/lib/components/resourceTypeMatchRank.test.ts
@@ -10,7 +10,9 @@ const TYPES = [
 	{ name: 'gcal', description: 'Google OAuth token authorizing the Google Calendar API.' },
 	{ name: 'googleai', description: 'API key for Google AI (Gemini), optionally on Vertex AI.' },
 	{ name: 'gmail', description: 'Google OAuth token authorizing the Gmail API.' },
-	{ name: 'mailchimp', description: 'Mailchimp API key.' }
+	{ name: 'mailchimp', description: 'Mailchimp API key.' },
+	{ name: 'ms_sql_server', description: 'Connection settings for a SQL Server database.' },
+	{ name: 'azure', description: 'Microsoft Azure tenant credentials.' }
 ]
 
 const sorted = (query: string) =>
@@ -34,6 +36,12 @@ describe('sortResourceTypesByMatch', () => {
 	it('ranks a name the query starts above one where it appears mid-word', () => {
 		const order = sorted('mail')
 		expect(order.indexOf('mailchimp')).toBeLessThan(order.indexOf('gmail'))
+	})
+
+	it('ranks a match on the display name above a description match', () => {
+		// `ms_sql_server` displays as "Microsoft SQL Server"; azure only mentions Microsoft.
+		const order = sorted('microsoft')
+		expect(order.indexOf('ms_sql_server')).toBeLessThan(order.indexOf('azure'))
 	})
 
 	it('keeps the incoming order for an empty query', () => {

--- a/frontend/src/lib/components/resourceTypeMatchRank.test.ts
+++ b/frontend/src/lib/components/resourceTypeMatchRank.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { resourceTypeDisplayName, sortResourceTypesByMatch } from './resourceTypeDisplay'
+import {
+	addResourceTitle,
+	resourceTypeDisplayName,
+	sortResourceTypesByMatch
+} from './resourceTypeDisplay'
 
 // Descriptions abridged from the hub.
 const TYPES = [
@@ -60,5 +64,16 @@ describe('resourceTypeDisplayName', () => {
 
 	it('capitalizes anything the tables do not cover', () => {
 		expect(resourceTypeDisplayName('stripe')).toBe('Stripe')
+	})
+})
+
+describe('addResourceTitle', () => {
+	it('names the picked type without an article', () => {
+		expect(addResourceTitle('rest')).toBe('Add REST resource')
+		expect(addResourceTitle('stripe')).toBe('Add Stripe resource')
+	})
+
+	it('falls back to the generic title before a type is picked', () => {
+		expect(addResourceTitle(undefined)).toBe('Add a resource')
 	})
 })

--- a/frontend/src/lib/components/resourceTypeMatchRank.test.ts
+++ b/frontend/src/lib/components/resourceTypeMatchRank.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sortResourceTypesByMatch } from './resourceTypeDisplay'
+import { resourceTypeDisplayName, sortResourceTypesByMatch } from './resourceTypeDisplay'
 
 // Descriptions abridged from the hub.
 const TYPES = [
@@ -46,5 +46,19 @@ describe('sortResourceTypesByMatch', () => {
 
 	it('keeps the incoming order for an empty query', () => {
 		expect(sorted('  ')).toEqual(TYPES.map((t) => t.name))
+	})
+})
+
+describe('resourceTypeDisplayName', () => {
+	it('takes the whole-name override when there is one', () => {
+		expect(resourceTypeDisplayName('ms_sql_server')).toBe('Microsoft SQL Server')
+	})
+
+	it('drops the custom-type prefix and re-cases the rest', () => {
+		expect(resourceTypeDisplayName('c_acme_api')).toBe('Acme API')
+	})
+
+	it('capitalizes anything the tables do not cover', () => {
+		expect(resourceTypeDisplayName('stripe')).toBe('Stripe')
 	})
 })


### PR DESCRIPTION
## Summary

The "Add a resource" drawer listed 273 resource types as bordered chips in three columns, labelled by raw type name (`adobe_acrobat_sign`, `bigquery`), with each type's description reachable only by searching for words inside it. Picking a type meant scanning a wall of identifiers.

Each type is now a row carrying its product name, its type name, and its description, in a single borderless column under a sticky search field, drivable from the keyboard.

## Changes

- **Rows instead of a 3-column chip grid.** Product name + mono type name on the first line, description on the second, truncated to one line with the full text as a tooltip when it is cut off. Borderless, aligned with the drawer's own padding, 700px drawer (was 800px).
- **Display names.** `resourceTypeDisplayName` infers a product name from the type name (`mysql` → MySQL, `adobe_acrobat_sign` → Adobe Acrobat Sign, `c_acme_api` → Acme API), with a per-word table for acronyms and internal capitals and a whole-name table for the dozen that don't compose (`gdrive` → Google Drive). Checked against all 273 types on a hub-synced instance. It also feeds the drawer title, so `resourceTypeLabel` is gone.
- **Search ranks name → display name → description**, each field preferring an opening match over a word-start over a mid-word one. `microsoft` used to return `azure` first; it now leads with `ms_sql_server` and `ms_teams_webhook`. While a filter is active the native-database-first grouping is dropped, since it outranked the search itself (`sql` led with `mysql` over `ms_sql_server`).
- **Keyboard navigation.** The search field takes focus on open; ↑/↓ walk every row across all sections as one list; Enter opens the highlighted type. Hover and the arrow keys move one shared highlight — the variant's own hover is off so two rows are never lit at once.
- **A "Custom resource types" section** above the rest, for types made in this workspace (the `c_` prefix the resources page adds, or a non-`admins` `workspace_id`). Hidden when there are none.
- **Fix: the Google sign-in button on step 1.** `isGoogleSignin` was tied to `step == 1`, correct in 2022 when step 1's footer button started the OAuth flow. Today a row click advances to step 2, so the branded button only ever appeared after pressing Back from a Google type. It now tracks the control that actually starts the sign-in: `step == 2 && !manual`.

`ResourceTypePicker` (the schema-narrowing picker) keeps its 3-column grid — it renders in narrow panels where a description column doesn't fit — but picked up the same borderless, left-aligned rows.

## Screenshots

![drawer-list](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/resource-align/1787137018-drawer-list.png)

![drawer-search](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/resource-align/1787137021-drawer-search.png)

## Test plan

- [ ] Open Resources → Add resource: rows show name, type name and description; the search field has focus.
- [ ] Type `microsoft`: `ms_sql_server` and `ms_teams_webhook` come before the azure rows, and the first is highlighted. Enter opens it.
- [ ] Hold ↓ with the mouse parked over the list: the highlight advances one row at a time and does not jump back under the cursor. Tab into a row, then ↓: focus follows the highlight, so Enter opens the lit row.
- [ ] Hover a row with a clipped description: the full text appears as a tooltip. A short description gets none.
- [ ] In a workspace with a `c_`-prefixed type, the "Custom resource types" section renders above the others; with none, it is absent.
- [ ] Pick Google Sheets, then press Back: step 1 shows the normal "Next" button, not the Google sign-in image. With an instance Google OAuth client configured, picking it from the OAuth section shows the Google button on step 2.

## Notes

Verified against a local instance throughout, including the OAuth path (by configuring a dummy `gsheets` client and clearing it afterwards) and the custom section (by creating a `c_` type). `npm run check:fast` clean; `resourceTypeMatchRank.test.ts` covers the new display-name ranking tier and `resourceTypeDisplayName` itself (8 tests).

The local Codex review could not run — that account is over its usage limit until Aug 20 — so only the Claude branch review ran locally; its findings are addressed in 5c8b2ded39.