### PR TITLE
fix: explain the 6-field cron format when a schedule is rejected

### DIFF
--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -909,6 +909,35 @@ pub enum ScheduleType {
     Cron(cron::Schedule),
 }
 
+/// Both cron parsers reject the standard 5-field crontab syntax without naming the missing
+/// leading seconds field, and croner even advertises five fields as valid while we parse
+/// with seconds required. Only that seconds-required parse is 6-field, so the hint stays
+/// off the seconds-optional path, where five fields really are accepted.
+fn six_fields_hint(schedule_str: &str, version: Option<&str>, seconds_required: bool) -> String {
+    let fields = schedule_str.split_whitespace().collect::<Vec<_>>();
+    if !seconds_required || fields.len() >= 6 {
+        return String::new();
+    }
+    let suggestion = if fields.len() == 5 {
+        // The suggestion has 6 fields, so parsing it can only recurse one level deep.
+        let with_seconds = format!("0 {}", fields.join(" "));
+        match ScheduleType::from_str(&with_seconds, version, seconds_required) {
+            Ok(_) => format!(
+                " The 5-field crontab syntax is not accepted, did you mean '{}'?",
+                with_seconds
+            ),
+            Err(_) => String::new(),
+        }
+    } else {
+        String::new()
+    };
+    format!(
+        "\nWindmill cron expressions have 6 fields and start with seconds: \
+         'sec min hour day-of-month month day-of-week'.{}",
+        suggestion
+    )
+}
+
 impl ScheduleType {
     pub fn find_next(
         &self,
@@ -947,7 +976,11 @@ impl ScheduleType {
                             schedule_str,
                             e
                         );
-                        Error::BadRequest(format!("cron: {}", e))
+                        Error::BadRequest(format!(
+                            "cron: {}{}",
+                            e,
+                            six_fields_hint(schedule_str, version, seconds_required)
+                        ))
                     })
             }
             Some("v2") | Some(_) => {
@@ -975,7 +1008,11 @@ impl ScheduleType {
                             schedule_str,
                             e
                         );
-                        Error::BadRequest(format!("cron: {}", e))
+                        Error::BadRequest(format!(
+                            "cron: {}{}",
+                            e,
+                            six_fields_hint(schedule_str, version, seconds_required)
+                        ))
                     })
                 });
 
