### PR TITLE
fix: scope the raw-script caches to the caller's authorization identity

### DIFF
--- a/backend/tests/fixtures/raw_script_cache_authz.sql
+++ b/backend/tests/fixtures/raw_script_cache_authz.sql
@@ -1,0 +1,32 @@
+-- Fixture for the raw-script content-cache authorization regression test.
+-- Layered on top of `base` (test-workspace, admin `test-user`/SECRET_TOKEN, plain
+-- member `test-user-2`/SECRET_TOKEN_2).
+--
+-- Folder `secret` is owned by `u/test-user` only and grants nothing through
+-- `extra_perms`, so `f/secret/lib` is invisible to test-user-2 under the script
+-- table's folder RLS policy.
+
+INSERT INTO public.folder (workspace_id, name, display_name, owners, extra_perms, created_by)
+VALUES ('test-workspace', 'secret', 'Secret Folder', '{"u/test-user"}', '{}', 'test-user');
+
+INSERT INTO public.script(workspace_id, created_by, content, schema, summary, description, path, hash, language, lock, extra_perms) VALUES (
+'test-workspace',
+'test-user',
+'TOP_SECRET_CONTENT = "leak-canary"
+',
+'{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{},"required":[],"type":"object"}',
+'',
+'',
+'f/secret/lib', 424200, 'python3', '', '{}');
+
+-- Nested one level deeper so a probe of the intermediate `f/secret/pkg` has the
+-- >2 path segments that arm the folder-existence cache.
+INSERT INTO public.script(workspace_id, created_by, content, schema, summary, description, path, hash, language, lock, extra_perms) VALUES (
+'test-workspace',
+'test-user',
+'LEAF = 1
+',
+'{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{},"required":[],"type":"object"}',
+'',
+'',
+'f/secret/pkg/leaf', 424201, 'python3', '', '{}');