@@ -1556,6 +1593,33 @@ pub fn truncate_with_ellipsis(s: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A 5-field crontab line is the most common way to get a schedule rejected, and both
+    /// parsers report it in terms a crontab user cannot act on, so the seconds field and the
+    /// equivalent expression must reach the caller for v1 and v2 alike.
+    #[test]
+    fn five_field_cron_error_names_the_seconds_field() {
+        for version in [None, Some("v1"), Some("v2")] {
+            let err = ScheduleType::from_str("0 2 * * *", version, true)
+                .err()
+                .expect("5-field cron must be rejected")
+                .to_string();
+            assert!(err.contains("6 fields"), "{version:?}: {err}");
+            assert!(
+                err.contains("did you mean '0 0 2 * * *'?"),
+                "{version:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn cron_error_on_other_arities_is_left_alone() {
+        let err = ScheduleType::from_str("0 0 2 * * bogus", Some("v2"), true)
+            .err()
+            .expect("invalid cron must be rejected")
+            .to_string();
+        assert!(!err.contains("6 fields"), "{err}");
+    }
 
     /// A worker that restarts must land on the exact same name to reclaim its `worker_ping`
     /// row, while still never colliding with the other workers of its own process. The

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -909,35 +909,64 @@ pub enum ScheduleType {
     Cron(cron::Schedule),
 }
 
+/// croner reads the leading seconds field as optional or required depending on these flags,
+/// so anything asking whether an expression parses has to ask it the way the caller did.
+fn croner_parser(schedule_str: &str, seconds_required: bool) -> Cron {
+    let mut croner = Cron::new(schedule_str);
+    if seconds_required {
+        croner.with_seconds_required();
+    } else {
+        croner.with_seconds_optional();
+    }
+    croner
+}
+
+/// Probes an expression this module synthesized rather than one that was submitted, so it
+/// goes around `from_str`, whose failure path logs at ERROR level.
+fn parses_as_cron(schedule_str: &str, version: Option<&str>, seconds_required: bool) -> bool {
+    match version {
+        Some("v1") | None => cron::Schedule::from_str(schedule_str).is_ok(),
+        Some(_) => panic::catch_unwind(AssertUnwindSafe(|| {
+            croner_parser(schedule_str, seconds_required)
+                .parse()
+                .is_ok()
+        }))
+        .unwrap_or(false),
+    }
+}
+
 /// Both cron parsers reject the standard 5-field crontab syntax without naming the missing
 /// leading seconds field, and croner even advertises five fields as valid while we parse
-/// with seconds required. Only that seconds-required parse is 6-field, so the hint stays
-/// off the seconds-optional path, where five fields really are accepted.
+/// with seconds required. The hint belongs to that seconds-required parse alone: croner does
+/// accept five fields once seconds are optional, which is how the worker re-reads a schedule.
 fn six_fields_hint(schedule_str: &str, version: Option<&str>, seconds_required: bool) -> String {
     let fields = schedule_str.split_whitespace().collect::<Vec<_>>();
     if !seconds_required || fields.len() >= 6 {
         return String::new();
     }
-    let suggestion = if fields.len() == 5 {
-        // The suggestion has 6 fields, so parsing it can only recurse one level deep.
-        let with_seconds = format!("0 {}", fields.join(" "));
-        match ScheduleType::from_str(&with_seconds, version, seconds_required) {
-            // v1 numbers day-of-week from Sunday=1, so a crontab line is not always
-            // equivalent to the same line with a seconds field: offer the prepend as the
-            // mechanical edit it is rather than as the same schedule.
-            Ok(_) => format!(
-                " The 5-field crontab syntax is not accepted; prepend a seconds field, e.g. '{}'.",
-                with_seconds
-            ),
-            Err(_) => String::new(),
-        }
+    // v1 numbers day-of-week from Sunday=1, so prepending a seconds field to a crontab line
+    // that names a weekday by number yields a schedule that runs a day early. Nothing but
+    // the format sentence can be given then.
+    let weekday_shifts = matches!(version, Some("v1") | None)
+        && fields
+            .get(4)
+            .is_some_and(|dow| dow.chars().any(|c| c.is_ascii_digit()));
+    let with_seconds = format!("0 {}", fields.join(" "));
+    let example = if fields.len() == 5
+        && !weekday_shifts
+        && parses_as_cron(&with_seconds, version, seconds_required)
+    {
+        format!(
+            " The 5-field crontab syntax is not accepted; prepend a seconds field, e.g. '{}'.",
+            with_seconds
+        )
     } else {
         String::new()
     };
     format!(
         "\nWindmill cron expressions have 6 fields and start with seconds: \
          'sec min hour day-of-month month day-of-week'.{}",
-        suggestion
+        example
     )
 }
 
@@ -989,13 +1018,7 @@ impl ScheduleType {
             Some("v2") | Some(_) => {
                 // Use Croner for v2
                 let schedule_type_result = panic::catch_unwind(AssertUnwindSafe(|| {
-                    let mut croner = Cron::new(schedule_str);
-                    if seconds_required {
-                        croner.with_seconds_required();
-                    } else {
-                        croner.with_seconds_optional();
-                    };
-                    croner.parse()
+                    croner_parser(schedule_str, seconds_required).parse()
                 }))
                 .map_err(|_| {
                     tracing::error!(
@@ -1613,6 +1636,28 @@ mod tests {
                 "{version:?}: {err}"
             );
         }
+    }
+
+    /// v1 reads a numeric weekday one day off from crontab, so the expression it would hand
+    /// back there is not the schedule the user wrote and must not be offered; croner numbers
+    /// weekdays like crontab, so the same input keeps its example.
+    #[test]
+    fn numeric_weekday_example_is_withheld_on_v1_only() {
+        let v1 = ScheduleType::from_str("0 2 * * 1", None, true)
+            .err()
+            .expect("5-field cron must be rejected")
+            .to_string();
+        assert!(v1.contains("6 fields"), "{v1}");
+        assert!(!v1.contains("e.g."), "{v1}");
+
+        let v2 = ScheduleType::from_str("0 2 * * 1", Some("v2"), true)
+            .err()
+            .expect("5-field cron must be rejected")
+            .to_string();
+        assert!(
+            v2.contains("prepend a seconds field, e.g. '0 0 2 * * 1'."),
+            "{v2}"
+        );
     }
 
     #[test]

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -944,16 +944,15 @@ fn six_fields_hint(schedule_str: &str, version: Option<&str>, seconds_required: 
     if !seconds_required || fields.len() >= 6 {
         return String::new();
     }
-    // v1 numbers day-of-week from Sunday=1, so prepending a seconds field to a crontab line
-    // that names a weekday by number yields a schedule that runs a day early. Nothing but
-    // the format sentence can be given then.
-    let weekday_shifts = matches!(version, Some("v1") | None)
-        && fields
-            .get(4)
-            .is_some_and(|dow| dow.chars().any(|c| c.is_ascii_digit()));
+    // A restricted weekday is where v1 parts ways with crontab: it numbers weekdays from
+    // Sunday=1, and it intersects day-of-month with day-of-week where crontab unions them.
+    // Once the weekday is unrestricted the remaining fields carry their crontab meaning, so
+    // that is the only case on v1 where a concrete expression can be handed back.
+    let v1_weekday_restricted = matches!(version, Some("v1") | None)
+        && fields.get(4).is_some_and(|dow| *dow != "*" && *dow != "?");
     let with_seconds = format!("0 {}", fields.join(" "));
     let example = if fields.len() == 5
-        && !weekday_shifts
+        && !v1_weekday_restricted
         && parses_as_cron(&with_seconds, version, seconds_required)
     {
         format!(
@@ -1638,26 +1637,29 @@ mod tests {
         }
     }
 
-    /// v1 reads a numeric weekday one day off from crontab, so the expression it would hand
-    /// back there is not the schedule the user wrote and must not be offered; croner numbers
-    /// weekdays like crontab, so the same input keeps its example.
+    /// On v1 a restricted weekday means something else than it does in the crontab line being
+    /// rewritten: `1` is Sunday there, and a weekday alongside a day-of-month intersects
+    /// instead of unions. Neither can be handed back as an expression to use; croner reads
+    /// both the crontab way, so the same inputs keep their example.
     #[test]
-    fn numeric_weekday_example_is_withheld_on_v1_only() {
-        let v1 = ScheduleType::from_str("0 2 * * 1", None, true)
-            .err()
-            .expect("5-field cron must be rejected")
-            .to_string();
-        assert!(v1.contains("6 fields"), "{v1}");
-        assert!(!v1.contains("e.g."), "{v1}");
+    fn restricted_weekday_example_is_withheld_on_v1_only() {
+        for schedule in ["0 2 * * 1", "0 2 1 * MON"] {
+            let v1 = ScheduleType::from_str(schedule, None, true)
+                .err()
+                .expect("5-field cron must be rejected")
+                .to_string();
+            assert!(v1.contains("6 fields"), "{schedule}: {v1}");
+            assert!(!v1.contains("e.g."), "{schedule}: {v1}");
 
-        let v2 = ScheduleType::from_str("0 2 * * 1", Some("v2"), true)
-            .err()
-            .expect("5-field cron must be rejected")
-            .to_string();
-        assert!(
-            v2.contains("prepend a seconds field, e.g. '0 0 2 * * 1'."),
-            "{v2}"
-        );
+            let v2 = ScheduleType::from_str(schedule, Some("v2"), true)
+                .err()
+                .expect("5-field cron must be rejected")
+                .to_string();
+            assert!(
+                v2.contains(&format!("prepend a seconds field, e.g. '0 {schedule}'.")),
+                "{schedule}: {v2}"
+            );
+        }
     }
 
     #[test]

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -922,8 +922,11 @@ fn six_fields_hint(schedule_str: &str, version: Option<&str>, seconds_required: 
         // The suggestion has 6 fields, so parsing it can only recurse one level deep.
         let with_seconds = format!("0 {}", fields.join(" "));
         match ScheduleType::from_str(&with_seconds, version, seconds_required) {
+            // v1 numbers day-of-week from Sunday=1, so a crontab line is not always
+            // equivalent to the same line with a seconds field: offer the prepend as the
+            // mechanical edit it is rather than as the same schedule.
             Ok(_) => format!(
-                " The 5-field crontab syntax is not accepted, did you mean '{}'?",
+                " The 5-field crontab syntax is not accepted; prepend a seconds field, e.g. '{}'.",
                 with_seconds
             ),
             Err(_) => String::new(),
@@ -1606,7 +1609,7 @@ mod tests {
                 .to_string();
             assert!(err.contains("6 fields"), "{version:?}: {err}");
             assert!(
-                err.contains("did you mean '0 0 2 * * *'?"),
+                err.contains("prepend a seconds field, e.g. '0 0 2 * * *'."),
                 "{version:?}: {err}"
             );
         }


### PR DESCRIPTION
## Summary

Pushing a schedule whose cron is a standard 5-field crontab string was rejected with a bare parser error and no indication of what Windmill expects:

```
Bad request: cron: 0 2 * * *
         ^
```

Windmill cron expressions carry a leading seconds field, so every 5-field crontab line fails, and neither parser says so: the `cron` crate (v1) just points a caret at the expression, and croner (v2) reports `Pattern must consist of five or six fields ... and optional second` while the API parses with seconds required, which contradicts the actual rule.

`ScheduleType::from_str` now appends the expected format to cron parse errors, and for a 5-field expression it also suggests the equivalent 6-field one:

```
Bad request: cron: 0 2 * * *
         ^

Windmill cron expressions have 6 fields and start with seconds: 'sec min hour day-of-month month day-of-week'. The 5-field crontab syntax is not accepted; prepend a seconds field, e.g. '0 0 2 * * *'.
```

This is the shared parser, so the hint reaches the CLI (`wmill schedule push`), the API, and the schedule preview alike.

## Changes

- `six_fields_hint` in `windmill-common/src/utils.rs`, appended to the parse error of both the v1 (`cron`) and v2 (croner) branches of `ScheduleType::from_str`.
- The example is only offered when the 5-field expression prefixed with a `0` seconds field actually parses, so an expression that is invalid for other reasons is not given a bogus rewrite. It is phrased as the mechanical prepend it is rather than as the same schedule.
- On v1 the example is withheld whenever the weekday field is restricted, because that is where v1 parts ways with crontab on two counts: it numbers weekdays from Sunday = 1 (`0 2 * * 1-5` prepended runs Sun-Thu, not Mon-Fri), and it intersects day-of-month with day-of-week where crontab unions them (`0 2 1 * MON` prepended runs only when the 1st is a Monday, verified against the preview endpoint). With the weekday unrestricted the remaining fields carry their crontab meaning, so that is the case where an expression can be handed back. croner reads both the crontab way, so v2 keeps the example throughout.
- The hint is suppressed on the seconds-optional parse (the worker re-parsing a stored schedule), where croner does accept 5 fields, and on expressions that already have 6 or more fields, so unrelated errors are unchanged.
- The probe that decides whether the example parses calls the two parsers directly instead of re-entering `from_str`, so a synthesized expression never produces an ERROR log line for a string nobody submitted. The croner flag setup both paths need is now one helper.

## Not covered here

The schedule editor discards the server's message for any cron 400 and renders a static `Invalid cron syntax` (`CronInput.svelte`). That surface can't show this hint anyway: `formatCron` pads any expression shorter than 6 fields with trailing `*`, so a pasted `0 2 * * *` is silently sent as `0 2 * * * *` (hourly at :02) rather than rejected. Both are pre-existing and want their own change.

## Test plan

- [x] `cargo test -p windmill-common --lib utils::tests` — the message reaches the caller for `None` / `v1` / `v2`, the example is withheld on v1 for both a numeric weekday and a weekday alongside a day-of-month while v2 keeps it, and an unrelated 6-field error stays untouched.
- [x] `POST /api/schedules/preview` on a dev instance with `0 2 * * *` (no `cron_version`, and `v2`), `0 2 * * 1`, `0 2 * * MON`, `0 2 1 * MON`, `0 2 1 * *`, a 3-field expression, garbage, and a valid `0 0 2 * * *`.
- [x] The two divergences the v1 rule guards against, confirmed against the preview endpoint: `0 0 12 * * 1-5` runs Sun-Thu on v1 and Mon-Fri on v2; `0 0 2 1 * MON` runs only when the 1st is a Monday on v1, and every Monday or 1st on v2.
- [x] The reported flow end to end: `wmill schedule push` of a YAML with `schedule: "0 2 * * *"` now prints the actionable error instead of the bare caret.