--- a/backend/tests/raw_script_cache_authz.rs
+++ b/backend/tests/raw_script_cache_authz.rs
@@ -1,0 +1,109 @@
+//! Regression test for the raw-script cache authorization bypass.
+//!
+//! `GET /scripts/raw/p/{path}` answers from two process-global caches *before* the
+//! authed RLS transaction runs: `RAW_SCRIPT_CACHE` (script content, keyed partly on
+//! the caller-supplied `cache_key` query parameter) and `CACHE_FOLDERS_PATH` (folder
+//! existence). Both were populated by authorized reads but keyed without any caller
+//! identity, so any workspace member could replay another caller's request and read
+//! folder-protected content, or learn that a folder they cannot see exists.
+//!
+//! Both keys now lead with `auth_identity(&authed)`, so a hit is only ever returned
+//! to the caller whose own authorized read populated it. This pins that the caches
+//! still hit for the warming caller (a key change must not silently disable them)
+//! while a different caller replaying the same URL falls through to the RLS path and
+//! is denied — for content on both the pinned and unpinned routes.
+
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+const CANARY: &str = "leak-canary";
+const IS_FOLDER: &str = "WINDMILL_IS_FOLDER";
+/// Replayed verbatim by the attacker: `cache_key` is caller-controlled, so an
+/// attacker who learns (or guesses) a warmed one must still not get a hit.
+const CACHE_KEY: &str = "424200";
+
+async fn get(base: &str, path: &str, token: &str) -> (reqwest::StatusCode, String) {
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/{path}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    (status, resp.text().await.expect("body"))
+}
+
+#[sqlx::test(fixtures("base", "raw_script_cache_authz"))]
+async fn test_raw_script_caches_are_scoped_to_caller(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let base = format!(
+        "http://localhost:{}/api/w/test-workspace/scripts",
+        server.addr.port()
+    );
+
+    for route in ["raw", "raw_unpinned"] {
+        let url = format!("{route}/p/f/secret/lib.py?cache_key={CACHE_KEY}");
+
+        // The folder owner populates the content cache, then hits it. Both must
+        // return the content: a second miss would mean the identity-scoped key
+        // broke caching.
+        for attempt in ["warm", "hit"] {
+            let (status, body) = get(&base, &url, "SECRET_TOKEN").await;
+            assert_eq!(
+                status,
+                reqwest::StatusCode::OK,
+                "owner {attempt} on /{route} must succeed: {body}"
+            );
+            assert!(
+                body.contains(CANARY),
+                "owner {attempt} on /{route} returned unexpected content: {body}"
+            );
+        }
+
+        // CORE REGRESSION: a member with no access to folder `secret` replays the
+        // identical URL. Pre-fix this returned 200 with the content off the warm
+        // cache, before any RLS query ran.
+        let (status, body) = get(&base, &url, "SECRET_TOKEN_2").await;
+        assert_ne!(
+            status,
+            reqwest::StatusCode::OK,
+            "non-member must not read f/secret/lib via /{route} (got {status}): {body}"
+        );
+        assert!(
+            !body.contains(CANARY),
+            "non-member response on /{route} leaked the script content: {body}"
+        );
+    }
+
+    // Folder-existence cache: reading the leaf caches every ancestor folder, so a
+    // later probe of the intermediate path answers WINDMILL_IS_FOLDER off the cache.
+    let (status, _) = get(
+        &base,
+        "raw/p/f/secret/pkg/leaf.py?cache_folders=true",
+        "SECRET_TOKEN",
+    )
+    .await;
+    assert_eq!(status, reqwest::StatusCode::OK, "owner must read the leaf");
+
+    let probe = "raw/p/f/secret/pkg.py?cache_folders=true";
+    let (status, body) = get(&base, probe, "SECRET_TOKEN").await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert_eq!(body, IS_FOLDER, "owner probe must hit the folder cache");
+
+    // Pre-fix the non-member got that same 200/WINDMILL_IS_FOLDER, revealing that a
+    // folder they cannot see exists.
+    let (status, body) = get(&base, probe, "SECRET_TOKEN_2").await;
+    assert_ne!(
+        status,
+        reqwest::StatusCode::OK,
+        "non-member folder probe must not succeed (got {status}): {body}"
+    );
+    assert!(
+        !body.contains(IS_FOLDER),
+        "non-member folder probe leaked folder existence: {body}"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -13,6 +13,7 @@ use windmill_api_auth::{
     ApiAuthed,
 };
 use windmill_common::{
+    db::auth_identity,
     user_drafts::{overlay_or_draft_only, DraftUserRef, UserDraftItemKind, WithDraftOverlay},
     utils::{BulkDeleteRequest, WithStarredInfoQuery, HTTP_CLIENT},
     webhook::{WebhookMessage, WebhookShared},
@@ -2992,8 +2993,8 @@ lazy_static::lazy_static! {
 
 lazy_static::lazy_static! {
     // Imported-script content, keyed by
-    // `{ws}:{path}:{importer_cache_key}[:unpinned]:{latest_hash}`. Including the
-    // imported script's own latest hash makes each entry immutable, so no
+    // `{auth_identity}:{ws}:{path}:{importer_cache_key}[:unpinned]:{latest_hash}`.
+    // Including the imported script's own latest hash makes each entry immutable, so no
     // per-entry TTL is needed; staleness is bounded by RAW_SCRIPT_LATEST_HASH_CACHE.
     pub static ref RAW_SCRIPT_CACHE: Cache<String, String> = Cache::new(1000);
     // `{ws}:{path}` (bare path) -> (latest non-archived hash, unix_ts cached).
@@ -3081,14 +3082,22 @@ async fn raw_script_by_path_internal(
     // importer's runnable hash (`query.cache_key`). The importer hash never moves
     // when only an imported script's content changes (relock is in-place — see
     // #6769), so keying solely on it served stale content indefinitely. The
-    // importer + unpin dimensions are kept to preserve per-runnable authorization
-    // scoping (a content-cache hit skips the authed RLS query, so an entry must
-    // stay scoped to the runnable that fetched it); the imported latest hash is
-    // appended for content correctness.
-    let cache_path_base = query
-        .cache_key
-        .as_ref()
-        .map(|x| format!("{w_id}:{path}:{x}{}", if unpin { ":unpinned" } else { "" }));
+    // importer + unpin dimensions are kept because they select which content is
+    // returned; the imported latest hash is appended for content correctness.
+    //
+    // `identity` leads the key because a content-cache hit returns before the authed
+    // RLS query below runs: `query.cache_key` is caller-supplied, so without it any
+    // workspace member could replay another caller's cache_key and read a
+    // folder-protected script they cannot see. Keying on the caller's full
+    // authorization context also makes a revoked group/folder produce a miss rather
+    // than serving the old entry for the rest of the TTL.
+    let identity = auth_identity(&authed);
+    let cache_path_base = query.cache_key.as_ref().map(|x| {
+        format!(
+            "{identity}:{w_id}:{path}:{x}{}",
+            if unpin { ":unpinned" } else { "" }
+        )
+    });
 
     // Resolve the imported script's latest hash from RAW_SCRIPT_LATEST_HASH_CACHE
     // (keyed by the bare path so the deploy event can evict it). A fresh entry

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -3089,8 +3089,8 @@ async fn raw_script_by_path_internal(
     // RLS query below runs: `query.cache_key` is caller-supplied, so without it any
     // workspace member could replay another caller's cache_key and read a
     // folder-protected script they cannot see. Keying on the caller's full
-    // authorization context also makes a revoked group/folder produce a miss rather
-    // than serving the old entry for the rest of the TTL.
+    // authorization context also makes a revoked group or folder produce a miss —
+    // entries here carry no TTL, so otherwise they stayed readable until evicted.
     let identity = auth_identity(&authed);
     let cache_path_base = query.cache_key.as_ref().map(|x| {
         format!(
@@ -3134,9 +3134,12 @@ async fn raw_script_by_path_internal(
 
     // folder cache is only useful for python given it needs to recuse over all intermediate folders to find the package.
     // When a script exists in a folder, we can cache the fact that the folder exists to avoid extra db calls.
+    // Identity-scoped for the same reason as the content cache above: this hit also
+    // returns before the RLS query, and answering WINDMILL_IS_FOLDER off an entry a
+    // privileged caller warmed tells a non-member the folder exists.
     let mut split_path = path.split("/").collect::<Vec<&str>>();
     let folder_path = if query.cache_folders.is_some() && split_path.len() > 2 {
-        Some(format!("{w_id}:{path}/"))
+        Some(format!("{identity}:{w_id}:{path}/"))
     } else {
         None
     };
@@ -3238,7 +3241,10 @@ async fn raw_script_by_path_internal(
         while split_path.len() >= 2 {
             split_path.pop();
             let npath = split_path.join("/");
-            CACHE_FOLDERS_PATH.insert(format!("{w_id}:{npath}/"), chrono::Utc::now().timestamp());
+            CACHE_FOLDERS_PATH.insert(
+                format!("{identity}:{w_id}:{npath}/"),
+                chrono::Utc::now().timestamp(),
+            );
         }
     }
 

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -1,3 +1,4 @@
+use sha2::{Digest, Sha256};
 use sqlx::{Acquire, PgConnection, PgExecutor, Pool, Postgres, Transaction};
 
 use crate::audit::AuditAuthor;
@@ -117,6 +118,54 @@ impl Authable for Authed {
     fn username(&self) -> &str {
         &self.username
     }
+}
+
+/// Hash the caller's full authorization context into a stable identity string.
+///
+/// Caches that are consulted *before* the RLS query they short-circuit must key on this,
+/// so a hit can only ever be returned to a caller whose own authorized read populated it.
+///
+/// Email alone is **not** a sufficient scope: the same email can resolve to different
+/// effective permissions (`username`, groups, folders, scopes, admin/operator) through
+/// job- or owner-scoped tokens that share an email but carry a narrower `permissioned_as`.
+/// Every input that determines what the caller may read is folded in, mirroring
+/// `job_read_access_cache_key` in windmill-api, so a lower-privilege context can never
+/// reuse a higher-privilege context's cache entry. Variable-length fields are
+/// length-prefixed to keep the encoding injective.
+pub fn auth_identity<A: Authable + ?Sized>(authed: &A) -> String {
+    let mut hasher = Sha256::new();
+    let field = |hasher: &mut Sha256, bytes: &[u8]| {
+        hasher.update((bytes.len() as u32).to_be_bytes());
+        hasher.update(bytes);
+    };
+    hasher.update([authed.is_admin() as u8, authed.is_operator() as u8]);
+    field(&mut hasher, authed.email().as_bytes());
+    field(&mut hasher, authed.username().as_bytes());
+    let mut groups: Vec<&str> = authed.groups().iter().map(String::as_str).collect();
+    groups.sort_unstable();
+    hasher.update((groups.len() as u32).to_be_bytes());
+    for g in groups {
+        field(&mut hasher, g.as_bytes());
+    }
+    let mut folders: Vec<&str> = authed.folders().iter().map(|f| f.0.as_str()).collect();
+    folders.sort_unstable();
+    hasher.update((folders.len() as u32).to_be_bytes());
+    for f in folders {
+        field(&mut hasher, f.as_bytes());
+    }
+    match authed.scopes() {
+        // u32::MAX length-prefix marks "no scopes" so it can't collide with an empty list.
+        None => hasher.update(u32::MAX.to_be_bytes()),
+        Some(scopes) => {
+            let mut scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
+            scopes.sort_unstable();
+            hasher.update((scopes.len() as u32).to_be_bytes());
+            for s in scopes {
+                field(&mut hasher, s.as_bytes());
+            }
+        }
+    }
+    hex::encode(hasher.finalize())
 }
 
 lazy_static::lazy_static! {
@@ -288,5 +337,70 @@ impl<'b> DbExecutor<'b> for &'b mut PgConnection {
     }
     fn populate<'a>(&'a mut self) -> impl DbExecutor<'a> {
         &mut **self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_authed() -> Authed {
+        Authed {
+            email: "alice@x.dev".to_string(),
+            username: "alice".to_string(),
+            is_admin: false,
+            is_operator: false,
+            groups: vec!["all".to_string()],
+            folders: vec![("shared".to_string(), false, false)],
+            scopes: None,
+            token_prefix: None,
+        }
+    }
+
+    // Email alone must NOT determine the cache identity: two contexts that share an email
+    // but resolve to different effective permissions must get distinct identities, so a
+    // lower-privilege context can never reuse a higher-privilege one's cached read.
+    #[test]
+    fn auth_identity_is_not_just_email() {
+        let base = auth_identity(&base_authed());
+
+        let mut more_folders = base_authed();
+        more_folders
+            .folders
+            .push(("secret".to_string(), false, false));
+        assert_ne!(base, auth_identity(&more_folders), "folders must matter");
+
+        let mut more_groups = base_authed();
+        more_groups.groups.push("devs".to_string());
+        assert_ne!(base, auth_identity(&more_groups), "groups must matter");
+
+        let mut other_user = base_authed();
+        other_user.username = "bob".to_string();
+        assert_ne!(base, auth_identity(&other_user), "username must matter");
+
+        let mut admin = base_authed();
+        admin.is_admin = true;
+        assert_ne!(base, auth_identity(&admin), "is_admin must matter");
+
+        let mut operator = base_authed();
+        operator.is_operator = true;
+        assert_ne!(base, auth_identity(&operator), "is_operator must matter");
+
+        let mut scoped = base_authed();
+        scoped.scopes = Some(vec!["resources:read:f/secret/x".to_string()]);
+        assert_ne!(base, auth_identity(&scoped), "scopes must matter");
+    }
+
+    // Identical authorization contexts must produce the same identity (so the same caller
+    // gets a cache hit), and ordering of groups/folders must not change the identity.
+    #[test]
+    fn auth_identity_is_stable_and_order_independent() {
+        assert_eq!(auth_identity(&base_authed()), auth_identity(&base_authed()));
+
+        let mut reordered = base_authed();
+        reordered.groups = vec!["all".to_string(), "devs".to_string()];
+        let mut other_order = base_authed();
+        other_order.groups = vec!["devs".to_string(), "all".to_string()];
+        assert_eq!(auth_identity(&reordered), auth_identity(&other_order));
     }
 }

--- a/backend/windmill-store/src/var_resource_cache.rs
+++ b/backend/windmill-store/src/var_resource_cache.rs
@@ -8,9 +8,7 @@
 
 use quick_cache::sync::Cache;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
-use windmill_common::db::Authable;
 
 /// Cache TTL for variables and resources (30seconds)
 const CACHE_TTL_SECS: u64 = 30;
@@ -67,50 +65,9 @@ pub fn cache_key(workspace_id: &str, path: &str) -> String {
     format!("{}:{}", workspace_id, path)
 }
 
-/// Hash the caller's full authorization context into a stable identity string.
-///
-/// Email alone is **not** a sufficient scope: the same email can resolve to different
-/// effective permissions (`username`, groups, folders, scopes, admin/operator) through
-/// job- or owner-scoped tokens that share an email but carry a narrower `permissioned_as`.
-/// Every input that determines what the caller may read is folded in, mirroring
-/// `job_read_access_cache_key` in windmill-api, so a lower-privilege context can never
-/// reuse a higher-privilege context's cache entry. Variable-length fields are
-/// length-prefixed to keep the encoding injective.
-pub fn auth_identity<A: Authable + ?Sized>(authed: &A) -> String {
-    let mut hasher = Sha256::new();
-    let field = |hasher: &mut Sha256, bytes: &[u8]| {
-        hasher.update((bytes.len() as u32).to_be_bytes());
-        hasher.update(bytes);
-    };
-    hasher.update([authed.is_admin() as u8, authed.is_operator() as u8]);
-    field(&mut hasher, authed.email().as_bytes());
-    field(&mut hasher, authed.username().as_bytes());
-    let mut groups: Vec<&str> = authed.groups().iter().map(String::as_str).collect();
-    groups.sort_unstable();
-    hasher.update((groups.len() as u32).to_be_bytes());
-    for g in groups {
-        field(&mut hasher, g.as_bytes());
-    }
-    let mut folders: Vec<&str> = authed.folders().iter().map(|f| f.0.as_str()).collect();
-    folders.sort_unstable();
-    hasher.update((folders.len() as u32).to_be_bytes());
-    for f in folders {
-        field(&mut hasher, f.as_bytes());
-    }
-    match authed.scopes() {
-        // u32::MAX length-prefix marks "no scopes" so it can't collide with an empty list.
-        None => hasher.update(u32::MAX.to_be_bytes()),
-        Some(scopes) => {
-            let mut scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
-            scopes.sort_unstable();
-            hasher.update((scopes.len() as u32).to_be_bytes());
-            for s in scopes {
-                field(&mut hasher, s.as_bytes());
-            }
-        }
-    }
-    hex::encode(hasher.finalize())
-}
+// Canonical home is `windmill_common::db`, shared with every other cache that
+// short-circuits an RLS query; re-exported here for this module's callers.
+pub use windmill_common::db::auth_identity;
 
 /// Generate an identity-scoped cache key (`identity:workspace_id:path`).
 ///
@@ -205,107 +162,4 @@ pub fn clear_all_caches() {
     VARIABLE_CACHE.clear();
     RESOURCE_CACHE.clear();
     tracing::debug!("All variable/resource caches cleared");
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Minimal [`Authable`] double so we can assert which authorization fields the
-    /// cache identity is sensitive to, without standing up a full auth stack.
-    struct FakeAuthed {
-        email: String,
-        username: String,
-        is_admin: bool,
-        is_operator: bool,
-        groups: Vec<String>,
-        folders: Vec<(String, bool, bool)>,
-        scopes: Option<Vec<String>>,
-    }
-
-    impl FakeAuthed {
-        fn base() -> Self {
-            Self {
-                email: "alice@x.dev".to_string(),
-                username: "alice".to_string(),
-                is_admin: false,
-                is_operator: false,
-                groups: vec!["all".to_string()],
-                folders: vec![("shared".to_string(), false, false)],
-                scopes: None,
-            }
-        }
-    }
-
-    impl Authable for FakeAuthed {
-        fn email(&self) -> &str {
-            &self.email
-        }
-        fn username(&self) -> &str {
-            &self.username
-        }
-        fn is_admin(&self) -> bool {
-            self.is_admin
-        }
-        fn is_operator(&self) -> bool {
-            self.is_operator
-        }
-        fn groups(&self) -> &[String] {
-            &self.groups
-        }
-        fn folders(&self) -> &[(String, bool, bool)] {
-            &self.folders
-        }
-        fn scopes(&self) -> Option<&[String]> {
-            self.scopes.as_deref()
-        }
-    }
-
-    // Email alone must NOT determine the cache identity: two contexts that share an email
-    // but resolve to different effective permissions must get distinct identities, so a
-    // lower-privilege context can never reuse a higher-privilege one's cached secret.
-    #[test]
-    fn auth_identity_is_not_just_email() {
-        let base = auth_identity(&FakeAuthed::base());
-
-        let mut more_folders = FakeAuthed::base();
-        more_folders
-            .folders
-            .push(("secret".to_string(), false, false));
-        assert_ne!(base, auth_identity(&more_folders), "folders must matter");
-
-        let mut more_groups = FakeAuthed::base();
-        more_groups.groups.push(("devs").to_string());
-        assert_ne!(base, auth_identity(&more_groups), "groups must matter");
-
-        let mut other_user = FakeAuthed::base();
-        other_user.username = "bob".to_string();
-        assert_ne!(base, auth_identity(&other_user), "username must matter");
-
-        let mut admin = FakeAuthed::base();
-        admin.is_admin = true;
-        assert_ne!(base, auth_identity(&admin), "is_admin must matter");
-
-        let mut operator = FakeAuthed::base();
-        operator.is_operator = true;
-        assert_ne!(base, auth_identity(&operator), "is_operator must matter");
-
-        let mut scoped = FakeAuthed::base();
-        scoped.scopes = Some(vec!["resources:read:f/secret/x".to_string()]);
-        assert_ne!(base, auth_identity(&scoped), "scopes must matter");
-    }
-
-    // Identical authorization contexts must produce the same identity (so the same caller
-    // gets a cache hit), and ordering of groups/folders must not change the identity.
-    #[test]
-    fn auth_identity_is_stable_and_order_independent() {
-        let a = FakeAuthed::base();
-        assert_eq!(auth_identity(&a), auth_identity(&FakeAuthed::base()));
-
-        let mut reordered = FakeAuthed::base();
-        reordered.groups = vec!["all".to_string(), "devs".to_string()];
-        let mut other_order = FakeAuthed::base();
-        other_order.groups = vec!["devs".to_string(), "all".to_string()];
-        assert_eq!(auth_identity(&reordered), auth_identity(&other_order));
-    }
 }


### PR DESCRIPTION
Fixes WIN-2410

## Problem

`raw_script_by_path_internal` (the `/scripts/raw/p/{path}` and `/scripts/raw_unpinned/p/{path}` endpoints) answers from two process-global caches **before** the authed RLS transaction runs, and both were keyed without any caller identity:

- **`RAW_SCRIPT_CACHE`** (script content), keyed `{ws}:{path}:{cache_key}[:unpinned]:{latest_hash}`. `cache_key` is a caller-supplied query parameter — the Python import loader passes `WM_RUNNABLE_ID` — so any authenticated workspace member could replay a `cache_key` that a privileged caller had warmed and read folder-protected script content.
- **`CACHE_FOLDERS_PATH`** (folder existence), keyed `{ws}:{path}/`. A member with no access to the folder got `WINDMILL_IS_FOLDER`/200 off a warm entry instead of a 404, revealing that a folder they cannot see exists.

Neither cache has an identity component, so entries also stayed valid after a caller's permissions were revoked. The content cache carries no TTL at all (entries are immutable, keyed by the imported script's hash), so a revoked caller kept hitting it until LRU eviction.

## Fix

Both keys now lead with `auth_identity(&authed)` — the hash of the caller's full authorization context (is_admin, is_operator, email, username, groups, folders, scopes). A hit can only ever be returned to a caller whose own authorized read populated it, and a revoked group or folder changes the identity, producing a miss that falls through to the RLS path.

This is the pattern already used by the variable and resource caches in `var_resource_cache.rs`. `auth_identity` moves to `windmill_common::db`, next to the `Authable` trait it operates on and the `UserDB::begin` that sets the RLS session context, and is re-exported from its old path. The function body is unchanged, so existing variable/resource cache keys do not churn.

The folder-existence cache is beyond the issue's literal scope (which named `RAW_SCRIPT_CACHE`), but it is the same defect in the same handler and one prefix away from being closed, so it is fixed here rather than left documented.

## Cache efficacy

Unaffected for the intended consumer. Job JWTs are minted with `scopes: None` and `token_prefix` is not an `Authable` field, so a job token and a session token for the same principal hash to the same identity — the UI and jobs share entries as before. Verified on a running instance: a Python script with nested relative imports (`from f.secret.lib import ...`, `from f.secret.pkg.leaf import ...`) hits both the content cache and the folder cache on its second run.

## Verification

- New integration test `backend/tests/raw_script_cache_authz.rs`: the folder owner warms and then hits each cache, and a non-member replaying the identical URL is denied on the pinned content route, the unpinned content route, and the folder probe. Confirmed it fails on the pre-fix code for each half independently (200 + leaked content; 200 + `WINDMILL_IS_FOLDER`).
- The two `auth_identity` unit tests moved with the function and now run against the real `Authed` struct instead of a hand-written double.
- Exercised end to end on a dev instance with two real users: reproduced the leak against the pre-fix binary (HTTP 200 with the protected content), then confirmed 404 after the fix, on both routes and for the folder probe.
- Ran real Python jobs resolving relative imports through the endpoint before and after; results correct and both caches still hit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the raw-script content and folder caches to the caller’s authorization identity to close WIN-2410. Previously both caches returned before RLS and were keyed without identity, allowing cache replay to read protected content and reveal folder existence; now the keys are prefixed with `auth_identity(&authed)` so only the authorizing caller can hit, and revocations cause misses.

- Affects `/scripts/raw/p/{path}` and `/scripts/raw_unpinned/p/{path}`: `RAW_SCRIPT_CACHE` and `CACHE_FOLDERS_PATH` keys now start with the caller identity; unauthorized callers get RLS-enforced errors instead of cached 200s.
- Adds `auth_identity` to `windmill_common::db` (re-exported in `windmill-store::var_resource_cache`); the function body is unchanged, so variable/resource cache keys do not churn.
- Security impact: removes content and folder-existence leaks; identity changes on permission updates invalidate prior entries naturally.
- Rollout: no configuration or data migration; caches will repopulate on demand; UI and jobs still share entries (job tokens hash to the same identity).
- Verification: new integration test `backend/tests/raw_script_cache_authz.rs` covers both caches; unit tests for `auth_identity` moved to run against the real `Authed`.

<sup>Written for commit 67b9e0a6cea9a1aec739a375dc832e47ac2af780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

