### PR TITLE
feat(cli): deduplicate identical script lockfiles (dedupeLockfiles)

### DIFF
--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -412,6 +412,44 @@ export async function rehashOnly(
   return counts;
 }
 
+/**
+ * Normalize the tree's shared lockfiles, unless the run asked to stay inside one
+ * folder: shared lockfiles are workspace-wide, so the pass reads and rewrites
+ * metadata outside it, which `--strict-folder-boundaries` promises not to do.
+ */
+async function maybeDedupeLockfiles(
+  opts: GlobalOptions & SyncOptions & { strictFolderBoundaries?: boolean },
+  workspace: Workspace,
+  codebases: SyncCodebase[],
+  ignore: (p: string, isD: boolean) => boolean,
+  rawWorkspaceDependencies: Record<string, string>,
+  tree: DoubleLinkedDependencyTree,
+  folder: string | undefined,
+): Promise<void> {
+  if (!opts.dedupeLockfiles) return;
+  if (folder && opts.strictFolderBoundaries) {
+    log.info(
+      colors.yellow(
+        `Skipping lockfile deduplication: it spans the whole workspace, and --strict-folder-boundaries keeps this run inside "${folder}".`,
+      ),
+    );
+    return;
+  }
+  await beginLockfileBatch();
+  try {
+    await dedupeLockfilesOnDisk(
+      opts,
+      workspace,
+      codebases,
+      ignore,
+      rawWorkspaceDependencies,
+      tree,
+    );
+  } finally {
+    await flushLockfileBatch();
+  }
+}
+
 export async function generateMetadata(
   opts: GlobalOptions & {
     yes?: boolean;
@@ -611,6 +649,10 @@ export async function generateMetadata(
   // === Show stale items and confirm ===
   if (filteredItems.length === 0) {
     log.info(colors.green("All metadata up-to-date"));
+    // Turning `dedupeLockfiles` on in a repo whose metadata is already current
+    // is exactly the case where nothing is stale, and the conversion still has
+    // to happen — the sync compares against a deduplicated remote either way.
+    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder);
     return;
   }
 
@@ -777,19 +819,11 @@ export async function generateMetadata(
     const allStaleDeps = staleItems.filter((i) => i.type === "dependencies");
     await tree.persistDepsHashes(allStaleDeps.map((d) => d.path));
 
-    if (opts.dedupeLockfiles) {
-      await dedupeLockfilesOnDisk(
-        opts,
-        workspace,
-        codebases,
-        ignore,
-        rawWorkspaceDependencies,
-        tree,
-      );
-    }
   } finally {
     await flushLockfileBatch();
   }
+
+  await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder);
 
   const succeeded = total - errors.length;
   log.info("");

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -19,6 +19,7 @@ import {
 import { generateFlowLockInternal, FlowLocksResult } from "../flow/flow_metadata.ts";
 import { generateAppLocksInternal, AppLocksResult } from "../app/app_metadata.ts";
 import {
+  dedupeLockfilesOnDisk,
   elementsToMap,
   FSFSElement,
   ignoreF,
@@ -775,6 +776,17 @@ export async function generateMetadata(
     // Persist all stale workspace dep hashes (not just filtered — deps are global, not folder-scoped)
     const allStaleDeps = staleItems.filter((i) => i.type === "dependencies");
     await tree.persistDepsHashes(allStaleDeps.map((d) => d.path));
+
+    if (opts.dedupeLockfiles) {
+      await dedupeLockfilesOnDisk(
+        opts,
+        workspace,
+        codebases,
+        ignore,
+        rawWorkspaceDependencies,
+        tree,
+      );
+    }
   } finally {
     await flushLockfileBatch();
   }

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -426,7 +426,6 @@ async function maybeDedupeLockfiles(
   tree: DoubleLinkedDependencyTree,
   folder: string | undefined,
   failed: string[] = [],
-  movedDepFiles: string[] = [],
 ): Promise<void> {
   if (!opts.dedupeLockfiles) return;
   if (folder && opts.strictFolderBoundaries) {
@@ -445,7 +444,6 @@ async function maybeDedupeLockfiles(
     rawWorkspaceDependencies,
     tree,
     failed,
-    movedDepFiles,
   };
   if (opts.dryRun) {
     await dedupeLockfilesOnDisk({ ...args, dryRun: true });
@@ -840,7 +838,6 @@ export async function generateMetadata(
   await maybeDedupeLockfiles(
     opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder,
     errors.map((e) => e.path),
-    staleItems.filter((i) => i.type === "dependencies").map((i) => i.path),
   );
 
   const succeeded = total - errors.length;

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -23,9 +23,7 @@ import {
   elementsToMap,
   FSFSElement,
   ignoreF,
-  snapshotSharedLocks,
 } from "../sync/sync.ts";
-import { type ExistingSharedLocks } from "../../utils/lock_dedup.ts";
 import { hasScriptExt } from "../script/script.ts";
 import { isFolderResourcePathAnyFormat, isScriptModulePath, isModuleEntryPoint, scriptPathToRemotePath } from "../../utils/resource_folders.ts";
 import { listSyncCodebases, SyncCodebase } from "../../utils/codebase.ts";
@@ -427,7 +425,6 @@ async function maybeDedupeLockfiles(
   rawWorkspaceDependencies: Record<string, string>,
   tree: DoubleLinkedDependencyTree,
   folder: string | undefined,
-  existing: ExistingSharedLocks,
   failed: string[] = [],
 ): Promise<void> {
   if (!opts.dedupeLockfiles) return;
@@ -446,7 +443,6 @@ async function maybeDedupeLockfiles(
     ignore,
     rawWorkspaceDependencies,
     tree,
-    existing,
     failed,
   };
   if (opts.dryRun) {
@@ -506,10 +502,6 @@ export async function generateMetadata(
   // Build dependency tree for relative import tracking
   const tree = new DoubleLinkedDependencyTree();
   tree.setWorkspaceDeps(rawWorkspaceDependencies);
-
-  // Before anything regenerates: which shared lockfile each group owns is only
-  // visible while its scripts still reference it.
-  const sharedLocksBefore = await snapshotSharedLocks(opts);
 
   // === Collect stale scripts ===
   if (!skipScripts) {
@@ -667,7 +659,7 @@ export async function generateMetadata(
     // Turning `dedupeLockfiles` on in a repo whose metadata is already current
     // is exactly the case where nothing is stale, and the conversion still has
     // to happen — the sync compares against a deduplicated remote either way.
-    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder, sharedLocksBefore);
+    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder);
     return;
   }
 
@@ -697,7 +689,7 @@ export async function generateMetadata(
   if (opts.dryRun) {
     // The preview belongs on this path too: the conversion is what a stale tree
     // is about to get, and only the up-to-date path reported it.
-    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder, sharedLocksBefore);
+    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder);
     return;
   }
 
@@ -845,7 +837,7 @@ export async function generateMetadata(
   // not be re-hashed as though this run had refreshed them.
   await maybeDedupeLockfiles(
     opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder,
-    sharedLocksBefore, errors.map((e) => e.path),
+    errors.map((e) => e.path),
   );
 
   const succeeded = total - errors.length;

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -426,6 +426,7 @@ async function maybeDedupeLockfiles(
   tree: DoubleLinkedDependencyTree,
   folder: string | undefined,
   failed: string[] = [],
+  movedDepFiles: string[] = [],
 ): Promise<void> {
   if (!opts.dedupeLockfiles) return;
   if (folder && opts.strictFolderBoundaries) {
@@ -444,6 +445,7 @@ async function maybeDedupeLockfiles(
     rawWorkspaceDependencies,
     tree,
     failed,
+    movedDepFiles,
   };
   if (opts.dryRun) {
     await dedupeLockfilesOnDisk({ ...args, dryRun: true });
@@ -838,6 +840,7 @@ export async function generateMetadata(
   await maybeDedupeLockfiles(
     opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder,
     errors.map((e) => e.path),
+    staleItems.filter((i) => i.type === "dependencies").map((i) => i.path),
   );
 
   const succeeded = total - errors.length;

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -23,7 +23,9 @@ import {
   elementsToMap,
   FSFSElement,
   ignoreF,
+  snapshotSharedLocks,
 } from "../sync/sync.ts";
+import { type ExistingSharedLocks } from "../../utils/lock_dedup.ts";
 import { hasScriptExt } from "../script/script.ts";
 import { isFolderResourcePathAnyFormat, isScriptModulePath, isModuleEntryPoint, scriptPathToRemotePath } from "../../utils/resource_folders.ts";
 import { listSyncCodebases, SyncCodebase } from "../../utils/codebase.ts";
@@ -425,6 +427,7 @@ async function maybeDedupeLockfiles(
   rawWorkspaceDependencies: Record<string, string>,
   tree: DoubleLinkedDependencyTree,
   folder: string | undefined,
+  existing: ExistingSharedLocks,
 ): Promise<void> {
   if (!opts.dedupeLockfiles) return;
   if (folder && opts.strictFolderBoundaries) {
@@ -435,28 +438,22 @@ async function maybeDedupeLockfiles(
     );
     return;
   }
+  const args = {
+    opts,
+    workspace,
+    codebases,
+    ignore,
+    rawWorkspaceDependencies,
+    tree,
+    existing,
+  };
   if (opts.dryRun) {
-    await dedupeLockfilesOnDisk(
-      opts,
-      workspace,
-      codebases,
-      ignore,
-      rawWorkspaceDependencies,
-      tree,
-      true,
-    );
+    await dedupeLockfilesOnDisk({ ...args, dryRun: true });
     return;
   }
   await beginLockfileBatch();
   try {
-    await dedupeLockfilesOnDisk(
-      opts,
-      workspace,
-      codebases,
-      ignore,
-      rawWorkspaceDependencies,
-      tree,
-    );
+    await dedupeLockfilesOnDisk(args);
   } finally {
     await flushLockfileBatch();
   }
@@ -507,6 +504,10 @@ export async function generateMetadata(
   // Build dependency tree for relative import tracking
   const tree = new DoubleLinkedDependencyTree();
   tree.setWorkspaceDeps(rawWorkspaceDependencies);
+
+  // Before anything regenerates: which shared lockfile each group owns is only
+  // visible while its scripts still reference it.
+  const sharedLocksBefore = await snapshotSharedLocks(opts);
 
   // === Collect stale scripts ===
   if (!skipScripts) {
@@ -664,7 +665,7 @@ export async function generateMetadata(
     // Turning `dedupeLockfiles` on in a repo whose metadata is already current
     // is exactly the case where nothing is stale, and the conversion still has
     // to happen — the sync compares against a deduplicated remote either way.
-    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder);
+    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder, sharedLocksBefore);
     return;
   }
 
@@ -835,7 +836,7 @@ export async function generateMetadata(
     await flushLockfileBatch();
   }
 
-  await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder);
+  await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder, sharedLocksBefore);
 
   const succeeded = total - errors.length;
   log.info("");

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -428,6 +428,7 @@ async function maybeDedupeLockfiles(
   tree: DoubleLinkedDependencyTree,
   folder: string | undefined,
   existing: ExistingSharedLocks,
+  failed: string[] = [],
 ): Promise<void> {
   if (!opts.dedupeLockfiles) return;
   if (folder && opts.strictFolderBoundaries) {
@@ -446,6 +447,7 @@ async function maybeDedupeLockfiles(
     rawWorkspaceDependencies,
     tree,
     existing,
+    failed,
   };
   if (opts.dryRun) {
     await dedupeLockfilesOnDisk({ ...args, dryRun: true });
@@ -839,7 +841,12 @@ export async function generateMetadata(
     await flushLockfileBatch();
   }
 
-  await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder, sharedLocksBefore);
+  // The scripts whose generation failed keep whatever lock they had, and must
+  // not be re-hashed as though this run had refreshed them.
+  await maybeDedupeLockfiles(
+    opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder,
+    sharedLocksBefore, errors.map((e) => e.path),
+  );
 
   const succeeded = total - errors.length;
   log.info("");

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -693,6 +693,9 @@ export async function generateMetadata(
   printItems("Apps", apps);
 
   if (opts.dryRun) {
+    // The preview belongs on this path too: the conversion is what a stale tree
+    // is about to get, and only the up-to-date path reported it.
+    await maybeDedupeLockfiles(opts, workspace, codebases, ignore, rawWorkspaceDependencies, tree, folder, sharedLocksBefore);
     return;
   }
 

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -435,6 +435,18 @@ async function maybeDedupeLockfiles(
     );
     return;
   }
+  if (opts.dryRun) {
+    await dedupeLockfilesOnDisk(
+      opts,
+      workspace,
+      codebases,
+      ignore,
+      rawWorkspaceDependencies,
+      tree,
+      true,
+    );
+    return;
+  }
   await beginLockfileBatch();
   try {
     await dedupeLockfilesOnDisk(

--- a/cli/src/commands/init/template.ts
+++ b/cli/src/commands/init/template.ts
@@ -117,7 +117,7 @@ export const CONFIG_REFERENCE: ConfigOption[] = [
     section: "Sync behavior", commented: true, templateValue: "4" },
   { name: "locksRequired", type: "boolean", default: "false", description: "Require lock files for all scripts",
     commented: true, templateValue: "true" },
-  { name: "dedupeLockfiles", type: "boolean", default: "false", description: "Share one lockfile per language in dependencies/locks/, instead of an identical .script.lock per script",
+  { name: "dedupeLockfiles", type: "boolean", default: "false", description: "Share one lockfile per language in locks/, instead of an identical .script.lock per script",
     commented: true, templateValue: "true" },
   { name: "lint", type: "boolean", default: "false", description: "Run linting before push",
     commented: true, templateValue: "true" },

--- a/cli/src/commands/init/template.ts
+++ b/cli/src/commands/init/template.ts
@@ -117,6 +117,8 @@ export const CONFIG_REFERENCE: ConfigOption[] = [
     section: "Sync behavior", commented: true, templateValue: "4" },
   { name: "locksRequired", type: "boolean", default: "false", description: "Require lock files for all scripts",
     commented: true, templateValue: "true" },
+  { name: "dedupeLockfiles", type: "boolean", default: "false", description: "Share one lockfile per language in dependencies/locks/, instead of an identical .script.lock per script",
+    commented: true, templateValue: "true" },
   { name: "lint", type: "boolean", default: "false", description: "Run linting before push",
     commented: true, templateValue: "true" },
   { name: "plainSecrets", type: "boolean", default: "false", description: "Handle secrets as plain text (not recommended)",

--- a/cli/src/commands/init/template.ts
+++ b/cli/src/commands/init/template.ts
@@ -117,7 +117,7 @@ export const CONFIG_REFERENCE: ConfigOption[] = [
     section: "Sync behavior", commented: true, templateValue: "4" },
   { name: "locksRequired", type: "boolean", default: "false", description: "Require lock files for all scripts",
     commented: true, templateValue: "true" },
-  { name: "dedupeLockfiles", type: "boolean", default: "false", description: "Share one lockfile per language in locks/, instead of an identical .script.lock per script",
+  { name: "dedupeLockfiles", type: "boolean", default: "false", description: "Share one lockfile per workspace dependency file (locks/<depfile>.lock), instead of an identical .script.lock per script",
     commented: true, templateValue: "true" },
   { name: "lint", type: "boolean", default: "false", description: "Run linting before push",
     commented: true, templateValue: "true" },

--- a/cli/src/commands/lint/lint.ts
+++ b/cli/src/commands/lint/lint.ts
@@ -134,6 +134,7 @@ function formatYamlDiagnostics(parsed: { diagnostics?: Array<{ message?: string 
 async function isLockResolved(
   lockValue: string | string[] | undefined,
   baseDir: string,
+  sharedLockBase?: string,
 ): Promise<boolean> {
   if (lockValue === undefined) return false;
 
@@ -142,7 +143,11 @@ async function isLockResolved(
     const joined = lockValue.join("\n");
     if (joined === "") return false;
     if (joined.startsWith("!inline ")) {
-      return await checkInlineFile(joined.substring("!inline ".length), baseDir);
+      return await checkInlineFile(
+        joined.substring("!inline ".length),
+        baseDir,
+        sharedLockBase,
+      );
     }
     return true;
   }
@@ -151,7 +156,11 @@ async function isLockResolved(
 
   // Inline file reference
   if (lockValue.startsWith("!inline ")) {
-    return await checkInlineFile(lockValue.substring("!inline ".length), baseDir);
+    return await checkInlineFile(
+      lockValue.substring("!inline ".length),
+      baseDir,
+      sharedLockBase,
+    );
   }
 
   // Embedded lock content
@@ -161,19 +170,37 @@ async function isLockResolved(
 async function checkInlineFile(
   relativePath: string,
   baseDir: string,
+  sharedLockBase?: string,
 ): Promise<boolean> {
   const trimmed = relativePath.trim();
-  // A shared lockfile (`dedupeLockfiles`) is referenced from the sync root —
-  // which is the working directory, since every command runs from where
-  // wmill.yaml is — and not from the directory being linted.
-  const fullPath = isSharedLockPath(trimmed)
-    ? path.resolve(process.cwd(), trimmed)
-    : path.join(baseDir, trimmed);
+  // A shared lockfile (`dedupeLockfiles`) is referenced from the sync root, not
+  // from the directory being linted. Only a standalone script's metadata passes
+  // a base for it: a flow or app inline lock is folder-relative even when its
+  // name happens to look like one.
+  const fullPath =
+    sharedLockBase !== undefined && isSharedLockPath(trimmed)
+      ? path.resolve(sharedLockBase, trimmed)
+      : path.join(baseDir, trimmed);
   try {
     const s = await stat(fullPath);
     return s.size > 0;
   } catch {
     return false;
+  }
+}
+
+/** Where a repo-root-relative reference resolves from: the directory holding
+ *  wmill.yaml at or above the linted one, and that directory itself when there
+ *  is none. */
+async function findSyncRoot(dir: string): Promise<string> {
+  let current = path.resolve(dir);
+  while (true) {
+    if (await stat(path.join(current, "wmill.yaml")).then(() => true).catch(() => false)) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(dir);
+    current = parent;
   }
 }
 
@@ -513,6 +540,7 @@ export async function checkMissingLocks(
         const lockResolved = await isLockResolved(
           metadata?.lock,
           targetDirectory,
+          await findSyncRoot(targetDirectory),
         );
         if (!lockResolved) {
           issues.push({

--- a/cli/src/commands/lint/lint.ts
+++ b/cli/src/commands/lint/lint.ts
@@ -515,6 +515,7 @@ export async function checkMissingLocks(
   }
 
   // Check standalone scripts
+  const syncRoot = await findSyncRoot(targetDirectory);
   for (const yamlPath of scriptYamls) {
     const basePath = yamlPath.replace(/\.script\.yaml$/, "");
 
@@ -540,7 +541,7 @@ export async function checkMissingLocks(
         const lockResolved = await isLockResolved(
           metadata?.lock,
           targetDirectory,
-          await findSyncRoot(targetDirectory),
+          syncRoot,
         );
         if (!lockResolved) {
           issues.push({

--- a/cli/src/commands/lint/lint.ts
+++ b/cli/src/commands/lint/lint.ts
@@ -26,13 +26,13 @@ import {
   inferContentTypeFromFilePath,
   languageNeedsLock,
   ScriptLanguage,
+  isSharedLockPath,
 } from "../../utils/script_common.ts";
 import {
   isFlowInlineScriptPath,
   isAppInlineScriptPath,
   isRawAppPath,
   getFolderSuffix,
-  isSharedLockPath,
 } from "../../utils/resource_folders.ts";
 import { exts } from "../script/script.ts";
 

--- a/cli/src/commands/lint/lint.ts
+++ b/cli/src/commands/lint/lint.ts
@@ -32,6 +32,7 @@ import {
   isAppInlineScriptPath,
   isRawAppPath,
   getFolderSuffix,
+  isSharedLockPath,
 } from "../../utils/resource_folders.ts";
 import { exts } from "../script/script.ts";
 
@@ -161,7 +162,13 @@ async function checkInlineFile(
   relativePath: string,
   baseDir: string,
 ): Promise<boolean> {
-  const fullPath = path.join(baseDir, relativePath.trim());
+  const trimmed = relativePath.trim();
+  // A shared lockfile (`dedupeLockfiles`) is referenced from the sync root —
+  // which is the working directory, since every command runs from where
+  // wmill.yaml is — and not from the directory being linted.
+  const fullPath = isSharedLockPath(trimmed)
+    ? path.resolve(process.cwd(), trimmed)
+    : path.join(baseDir, trimmed);
   try {
     const s = await stat(fullPath);
     return s.size > 0;

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2520,8 +2520,7 @@ async function compareDynFSElement(
   // represents them. Collapsing the remote side (in both directions) is what
   // makes the two sides comparable: a pull then writes the shared file instead
   // of thousands of copies, and a push sees no diff for the copies it does not
-  // keep. The working tree is read unfiltered, because the shared files it holds
-  // are read by scripts these maps may not cover.
+  // keep.
   if (skips.dedupeLockfiles) {
     const remoteMap = isEls1Remote === true ? m1 : m2;
     applySharedLockPlanToMap(
@@ -4482,9 +4481,18 @@ export async function push(
   // (their lock is on disk already, in the shared file), and `--auto-metadata`
   // would otherwise run one dependency job per script sharing the lock.
   const changedPaths = new Set(changes.map((c) => c.path));
+  let unconvertedTree = false;
   for (let i = changes.length - 1; i >= 0; i--) {
     const change = changes[i];
-    if (change.name === "deleted" || !isSharedLockPath(change.path)) continue;
+    if (!isSharedLockPath(change.path)) continue;
+    if (change.name === "deleted") {
+      // The remote view is deduplicated whether or not the tree is: a shared
+      // lockfile missing from the tree reads as a deletion to push, and there is
+      // no such object to delete. Left in, it is reported on every push forever.
+      unconvertedTree = true;
+      changes.splice(i, 1);
+      continue;
+    }
     const referrers = scriptsReferencingSharedLock(localMap, change.path);
     if (referrers.length === 0) {
       // A shared lockfile no script reads is not a change to the remote in any
@@ -4506,6 +4514,13 @@ export async function push(
         after: localMap[metaPath],
       });
     }
+  }
+  if (unconvertedTree) {
+    log.warn(
+      colors.yellow(
+        `dedupeLockfiles is on but this checkout still holds one lockfile per script. Run 'wmill generate-metadata' (or pull) to convert it — until then every script reads as changed.`,
+      ),
+    );
   }
 
   const autoRegenerate = !!(opts as any).autoMetadata;

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -180,7 +180,8 @@ import { isSharedLockPath, SHARED_LOCK_DIR } from "../../utils/script_common.ts"
 import {
   applySharedLockPlanToDisk,
   applySharedLockPlanToMap,
-  metadataReadsSharedLock,
+  metadataLockUnreadable,
+  sharedLockRefOf,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
@@ -194,22 +195,91 @@ function isScriptLockPath(p: string): boolean {
 }
 
 /**
+ * Every shared lockfile the tree still reads, from a single walk.
+ *
+ * One pull can retire several at once — `--skip-workspace-dependencies` retires
+ * all of them, and consolidating k dependency files retires k-1 — so a walk per
+ * deletion would re-read and re-parse the same metadata each time. Read after
+ * the pull has applied (or refused) every metadata change, because that is the
+ * only moment the answer is settled.
+ */
+export type SharedLockReaders = {
+  /** Reference (`locks/<depfile>.lock`) to the metadata files reading it. */
+  byRef: Map<string, string[]>;
+  /** Metadata whose `lock` cannot be read, which pins every shared lockfile. */
+  unreadable: string[];
+};
+
+export async function collectSharedLockReaders(
+  json: boolean,
+): Promise<SharedLockReaders> {
+  const metaExt = json ? ".script.json" : ".script.yaml";
+  const modMeta = json ? "__mod/script.json" : "__mod/script.yaml";
+  const readers: SharedLockReaders = { byRef: new Map(), unreadable: [] };
+  const walk = async (dir: string): Promise<void> => {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (e) {
+      // A directory that is not there holds no reader. Anything else hides
+      // scripts, and a lockfile deleted out from under one resolves to nothing.
+      if ((e as { code?: string })?.code === "ENOENT") return;
+      throw e;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (isNeverWalkedDir(entry.name)) continue;
+        await walk(full);
+        continue;
+      }
+      const rel = full.replaceAll(SEP, "/");
+      if (!rel.endsWith(metaExt) && !rel.endsWith(modMeta)) continue;
+      const content = await readTextFile(full);
+      // The `lock` field, not the raw text: a folded line, a summary quoting
+      // the path, or a stale twin of the other format would each answer wrongly.
+      const ref = sharedLockRefOf(rel, content, json);
+      if (ref === undefined) {
+        if (metadataLockUnreadable(rel, content, json)) readers.unreadable.push(rel);
+        continue;
+      }
+      const existing = readers.byRef.get(ref);
+      if (existing) existing.push(rel);
+      else readers.byRef.set(ref, [rel]);
+    }
+  };
+  for (const root of ["f", "u", "g"]) {
+    await walk(root);
+  }
+  return readers;
+}
+
+/**
  * Whether the metadata beside a script lockfile still points at it. Read from
  * disk, after the pull has applied (or refused) every metadata change, because
- * that is the only moment the answer is settled — and from the `lock` field of
+ * that is the only moment the answer is settled - and from the `lock` field of
  * the twin this sync reads, not the raw text: a folded line, a summary quoting
  * the path, or a stale twin of the other format would each answer wrongly.
+ *
+ * Returns the reason it is kept, or undefined when nothing reads it.
  */
-async function isLockStillRead(
+async function lockStillReadBecause(
   lockPath: string,
   json: boolean,
-): Promise<boolean> {
+  sharedReaders: SharedLockReaders,
+): Promise<string | undefined> {
   const n = lockPath.replaceAll(SEP, "/");
   // A shared lockfile is read by any number of scripts, so the whole tree
-  // answers rather than one sibling. Only ever reached when one is on its way
-  // out, which is rare enough to pay for a walk.
+  // answers rather than one sibling.
   if (isSharedLockPath(n)) {
-    return await anyScriptReferences(n, json);
+    const readers = sharedReaders.byRef.get(n)?.length ?? 0;
+    if (readers > 0) return `${readers} script(s) on disk still reference it`;
+    if (sharedReaders.unreadable.length > 0) {
+      // Naming the file matters: on a dependency-file deletion this line is the
+      // only signal, and "still references it" would point away from the fix.
+      return `${sharedReaders.unreadable[0]} cannot be parsed, so what it reads is unknown`;
+    }
+    return undefined;
   }
   const metaPath = n.endsWith("__mod/script.lock")
     ? n.slice(0, -".lock".length) + (json ? ".json" : ".yaml")
@@ -219,60 +289,19 @@ async function isLockStillRead(
   try {
     content = await readTextFile(metaPath.replaceAll("/", SEP));
   } catch {
-    return false; // no metadata: nothing reads it
+    return undefined; // no metadata: nothing reads it
   }
   try {
     const parsed = json
       ? JSON.parse(content)
       : yamlParseContent(metaPath, content);
-    return parsed?.["lock"] === "!inline " + n;
+    return parsed?.["lock"] === "!inline " + n
+      ? `${metaPath} still references it`
+      : undefined;
   } catch {
     // Unparseable metadata is not proof that nothing reads the lock.
-    return true;
+    return `${metaPath} cannot be parsed, so what it reads is unknown`;
   }
-}
-
-/**
- * Whether any script in the workspace still reads a given lockfile, read from
- * disk after the pull has applied (or refused) every metadata change.
- */
-async function anyScriptReferences(
-  lockRef: string,
-  json: boolean,
-): Promise<boolean> {
-  const metaExt = json ? ".script.json" : ".script.yaml";
-  const modMeta = json ? "__mod/script.json" : "__mod/script.yaml";
-  const walk = async (dir: string): Promise<boolean> => {
-    let entries: Dirent[];
-    try {
-      entries = await readdir(dir, { withFileTypes: true });
-    } catch (e) {
-      // A directory that is not there holds no reader. Anything else hides
-      // scripts, and a lockfile deleted out from under one resolves to nothing.
-      if ((e as { code?: string })?.code === "ENOENT") return false;
-      throw e;
-    }
-    for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (isNeverWalkedDir(entry.name)) continue;
-        if (await walk(full)) return true;
-        continue;
-      }
-      const rel = full.replaceAll(SEP, "/");
-      if (!rel.endsWith(metaExt) && !rel.endsWith(modMeta)) continue;
-      // The `lock` field, not the raw text: a folded line, a summary quoting the
-      // path, or a stale twin of the other format would each answer wrongly.
-      if (metadataReadsSharedLock(rel, await readTextFile(full), json, lockRef)) {
-        return true;
-      }
-    }
-    return false;
-  };
-  for (const root of ["f", "u", "g"]) {
-    if (await walk(root)) return true;
-  }
-  return false;
 }
 
 /** Sync maps are keyed with the platform separator; `!inline` refs are not. */
@@ -3859,13 +3888,19 @@ export async function pull(
       }
     }
 
+    const sharedReaders = deferredLockDeletions.some((d) =>
+      isSharedLockPath(d.path),
+    )
+      ? await collectSharedLockReaders(opts.json ?? false)
+      : { byRef: new Map(), unreadable: [] };
     for (const deferred of deferredLockDeletions) {
-      if (await isLockStillRead(deferred.path, opts.json ?? false)) {
-        log.info(
-          colors.yellow(
-            `Keeping ${deferred.path}: metadata on disk still references it.`,
-          ),
-        );
+      const keptBecause = await lockStillReadBecause(
+        deferred.path,
+        opts.json ?? false,
+        sharedReaders,
+      );
+      if (keptBecause !== undefined) {
+        log.info(colors.yellow(`Keeping ${deferred.path}: ${keptBecause}.`));
         continue;
       }
       log.info(`Deleting ${changeTypeLabel(deferred.path)}${deferred.path}`);
@@ -4652,6 +4687,10 @@ export async function push(
   // would otherwise run one dependency job per script sharing the lock.
   const changedPaths = new Set(changes.map((c) => c.path));
   let unconvertedTree = false;
+  // The whole tree, not `localMap`: `includes`/`excludes` have already filtered
+  // that, and a shared lockfile's readers are exactly what the filter hides.
+  // Built once, on the first shared-lock change and never otherwise.
+  let treeReaders: SharedLockReaders | undefined;
   for (let i = changes.length - 1; i >= 0; i--) {
     const change = changes[i];
     if (!isSharedLockPath(change.path)) continue;
@@ -4664,10 +4703,25 @@ export async function push(
       continue;
     }
     const referrers = scriptsReferencingSharedLock(localMap, change.path);
+    treeReaders ??= await collectSharedLockReaders(opts.json ?? false);
+    const outOfScope =
+      (treeReaders.byRef.get(change.path.replaceAll(SEP, "/"))?.length ?? 0) -
+      referrers.length;
     // Out of `changes` either way: a shared lockfile has no object on the
     // remote, so the apply loop skips it. Left in, the preview and the "N
     // changes" count would report something no push ever applies as such.
     changes.splice(i, 1);
+    // A scoped push deploys what it was scoped to, so the readers the filter
+    // excluded keep the previous lock on the remote. Silence there is the
+    // trap: the changed file has no object of its own, so nothing else in the
+    // output would account for it.
+    if (outOfScope > 0) {
+      log.warn(
+        colors.yellow(
+          `${change.path} changed, but ${outOfScope} of the script(s) sharing it are outside this push's scope and keep the previous lock on the remote. Widen --includes/--excludes to deploy the new lock to all of them.`,
+        ),
+      );
+    }
     if (referrers.length === 0) continue;
     log.info(
       colors.gray(

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4689,7 +4689,13 @@ export async function push(
   let unconvertedTree = false;
   // The whole tree, not `localMap`: `includes`/`excludes` have already filtered
   // that, and a shared lockfile's readers are exactly what the filter hides.
-  // Built once, on the first shared-lock change and never otherwise.
+  // Nothing to hide when nothing filters, so the walk is for narrowed pushes
+  // only, once, on the first shared-lock change.
+  const scopeIsNarrowed = [
+    opts.includes,
+    opts.excludes,
+    opts.extraIncludes,
+  ].some((p) => (p?.length ?? 0) > 0);
   let treeReaders: SharedLockReaders | undefined;
   for (let i = changes.length - 1; i >= 0; i--) {
     const change = changes[i];
@@ -4703,9 +4709,19 @@ export async function push(
       continue;
     }
     const referrers = scriptsReferencingSharedLock(localMap, change.path);
-    treeReaders ??= await collectSharedLockReaders(opts.json ?? false);
+    if (scopeIsNarrowed && treeReaders === undefined) {
+      try {
+        treeReaders = await collectSharedLockReaders(opts.json ?? false);
+      } catch (e) {
+        // The walk is fail-loud because a deletion hangs on it. Nothing hangs
+        // on an advisory, so an unreadable directory costs the advisory, not
+        // the push.
+        log.debug(`Could not scan for shared-lock readers: ${e}`);
+        treeReaders = { byRef: new Map(), unreadable: [] };
+      }
+    }
     const outOfScope =
-      (treeReaders.byRef.get(change.path.replaceAll(SEP, "/"))?.length ?? 0) -
+      (treeReaders?.byRef.get(change.path.replaceAll(SEP, "/"))?.length ?? 0) -
       referrers.length;
     // Out of `changes` either way: a shared lockfile has no object on the
     // remote, so the apply loop skips it. Left in, the preview and the "N

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4689,13 +4689,8 @@ export async function push(
   let unconvertedTree = false;
   // The whole tree, not `localMap`: `includes`/`excludes` have already filtered
   // that, and a shared lockfile's readers are exactly what the filter hides.
-  // Nothing to hide when nothing filters, so the walk is for narrowed pushes
-  // only, once, on the first shared-lock change.
-  const scopeIsNarrowed = [
-    opts.includes,
-    opts.excludes,
-    opts.extraIncludes,
-  ].some((p) => (p?.length ?? 0) > 0);
+  // One metadata pass, on the first shared-lock change and never otherwise, so
+  // it is a dependency bump that pays for it and not an ordinary push.
   let treeReaders: SharedLockReaders | undefined;
   for (let i = changes.length - 1; i >= 0; i--) {
     const change = changes[i];
@@ -4709,7 +4704,7 @@ export async function push(
       continue;
     }
     const referrers = scriptsReferencingSharedLock(localMap, change.path);
-    if (scopeIsNarrowed && treeReaders === undefined) {
+    if (treeReaders === undefined) {
       try {
         treeReaders = await collectSharedLockReaders(opts.json ?? false);
       } catch (e) {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -9,7 +9,7 @@ import {
   copyFile,
   mkdir,
 } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, type Dirent } from "node:fs";
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
 import { Confirm } from "@cliffy/prompt/confirm";
@@ -204,6 +204,12 @@ async function isLockStillRead(
   json: boolean,
 ): Promise<boolean> {
   const n = lockPath.replaceAll(SEP, "/");
+  // A shared lockfile is read by any number of scripts, so the whole tree
+  // answers rather than one sibling. Only ever reached when one is on its way
+  // out, which is rare enough to pay for a walk.
+  if (isSharedLockPath(n)) {
+    return await anyScriptReferences(n, json);
+  }
   const metaPath = n.endsWith("__mod/script.lock")
     ? n.slice(0, -".lock".length) + (json ? ".json" : ".yaml")
     : n.slice(0, -".script.lock".length) +
@@ -223,6 +229,48 @@ async function isLockStillRead(
     // Unparseable metadata is not proof that nothing reads the lock.
     return true;
   }
+}
+
+/**
+ * Whether any script in the workspace still reads a given lockfile, read from
+ * disk after the pull has applied (or refused) every metadata change.
+ */
+async function anyScriptReferences(
+  lockRef: string,
+  json: boolean,
+): Promise<boolean> {
+  const reference = "!inline " + lockRef;
+  const metaExt = json ? ".script.json" : ".script.yaml";
+  const modMeta = json ? "__mod/script.json" : "__mod/script.yaml";
+  const walk = async (dir: string): Promise<boolean> => {
+    let entries: Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (isNeverWalkedDir(entry.name)) continue;
+        if (await walk(full)) return true;
+        continue;
+      }
+      const rel = full.replaceAll(SEP, "/");
+      if (!rel.endsWith(metaExt) && !rel.endsWith(modMeta)) continue;
+      try {
+        if ((await readTextFile(full)).includes(reference)) return true;
+      } catch {
+        // unreadable: cannot rule it out, so keep the lockfile
+        return true;
+      }
+    }
+    return false;
+  };
+  for (const root of ["f", "u", "g"]) {
+    if (await walk(root)) return true;
+  }
+  return false;
 }
 
 /** Sync maps are keyed with the platform separator; `!inline` refs are not. */
@@ -3792,7 +3840,7 @@ export async function pull(
         // and a conflict resolved as "preserve local" keeps metadata that still
         // reads one. Deleted here, that reference would dangle and the script
         // would deploy with an empty lock.
-        if (isScriptLockPath(change.path)) {
+        if (isScriptLockPath(change.path) || isSharedLockPath(change.path)) {
           deferredLockDeletions.push({ path: change.path, target, stateTarget });
           continue;
         }
@@ -4058,7 +4106,9 @@ export async function dedupeLockfilesOnDisk(args: {
   );
   const plan = computeSharedLockPlan(map, {
     defaultTs: opts.defaultTs,
-    depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
+    depFiles: opts.skipWorkspaceDependencies
+      ? Object.keys(await getRawWorkspaceDependencies(false))
+      : undefined,
   });
   if (isEmptySharedLockPlan(plan)) return;
 

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -1736,6 +1736,18 @@ function ZipFSElement(
   return _internal_folder("." + SEP, zip);
 }
 
+/**
+ * Directories no walk over a workspace ever descends, whatever the sync scope:
+ * dependency trees and tool state, never Windmill content. Exported because a
+ * second walk that disagrees with this one reads files sync will never see, and
+ * draws conclusions from them.
+ */
+export function isNeverWalkedDir(dirName: string | undefined): boolean {
+  return (
+    dirName === "node_modules" || (dirName !== undefined && dirName.startsWith("."))
+  );
+}
+
 export async function* readDirRecursiveWithIgnore(
   ignore: (path: string, isDirectory: boolean) => boolean,
   root: DynFSElement,
@@ -1772,15 +1784,8 @@ export async function* readDirRecursiveWithIgnore(
     const e = stack.pop()!;
     yield e;
     for await (const e2 of e.c()) {
-      if (e2.isDirectory) {
-        const dirName = e2.path.split(SEP).pop();
-        if (
-          dirName == "node_modules" ||
-          dirName == ".claude" ||
-          dirName?.startsWith(".")
-        ) {
-          continue;
-        }
+      if (e2.isDirectory && isNeverWalkedDir(e2.path.split(SEP).pop())) {
+        continue;
       }
       stack.push({
         path: e2.path,

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -189,6 +189,35 @@ import {
   type LockDedupOptions,
 } from "../../utils/lock_dedup.ts";
 
+/** A lockfile belonging to one script, as opposed to a shared one. */
+function isScriptLockPath(p: string): boolean {
+  const n = p.replaceAll(SEP, "/");
+  return n.endsWith(".script.lock") || n.endsWith("__mod/script.lock");
+}
+
+/**
+ * Whether the metadata beside a script lockfile still points at it. Read from
+ * disk, after the pull has applied (or refused) every metadata change, because
+ * that is the only moment the answer is settled.
+ */
+async function isLockStillRead(lockPath: string): Promise<boolean> {
+  const n = lockPath.replaceAll(SEP, "/");
+  const base = n.endsWith("__mod/script.lock")
+    ? n.slice(0, -".lock".length)
+    : n.slice(0, -".script.lock".length);
+  const reference = "!inline " + n;
+  for (const meta of [base + ".script.yaml", base + ".script.json", base + ".yaml", base + ".json"]) {
+    try {
+      if ((await readTextFile(meta.replaceAll("/", SEP))).includes(reference)) {
+        return true;
+      }
+    } catch {
+      // no such metadata twin
+    }
+  }
+  return false;
+}
+
 /** Sync maps are keyed with the platform separator; `!inline` refs are not. */
 const toMapKeySep = (refPath: string) => refPath.replaceAll("/", SEP);
 
@@ -3599,6 +3628,13 @@ export async function pull(
       return;
     }
 
+    // Script lockfile deletions, held back until every metadata edit has been
+    // applied or refused — see the deletion branch below.
+    const deferredLockDeletions: {
+      path: string;
+      target: string;
+      stateTarget: string;
+    }[] = [];
     const conflicts = [];
 
     log.info(colors.gray(`Applying changes to files ...`));
@@ -3738,6 +3774,15 @@ export async function pull(
           await copyFile(target, stateTarget);
         }
       } else if (change.name === "deleted") {
+        // A script's lockfile goes last, once the metadata around it has
+        // settled: `dedupeLockfiles` deletes the per-script locks it collapses,
+        // and a conflict resolved as "preserve local" keeps metadata that still
+        // reads one. Deleted here, that reference would dangle and the script
+        // would deploy with an empty lock.
+        if (isScriptLockPath(change.path)) {
+          deferredLockDeletions.push({ path: change.path, target, stateTarget });
+          continue;
+        }
         log.info(`Deleting ${changeTypeLabel(change.path)}${change.path}`);
         // `force` on both: the goal is that neither copy exists, and a file
         // already absent — a dbt project's optional descriptor is never written
@@ -3748,6 +3793,22 @@ export async function pull(
         if (opts.stateful) {
           await rm(stateTarget, { force: true });
         }
+      }
+    }
+
+    for (const deferred of deferredLockDeletions) {
+      if (await isLockStillRead(deferred.path)) {
+        log.info(
+          colors.yellow(
+            `Keeping ${deferred.path}: metadata on disk still references it.`,
+          ),
+        );
+        continue;
+      }
+      log.info(`Deleting ${changeTypeLabel(deferred.path)}${deferred.path}`);
+      await rm(deferred.target, { force: true });
+      if (opts.stateful) {
+        await rm(deferred.stateTarget, { force: true });
       }
     }
     if (opts.failConflicts) {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2531,6 +2531,7 @@ async function compareDynFSElement(
         remoteMap,
         skips.defaultTs,
         await collectExistingSharedLocks(process.cwd()),
+        json,
       ),
     );
   }
@@ -3968,7 +3969,12 @@ export async function dedupeLockfilesOnDisk(args: {
     opts.json ?? false,
     opts,
   );
-  const plan = computeSharedLockPlan(map, opts.defaultTs, existing);
+  const plan = computeSharedLockPlan(
+    map,
+    opts.defaultTs,
+    existing,
+    opts.json ?? false,
+  );
   if (isEmptySharedLockPlan(plan)) return;
 
   const summary = `${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`;
@@ -4551,7 +4557,10 @@ export async function push(
   }
 
   const autoRegenerate = !!(opts as any).autoMetadata;
-  const sharedLocksBefore = await snapshotSharedLocks(opts);
+  // Only the regeneration below reads it, and it walks the whole tree.
+  const sharedLocksBefore = autoRegenerate
+    ? await snapshotSharedLocks(opts)
+    : NO_EXISTING_SHARED_LOCKS;
   const staleScripts: string[] = [];
   const staleFlows: string[] = [];
   const staleApps: string[] = [];
@@ -4723,6 +4732,7 @@ export async function push(
           rawWorkspaceDependencies,
           tree,
           existing: sharedLocksBefore,
+          dryRun: opts.dryRun,
         });
       } finally {
         await flushLockfileBatch();

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -180,7 +180,7 @@ import { isSharedLockPath, SHARED_LOCK_DIR } from "../../utils/script_common.ts"
 import {
   applySharedLockPlanToDisk,
   applySharedLockPlanToMap,
-  sharedLockRefOf,
+  metadataReadsSharedLock,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
@@ -263,7 +263,7 @@ async function anyScriptReferences(
       if (!rel.endsWith(metaExt) && !rel.endsWith(modMeta)) continue;
       // The `lock` field, not the raw text: a folded line, a summary quoting the
       // path, or a stale twin of the other format would each answer wrongly.
-      if (sharedLockRefOf(rel, await readTextFile(full), json) === lockRef) {
+      if (metadataReadsSharedLock(rel, await readTextFile(full), json, lockRef)) {
         return true;
       }
     }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3930,6 +3930,7 @@ export async function dedupeLockfilesOnDisk(
   ignore: (p: string, isD: boolean) => boolean,
   rawWorkspaceDependencies: Record<string, string>,
   tree: DoubleLinkedDependencyTree,
+  dryRun?: boolean,
 ): Promise<void> {
   const map = await elementsToMap(
     await FSFSElement(process.cwd(), codebases, false),
@@ -3944,10 +3945,14 @@ export async function dedupeLockfilesOnDisk(
   );
   if (isEmptySharedLockPlan(plan)) return;
 
+  const summary = `${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`;
+  if (dryRun) {
+    log.info(`Would deduplicate lockfiles: ${summary}`);
+    return;
+  }
+
   await applySharedLockPlanToDisk(plan);
-  log.info(
-    `Deduplicated lockfiles: ${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`,
-  );
+  log.info(`Deduplicated lockfiles: ${summary}`);
 
   for (const rewritten of Object.keys(plan.writes)) {
     // Metadata only — the lockfiles the plan also writes are not hashed.

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -184,6 +184,8 @@ import {
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
+  NO_EXISTING_SHARED_LOCKS,
+  type ExistingSharedLocks,
   type LockDedupOptions,
 } from "../../utils/lock_dedup.ts";
 
@@ -3910,6 +3912,20 @@ export async function pull(
 }
 
 /**
+ * The shared lockfiles a run starts from. Take it BEFORE regenerating anything:
+ * `updateScriptLock` moves a script off its shared file as soon as its lock
+ * resolves differently, and a snapshot taken after that no longer shows which
+ * file the group owns.
+ */
+export async function snapshotSharedLocks(
+  opts: SyncOptions,
+): Promise<ExistingSharedLocks> {
+  return opts.dedupeLockfiles
+    ? await collectExistingSharedLocks(process.cwd())
+    : NO_EXISTING_SHARED_LOCKS;
+}
+
+/**
  * Fold the lockfile that the scripts of a language share back into the one
  * shared file (`dedupeLockfiles`), and give the scripts that ended up with a
  * lock of their own theirs back.
@@ -3922,26 +3938,37 @@ export async function pull(
  * recorded, so every rewritten script is re-hashed from disk — the same
  * lock-untouching pass `sync pull` runs, no dependency job involved.
  */
-export async function dedupeLockfilesOnDisk(
-  opts: GlobalOptions & SyncOptions,
-  workspace: Workspace,
-  codebases: SyncCodebase[],
-  ignore: (p: string, isD: boolean) => boolean,
-  rawWorkspaceDependencies: Record<string, string>,
-  tree: DoubleLinkedDependencyTree,
-  dryRun?: boolean,
-): Promise<void> {
+export async function dedupeLockfilesOnDisk(args: {
+  opts: GlobalOptions & SyncOptions;
+  workspace: Workspace;
+  codebases: SyncCodebase[];
+  ignore: (p: string, isD: boolean) => boolean;
+  rawWorkspaceDependencies: Record<string, string>;
+  tree: DoubleLinkedDependencyTree;
+  /** The tree BEFORE this run regenerated anything — see `snapshotSharedLocks`.
+   *  Passed in rather than collected here: taken afterwards it would show the
+   *  scripts regeneration has already moved off their shared file, and the group
+   *  would be handed a new name instead of keeping its own. */
+  existing: ExistingSharedLocks;
+  dryRun?: boolean;
+}): Promise<void> {
+  const {
+    opts,
+    workspace,
+    codebases,
+    ignore,
+    rawWorkspaceDependencies,
+    tree,
+    existing,
+    dryRun,
+  } = args;
   const map = await elementsToMap(
     await FSFSElement(process.cwd(), codebases, false),
     ignore,
     opts.json ?? false,
     opts,
   );
-  const plan = computeSharedLockPlan(
-    map,
-    opts.defaultTs,
-    await collectExistingSharedLocks(process.cwd()),
-  );
+  const plan = computeSharedLockPlan(map, opts.defaultTs, existing);
   if (isEmptySharedLockPlan(plan)) return;
 
   const summary = `${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`;
@@ -4524,6 +4551,7 @@ export async function push(
   }
 
   const autoRegenerate = !!(opts as any).autoMetadata;
+  const sharedLocksBefore = await snapshotSharedLocks(opts);
   const staleScripts: string[] = [];
   const staleFlows: string[] = [];
   const staleApps: string[] = [];
@@ -4687,14 +4715,15 @@ export async function push(
       // would otherwise cost.
       await beginLockfileBatch();
       try {
-        await dedupeLockfilesOnDisk(
+        await dedupeLockfilesOnDisk({
           opts,
           workspace,
           codebases,
-          await ignoreF(opts),
+          ignore: await ignoreF(opts),
           rawWorkspaceDependencies,
           tree,
-        );
+          existing: sharedLocksBefore,
+        });
       } finally {
         await flushLockfileBatch();
       }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2569,9 +2569,23 @@ async function compareDynFSElement(
   // keep.
   if (skips.dedupeLockfiles) {
     const remoteMap = isEls1Remote === true ? m1 : m2;
+    const localMapForLocks = isEls1Remote === true ? m2 : m1;
+    // The local side supplies what the remote never serializes: the shared
+    // lockfiles already on disk, so one whose scripts are out of this sync's
+    // scope is carried forward rather than read as a deletion.
+    const present: Record<string, string> = {};
+    for (const [key, content] of Object.entries(localMapForLocks)) {
+      if (isSharedLockPath(key)) present[key.replaceAll(SEP, "/")] = content;
+    }
     applySharedLockPlanToMap(
       remoteMap,
-      computeSharedLockPlan(remoteMap, { defaultTs: skips.defaultTs }),
+      computeSharedLockPlan(remoteMap, {
+        defaultTs: skips.defaultTs,
+        // From disk as well: `--skip-workspace-dependencies` keeps dependency
+        // files out of both maps, and absent is not the same as gone.
+        depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
+        present,
+      }),
     );
   }
 
@@ -4039,7 +4053,10 @@ export async function dedupeLockfilesOnDisk(args: {
     opts.json ?? false,
     opts,
   );
-  const plan = computeSharedLockPlan(map, { defaultTs: opts.defaultTs });
+  const plan = computeSharedLockPlan(map, {
+    defaultTs: opts.defaultTs,
+    depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
+  });
   if (isEmptySharedLockPlan(plan)) return;
 
   const summary = `${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`;

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -173,7 +173,16 @@ import {
   hasWrongFormatSuffix,
   DBT_DESCRIPTOR_NAME,
   isDbtDescriptorPath,
+  isSharedLockPath,
 } from "../../utils/resource_folders.ts";
+import {
+  applySharedLockPlanToDisk,
+  applySharedLockPlanToMap,
+  computeSharedLockPlan,
+  isEmptySharedLockPlan,
+  scriptsReferencingSharedLock,
+  type LockDedupOptions,
+} from "../../utils/lock_dedup.ts";
 
 let branchDeprecationWarned = false;
 
@@ -1941,7 +1950,13 @@ export async function elementsToMap(
     try {
       const fileType = getTypeStrFromPath(path);
       if (skips.skipVariables && fileType === "variable") continue;
-      if (skips.skipScripts && fileType === "script") continue;
+      // A shared lockfile is part of the scripts that reference it.
+      if (
+        skips.skipScripts &&
+        (fileType === "script" || fileType === "shared_lock")
+      ) {
+        continue;
+      }
       if (skips.skipFlows && fileType === "flow") continue;
       if (skips.skipApps && fileType === "app") continue;
       if (skips.skipFolders && fileType === "folder") continue;
@@ -2409,7 +2424,7 @@ async function compareDynFSElement(
   els2: DynFSElement | undefined,
   ignore: (path: string, isDirectory: boolean) => boolean,
   json: boolean,
-  skips: Skips,
+  skips: Skips & LockDedupOptions,
   ignoreMetadataDeletion: boolean,
   codebases: SyncCodebase[],
   ignoreCodebaseChanges: boolean,
@@ -2498,6 +2513,19 @@ async function compareDynFSElement(
     preservePendingScriptLocks(m1, m2);
   }
 
+  // The remote serializes one lock per script; `dedupeLockfiles` is how the repo
+  // represents them. Collapsing the remote side (in both directions) is what
+  // makes the two sides comparable: a pull then writes the shared file instead
+  // of thousands of copies, and a push sees no diff for the copies it does not
+  // keep.
+  if (skips.dedupeLockfiles) {
+    const remoteMap = isEls1Remote === true ? m1 : m2;
+    applySharedLockPlanToMap(
+      remoteMap,
+      computeSharedLockPlan(remoteMap, skips.defaultTs),
+    );
+  }
+
   const changes: Change[] = [];
 
   function parseYaml(k: string, v: string) {
@@ -2549,7 +2577,7 @@ async function compareDynFSElement(
       if (skipMetadata) {
         continue;
       }
-      if (k.startsWith("dependencies/")) {
+      if (k.startsWith("dependencies/") && !isSharedLockPath(k)) {
         if (!workspaceDependenciesPathToLanguageAndFilename(k)) {
           log.warn(`Skipping unrecognized workspace dependencies file: ${k}`);
           continue;
@@ -2885,6 +2913,12 @@ export async function ignoreF(wmillconf: {
           fileType === "workspace_dependencies"
         ) {
           return false; // Don't ignore workspace dependencies (they are always included unless explicitly skipped)
+        }
+        // A shared lockfile lives outside the u/f/g namespaces the include
+        // patterns are written against, and dropping it from the diff would
+        // leave every script that references it pointing at nothing.
+        if (fileType === "shared_lock") {
+          return false;
         }
         // `migrations/datatable/**` is outside the u/f/g namespaces the path
         // filters are written against, so the skip flag is its only control.
@@ -3868,6 +3902,68 @@ export async function pull(
   // stays exported for callers that want the same commit/push behavior.
 }
 
+/**
+ * Fold the lockfile that the scripts of a language share back into the one
+ * shared file (`dedupeLockfiles`), and give the scripts that ended up with a
+ * lock of their own theirs back.
+ *
+ * A lock is regenerated one script at a time, so only a pass over the whole
+ * tree can tell a dependency bump every script took (the shared file moves)
+ * from one script drifting away from the rest (it gets a lock of its own).
+ *
+ * Rewriting a script's metadata invalidates the hash the generation above just
+ * recorded, so every rewritten script is re-hashed from disk — the same
+ * lock-untouching pass `sync pull` runs, no dependency job involved.
+ */
+export async function dedupeLockfilesOnDisk(
+  opts: GlobalOptions & SyncOptions,
+  workspace: Workspace,
+  codebases: SyncCodebase[],
+  ignore: (p: string, isD: boolean) => boolean,
+  rawWorkspaceDependencies: Record<string, string>,
+  tree: DoubleLinkedDependencyTree,
+): Promise<void> {
+  const map = await elementsToMap(
+    await FSFSElement(process.cwd(), codebases, false),
+    ignore,
+    opts.json ?? false,
+    opts,
+  );
+  const plan = computeSharedLockPlan(map, opts.defaultTs);
+  if (isEmptySharedLockPlan(plan)) return;
+
+  await applySharedLockPlanToDisk(plan);
+  log.info(
+    `Deduplicated lockfiles: ${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`,
+  );
+
+  for (const rewritten of Object.keys(plan.writes)) {
+    // Metadata only — the lockfiles the plan also writes are not hashed.
+    if (!rewritten.endsWith(".yaml") && !rewritten.endsWith(".json")) continue;
+    let contentPath: string | undefined;
+    try {
+      contentPath = await findContentFile(rewritten);
+    } catch {
+      continue;
+    }
+    if (!contentPath) continue;
+    await generateScriptMetadataInternal(
+      contentPath,
+      workspace,
+      opts,
+      false, // dryRun
+      true, // noStaleMessage
+      rawWorkspaceDependencies,
+      codebases,
+      true, // justUpdateMetadataLock: re-hash from disk, no lock generation
+      // The same tree the generation above ran with: it is what decides whether
+      // the workspace dependencies are part of the hash, and a hash written the
+      // other way would read as stale on every later run.
+      tree,
+    );
+  }
+}
+
 // Internal git-sync deployment-callback entrypoint. Invoked only by the
 // git-sync hub script (not user-facing — see the hidden `git-deploy`
 // subcommand). Runs inside an existing clone of the repo: switches to the
@@ -4356,6 +4452,37 @@ export async function push(
     });
   }
 
+  // A shared lockfile (`dedupeLockfiles`) has no object of its own on the
+  // remote: it IS the lock of every script that references it, and those
+  // scripts are what carries its new content over. Nothing else queues them —
+  // their own metadata is byte-identical on both sides.
+  const changedPaths = new Set(changes.map((c) => c.path));
+  for (let i = changes.length - 1; i >= 0; i--) {
+    const change = changes[i];
+    if (change.name === "deleted" || !isSharedLockPath(change.path)) continue;
+    const referrers = scriptsReferencingSharedLock(localMap, change.path);
+    if (referrers.length === 0) {
+      // A shared lockfile no script reads is not a change to the remote in any
+      // sense; left in, it would be reported as pushed on every push, forever.
+      changes.splice(i, 1);
+      continue;
+    }
+    log.info(
+      colors.gray(
+        `${change.path} changed: re-pushing the ${referrers.length} script(s) sharing it`,
+      ),
+    );
+    for (const metaPath of referrers) {
+      if (changedPaths.has(metaPath)) continue;
+      changes.push({
+        name: "edited",
+        path: metaPath,
+        before: localMap[metaPath],
+        after: localMap[metaPath],
+      });
+    }
+  }
+
   const rawWorkspaceDependencies = await getRawWorkspaceDependencies(true);
 
   const tracker: ChangeTracker = await buildTracker(changes);
@@ -4516,6 +4643,17 @@ export async function push(
       if (generated) {
         staleApps.push(generated as string);
       }
+    }
+
+    if (opts.dedupeLockfiles) {
+      await dedupeLockfilesOnDisk(
+        opts,
+        workspace,
+        codebases,
+        await ignoreF(opts),
+        rawWorkspaceDependencies,
+        tree,
+      );
     }
   }
 
@@ -5085,6 +5223,11 @@ export async function push(
           }
 
           for await (const change of changes) {
+            // A shared lockfile is a repo-side artifact: the scripts queued
+            // above are what deploys its content.
+            if (isSharedLockPath(change.path)) {
+              continue;
+            }
             // A datatable migration is one record across two files; upsert/delete
             // it from disk once (deduped), regardless of which file changed.
             if (isDatatableMigrationPath(change.path)) {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2585,6 +2585,13 @@ async function compareDynFSElement(
         // files out of both maps, and absent is not the same as gone.
         depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
         present,
+        // A dependency file the two sides disagree on is one this sync moves,
+        // so a lock that disagrees with the shared file came from the bump.
+        movedDepFiles: Object.keys(remoteMap).filter(
+          (k) =>
+            k.replaceAll(SEP, "/").startsWith("dependencies/") &&
+            remoteMap[k] !== localMapForLocks[k],
+        ),
       }),
     );
   }
@@ -4035,6 +4042,8 @@ export async function dedupeLockfilesOnDisk(args: {
    *  rewritten, but never re-hashed: recording a hash for a script whose lock
    *  never regenerated marks it up-to-date, and it is never retried. */
   failed?: string[];
+  /** Dependency files this run regenerated against — see the planner. */
+  movedDepFiles?: string[];
   dryRun?: boolean;
 }): Promise<void> {
   const {
@@ -4045,6 +4054,7 @@ export async function dedupeLockfilesOnDisk(args: {
     rawWorkspaceDependencies,
     tree,
     failed = [],
+    movedDepFiles = [],
     dryRun,
   } = args;
   const map = await elementsToMap(
@@ -4056,6 +4066,7 @@ export async function dedupeLockfilesOnDisk(args: {
   const plan = computeSharedLockPlan(map, {
     defaultTs: opts.defaultTs,
     depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
+    movedDepFiles,
   });
   if (isEmptySharedLockPlan(plan)) return;
 
@@ -4808,6 +4819,9 @@ export async function push(
           ignore: await ignoreF(opts),
           rawWorkspaceDependencies,
           tree,
+          // `getRawWorkspaceDependencies(true)` returns only the files that are
+          // not up to date, which is exactly what this run regenerated against.
+          movedDepFiles: Object.keys(rawWorkspaceDependencies),
           dryRun: opts.dryRun,
         });
       } finally {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2585,13 +2585,6 @@ async function compareDynFSElement(
         // files out of both maps, and absent is not the same as gone.
         depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
         present,
-        // A dependency file the two sides disagree on is one this sync moves,
-        // so a lock that disagrees with the shared file came from the bump.
-        movedDepFiles: Object.keys(remoteMap).filter(
-          (k) =>
-            k.replaceAll(SEP, "/").startsWith("dependencies/") &&
-            remoteMap[k] !== localMapForLocks[k],
-        ),
       }),
     );
   }
@@ -4042,8 +4035,6 @@ export async function dedupeLockfilesOnDisk(args: {
    *  rewritten, but never re-hashed: recording a hash for a script whose lock
    *  never regenerated marks it up-to-date, and it is never retried. */
   failed?: string[];
-  /** Dependency files this run regenerated against — see the planner. */
-  movedDepFiles?: string[];
   dryRun?: boolean;
 }): Promise<void> {
   const {
@@ -4054,7 +4045,6 @@ export async function dedupeLockfilesOnDisk(args: {
     rawWorkspaceDependencies,
     tree,
     failed = [],
-    movedDepFiles = [],
     dryRun,
   } = args;
   const map = await elementsToMap(
@@ -4066,7 +4056,6 @@ export async function dedupeLockfilesOnDisk(args: {
   const plan = computeSharedLockPlan(map, {
     defaultTs: opts.defaultTs,
     depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
-    movedDepFiles,
   });
   if (isEmptySharedLockPlan(plan)) return;
 
@@ -4819,9 +4808,6 @@ export async function push(
           ignore: await ignoreF(opts),
           rawWorkspaceDependencies,
           tree,
-          // `getRawWorkspaceDependencies(true)` returns only the files that are
-          // not up to date, which is exactly what this run regenerated against.
-          movedDepFiles: Object.keys(rawWorkspaceDependencies),
           dryRun: opts.dryRun,
         });
       } finally {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -198,24 +198,34 @@ function isScriptLockPath(p: string): boolean {
 /**
  * Whether the metadata beside a script lockfile still points at it. Read from
  * disk, after the pull has applied (or refused) every metadata change, because
- * that is the only moment the answer is settled.
+ * that is the only moment the answer is settled — and from the `lock` field of
+ * the twin this sync reads, not the raw text: a folded line, a summary quoting
+ * the path, or a stale twin of the other format would each answer wrongly.
  */
-async function isLockStillRead(lockPath: string): Promise<boolean> {
+async function isLockStillRead(
+  lockPath: string,
+  json: boolean,
+): Promise<boolean> {
   const n = lockPath.replaceAll(SEP, "/");
-  const base = n.endsWith("__mod/script.lock")
-    ? n.slice(0, -".lock".length)
-    : n.slice(0, -".script.lock".length);
-  const reference = "!inline " + n;
-  for (const meta of [base + ".script.yaml", base + ".script.json", base + ".yaml", base + ".json"]) {
-    try {
-      if ((await readTextFile(meta.replaceAll("/", SEP))).includes(reference)) {
-        return true;
-      }
-    } catch {
-      // no such metadata twin
-    }
+  const metaPath = n.endsWith("__mod/script.lock")
+    ? n.slice(0, -".lock".length) + (json ? ".json" : ".yaml")
+    : n.slice(0, -".script.lock".length) +
+      (json ? ".script.json" : ".script.yaml");
+  let content: string;
+  try {
+    content = await readTextFile(metaPath.replaceAll("/", SEP));
+  } catch {
+    return false; // no metadata: nothing reads it
   }
-  return false;
+  try {
+    const parsed = json
+      ? JSON.parse(content)
+      : yamlParseContent(metaPath, content);
+    return parsed?.["lock"] === "!inline " + n;
+  } catch {
+    // Unparseable metadata is not proof that nothing reads the lock.
+    return true;
+  }
 }
 
 /** Sync maps are keyed with the platform separator; `!inline` refs are not. */
@@ -1767,9 +1777,9 @@ function ZipFSElement(
 
 /**
  * Directories no walk over a workspace ever descends, whatever the sync scope:
- * dependency trees and tool state, never Windmill content. Exported because a
- * second walk that disagrees with this one reads files sync will never see, and
- * draws conclusions from them.
+ * dependency trees, and the dot-directories that hold tooling state and
+ * fixtures. Exported because a second walk that disagrees with this one reads
+ * files sync will never see, and draws conclusions from them.
  */
 export function isNeverWalkedDir(dirName: string | undefined): boolean {
   return (
@@ -3797,7 +3807,7 @@ export async function pull(
     }
 
     for (const deferred of deferredLockDeletions) {
-      if (await isLockStillRead(deferred.path)) {
+      if (await isLockStillRead(deferred.path, opts.json ?? false)) {
         log.info(
           colors.yellow(
             `Keeping ${deferred.path}: metadata on disk still references it.`,

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -180,6 +180,7 @@ import { isSharedLockPath, SHARED_LOCK_DIR } from "../../utils/script_common.ts"
 import {
   applySharedLockPlanToDisk,
   applySharedLockPlanToMap,
+  sharedLockRefOf,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
@@ -239,15 +240,17 @@ async function anyScriptReferences(
   lockRef: string,
   json: boolean,
 ): Promise<boolean> {
-  const reference = "!inline " + lockRef;
   const metaExt = json ? ".script.json" : ".script.yaml";
   const modMeta = json ? "__mod/script.json" : "__mod/script.yaml";
   const walk = async (dir: string): Promise<boolean> => {
     let entries: Dirent[];
     try {
       entries = await readdir(dir, { withFileTypes: true });
-    } catch {
-      return false;
+    } catch (e) {
+      // A directory that is not there holds no reader. Anything else hides
+      // scripts, and a lockfile deleted out from under one resolves to nothing.
+      if ((e as { code?: string })?.code === "ENOENT") return false;
+      throw e;
     }
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
@@ -258,10 +261,9 @@ async function anyScriptReferences(
       }
       const rel = full.replaceAll(SEP, "/");
       if (!rel.endsWith(metaExt) && !rel.endsWith(modMeta)) continue;
-      try {
-        if ((await readTextFile(full)).includes(reference)) return true;
-      } catch {
-        // unreadable: cannot rule it out, so keep the lockfile
+      // The `lock` field, not the raw text: a folded line, a summary quoting the
+      // path, or a stale twin of the other format would each answer wrongly.
+      if (sharedLockRefOf(rel, await readTextFile(full), json) === lockRef) {
         return true;
       }
     }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -180,12 +180,9 @@ import { isSharedLockPath, SHARED_LOCK_DIR } from "../../utils/script_common.ts"
 import {
   applySharedLockPlanToDisk,
   applySharedLockPlanToMap,
-  collectExistingSharedLocks,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
-  NO_EXISTING_SHARED_LOCKS,
-  type ExistingSharedLocks,
   type LockDedupOptions,
 } from "../../utils/lock_dedup.ts";
 
@@ -2572,20 +2569,9 @@ async function compareDynFSElement(
   // keep.
   if (skips.dedupeLockfiles) {
     const remoteMap = isEls1Remote === true ? m1 : m2;
-    const localMapForScope = isEls1Remote === true ? m2 : m1;
     applySharedLockPlanToMap(
       remoteMap,
-      computeSharedLockPlan(remoteMap, {
-        defaultTs: skips.defaultTs,
-        existing: await collectExistingSharedLocks(process.cwd()),
-        json,
-        // Scope is what the LOCAL side holds: a script added locally and not yet
-        // pushed is absent from the remote map but is covered by this sync, and
-        // counting it as an unseen reader would explode its group.
-        inScope: (metaRef) =>
-          localMapForScope[toMapKeySep(metaRef)] !== undefined ||
-          localMapForScope[metaRef] !== undefined,
-      }),
+      computeSharedLockPlan(remoteMap, { defaultTs: skips.defaultTs }),
     );
   }
 
@@ -4012,20 +3998,6 @@ export async function pull(
 }
 
 /**
- * The shared lockfiles a run starts from. Take it BEFORE regenerating anything:
- * `updateScriptLock` moves a script off its shared file as soon as its lock
- * resolves differently, and a snapshot taken after that no longer shows which
- * file the group owns.
- */
-export async function snapshotSharedLocks(
-  opts: SyncOptions,
-): Promise<ExistingSharedLocks> {
-  return opts.dedupeLockfiles
-    ? await collectExistingSharedLocks(process.cwd())
-    : NO_EXISTING_SHARED_LOCKS;
-}
-
-/**
  * Fold the lockfile that the scripts of a language share back into the one
  * shared file (`dedupeLockfiles`), and give the scripts that ended up with a
  * lock of their own theirs back.
@@ -4045,11 +4017,6 @@ export async function dedupeLockfilesOnDisk(args: {
   ignore: (p: string, isD: boolean) => boolean;
   rawWorkspaceDependencies: Record<string, string>;
   tree: DoubleLinkedDependencyTree;
-  /** The tree BEFORE this run regenerated anything — see `snapshotSharedLocks`.
-   *  Passed in rather than collected here: taken afterwards it would show the
-   *  scripts regeneration has already moved off their shared file, and the group
-   *  would be handed a new name instead of keeping its own. */
-  existing: ExistingSharedLocks;
   /** Content paths whose generation failed this run. Their metadata may be
    *  rewritten, but never re-hashed: recording a hash for a script whose lock
    *  never regenerated marks it up-to-date, and it is never retried. */
@@ -4063,7 +4030,6 @@ export async function dedupeLockfilesOnDisk(args: {
     ignore,
     rawWorkspaceDependencies,
     tree,
-    existing,
     failed = [],
     dryRun,
   } = args;
@@ -4073,11 +4039,7 @@ export async function dedupeLockfilesOnDisk(args: {
     opts.json ?? false,
     opts,
   );
-  const plan = computeSharedLockPlan(map, {
-    defaultTs: opts.defaultTs,
-    existing,
-    json: opts.json ?? false,
-  });
+  const plan = computeSharedLockPlan(map, { defaultTs: opts.defaultTs });
   if (isEmptySharedLockPlan(plan)) return;
 
   const summary = `${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`;
@@ -4659,10 +4621,6 @@ export async function push(
   }
 
   const autoRegenerate = !!(opts as any).autoMetadata;
-  // Only the regeneration below reads it, and it walks the whole tree.
-  const sharedLocksBefore = autoRegenerate
-    ? await snapshotSharedLocks(opts)
-    : NO_EXISTING_SHARED_LOCKS;
   const staleScripts: string[] = [];
   const staleFlows: string[] = [];
   const staleApps: string[] = [];
@@ -4833,7 +4791,6 @@ export async function push(
           ignore: await ignoreF(opts),
           rawWorkspaceDependencies,
           tree,
-          existing: sharedLocksBefore,
           dryRun: opts.dryRun,
         });
       } finally {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -175,9 +175,8 @@ import {
   hasWrongFormatSuffix,
   DBT_DESCRIPTOR_NAME,
   isDbtDescriptorPath,
-  isSharedLockPath,
-  SHARED_LOCK_DIR,
 } from "../../utils/resource_folders.ts";
+import { isSharedLockPath, SHARED_LOCK_DIR } from "../../utils/script_common.ts";
 import {
   applySharedLockPlanToDisk,
   applySharedLockPlanToMap,
@@ -189,6 +188,9 @@ import {
   type ExistingSharedLocks,
   type LockDedupOptions,
 } from "../../utils/lock_dedup.ts";
+
+/** Sync maps are keyed with the platform separator; `!inline` refs are not. */
+const toMapKeySep = (refPath: string) => refPath.replaceAll("/", SEP);
 
 let branchDeprecationWarned = false;
 
@@ -2526,14 +2528,20 @@ async function compareDynFSElement(
   // keep.
   if (skips.dedupeLockfiles) {
     const remoteMap = isEls1Remote === true ? m1 : m2;
+    const localMapForScope = isEls1Remote === true ? m2 : m1;
     applySharedLockPlanToMap(
       remoteMap,
-      computeSharedLockPlan(
-        remoteMap,
-        skips.defaultTs,
-        await collectExistingSharedLocks(process.cwd()),
+      computeSharedLockPlan(remoteMap, {
+        defaultTs: skips.defaultTs,
+        existing: await collectExistingSharedLocks(process.cwd()),
         json,
-      ),
+        // Scope is what the LOCAL side holds: a script added locally and not yet
+        // pushed is absent from the remote map but is covered by this sync, and
+        // counting it as an unseen reader would explode its group.
+        inScope: (metaRef) =>
+          localMapForScope[toMapKeySep(metaRef)] !== undefined ||
+          localMapForScope[metaRef] !== undefined,
+      }),
     );
   }
 
@@ -2862,6 +2870,7 @@ export async function ignoreF(wmillconf: {
   includes?: string[];
   excludes?: string[];
   extraIncludes?: string[];
+  dedupeLockfiles?: boolean;
   skipResourceTypes?: boolean;
   skipWorkspaceDependencies?: boolean;
   skipDatatableMigrations?: boolean;
@@ -2902,6 +2911,15 @@ export async function ignoreF(wmillconf: {
   // new Gitignore.default({ initialRules: ignoreContent.split("\n")}).ignoreContent).compile();
 
   return (p: string, isDirectory: boolean) => {
+    // Without the option, `locks/` is not Windmill's: a repo that keeps its own
+    // lockfiles there would otherwise see them pulled into the diff and deleted
+    // as absent from a remote that never serializes shared locks.
+    if (
+      !wmillconf.dedupeLockfiles &&
+      (p === SHARED_LOCK_DIR || p.startsWith(SHARED_LOCK_DIR + SEP))
+    ) {
+      return true;
+    }
     const ext = wmillconf.json ? ".json" : ".yaml";
     if (!isDirectory && p.endsWith(".resource-type" + ext)) {
       return wmillconf.skipResourceTypes ?? false;
@@ -3974,12 +3992,11 @@ export async function dedupeLockfilesOnDisk(args: {
     opts.json ?? false,
     opts,
   );
-  const plan = computeSharedLockPlan(
-    map,
-    opts.defaultTs,
+  const plan = computeSharedLockPlan(map, {
+    defaultTs: opts.defaultTs,
     existing,
-    opts.json ?? false,
-  );
+    json: opts.json ?? false,
+  });
   if (isEmptySharedLockPlan(plan)) return;
 
   const summary = `${Object.keys(plan.writes).length} file(s) written, ${plan.deletes.length} removed`;
@@ -4526,18 +4543,17 @@ export async function push(
     if (change.name === "deleted") {
       // The remote view is deduplicated whether or not the tree is: a shared
       // lockfile missing from the tree reads as a deletion to push, and there is
-      // no such object to delete. Left in, it is reported on every push forever.
+      // no such object to delete.
       unconvertedTree = true;
       changes.splice(i, 1);
       continue;
     }
     const referrers = scriptsReferencingSharedLock(localMap, change.path);
-    if (referrers.length === 0) {
-      // A shared lockfile no script reads is not a change to the remote in any
-      // sense; left in, it would be reported as pushed on every push, forever.
-      changes.splice(i, 1);
-      continue;
-    }
+    // Out of `changes` either way: a shared lockfile has no object on the
+    // remote, so the apply loop skips it. Left in, the preview and the "N
+    // changes" count would report something no push ever applies as such.
+    changes.splice(i, 1);
+    if (referrers.length === 0) continue;
     log.info(
       colors.gray(
         `${change.path} changed: re-pushing the ${referrers.length} script(s) sharing it`,

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3974,6 +3974,10 @@ export async function dedupeLockfilesOnDisk(args: {
    *  scripts regeneration has already moved off their shared file, and the group
    *  would be handed a new name instead of keeping its own. */
   existing: ExistingSharedLocks;
+  /** Content paths whose generation failed this run. Their metadata may be
+   *  rewritten, but never re-hashed: recording a hash for a script whose lock
+   *  never regenerated marks it up-to-date, and it is never retried. */
+  failed?: string[];
   dryRun?: boolean;
 }): Promise<void> {
   const {
@@ -3984,6 +3988,7 @@ export async function dedupeLockfilesOnDisk(args: {
     rawWorkspaceDependencies,
     tree,
     existing,
+    failed = [],
     dryRun,
   } = args;
   const map = await elementsToMap(
@@ -4017,7 +4022,7 @@ export async function dedupeLockfilesOnDisk(args: {
     } catch {
       continue;
     }
-    if (!contentPath) continue;
+    if (!contentPath || failed.includes(contentPath)) continue;
     await generateScriptMetadataInternal(
       contentPath,
       workspace,

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -113,6 +113,8 @@ import { Workspace } from "../workspace/workspace.ts";
 import { removePathPrefix } from "../../types.ts";
 import { listSyncCodebases, SyncCodebase } from "../../utils/codebase.ts";
 import {
+  beginLockfileBatch,
+  flushLockfileBatch,
   generateScriptMetadataInternal,
   getRawWorkspaceDependencies,
   readLockfile,
@@ -178,6 +180,7 @@ import {
 import {
   applySharedLockPlanToDisk,
   applySharedLockPlanToMap,
+  collectExistingSharedLocks,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
@@ -2517,12 +2520,17 @@ async function compareDynFSElement(
   // represents them. Collapsing the remote side (in both directions) is what
   // makes the two sides comparable: a pull then writes the shared file instead
   // of thousands of copies, and a push sees no diff for the copies it does not
-  // keep.
+  // keep. The working tree is read unfiltered, because the shared files it holds
+  // are read by scripts these maps may not cover.
   if (skips.dedupeLockfiles) {
     const remoteMap = isEls1Remote === true ? m1 : m2;
     applySharedLockPlanToMap(
       remoteMap,
-      computeSharedLockPlan(remoteMap, skips.defaultTs),
+      computeSharedLockPlan(
+        remoteMap,
+        skips.defaultTs,
+        await collectExistingSharedLocks(process.cwd()),
+      ),
     );
   }
 
@@ -3929,7 +3937,11 @@ export async function dedupeLockfilesOnDisk(
     opts.json ?? false,
     opts,
   );
-  const plan = computeSharedLockPlan(map, opts.defaultTs);
+  const plan = computeSharedLockPlan(
+    map,
+    opts.defaultTs,
+    await collectExistingSharedLocks(process.cwd()),
+  );
   if (isEmptySharedLockPlan(plan)) return;
 
   await applySharedLockPlanToDisk(plan);
@@ -4452,10 +4464,18 @@ export async function push(
     });
   }
 
+  const rawWorkspaceDependencies = await getRawWorkspaceDependencies(true);
+
+  const tracker: ChangeTracker = await buildTracker(changes);
+
   // A shared lockfile (`dedupeLockfiles`) has no object of its own on the
   // remote: it IS the lock of every script that references it, and those
   // scripts are what carries its new content over. Nothing else queues them —
   // their own metadata is byte-identical on both sides.
+  //
+  // After the tracker on purpose: these scripts need no metadata regeneration
+  // (their lock is on disk already, in the shared file), and `--auto-metadata`
+  // would otherwise run one dependency job per script sharing the lock.
   const changedPaths = new Set(changes.map((c) => c.path));
   for (let i = changes.length - 1; i >= 0; i--) {
     const change = changes[i];
@@ -4482,10 +4502,6 @@ export async function push(
       });
     }
   }
-
-  const rawWorkspaceDependencies = await getRawWorkspaceDependencies(true);
-
-  const tracker: ChangeTracker = await buildTracker(changes);
 
   const autoRegenerate = !!(opts as any).autoMetadata;
   const staleScripts: string[] = [];
@@ -4646,14 +4662,22 @@ export async function push(
     }
 
     if (opts.dedupeLockfiles) {
-      await dedupeLockfilesOnDisk(
-        opts,
-        workspace,
-        codebases,
-        await ignoreF(opts),
-        rawWorkspaceDependencies,
-        tree,
-      );
+      // Batched: the pass re-hashes every metadata file it rewrites, and one
+      // wmill-lock.yaml write per script is what a workspace-wide conversion
+      // would otherwise cost.
+      await beginLockfileBatch();
+      try {
+        await dedupeLockfilesOnDisk(
+          opts,
+          workspace,
+          codebases,
+          await ignoreF(opts),
+          rawWorkspaceDependencies,
+          tree,
+        );
+      } finally {
+        await flushLockfileBatch();
+      }
     }
   }
 

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -176,6 +176,7 @@ import {
   DBT_DESCRIPTOR_NAME,
   isDbtDescriptorPath,
   isSharedLockPath,
+  SHARED_LOCK_DIR,
 } from "../../utils/resource_folders.ts";
 import {
   applySharedLockPlanToDisk,
@@ -2587,7 +2588,7 @@ async function compareDynFSElement(
       if (skipMetadata) {
         continue;
       }
-      if (k.startsWith("dependencies/") && !isSharedLockPath(k)) {
+      if (k.startsWith("dependencies/")) {
         if (!workspaceDependenciesPathToLanguageAndFilename(k)) {
           log.warn(`Skipping unrecognized workspace dependencies file: ${k}`);
           continue;
@@ -2799,6 +2800,7 @@ const isNotWmillFile = (p: string, isDirectory: boolean) => {
       !p.startsWith("users" + SEP) &&
       !p.startsWith("groups" + SEP) &&
       !p.startsWith("dependencies" + SEP) &&
+      !p.startsWith(SHARED_LOCK_DIR + SEP) &&
       !p.startsWith("migrations" + SEP)
     );
   }
@@ -2823,6 +2825,8 @@ const isNotWmillFile = (p: string, isDirectory: boolean) => {
       typ == "encryption_key"
     ) {
       return p.includes(SEP);
+    } else if (typ == "shared_lock") {
+      return false;
     } else {
       return (
         !p.startsWith("u" + SEP) &&
@@ -2849,6 +2853,7 @@ export const isWhitelisted = (p: string) => {
     p == "users" ||
     p == "groups" ||
     p == "dependencies" ||
+    p == SHARED_LOCK_DIR ||
     p == "migrations"
   );
 };

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2581,10 +2581,13 @@ async function compareDynFSElement(
       remoteMap,
       computeSharedLockPlan(remoteMap, {
         defaultTs: skips.defaultTs,
-        // From disk as well: `--skip-workspace-dependencies` keeps dependency
-        // files out of both maps, and absent is not the same as gone.
-        depFiles: Object.keys(await getRawWorkspaceDependencies(false)),
         present,
+        // Only when the map cannot speak for them: with dependency files in the
+        // map, its absences are real deletions, and reading disk here would keep
+        // a lockfile alive one sync past the file it is named after.
+        depFiles: skips.skipWorkspaceDependencies
+          ? Object.keys(await getRawWorkspaceDependencies(false))
+          : undefined,
       }),
     );
   }

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -109,6 +109,7 @@ export interface SyncOptions {
   promotion?: string;
   lint?: boolean;
   locksRequired?: boolean;
+  dedupeLockfiles?: boolean;
   syncBehavior?: string;
 }
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -384,8 +384,7 @@ export function getTypeStrFromPath(
   if (isRawAppPath(p)) {
     return "raw_app";
   }
-  // Before the `dependencies/` catch-all: a shared lockfile lives in there but
-  // is not a workspace dependency file — it has no object on the server.
+  // A repo-side artifact of `dedupeLockfiles`: it has no object on the server.
   if (isSharedLockPath(p)) {
     return "shared_lock";
   }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -34,8 +34,8 @@ import {
   extractResourceName,
   buildFolderPath,
   isScriptModulePath,
-  isSharedLockPath,
 } from "./utils/resource_folders.ts";
+import { isSharedLockPath } from "./utils/script_common.ts";
 
 export interface DifferenceCreate {
   type: "CREATE";

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -34,6 +34,7 @@ import {
   extractResourceName,
   buildFolderPath,
   isScriptModulePath,
+  isSharedLockPath,
 } from "./utils/resource_folders.ts";
 
 export interface DifferenceCreate {
@@ -366,6 +367,7 @@ export function getTypeStrFromPath(
   | "group"
   | "settings"
   | "encryption_key"
+  | "shared_lock"
   | "workspace_dependencies" {
   if (isDatatableMigrationPath(p)) {
     return "datatable_migration";
@@ -381,6 +383,11 @@ export function getTypeStrFromPath(
   }
   if (isRawAppPath(p)) {
     return "raw_app";
+  }
+  // Before the `dependencies/` catch-all: a shared lockfile lives in there but
+  // is not a workspace dependency file — it has no object on the server.
+  if (isSharedLockPath(p)) {
+    return "shared_lock";
   }
   if (p.startsWith("dependencies" + SEP)) {
     return "workspace_dependencies";

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -216,15 +216,8 @@ function collectScripts(
     const meta = scriptMetaBase(metaKey);
     if (!meta) continue;
 
-    let parsed: any;
-    try {
-      parsed = meta.isJson
-        ? JSON.parse(metaContent)
-        : yamlParseContent(metaKey, metaContent);
-    } catch {
-      continue;
-    }
-    if (typeof parsed !== "object" || parsed === null) continue;
+    const parsed = parseMetadata(metaKey, metaContent, meta.isJson);
+    if (parsed === undefined) continue;
 
     const lockRef = parsed["lock"];
     if (typeof lockRef !== "string" || !lockRef.startsWith(INLINE_PREFIX)) {
@@ -410,11 +403,7 @@ export function computeSharedLockPlan(
     (script) => script.endsWith(metaExt) && !inScope(script),
   );
   const partialView = unseen.length > 0;
-  if (partialView) {
-    log.debug(
-      `Lockfile dedup: ${unseen.length} script(s) outside this sync's scope (e.g. ${unseen[0]}); keeping existing groups but forming none.`,
-    );
-  }
+  let suppressedGroups = 0;
 
   // Where every script ends up, so a shared file with nothing left reading it
   // can be dropped. Seeded with the whole tree, out-of-scope scripts included.
@@ -433,12 +422,12 @@ export function computeSharedLockPlan(
 
     for (const [content, group] of groups) {
       let target = incumbentFor(group, content, activeExisting, inScope, claimed);
-      if (
-        target === undefined &&
-        !partialView &&
-        group.length >= MIN_SHARED_GROUP
-      ) {
-        target = allocateName(language, group, activeExisting, claimed);
+      if (target === undefined && group.length >= MIN_SHARED_GROUP) {
+        if (partialView) {
+          suppressedGroups++;
+        } else {
+          target = allocateName(language, group, activeExisting, claimed);
+        }
       }
       if (target !== undefined) {
         claimed.add(target);
@@ -475,6 +464,15 @@ export function computeSharedLockPlan(
       // delete the file those scripts read.
       plan.writes[key] = content;
     }
+  }
+
+  // Said out loud rather than left as silence: a tree that never converts
+  // because one script sits outside this sync's scope is otherwise impossible
+  // to tell from one with nothing to deduplicate.
+  if (suppressedGroups > 0) {
+    log.info(
+      `Lockfile dedup: ${suppressedGroups} group(s) left alone because ${unseen.length} script(s) are outside this sync's scope (e.g. ${unseen[0]}).`,
+    );
   }
 
   // Deletes are applied after writes, so a path some script still writes must
@@ -514,6 +512,29 @@ const SHARED_LOCK_REF_RE = new RegExp(
 );
 
 /**
+ * Both parsers, declared format first. YAML is a superset of JSON, and
+ * flow-style YAML (`{summary: x, lock: '!inline …'}`) starts with `{` while
+ * failing `JSON.parse` — deciding by the first character loses the reference.
+ */
+function parseMetadata(
+  metaPath: string,
+  metaContent: string,
+  isJson: boolean,
+): Record<string, any> | undefined {
+  for (const asJson of isJson ? [true, false] : [false, true]) {
+    try {
+      const parsed = asJson
+        ? JSON.parse(metaContent)
+        : yamlParseContent(metaPath, metaContent);
+      if (typeof parsed === "object" && parsed !== null) return parsed;
+    } catch {
+      // try the other one
+    }
+  }
+  return undefined;
+}
+
+/**
  * The shared lockfile a metadata file's `lock` field names, if any. The raw text
  * is only a prefilter: a summary or a comment can carry the same words, and
  * `!inline` decides where a lock is written, so it is read from the parsed
@@ -525,12 +546,7 @@ function sharedLockRefOf(
   isJson: boolean,
 ): string | undefined {
   if (!SHARED_LOCK_REF_RE.test(metaContent)) return undefined;
-  let parsed: any;
-  try {
-    parsed = isJson ? JSON.parse(metaContent) : yamlParseContent(metaPath, metaContent);
-  } catch {
-    return undefined;
-  }
+  const parsed = parseMetadata(metaPath, metaContent, isJson);
   const lock = parsed?.["lock"];
   if (typeof lock !== "string" || !lock.startsWith(INLINE_PREFIX)) return undefined;
   const ref = lock.slice(INLINE_PREFIX.length);
@@ -546,10 +562,10 @@ function sharedLockRefOf(
  */
 export function sharedLockRefIn(
   metadataContent: string,
+  isJson: boolean,
   root: string = ".",
 ): string | undefined {
-  const meta = { isJson: metadataContent.trimStart().startsWith("{") };
-  const ref = sharedLockRefOf("metadata", metadataContent, meta.isJson);
+  const ref = sharedLockRefOf("metadata", metadataContent, isJson);
   return ref && existsSync(path.resolve(root, ref)) ? ref : undefined;
 }
 
@@ -620,12 +636,10 @@ export async function collectExistingSharedLocks(
         if (meta === undefined || !isInWindmillNamespace(rel)) return;
         existing.scripts.add(rel);
         if (!anyShared) return;
-        let content: string;
-        try {
-          content = await readFile(full, "utf-8");
-        } catch {
-          return; // vanished or unreadable mid-walk; it reads nothing for us
-        }
+        // Deliberately unguarded: a metadata file this cannot read is a script
+        // whose lockfile is unknown, and treating it as a non-reader would let
+        // its shared lock be rewritten or swept underneath it.
+        const content = await readFile(full, "utf-8");
         const ref = sharedLockRefOf(rel, content, meta.isJson);
         if (ref) existing.refs.set(rel, ref);
     });

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -34,11 +34,11 @@ import {
  * narrowed to a single script (the git-sync deploy callback) computes the same
  * NAME as a full one.
  *
- * The CONTENT is a separate question, because a lock is not always a pure
- * function of its dependency file: a script can pin a Python version or carry an
- * `//npm` annotation, which the worker also locks. The stamp the worker writes
- * into each lock says whether the dependency inputs changed, which is most of
- * that question; scripts agreeing with each other answer the rest.
+ * The CONTENT follows, because a group only ever holds scripts whose lock IS
+ * that file's lock: one carrying an annotation the worker acts on — a pinned
+ * interpreter, `npm`, `nobundling` — never joins, so there is no variant inside
+ * a group to tell apart from a bump. What is left is a script whose committed
+ * lock is simply behind, and the many outvote it.
  *
  * Two cases are not shared at all and keep a `.script.lock` of their own: a
  * script whose annotation is `extra_` or carries inline dependencies (its lock

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -281,6 +281,11 @@ export function computeSharedLockPlan(
     }
   }
 
+  // Deletes are applied after writes, so a path some script still writes must
+  // not also be dropped — two metadata files pointing at one lock file would
+  // otherwise cancel each other out and leave the survivor without a lock.
+  plan.deletes = plan.deletes.filter((key) => plan.writes[key] === undefined);
+
   return plan;
 }
 

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import * as path from "node:path";
 import { yamlOptions } from "../commands/sync/sync.ts";
+import * as log from "../core/log.ts";
 import { yamlParseContent } from "./yaml.ts";
 import {
   inferContentTypeFromFilePath,
@@ -111,6 +112,7 @@ type ScriptEntry = {
   /** `metaKey` forward-slashed, i.e. how the working-tree scan names it. */
   metaRef: string;
   isJson: boolean;
+  compactJson: boolean;
   parsed: Record<string, any>;
   /** The lock file the metadata references today, as a map key. */
   lockKey: string;
@@ -241,6 +243,7 @@ function collectScripts(
       metaKey,
       metaRef: toRefPath(metaKey),
       isJson: meta.isJson,
+      compactJson: !metaContent.includes("\n"),
       parsed,
       lockKey: lockFile.key,
       ownLockKey: toMapKey(meta.ownLockKey),
@@ -252,9 +255,13 @@ function collectScripts(
 }
 
 function serializeMetadata(entry: ScriptEntry): string {
-  return entry.isJson
-    ? JSON.stringify(entry.parsed, null, 2)
-    : yamlStringify(entry.parsed, yamlOptions);
+  if (!entry.isJson) return yamlStringify(entry.parsed, yamlOptions);
+  // Indented or compact as it was found: `sync` writes JSON metadata indented
+  // and `generate-metadata` writes it compact, so imposing either one here
+  // reformats files this feature exists to keep quiet.
+  return entry.compactJson
+    ? JSON.stringify(entry.parsed)
+    : JSON.stringify(entry.parsed, null, 2);
 }
 
 /**
@@ -356,6 +363,7 @@ export function computeSharedLockPlan(
   map: Record<string, string>,
   defaultTs: "bun" | "deno" | undefined,
   existing: ExistingSharedLocks = NO_EXISTING_SHARED_LOCKS,
+  json = false,
 ): SharedLockPlan {
   const plan: SharedLockPlan = { writes: {}, deletes: [] };
   const byLanguage = new Map<string, Map<string, ScriptEntry[]>>();
@@ -373,10 +381,23 @@ export function computeSharedLockPlan(
     }
   }
 
-  // A sync that cannot see the whole tree conserves only (see the header).
-  const partialView = [...existing.scripts].some(
-    (script) => map[toMapKey(script)] === undefined && map[script] === undefined,
+  // A sync that cannot see the whole tree conserves only (see the header). Only
+  // the metadata twin this sync reads counts as missing: a leftover
+  // `.script.json` in a YAML repo is dropped by the map for reasons that have
+  // nothing to do with scope, and would otherwise put the tree in conserve-only
+  // mode for good.
+  const unseen = [...existing.scripts].filter(
+    (script) =>
+      script.endsWith(json ? ".json" : ".yaml") &&
+      map[toMapKey(script)] === undefined &&
+      map[script] === undefined,
   );
+  const partialView = unseen.length > 0;
+  if (partialView) {
+    log.debug(
+      `Lockfile dedup: ${unseen.length} script(s) outside this sync's scope (e.g. ${unseen[0]}); keeping existing groups but forming none.`,
+    );
+  }
 
   // Where every script ends up, so a shared file with nothing left reading it
   // can be dropped. Seeded with the whole tree, out-of-scope scripts included.
@@ -475,6 +496,21 @@ const SHARED_LOCK_REF_RE = new RegExp(
   `${INLINE_PREFIX}(${SHARED_LOCK_DIR}/[^\\s'"]+\\.lock)`,
 );
 
+/**
+ * The shared lockfile a metadata FILE reads, when it reads one that is there.
+ * `parseMetadataFile` resolves `lock` to the lockfile's content, so the
+ * reference itself survives only in the raw text.
+ */
+export function sharedLockRefIn(
+  metadataContent: string,
+  root: string = ".",
+): string | undefined {
+  const ref = SHARED_LOCK_REF_RE.exec(metadataContent)?.[1];
+  return ref && isSharedLockPath(ref) && existsSync(path.resolve(root, ref))
+    ? ref
+    : undefined;
+}
+
 // `.wmill` is the stateful-push mirror: its copies of a script's metadata would
 // be counted as extra readers of a shared lockfile and freeze its content.
 // `.git` and `node_modules` cannot be Windmill paths and are where the walk
@@ -482,6 +518,9 @@ const SHARED_LOCK_REF_RE = new RegExp(
 // like `dist` is a legal folder, and a script hidden from this scan is exactly
 // the script the scan exists to protect.
 const SCAN_SKIP_DIRS = new Set([".git", ".wmill", "node_modules"]);
+
+/** Workspace-shared raw-app components, which sync handles on its own. */
+const SCAN_SKIP_ROOTS = ["ui/"];
 
 /**
  * The shared lockfiles in the working tree, the scripts that read them, and
@@ -521,6 +560,7 @@ export async function collectExistingSharedLocks(
         continue;
       }
       if (scriptMetaBase(rel) === undefined) continue;
+      if (SCAN_SKIP_ROOTS.some((root) => rel.startsWith(root))) continue;
       existing.scripts.add(rel);
       // A substring match on the raw text rather than a parse: this reads every
       // script metadata file in the workspace, and the reference is a literal.

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -281,6 +281,11 @@ function depFilesByKey(paths: Iterable<string>): Map<string, string> {
   for (const key of paths) {
     const ref = toRefPath(key);
     if (!ref.startsWith("dependencies/")) continue;
+    // A set named `team/python` exports as `dependencies/team/python.<file>`,
+    // which has no distinct name under `locks/`: flattened it collides with the
+    // top-level file, and the sweep would then retire a lockfile whose scripts
+    // still read it. Such a set shares nothing and its scripts keep own locks.
+    if (ref.slice("dependencies/".length).includes("/")) continue;
     const depKey = depKeyOf(ref);
     if (depKey) byKey.set(depKey, ref);
   }

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -1,18 +1,19 @@
 import { stringify as yamlStringify } from "yaml";
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { existsSync, type Dirent } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import * as path from "node:path";
-import { isNeverWalkedDir, yamlOptions } from "../commands/sync/sync.ts";
-import * as log from "../core/log.ts";
+import { yamlOptions } from "../commands/sync/sync.ts";
 import { yamlParseContent } from "./yaml.ts";
 import {
+  depFileOfSharedLock,
+  extractWorkspaceDepsAnnotation,
   inferContentTypeFromFilePath,
   isSharedLockPath,
   languageNeedsLock,
-  sharedLockPath,
-  SHARED_LOCK_DIR,
+  sharedLockPathFor,
+  workspaceDependenciesPathToLanguageAndFilename,
+  type ScriptLanguage,
 } from "./script_common.ts";
-
 
 /**
  * Lockfile deduplication (`dedupeLockfiles` in wmill.yaml).
@@ -22,52 +23,27 @@ import {
  * thousands of byte-identical `.script.lock` files: one dependency bump rewrites
  * all of them, and every open branch conflicts on all of them.
  *
- * With dedup on, scripts that share a lock reference ONE file under `locks/`,
- * through the `!inline` indirection their metadata already uses — so the bump is
- * a one-file diff.
+ * With dedup on, the scripts that resolve against a workspace dependency file
+ * reference ONE lockfile named after it — `dependencies/requirements.in` ->
+ * `locks/requirements.in.lock` — through the `!inline` indirection their
+ * metadata already uses. A dependency bump is a one-file diff.
  *
- * Three rules make that hold, and each is load-bearing:
+ * Identity comes from the dependency file, never from the content or from which
+ * scripts happen to be in view. That is what makes the pass stateless: a sync
+ * narrowed to a single script (the git-sync deploy callback) computes the same
+ * name as a full one, because the lock that script holds IS that dependency
+ * file's lock — the worker resolves it from the file alone, ignoring the body.
  *
- * - **A shared file's name never encodes its content.** A content-addressed name
- *   would move on every bump and put the churn straight back into the metadata
- *   of every script. A group of scripts KEEPS the file it already references
- *   (its incumbent) and the file's CONTENT is what changes. Only a group with no
- *   incumbent is given a name: `<language>.lock`, then `<language>-2.lock`, …
- * - **A shared file's content only moves when every script that reads it agrees.**
- *   Referrers are counted from the whole working tree, never from the sync map,
- *   which wmill.yaml's includes/excludes narrow — and which the git-sync deploy
- *   callback narrows to a single item. A script the current sync does not cover
- *   still reads the file, and rewriting or deleting it underneath would change
- *   that script's lock silently.
- * - **A sync that cannot see the whole tree only conserves.** It keeps existing
- *   groups together but never forms new ones, so a per-item deploy does not
- *   invent shared files that a later full sync has to undo.
+ * Two cases are therefore NOT shared and keep a `.script.lock` of their own: a
+ * script whose annotation is `extra_` or carries inline dependencies (its lock
+ * folds in its own imports), and one naming several dependency files at once
+ * (its lock is no single file's).
  */
 
 const INLINE_PREFIX = "!inline ";
 
-/** Content-file extensions of the languages that carry a lock, longest first.
- *  A language absent here is simply never deduplicated.
- *  for related places search: ADD_NEW_LANG */
-const LOCKABLE_EXTS = [
-  ".fetch.ts",
-  ".deno.ts",
-  ".bun.ts",
-  ".playbook.yml",
-  ".ts",
-  ".py",
-  ".go",
-  ".php",
-  ".rs",
-];
-
-/** Below this a shared file would trade one lock file for two. It gates only
- *  NEW shared files: a script already on one stays there however few are left,
- *  or a narrowed sync scope would tear the group apart. */
-const MIN_SHARED_GROUP = 2;
-
-/** Sync maps are keyed with the platform separator (`path.join`), while an
- *  `!inline` reference is always forward-slash. */
+/** Sync maps are keyed with the platform separator, while an `!inline`
+ *  reference is always forward-slash. */
 const toMapKey = (refPath: string) => refPath.replaceAll("/", path.sep);
 const toRefPath = (mapKey: string) => mapKey.replaceAll("\\", "/");
 
@@ -76,23 +52,6 @@ const toRefPath = (mapKey: string) => mapKey.replaceAll("\\", "/");
 export type LockDedupOptions = {
   dedupeLockfiles?: boolean | undefined;
   defaultTs?: "bun" | "deno" | undefined;
-};
-
-/** The working tree as it stands, collected unfiltered (see the header).
- *  Paths are forward-slashed. */
-export type ExistingSharedLocks = {
-  /** script metadata file -> the shared lockfile it references */
-  refs: Map<string, string>;
-  /** shared lockfile -> its content */
-  contents: Map<string, string>;
-  /** every script metadata file in the tree, referencing a shared lock or not */
-  scripts: Set<string>;
-};
-
-export const NO_EXISTING_SHARED_LOCKS: ExistingSharedLocks = {
-  refs: new Map(),
-  contents: new Map(),
-  scripts: new Set(),
 };
 
 /** The files a dedup pass writes and removes, as paths relative to the sync
@@ -108,17 +67,16 @@ export function isEmptySharedLockPlan(plan: SharedLockPlan): boolean {
 
 type ScriptEntry = {
   metaKey: string;
-  /** `metaKey` forward-slashed, i.e. how the working-tree scan names it. */
-  metaRef: string;
   isJson: boolean;
   compactJson: boolean;
   parsed: Record<string, any>;
-  /** The lock file the metadata references today, as a map key. */
+  /** The lockfile the metadata references today, as a map key. */
   lockKey: string;
-  /** The lock file this script owns when it is not sharing one. */
+  /** The lockfile this script owns when it is not sharing one. */
   ownLockKey: string;
-  language: string;
   lock: string;
+  /** The workspace dependency file whose lock this is, when it is one. */
+  depFile: string | undefined;
 };
 
 /** `f/foo.script.yaml` -> base `f/foo`, lock `f/foo.script.lock`;
@@ -152,42 +110,63 @@ function scriptMetaBase(
   return undefined;
 }
 
-/** Map keys grouped by directory. A script's content file is looked up among
+/** Content-file extensions of the languages that carry a lock, longest first.
+ *  A language absent here is simply never deduplicated.
+ *  for related places search: ADD_NEW_LANG */
+const LOCKABLE_EXTS = [
+  ".fetch.ts",
+  ".deno.ts",
+  ".bun.ts",
+  ".playbook.yml",
+  ".ts",
+  ".py",
+  ".go",
+  ".php",
+  ".rs",
+];
+
+/** Map keys grouped by directory, so a script's content file is looked up among
  *  its own directory's entries: splitting a name at its first dot would put
  *  `f/a.b.py` under `f/a` and leave every dotted script path undeduplicated. */
-function indexByDirectory(map: Record<string, string>): Map<string, string[]> {
-  const index = new Map<string, string[]>();
+function indexByDirectory(
+  map: Record<string, string>,
+): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
   for (const key of Object.keys(map)) {
     const ref = toRefPath(key);
     const dir = ref.slice(0, ref.lastIndexOf("/") + 1);
     const bucket = index.get(dir);
     if (bucket) {
-      bucket.push(ref);
+      bucket.add(ref);
     } else {
-      index.set(dir, [ref]);
+      index.set(dir, new Set([ref]));
     }
   }
   return index;
 }
 
-function languageOfScript(
+/** A script's content file and its language: `<base><ext>` and nothing looser,
+ *  since `f/a.b.py` is the content file of `f/a.b`, not of `f/a`. */
+function contentOfScript(
+  map: Record<string, string>,
   base: string,
-  byDirectory: Map<string, string[]>,
+  byDirectory: Map<string, Set<string>>,
   defaultTs: "bun" | "deno" | undefined,
-): string | undefined {
-  const dir = base.slice(0, base.lastIndexOf("/") + 1);
-  const siblings = new Set(byDirectory.get(dir) ?? []);
-  // `<base><ext>` and nothing looser: `f/a.b.py` is the content file of the
-  // script `f/a.b`, not of `f/a`, and a prefix match would read one script's
-  // language off another's file. Longest extension first, so `.bun.ts` is not
-  // taken for `.ts` (dbt is absent from the list, and stays out of dedup).
+): { content: string; language: ScriptLanguage } | undefined {
+  const siblings = byDirectory.get(base.slice(0, base.lastIndexOf("/") + 1));
+  if (!siblings) return undefined;
   for (const ext of LOCKABLE_EXTS) {
-    if (siblings.has(base + ext)) {
-      try {
-        return inferContentTypeFromFilePath(base + ext, defaultTs);
-      } catch {
-        // not a language this CLI knows
-      }
+    const candidate = base + ext;
+    if (!siblings.has(candidate)) continue;
+    const content = map[toMapKey(candidate)] ?? map[candidate];
+    if (content === undefined) continue;
+    try {
+      return {
+        content,
+        language: inferContentTypeFromFilePath(candidate, defaultTs),
+      };
+    } catch {
+      // not a language this CLI knows
     }
   }
   return undefined;
@@ -205,311 +184,6 @@ function lookup(
   }
   return undefined;
 }
-
-function collectScripts(
-  map: Record<string, string>,
-  defaultTs: "bun" | "deno" | undefined,
-): ScriptEntry[] {
-  const byDirectory = indexByDirectory(map);
-  const entries: ScriptEntry[] = [];
-  for (const [metaKey, metaContent] of Object.entries(map)) {
-    const meta = scriptMetaBase(metaKey);
-    if (!meta) continue;
-
-    const parsed = parseMetadata(metaKey, metaContent, meta.isJson);
-    if (parsed === undefined) continue;
-
-    const lockRef = parsed["lock"];
-    if (typeof lockRef !== "string" || !lockRef.startsWith(INLINE_PREFIX)) {
-      continue;
-    }
-    const lockFile = lookup(map, lockRef.slice(INLINE_PREFIX.length));
-    // An absent or empty lock is not a lock to share: a script with no
-    // dependencies carries `lock: ''` and no file at all.
-    if (lockFile === undefined || lockFile.content === "") continue;
-
-    const language = languageOfScript(meta.base, byDirectory, defaultTs);
-    if (language === undefined || !languageNeedsLock(language)) continue;
-
-    entries.push({
-      metaKey,
-      metaRef: toRefPath(metaKey),
-      isJson: meta.isJson,
-      compactJson: !metaContent.includes("\n"),
-      parsed,
-      lockKey: lockFile.key,
-      ownLockKey: toMapKey(meta.ownLockKey),
-      language,
-      lock: lockFile.content,
-    });
-  }
-  return entries;
-}
-
-function serializeMetadata(entry: ScriptEntry): string {
-  if (!entry.isJson) return yamlStringify(entry.parsed, yamlOptions);
-  // Indented or compact as it was found: `sync` writes JSON metadata indented
-  // and `generate-metadata` writes it compact, so imposing either one here
-  // reformats files this feature exists to keep quiet.
-  return entry.compactJson
-    ? JSON.stringify(entry.parsed)
-    : JSON.stringify(entry.parsed, null, 2);
-}
-
-/**
- * Scripts that read a shared lockfile and that this plan does not speak for:
- * the ones this sync's scope leaves out. Readers inside the scope are being
- * reassigned by this same plan, so they cannot be surprised by a content change
- * — counting them would hand a lagging minority a veto over the majority's file.
- */
-function unrepresentedReaders(
-  existing: ExistingSharedLocks,
-  inScope: (metaRef: string) => boolean,
-  sharedRef: string,
-): number {
-  let count = 0;
-  for (const [metaRef, ref] of existing.refs) {
-    if (ref === sharedRef && !inScope(metaRef)) count++;
-  }
-  return count;
-}
-
-/**
- * The shared file a group of scripts is entitled to keep: the one most of them
- * already reference. Undefined when the group has no incumbent, or when keeping
- * it would move its content underneath scripts outside the group.
- */
-function incumbentFor(
-  group: ScriptEntry[],
-  content: string,
-  existing: ExistingSharedLocks,
-  inScope: (metaRef: string) => boolean,
-  claimed: Set<string>,
-): string | undefined {
-  const votes = new Map<string, number>();
-  for (const entry of group) {
-    const ref = existing.refs.get(entry.metaRef);
-    if (ref === undefined || claimed.has(ref)) continue;
-    votes.set(ref, (votes.get(ref) ?? 0) + 1);
-  }
-  let best: string | undefined;
-  let bestVotes = 0;
-  for (const [ref, count] of votes) {
-    if (
-      count > bestVotes ||
-      (count === bestVotes && best !== undefined && ref < best)
-    ) {
-      best = ref;
-      bestVotes = count;
-    }
-  }
-  if (best === undefined) return undefined;
-  // Keeping the name costs nothing while the content is unchanged. Moving the
-  // content takes a real group speaking for every reader — otherwise one script
-  // that drifted would rename the file for all the others, or keep a shared
-  // file to itself.
-  if (
-    existing.contents.get(best) !== content &&
-    (group.length < MIN_SHARED_GROUP ||
-      unrepresentedReaders(existing, inScope, best) > 0)
-  ) {
-    return undefined;
-  }
-  return best;
-}
-
-/** The first `<language>[-N].lock` no other group in this run holds and no
- *  script outside the group still reads. */
-function allocateName(
-  language: string,
-  group: ScriptEntry[],
-  existing: ExistingSharedLocks,
-  claimed: Set<string>,
-): string {
-  const inGroup = new Set(group.map((e) => e.metaRef));
-  for (let n = 1; ; n++) {
-    const candidate = sharedLockPath(language, n);
-    if (claimed.has(candidate)) continue;
-    let readByOthers = false;
-    for (const [metaRef, ref] of existing.refs) {
-      if (ref === candidate && !inGroup.has(metaRef)) {
-        readByOthers = true;
-        break;
-      }
-    }
-    if (!readByOthers) return candidate;
-  }
-}
-
-/**
- * What a sync map (path -> content) has to change for duplicated script locks to
- * become one shared file per group. Pure: neither argument is touched.
- */
-export type SharedLockPlanContext = {
-  defaultTs?: "bun" | "deno" | undefined;
-  /** The working tree as it stands, unfiltered (see the header). */
-  existing?: ExistingSharedLocks;
-  /** Whether metadata is JSON rather than YAML in this workspace. */
-  json?: boolean;
-  /**
-   * Whether a script metadata path is one this sync covers. NOT the same as
-   * "present in `map`": on a pull the map is the remote, and a script added
-   * locally but never pushed is in scope while absent from it.
-   */
-  inScope?: (metaRef: string) => boolean;
-};
-
-export function computeSharedLockPlan(
-  map: Record<string, string>,
-  ctx: SharedLockPlanContext = {},
-): SharedLockPlan {
-  const {
-    defaultTs,
-    existing = NO_EXISTING_SHARED_LOCKS,
-    json = false,
-    inScope = (metaRef: string) =>
-      map[toMapKey(metaRef)] !== undefined || map[metaRef] !== undefined,
-  } = ctx;
-  const plan: SharedLockPlan = { writes: {}, deletes: [] };
-  const byLanguage = new Map<string, Map<string, ScriptEntry[]>>();
-  for (const entry of collectScripts(map, defaultTs)) {
-    let byLock = byLanguage.get(entry.language);
-    if (!byLock) {
-      byLock = new Map();
-      byLanguage.set(entry.language, byLock);
-    }
-    const group = byLock.get(entry.lock);
-    if (group) {
-      group.push(entry);
-    } else {
-      byLock.set(entry.lock, [entry]);
-    }
-  }
-
-  // The metadata twin this sync does not read is not a reader: it is never
-  // pushed, and letting it vote would veto changes on behalf of a dead file.
-  const metaExt = json ? ".json" : ".yaml";
-  const activeRefs = new Map(
-    [...existing.refs].filter(([metaRef]) => metaRef.endsWith(metaExt)),
-  );
-  const activeExisting: ExistingSharedLocks = { ...existing, refs: activeRefs };
-
-  // A sync that cannot see the whole tree conserves only (see the header). Only
-  // the metadata twin this sync reads counts as missing: a leftover
-  // `.script.json` in a YAML repo is dropped by the map for reasons that have
-  // nothing to do with scope, and would otherwise put the tree in conserve-only
-  // mode for good.
-  const unseen = [...existing.scripts].filter(
-    (script) => script.endsWith(metaExt) && !inScope(script),
-  );
-  const partialView = unseen.length > 0;
-  let suppressedGroups = 0;
-
-  // Where every script ends up, so a shared file with nothing left reading it
-  // can be dropped. Seeded with the whole tree, out-of-scope scripts included.
-  const finalRefs = new Map(activeRefs);
-  const claimed = new Set<string>();
-
-  for (const [language, byLock] of [...byLanguage].sort(([a], [b]) =>
-    a.localeCompare(b),
-  )) {
-    // Biggest group first: it has the strongest claim to a name, and ties break
-    // on the content itself so the outcome never depends on map ordering.
-    const groups = [...byLock].sort(
-      ([contentA, a], [contentB, b]) =>
-        b.length - a.length || contentA.localeCompare(contentB),
-    );
-
-    for (const [content, group] of groups) {
-      let target = incumbentFor(group, content, activeExisting, inScope, claimed);
-      if (target === undefined && group.length >= MIN_SHARED_GROUP) {
-        if (partialView) {
-          suppressedGroups++;
-        } else {
-          target = allocateName(language, group, activeExisting, claimed);
-        }
-      }
-      if (target !== undefined) {
-        claimed.add(target);
-        const sharedKey = toMapKey(target);
-        if (map[sharedKey] !== content) plan.writes[sharedKey] = content;
-      }
-
-      for (const entry of group) {
-        const targetKey =
-          target !== undefined ? toMapKey(target) : entry.ownLockKey;
-        finalRefs.set(entry.metaRef, toRefPath(targetKey));
-        if (entry.lockKey === targetKey) continue;
-        if (target === undefined && map[targetKey] !== entry.lock) {
-          plan.writes[targetKey] = entry.lock;
-        }
-        // A shared file is only ever dropped by the sweep below, which knows
-        // who else reads it.
-        if (!isSharedLockPath(entry.lockKey)) plan.deletes.push(entry.lockKey);
-        entry.parsed["lock"] = INLINE_PREFIX + toRefPath(targetKey);
-        plan.writes[entry.metaKey] = serializeMetadata(entry);
-      }
-    }
-  }
-
-  const stillRead = new Set(finalRefs.values());
-  for (const [sharedRef, content] of existing.contents) {
-    const key = toMapKey(sharedRef);
-    if (!stillRead.has(sharedRef)) {
-      // Nothing reads it any more: its scripts diverged, or the sync deleted them.
-      if (plan.writes[key] === undefined) plan.deletes.push(key);
-    } else if (plan.writes[key] === undefined && map[key] === undefined) {
-      // Read by a script this sync does not cover, and absent from the map (the
-      // remote never serializes shared files). Carried over, or the diff would
-      // delete the file those scripts read.
-      plan.writes[key] = content;
-    }
-  }
-
-  // Said out loud rather than left as silence: a tree that never converts
-  // because one script sits outside this sync's scope is otherwise impossible
-  // to tell from one with nothing to deduplicate.
-  if (suppressedGroups > 0) {
-    log.info(
-      `Lockfile dedup: ${suppressedGroups} group(s) left alone because ${unseen.length} script(s) are outside this sync's scope (e.g. ${unseen[0]}).`,
-    );
-  }
-
-  // Deletes are applied after writes, so a path some script still writes must
-  // not also be dropped — two metadata files pointing at one lock file would
-  // otherwise cancel each other out and leave the survivor without a lock.
-  plan.deletes = plan.deletes.filter((key) => plan.writes[key] === undefined);
-
-  return plan;
-}
-
-export function applySharedLockPlanToMap(
-  map: Record<string, string>,
-  plan: SharedLockPlan,
-): void {
-  for (const [key, content] of Object.entries(plan.writes)) {
-    map[key] = content;
-  }
-  for (const key of plan.deletes) {
-    delete map[key];
-  }
-}
-
-export async function applySharedLockPlanToDisk(
-  plan: SharedLockPlan,
-): Promise<void> {
-  for (const [key, content] of Object.entries(plan.writes)) {
-    await mkdir(path.dirname(key), { recursive: true });
-    await writeFile(key, content, "utf-8");
-  }
-  for (const key of plan.deletes) {
-    await rm(key, { force: true });
-  }
-}
-
-const SHARED_LOCK_REF_RE = new RegExp(
-  `${INLINE_PREFIX}(${SHARED_LOCK_DIR}/[^\\s'"]+\\.lock)`,
-);
 
 /**
  * Both parsers, declared format first. YAML is a superset of JSON, and
@@ -537,21 +211,20 @@ function parseMetadata(
 /**
  * The shared lockfile a metadata file's `lock` field names, if any. The raw text
  * is only a prefilter: a summary or a comment can carry the same words, and
- * `!inline` decides where a lock is written, so it is read from the parsed
- * field and nowhere else.
+ * `!inline` decides where a lock is written, so it is read from the parsed field
+ * and nowhere else.
  */
 function sharedLockRefOf(
   metaPath: string,
   metaContent: string,
   isJson: boolean,
 ): string | undefined {
-  if (!SHARED_LOCK_REF_RE.test(metaContent)) return undefined;
-  const parsed = parseMetadata(metaPath, metaContent, isJson);
-  const lock = parsed?.["lock"];
-  if (typeof lock !== "string" || !lock.startsWith(INLINE_PREFIX)) return undefined;
+  if (!metaContent.includes(INLINE_PREFIX)) return undefined;
+  const lock = parseMetadata(metaPath, metaContent, isJson)?.["lock"];
+  if (typeof lock !== "string" || !lock.startsWith(INLINE_PREFIX)) {
+    return undefined;
+  }
   const ref = lock.slice(INLINE_PREFIX.length);
-  // Validated, not just matched: a reference is repo content and becomes a path
-  // this pass writes to.
   return isSharedLockPath(ref) ? ref : undefined;
 }
 
@@ -569,96 +242,221 @@ export function sharedLockRefIn(
   return ref && existsSync(path.resolve(root, ref)) ? ref : undefined;
 }
 
-/** Runs `fn` over `items`, at most `size` at a time. */
-async function inBatches<T>(
-  items: readonly T[],
-  size: number,
-  fn: (item: T) => Promise<void>,
-): Promise<void> {
-  for (let i = 0; i < items.length; i += size) {
-    await Promise.all(items.slice(i, i + size).map((item) => fn(item)));
+/** Workspace dependency files keyed by the language and name a script names. */
+function depFilesByKey(paths: Iterable<string>): Map<string, string> {
+  const byKey = new Map<string, string>();
+  for (const key of paths) {
+    const ref = toRefPath(key);
+    if (!ref.startsWith("dependencies/")) continue;
+    const info = workspaceDependenciesPathToLanguageAndFilename(ref);
+    if (!info || !languageNeedsLock(info.language)) continue;
+    byKey.set(`${info.language} ${info.name ?? "default"}`, ref);
   }
+  return byKey;
 }
 
 /**
- * The shared lockfiles in the working tree, the scripts that read them, and
- * every script metadata file there is — deliberately NOT filtered by the sync's
- * includes/excludes, which is what lets a plan tell what its map leaves out.
+ * The workspace dependency file whose lock a script's lock IS — undefined when
+ * the script's lock is its own (see the header for the two cases).
  */
-export async function collectExistingSharedLocks(
-  root: string,
-): Promise<ExistingSharedLocks> {
-  const existing: ExistingSharedLocks = {
-    refs: new Map(),
-    contents: new Map(),
-    scripts: new Set(),
-  };
-  // With no shared lockfiles yet there is no reference to read: the walk still
-  // has to enumerate the scripts, because whether this sync covers all of them
-  // is what decides if it may form groups at all.
-  const anyShared = existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")));
+function shareableDepFile(
+  scriptContent: string,
+  language: ScriptLanguage,
+  depFiles: Map<string, string>,
+): string | undefined {
+  const annotation = extractWorkspaceDepsAnnotation(scriptContent, language);
+  if (annotation && (annotation.mode === "extra" || annotation.inline)) {
+    return undefined;
+  }
+  const names = annotation ? annotation.external : ["default"];
+  if (names.length !== 1) return undefined;
+  return depFiles.get(`${language} ${names[0]}`);
+}
 
-  // Only where scripts and shared lockfiles can live. Scoping the walk is what
-  // keeps `docs/notes.script.yaml` out of the picture, and keeps the fail-closed
-  // read below from covering directories that cannot affect the plan.
-  const roots = ["f", "u", "g", SHARED_LOCK_DIR];
+/**
+ * The shared lockfile a script belongs in, given the workspace dependency files
+ * available — the one place that decides it, for both the sync planner and the
+ * per-script regeneration in `updateScriptLock`.
+ */
+export function sharedLockTargetFor(
+  scriptContent: string,
+  language: ScriptLanguage,
+  depPaths: Iterable<string>,
+): string | undefined {
+  const depFile = shareableDepFile(
+    scriptContent,
+    language,
+    depFilesByKey(depPaths),
+  );
+  return depFile === undefined ? undefined : sharedLockPathFor(depFile);
+}
 
-  // Traversal first, reads second: recursing inside a batch would multiply the
-  // fan-out at every level, and the reads below are deliberately unguarded.
-  const toRead: { rel: string; isJson: boolean; shared: boolean }[] = [];
-  let walkedRoot = "";
-  const walk = async (dir: string): Promise<void> => {
-    let entries: Dirent[];
-    try {
-      entries = await readdir(path.join(root, dir), { withFileTypes: true });
-    } catch (e) {
-      // Only a directory that is not there is nothing to read. Anything else —
-      // a permission error, a broken mount — hides scripts whose lockfiles this
-      // pass would then rewrite or sweep as unread.
-      if ((e as { code?: string })?.code === "ENOENT") return;
-      throw e;
+function collectScripts(
+  map: Record<string, string>,
+  defaultTs: "bun" | "deno" | undefined,
+): ScriptEntry[] {
+  const byDirectory = indexByDirectory(map);
+  const depFiles = depFilesByKey(Object.keys(map));
+  const entries: ScriptEntry[] = [];
+  for (const [metaKey, metaContent] of Object.entries(map)) {
+    const meta = scriptMetaBase(metaKey);
+    if (!meta) continue;
+
+    const parsed = parseMetadata(metaKey, metaContent, meta.isJson);
+    if (parsed === undefined) continue;
+
+    const lockRef = parsed["lock"];
+    if (typeof lockRef !== "string" || !lockRef.startsWith(INLINE_PREFIX)) {
+      continue;
     }
-    for (const entry of entries) {
-      const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
-      if (entry.isDirectory()) {
-        // The same exclusions sync's own walk applies: a directory it never
-        // descends holds no script this pass may draw conclusions from — and
-        // `.wmill`, the stateful mirror, holds copies that would be counted as
-        // extra readers and freeze a shared lockfile's content.
-        if (!isNeverWalkedDir(entry.name)) await walk(rel);
-        continue;
-      }
-      if (isSharedLockPath(rel)) {
-        toRead.push({ rel, isJson: false, shared: true });
-        continue;
-      }
-      // `locks/` is walked for the shared files themselves; a metadata file
-      // sitting there is not a script sync will ever see, and counting it would
-      // pin the planner in conserve-only mode for good.
-      const meta = walkedRoot === SHARED_LOCK_DIR ? undefined : scriptMetaBase(rel);
-      if (meta === undefined) continue;
-      existing.scripts.add(rel);
-      if (anyShared) toRead.push({ rel, isJson: meta.isJson, shared: false });
+    const lockFile = lookup(map, lockRef.slice(INLINE_PREFIX.length));
+    // An absent or empty lock is not a lock to share: a script with no
+    // dependencies carries `lock: ''` and no file at all.
+    if (lockFile === undefined || lockFile.content === "") continue;
+
+    const script = contentOfScript(map, meta.base, byDirectory, defaultTs);
+    if (script === undefined || !languageNeedsLock(script.language)) continue;
+
+    entries.push({
+      metaKey,
+      isJson: meta.isJson,
+      compactJson: !metaContent.includes("\n"),
+      parsed,
+      lockKey: lockFile.key,
+      ownLockKey: toMapKey(meta.ownLockKey),
+      lock: lockFile.content,
+      depFile: shareableDepFile(script.content, script.language, depFiles),
+    });
+  }
+  return entries;
+}
+
+function serializeMetadata(entry: ScriptEntry): string {
+  if (!entry.isJson) return yamlStringify(entry.parsed, yamlOptions);
+  // Indented or compact as it was found: `sync` writes JSON metadata indented
+  // and `generate-metadata` writes it compact, so imposing either one here
+  // reformats files this feature exists to keep quiet.
+  return entry.compactJson
+    ? JSON.stringify(entry.parsed)
+    : JSON.stringify(entry.parsed, null, 2);
+}
+
+/**
+ * What a sync map (path -> content) has to change for the scripts of a workspace
+ * dependency file to share one lockfile. Pure: the map is not touched.
+ */
+export function computeSharedLockPlan(
+  map: Record<string, string>,
+  ctx: { defaultTs?: "bun" | "deno" | undefined } = {},
+): SharedLockPlan {
+  const plan: SharedLockPlan = { writes: {}, deletes: [] };
+  const byDepFile = new Map<string, ScriptEntry[]>();
+  const ownLock: ScriptEntry[] = [];
+  for (const entry of collectScripts(map, ctx.defaultTs)) {
+    if (entry.depFile === undefined) {
+      ownLock.push(entry);
+      continue;
     }
-  };
-  for (const r of roots) {
-    walkedRoot = r;
-    await walk(r);
+    byDepFile.set(entry.depFile, [
+      ...(byDepFile.get(entry.depFile) ?? []),
+      entry,
+    ]);
   }
 
-  await inBatches(toRead, 32, async ({ rel, isJson, shared }) => {
-    // Deliberately unguarded: a metadata file this cannot read is a script whose
-    // lockfile is unknown, and treating it as a non-reader would let its shared
-    // lock be rewritten or swept underneath it.
-    const content = await readFile(path.join(root, ...rel.split("/")), "utf-8");
-    if (shared) {
-      existing.contents.set(rel, content);
-      return;
+  const point = (entry: ScriptEntry, targetKey: string) => {
+    if (entry.lockKey === targetKey) return;
+    // A shared lockfile is dropped by the sweep below, which knows whether its
+    // dependency file is still there; only a private one goes with its script.
+    if (!isSharedLockPath(entry.lockKey)) plan.deletes.push(entry.lockKey);
+    entry.parsed["lock"] = INLINE_PREFIX + toRefPath(targetKey);
+    plan.writes[entry.metaKey] = serializeMetadata(entry);
+  };
+
+  const takeOwnLock = (entry: ScriptEntry) => {
+    if (map[entry.ownLockKey] !== entry.lock) {
+      plan.writes[entry.ownLockKey] = entry.lock;
     }
-    const ref = sharedLockRefOf(rel, content, isJson);
-    if (ref) existing.refs.set(rel, ref);
-  });
-  return existing;
+    point(entry, entry.ownLockKey);
+  };
+
+  for (const [depFile, group] of byDepFile) {
+    // Every one of these scripts resolves against the same file in the same
+    // mode, so their locks are identical by construction. A stale committed lock
+    // is the exception, and the many outvote the one; ties break on the content
+    // itself so the outcome never depends on map ordering.
+    const byContent = new Map<string, ScriptEntry[]>();
+    for (const entry of group) {
+      byContent.set(entry.lock, [...(byContent.get(entry.lock) ?? []), entry]);
+    }
+    let content = "";
+    let count = 0;
+    for (const [lock, members] of byContent) {
+      if (
+        members.length > count ||
+        (members.length === count && lock < content)
+      ) {
+        content = lock;
+        count = members.length;
+      }
+    }
+
+    const sharedKey = toMapKey(sharedLockPathFor(depFile));
+    if (map[sharedKey] !== content) plan.writes[sharedKey] = content;
+    for (const entry of group) {
+      if (entry.lock === content) point(entry, sharedKey);
+      else takeOwnLock(entry);
+    }
+  }
+
+  // A script that stopped resolving against a dependency file takes its lock
+  // back with it.
+  for (const entry of ownLock) {
+    if (entry.lockKey !== entry.ownLockKey) takeOwnLock(entry);
+  }
+
+  // A shared lockfile lives exactly as long as the dependency file it is named
+  // after. Asking that, rather than "does any script still read it", is what
+  // lets a sync narrowed to one item leave the rest of the workspace alone.
+  for (const key of Object.keys(map)) {
+    const depFile = depFileOfSharedLock(toRefPath(key));
+    if (depFile === undefined) continue;
+    const stillThere =
+      map[toMapKey(depFile)] !== undefined || map[depFile] !== undefined;
+    if (!stillThere && plan.writes[key] === undefined) plan.deletes.push(key);
+  }
+
+  // Deletes are applied after writes, so a path some script still writes must
+  // not also be dropped — two metadata files pointing at one lock file would
+  // otherwise cancel each other out and leave the survivor without a lock.
+  plan.deletes = plan.deletes.filter((key) => plan.writes[key] === undefined);
+
+  return plan;
+}
+
+export function applySharedLockPlanToMap(
+  map: Record<string, string>,
+  plan: SharedLockPlan,
+): void {
+  for (const [key, content] of Object.entries(plan.writes)) {
+    map[key] = content;
+  }
+  for (const key of plan.deletes) {
+    delete map[key];
+  }
+}
+
+export async function applySharedLockPlanToDisk(
+  plan: SharedLockPlan,
+): Promise<void> {
+  for (const [key, content] of Object.entries(plan.writes)) {
+    // Per write, so `locks/` comes into existence only when there is a shared
+    // lockfile to put in it.
+    await mkdir(path.dirname(key), { recursive: true });
+    await writeFile(key, content, "utf-8");
+  }
+  for (const key of plan.deletes) {
+    await rm(key, { force: true });
+  }
 }
 
 /**
@@ -669,23 +467,14 @@ export function scriptsReferencingSharedLock(
   map: Record<string, string>,
   sharedKey: string,
 ): string[] {
-  const reference = INLINE_PREFIX + toRefPath(sharedKey);
+  const reference = toRefPath(sharedKey);
   const referrers: string[] = [];
   for (const [metaKey, metaContent] of Object.entries(map)) {
     const meta = scriptMetaBase(metaKey);
     if (!meta) continue;
-    // A string test before parsing: the metadata of every script in the
-    // workspace would otherwise be parsed to answer this.
-    if (!metaContent.includes(reference)) continue;
-    let parsed: any;
-    try {
-      parsed = meta.isJson
-        ? JSON.parse(metaContent)
-        : yamlParseContent(metaKey, metaContent);
-    } catch {
-      continue;
+    if (sharedLockRefOf(metaKey, metaContent, meta.isJson) === reference) {
+      referrers.push(metaKey);
     }
-    if (parsed?.["lock"] === reference) referrers.push(metaKey);
   }
   return referrers;
 }

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -7,6 +7,7 @@ import { yamlParseContent } from "./yaml.ts";
 import {
   depFileOfSharedLock,
   extractWorkspaceDepsAnnotation,
+  hasLockAffectingAnnotation,
   inferContentTypeFromFilePath,
   isSharedLockPath,
   languageNeedsLock,
@@ -255,40 +256,6 @@ function depKeyOf(depFilePath: string): string | undefined {
     : undefined;
 }
 
-/**
- * The dependency inputs a lock was generated from, as the worker recorded them
- * in the lock itself (`WorkspaceDependenciesPrefetched::to_lock_header`):
- *
- *     # workspace-dependencies-mode: manual
- *     # workspace-dependencies: default:<sha of the dependency file's content>
- *
- * This is what separates the two reasons a lock can differ from the one its
- * dependency file's scripts share. Same inputs, different body: the script
- * pinned something the worker also locks, and the file is not its to move.
- * Different inputs: the file moved, and one script is evidence enough.
- *
- * Undefined when the header is absent — old workers do not write one
- * (`min_version_supports_v0_workspace_dependencies`), and the caller falls back
- * to what it can infer.
- */
-function depInputsOf(lock: string): string | undefined {
-  const inputs: string[] = [];
-  for (const line of lock.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed === "") continue;
-    const match = /^(?:#|\/\/)\s*workspace-dependencies(-mode)?:\s*(.+)$/.exec(
-      trimmed,
-    );
-    if (match) {
-      inputs.push(match[2].trim());
-      continue;
-    }
-    if (trimmed.startsWith("#") || trimmed.startsWith("//")) continue;
-    break; // past the header block
-  }
-  return inputs.length > 0 ? inputs.sort().join("|") : undefined;
-}
-
 /** Workspace dependency files keyed by the language and name a script names. */
 function depFilesByKey(paths: Iterable<string>): Map<string, string> {
   const byKey = new Map<string, string>();
@@ -310,6 +277,10 @@ function shareableDepFile(
   language: ScriptLanguage,
   depFiles: Map<string, string>,
 ): string | undefined {
+  // A script the worker locks differently for reasons of its own — a pinned
+  // interpreter, `//npm`, `//nobundling` — cannot stand for its dependency
+  // file's lock, so it never joins a group and its lock stays its own.
+  if (hasLockAffectingAnnotation(scriptContent, language)) return undefined;
   const annotation = extractWorkspaceDepsAnnotation(scriptContent, language);
   if (annotation && (annotation.mode === "extra" || annotation.inline)) {
     return undefined;
@@ -407,13 +378,6 @@ export type SharedLockPlanContext = {
    * is left with an `!inline` that resolves to nothing.
    */
   present?: Record<string, string>;
-  /**
-   * Dependency files whose content this operation changed. It is what separates
-   * the two reasons a script's lock can disagree with the shared one: the file
-   * moved and this script took the bump, or the script pins something the
-   * worker also locks and the file is not its to move.
-   */
-  movedDepFiles?: Iterable<string>;
 };
 
 export function computeSharedLockPlan(
@@ -422,9 +386,6 @@ export function computeSharedLockPlan(
 ): SharedLockPlan {
   const plan: SharedLockPlan = { writes: {}, deletes: [] };
   const depFiles = depFilesByKey([...Object.keys(map), ...(ctx.depFiles ?? [])]);
-  const movedDepFiles = new Set(
-    [...(ctx.movedDepFiles ?? [])].map((p) => toRefPath(p)),
-  );
   // Every shared lockfile this sync can see, from either side.
   const present: Record<string, string> = { ...ctx.present };
   for (const [key, content] of Object.entries(map)) {
@@ -461,9 +422,9 @@ export function computeSharedLockPlan(
   };
 
   for (const [depFile, group] of byDepFile) {
-    // These scripts resolve against the same file, so their locks agree unless
-    // one of them pins something the worker also locks (a Python version, an
-    // `//npm` annotation). The many outvote the one; ties break on the content
+    // Every script here resolves against the same file and carries nothing the
+    // worker locks separately, so their locks agree — unless one's committed
+    // lock is simply behind. The many outvote the one; ties break on the content
     // itself so the outcome never depends on map ordering.
     const byContent = new Map<string, ScriptEntry[]>();
     for (const entry of group) {
@@ -481,34 +442,10 @@ export function computeSharedLockPlan(
       }
     }
 
-    const sharedRef = sharedLockPathFor(depFile);
-    const sharedKey = toMapKey(sharedRef);
-    const held = present[sharedRef];
-    // Whether the file takes this content, for any of four reasons.
-    const heldInputs = held === undefined ? undefined : depInputsOf(held);
-    const contentInputs = depInputsOf(content);
-    const inputsChanged =
-      heldInputs !== undefined && contentInputs !== undefined
-        ? // The worker stamps the dependency inputs it resolved into each lock:
-          // equal inputs with different bodies mean this script pinned something
-          // and the file is not its to move.
-          heldInputs !== contentInputs
-        : // Unstamped — a worker too old to say — so fall back to what the sync
-          // itself observed about the dependency file.
-          movedDepFiles.has(depFile);
-    const moves =
-      held === undefined ||
-      content === held ||
-      // Scripts agreeing with each other and not with the file outrank it,
-      // whatever the stamps say: a dependency file can re-resolve without
-      // changing (an unpinned `requirements.in` picking up a new patch), and
-      // this is also what corrects a file some lone variant planted itself on.
-      count >= 2 ||
-      inputsChanged;
-    const finalContent = moves ? content : held;
-    if (map[sharedKey] !== finalContent) plan.writes[sharedKey] = finalContent;
+    const sharedKey = toMapKey(sharedLockPathFor(depFile));
+    if (map[sharedKey] !== content) plan.writes[sharedKey] = content;
     for (const entry of group) {
-      if (entry.lock === finalContent) point(entry, sharedKey);
+      if (entry.lock === content) point(entry, sharedKey);
       else takeOwnLock(entry);
     }
   }

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -46,6 +46,21 @@ import {
 
 const INLINE_PREFIX = "!inline ";
 
+/** Content-file extensions of the languages that carry a lock, longest first.
+ *  A language absent here is simply never deduplicated.
+ *  for related places search: ADD_NEW_LANG */
+const LOCKABLE_EXTS = [
+  ".fetch.ts",
+  ".deno.ts",
+  ".bun.ts",
+  ".playbook.yml",
+  ".ts",
+  ".py",
+  ".go",
+  ".php",
+  ".rs",
+];
+
 /** Below this a shared file would trade one lock file for two. It gates only
  *  NEW shared files: a script already on one stays there however few are left,
  *  or a narrowed sync scope would tear the group apart. */
@@ -63,11 +78,8 @@ export type LockDedupOptions = {
   defaultTs?: "bun" | "deno" | undefined;
 };
 
-/**
- * The working tree as it stands: which shared lockfiles it holds, who reads
- * them, and every script in it. Collected unfiltered, so a plan can tell what a
- * narrowed sync map is leaving out. Paths are forward-slashed.
- */
+/** The working tree as it stands, collected unfiltered (see the header).
+ *  Paths are forward-slashed. */
 export type ExistingSharedLocks = {
   /** script metadata file -> the shared lockfile it references */
   refs: Map<string, string>;
@@ -163,23 +175,18 @@ function languageOfScript(
   defaultTs: "bun" | "deno" | undefined,
 ): string | undefined {
   const dir = base.slice(0, base.lastIndexOf("/") + 1);
-  // A script's content file is `<base>.<ext>`, and never `.yaml`/`.json`/`.lock`
-  // — those are its metadata and its lock (`.playbook.yml` is `.yml`, and a dbt
-  // descriptor belongs to a base of its own, so dbt stays out of dedup).
-  const candidates = (byDirectory.get(dir) ?? []).filter(
-    (c) =>
-      c.startsWith(base + ".") &&
-      !c.endsWith(".yaml") &&
-      !c.endsWith(".json") &&
-      !c.endsWith(".lock"),
-  );
-  // Sorted so a base that somehow carries two content files resolves the same
-  // way on every run, rather than following map insertion order.
-  for (const candidate of candidates.sort()) {
-    try {
-      return inferContentTypeFromFilePath(candidate, defaultTs);
-    } catch {
-      // not a script content file (a resource, a schema, …)
+  const siblings = new Set(byDirectory.get(dir) ?? []);
+  // `<base><ext>` and nothing looser: `f/a.b.py` is the content file of the
+  // script `f/a.b`, not of `f/a`, and a prefix match would read one script's
+  // language off another's file. Longest extension first, so `.bun.ts` is not
+  // taken for `.ts` (dbt is absent from the list, and stays out of dedup).
+  for (const ext of LOCKABLE_EXTS) {
+    if (siblings.has(base + ext)) {
+      try {
+        return inferContentTypeFromFilePath(base + ext, defaultTs);
+      } catch {
+        // not a language this CLI knows
+      }
     }
   }
   return undefined;
@@ -250,14 +257,23 @@ function serializeMetadata(entry: ScriptEntry): string {
     : yamlStringify(entry.parsed, yamlOptions);
 }
 
-/** How many scripts in the whole tree read a given shared lockfile. */
-function referrerCount(
+/**
+ * Scripts that read a shared lockfile and that this plan does not speak for,
+ * i.e. the ones outside the sync map. Referrers inside it are being reassigned
+ * by this same plan, so they cannot be surprised by a content change — counting
+ * them would hand a lagging minority a veto over the majority's own file.
+ */
+function unrepresentedReaders(
   existing: ExistingSharedLocks,
+  map: Record<string, string>,
   sharedRef: string,
 ): number {
   let count = 0;
-  for (const ref of existing.refs.values()) {
-    if (ref === sharedRef) count++;
+  for (const [metaRef, ref] of existing.refs) {
+    if (ref !== sharedRef) continue;
+    if (map[toMapKey(metaRef)] === undefined && map[metaRef] === undefined) {
+      count++;
+    }
   }
   return count;
 }
@@ -271,6 +287,7 @@ function incumbentFor(
   group: ScriptEntry[],
   content: string,
   existing: ExistingSharedLocks,
+  map: Record<string, string>,
   claimed: Set<string>,
 ): string | undefined {
   const votes = new Map<string, number>();
@@ -292,10 +309,13 @@ function incumbentFor(
   }
   if (best === undefined) return undefined;
   // Keeping the name costs nothing while the content is unchanged. Moving the
-  // content is only this group's call when no one else reads the file.
+  // content takes a real group speaking for every reader — otherwise one script
+  // that drifted would rename the file for all the others, or keep a shared
+  // file to itself.
   if (
     existing.contents.get(best) !== content &&
-    bestVotes < referrerCount(existing, best)
+    (group.length < MIN_SHARED_GROUP ||
+      unrepresentedReaders(existing, map, best) > 0)
   ) {
     return undefined;
   }
@@ -331,10 +351,6 @@ function allocateName(
 /**
  * What a sync map (path -> content) has to change for duplicated script locks to
  * become one shared file per group. Pure: neither argument is touched.
- *
- * `existing` is the working tree as it stands, unfiltered — it is what keeps
- * names stable across a dependency bump and what protects the scripts a
- * narrowed sync map leaves out.
  */
 export function computeSharedLockPlan(
   map: Record<string, string>,
@@ -357,17 +373,13 @@ export function computeSharedLockPlan(
     }
   }
 
-  // Whether this sync covers the whole tree. A partial one — narrowed includes,
-  // or the per-item `extraIncludes` the git-sync deploy callback passes — may
-  // hold groups together but must not form new ones, since what it cannot see
-  // may belong to them.
+  // A sync that cannot see the whole tree conserves only (see the header).
   const partialView = [...existing.scripts].some(
     (script) => map[toMapKey(script)] === undefined && map[script] === undefined,
   );
 
   // Where every script ends up, so a shared file with nothing left reading it
-  // can be dropped. Seeded with the tree's own scripts, the ones out of scope
-  // included.
+  // can be dropped. Seeded with the whole tree, out-of-scope scripts included.
   const finalRefs = new Map(existing.refs);
   const claimed = new Set<string>();
 
@@ -382,7 +394,7 @@ export function computeSharedLockPlan(
     );
 
     for (const [content, group] of groups) {
-      let target = incumbentFor(group, content, existing, claimed);
+      let target = incumbentFor(group, content, existing, map, claimed);
       if (
         target === undefined &&
         !partialView &&
@@ -473,11 +485,8 @@ const SCAN_SKIP_DIRS = new Set([".git", ".wmill", "node_modules"]);
 
 /**
  * The shared lockfiles in the working tree, the scripts that read them, and
- * every script metadata file there is.
- *
- * Deliberately NOT filtered by the sync's includes/excludes: a script this sync
- * does not cover still reads its lockfile, and a plan blind to it would rewrite
- * or delete that file underneath it.
+ * every script metadata file there is — deliberately NOT filtered by the sync's
+ * includes/excludes, which is what lets a plan tell what its map leaves out.
  */
 export async function collectExistingSharedLocks(
   root: string,
@@ -516,7 +525,10 @@ export async function collectExistingSharedLocks(
       // A substring match on the raw text rather than a parse: this reads every
       // script metadata file in the workspace, and the reference is a literal.
       const match = SHARED_LOCK_REF_RE.exec(await readFile(full, "utf-8"));
-      if (match) existing.refs.set(rel, match[1]);
+      // Validated, not just matched: a reference is repo content, it becomes a
+      // path this pass writes to, and `dependencies/locks/../../../x.lock`
+      // satisfies the pattern while resolving outside the workspace.
+      if (match && isSharedLockPath(match[1])) existing.refs.set(rel, match[1]);
     }
   };
   await walk("");

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -242,15 +242,22 @@ export function sharedLockRefIn(
   return ref && existsSync(path.resolve(root, ref)) ? ref : undefined;
 }
 
+/** The key a dependency file answers to, i.e. what a script names it by. */
+function depKeyOf(depFilePath: string): string | undefined {
+  const info = workspaceDependenciesPathToLanguageAndFilename(depFilePath);
+  return info && languageNeedsLock(info.language)
+    ? `${info.language} ${info.name ?? "default"}`
+    : undefined;
+}
+
 /** Workspace dependency files keyed by the language and name a script names. */
 function depFilesByKey(paths: Iterable<string>): Map<string, string> {
   const byKey = new Map<string, string>();
   for (const key of paths) {
     const ref = toRefPath(key);
     if (!ref.startsWith("dependencies/")) continue;
-    const info = workspaceDependenciesPathToLanguageAndFilename(ref);
-    if (!info || !languageNeedsLock(info.language)) continue;
-    byKey.set(`${info.language} ${info.name ?? "default"}`, ref);
+    const depKey = depKeyOf(ref);
+    if (depKey) byKey.set(depKey, ref);
   }
   return byKey;
 }
@@ -294,9 +301,9 @@ export function sharedLockTargetFor(
 function collectScripts(
   map: Record<string, string>,
   defaultTs: "bun" | "deno" | undefined,
+  depFiles: Map<string, string>,
 ): ScriptEntry[] {
   const byDirectory = indexByDirectory(map);
-  const depFiles = depFilesByKey(Object.keys(map));
   const entries: ScriptEntry[] = [];
   for (const [metaKey, metaContent] of Object.entries(map)) {
     const meta = scriptMetaBase(metaKey);
@@ -345,14 +352,39 @@ function serializeMetadata(entry: ScriptEntry): string {
  * What a sync map (path -> content) has to change for the scripts of a workspace
  * dependency file to share one lockfile. Pure: the map is not touched.
  */
+export type SharedLockPlanContext = {
+  defaultTs?: "bun" | "deno" | undefined;
+  /**
+   * Workspace dependency files this sync knows of beyond the ones in `map`.
+   * The map is not the whole truth: `--skip-workspace-dependencies` drops them
+   * from it, and a dependency file missing from the map is not a dependency
+   * file that is gone.
+   */
+  depFiles?: Iterable<string>;
+  /**
+   * Shared lockfiles the working tree already holds. The remote never
+   * serializes one, so without this a sync that has no script for a dependency
+   * file reads its lockfile as deleted — and every script still pointing at it
+   * is left with an `!inline` that resolves to nothing.
+   */
+  present?: Record<string, string>;
+};
+
 export function computeSharedLockPlan(
   map: Record<string, string>,
-  ctx: { defaultTs?: "bun" | "deno" | undefined } = {},
+  ctx: SharedLockPlanContext = {},
 ): SharedLockPlan {
   const plan: SharedLockPlan = { writes: {}, deletes: [] };
+  const depFiles = depFilesByKey([...Object.keys(map), ...(ctx.depFiles ?? [])]);
+  // Every shared lockfile this sync can see, from either side.
+  const present: Record<string, string> = { ...ctx.present };
+  for (const [key, content] of Object.entries(map)) {
+    if (isSharedLockPath(toRefPath(key))) present[toRefPath(key)] = content;
+  }
+
   const byDepFile = new Map<string, ScriptEntry[]>();
   const ownLock: ScriptEntry[] = [];
-  for (const entry of collectScripts(map, ctx.defaultTs)) {
+  for (const entry of collectScripts(map, ctx.defaultTs, depFiles)) {
     if (entry.depFile === undefined) {
       ownLock.push(entry);
       continue;
@@ -380,9 +412,9 @@ export function computeSharedLockPlan(
   };
 
   for (const [depFile, group] of byDepFile) {
-    // Every one of these scripts resolves against the same file in the same
-    // mode, so their locks are identical by construction. A stale committed lock
-    // is the exception, and the many outvote the one; ties break on the content
+    // These scripts resolve against the same file, so their locks agree unless
+    // one of them pins something the worker also locks (a Python version, an
+    // `//npm` annotation). The many outvote the one; ties break on the content
     // itself so the outcome never depends on map ordering.
     const byContent = new Map<string, ScriptEntry[]>();
     for (const entry of group) {
@@ -400,10 +432,17 @@ export function computeSharedLockPlan(
       }
     }
 
-    const sharedKey = toMapKey(sharedLockPathFor(depFile));
-    if (map[sharedKey] !== content) plan.writes[sharedKey] = content;
+    const sharedRef = sharedLockPathFor(depFile);
+    const sharedKey = toMapKey(sharedRef);
+    const held = present[sharedRef];
+    // One script is not enough to move a lockfile others read: it may be the
+    // one that pins something, rather than the first of a bump everyone took.
+    // Two agreeing scripts settle it, and a full sync heals what one deferred.
+    const moved = held === undefined || content === held || count >= 2;
+    const finalContent = moved ? content : held;
+    if (map[sharedKey] !== finalContent) plan.writes[sharedKey] = finalContent;
     for (const entry of group) {
-      if (entry.lock === content) point(entry, sharedKey);
+      if (entry.lock === finalContent) point(entry, sharedKey);
       else takeOwnLock(entry);
     }
   }
@@ -416,13 +455,18 @@ export function computeSharedLockPlan(
 
   // A shared lockfile lives exactly as long as the dependency file it is named
   // after. Asking that, rather than "does any script still read it", is what
-  // lets a sync narrowed to one item leave the rest of the workspace alone.
-  for (const key of Object.keys(map)) {
-    const depFile = depFileOfSharedLock(toRefPath(key));
+  // lets a sync narrowed to one item leave the rest of the workspace alone: a
+  // lockfile with no script in view is carried forward, not deleted.
+  for (const [sharedRef, content] of Object.entries(present)) {
+    const depFile = depFileOfSharedLock(sharedRef);
     if (depFile === undefined) continue;
-    const stillThere =
-      map[toMapKey(depFile)] !== undefined || map[depFile] !== undefined;
-    if (!stillThere && plan.writes[key] === undefined) plan.deletes.push(key);
+    const key = toMapKey(sharedRef);
+    if (plan.writes[key] !== undefined) continue;
+    if (depFiles.has(depKeyOf(depFile) ?? "")) {
+      if (map[key] === undefined) plan.writes[key] = content;
+    } else {
+      plan.deletes.push(key);
+    }
   }
 
   // Deletes are applied after writes, so a path some script still writes must

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -368,6 +368,13 @@ export type SharedLockPlanContext = {
    * is left with an `!inline` that resolves to nothing.
    */
   present?: Record<string, string>;
+  /**
+   * Dependency files whose content this operation changed. It is what separates
+   * the two reasons a script's lock can disagree with the shared one: the file
+   * moved and this script took the bump, or the script pins something the
+   * worker also locks and the file is not its to move.
+   */
+  movedDepFiles?: Iterable<string>;
 };
 
 export function computeSharedLockPlan(
@@ -376,6 +383,9 @@ export function computeSharedLockPlan(
 ): SharedLockPlan {
   const plan: SharedLockPlan = { writes: {}, deletes: [] };
   const depFiles = depFilesByKey([...Object.keys(map), ...(ctx.depFiles ?? [])]);
+  const movedDepFiles = new Set(
+    [...(ctx.movedDepFiles ?? [])].map((p) => toRefPath(p)),
+  );
   // Every shared lockfile this sync can see, from either side.
   const present: Record<string, string> = { ...ctx.present };
   for (const [key, content] of Object.entries(map)) {
@@ -435,11 +445,12 @@ export function computeSharedLockPlan(
     const sharedRef = sharedLockPathFor(depFile);
     const sharedKey = toMapKey(sharedRef);
     const held = present[sharedRef];
-    // One script is not enough to move a lockfile others read: it may be the
-    // one that pins something, rather than the first of a bump everyone took.
-    // Two agreeing scripts settle it, and a full sync heals what one deferred.
-    const moved = held === undefined || content === held || count >= 2;
-    const finalContent = moved ? content : held;
+    // A disagreement moves the file only when the file itself moved. Counting
+    // scripts instead would leave a one-script dependency file — or any bump a
+    // narrowed sync sees one script at a time — stuck on a stale lock forever.
+    const moves =
+      held === undefined || content === held || movedDepFiles.has(depFile);
+    const finalContent = moves ? content : held;
     if (map[sharedKey] !== finalContent) plan.writes[sharedKey] = finalContent;
     for (const entry of group) {
       if (entry.lock === finalContent) point(entry, sharedKey);

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -2,7 +2,7 @@ import { stringify as yamlStringify } from "yaml";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { existsSync, type Dirent } from "node:fs";
 import * as path from "node:path";
-import { yamlOptions } from "../commands/sync/sync.ts";
+import { isNeverWalkedDir, yamlOptions } from "../commands/sync/sync.ts";
 import * as log from "../core/log.ts";
 import { yamlParseContent } from "./yaml.ts";
 import {
@@ -575,8 +575,6 @@ export function sharedLockRefIn(
 // would otherwise spend its time. Nothing else is skipped — a build-output name
 // like `dist` is a legal folder, and a script hidden from this scan is exactly
 // the script the scan exists to protect.
-const SCAN_SKIP_DIRS = new Set([".git", ".wmill", "node_modules"]);
-
 /** Runs `fn` over `items`, at most `size` at a time. */
 async function inBatches<T>(
   items: readonly T[],
@@ -620,13 +618,17 @@ export async function collectExistingSharedLocks(
     let entries: Dirent[];
     try {
       entries = await readdir(path.join(root, dir), { withFileTypes: true });
-    } catch {
-      return;
+    } catch (e) {
+      // Only a directory that is not there is nothing to read. Anything else —
+      // a permission error, a broken mount — hides scripts whose lockfiles this
+      // pass would then rewrite or sweep as unread.
+      if ((e as { code?: string })?.code === "ENOENT") return;
+      throw e;
     }
     for (const entry of entries) {
       const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
       if (entry.isDirectory()) {
-        if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
+        if (!isNeverWalkedDir(entry.name)) await walk(rel);
         continue;
       }
       if (isSharedLockPath(rel)) {

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -23,9 +23,9 @@ import {
  * thousands of byte-identical `.script.lock` files: one dependency bump rewrites
  * all of them, and every open branch conflicts on all of them.
  *
- * With dedup on, scripts that share a lock reference ONE file under
- * `dependencies/locks/`, through the `!inline` indirection their metadata
- * already uses — so the bump is a one-file diff.
+ * With dedup on, scripts that share a lock reference ONE file under `locks/`,
+ * through the `!inline` indirection their metadata already uses — so the bump is
+ * a one-file diff.
  *
  * Three rules make that hold, and each is load-bearing:
  *
@@ -566,7 +566,7 @@ export async function collectExistingSharedLocks(
       // script metadata file in the workspace, and the reference is a literal.
       const match = SHARED_LOCK_REF_RE.exec(await readFile(full, "utf-8"));
       // Validated, not just matched: a reference is repo content, it becomes a
-      // path this pass writes to, and `dependencies/locks/../../../x.lock`
+      // path this pass writes to, and `locks/../../../x.lock`
       // satisfies the pattern while resolving outside the workspace.
       if (match && isSharedLockPath(match[1])) existing.refs.set(rel, match[1]);
     }

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -1,0 +1,338 @@
+import { stringify as yamlStringify } from "yaml";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { yamlOptions } from "../commands/sync/sync.ts";
+import { yamlParseContent } from "./yaml.ts";
+import {
+  inferContentTypeFromFilePath,
+  languageNeedsLock,
+} from "./script_common.ts";
+import { isSharedLockPath, sharedLockPath } from "./resource_folders.ts";
+
+/**
+ * Lockfile deduplication (`dedupeLockfiles` in wmill.yaml).
+ *
+ * A workspace whose dependencies come from `dependencies/<file>` resolves to the
+ * very same lock for every script of that language, so the repo ends up holding
+ * thousands of byte-identical `.script.lock` files: one dependency bump rewrites
+ * all of them, and every open branch conflicts on all of them.
+ *
+ * With dedup on, the scripts of a language that share a lock reference ONE file,
+ * `dependencies/locks/<language>.lock`, through the `!inline` indirection their
+ * metadata already uses — so the bump is a one-file diff. Scripts whose lock
+ * differs (extra imports, a named dependency set) keep their own `.script.lock`.
+ *
+ * The shared file is named after the LANGUAGE, never after the content it holds:
+ * a content-addressed name would move on every bump and put the churn back in
+ * the metadata of every script.
+ */
+
+const INLINE_PREFIX = "!inline ";
+
+/** Below this, a shared file would trade one lock file for two. */
+const MIN_SHARED_GROUP = 2;
+
+/** Sync maps are keyed with the platform separator (`path.join`), while an
+ *  `!inline` reference is always forward-slash. */
+const toMapKey = (refPath: string) => refPath.replaceAll("/", path.sep);
+const toRefPath = (mapKey: string) => mapKey.replaceAll("\\", "/");
+
+/** What the sync layer needs to know to dedup: whether to, and how to read a
+ *  `.ts` script's language. Both ride on the same `wmill.yaml` options object. */
+export type LockDedupOptions = {
+  dedupeLockfiles?: boolean | undefined;
+  defaultTs?: "bun" | "deno" | undefined;
+};
+
+/** The files a dedup pass writes and removes, as paths relative to the sync
+ *  root — applicable to an in-memory sync map or to the working tree. */
+export type SharedLockPlan = {
+  writes: Record<string, string>;
+  deletes: string[];
+};
+
+export function isEmptySharedLockPlan(plan: SharedLockPlan): boolean {
+  return Object.keys(plan.writes).length === 0 && plan.deletes.length === 0;
+}
+
+type ScriptEntry = {
+  metaKey: string;
+  isJson: boolean;
+  parsed: Record<string, any>;
+  /** The lock file the metadata references today, as a map key. */
+  lockKey: string;
+  /** The lock file this script owns when it is not sharing one. */
+  ownLockKey: string;
+  language: string;
+  lock: string;
+};
+
+/** `f/foo.script.yaml` -> base `f/foo`, lock `f/foo.script.lock`;
+ *  `f/foo__mod/script.yaml` -> base `f/foo__mod/script`, lock `…/script.lock`.
+ *  The base is what the script's content file is named after. Both are returned
+ *  forward-slashed, whatever the map's separator. */
+function scriptMetaBase(
+  key: string,
+): { base: string; ownLockKey: string; isJson: boolean } | undefined {
+  const ref = toRefPath(key);
+  for (const [suffix, isJson] of [
+    [".script.yaml", false],
+    [".script.json", true],
+    ["/script.yaml", false],
+    ["/script.json", true],
+  ] as const) {
+    if (!ref.endsWith(suffix)) continue;
+    const stripped = ref.slice(0, ref.length - suffix.length);
+    if (suffix.startsWith("/")) {
+      // `/script.yaml` is only script metadata inside a module folder; anywhere
+      // else it is an ordinary file that happens to be called `script.yaml`.
+      if (!stripped.endsWith("__mod")) return undefined;
+      return {
+        base: stripped + "/script",
+        ownLockKey: stripped + "/script.lock",
+        isJson,
+      };
+    }
+    return { base: stripped, ownLockKey: stripped + ".script.lock", isJson };
+  }
+  return undefined;
+}
+
+/** Everything sharing a metadata file's base name, i.e. its content file and
+ *  its lock — indexed once, because resolving it per script by scanning the map
+ *  is quadratic in the number of files. */
+function indexByBase(map: Record<string, string>): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const key of Object.keys(map)) {
+    const ref = toRefPath(key);
+    const slash = ref.lastIndexOf("/");
+    const dot = ref.indexOf(".", slash + 1);
+    if (dot === -1) continue;
+    const base = ref.slice(0, dot);
+    const bucket = index.get(base);
+    if (bucket) {
+      bucket.push(ref);
+    } else {
+      index.set(base, [ref]);
+    }
+  }
+  return index;
+}
+
+function languageOfScript(
+  base: string,
+  byBase: Map<string, string[]>,
+  defaultTs: "bun" | "deno" | undefined,
+): string | undefined {
+  // A script's content file is never `.yaml`/`.json`/`.lock` — those are its
+  // metadata and its lock (`.playbook.yml` is `.yml`, and a dbt descriptor
+  // belongs to a base of its own, so dbt is left out of dedup entirely).
+  const candidates = (byBase.get(base) ?? []).filter(
+    (c) => !c.endsWith(".yaml") && !c.endsWith(".json") && !c.endsWith(".lock"),
+  );
+  // Sorted so a base that somehow carries two content files resolves the same
+  // way on every run, rather than following map insertion order.
+  for (const candidate of candidates.sort()) {
+    try {
+      return inferContentTypeFromFilePath(candidate, defaultTs);
+    } catch {
+      // not a script content file (a resource, a schema, …)
+    }
+  }
+  return undefined;
+}
+
+/** A map entry addressed by a forward-slashed path, whatever separator the map
+ *  was keyed with. */
+function lookup(
+  map: Record<string, string>,
+  refPath: string,
+): { key: string; content: string } | undefined {
+  for (const key of [toMapKey(refPath), refPath]) {
+    const content = map[key];
+    if (content !== undefined) return { key, content };
+  }
+  return undefined;
+}
+
+function collectScripts(
+  map: Record<string, string>,
+  defaultTs: "bun" | "deno" | undefined,
+): ScriptEntry[] {
+  const byBase = indexByBase(map);
+  const entries: ScriptEntry[] = [];
+  for (const [metaKey, metaContent] of Object.entries(map)) {
+    const meta = scriptMetaBase(metaKey);
+    if (!meta) continue;
+
+    let parsed: any;
+    try {
+      parsed = meta.isJson
+        ? JSON.parse(metaContent)
+        : yamlParseContent(metaKey, metaContent);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+
+    const lockRef = parsed["lock"];
+    if (typeof lockRef !== "string" || !lockRef.startsWith(INLINE_PREFIX)) {
+      continue;
+    }
+    const lockFile = lookup(map, lockRef.slice(INLINE_PREFIX.length));
+    // An absent or empty lock is not a lock to share: a script with no
+    // dependencies carries `lock: ''` and no file at all.
+    if (lockFile === undefined || lockFile.content === "") continue;
+
+    const language = languageOfScript(meta.base, byBase, defaultTs);
+    if (language === undefined || !languageNeedsLock(language)) continue;
+
+    entries.push({
+      metaKey,
+      isJson: meta.isJson,
+      parsed,
+      lockKey: lockFile.key,
+      ownLockKey: toMapKey(meta.ownLockKey),
+      language,
+      lock: lockFile.content,
+    });
+  }
+  return entries;
+}
+
+function serializeMetadata(entry: ScriptEntry): string {
+  return entry.isJson
+    ? JSON.stringify(entry.parsed, null, 2)
+    : yamlStringify(entry.parsed, yamlOptions);
+}
+
+/**
+ * What a sync map (path -> content) has to change for every duplicated script
+ * lock to become one shared file per language. Pure: the map is not touched.
+ */
+export function computeSharedLockPlan(
+  map: Record<string, string>,
+  defaultTs: "bun" | "deno" | undefined,
+): SharedLockPlan {
+  const plan: SharedLockPlan = { writes: {}, deletes: [] };
+  const byLanguage = new Map<string, Map<string, ScriptEntry[]>>();
+  for (const entry of collectScripts(map, defaultTs)) {
+    let byLock = byLanguage.get(entry.language);
+    if (!byLock) {
+      byLock = new Map();
+      byLanguage.set(entry.language, byLock);
+    }
+    const group = byLock.get(entry.lock);
+    if (group) {
+      group.push(entry);
+    } else {
+      byLock.set(entry.lock, [entry]);
+    }
+  }
+
+  for (const [language, byLock] of byLanguage) {
+    // The most widely shared lock wins the language's shared file, so the odd
+    // script out is the one that keeps a lock of its own. Ties break on the
+    // content itself: any ordering derived from the map would make the winner
+    // depend on how the workspace was walked.
+    let winner: string | undefined;
+    let winnerCount = 0;
+    for (const [lock, group] of byLock) {
+      if (
+        group.length > winnerCount ||
+        (group.length === winnerCount && winner !== undefined && lock < winner)
+      ) {
+        winner = lock;
+        winnerCount = group.length;
+      }
+    }
+    if (winnerCount < MIN_SHARED_GROUP) winner = undefined;
+
+    const sharedKey = toMapKey(sharedLockPath(language));
+    if (winner !== undefined && map[sharedKey] !== winner) {
+      plan.writes[sharedKey] = winner;
+    }
+
+    for (const [lock, group] of byLock) {
+      const shared = winner !== undefined && lock === winner;
+      for (const entry of group) {
+        const target = shared ? sharedKey : entry.ownLockKey;
+        if (entry.lockKey === target) continue;
+        if (!shared && map[target] !== entry.lock) {
+          plan.writes[target] = entry.lock;
+        }
+        // Never drop the shared file itself: the scripts still on it need it.
+        if (!isSharedLockPath(entry.lockKey)) {
+          plan.deletes.push(entry.lockKey);
+        }
+        entry.parsed["lock"] = INLINE_PREFIX + toRefPath(target);
+        plan.writes[entry.metaKey] = serializeMetadata(entry);
+      }
+    }
+
+    // A shared file nothing references any more (the language lost its scripts,
+    // or they all diverged) is left behind by the loop above.
+    if (
+      winner === undefined &&
+      map[sharedKey] !== undefined &&
+      !plan.deletes.includes(sharedKey)
+    ) {
+      plan.deletes.push(sharedKey);
+    }
+  }
+
+  return plan;
+}
+
+export function applySharedLockPlanToMap(
+  map: Record<string, string>,
+  plan: SharedLockPlan,
+): void {
+  for (const [key, content] of Object.entries(plan.writes)) {
+    map[key] = content;
+  }
+  for (const key of plan.deletes) {
+    delete map[key];
+  }
+}
+
+export async function applySharedLockPlanToDisk(
+  plan: SharedLockPlan,
+): Promise<void> {
+  for (const [key, content] of Object.entries(plan.writes)) {
+    await mkdir(path.dirname(key), { recursive: true });
+    await writeFile(key, content, "utf-8");
+  }
+  for (const key of plan.deletes) {
+    await rm(key, { force: true });
+  }
+}
+
+/**
+ * The script metadata files that read a given shared lockfile. A change to that
+ * file is a change to their lock, and they are what carries it to the remote.
+ */
+export function scriptsReferencingSharedLock(
+  map: Record<string, string>,
+  sharedKey: string,
+): string[] {
+  const reference = INLINE_PREFIX + toRefPath(sharedKey);
+  const referrers: string[] = [];
+  for (const [metaKey, metaContent] of Object.entries(map)) {
+    const meta = scriptMetaBase(metaKey);
+    if (!meta) continue;
+    // A string test before parsing: the metadata of every script in the
+    // workspace would otherwise be parsed to answer this.
+    if (!metaContent.includes(reference)) continue;
+    let parsed: any;
+    try {
+      parsed = meta.isJson
+        ? JSON.parse(metaContent)
+        : yamlParseContent(metaKey, metaContent);
+    } catch {
+      continue;
+    }
+    if (parsed?.["lock"] === reference) referrers.push(metaKey);
+  }
+  return referrers;
+}

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -225,13 +225,35 @@ export function sharedLockRefOf(
   metaContent: string,
   isJson: boolean,
 ): string | undefined {
-  if (!metaContent.includes(INLINE_PREFIX)) return undefined;
+  // Without the trailing space: the YAML serializer folds a long `lock:` line
+  // at a space, so `!inline locks/…` can reach disk as `!inline\n  locks/…`
+  // and a prefilter looking for the space would call it a non-reader.
+  if (!metaContent.includes(INLINE_PREFIX.trimEnd())) return undefined;
   const lock = parseMetadata(metaPath, metaContent, isJson)?.["lock"];
   if (typeof lock !== "string" || !lock.startsWith(INLINE_PREFIX)) {
     return undefined;
   }
   const ref = lock.slice(INLINE_PREFIX.length);
   return isSharedLockPath(ref) ? ref : undefined;
+}
+
+/**
+ * Whether a metadata file reads a given shared lockfile.
+ *
+ * Unparseable metadata counts as a reader: a `.script.yaml` carrying git
+ * conflict markers is a file whose `lock` cannot be read, not one that reads
+ * nothing, and deleting the lockfile it may point at is the unrecoverable half
+ * of that guess.
+ */
+export function metadataReadsSharedLock(
+  metaPath: string,
+  metaContent: string,
+  isJson: boolean,
+  lockRef: string,
+): boolean {
+  if (!metaContent.includes(INLINE_PREFIX.trimEnd())) return false;
+  if (parseMetadata(metaPath, metaContent, isJson) === undefined) return true;
+  return sharedLockRefOf(metaPath, metaContent, isJson) === lockRef;
 }
 
 /**

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -238,22 +238,19 @@ export function sharedLockRefOf(
 }
 
 /**
- * Whether a metadata file reads a given shared lockfile.
+ * Whether a metadata file may reference a shared lockfile but cannot say which.
  *
- * Unparseable metadata counts as a reader: a `.script.yaml` carrying git
- * conflict markers is a file whose `lock` cannot be read, not one that reads
- * nothing, and deleting the lockfile it may point at is the unrecoverable half
- * of that guess.
+ * A `.script.yaml` carrying git conflict markers is a file whose `lock` cannot
+ * be read, not one that reads nothing, and deleting a lockfile it may point at
+ * is the unrecoverable half of that guess.
  */
-export function metadataReadsSharedLock(
+export function metadataLockUnreadable(
   metaPath: string,
   metaContent: string,
   isJson: boolean,
-  lockRef: string,
 ): boolean {
   if (!metaContent.includes(INLINE_PREFIX.trimEnd())) return false;
-  if (parseMetadata(metaPath, metaContent, isJson) === undefined) return true;
-  return sharedLockRefOf(metaPath, metaContent, isJson) === lockRef;
+  return parseMetadata(metaPath, metaContent, isJson) === undefined;
 }
 
 /**

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -1,6 +1,6 @@
 import { stringify as yamlStringify } from "yaml";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, type Dirent } from "node:fs";
 import * as path from "node:path";
 import { yamlOptions } from "../commands/sync/sync.ts";
 import * as log from "../core/log.ts";
@@ -393,13 +393,21 @@ export function computeSharedLockPlan(
     }
   }
 
+  // The metadata twin this sync does not read is not a reader: it is never
+  // pushed, and letting it vote would veto changes on behalf of a dead file.
+  const metaExt = json ? ".json" : ".yaml";
+  const activeRefs = new Map(
+    [...existing.refs].filter(([metaRef]) => metaRef.endsWith(metaExt)),
+  );
+  const activeExisting: ExistingSharedLocks = { ...existing, refs: activeRefs };
+
   // A sync that cannot see the whole tree conserves only (see the header). Only
   // the metadata twin this sync reads counts as missing: a leftover
   // `.script.json` in a YAML repo is dropped by the map for reasons that have
   // nothing to do with scope, and would otherwise put the tree in conserve-only
   // mode for good.
   const unseen = [...existing.scripts].filter(
-    (script) => script.endsWith(json ? ".json" : ".yaml") && !inScope(script),
+    (script) => script.endsWith(metaExt) && !inScope(script),
   );
   const partialView = unseen.length > 0;
   if (partialView) {
@@ -410,7 +418,7 @@ export function computeSharedLockPlan(
 
   // Where every script ends up, so a shared file with nothing left reading it
   // can be dropped. Seeded with the whole tree, out-of-scope scripts included.
-  const finalRefs = new Map(existing.refs);
+  const finalRefs = new Map(activeRefs);
   const claimed = new Set<string>();
 
   for (const [language, byLock] of [...byLanguage].sort(([a], [b]) =>
@@ -424,13 +432,13 @@ export function computeSharedLockPlan(
     );
 
     for (const [content, group] of groups) {
-      let target = incumbentFor(group, content, existing, inScope, claimed);
+      let target = incumbentFor(group, content, activeExisting, inScope, claimed);
       if (
         target === undefined &&
         !partialView &&
         group.length >= MIN_SHARED_GROUP
       ) {
-        target = allocateName(language, group, existing, claimed);
+        target = allocateName(language, group, activeExisting, claimed);
       }
       if (target !== undefined) {
         claimed.add(target);
@@ -506,6 +514,32 @@ const SHARED_LOCK_REF_RE = new RegExp(
 );
 
 /**
+ * The shared lockfile a metadata file's `lock` field names, if any. The raw text
+ * is only a prefilter: a summary or a comment can carry the same words, and
+ * `!inline` decides where a lock is written, so it is read from the parsed
+ * field and nowhere else.
+ */
+function sharedLockRefOf(
+  metaPath: string,
+  metaContent: string,
+  isJson: boolean,
+): string | undefined {
+  if (!SHARED_LOCK_REF_RE.test(metaContent)) return undefined;
+  let parsed: any;
+  try {
+    parsed = isJson ? JSON.parse(metaContent) : yamlParseContent(metaPath, metaContent);
+  } catch {
+    return undefined;
+  }
+  const lock = parsed?.["lock"];
+  if (typeof lock !== "string" || !lock.startsWith(INLINE_PREFIX)) return undefined;
+  const ref = lock.slice(INLINE_PREFIX.length);
+  // Validated, not just matched: a reference is repo content and becomes a path
+  // this pass writes to.
+  return isSharedLockPath(ref) ? ref : undefined;
+}
+
+/**
  * The shared lockfile a metadata FILE reads, when it reads one that is there.
  * `parseMetadataFile` resolves `lock` to the lockfile's content, so the
  * reference itself survives only in the raw text.
@@ -514,10 +548,9 @@ export function sharedLockRefIn(
   metadataContent: string,
   root: string = ".",
 ): string | undefined {
-  const ref = SHARED_LOCK_REF_RE.exec(metadataContent)?.[1];
-  return ref && isSharedLockPath(ref) && existsSync(path.resolve(root, ref))
-    ? ref
-    : undefined;
+  const meta = { isJson: metadataContent.trimStart().startsWith("{") };
+  const ref = sharedLockRefOf("metadata", metadataContent, meta.isJson);
+  return ref && existsSync(path.resolve(root, ref)) ? ref : undefined;
 }
 
 // `.wmill` is the stateful-push mirror: its copies of a script's metadata would
@@ -528,8 +561,22 @@ export function sharedLockRefIn(
 // the script the scan exists to protect.
 const SCAN_SKIP_DIRS = new Set([".git", ".wmill", "node_modules"]);
 
-/** Workspace-shared raw-app components, which sync handles on its own. */
-const SCAN_SKIP_ROOTS = ["ui/"];
+async function inBatches<T>(
+  items: readonly T[],
+  size: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  for (let i = 0; i < items.length; i += size) {
+    await Promise.all(items.slice(i, i + size).map((item) => fn(item)));
+  }
+}
+
+/** Script metadata only counts where sync looks for it: `docs/notes.script.yaml`
+ *  is a file that happens to be named like one, and counting it would leave the
+ *  planner in conserve-only mode for good. */
+function isInWindmillNamespace(rel: string): boolean {
+  return ["f/", "u/", "g/"].some((ns) => rel.startsWith(ns));
+}
 
 /**
  * The shared lockfiles in the working tree, the scripts that read them, and
@@ -550,14 +597,15 @@ export async function collectExistingSharedLocks(
   const anyShared = existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")));
 
   const walk = async (dir: string): Promise<void> => {
-    let entries;
+    let entries: Dirent[];
     try {
       entries = await readdir(path.join(root, dir), { withFileTypes: true });
     } catch {
       return;
     }
-    await Promise.all(
-      entries.map(async (entry) => {
+    // Bounded: a workspace is thousands of files deep and an unbounded fan-out
+    // would open as many descriptors at once.
+    await inBatches(entries, 32, async (entry) => {
         const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
         if (entry.isDirectory()) {
           if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
@@ -568,18 +616,19 @@ export async function collectExistingSharedLocks(
           existing.contents.set(rel, await readFile(full, "utf-8"));
           return;
         }
-        if (scriptMetaBase(rel) === undefined) return;
-        if (SCAN_SKIP_ROOTS.some((skipped) => rel.startsWith(skipped))) return;
+        const meta = scriptMetaBase(rel);
+        if (meta === undefined || !isInWindmillNamespace(rel)) return;
         existing.scripts.add(rel);
         if (!anyShared) return;
-        // A substring match on the raw text rather than a parse: this reads every
-        // script metadata file in the workspace, and the reference is a literal.
-        const match = SHARED_LOCK_REF_RE.exec(await readFile(full, "utf-8"));
-        // Validated, not just matched: a reference is repo content and becomes a
-        // path this pass writes to.
-        if (match && isSharedLockPath(match[1])) existing.refs.set(rel, match[1]);
-      }),
-    );
+        let content: string;
+        try {
+          content = await readFile(full, "utf-8");
+        } catch {
+          return; // vanished or unreadable mid-walk; it reads nothing for us
+        }
+        const ref = sharedLockRefOf(rel, content, meta.isJson);
+        if (ref) existing.refs.set(rel, ref);
+    });
   };
   await walk("");
   return existing;

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -35,9 +35,9 @@ import {
  *
  * The CONTENT is a separate question, because a lock is not always a pure
  * function of its dependency file: a script can pin a Python version or carry an
- * `//npm` annotation, which the worker also locks. Locks say which it is — the
- * worker stamps the dependency inputs it resolved into each one — and
- * `depInputsOf` reads that stamp rather than guessing from head counts.
+ * `//npm` annotation, which the worker also locks. The stamp the worker writes
+ * into each lock says whether the dependency inputs changed, which is most of
+ * that question; scripts agreeing with each other answer the rest.
  *
  * Two cases are not shared at all and keep a `.script.lock` of their own: a
  * script whose annotation is `extra_` or carries inline dependencies (its lock
@@ -484,21 +484,27 @@ export function computeSharedLockPlan(
     const sharedRef = sharedLockPathFor(depFile);
     const sharedKey = toMapKey(sharedRef);
     const held = present[sharedRef];
-    // Whether a disagreement moves the file. The locks say why they differ:
-    // the worker stamps the dependency inputs it resolved into each one.
+    // Whether a disagreement moves the file, for three independent reasons.
     const heldInputs = held === undefined ? undefined : depInputsOf(held);
     const contentInputs = depInputsOf(content);
+    const inputsChanged =
+      heldInputs !== undefined && contentInputs !== undefined
+        ? // The worker stamps the dependency inputs it resolved into each lock:
+          // equal inputs with different bodies mean this script pinned something
+          // and the file is not its to move.
+          heldInputs !== contentInputs
+        : // Unstamped — a worker too old to say — so fall back to what the sync
+          // itself observed about the dependency file.
+          movedDepFiles.has(depFile);
     const moves =
-      held === undefined || content === held
-        ? true
-        : heldInputs !== undefined && contentInputs !== undefined
-          ? // Both stamped: equal inputs mean this script pinned something and
-            // the file is not its to move; different inputs mean the file moved.
-            heldInputs !== contentInputs
-          : // Unstamped, so a worker too old to say. The dependency file having
-            // moved, or two scripts agreeing on something else, is the most that
-            // can be inferred.
-            movedDepFiles.has(depFile) || count >= 2;
+      held === undefined ||
+      content === held ||
+      // Scripts agreeing with each other and not with the file outrank it,
+      // whatever the stamps say: a dependency file can re-resolve without
+      // changing (an unpinned `requirements.in` picking up a new patch), and
+      // this is also what corrects a file some lone variant planted itself on.
+      count >= 2 ||
+      inputsChanged;
     const finalContent = moves ? content : held;
     if (map[sharedKey] !== finalContent) plan.writes[sharedKey] = finalContent;
     for (const entry of group) {

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -463,7 +463,13 @@ const SHARED_LOCK_REF_RE = new RegExp(
   `${INLINE_PREFIX}(${SHARED_LOCK_DIR}/[^\\s'"]+\\.lock)`,
 );
 
-const SCAN_SKIP_DIRS = new Set([".git", "node_modules", ".wmill", "dist"]);
+// `.wmill` is the stateful-push mirror: its copies of a script's metadata would
+// be counted as extra readers of a shared lockfile and freeze its content.
+// `.git` and `node_modules` cannot be Windmill paths and are where the walk
+// would otherwise spend its time. Nothing else is skipped — a build-output name
+// like `dist` is a legal folder, and a script hidden from this scan is exactly
+// the script the scan exists to protect.
+const SCAN_SKIP_DIRS = new Set([".git", ".wmill", "node_modules"]);
 
 /**
  * The shared lockfiles in the working tree, the scripts that read them, and

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -365,10 +365,11 @@ function serializeMetadata(entry: ScriptEntry): string {
 export type SharedLockPlanContext = {
   defaultTs?: "bun" | "deno" | undefined;
   /**
-   * Workspace dependency files this sync knows of beyond the ones in `map`.
-   * The map is not the whole truth: `--skip-workspace-dependencies` drops them
-   * from it, and a dependency file missing from the map is not a dependency
-   * file that is gone.
+   * Workspace dependency files to consider beyond the ones in `map`, for the
+   * one caller whose map cannot hold them: `--skip-workspace-dependencies`.
+   * Pass nothing otherwise — with dependency files in the map, an absence there
+   * is a deletion, and adding disk's copy would keep a lockfile alive one sync
+   * past the file it is named after.
    */
   depFiles?: Iterable<string>;
   /**
@@ -399,10 +400,12 @@ export function computeSharedLockPlan(
       ownLock.push(entry);
       continue;
     }
-    byDepFile.set(entry.depFile, [
-      ...(byDepFile.get(entry.depFile) ?? []),
-      entry,
-    ]);
+    // Push into the existing array rather than rebuild it: a workspace where
+    // every script shares one dependency file is the case this exists for, and
+    // copying the group per insert makes that quadratic.
+    const group = byDepFile.get(entry.depFile);
+    if (group) group.push(entry);
+    else byDepFile.set(entry.depFile, [entry]);
   }
 
   const point = (entry: ScriptEntry, targetKey: string) => {
@@ -428,7 +431,9 @@ export function computeSharedLockPlan(
     // itself so the outcome never depends on map ordering.
     const byContent = new Map<string, ScriptEntry[]>();
     for (const entry of group) {
-      byContent.set(entry.lock, [...(byContent.get(entry.lock) ?? []), entry]);
+      const sameLock = byContent.get(entry.lock);
+      if (sameLock) sameLock.push(entry);
+      else byContent.set(entry.lock, [entry]);
     }
     let content = "";
     let count = 0;

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -577,6 +577,7 @@ export function sharedLockRefIn(
 // the script the scan exists to protect.
 const SCAN_SKIP_DIRS = new Set([".git", ".wmill", "node_modules"]);
 
+/** Runs `fn` over `items`, at most `size` at a time. */
 async function inBatches<T>(
   items: readonly T[],
   size: number,
@@ -612,6 +613,9 @@ export async function collectExistingSharedLocks(
   // is what decides if it may form groups at all.
   const anyShared = existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")));
 
+  // Traversal first, reads second: recursing inside a batch would multiply the
+  // fan-out at every level, and the reads below are deliberately unguarded.
+  const toRead: { rel: string; isJson: boolean; shared: boolean }[] = [];
   const walk = async (dir: string): Promise<void> => {
     let entries: Dirent[];
     try {
@@ -619,32 +623,36 @@ export async function collectExistingSharedLocks(
     } catch {
       return;
     }
-    // Bounded: a workspace is thousands of files deep and an unbounded fan-out
-    // would open as many descriptors at once.
-    await inBatches(entries, 32, async (entry) => {
-        const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
-        if (entry.isDirectory()) {
-          if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
-          return;
-        }
-        const full = path.join(root, ...rel.split("/"));
-        if (isSharedLockPath(rel)) {
-          existing.contents.set(rel, await readFile(full, "utf-8"));
-          return;
-        }
-        const meta = scriptMetaBase(rel);
-        if (meta === undefined || !isInWindmillNamespace(rel)) return;
-        existing.scripts.add(rel);
-        if (!anyShared) return;
-        // Deliberately unguarded: a metadata file this cannot read is a script
-        // whose lockfile is unknown, and treating it as a non-reader would let
-        // its shared lock be rewritten or swept underneath it.
-        const content = await readFile(full, "utf-8");
-        const ref = sharedLockRefOf(rel, content, meta.isJson);
-        if (ref) existing.refs.set(rel, ref);
-    });
+    for (const entry of entries) {
+      const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
+        continue;
+      }
+      if (isSharedLockPath(rel)) {
+        toRead.push({ rel, isJson: false, shared: true });
+        continue;
+      }
+      const meta = scriptMetaBase(rel);
+      if (meta === undefined || !isInWindmillNamespace(rel)) continue;
+      existing.scripts.add(rel);
+      if (anyShared) toRead.push({ rel, isJson: meta.isJson, shared: false });
+    }
   };
   await walk("");
+
+  await inBatches(toRead, 32, async ({ rel, isJson, shared }) => {
+    // Deliberately unguarded: a metadata file this cannot read is a script whose
+    // lockfile is unknown, and treating it as a non-reader would let its shared
+    // lock be rewritten or swept underneath it.
+    const content = await readFile(path.join(root, ...rel.split("/")), "utf-8");
+    if (shared) {
+      existing.contents.set(rel, content);
+      return;
+    }
+    const ref = sharedLockRefOf(rel, content, isJson);
+    if (ref) existing.refs.set(rel, ref);
+  });
   return existing;
 }
 

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -484,7 +484,7 @@ export function computeSharedLockPlan(
     const sharedRef = sharedLockPathFor(depFile);
     const sharedKey = toMapKey(sharedRef);
     const held = present[sharedRef];
-    // Whether a disagreement moves the file, for three independent reasons.
+    // Whether the file takes this content, for any of four reasons.
     const heldInputs = held === undefined ? undefined : depInputsOf(held);
     const contentInputs = depInputsOf(content);
     const inputsChanged =

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -31,10 +31,15 @@ import {
  * Identity comes from the dependency file, never from the content or from which
  * scripts happen to be in view. That is what makes the pass stateless: a sync
  * narrowed to a single script (the git-sync deploy callback) computes the same
- * name as a full one, because the lock that script holds IS that dependency
- * file's lock — the worker resolves it from the file alone, ignoring the body.
+ * NAME as a full one.
  *
- * Two cases are therefore NOT shared and keep a `.script.lock` of their own: a
+ * The CONTENT is a separate question, because a lock is not always a pure
+ * function of its dependency file: a script can pin a Python version or carry an
+ * `//npm` annotation, which the worker also locks. Locks say which it is — the
+ * worker stamps the dependency inputs it resolved into each one — and
+ * `depInputsOf` reads that stamp rather than guessing from head counts.
+ *
+ * Two cases are not shared at all and keep a `.script.lock` of their own: a
  * script whose annotation is `extra_` or carries inline dependencies (its lock
  * folds in its own imports), and one naming several dependency files at once
  * (its lock is no single file's).
@@ -250,6 +255,40 @@ function depKeyOf(depFilePath: string): string | undefined {
     : undefined;
 }
 
+/**
+ * The dependency inputs a lock was generated from, as the worker recorded them
+ * in the lock itself (`WorkspaceDependenciesPrefetched::to_lock_header`):
+ *
+ *     # workspace-dependencies-mode: manual
+ *     # workspace-dependencies: default:<sha of the dependency file's content>
+ *
+ * This is what separates the two reasons a lock can differ from the one its
+ * dependency file's scripts share. Same inputs, different body: the script
+ * pinned something the worker also locks, and the file is not its to move.
+ * Different inputs: the file moved, and one script is evidence enough.
+ *
+ * Undefined when the header is absent — old workers do not write one
+ * (`min_version_supports_v0_workspace_dependencies`), and the caller falls back
+ * to what it can infer.
+ */
+function depInputsOf(lock: string): string | undefined {
+  const inputs: string[] = [];
+  for (const line of lock.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    const match = /^(?:#|\/\/)\s*workspace-dependencies(-mode)?:\s*(.+)$/.exec(
+      trimmed,
+    );
+    if (match) {
+      inputs.push(match[2].trim());
+      continue;
+    }
+    if (trimmed.startsWith("#") || trimmed.startsWith("//")) continue;
+    break; // past the header block
+  }
+  return inputs.length > 0 ? inputs.sort().join("|") : undefined;
+}
+
 /** Workspace dependency files keyed by the language and name a script names. */
 function depFilesByKey(paths: Iterable<string>): Map<string, string> {
   const byKey = new Map<string, string>();
@@ -445,18 +484,21 @@ export function computeSharedLockPlan(
     const sharedRef = sharedLockPathFor(depFile);
     const sharedKey = toMapKey(sharedRef);
     const held = present[sharedRef];
-    // When a disagreement is allowed to move the file. Both clauses are needed:
-    // the dependency file moving is what lets a bump through a sync that sees
-    // one script at a time (a one-script dependency file has no second opinion
-    // to offer), and two agreeing scripts are what corrects a file some lone
-    // script planted its variant on. What neither admits is a single script
-    // disagreeing for its own reasons — a pinned Python version, an `//npm`
-    // annotation — while its dependency file sits still.
+    // Whether a disagreement moves the file. The locks say why they differ:
+    // the worker stamps the dependency inputs it resolved into each one.
+    const heldInputs = held === undefined ? undefined : depInputsOf(held);
+    const contentInputs = depInputsOf(content);
     const moves =
-      held === undefined ||
-      content === held ||
-      movedDepFiles.has(depFile) ||
-      count >= 2;
+      held === undefined || content === held
+        ? true
+        : heldInputs !== undefined && contentInputs !== undefined
+          ? // Both stamped: equal inputs mean this script pinned something and
+            // the file is not its to move; different inputs mean the file moved.
+            heldInputs !== contentInputs
+          : // Unstamped, so a worker too old to say. The dependency file having
+            // moved, or two scripts agreeing on something else, is the most that
+            // can be inferred.
+            movedDepFiles.has(depFile) || count >= 2;
     const finalContent = moves ? content : held;
     if (map[sharedKey] !== finalContent) plan.writes[sharedKey] = finalContent;
     for (const entry of group) {

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -445,11 +445,18 @@ export function computeSharedLockPlan(
     const sharedRef = sharedLockPathFor(depFile);
     const sharedKey = toMapKey(sharedRef);
     const held = present[sharedRef];
-    // A disagreement moves the file only when the file itself moved. Counting
-    // scripts instead would leave a one-script dependency file — or any bump a
-    // narrowed sync sees one script at a time — stuck on a stale lock forever.
+    // When a disagreement is allowed to move the file. Both clauses are needed:
+    // the dependency file moving is what lets a bump through a sync that sees
+    // one script at a time (a one-script dependency file has no second opinion
+    // to offer), and two agreeing scripts are what corrects a file some lone
+    // script planted its variant on. What neither admits is a single script
+    // disagreeing for its own reasons — a pinned Python version, an `//npm`
+    // annotation — while its dependency file sits still.
     const moves =
-      held === undefined || content === held || movedDepFiles.has(depFile);
+      held === undefined ||
+      content === held ||
+      movedDepFiles.has(depFile) ||
+      count >= 2;
     const finalContent = moves ? content : held;
     if (map[sharedKey] !== finalContent) plan.writes[sharedKey] = finalContent;
     for (const entry of group) {

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -569,12 +569,6 @@ export function sharedLockRefIn(
   return ref && existsSync(path.resolve(root, ref)) ? ref : undefined;
 }
 
-// `.wmill` is the stateful-push mirror: its copies of a script's metadata would
-// be counted as extra readers of a shared lockfile and freeze its content.
-// `.git` and `node_modules` cannot be Windmill paths and are where the walk
-// would otherwise spend its time. Nothing else is skipped — a build-output name
-// like `dist` is a legal folder, and a script hidden from this scan is exactly
-// the script the scan exists to protect.
 /** Runs `fn` over `items`, at most `size` at a time. */
 async function inBatches<T>(
   items: readonly T[],
@@ -584,13 +578,6 @@ async function inBatches<T>(
   for (let i = 0; i < items.length; i += size) {
     await Promise.all(items.slice(i, i + size).map((item) => fn(item)));
   }
-}
-
-/** Script metadata only counts where sync looks for it: `docs/notes.script.yaml`
- *  is a file that happens to be named like one, and counting it would leave the
- *  planner in conserve-only mode for good. */
-function isInWindmillNamespace(rel: string): boolean {
-  return ["f/", "u/", "g/"].some((ns) => rel.startsWith(ns));
 }
 
 /**
@@ -611,6 +598,11 @@ export async function collectExistingSharedLocks(
   // is what decides if it may form groups at all.
   const anyShared = existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")));
 
+  // Only where scripts and shared lockfiles can live. Scoping the walk is what
+  // keeps `docs/notes.script.yaml` out of the picture, and keeps the fail-closed
+  // read below from covering directories that cannot affect the plan.
+  const roots = ["f", "u", "g", SHARED_LOCK_DIR];
+
   // Traversal first, reads second: recursing inside a batch would multiply the
   // fan-out at every level, and the reads below are deliberately unguarded.
   const toRead: { rel: string; isJson: boolean; shared: boolean }[] = [];
@@ -628,6 +620,10 @@ export async function collectExistingSharedLocks(
     for (const entry of entries) {
       const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
       if (entry.isDirectory()) {
+        // The same exclusions sync's own walk applies: a directory it never
+        // descends holds no script this pass may draw conclusions from — and
+        // `.wmill`, the stateful mirror, holds copies that would be counted as
+        // extra readers and freeze a shared lockfile's content.
         if (!isNeverWalkedDir(entry.name)) await walk(rel);
         continue;
       }
@@ -636,12 +632,12 @@ export async function collectExistingSharedLocks(
         continue;
       }
       const meta = scriptMetaBase(rel);
-      if (meta === undefined || !isInWindmillNamespace(rel)) continue;
+      if (meta === undefined) continue;
       existing.scripts.add(rel);
       if (anyShared) toRead.push({ rel, isJson: meta.isJson, shared: false });
     }
   };
-  await walk("");
+  for (const root_ of roots) await walk(root_);
 
   await inBatches(toRead, 32, async ({ rel, isJson, shared }) => {
     // Deliberately unguarded: a metadata file this cannot read is a script whose

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -1,5 +1,6 @@
 import { stringify as yamlStringify } from "yaml";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import * as path from "node:path";
 import { yamlOptions } from "../commands/sync/sync.ts";
 import { yamlParseContent } from "./yaml.ts";
@@ -7,7 +8,11 @@ import {
   inferContentTypeFromFilePath,
   languageNeedsLock,
 } from "./script_common.ts";
-import { isSharedLockPath, sharedLockPath } from "./resource_folders.ts";
+import {
+  SHARED_LOCK_DIR,
+  isSharedLockPath,
+  sharedLockPath,
+} from "./resource_folders.ts";
 
 /**
  * Lockfile deduplication (`dedupeLockfiles` in wmill.yaml).
@@ -17,19 +22,33 @@ import { isSharedLockPath, sharedLockPath } from "./resource_folders.ts";
  * thousands of byte-identical `.script.lock` files: one dependency bump rewrites
  * all of them, and every open branch conflicts on all of them.
  *
- * With dedup on, the scripts of a language that share a lock reference ONE file,
- * `dependencies/locks/<language>.lock`, through the `!inline` indirection their
- * metadata already uses — so the bump is a one-file diff. Scripts whose lock
- * differs (extra imports, a named dependency set) keep their own `.script.lock`.
+ * With dedup on, scripts that share a lock reference ONE file under
+ * `dependencies/locks/`, through the `!inline` indirection their metadata
+ * already uses — so the bump is a one-file diff.
  *
- * The shared file is named after the LANGUAGE, never after the content it holds:
- * a content-addressed name would move on every bump and put the churn back in
- * the metadata of every script.
+ * Three rules make that hold, and each is load-bearing:
+ *
+ * - **A shared file's name never encodes its content.** A content-addressed name
+ *   would move on every bump and put the churn straight back into the metadata
+ *   of every script. A group of scripts KEEPS the file it already references
+ *   (its incumbent) and the file's CONTENT is what changes. Only a group with no
+ *   incumbent is given a name: `<language>.lock`, then `<language>-2.lock`, …
+ * - **A shared file's content only moves when every script that reads it agrees.**
+ *   Referrers are counted from the whole working tree, never from the sync map,
+ *   which wmill.yaml's includes/excludes narrow — and which the git-sync deploy
+ *   callback narrows to a single item. A script the current sync does not cover
+ *   still reads the file, and rewriting or deleting it underneath would change
+ *   that script's lock silently.
+ * - **A sync that cannot see the whole tree only conserves.** It keeps existing
+ *   groups together but never forms new ones, so a per-item deploy does not
+ *   invent shared files that a later full sync has to undo.
  */
 
 const INLINE_PREFIX = "!inline ";
 
-/** Below this, a shared file would trade one lock file for two. */
+/** Below this a shared file would trade one lock file for two. It gates only
+ *  NEW shared files: a script already on one stays there however few are left,
+ *  or a narrowed sync scope would tear the group apart. */
 const MIN_SHARED_GROUP = 2;
 
 /** Sync maps are keyed with the platform separator (`path.join`), while an
@@ -42,6 +61,26 @@ const toRefPath = (mapKey: string) => mapKey.replaceAll("\\", "/");
 export type LockDedupOptions = {
   dedupeLockfiles?: boolean | undefined;
   defaultTs?: "bun" | "deno" | undefined;
+};
+
+/**
+ * The working tree as it stands: which shared lockfiles it holds, who reads
+ * them, and every script in it. Collected unfiltered, so a plan can tell what a
+ * narrowed sync map is leaving out. Paths are forward-slashed.
+ */
+export type ExistingSharedLocks = {
+  /** script metadata file -> the shared lockfile it references */
+  refs: Map<string, string>;
+  /** shared lockfile -> its content */
+  contents: Map<string, string>;
+  /** every script metadata file in the tree, referencing a shared lock or not */
+  scripts: Set<string>;
+};
+
+export const NO_EXISTING_SHARED_LOCKS: ExistingSharedLocks = {
+  refs: new Map(),
+  contents: new Map(),
+  scripts: new Set(),
 };
 
 /** The files a dedup pass writes and removes, as paths relative to the sync
@@ -57,6 +96,8 @@ export function isEmptySharedLockPlan(plan: SharedLockPlan): boolean {
 
 type ScriptEntry = {
   metaKey: string;
+  /** `metaKey` forward-slashed, i.e. how the working-tree scan names it. */
+  metaRef: string;
   isJson: boolean;
   parsed: Record<string, any>;
   /** The lock file the metadata references today, as a map key. */
@@ -69,7 +110,7 @@ type ScriptEntry = {
 
 /** `f/foo.script.yaml` -> base `f/foo`, lock `f/foo.script.lock`;
  *  `f/foo__mod/script.yaml` -> base `f/foo__mod/script`, lock `…/script.lock`.
- *  The base is what the script's content file is named after. Both are returned
+ *  The base is what the script's content file is named after. All returned
  *  forward-slashed, whatever the map's separator. */
 function scriptMetaBase(
   key: string,
@@ -98,22 +139,19 @@ function scriptMetaBase(
   return undefined;
 }
 
-/** Everything sharing a metadata file's base name, i.e. its content file and
- *  its lock — indexed once, because resolving it per script by scanning the map
- *  is quadratic in the number of files. */
-function indexByBase(map: Record<string, string>): Map<string, string[]> {
+/** Map keys grouped by directory. A script's content file is looked up among
+ *  its own directory's entries: splitting a name at its first dot would put
+ *  `f/a.b.py` under `f/a` and leave every dotted script path undeduplicated. */
+function indexByDirectory(map: Record<string, string>): Map<string, string[]> {
   const index = new Map<string, string[]>();
   for (const key of Object.keys(map)) {
     const ref = toRefPath(key);
-    const slash = ref.lastIndexOf("/");
-    const dot = ref.indexOf(".", slash + 1);
-    if (dot === -1) continue;
-    const base = ref.slice(0, dot);
-    const bucket = index.get(base);
+    const dir = ref.slice(0, ref.lastIndexOf("/") + 1);
+    const bucket = index.get(dir);
     if (bucket) {
       bucket.push(ref);
     } else {
-      index.set(base, [ref]);
+      index.set(dir, [ref]);
     }
   }
   return index;
@@ -121,14 +159,19 @@ function indexByBase(map: Record<string, string>): Map<string, string[]> {
 
 function languageOfScript(
   base: string,
-  byBase: Map<string, string[]>,
+  byDirectory: Map<string, string[]>,
   defaultTs: "bun" | "deno" | undefined,
 ): string | undefined {
-  // A script's content file is never `.yaml`/`.json`/`.lock` — those are its
-  // metadata and its lock (`.playbook.yml` is `.yml`, and a dbt descriptor
-  // belongs to a base of its own, so dbt is left out of dedup entirely).
-  const candidates = (byBase.get(base) ?? []).filter(
-    (c) => !c.endsWith(".yaml") && !c.endsWith(".json") && !c.endsWith(".lock"),
+  const dir = base.slice(0, base.lastIndexOf("/") + 1);
+  // A script's content file is `<base>.<ext>`, and never `.yaml`/`.json`/`.lock`
+  // — those are its metadata and its lock (`.playbook.yml` is `.yml`, and a dbt
+  // descriptor belongs to a base of its own, so dbt stays out of dedup).
+  const candidates = (byDirectory.get(dir) ?? []).filter(
+    (c) =>
+      c.startsWith(base + ".") &&
+      !c.endsWith(".yaml") &&
+      !c.endsWith(".json") &&
+      !c.endsWith(".lock"),
   );
   // Sorted so a base that somehow carries two content files resolves the same
   // way on every run, rather than following map insertion order.
@@ -159,7 +202,7 @@ function collectScripts(
   map: Record<string, string>,
   defaultTs: "bun" | "deno" | undefined,
 ): ScriptEntry[] {
-  const byBase = indexByBase(map);
+  const byDirectory = indexByDirectory(map);
   const entries: ScriptEntry[] = [];
   for (const [metaKey, metaContent] of Object.entries(map)) {
     const meta = scriptMetaBase(metaKey);
@@ -184,11 +227,12 @@ function collectScripts(
     // dependencies carries `lock: ''` and no file at all.
     if (lockFile === undefined || lockFile.content === "") continue;
 
-    const language = languageOfScript(meta.base, byBase, defaultTs);
+    const language = languageOfScript(meta.base, byDirectory, defaultTs);
     if (language === undefined || !languageNeedsLock(language)) continue;
 
     entries.push({
       metaKey,
+      metaRef: toRefPath(metaKey),
       isJson: meta.isJson,
       parsed,
       lockKey: lockFile.key,
@@ -206,13 +250,96 @@ function serializeMetadata(entry: ScriptEntry): string {
     : yamlStringify(entry.parsed, yamlOptions);
 }
 
+/** How many scripts in the whole tree read a given shared lockfile. */
+function referrerCount(
+  existing: ExistingSharedLocks,
+  sharedRef: string,
+): number {
+  let count = 0;
+  for (const ref of existing.refs.values()) {
+    if (ref === sharedRef) count++;
+  }
+  return count;
+}
+
 /**
- * What a sync map (path -> content) has to change for every duplicated script
- * lock to become one shared file per language. Pure: the map is not touched.
+ * The shared file a group of scripts is entitled to keep: the one most of them
+ * already reference. Undefined when the group has no incumbent, or when keeping
+ * it would move its content underneath scripts outside the group.
+ */
+function incumbentFor(
+  group: ScriptEntry[],
+  content: string,
+  existing: ExistingSharedLocks,
+  claimed: Set<string>,
+): string | undefined {
+  const votes = new Map<string, number>();
+  for (const entry of group) {
+    const ref = existing.refs.get(entry.metaRef);
+    if (ref === undefined || claimed.has(ref)) continue;
+    votes.set(ref, (votes.get(ref) ?? 0) + 1);
+  }
+  let best: string | undefined;
+  let bestVotes = 0;
+  for (const [ref, count] of votes) {
+    if (
+      count > bestVotes ||
+      (count === bestVotes && best !== undefined && ref < best)
+    ) {
+      best = ref;
+      bestVotes = count;
+    }
+  }
+  if (best === undefined) return undefined;
+  // Keeping the name costs nothing while the content is unchanged. Moving the
+  // content is only this group's call when no one else reads the file.
+  if (
+    existing.contents.get(best) !== content &&
+    bestVotes < referrerCount(existing, best)
+  ) {
+    return undefined;
+  }
+  return best;
+}
+
+/** The first `<language>[-N].lock` no other group in this run holds and no
+ *  script outside the group still reads. */
+function allocateName(
+  language: string,
+  group: ScriptEntry[],
+  existing: ExistingSharedLocks,
+  claimed: Set<string>,
+): string {
+  const inGroup = new Set(group.map((e) => e.metaRef));
+  for (let n = 1; ; n++) {
+    const candidate =
+      n === 1
+        ? sharedLockPath(language)
+        : `${SHARED_LOCK_DIR}/${language}-${n}.lock`;
+    if (claimed.has(candidate)) continue;
+    let readByOthers = false;
+    for (const [metaRef, ref] of existing.refs) {
+      if (ref === candidate && !inGroup.has(metaRef)) {
+        readByOthers = true;
+        break;
+      }
+    }
+    if (!readByOthers) return candidate;
+  }
+}
+
+/**
+ * What a sync map (path -> content) has to change for duplicated script locks to
+ * become one shared file per group. Pure: neither argument is touched.
+ *
+ * `existing` is the working tree as it stands, unfiltered — it is what keeps
+ * names stable across a dependency bump and what protects the scripts a
+ * narrowed sync map leaves out.
  */
 export function computeSharedLockPlan(
   map: Record<string, string>,
   defaultTs: "bun" | "deno" | undefined,
+  existing: ExistingSharedLocks = NO_EXISTING_SHARED_LOCKS,
 ): SharedLockPlan {
   const plan: SharedLockPlan = { writes: {}, deletes: [] };
   const byLanguage = new Map<string, Map<string, ScriptEntry[]>>();
@@ -230,54 +357,73 @@ export function computeSharedLockPlan(
     }
   }
 
-  for (const [language, byLock] of byLanguage) {
-    // The most widely shared lock wins the language's shared file, so the odd
-    // script out is the one that keeps a lock of its own. Ties break on the
-    // content itself: any ordering derived from the map would make the winner
-    // depend on how the workspace was walked.
-    let winner: string | undefined;
-    let winnerCount = 0;
-    for (const [lock, group] of byLock) {
+  // Whether this sync covers the whole tree. A partial one — narrowed includes,
+  // or the per-item `extraIncludes` the git-sync deploy callback passes — may
+  // hold groups together but must not form new ones, since what it cannot see
+  // may belong to them.
+  const partialView = [...existing.scripts].some(
+    (script) => map[toMapKey(script)] === undefined && map[script] === undefined,
+  );
+
+  // Where every script ends up, so a shared file with nothing left reading it
+  // can be dropped. Seeded with the tree's own scripts, the ones out of scope
+  // included.
+  const finalRefs = new Map(existing.refs);
+  const claimed = new Set<string>();
+
+  for (const [language, byLock] of [...byLanguage].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    // Biggest group first: it has the strongest claim to a name, and ties break
+    // on the content itself so the outcome never depends on map ordering.
+    const groups = [...byLock].sort(
+      ([contentA, a], [contentB, b]) =>
+        b.length - a.length || contentA.localeCompare(contentB),
+    );
+
+    for (const [content, group] of groups) {
+      let target = incumbentFor(group, content, existing, claimed);
       if (
-        group.length > winnerCount ||
-        (group.length === winnerCount && winner !== undefined && lock < winner)
+        target === undefined &&
+        !partialView &&
+        group.length >= MIN_SHARED_GROUP
       ) {
-        winner = lock;
-        winnerCount = group.length;
+        target = allocateName(language, group, existing, claimed);
       }
-    }
-    if (winnerCount < MIN_SHARED_GROUP) winner = undefined;
+      if (target !== undefined) {
+        claimed.add(target);
+        const sharedKey = toMapKey(target);
+        if (map[sharedKey] !== content) plan.writes[sharedKey] = content;
+      }
 
-    const sharedKey = toMapKey(sharedLockPath(language));
-    if (winner !== undefined && map[sharedKey] !== winner) {
-      plan.writes[sharedKey] = winner;
-    }
-
-    for (const [lock, group] of byLock) {
-      const shared = winner !== undefined && lock === winner;
       for (const entry of group) {
-        const target = shared ? sharedKey : entry.ownLockKey;
-        if (entry.lockKey === target) continue;
-        if (!shared && map[target] !== entry.lock) {
-          plan.writes[target] = entry.lock;
+        const targetKey =
+          target !== undefined ? toMapKey(target) : entry.ownLockKey;
+        finalRefs.set(entry.metaRef, toRefPath(targetKey));
+        if (entry.lockKey === targetKey) continue;
+        if (target === undefined && map[targetKey] !== entry.lock) {
+          plan.writes[targetKey] = entry.lock;
         }
-        // Never drop the shared file itself: the scripts still on it need it.
-        if (!isSharedLockPath(entry.lockKey)) {
-          plan.deletes.push(entry.lockKey);
-        }
-        entry.parsed["lock"] = INLINE_PREFIX + toRefPath(target);
+        // A shared file is only ever dropped by the sweep below, which knows
+        // who else reads it.
+        if (!isSharedLockPath(entry.lockKey)) plan.deletes.push(entry.lockKey);
+        entry.parsed["lock"] = INLINE_PREFIX + toRefPath(targetKey);
         plan.writes[entry.metaKey] = serializeMetadata(entry);
       }
     }
+  }
 
-    // A shared file nothing references any more (the language lost its scripts,
-    // or they all diverged) is left behind by the loop above.
-    if (
-      winner === undefined &&
-      map[sharedKey] !== undefined &&
-      !plan.deletes.includes(sharedKey)
-    ) {
-      plan.deletes.push(sharedKey);
+  const stillRead = new Set(finalRefs.values());
+  for (const [sharedRef, content] of existing.contents) {
+    const key = toMapKey(sharedRef);
+    if (!stillRead.has(sharedRef)) {
+      // Nothing reads it any more: its scripts diverged, or the sync deleted them.
+      if (plan.writes[key] === undefined) plan.deletes.push(key);
+    } else if (plan.writes[key] === undefined && map[key] === undefined) {
+      // Read by a script this sync does not cover, and absent from the map (the
+      // remote never serializes shared files). Carried over, or the diff would
+      // delete the file those scripts read.
+      plan.writes[key] = content;
     }
   }
 
@@ -311,6 +457,64 @@ export async function applySharedLockPlanToDisk(
   for (const key of plan.deletes) {
     await rm(key, { force: true });
   }
+}
+
+const SHARED_LOCK_REF_RE = new RegExp(
+  `${INLINE_PREFIX}(${SHARED_LOCK_DIR}/[^\\s'"]+\\.lock)`,
+);
+
+const SCAN_SKIP_DIRS = new Set([".git", "node_modules", ".wmill", "dist"]);
+
+/**
+ * The shared lockfiles in the working tree, the scripts that read them, and
+ * every script metadata file there is.
+ *
+ * Deliberately NOT filtered by the sync's includes/excludes: a script this sync
+ * does not cover still reads its lockfile, and a plan blind to it would rewrite
+ * or delete that file underneath it.
+ */
+export async function collectExistingSharedLocks(
+  root: string,
+): Promise<ExistingSharedLocks> {
+  const existing: ExistingSharedLocks = {
+    refs: new Map(),
+    contents: new Map(),
+    scripts: new Set(),
+  };
+  // With no shared lockfiles there is no name to keep stable and nothing to
+  // protect — and no reason to read every metadata file in the workspace.
+  if (!existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")))) {
+    return existing;
+  }
+
+  const walk = async (dir: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(path.join(root, dir), { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
+        continue;
+      }
+      const full = path.join(root, ...rel.split("/"));
+      if (isSharedLockPath(rel)) {
+        existing.contents.set(rel, await readFile(full, "utf-8"));
+        continue;
+      }
+      if (scriptMetaBase(rel) === undefined) continue;
+      existing.scripts.add(rel);
+      // A substring match on the raw text rather than a parse: this reads every
+      // script metadata file in the workspace, and the reference is a literal.
+      const match = SHARED_LOCK_REF_RE.exec(await readFile(full, "utf-8"));
+      if (match) existing.refs.set(rel, match[1]);
+    }
+  };
+  await walk("");
+  return existing;
 }
 
 /**

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -220,7 +220,7 @@ function parseMetadata(
  * `!inline` decides where a lock is written, so it is read from the parsed field
  * and nowhere else.
  */
-function sharedLockRefOf(
+export function sharedLockRefOf(
   metaPath: string,
   metaContent: string,
   isJson: boolean,

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -606,6 +606,7 @@ export async function collectExistingSharedLocks(
   // Traversal first, reads second: recursing inside a batch would multiply the
   // fan-out at every level, and the reads below are deliberately unguarded.
   const toRead: { rel: string; isJson: boolean; shared: boolean }[] = [];
+  let walkedRoot = "";
   const walk = async (dir: string): Promise<void> => {
     let entries: Dirent[];
     try {
@@ -631,13 +632,19 @@ export async function collectExistingSharedLocks(
         toRead.push({ rel, isJson: false, shared: true });
         continue;
       }
-      const meta = scriptMetaBase(rel);
+      // `locks/` is walked for the shared files themselves; a metadata file
+      // sitting there is not a script sync will ever see, and counting it would
+      // pin the planner in conserve-only mode for good.
+      const meta = walkedRoot === SHARED_LOCK_DIR ? undefined : scriptMetaBase(rel);
       if (meta === undefined) continue;
       existing.scripts.add(rel);
       if (anyShared) toRead.push({ rel, isJson: meta.isJson, shared: false });
     }
   };
-  for (const root_ of roots) await walk(root_);
+  for (const r of roots) {
+    walkedRoot = r;
+    await walk(r);
+  }
 
   await inBatches(toRead, 32, async ({ rel, isJson, shared }) => {
     // Deliberately unguarded: a metadata file this cannot read is a script whose

--- a/cli/src/utils/lock_dedup.ts
+++ b/cli/src/utils/lock_dedup.ts
@@ -7,13 +7,12 @@ import * as log from "../core/log.ts";
 import { yamlParseContent } from "./yaml.ts";
 import {
   inferContentTypeFromFilePath,
-  languageNeedsLock,
-} from "./script_common.ts";
-import {
-  SHARED_LOCK_DIR,
   isSharedLockPath,
+  languageNeedsLock,
   sharedLockPath,
-} from "./resource_folders.ts";
+  SHARED_LOCK_DIR,
+} from "./script_common.ts";
+
 
 /**
  * Lockfile deduplication (`dedupeLockfiles` in wmill.yaml).
@@ -265,22 +264,19 @@ function serializeMetadata(entry: ScriptEntry): string {
 }
 
 /**
- * Scripts that read a shared lockfile and that this plan does not speak for,
- * i.e. the ones outside the sync map. Referrers inside it are being reassigned
- * by this same plan, so they cannot be surprised by a content change — counting
- * them would hand a lagging minority a veto over the majority's own file.
+ * Scripts that read a shared lockfile and that this plan does not speak for:
+ * the ones this sync's scope leaves out. Readers inside the scope are being
+ * reassigned by this same plan, so they cannot be surprised by a content change
+ * — counting them would hand a lagging minority a veto over the majority's file.
  */
 function unrepresentedReaders(
   existing: ExistingSharedLocks,
-  map: Record<string, string>,
+  inScope: (metaRef: string) => boolean,
   sharedRef: string,
 ): number {
   let count = 0;
   for (const [metaRef, ref] of existing.refs) {
-    if (ref !== sharedRef) continue;
-    if (map[toMapKey(metaRef)] === undefined && map[metaRef] === undefined) {
-      count++;
-    }
+    if (ref === sharedRef && !inScope(metaRef)) count++;
   }
   return count;
 }
@@ -294,7 +290,7 @@ function incumbentFor(
   group: ScriptEntry[],
   content: string,
   existing: ExistingSharedLocks,
-  map: Record<string, string>,
+  inScope: (metaRef: string) => boolean,
   claimed: Set<string>,
 ): string | undefined {
   const votes = new Map<string, number>();
@@ -322,7 +318,7 @@ function incumbentFor(
   if (
     existing.contents.get(best) !== content &&
     (group.length < MIN_SHARED_GROUP ||
-      unrepresentedReaders(existing, map, best) > 0)
+      unrepresentedReaders(existing, inScope, best) > 0)
   ) {
     return undefined;
   }
@@ -339,10 +335,7 @@ function allocateName(
 ): string {
   const inGroup = new Set(group.map((e) => e.metaRef));
   for (let n = 1; ; n++) {
-    const candidate =
-      n === 1
-        ? sharedLockPath(language)
-        : `${SHARED_LOCK_DIR}/${language}-${n}.lock`;
+    const candidate = sharedLockPath(language, n);
     if (claimed.has(candidate)) continue;
     let readByOthers = false;
     for (const [metaRef, ref] of existing.refs) {
@@ -359,12 +352,31 @@ function allocateName(
  * What a sync map (path -> content) has to change for duplicated script locks to
  * become one shared file per group. Pure: neither argument is touched.
  */
+export type SharedLockPlanContext = {
+  defaultTs?: "bun" | "deno" | undefined;
+  /** The working tree as it stands, unfiltered (see the header). */
+  existing?: ExistingSharedLocks;
+  /** Whether metadata is JSON rather than YAML in this workspace. */
+  json?: boolean;
+  /**
+   * Whether a script metadata path is one this sync covers. NOT the same as
+   * "present in `map`": on a pull the map is the remote, and a script added
+   * locally but never pushed is in scope while absent from it.
+   */
+  inScope?: (metaRef: string) => boolean;
+};
+
 export function computeSharedLockPlan(
   map: Record<string, string>,
-  defaultTs: "bun" | "deno" | undefined,
-  existing: ExistingSharedLocks = NO_EXISTING_SHARED_LOCKS,
-  json = false,
+  ctx: SharedLockPlanContext = {},
 ): SharedLockPlan {
+  const {
+    defaultTs,
+    existing = NO_EXISTING_SHARED_LOCKS,
+    json = false,
+    inScope = (metaRef: string) =>
+      map[toMapKey(metaRef)] !== undefined || map[metaRef] !== undefined,
+  } = ctx;
   const plan: SharedLockPlan = { writes: {}, deletes: [] };
   const byLanguage = new Map<string, Map<string, ScriptEntry[]>>();
   for (const entry of collectScripts(map, defaultTs)) {
@@ -387,10 +399,7 @@ export function computeSharedLockPlan(
   // nothing to do with scope, and would otherwise put the tree in conserve-only
   // mode for good.
   const unseen = [...existing.scripts].filter(
-    (script) =>
-      script.endsWith(json ? ".json" : ".yaml") &&
-      map[toMapKey(script)] === undefined &&
-      map[script] === undefined,
+    (script) => script.endsWith(json ? ".json" : ".yaml") && !inScope(script),
   );
   const partialView = unseen.length > 0;
   if (partialView) {
@@ -415,7 +424,7 @@ export function computeSharedLockPlan(
     );
 
     for (const [content, group] of groups) {
-      let target = incumbentFor(group, content, existing, map, claimed);
+      let target = incumbentFor(group, content, existing, inScope, claimed);
       if (
         target === undefined &&
         !partialView &&
@@ -535,11 +544,10 @@ export async function collectExistingSharedLocks(
     contents: new Map(),
     scripts: new Set(),
   };
-  // With no shared lockfiles there is no name to keep stable and nothing to
-  // protect — and no reason to read every metadata file in the workspace.
-  if (!existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")))) {
-    return existing;
-  }
+  // With no shared lockfiles yet there is no reference to read: the walk still
+  // has to enumerate the scripts, because whether this sync covers all of them
+  // is what decides if it may form groups at all.
+  const anyShared = existsSync(path.join(root, ...SHARED_LOCK_DIR.split("/")));
 
   const walk = async (dir: string): Promise<void> => {
     let entries;
@@ -548,28 +556,30 @@ export async function collectExistingSharedLocks(
     } catch {
       return;
     }
-    for (const entry of entries) {
-      const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
-      if (entry.isDirectory()) {
-        if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
-        continue;
-      }
-      const full = path.join(root, ...rel.split("/"));
-      if (isSharedLockPath(rel)) {
-        existing.contents.set(rel, await readFile(full, "utf-8"));
-        continue;
-      }
-      if (scriptMetaBase(rel) === undefined) continue;
-      if (SCAN_SKIP_ROOTS.some((root) => rel.startsWith(root))) continue;
-      existing.scripts.add(rel);
-      // A substring match on the raw text rather than a parse: this reads every
-      // script metadata file in the workspace, and the reference is a literal.
-      const match = SHARED_LOCK_REF_RE.exec(await readFile(full, "utf-8"));
-      // Validated, not just matched: a reference is repo content, it becomes a
-      // path this pass writes to, and `locks/../../../x.lock`
-      // satisfies the pattern while resolving outside the workspace.
-      if (match && isSharedLockPath(match[1])) existing.refs.set(rel, match[1]);
-    }
+    await Promise.all(
+      entries.map(async (entry) => {
+        const rel = dir === "" ? entry.name : `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+          if (!SCAN_SKIP_DIRS.has(entry.name)) await walk(rel);
+          return;
+        }
+        const full = path.join(root, ...rel.split("/"));
+        if (isSharedLockPath(rel)) {
+          existing.contents.set(rel, await readFile(full, "utf-8"));
+          return;
+        }
+        if (scriptMetaBase(rel) === undefined) return;
+        if (SCAN_SKIP_ROOTS.some((skipped) => rel.startsWith(skipped))) return;
+        existing.scripts.add(rel);
+        if (!anyShared) return;
+        // A substring match on the raw text rather than a parse: this reads every
+        // script metadata file in the workspace, and the reference is a literal.
+        const match = SHARED_LOCK_REF_RE.exec(await readFile(full, "utf-8"));
+        // Validated, not just matched: a reference is repo content and becomes a
+        // path this pass writes to.
+        if (match && isSharedLockPath(match[1])) existing.refs.set(rel, match[1]);
+      }),
+    );
   };
   await walk("");
   return existing;

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -4,7 +4,7 @@ import { colors } from "@cliffy/ansi/colors";
 import * as log from "../core/log.ts";
 import { stringify as yamlStringify } from "yaml";
 import { yamlParseFile } from "./yaml.ts";
-import { writeFile, stat, rm, readdir } from "node:fs/promises";
+import { writeFile, stat, rm, readdir, mkdir } from "node:fs/promises";
 import { readFileSync, existsSync, readdirSync, statSync, mkdirSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
@@ -17,9 +17,19 @@ import {
   ScriptLanguage,
   workspaceDependenciesLanguages,
   languageNeedsLock,
-  sharedLockPath,
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
+// Workspace-dependency vocabulary lives with the languages it describes; these
+// re-exports keep the CLI's existing import sites working.
+export {
+  workspaceDependenciesPathToLanguageAndFilename,
+  extractWorkspaceDepsAnnotation,
+  type WorkspaceDepsAnnotation,
+} from "./script_common.ts";
+import {
+  workspaceDependenciesPathToLanguageAndFilename,
+  extractWorkspaceDepsAnnotation,
+} from "./script_common.ts";
 import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath } from "./resource_folders.ts";
 import { findCodebase, yamlOptions } from "../commands/sync/sync.ts";
 import { generateHash, readInlinePathSync, getHeaders, readTextFile, readTextFileSync } from "./utils.ts";
@@ -32,7 +42,7 @@ import { getIsWin } from "./utils.ts";
 import { extractRelativeImports } from "./relative_imports.ts";
 import { DoubleLinkedDependencyTree } from "./dependency_tree.ts";
 import { pollJobWithQueueLogging } from "./job_polling.ts";
-import { sharedLockRefIn } from "./lock_dedup.ts";
+import { sharedLockRefIn, sharedLockTargetFor } from "./lock_dedup.ts";
 
 const _require = createRequire(import.meta.url);
 const _parserCache = new Map<string, Promise<any>>();
@@ -108,17 +118,6 @@ export async function getRawWorkspaceDependencies(legacyBehaviour: boolean): Pro
   return rawWorkspaceDeps;
 }
 
-export function workspaceDependenciesPathToLanguageAndFilename(path: string): { name: string | undefined, language: ScriptLanguage } | undefined {
-  const relativePath = path.replace("dependencies/", "");
-  for (const { filename, language } of workspaceDependenciesLanguages) {
-    if (relativePath.endsWith(filename)) {
-      return {
-        name: relativePath === filename ? undefined : relativePath.replace("." + filename, ""),
-        language
-      };
-    }
-  }
-}
 
 /**
  * Filters raw workspace dependencies to only include those that:
@@ -378,11 +377,14 @@ export async function generateScriptMetadataInternal(
         filteredRawWorkspaceDependencies,
         tempScriptRefs,
         lockPathOverride,
-        // The group's file when the script already reads one, its language's
-        // otherwise: a script joins the default group by resolving to its lock.
+        // The lockfile of the workspace dependency file this script resolves
+        // against, if any: joining it is a matter of resolving to its content.
         opts.dedupeLockfiles
-          ? (sharedLockRefIn(metadataContent, metadataWithType.isJson) ??
-            sharedLockPath(language))
+          ? sharedLockTargetFor(
+              scriptContent,
+              language,
+              Object.keys(rawWorkspaceDependencies),
+            )
           : undefined,
       );
     } else {
@@ -515,99 +517,6 @@ export async function updateScriptSchema(
 // exactly the parts of scriptContent that affect lockfile generation.
 // ---------------------------------------------------------------------------
 
-type AnnotationMode = "manual" | "extra";
-
-interface WorkspaceDepsAnnotation {
-  mode: AnnotationMode;
-  external: string[];
-  inline: string | null;
-}
-
-const LANG_ANNOTATION_CONFIG: Partial<
-  Record<ScriptLanguage, { comment: string; keyword: string; validityRe?: RegExp }>
-> = {
-  python3: { comment: "#", keyword: "requirements", validityRe: /^#\s?(\S+)\s*$/ },
-  bun: { comment: "//", keyword: "package_json" },
-  nativets: { comment: "//", keyword: "package_json" },
-  go: { comment: "//", keyword: "go_mod" },
-  php: { comment: "//", keyword: "composer_json" },
-  powershell: { comment: "#", keyword: "modules_json" },
-};
-
-export function extractWorkspaceDepsAnnotation(
-  scriptContent: string,
-  language: ScriptLanguage,
-): WorkspaceDepsAnnotation | null {
-  const config = LANG_ANNOTATION_CONFIG[language];
-  if (!config) return null;
-
-  const { comment, keyword, validityRe } = config;
-  const extraMarkerUnderscore = `extra_${keyword}:`;
-  const extraMarkerHyphen = `extra-${keyword}:`;
-  const manualMarker = `${keyword}:`;
-
-  const stripComment = (l: string): string | null => {
-    if (!l.startsWith(comment)) return null;
-    return l.substring(comment.length).trimStart();
-  };
-  const isExtra = (l: string): boolean => {
-    const s = stripComment(l);
-    return s !== null && (s.startsWith(extraMarkerUnderscore) || s.startsWith(extraMarkerHyphen));
-  };
-  const isManual = (l: string): boolean => {
-    const s = stripComment(l);
-    return s !== null && s.startsWith(manualMarker);
-  };
-
-  const lines = scriptContent.split("\n");
-
-  // Find first annotation line (mirrors Rust find_position)
-  let pos = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (isExtra(lines[i]) || isManual(lines[i])) {
-      pos = i;
-      break;
-    }
-  }
-  if (pos === -1) return null;
-
-  const annotationLine = lines[pos];
-  const mode: AnnotationMode = isExtra(annotationLine) ? "extra" : "manual";
-
-  // Parse external references from the annotation line
-  const marker = mode === "extra"
-    ? (annotationLine.includes(extraMarkerUnderscore) ? extraMarkerUnderscore : extraMarkerHyphen)
-    : manualMarker;
-  const unparsed = annotationLine.replaceAll(marker, "").replaceAll(comment, "");
-  const external = unparsed
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-
-  // Parse inline deps from subsequent lines
-  const inlineParts: string[] = [];
-  for (let i = pos + 1; i < lines.length; i++) {
-    const l = lines[i];
-    if (validityRe) {
-      const match = validityRe.exec(l);
-      if (match && match[1]) {
-        inlineParts.push(match[1]);
-      } else {
-        break;
-      }
-    } else {
-      if (!l.startsWith(comment)) {
-        break;
-      }
-      inlineParts.push(l.substring(comment.length));
-    }
-  }
-
-  const inlineStr = inlineParts.join("\n");
-  const inline = inlineStr.trim().length > 0 ? inlineStr : null;
-
-  return { mode, external, inline };
-}
 
 // Mirrors backend ScriptLang::as_comment_lit (windmill-types/src/scripts.rs)
 // for the languages that can reach the lock cache.
@@ -833,14 +742,14 @@ async function updateScriptLock(
 
   const lockPath = lockPathOverride ?? remotePath + ".script.lock";
   if (lock != "") {
-    // Under `dedupeLockfiles`, a lock that still resolves to what this script's
-    // group shares stays in the one shared file. Writing a copy here is what
-    // would put the 1900-file diff back, one regenerated script at a time.
-    if (
-      sharedLockRef &&
-      existsSync(sharedLockRef) &&
-      readTextFileSync(sharedLockRef) === lock
-    ) {
+    // Under `dedupeLockfiles` this lock IS the workspace dependency file's lock
+    // — the worker resolved it from that file alone — so it belongs in the file
+    // named after it, whether or not the content moved. Writing a copy beside
+    // the script is what would put the 1900-file diff back, one regenerated
+    // script at a time.
+    if (sharedLockRef) {
+      await mkdir(path.dirname(sharedLockRef), { recursive: true });
+      await writeFile(sharedLockRef, lock, "utf-8");
       if (existsSync(lockPath)) {
         await rm(lockPath);
       }

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -17,6 +17,7 @@ import {
   ScriptLanguage,
   workspaceDependenciesLanguages,
   languageNeedsLock,
+  LANG_COMMENT_LIT,
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
 // Workspace-dependency vocabulary lives with the languages it describes; these
@@ -520,18 +521,6 @@ export async function updateScriptSchema(
 
 // Mirrors backend ScriptLang::as_comment_lit (windmill-types/src/scripts.rs)
 // for the languages that can reach the lock cache.
-const LANG_COMMENT_LIT: Partial<Record<ScriptLanguage, string>> = {
-  python3: "#",
-  ansible: "#",
-  powershell: "#",
-  bun: "//",
-  nativets: "//",
-  deno: "//",
-  go: "//",
-  php: "//",
-  rust: "//!",
-};
-
 /**
  * Returns the leading comment/blank-line block of the script, verbatim.
  *

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -381,7 +381,8 @@ export async function generateScriptMetadataInternal(
         // The group's file when the script already reads one, its language's
         // otherwise: a script joins the default group by resolving to its lock.
         opts.dedupeLockfiles
-          ? (sharedLockRefIn(metadataContent) ?? sharedLockPath(language))
+          ? (sharedLockRefIn(metadataContent, metadataWithType.isJson) ??
+            sharedLockPath(language))
           : undefined,
       );
     } else {
@@ -418,7 +419,7 @@ export async function generateScriptMetadataInternal(
     // reference has to be restored from the raw text — including a shared one
     // (`dedupeLockfiles`), which `--schema-only` would otherwise replace with a
     // per-script path whose file deduplication removed.
-    const sharedRef = sharedLockRefIn(metadataContent);
+    const sharedRef = sharedLockRefIn(metadataContent, metadataWithType.isJson);
     if (sharedRef) {
       metadataParsedContent.lock = "!inline " + sharedRef;
     } else if (metadataInFolder) {

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -17,9 +17,10 @@ import {
   ScriptLanguage,
   workspaceDependenciesLanguages,
   languageNeedsLock,
+  sharedLockPath,
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
-import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath, sharedLockPath } from "./resource_folders.ts";
+import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath } from "./resource_folders.ts";
 import { findCodebase, yamlOptions } from "../commands/sync/sync.ts";
 import { generateHash, readInlinePathSync, getHeaders, readTextFile, readTextFileSync } from "./utils.ts";
 import { DBT_DESCRIPTOR_NAME, isMissingDbtDescriptor } from "./resource_folders.ts";

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -512,15 +512,7 @@ export async function updateScriptSchema(
   delete metadataContent.no_main_func;
 }
 
-// ---------------------------------------------------------------------------
-// Annotation parser — mirrors backend's WorkspaceDependenciesAnnotatedRefs::parse
-// (windmill-common/src/workspace_dependencies.rs) so the cache key captures
-// exactly the parts of scriptContent that affect lockfile generation.
-// ---------------------------------------------------------------------------
 
-
-// Mirrors backend ScriptLang::as_comment_lit (windmill-types/src/scripts.rs)
-// for the languages that can reach the lock cache.
 /**
  * Returns the leading comment/blank-line block of the script, verbatim.
  *

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -742,22 +742,12 @@ async function updateScriptLock(
 
   const lockPath = lockPathOverride ?? remotePath + ".script.lock";
   if (lock != "") {
-    // Under `dedupeLockfiles`, a lock that resolves to what the dependency
-    // file's scripts share stays in the one shared file; writing a copy beside
-    // the script is what would put the 1900-file diff back, one regenerated
-    // script at a time.
-    //
-    // Only when it agrees, though: two scripts on one dependency file can still
-    // resolve differently — a pinned Python version or an `//npm` annotation is
-    // part of what the worker locks — and overwriting the shared file would
-    // hand that variant to every other script reading it. A disagreeing script
-    // takes a private lock, and the whole-tree pass decides which content the
-    // shared file keeps.
-    // Joins, never creates: this runs once per script and in parallel, so two
-    // scripts that resolve differently — a pinned Python version, an `//npm`
-    // annotation — would both find the file absent, both write, and one would
-    // lose its lock with no copy left anywhere. Creating and moving a shared
-    // lockfile is the whole-tree pass's job, which sees every script at once.
+    // Joins an agreeing shared lockfile, and never creates or moves one: this
+    // runs per script and in parallel, so two scripts that resolve differently
+    // — a pinned Python version, an `//npm` annotation — would both find the
+    // file absent, both write it, and one would lose its lock with no copy left
+    // anywhere. Deciding a shared lockfile's content is the whole-tree pass's
+    // job, which sees every script at once.
     if (
       sharedLockRef &&
       existsSync(sharedLockRef) &&

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -412,7 +412,14 @@ export async function generateScriptMetadataInternal(
       );
     }
   } else {
-    if (metadataInFolder) {
+    // `parseMetadataFile` resolved `lock` to the lockfile's CONTENT, so the
+    // reference has to be restored from the raw text — including a shared one
+    // (`dedupeLockfiles`), which `--schema-only` would otherwise replace with a
+    // per-script path whose file deduplication removed.
+    const sharedRef = sharedLockRefIn(metadataContent);
+    if (sharedRef) {
+      metadataParsedContent.lock = "!inline " + sharedRef;
+    } else if (metadataInFolder) {
       metadataParsedContent.lock =
         "!inline " + remotePath.replaceAll(SEP, "/") + getModuleFolderSuffix() + "/script.lock";
     } else {

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -19,7 +19,7 @@ import {
   languageNeedsLock,
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
-import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath } from "./resource_folders.ts";
+import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath, sharedLockPath } from "./resource_folders.ts";
 import { findCodebase, yamlOptions } from "../commands/sync/sync.ts";
 import { generateHash, readInlinePathSync, getHeaders, readTextFile, readTextFileSync } from "./utils.ts";
 import { DBT_DESCRIPTOR_NAME, isMissingDbtDescriptor } from "./resource_folders.ts";
@@ -203,6 +203,7 @@ export async function generateScriptMetadataInternal(
     schemaOnly?: boolean | undefined;
     defaultTs?: "bun" | "deno";
     rehashOnly?: boolean | undefined;
+    dedupeLockfiles?: boolean | undefined;
   },
   dryRun: boolean,
   noStaleMessage: boolean,
@@ -375,6 +376,7 @@ export async function generateScriptMetadataInternal(
         filteredRawWorkspaceDependencies,
         tempScriptRefs,
         lockPathOverride,
+        opts.dedupeLockfiles,
       );
     } else {
       metadataParsedContent.lock = "";
@@ -783,6 +785,7 @@ async function updateScriptLock(
   rawWorkspaceDependencies: Record<string, string>,
   tempScriptRefs?: Record<string, string>,
   lockPathOverride?: string,
+  dedupeLockfiles?: boolean,
 ): Promise<void> {
   if (!languageNeedsLock(language)) {
     // A dbt lock is written by the dependency job on a worker, from a real
@@ -816,6 +819,17 @@ async function updateScriptLock(
 
   const lockPath = lockPathOverride ?? remotePath + ".script.lock";
   if (lock != "") {
+    // Under `dedupeLockfiles`, a lock that still resolves to what the language's
+    // scripts share stays in the one shared file. Writing a copy here is what
+    // would put the 1900-file diff back, one regenerated script at a time.
+    const shared = sharedLockPath(language);
+    if (dedupeLockfiles && existsSync(shared) && readTextFileSync(shared) === lock) {
+      if (existsSync(lockPath)) {
+        await rm(lockPath);
+      }
+      metadataContent.lock = "!inline " + shared;
+      return;
+    }
     await writeFile(lockPath, lock, "utf-8");
     metadataContent.lock = "!inline " + lockPath.replaceAll(SEP, "/");
   } else {

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -19,7 +19,7 @@ import {
   languageNeedsLock,
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
-import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath, isSharedLockPath, sharedLockPath } from "./resource_folders.ts";
+import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath, sharedLockPath } from "./resource_folders.ts";
 import { findCodebase, yamlOptions } from "../commands/sync/sync.ts";
 import { generateHash, readInlinePathSync, getHeaders, readTextFile, readTextFileSync } from "./utils.ts";
 import { DBT_DESCRIPTOR_NAME, isMissingDbtDescriptor } from "./resource_folders.ts";
@@ -31,6 +31,7 @@ import { getIsWin } from "./utils.ts";
 import { extractRelativeImports } from "./relative_imports.ts";
 import { DoubleLinkedDependencyTree } from "./dependency_tree.ts";
 import { pollJobWithQueueLogging } from "./job_polling.ts";
+import { sharedLockRefIn } from "./lock_dedup.ts";
 
 const _require = createRequire(import.meta.url);
 const _parserCache = new Map<string, Promise<any>>();
@@ -785,19 +786,6 @@ async function fetchScriptLock(
     lockCache.set(cacheKey, lock);
   }
   return lock;
-}
-
-/**
- * The shared lockfile a metadata FILE reads, when it reads one that exists.
- * `parseMetadataFile` resolves `lock` to the lockfile's content, so the
- * reference itself survives only in the raw text.
- */
-function sharedLockRefIn(metadataContent: string): string | undefined {
-  const match = /!inline (dependencies\/locks\/[^\s'"]+\.lock)/.exec(
-    metadataContent,
-  );
-  const ref = match?.[1];
-  return ref && isSharedLockPath(ref) && existsSync(ref) ? ref : undefined;
 }
 
 async function updateScriptLock(

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -19,7 +19,7 @@ import {
   languageNeedsLock,
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
-import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath, sharedLockPath } from "./resource_folders.ts";
+import { dbtGeneratedDirs, isUnderGeneratedDir, isBundledModuleFile, getModuleFolderSuffix, isModuleEntryPoint, scriptPathToRemotePath, isSharedLockPath, sharedLockPath } from "./resource_folders.ts";
 import { findCodebase, yamlOptions } from "../commands/sync/sync.ts";
 import { generateHash, readInlinePathSync, getHeaders, readTextFile, readTextFileSync } from "./utils.ts";
 import { DBT_DESCRIPTOR_NAME, isMissingDbtDescriptor } from "./resource_folders.ts";
@@ -376,7 +376,11 @@ export async function generateScriptMetadataInternal(
         filteredRawWorkspaceDependencies,
         tempScriptRefs,
         lockPathOverride,
-        opts.dedupeLockfiles,
+        // The group's file when the script already reads one, its language's
+        // otherwise: a script joins the default group by resolving to its lock.
+        opts.dedupeLockfiles
+          ? (sharedLockRefIn(metadataContent) ?? sharedLockPath(language))
+          : undefined,
       );
     } else {
       metadataParsedContent.lock = "";
@@ -776,6 +780,19 @@ async function fetchScriptLock(
   return lock;
 }
 
+/**
+ * The shared lockfile a metadata FILE reads, when it reads one that exists.
+ * `parseMetadataFile` resolves `lock` to the lockfile's content, so the
+ * reference itself survives only in the raw text.
+ */
+function sharedLockRefIn(metadataContent: string): string | undefined {
+  const match = /!inline (dependencies\/locks\/[^\s'"]+\.lock)/.exec(
+    metadataContent,
+  );
+  const ref = match?.[1];
+  return ref && isSharedLockPath(ref) && existsSync(ref) ? ref : undefined;
+}
+
 async function updateScriptLock(
   workspace: Workspace,
   scriptContent: string,
@@ -785,7 +802,7 @@ async function updateScriptLock(
   rawWorkspaceDependencies: Record<string, string>,
   tempScriptRefs?: Record<string, string>,
   lockPathOverride?: string,
-  dedupeLockfiles?: boolean,
+  sharedLockRef?: string,
 ): Promise<void> {
   if (!languageNeedsLock(language)) {
     // A dbt lock is written by the dependency job on a worker, from a real
@@ -819,15 +836,18 @@ async function updateScriptLock(
 
   const lockPath = lockPathOverride ?? remotePath + ".script.lock";
   if (lock != "") {
-    // Under `dedupeLockfiles`, a lock that still resolves to what the language's
-    // scripts share stays in the one shared file. Writing a copy here is what
+    // Under `dedupeLockfiles`, a lock that still resolves to what this script's
+    // group shares stays in the one shared file. Writing a copy here is what
     // would put the 1900-file diff back, one regenerated script at a time.
-    const shared = sharedLockPath(language);
-    if (dedupeLockfiles && existsSync(shared) && readTextFileSync(shared) === lock) {
+    if (
+      sharedLockRef &&
+      existsSync(sharedLockRef) &&
+      readTextFileSync(sharedLockRef) === lock
+    ) {
       if (existsSync(lockPath)) {
         await rm(lockPath);
       }
-      metadataContent.lock = "!inline " + shared;
+      metadataContent.lock = "!inline " + sharedLockRef;
       return;
     }
     await writeFile(lockPath, lock, "utf-8");

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -753,18 +753,21 @@ async function updateScriptLock(
     // hand that variant to every other script reading it. A disagreeing script
     // takes a private lock, and the whole-tree pass decides which content the
     // shared file keeps.
-    if (sharedLockRef) {
-      if (!existsSync(sharedLockRef)) {
-        await mkdir(path.dirname(sharedLockRef), { recursive: true });
-        await writeFile(sharedLockRef, lock, "utf-8");
+    // Joins, never creates: this runs once per script and in parallel, so two
+    // scripts that resolve differently — a pinned Python version, an `//npm`
+    // annotation — would both find the file absent, both write, and one would
+    // lose its lock with no copy left anywhere. Creating and moving a shared
+    // lockfile is the whole-tree pass's job, which sees every script at once.
+    if (
+      sharedLockRef &&
+      existsSync(sharedLockRef) &&
+      readTextFileSync(sharedLockRef) === lock
+    ) {
+      if (existsSync(lockPath)) {
+        await rm(lockPath);
       }
-      if (readTextFileSync(sharedLockRef) === lock) {
-        if (existsSync(lockPath)) {
-          await rm(lockPath);
-        }
-        metadataContent.lock = "!inline " + sharedLockRef;
-        return;
-      }
+      metadataContent.lock = "!inline " + sharedLockRef;
+      return;
     }
     await writeFile(lockPath, lock, "utf-8");
     metadataContent.lock = "!inline " + lockPath.replaceAll(SEP, "/");

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -742,19 +742,29 @@ async function updateScriptLock(
 
   const lockPath = lockPathOverride ?? remotePath + ".script.lock";
   if (lock != "") {
-    // Under `dedupeLockfiles` this lock IS the workspace dependency file's lock
-    // — the worker resolved it from that file alone — so it belongs in the file
-    // named after it, whether or not the content moved. Writing a copy beside
+    // Under `dedupeLockfiles`, a lock that resolves to what the dependency
+    // file's scripts share stays in the one shared file; writing a copy beside
     // the script is what would put the 1900-file diff back, one regenerated
     // script at a time.
+    //
+    // Only when it agrees, though: two scripts on one dependency file can still
+    // resolve differently — a pinned Python version or an `//npm` annotation is
+    // part of what the worker locks — and overwriting the shared file would
+    // hand that variant to every other script reading it. A disagreeing script
+    // takes a private lock, and the whole-tree pass decides which content the
+    // shared file keeps.
     if (sharedLockRef) {
-      await mkdir(path.dirname(sharedLockRef), { recursive: true });
-      await writeFile(sharedLockRef, lock, "utf-8");
-      if (existsSync(lockPath)) {
-        await rm(lockPath);
+      if (!existsSync(sharedLockRef)) {
+        await mkdir(path.dirname(sharedLockRef), { recursive: true });
+        await writeFile(sharedLockRef, lock, "utf-8");
       }
-      metadataContent.lock = "!inline " + sharedLockRef;
-      return;
+      if (readTextFileSync(sharedLockRef) === lock) {
+        if (existsSync(lockPath)) {
+          await rm(lockPath);
+        }
+        metadataContent.lock = "!inline " + sharedLockRef;
+        return;
+      }
     }
     await writeFile(lockPath, lock, "utf-8");
     metadataContent.lock = "!inline " + lockPath.replaceAll(SEP, "/");

--- a/cli/src/utils/resource_folders.ts
+++ b/cli/src/utils/resource_folders.ts
@@ -550,6 +550,22 @@ export function getModuleFolderSuffix(language?: string): string {
   return language === "dbt" ? DBT_MODULE_SUFFIX : MODULE_SUFFIX;
 }
 
+/** Where the lockfiles shared by the scripts of a language live when
+ *  `dedupeLockfiles` is on — see `utils/lock_dedup.ts`. Inside `dependencies/`
+ *  because that is where the workspace dependency files they resolve live. */
+export const SHARED_LOCK_DIR = "dependencies/locks";
+
+export function sharedLockPath(language: string): string {
+  return `${SHARED_LOCK_DIR}/${language}.lock`;
+}
+
+export function isSharedLockPath(p: string): boolean {
+  const normalized = normalizeSep(p);
+  if (!normalized.startsWith(SHARED_LOCK_DIR + "/")) return false;
+  const name = normalized.slice(SHARED_LOCK_DIR.length + 1);
+  return name.endsWith(".lock") && !name.includes("/");
+}
+
 /**
  * Check if a path is inside a script module folder.
  * Matches patterns like: .../my_script__mod/... or .../my_project__dbt/...

--- a/cli/src/utils/resource_folders.ts
+++ b/cli/src/utils/resource_folders.ts
@@ -550,23 +550,6 @@ export function getModuleFolderSuffix(language?: string): string {
   return language === "dbt" ? DBT_MODULE_SUFFIX : MODULE_SUFFIX;
 }
 
-/** Where the lockfiles shared by several scripts live when `dedupeLockfiles`
- *  is on — see `utils/lock_dedup.ts`. A top-level directory of its own: what a
- *  group shares is a resolved lock, which needs no workspace dependency file
- *  behind it, and inline-script locks would belong here too. */
-export const SHARED_LOCK_DIR = "locks";
-
-export function sharedLockPath(language: string): string {
-  return `${SHARED_LOCK_DIR}/${language}.lock`;
-}
-
-export function isSharedLockPath(p: string): boolean {
-  const normalized = normalizeSep(p);
-  if (!normalized.startsWith(SHARED_LOCK_DIR + "/")) return false;
-  const name = normalized.slice(SHARED_LOCK_DIR.length + 1);
-  return name.endsWith(".lock") && !name.includes("/");
-}
-
 /**
  * Check if a path is inside a script module folder.
  * Matches patterns like: .../my_script__mod/... or .../my_project__dbt/...

--- a/cli/src/utils/resource_folders.ts
+++ b/cli/src/utils/resource_folders.ts
@@ -550,10 +550,11 @@ export function getModuleFolderSuffix(language?: string): string {
   return language === "dbt" ? DBT_MODULE_SUFFIX : MODULE_SUFFIX;
 }
 
-/** Where the lockfiles shared by the scripts of a language live when
- *  `dedupeLockfiles` is on — see `utils/lock_dedup.ts`. Inside `dependencies/`
- *  because that is where the workspace dependency files they resolve live. */
-export const SHARED_LOCK_DIR = "dependencies/locks";
+/** Where the lockfiles shared by several scripts live when `dedupeLockfiles`
+ *  is on — see `utils/lock_dedup.ts`. A top-level directory of its own: what a
+ *  group shares is a resolved lock, which needs no workspace dependency file
+ *  behind it, and inline-script locks would belong here too. */
+export const SHARED_LOCK_DIR = "locks";
 
 export function sharedLockPath(language: string): string {
   return `${SHARED_LOCK_DIR}/${language}.lock`;

--- a/cli/src/utils/script_common.ts
+++ b/cli/src/utils/script_common.ts
@@ -44,39 +44,148 @@ export const workspaceDependenciesLanguages: WorkspaceDependenciesLanguage[] = [
   { language: "powershell", filename: "modules.json" },
 ] as const;
 
+export function workspaceDependenciesPathToLanguageAndFilename(path: string): { name: string | undefined, language: ScriptLanguage } | undefined {
+  const relativePath = path.replace("dependencies/", "");
+  for (const { filename, language } of workspaceDependenciesLanguages) {
+    if (relativePath.endsWith(filename)) {
+      return {
+        name: relativePath === filename ? undefined : relativePath.replace("." + filename, ""),
+        language
+      };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Annotation parser — mirrors backend's WorkspaceDependenciesAnnotatedRefs::parse
+// (windmill-common/src/workspace_dependencies.rs), so the CLI can tell which
+// workspace dependency file a script resolves against without asking a worker.
+// ---------------------------------------------------------------------------
+
+export type AnnotationMode = "manual" | "extra";
+
+export interface WorkspaceDepsAnnotation {
+  mode: AnnotationMode;
+  external: string[];
+  inline: string | null;
+}
+
+const LANG_ANNOTATION_CONFIG: Partial<
+  Record<ScriptLanguage, { comment: string; keyword: string; validityRe?: RegExp }>
+> = {
+  python3: { comment: "#", keyword: "requirements", validityRe: /^#\s?(\S+)\s*$/ },
+  bun: { comment: "//", keyword: "package_json" },
+  nativets: { comment: "//", keyword: "package_json" },
+  go: { comment: "//", keyword: "go_mod" },
+  php: { comment: "//", keyword: "composer_json" },
+  powershell: { comment: "#", keyword: "modules_json" },
+};
+
+export function extractWorkspaceDepsAnnotation(
+  scriptContent: string,
+  language: ScriptLanguage,
+): WorkspaceDepsAnnotation | null {
+  const config = LANG_ANNOTATION_CONFIG[language];
+  if (!config) return null;
+
+  const { comment, keyword, validityRe } = config;
+  const extraMarkerUnderscore = `extra_${keyword}:`;
+  const extraMarkerHyphen = `extra-${keyword}:`;
+  const manualMarker = `${keyword}:`;
+
+  const stripComment = (l: string): string | null => {
+    if (!l.startsWith(comment)) return null;
+    return l.substring(comment.length).trimStart();
+  };
+  const isExtra = (l: string): boolean => {
+    const s = stripComment(l);
+    return s !== null && (s.startsWith(extraMarkerUnderscore) || s.startsWith(extraMarkerHyphen));
+  };
+  const isManual = (l: string): boolean => {
+    const s = stripComment(l);
+    return s !== null && s.startsWith(manualMarker);
+  };
+
+  const lines = scriptContent.split("\n");
+
+  // Find first annotation line (mirrors Rust find_position)
+  let pos = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (isExtra(lines[i]) || isManual(lines[i])) {
+      pos = i;
+      break;
+    }
+  }
+  if (pos === -1) return null;
+
+  const annotationLine = lines[pos];
+  const mode: AnnotationMode = isExtra(annotationLine) ? "extra" : "manual";
+
+  // Parse external references from the annotation line
+  const marker = mode === "extra"
+    ? (annotationLine.includes(extraMarkerUnderscore) ? extraMarkerUnderscore : extraMarkerHyphen)
+    : manualMarker;
+  const unparsed = annotationLine.replaceAll(marker, "").replaceAll(comment, "");
+  const external = unparsed
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  // Parse inline deps from subsequent lines
+  const inlineParts: string[] = [];
+  for (let i = pos + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (validityRe) {
+      const match = validityRe.exec(l);
+      if (match && match[1]) {
+        inlineParts.push(match[1]);
+      } else {
+        break;
+      }
+    } else {
+      if (!l.startsWith(comment)) {
+        break;
+      }
+      inlineParts.push(l.substring(comment.length));
+    }
+  }
+
+  const inlineStr = inlineParts.join("\n");
+  const inline = inlineStr.trim().length > 0 ? inlineStr : null;
+
+  return { mode, external, inline };
+}
+
 /** Where the lockfiles shared by several scripts live when `dedupeLockfiles`
  *  is on — see `utils/lock_dedup.ts`. A top-level directory of its own: what a
  *  group shares is a resolved lock, which needs no workspace dependency file
  *  behind it, and inline-script locks would belong here too. */
 export const SHARED_LOCK_DIR = "locks";
 
-export function sharedLockPath(language: string, n = 1): string {
-  return n === 1
-    ? `${SHARED_LOCK_DIR}/${language}.lock`
-    : `${SHARED_LOCK_DIR}/${language}-${n}.lock`;
+/** The lockfile shared by the scripts that resolve against a workspace
+ *  dependency file: its own name, plus `.lock`. Appending rather than replacing
+ *  the extension keeps the correspondence exact and reversible —
+ *  `dependencies/team_a.requirements.in` <-> `locks/team_a.requirements.in.lock`. */
+export function sharedLockPathFor(depFilePath: string): string {
+  const name = depFilePath.replaceAll("\\", "/").split("/").pop()!;
+  return `${SHARED_LOCK_DIR}/${name}.lock`;
 }
 
-/**
- * Whether a path is a shared lockfile Windmill would have written.
- *
- * Narrow on purpose: `locks/` is an ordinary word, so a repo may already have
- * one holding something else. Only the names `sharedLockPath` can produce are
- * claimed — anything else under `locks/` stays invisible to sync, and cannot be
- * swept as an unreferenced shared lock.
- */
-export function isSharedLockPath(p: string): boolean {
+/** The workspace dependency file a shared lockfile belongs to, if it is one. */
+export function depFileOfSharedLock(p: string): string | undefined {
   const normalized = p.replaceAll("\\", "/");
-  if (!normalized.startsWith(SHARED_LOCK_DIR + "/")) return false;
+  if (!normalized.startsWith(SHARED_LOCK_DIR + "/")) return undefined;
   const name = normalized.slice(SHARED_LOCK_DIR.length + 1);
-  if (name.includes("/")) return false;
-  const match = /^(.+?)(?:-(\d+))?\.lock$/.exec(name);
-  if (!match) return false;
-  const n = match[2] === undefined ? 1 : Number(match[2]);
-  return (
-    languageNeedsLock(match[1]) &&
-    n >= 1 &&
-    sharedLockPath(match[1], n) === normalized
-  );
+  if (name.includes("/") || !name.endsWith(".lock")) return undefined;
+  const depFile = "dependencies/" + name.slice(0, -".lock".length);
+  const info = workspaceDependenciesPathToLanguageAndFilename(depFile);
+  // `locks/vendor.lock` names no dependency file, so it is not Windmill's: a
+  // repo that already keeps lockfiles here keeps them.
+  return info && languageNeedsLock(info.language) ? depFile : undefined;
+}
+
+export function isSharedLockPath(p: string): boolean {
+  return depFileOfSharedLock(p) !== undefined;
 }
 
 /**

--- a/cli/src/utils/script_common.ts
+++ b/cli/src/utils/script_common.ts
@@ -156,6 +156,59 @@ export function extractWorkspaceDepsAnnotation(
   return { mode, external, inline };
 }
 
+/** The comment marker each language's annotations are written behind. */
+const LANG_COMMENT_LIT: Partial<Record<ScriptLanguage, string>> = {
+  python3: "#",
+  ansible: "#",
+  powershell: "#",
+  bun: "//",
+  nativets: "//",
+  deno: "//",
+  go: "//",
+  php: "//",
+  rust: "//!",
+};
+
+/**
+ * Whether a script's leading comment block carries an annotation, i.e. anything
+ * that is not prose and not the workspace-dependency selection.
+ *
+ * The worker reads that block for flags of its own — `# py311`, `# py: 3.11.11`,
+ * `//npm`, `//nobundling`, `//native`, `# go1_22_compat` (the `#[annotations]`
+ * structs in windmill-common) — and several of them change what it locks. A
+ * script carrying one cannot stand for its dependency file's lock.
+ *
+ * Recognised by shape rather than by a list of names, so an annotation this CLI
+ * has never heard of also disqualifies: a lone bare word, or `word: value`.
+ * Prose ("# syncs users nightly") is several words and stays eligible, which is
+ * what keeps ordinary documented scripts deduplicating.
+ */
+export function hasLockAffectingAnnotation(
+  scriptContent: string,
+  language: ScriptLanguage,
+): boolean {
+  const comment = LANG_COMMENT_LIT[language];
+  if (!comment) return true; // unknown language: assume it matters
+  const depsKeyword = LANG_ANNOTATION_CONFIG[language]?.keyword;
+  for (const line of scriptContent.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (!trimmed.startsWith(comment)) break; // past the header block
+    const body = trimmed.slice(comment.length).trim();
+    if (body === "") continue;
+    if (
+      depsKeyword &&
+      new RegExp(`^(extra[_-])?${depsKeyword}\\s*:`).test(body)
+    ) {
+      continue; // the dependency selection is what puts it in the group
+    }
+    if (/^[a-z0-9_]+$/i.test(body) || /^[a-z0-9_]+\s*:/i.test(body)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Where the lockfiles shared by several scripts live when `dedupeLockfiles`
  *  is on — see `utils/lock_dedup.ts`. A top-level directory of its own: what a
  *  group shares is a resolved lock, which needs no workspace dependency file

--- a/cli/src/utils/script_common.ts
+++ b/cli/src/utils/script_common.ts
@@ -44,6 +44,41 @@ export const workspaceDependenciesLanguages: WorkspaceDependenciesLanguage[] = [
   { language: "powershell", filename: "modules.json" },
 ] as const;
 
+/** Where the lockfiles shared by several scripts live when `dedupeLockfiles`
+ *  is on — see `utils/lock_dedup.ts`. A top-level directory of its own: what a
+ *  group shares is a resolved lock, which needs no workspace dependency file
+ *  behind it, and inline-script locks would belong here too. */
+export const SHARED_LOCK_DIR = "locks";
+
+export function sharedLockPath(language: string, n = 1): string {
+  return n === 1
+    ? `${SHARED_LOCK_DIR}/${language}.lock`
+    : `${SHARED_LOCK_DIR}/${language}-${n}.lock`;
+}
+
+/**
+ * Whether a path is a shared lockfile Windmill would have written.
+ *
+ * Narrow on purpose: `locks/` is an ordinary word, so a repo may already have
+ * one holding something else. Only the names `sharedLockPath` can produce are
+ * claimed — anything else under `locks/` stays invisible to sync, and cannot be
+ * swept as an unreferenced shared lock.
+ */
+export function isSharedLockPath(p: string): boolean {
+  const normalized = p.replaceAll("\\", "/");
+  if (!normalized.startsWith(SHARED_LOCK_DIR + "/")) return false;
+  const name = normalized.slice(SHARED_LOCK_DIR.length + 1);
+  if (name.includes("/")) return false;
+  const match = /^(.+?)(?:-(\d+))?\.lock$/.exec(name);
+  if (!match) return false;
+  const n = match[2] === undefined ? 1 : Number(match[2]);
+  return (
+    languageNeedsLock(match[1]) &&
+    n >= 1 &&
+    sharedLockPath(match[1], n) === normalized
+  );
+}
+
 /**
  * Returns true if a script in the given language requires a lock file.
  * Matches the condition in updateScriptLock (metadata.ts).

--- a/cli/src/utils/script_common.ts
+++ b/cli/src/utils/script_common.ts
@@ -157,7 +157,7 @@ export function extractWorkspaceDepsAnnotation(
 }
 
 /** The comment marker each language's annotations are written behind. */
-const LANG_COMMENT_LIT: Partial<Record<ScriptLanguage, string>> = {
+export const LANG_COMMENT_LIT: Partial<Record<ScriptLanguage, string>> = {
   python3: "#",
   ansible: "#",
   powershell: "#",
@@ -170,41 +170,54 @@ const LANG_COMMENT_LIT: Partial<Record<ScriptLanguage, string>> = {
 };
 
 /**
- * Whether a script's leading comment block carries an annotation, i.e. anything
- * that is not prose and not the workspace-dependency selection.
+ * The annotations each language recognises, by the exact names the worker
+ * matches (`#[annotations(..)]` structs in windmill-common/src/worker.rs).
+ * Several change what it locks — a pinned interpreter, `npm`, `nobundling` —
+ * and the rest are cheap to treat the same way, since the only cost is that
+ * such a script keeps a lockfile of its own.
+ * for related places search: ADD_NEW_LANG
+ */
+const LANG_ANNOTATIONS: Partial<Record<ScriptLanguage, string[]>> = {
+  python3: [
+    "no_cache",
+    "no_postinstall",
+    "py_select_latest",
+    "skip_result_postprocessing",
+    "py310",
+    "py311",
+    "py312",
+    "py313",
+    "sandbox",
+  ],
+  bun: ["npm", "nodejs", "native", "nobundling", "sandbox"],
+  nativets: ["npm", "nodejs", "native", "nobundling", "sandbox"],
+  deno: ["npm", "nodejs", "native", "nobundling", "sandbox"],
+  go: ["go1_22_compat"],
+};
+
+/**
+ * Whether a script's leading comment block carries an annotation the worker
+ * acts on, which means its lock may not be its dependency file's.
  *
- * The worker reads that block for flags of its own — `# py311`, `# py: 3.11.11`,
- * `//npm`, `//nobundling`, `//native`, `# go1_22_compat` (the `#[annotations]`
- * structs in windmill-common) — and several of them change what it locks. A
- * script carrying one cannot stand for its dependency file's lock.
- *
- * Recognised by shape rather than by a list of names, so an annotation this CLI
- * has never heard of also disqualifies: a lone bare word, or `word: value`.
- * Prose ("# syncs users nightly") is several words and stays eligible, which is
- * what keeps ordinary documented scripts deduplicating.
+ * Matched the way the worker matches: the key is the line, or what precedes the
+ * first `=`, and it has to BE one of the names above. Unknown keys are ignored
+ * there and so here — which is what keeps `# TODO:` or `# type: ignore` from
+ * quietly dropping an ordinary documented script out of deduplication.
  */
 export function hasLockAffectingAnnotation(
   scriptContent: string,
   language: ScriptLanguage,
 ): boolean {
   const comment = LANG_COMMENT_LIT[language];
-  if (!comment) return true; // unknown language: assume it matters
-  const depsKeyword = LANG_ANNOTATION_CONFIG[language]?.keyword;
+  const names = LANG_ANNOTATIONS[language];
+  if (!comment || !names) return false;
   for (const line of scriptContent.split("\n")) {
     const trimmed = line.trim();
     if (trimmed === "") continue;
     if (!trimmed.startsWith(comment)) break; // past the header block
     const body = trimmed.slice(comment.length).trim();
-    if (body === "") continue;
-    if (
-      depsKeyword &&
-      new RegExp(`^(extra[_-])?${depsKeyword}\\s*:`).test(body)
-    ) {
-      continue; // the dependency selection is what puts it in the group
-    }
-    if (/^[a-z0-9_]+$/i.test(body) || /^[a-z0-9_]+\s*:/i.test(body)) {
-      return true;
-    }
+    const key = body.split("=")[0].trim();
+    if (names.includes(key)) return true;
   }
   return false;
 }

--- a/cli/src/utils/script_common.ts
+++ b/cli/src/utils/script_common.ts
@@ -203,6 +203,10 @@ const LANG_ANNOTATIONS: Partial<Record<ScriptLanguage, string[]>> = {
  * first `=`, and it has to BE one of the names above. Unknown keys are ignored
  * there and so here — which is what keeps `# TODO:` or `# type: ignore` from
  * quietly dropping an ordinary documented script out of deduplication.
+ *
+ * `# py: <specifier>` is the exception the macro does not cover: the python
+ * import parser reads it directly (`windmill-parser-py-imports`, alongside the
+ * `py310`..`py313` flags) to pick the interpreter, which changes what resolves.
  */
 export function hasLockAffectingAnnotation(
   scriptContent: string,
@@ -215,6 +219,8 @@ export function hasLockAffectingAnnotation(
     const trimmed = line.trim();
     if (trimmed === "") continue;
     if (!trimmed.startsWith(comment)) break; // past the header block
+    // Matched on the raw line: the parser tests `# py:`/`#py:` before trimming.
+    if (language === "python3" && /^#\s?py:/.test(line)) return true;
     const body = trimmed.slice(comment.length).trim();
     const key = body.split("=")[0].trim();
     if (names.includes(key)) return true;

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -166,6 +166,28 @@ describe("computeSharedLockPlan", () => {
     );
   });
 
+  test("a script the worker locks differently keeps a private lockfile", () => {
+    // The worker reads these from the leading comment block and several of them
+    // change what it locks, so such a script cannot stand for the file's lock.
+    const map = workspace(PY_DEPS, BUN_DEPS);
+    ownLock(map, "f/pinned", ".py", OTHER_LOCK, "# py311\nimport requests");
+    ownLock(map, "f/plain", ".py", PY_LOCK);
+    ownLock(map, "f/plain2", ".py", PY_LOCK);
+    // Prose is not an annotation: a documented script still deduplicates.
+    ownLock(map, "f/doc", ".py", PY_LOCK, "# syncs users nightly\nimport requests");
+    ownLock(map, "f/npm", ".ts", "npm-lock", "//npm\nexport async function main() {}");
+    ownLock(map, "f/ts", ".ts", "bun-lock", "export async function main() {}");
+    ownLock(map, "f/ts2", ".ts", "bun-lock", "export async function main() {}");
+
+    applySharedLockPlanToMap(map, plan(map));
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map["f/doc.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+    expect(map[SHARED_BUN]).toEqual("bun-lock");
+    expect(map["f/npm.script.lock"]).toEqual("npm-lock");
+  });
+
   test("a script whose lock is its own keeps a private lockfile", () => {
     const map = workspace(PY_DEPS, TEAM_DEPS);
     // `extra_` folds the script's own imports into the lock…
@@ -252,125 +274,10 @@ describe("computeSharedLockPlan", () => {
     expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
   });
 
-  test("a script that disagrees moves the lockfile only if the file moved", () => {
-    // The dependency file is unchanged, so this script pins something the
-    // worker also locks (a Python version, an `//npm` annotation). It must not
-    // hand that variant to every other script reading the file.
-    const pinned = workspace(PY_DEPS);
-    ownLock(pinned, "f/pinned", ".py", OTHER_LOCK);
-    applySharedLockPlanToMap(
-      pinned,
-      computeSharedLockPlan(pinned, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: PY_LOCK },
-      }),
-    );
-    expect(pinned[SHARED_PY]).toEqual(PY_LOCK);
-    expect(pinned["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
 
-    // The same shape, but the dependency file moved: one script is enough, or a
-    // sync narrowed to one item could never carry a bump through.
-    const bumped = workspace(PY_DEPS);
-    ownLock(bumped, "f/a", ".py", PY_LOCK_BUMPED);
-    applySharedLockPlanToMap(
-      bumped,
-      computeSharedLockPlan(bumped, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: PY_LOCK },
-        movedDepFiles: [PY_DEPS],
-      }),
-    );
-    expect(bumped[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
-    expect(bumped["f/a.script.lock"]).toBeUndefined();
-    expect(lockRefOf(bumped["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-  });
 
-  test("a lock's own dependency stamp says whether it may move the file", () => {
-    const stamp = (dep: string, body: string) =>
-      `# workspace-dependencies-mode: manual\n# workspace-dependencies: default:${dep}\n${body}`;
 
-    // Same dependency inputs, different body: this script pinned something, and
-    // the file is not its to move — even alone, and even mid-bump.
-    const pinned = workspace(PY_DEPS);
-    ownLock(pinned, "f/pinned", ".py", stamp("aaa", OTHER_LOCK));
-    applySharedLockPlanToMap(
-      pinned,
-      computeSharedLockPlan(pinned, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: stamp("aaa", PY_LOCK) },
-        movedDepFiles: [PY_DEPS],
-      }),
-    );
-    expect(pinned[SHARED_PY]).toEqual(stamp("aaa", PY_LOCK));
-    expect(pinned["f/pinned.script.lock"]).toEqual(stamp("aaa", OTHER_LOCK));
 
-    // Different dependency inputs: the file moved, and one script is enough.
-    const bumped = workspace(PY_DEPS);
-    ownLock(bumped, "f/a", ".py", stamp("bbb", PY_LOCK_BUMPED));
-    applySharedLockPlanToMap(
-      bumped,
-      computeSharedLockPlan(bumped, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: stamp("aaa", PY_LOCK) },
-      }),
-    );
-    expect(bumped[SHARED_PY]).toEqual(stamp("bbb", PY_LOCK_BUMPED));
-    expect(bumped["f/a.script.lock"]).toBeUndefined();
-  });
-
-  test("a dependency file that re-resolves without changing still moves", () => {
-    // An unpinned `requirements.in` picking up a new patch release: same stamp,
-    // new bodies. Read as variants, the whole group would fork to private locks.
-    const stamp = (body: string) =>
-      `# workspace-dependencies: default:aaa\n${body}`;
-    const map = workspace(PY_DEPS);
-    ownLock(map, "f/a", ".py", stamp(PY_LOCK_BUMPED));
-    ownLock(map, "f/b", ".py", stamp(PY_LOCK_BUMPED));
-
-    applySharedLockPlanToMap(
-      map,
-      computeSharedLockPlan(map, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: stamp(PY_LOCK) },
-      }),
-    );
-
-    expect(map[SHARED_PY]).toEqual(stamp(PY_LOCK_BUMPED));
-    expect(map["f/a.script.lock"]).toBeUndefined();
-  });
-
-  test("the many correct a lockfile a lone script planted its variant on", () => {
-    const map = workspace(PY_DEPS);
-    ownLock(map, "f/a", ".py", PY_LOCK);
-    ownLock(map, "f/b", ".py", PY_LOCK);
-    applySharedLockPlanToMap(
-      map,
-      // The file holds a variant, and its dependency file has not moved.
-      computeSharedLockPlan(map, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: OTHER_LOCK },
-      }),
-    );
-
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map["f/a.script.lock"]).toBeUndefined();
-  });
-
-  test("a dependency file with a single script can still take a bump", () => {
-    const map = workspace(PY_DEPS);
-    ownLock(map, "f/only", ".py", PY_LOCK_BUMPED);
-    applySharedLockPlanToMap(
-      map,
-      computeSharedLockPlan(map, {
-        defaultTs: "bun",
-        present: { [SHARED_PY]: PY_LOCK },
-        movedDepFiles: [PY_DEPS],
-      }),
-    );
-
-    expect(map[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
-    expect(map["f/only.script.lock"]).toBeUndefined();
-  });
 
   test("a language that needs no lock is never deduplicated", () => {
     const map = workspace("dependencies/modules.json");

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -478,6 +478,9 @@ describe("collectExistingSharedLocks", () => {
         ),
       );
       await write("docs/example.script.yaml", readsShared);
+      // Sync never descends a dot-directory, so a fixture there is a file it can
+      // never see: counted as a script it would suppress every new group.
+      await write("f/team/.fixtures/example.script.yaml", readsShared);
 
       const existing = await collectExistingSharedLocks(root);
 
@@ -497,6 +500,9 @@ describe("collectExistingSharedLocks", () => {
       // sync reads, is not a script — counted, it would leave the planner in
       // conserve-only mode for good.
       expect(existing.scripts.has("docs/example.script.yaml")).toBe(false);
+      expect(existing.scripts.has("f/team/.fixtures/example.script.yaml")).toBe(
+        false,
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -114,7 +114,7 @@ describe("computeSharedLockPlan", () => {
     applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
     const tree = treeOf(map, { [SHARED_PY]: map[SHARED_PY] });
-    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", tree))).toBe(
+    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: tree }))).toBe(
       true,
     );
   });
@@ -132,7 +132,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(remote, "f/b", ".py", PY_LOCK_BUMPED);
     applySharedLockPlanToMap(
       remote,
-      computeSharedLockPlan(remote, "bun", tree),
+      computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }),
     );
 
     const changed = Object.keys(remote).filter((k) => remote[k] !== committed[k]);
@@ -163,7 +163,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(remote, "f/b", ".py", PY_LOCK);
     ownLock(remote, "f/c", ".py", OTHER_LOCK + "click==8.1.7\n");
     ownLock(remote, "f/d", ".py", OTHER_LOCK + "click==8.1.7\n");
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun", tree));
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }));
 
     expect(Object.keys(remote).filter((k) => remote[k] !== map[k])).toEqual([
       SHARED_PY_2,
@@ -184,7 +184,7 @@ describe("computeSharedLockPlan", () => {
       ownLock(remote, base, ".py", PY_LOCK_BUMPED);
     }
     ownLock(remote, "f/lag", ".py", PY_LOCK);
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun", tree));
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }));
 
     expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
     expect(remote[SHARED_PY_2]).toBeUndefined();
@@ -219,7 +219,7 @@ describe("computeSharedLockPlan", () => {
     for (const base of ["f/d", "f/e"]) {
       ownLock(remote, base, ".py", OTHER_LOCK + "click==8.1.7\n");
     }
-    const plan = computeSharedLockPlan(remote, "bun", tree);
+    const plan = computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree });
     applySharedLockPlanToMap(remote, plan);
 
     expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
@@ -251,7 +251,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(remote, "f/a", ".py", PY_LOCK);
     ownLock(remote, "f/b", ".py", PY_LOCK);
     ownLock(remote, "f/c", ".py", OTHER_LOCK);
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun", tree));
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }));
 
     expect(remote[SHARED_PY]).toEqual(PY_LOCK);
     expect(remote["f/c.script.lock"]).toEqual(OTHER_LOCK);
@@ -269,7 +269,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/a", ".py", OTHER_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK_BUMPED);
 
-    const plan = computeSharedLockPlan(map, "bun", tree);
+    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
     expect(plan.deletes).toContain(SHARED_PY);
   });
 
@@ -306,7 +306,7 @@ describe("computeSharedLockPlan", () => {
       "f/b__mod/script.lock": PY_LOCK,
     };
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun" }));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map["f/a__mod/script.lock"]).toBeUndefined();
@@ -365,7 +365,7 @@ describe("computeSharedLockPlan with a partial sync map", () => {
 
   test("keeps the shared file the scripts out of scope read", () => {
     const { map, tree } = partial(PY_LOCK);
-    const plan = computeSharedLockPlan(map, "bun", tree);
+    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
     applySharedLockPlanToMap(map, plan);
 
     expect(plan.deletes).not.toContain(SHARED_PY);
@@ -376,7 +376,7 @@ describe("computeSharedLockPlan with a partial sync map", () => {
 
   test("never rewrites the shared file from the scripts it can see", () => {
     const { map, tree } = partial(OTHER_LOCK);
-    const plan = computeSharedLockPlan(map, "bun", tree);
+    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
     applySharedLockPlanToMap(map, plan);
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
@@ -385,6 +385,33 @@ describe("computeSharedLockPlan with a partial sync map", () => {
     expect(lockRefOf(map["f/a.script.yaml"])).toEqual(
       "!inline f/a.script.lock",
     );
+  });
+
+  test("a script added locally but not yet pushed does not break the group", () => {
+    // On a pull the map is the REMOTE, so a script that exists only on disk is
+    // absent from it while being fully in scope. Counted as an unseen reader it
+    // would veto the bump and explode the group into per-script locks.
+    const committed: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/local"]) {
+      sharedLock(committed, base, ".py", SHARED_PY);
+    }
+    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
+
+    const remote: Record<string, string> = {};
+    ownLock(remote, "f/a", ".py", PY_LOCK_BUMPED);
+    ownLock(remote, "f/b", ".py", PY_LOCK_BUMPED);
+
+    applySharedLockPlanToMap(
+      remote,
+      computeSharedLockPlan(remote, {
+        defaultTs: "bun",
+        existing: tree,
+        inScope: (metaRef) => committed[metaRef] !== undefined,
+      }),
+    );
+
+    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(remote["f/a.script.lock"]).toBeUndefined();
   });
 
   test("forms no new group it cannot see the whole of", () => {
@@ -399,7 +426,7 @@ describe("computeSharedLockPlan with a partial sync map", () => {
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
 
-    const plan = computeSharedLockPlan(map, "bun", tree);
+    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
     expect(plan.writes[SHARED_PY]).toBeUndefined();
   });
 });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -217,6 +217,69 @@ describe("computeSharedLockPlan", () => {
     expect(plan(withoutDep).deletes).toContain(SHARED_PY);
   });
 
+  // The git-sync deploy callback narrows to one item, so a dependency file with
+  // no script in view is routine — and its lockfile is read by scripts this sync
+  // cannot see.
+  test("a dependency file with no script in view keeps its lockfile", () => {
+    const map = workspace(PY_DEPS, BUN_DEPS);
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    const present = { [SHARED_BUN]: "bun-lock" };
+
+    const result = computeSharedLockPlan(map, { defaultTs: "bun", present });
+    applySharedLockPlanToMap(map, result);
+
+    expect(result.deletes).not.toContain(SHARED_BUN);
+    // Carried into the map, or the diff reads it as a local-only deletion.
+    expect(map[SHARED_BUN]).toEqual("bun-lock");
+  });
+
+  test("dependency files absent from the map are not gone", () => {
+    // `--skip-workspace-dependencies` keeps them out of both maps; taking that
+    // as "deleted" would un-deduplicate the tree and sweep the lockfiles.
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+
+    const result = computeSharedLockPlan(map, {
+      defaultTs: "bun",
+      depFiles: [PY_DEPS],
+      present: { [SHARED_PY]: PY_LOCK },
+    });
+    applySharedLockPlanToMap(map, result);
+
+    expect(result.deletes).not.toContain(SHARED_PY);
+    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+  });
+
+  test("a lone script does not move a lockfile others read", () => {
+    // It may be the one pinning a Python version rather than the first of a
+    // bump everyone took — two agreeing scripts settle it.
+    const alone = workspace(PY_DEPS);
+    ownLock(alone, "f/pinned", ".py", OTHER_LOCK);
+    applySharedLockPlanToMap(
+      alone,
+      computeSharedLockPlan(alone, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: PY_LOCK },
+      }),
+    );
+    expect(alone[SHARED_PY]).toEqual(PY_LOCK);
+    expect(alone["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
+
+    const bumped = workspace(PY_DEPS);
+    ownLock(bumped, "f/a", ".py", PY_LOCK_BUMPED);
+    ownLock(bumped, "f/b", ".py", PY_LOCK_BUMPED);
+    applySharedLockPlanToMap(
+      bumped,
+      computeSharedLockPlan(bumped, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: PY_LOCK },
+      }),
+    );
+    expect(bumped[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+  });
+
   test("a language that needs no lock is never deduplicated", () => {
     const map = workspace("dependencies/modules.json");
     ownLock(map, "f/a", ".ps1", "some-lock", "echo hi");

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -171,9 +171,7 @@ describe("computeSharedLockPlan", () => {
     // change what it locks, so such a script cannot stand for the file's lock.
     const map = workspace(PY_DEPS, BUN_DEPS);
     ownLock(map, "f/pinned", ".py", OTHER_LOCK, "# py311\nimport requests");
-    // The interpreter pin the python import parser reads, which the annotations
-    // macro does not cover.
-    ownLock(map, "f/pyspec", ".py", OTHER_LOCK, "# py: 3.11\nimport requests");
+
     ownLock(map, "f/plain", ".py", PY_LOCK);
     ownLock(map, "f/plain2", ".py", PY_LOCK);
     // Only the names the worker matches count, so a documented script — or one
@@ -189,11 +187,28 @@ describe("computeSharedLockPlan", () => {
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
-    expect(map["f/pyspec.script.lock"]).toEqual(OTHER_LOCK);
     expect(lockRefOf(map["f/doc.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
     expect(map[SHARED_BUN]).toEqual("bun-lock");
     expect(map["f/npm.script.lock"]).toEqual("npm-lock");
     expect(map["f/nb.script.lock"]).toEqual("nb-lock");
+  });
+
+  test("an annotated script alone in its group creates no shared lockfile", () => {
+    // Alone, so nothing outvotes it: without the gate its variant would BECOME
+    // the dependency file's lock. `# py: <spec>` is the interpreter pin the
+    // python import parser reads, which the annotations macro does not cover.
+    for (const header of ["# py: 3.11", "#py:3.11.4", "# py311"]) {
+      const map = workspace(PY_DEPS);
+      ownLock(map, "f/only", ".py", OTHER_LOCK, `${header}\nimport requests`);
+
+      applySharedLockPlanToMap(map, plan(map));
+
+      expect(map[SHARED_PY]).toBeUndefined();
+      expect(map["f/only.script.lock"]).toEqual(OTHER_LOCK);
+      expect(lockRefOf(map["f/only.script.yaml"])).toEqual(
+        "!inline f/only.script.lock",
+      );
+    }
   });
 
   test("a script whose lock is its own keeps a private lockfile", () => {

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -354,6 +354,21 @@ describe("computeSharedLockPlan", () => {
       before.replace("f/a.script.lock", SHARED_PY),
     );
   });
+
+  test("a dependency set named with a slash shares nothing", () => {
+    // `dependencies/team/python.requirements.in` has no distinct name under
+    // `locks/`: flattened to `locks/python.requirements.in.lock` it names a
+    // different (top-level) dependency file, and every later sweep would then
+    // read the lockfile as orphaned and retire it.
+    const map = workspace("dependencies/team/python.requirements.in");
+    const body = "# requirements: team/python\ndef main(): ...";
+    ownLock(map, "f/a", ".py", PY_LOCK, body);
+    ownLock(map, "f/b", ".py", PY_LOCK, body);
+
+    const p = plan(map);
+    expect(p.writes).toEqual({});
+    expect(p.deletes).toEqual([]);
+  });
 });
 
 describe("isSharedLockPath", () => {

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -4,14 +4,15 @@
  * A workspace with one `dependencies/requirements.in` resolves the same lock for
  * every Python script, so the repo carries thousands of identical
  * `.script.lock` files: a dependency bump rewrites all of them and every open
- * branch conflicts on all of them. Dedup keeps ONE
- * `dependencies/locks/<language>.lock` and points the metadata at it.
+ * branch conflicts on all of them. Dedup keeps one file per group under
+ * `dependencies/locks/` and points the metadata at it.
  *
  * What these pin:
- *  - the shared file is named after the language, so a bump is a one-file diff
- *  - a script whose lock genuinely differs keeps its own, and can get it back
- *  - the pass is idempotent: a deduped tree produces no further changes, which
- *    is what keeps `sync pull`/`push` from seeing a diff on every run
+ *  - a group keeps the file it already reads, so a bump is a one-file diff
+ *  - a shared file is never rewritten or deleted under scripts the sync map does
+ *    not cover (the git-sync deploy callback narrows it to a single item)
+ *  - the pass is idempotent: a deduplicated tree produces no further changes,
+ *    which is what keeps `sync pull`/`push` from seeing a diff on every run
  */
 
 import { expect, test, describe } from "bun:test";
@@ -21,6 +22,7 @@ import {
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
+  type ExistingSharedLocks,
 } from "../src/utils/lock_dedup.ts";
 import { yamlOptions } from "../src/commands/sync/sync.ts";
 
@@ -28,6 +30,7 @@ const PY_LOCK = "requests==2.32.0\nurllib3==2.2.1\n";
 const PY_LOCK_BUMPED = "requests==2.32.3\nurllib3==2.2.1\n";
 const OTHER_LOCK = "requests==2.32.0\nurllib3==2.2.1\npandas==2.2.0\n";
 const SHARED_PY = "dependencies/locks/python3.lock";
+const SHARED_PY_2 = "dependencies/locks/python3-2.lock";
 const SHARED_BUN = "dependencies/locks/bun.lock";
 
 function meta(lockRef: string, summary = ""): string {
@@ -46,7 +49,7 @@ function ownLock(
   map[`${base}.script.lock`] = lock;
 }
 
-/** A script already pointing at a shared lock. */
+/** A script already reading a shared lock. */
 function sharedLock(
   map: Record<string, string>,
   base: string,
@@ -55,6 +58,22 @@ function sharedLock(
 ) {
   map[`${base}${ext}`] = "def main(): ...";
   map[`${base}.script.yaml`] = meta(`!inline ${shared}`);
+}
+
+/** The working tree the map was taken from, as the unfiltered scan reports it. */
+function treeOf(
+  map: Record<string, string>,
+  contents: Record<string, string> = {},
+): ExistingSharedLocks {
+  const refs = new Map<string, string>();
+  const scripts = new Set<string>();
+  for (const [key, value] of Object.entries(map)) {
+    if (!key.endsWith(".script.yaml")) continue;
+    scripts.add(key);
+    const match = /!inline (dependencies\/locks\/[^\s'"]+\.lock)/.exec(value);
+    if (match) refs.set(key, match[1]);
+  }
+  return { refs, scripts, contents: new Map(Object.entries(contents)) };
 }
 
 function lockRefOf(metaContent: string): string {
@@ -70,8 +89,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/ts", ".ts", "bun-lock-contents");
     ownLock(map, "f/ts2", ".ts", "bun-lock-contents");
 
-    const plan = computeSharedLockPlan(map, "bun");
-    applySharedLockPlanToMap(map, plan);
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map[SHARED_BUN]).toEqual("bun-lock-contents");
@@ -81,87 +99,113 @@ describe("computeSharedLockPlan", () => {
         `!inline ${SHARED_PY}`,
       );
     }
-    expect(map["f/ts.script.lock"]).toBeUndefined();
     expect(lockRefOf(map["f/ts.script.yaml"])).toEqual(`!inline ${SHARED_BUN}`);
   });
 
-  test("is idempotent — a deduped tree yields no further changes", () => {
+  test("is idempotent — a deduplicated tree yields no further changes", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
-    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+    const tree = treeOf(map, { [SHARED_PY]: map[SHARED_PY] });
+    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", tree))).toBe(
+      true,
+    );
   });
 
   test("a dependency bump moves only the shared file", () => {
-    const map: Record<string, string> = {};
-    sharedLock(map, "f/a", ".py", SHARED_PY);
-    sharedLock(map, "f/b", ".py", SHARED_PY);
-    map[SHARED_PY] = PY_LOCK;
+    const committed: Record<string, string> = {};
+    sharedLock(committed, "f/a", ".py", SHARED_PY);
+    sharedLock(committed, "f/b", ".py", SHARED_PY);
+    committed[SHARED_PY] = PY_LOCK;
+    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
 
     // What the remote sends after the bump: one lock per script, all bumped.
     const remote: Record<string, string> = {};
     ownLock(remote, "f/a", ".py", PY_LOCK_BUMPED);
     ownLock(remote, "f/b", ".py", PY_LOCK_BUMPED);
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun"));
+    applySharedLockPlanToMap(
+      remote,
+      computeSharedLockPlan(remote, "bun", tree),
+    );
 
-    const changed = Object.keys(remote).filter((k) => remote[k] !== map[k]);
+    const changed = Object.keys(remote).filter((k) => remote[k] !== committed[k]);
     expect(changed).toEqual([SHARED_PY]);
     expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
   });
 
-  test("the minority keeps its own lock; the majority shares", () => {
+  test("a second group gets a name of its own, and keeps it", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    ownLock(map, "f/odd", ".py", OTHER_LOCK);
+    ownLock(map, "f/c", ".py", OTHER_LOCK);
+    ownLock(map, "f/d", ".py", OTHER_LOCK);
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
-
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map["f/odd.script.lock"]).toEqual(OTHER_LOCK);
-    expect(lockRefOf(map["f/odd.script.yaml"])).toEqual(
-      "!inline f/odd.script.lock",
-    );
-  });
-
-  test("a script that diverges from the shared lock gets its own back", () => {
-    const map: Record<string, string> = {};
-    sharedLock(map, "f/a", ".py", SHARED_PY);
-    sharedLock(map, "f/b", ".py", SHARED_PY);
-    sharedLock(map, "f/c", ".py", SHARED_PY);
-    map[SHARED_PY] = PY_LOCK;
-    // f/c grew an import: the remote now sends it a lock of its own.
-    map["f/c.script.yaml"] = meta("!inline f/c.script.lock");
-    map["f/c.script.lock"] = OTHER_LOCK;
-
-    const plan = computeSharedLockPlan(map, "bun");
-    applySharedLockPlanToMap(map, plan);
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map["f/c.script.lock"]).toEqual(OTHER_LOCK);
-    expect(map["f/a.script.lock"]).toBeUndefined();
+    expect(map[SHARED_PY_2]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map["f/c.script.yaml"])).toEqual(`!inline ${SHARED_PY_2}`);
+
+    // Bumping the second group moves its file, not its name.
+    const tree = treeOf(map, {
+      [SHARED_PY]: map[SHARED_PY],
+      [SHARED_PY_2]: map[SHARED_PY_2],
+    });
+    const remote: Record<string, string> = {};
+    ownLock(remote, "f/a", ".py", PY_LOCK);
+    ownLock(remote, "f/b", ".py", PY_LOCK);
+    ownLock(remote, "f/c", ".py", OTHER_LOCK + "click==8.1.7\n");
+    ownLock(remote, "f/d", ".py", OTHER_LOCK + "click==8.1.7\n");
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun", tree));
+
+    expect(Object.keys(remote).filter((k) => remote[k] !== map[k])).toEqual([
+      SHARED_PY_2,
+    ]);
   });
 
-  test("a lone script is left with its own lock", () => {
+  test("a lone script keeps its own lock", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".py", PY_LOCK);
 
-    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+    expect(
+      isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", treeOf(map))),
+    ).toBe(true);
   });
 
-  test("a shared file nothing references any more is removed", () => {
+  test("a script that diverges gets its own lock back, the rest keep the file", () => {
+    const committed: Record<string, string> = {};
+    sharedLock(committed, "f/a", ".py", SHARED_PY);
+    sharedLock(committed, "f/b", ".py", SHARED_PY);
+    sharedLock(committed, "f/c", ".py", SHARED_PY);
+    committed[SHARED_PY] = PY_LOCK;
+    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
+
+    const remote: Record<string, string> = {};
+    ownLock(remote, "f/a", ".py", PY_LOCK);
+    ownLock(remote, "f/b", ".py", PY_LOCK);
+    ownLock(remote, "f/c", ".py", OTHER_LOCK);
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun", tree));
+
+    expect(remote[SHARED_PY]).toEqual(PY_LOCK);
+    expect(remote["f/c.script.lock"]).toEqual(OTHER_LOCK);
+    expect(remote["f/a.script.lock"]).toBeUndefined();
+  });
+
+  test("a shared file nothing reads any more is removed", () => {
+    const committed: Record<string, string> = {};
+    sharedLock(committed, "f/a", ".py", SHARED_PY);
+    sharedLock(committed, "f/b", ".py", SHARED_PY);
+    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
+
+    // Both scripts diverge, and to different locks: the file has no reader left.
     const map: Record<string, string> = {};
-    sharedLock(map, "f/a", ".py", SHARED_PY);
-    map[SHARED_PY] = PY_LOCK;
-    // The one remaining script diverged, so nothing shares that lock.
-    map["f/a.script.yaml"] = meta("!inline f/a.script.lock");
-    map["f/a.script.lock"] = OTHER_LOCK;
+    ownLock(map, "f/a", ".py", OTHER_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK_BUMPED);
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
-
-    expect(map[SHARED_PY]).toBeUndefined();
+    const plan = computeSharedLockPlan(map, "bun", tree);
+    expect(plan.deletes).toContain(SHARED_PY);
   });
 
   test("scripts without a lock file are untouched", () => {
@@ -172,15 +216,19 @@ describe("computeSharedLockPlan", () => {
       "f/b.script.yaml": meta(""),
     };
 
-    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+    expect(
+      isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", treeOf(map))),
+    ).toBe(true);
   });
 
-  test("a language that needs no lock is never deduped", () => {
+  test("a language that needs no lock is never deduplicated", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".sh", "some-lock");
     ownLock(map, "f/b", ".sh", "some-lock");
 
-    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+    expect(
+      isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", treeOf(map))),
+    ).toBe(true);
   });
 
   test("module-layout scripts share too, from their folder", () => {
@@ -197,9 +245,17 @@ describe("computeSharedLockPlan", () => {
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map["f/a__mod/script.lock"]).toBeUndefined();
-    expect(lockRefOf(map["f/a__mod/script.yaml"])).toEqual(
-      `!inline ${SHARED_PY}`,
-    );
+  });
+
+  test("a script path containing dots is deduplicated like any other", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a.b", ".py", PY_LOCK);
+    ownLock(map, "f/c.d", ".py", PY_LOCK);
+
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(lockRefOf(map["f/a.b.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
   });
 
   test("only the lock line of the metadata changes", () => {
@@ -209,11 +265,69 @@ describe("computeSharedLockPlan", () => {
     map["f/a.script.yaml"] = meta("!inline f/a.script.lock", "does a thing");
     const before = map["f/a.script.yaml"];
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
     expect(map["f/a.script.yaml"]).toEqual(
       before.replace("f/a.script.lock", SHARED_PY),
     );
+  });
+});
+
+// The git-sync deploy callback pulls with `extraIncludes` scoped to the item it
+// deploys, so a map holding one script out of a thousand is the normal case,
+// not an edge one. Anything the plan does to a shared file there lands on
+// scripts it cannot see.
+describe("computeSharedLockPlan with a partial sync map", () => {
+  /** The tree: three scripts on the shared lock. The map: only one of them. */
+  function partial(inScopeLock: string) {
+    const committed: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/c"]) {
+      sharedLock(committed, base, ".py", SHARED_PY);
+    }
+    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", inScopeLock);
+    return { map, tree };
+  }
+
+  test("keeps the shared file the scripts out of scope read", () => {
+    const { map, tree } = partial(PY_LOCK);
+    const plan = computeSharedLockPlan(map, "bun", tree);
+    applySharedLockPlanToMap(map, plan);
+
+    expect(plan.deletes).not.toContain(SHARED_PY);
+    // Carried into the map, or the diff would delete the committed file.
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+  });
+
+  test("never rewrites the shared file from the scripts it can see", () => {
+    const { map, tree } = partial(OTHER_LOCK);
+    const plan = computeSharedLockPlan(map, "bun", tree);
+    applySharedLockPlanToMap(map, plan);
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    // The one script in scope takes a lock of its own instead.
+    expect(map["f/a.script.lock"]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(
+      "!inline f/a.script.lock",
+    );
+  });
+
+  test("forms no new group it cannot see the whole of", () => {
+    const committed: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/c"]) {
+      ownLock(committed, base, ".py", PY_LOCK);
+    }
+    committed[SHARED_BUN] = "bun-lock-contents";
+    const tree = treeOf(committed, { [SHARED_BUN]: "bun-lock-contents" });
+
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+
+    const plan = computeSharedLockPlan(map, "bun", tree);
+    expect(plan.writes[SHARED_PY]).toBeUndefined();
   });
 });
 
@@ -223,11 +337,16 @@ describe("scriptsReferencingSharedLock", () => {
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
     ownLock(map, "f/odd", ".py", OTHER_LOCK);
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
     expect(scriptsReferencingSharedLock(map, SHARED_PY).sort()).toEqual([
       "f/a.script.yaml",
       "f/b.script.yaml",
     ]);
+  });
+
+  test("reports none for a shared file nothing reads", () => {
+    const map: Record<string, string> = { [SHARED_PY]: PY_LOCK };
+    expect(scriptsReferencingSharedLock(map, SHARED_PY)).toEqual([]);
   });
 });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -94,7 +94,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/ts", ".ts", "bun-lock-contents");
     ownLock(map, "f/ts2", ".ts", "bun-lock-contents");
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map[SHARED_BUN]).toEqual("bun-lock-contents");
@@ -111,7 +111,7 @@ describe("computeSharedLockPlan", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
 
     const tree = treeOf(map, { [SHARED_PY]: map[SHARED_PY] });
     expect(isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: tree }))).toBe(
@@ -147,7 +147,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/c", ".py", OTHER_LOCK);
     ownLock(map, "f/d", ".py", OTHER_LOCK);
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map[SHARED_PY_2]).toEqual(OTHER_LOCK);
@@ -235,7 +235,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/a", ".py", PY_LOCK);
 
     expect(
-      isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", treeOf(map))),
+      isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) })),
     ).toBe(true);
   });
 
@@ -282,7 +282,7 @@ describe("computeSharedLockPlan", () => {
     };
 
     expect(
-      isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", treeOf(map))),
+      isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) })),
     ).toBe(true);
   });
 
@@ -292,7 +292,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/b", ".sh", "some-lock");
 
     expect(
-      isEmptySharedLockPlan(computeSharedLockPlan(map, "bun", treeOf(map))),
+      isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) })),
     ).toBe(true);
   });
 
@@ -321,7 +321,7 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/a", ".go", "go-lock-contents");
     ownLock(map, "f/e", ".go", "go-lock-contents");
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(lockRefOf(map["f/a.b.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
@@ -338,7 +338,7 @@ describe("computeSharedLockPlan", () => {
     map["f/a.script.yaml"] = meta("!inline f/a.script.lock", "does a thing");
     const before = map["f/a.script.yaml"];
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
 
     expect(map["f/a.script.yaml"]).toEqual(
       before.replace("f/a.script.lock", SHARED_PY),
@@ -437,7 +437,7 @@ describe("scriptsReferencingSharedLock", () => {
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
     ownLock(map, "f/odd", ".py", OTHER_LOCK);
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
 
     expect(scriptsReferencingSharedLock(map, SHARED_PY).sort()).toEqual([
       "f/a.script.yaml",
@@ -470,6 +470,14 @@ describe("collectExistingSharedLocks", () => {
       // readers would freeze the shared file's content.
       await write(".wmill/f/team/a.script.yaml", readsShared);
       await write("f/team/escape.script.yaml", meta(`!inline ${TRAVERSING_REF}`));
+      await write(
+        "f/team/prose.script.yaml",
+        yamlStringify(
+          { summary: `see !inline ${SHARED_PY}`, lock: "!inline f/team/prose.script.lock" },
+          yamlOptions,
+        ),
+      );
+      await write("docs/example.script.yaml", readsShared);
 
       const existing = await collectExistingSharedLocks(root);
 
@@ -482,6 +490,13 @@ describe("collectExistingSharedLocks", () => {
       // one that escapes the workspace is not a reference at all.
       expect([...existing.refs.values()]).not.toContain(TRAVERSING_REF);
       expect(existing.refs.get("f/team/escape.script.yaml")).toBeUndefined();
+      // `!inline` in a summary is prose, not a reference: only the `lock` field
+      // decides which lockfile a script reads.
+      expect(existing.refs.get("f/team/prose.script.yaml")).toBeUndefined();
+      // And a file merely named like script metadata, outside the namespaces
+      // sync reads, is not a script — counted, it would leave the planner in
+      // conserve-only mode for good.
+      expect(existing.scripts.has("docs/example.script.yaml")).toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -25,8 +25,9 @@ import {
   applySharedLockPlanToMap,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
-  metadataReadsSharedLock,
+  metadataLockUnreadable,
   scriptsReferencingSharedLock,
+  sharedLockRefOf,
   sharedLockRefIn,
 } from "../src/utils/lock_dedup.ts";
 import { isSharedLockPath } from "../src/utils/script_common.ts";
@@ -434,30 +435,31 @@ describe("sharedLockRefIn", () => {
   });
 });
 
-describe("metadataReadsSharedLock", () => {
+describe("reading the lock field off disk", () => {
   test("a folded reference is still a reference", () => {
     // A long enough dependency-set name pushes `lock:` past the serializer's
     // 80-column default, which breaks the line at the space inside the value.
-    const ref = "locks/" + "very_long_set_name_".repeat(4) + "requirements.in.lock";
-    const folded = yamlStringify({ lock: `!inline ${ref}`, summary: "" }, yamlOptions);
+    const ref =
+      "locks/" + "very_long_set_name_".repeat(4) + "requirements.in.lock";
+    const folded = yamlStringify(
+      { lock: `!inline ${ref}`, summary: "" },
+      yamlOptions,
+    );
     expect(folded).not.toContain("!inline " + ref);
 
-    expect(metadataReadsSharedLock("f/a.script.yaml", folded, false, ref)).toBe(
-      true,
-    );
-    expect(
-      metadataReadsSharedLock("f/a.script.yaml", folded, false, SHARED_PY),
-    ).toBe(false);
+    expect(sharedLockRefOf("f/a.script.yaml", folded, false)).toEqual(ref);
+    expect(metadataLockUnreadable("f/a.script.yaml", folded, false)).toBe(false);
   });
 
-  test("unparseable metadata counts as a reader", () => {
+  test("metadata that cannot be parsed is flagged rather than read as empty", () => {
     const conflicted = `summary: ''\n<<<<<<< HEAD\nlock: '!inline ${SHARED_PY}'\n=======\nlock: '!inline ${SHARED_BUN}'\n>>>>>>> other\n`;
-    expect(
-      metadataReadsSharedLock("f/a.script.yaml", conflicted, false, SHARED_PY),
-    ).toBe(true);
+    expect(sharedLockRefOf("f/a.script.yaml", conflicted, false)).toBeUndefined();
+    expect(metadataLockUnreadable("f/a.script.yaml", conflicted, false)).toBe(
+      true,
+    );
     // Nothing to read: no reference of any kind in the file.
-    expect(
-      metadataReadsSharedLock("f/a.script.yaml", "summary: ''\n", false, SHARED_PY),
-    ).toBe(false);
+    expect(metadataLockUnreadable("f/a.script.yaml", "summary: ''\n", false)).toBe(
+      false,
+    );
   });
 });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -4,12 +4,14 @@
  * A workspace with one `dependencies/requirements.in` resolves the same lock for
  * every Python script, so the repo carries thousands of identical
  * `.script.lock` files: a dependency bump rewrites all of them and every open
- * branch conflicts on all of them. Dedup keeps one file per group under
- * `locks/` and points the metadata at it.
+ * branch conflicts on all of them. Dedup keeps one lockfile per dependency file,
+ * named after it, and points the metadata at it.
  *
  * What these pin, per the invariants in `lock_dedup.ts`:
- *  - a group keeps the file it already reads, so a bump is a one-file diff
- *  - nothing is rewritten or deleted under scripts the sync map does not cover
+ *  - the name comes from the dependency file, so a bump is a one-file diff and a
+ *    sync narrowed to one script reaches the same answer as a full one
+ *  - a script whose lock is its own (an `extra_`/inline annotation, or several
+ *    dependency files at once) keeps a `.script.lock`
  *  - the pass is idempotent, which is what keeps `sync pull`/`push` from seeing
  *    a diff on every run
  */
@@ -21,83 +23,80 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import {
   applySharedLockPlanToMap,
-  collectExistingSharedLocks,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
   sharedLockRefIn,
-  type ExistingSharedLocks,
 } from "../src/utils/lock_dedup.ts";
+import { isSharedLockPath } from "../src/utils/script_common.ts";
 import { yamlOptions } from "../src/commands/sync/sync.ts";
 
 const PY_LOCK = "requests==2.32.0\nurllib3==2.2.1\n";
 const PY_LOCK_BUMPED = "requests==2.32.3\nurllib3==2.2.1\n";
 const OTHER_LOCK = "requests==2.32.0\nurllib3==2.2.1\npandas==2.2.0\n";
-const SHARED_PY = "locks/python3.lock";
-const SHARED_PY_2 = "locks/python3-2.lock";
-const SHARED_BUN = "locks/bun.lock";
-const TRAVERSING_REF = "locks/../../../../tmp/escaped.lock";
+const PY_DEPS = "dependencies/requirements.in";
+const TEAM_DEPS = "dependencies/team_a.requirements.in";
+const BUN_DEPS = "dependencies/package.json";
+const SHARED_PY = "locks/requirements.in.lock";
+const SHARED_TEAM = "locks/team_a.requirements.in.lock";
+const SHARED_BUN = "locks/package.json.lock";
 
 function meta(lockRef: string, summary = ""): string {
   return yamlStringify({ summary, lock: lockRef }, yamlOptions);
 }
 
-/** A script with its own lock file, as `sync pull` writes it without dedup. */
+/** A workspace holding the given dependency files. */
+function workspace(...depFiles: string[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const dep of depFiles) map[dep] = "requests\n";
+  return map;
+}
+
+/** A script with its own lockfile, as `sync pull` writes it without dedup. */
 function ownLock(
   map: Record<string, string>,
   base: string,
   ext: string,
   lock: string,
+  body = "def main(): ...",
 ) {
-  map[`${base}${ext}`] = "def main(): ...";
+  map[`${base}${ext}`] = body;
   map[`${base}.script.yaml`] = meta(`!inline ${base}.script.lock`);
   map[`${base}.script.lock`] = lock;
 }
 
-/** A script already reading a shared lock. */
+/** A script already reading a shared lockfile. */
 function sharedLock(
   map: Record<string, string>,
   base: string,
   ext: string,
   shared: string,
+  body = "def main(): ...",
 ) {
-  map[`${base}${ext}`] = "def main(): ...";
+  map[`${base}${ext}`] = body;
   map[`${base}.script.yaml`] = meta(`!inline ${shared}`);
-}
-
-/** The working tree the map was taken from, as the unfiltered scan reports it. */
-function treeOf(
-  map: Record<string, string>,
-  contents: Record<string, string> = {},
-): ExistingSharedLocks {
-  const refs = new Map<string, string>();
-  const scripts = new Set<string>();
-  for (const [key, value] of Object.entries(map)) {
-    if (!key.endsWith(".script.yaml")) continue;
-    scripts.add(key);
-    const match = /!inline (locks\/[^\s'"]+\.lock)/.exec(value);
-    if (match) refs.set(key, match[1]);
-  }
-  return { refs, scripts, contents: new Map(Object.entries(contents)) };
 }
 
 function lockRefOf(metaContent: string): string {
   return metaContent.match(/lock: '(.*)'/)![1];
 }
 
+const plan = (map: Record<string, string>) =>
+  computeSharedLockPlan(map, { defaultTs: "bun" });
+
 describe("computeSharedLockPlan", () => {
-  test("collapses identical locks into one file per language", () => {
-    const map: Record<string, string> = {};
+  test("collapses the scripts of a dependency file into its lockfile", () => {
+    const map = workspace(PY_DEPS, BUN_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
     ownLock(map, "f/c", ".py", PY_LOCK);
-    ownLock(map, "f/ts", ".ts", "bun-lock-contents");
-    ownLock(map, "f/ts2", ".ts", "bun-lock-contents");
+    ownLock(map, "f/ts", ".ts", "bun-lock", "export async function main() {}");
+    ownLock(map, "f/ts2", ".ts", "bun-lock", "export async function main() {}");
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
+    applySharedLockPlanToMap(map, plan(map));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map[SHARED_BUN]).toEqual("bun-lock-contents");
+    expect(map[SHARED_BUN]).toEqual("bun-lock");
     for (const base of ["f/a", "f/b", "f/c"]) {
       expect(map[`${base}.script.lock`]).toBeUndefined();
       expect(lockRefOf(map[`${base}.script.yaml`])).toEqual(
@@ -108,237 +107,161 @@ describe("computeSharedLockPlan", () => {
   });
 
   test("is idempotent — a deduplicated tree yields no further changes", () => {
-    const map: Record<string, string> = {};
+    const map = workspace(PY_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
+    applySharedLockPlanToMap(map, plan(map));
 
-    const tree = treeOf(map, { [SHARED_PY]: map[SHARED_PY] });
-    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: tree }))).toBe(
-      true,
-    );
+    expect(isEmptySharedLockPlan(plan(map))).toBe(true);
   });
 
   test("a dependency bump moves only the shared file", () => {
-    const committed: Record<string, string> = {};
+    const committed = workspace(PY_DEPS);
     sharedLock(committed, "f/a", ".py", SHARED_PY);
     sharedLock(committed, "f/b", ".py", SHARED_PY);
     committed[SHARED_PY] = PY_LOCK;
-    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
 
     // What the remote sends after the bump: one lock per script, all bumped.
-    const remote: Record<string, string> = {};
+    const remote = workspace(PY_DEPS);
     ownLock(remote, "f/a", ".py", PY_LOCK_BUMPED);
     ownLock(remote, "f/b", ".py", PY_LOCK_BUMPED);
-    applySharedLockPlanToMap(
-      remote,
-      computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }),
-    );
+    applySharedLockPlanToMap(remote, plan(remote));
 
-    const changed = Object.keys(remote).filter((k) => remote[k] !== committed[k]);
-    expect(changed).toEqual([SHARED_PY]);
-    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(
+      Object.keys(remote).filter((k) => remote[k] !== committed[k]),
+    ).toEqual([SHARED_PY]);
   });
 
-  test("a second group gets a name of its own, and keeps it", () => {
+  test("each named dependency file gets a lockfile of its own", () => {
+    const map = workspace(PY_DEPS, TEAM_DEPS);
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    const team = "# requirements: team_a\ndef main(): ...";
+    ownLock(map, "f/t1", ".py", OTHER_LOCK, team);
+    ownLock(map, "f/t2", ".py", OTHER_LOCK, team);
+
+    applySharedLockPlanToMap(map, plan(map));
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map[SHARED_TEAM]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map["f/t1.script.yaml"])).toEqual(`!inline ${SHARED_TEAM}`);
+  });
+
+  // The git-sync deploy callback narrows the sync to a single item, so this is
+  // the normal case rather than an edge one.
+  test("one script in view reaches the same answer as the whole workspace", () => {
+    const full = workspace(PY_DEPS);
+    for (const base of ["f/a", "f/b", "f/c"]) {
+      ownLock(full, base, ".py", PY_LOCK);
+    }
+    applySharedLockPlanToMap(full, plan(full));
+
+    const narrow = workspace(PY_DEPS);
+    ownLock(narrow, "f/a", ".py", PY_LOCK);
+    applySharedLockPlanToMap(narrow, plan(narrow));
+
+    expect(narrow[SHARED_PY]).toEqual(full[SHARED_PY]);
+    expect(lockRefOf(narrow["f/a.script.yaml"])).toEqual(
+      lockRefOf(full["f/a.script.yaml"]),
+    );
+  });
+
+  test("a script whose lock is its own keeps a private lockfile", () => {
+    const map = workspace(PY_DEPS, TEAM_DEPS);
+    // `extra_` folds the script's own imports into the lock…
+    const extra = "# extra_requirements: default\ndef main(): ...";
+    ownLock(map, "f/extra", ".py", OTHER_LOCK, extra);
+    // …and naming two files makes it no single file's lock.
+    const both = "# requirements: default, team_a\ndef main(): ...";
+    ownLock(map, "f/both", ".py", OTHER_LOCK, both);
+    ownLock(map, "f/plain", ".py", PY_LOCK);
+    ownLock(map, "f/plain2", ".py", PY_LOCK);
+
+    applySharedLockPlanToMap(map, plan(map));
+
+    expect(map["f/extra.script.lock"]).toEqual(OTHER_LOCK);
+    expect(map["f/both.script.lock"]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map["f/extra.script.yaml"])).toEqual(
+      "!inline f/extra.script.lock",
+    );
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+  });
+
+  test("a script with no dependency file behind it is left alone", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    ownLock(map, "f/c", ".py", OTHER_LOCK);
-    ownLock(map, "f/d", ".py", OTHER_LOCK);
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
-
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map[SHARED_PY_2]).toEqual(OTHER_LOCK);
-    expect(lockRefOf(map["f/c.script.yaml"])).toEqual(`!inline ${SHARED_PY_2}`);
-
-    // Bumping the second group moves its file, not its name.
-    const tree = treeOf(map, {
-      [SHARED_PY]: map[SHARED_PY],
-      [SHARED_PY_2]: map[SHARED_PY_2],
-    });
-    const remote: Record<string, string> = {};
-    ownLock(remote, "f/a", ".py", PY_LOCK);
-    ownLock(remote, "f/b", ".py", PY_LOCK);
-    ownLock(remote, "f/c", ".py", OTHER_LOCK + "click==8.1.7\n");
-    ownLock(remote, "f/d", ".py", OTHER_LOCK + "click==8.1.7\n");
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }));
-
-    expect(Object.keys(remote).filter((k) => remote[k] !== map[k])).toEqual([
-      SHARED_PY_2,
-    ]);
+    expect(isEmptySharedLockPlan(plan(map))).toBe(true);
   });
 
-  test("the majority keeps the file when a minority lags behind", () => {
-    // The case the feature exists for: a bump that most scripts take. The one
-    // that lags must not hold the name hostage and rename the file for the rest.
-    const committed: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/c", "f/d", "f/lag"]) {
-      sharedLock(committed, base, ".py", SHARED_PY);
-    }
-    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
-
-    const remote: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/c", "f/d"]) {
-      ownLock(remote, base, ".py", PY_LOCK_BUMPED);
-    }
-    ownLock(remote, "f/lag", ".py", PY_LOCK);
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }));
-
-    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
-    expect(remote[SHARED_PY_2]).toBeUndefined();
-    for (const base of ["f/a", "f/b", "f/c", "f/d"]) {
-      expect(lockRefOf(remote[`${base}.script.yaml`])).toEqual(
-        `!inline ${SHARED_PY}`,
-      );
-    }
-    expect(remote["f/lag.script.lock"]).toEqual(PY_LOCK);
-  });
-
-  test("two groups bumped at once each keep their own file", () => {
-    // The shape that exposed a snapshot taken after regeneration: read late, the
-    // groups' own references are gone and the two files trade contents while
-    // every script's metadata is rewritten.
-    const committed: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/c"]) {
-      sharedLock(committed, base, ".py", SHARED_PY);
-    }
-    for (const base of ["f/d", "f/e"]) {
-      sharedLock(committed, base, ".py", SHARED_PY_2);
-    }
-    const tree = treeOf(committed, {
-      [SHARED_PY]: PY_LOCK,
-      [SHARED_PY_2]: OTHER_LOCK,
-    });
-
-    const remote: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/c"]) {
-      ownLock(remote, base, ".py", PY_LOCK_BUMPED);
-    }
-    for (const base of ["f/d", "f/e"]) {
-      ownLock(remote, base, ".py", OTHER_LOCK + "click==8.1.7\n");
-    }
-    const plan = computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree });
-    applySharedLockPlanToMap(remote, plan);
-
-    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
-    expect(remote[SHARED_PY_2]).toEqual(OTHER_LOCK + "click==8.1.7\n");
-    expect(lockRefOf(remote["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-    expect(lockRefOf(remote["f/d.script.yaml"])).toEqual(
-      `!inline ${SHARED_PY_2}`,
-    );
-  });
-
-  test("a lone script keeps its own lock", () => {
-    const map: Record<string, string> = {};
-    ownLock(map, "f/a", ".py", PY_LOCK);
-
-    expect(
-      isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) })),
-    ).toBe(true);
-  });
-
-  test("a script that diverges gets its own lock back, the rest keep the file", () => {
-    const committed: Record<string, string> = {};
-    sharedLock(committed, "f/a", ".py", SHARED_PY);
-    sharedLock(committed, "f/b", ".py", SHARED_PY);
-    sharedLock(committed, "f/c", ".py", SHARED_PY);
-    committed[SHARED_PY] = PY_LOCK;
-    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
-
-    const remote: Record<string, string> = {};
-    ownLock(remote, "f/a", ".py", PY_LOCK);
-    ownLock(remote, "f/b", ".py", PY_LOCK);
-    ownLock(remote, "f/c", ".py", OTHER_LOCK);
-    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, { defaultTs: "bun", existing: tree }));
-
-    expect(remote[SHARED_PY]).toEqual(PY_LOCK);
-    expect(remote["f/c.script.lock"]).toEqual(OTHER_LOCK);
-    expect(remote["f/a.script.lock"]).toBeUndefined();
-  });
-
-  test("a shared file nothing reads any more is removed", () => {
-    const committed: Record<string, string> = {};
-    sharedLock(committed, "f/a", ".py", SHARED_PY);
-    sharedLock(committed, "f/b", ".py", SHARED_PY);
-    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
-
-    // Both scripts diverge, and to different locks: the file has no reader left.
-    const map: Record<string, string> = {};
-    ownLock(map, "f/a", ".py", OTHER_LOCK);
+  test("a stale committed lock is outvoted, and keeps its own", () => {
+    const map = workspace(PY_DEPS);
+    ownLock(map, "f/a", ".py", PY_LOCK_BUMPED);
     ownLock(map, "f/b", ".py", PY_LOCK_BUMPED);
+    ownLock(map, "f/stale", ".py", PY_LOCK);
 
-    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
-    expect(plan.deletes).toContain(SHARED_PY);
+    applySharedLockPlanToMap(map, plan(map));
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(map["f/stale.script.lock"]).toEqual(PY_LOCK);
   });
 
-  test("scripts without a lock file are untouched", () => {
-    const map: Record<string, string> = {
-      "f/a.py": "def main(): ...",
-      "f/a.script.yaml": meta(""),
-      "f/b.py": "def main(): ...",
-      "f/b.script.yaml": meta(""),
-    };
+  test("a shared lockfile outlives its scripts but not its dependency file", () => {
+    // No script in view reads it — a narrowed sync must still leave it be.
+    const withDep = workspace(PY_DEPS);
+    withDep[SHARED_PY] = PY_LOCK;
+    expect(plan(withDep).deletes).not.toContain(SHARED_PY);
 
-    expect(
-      isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) })),
-    ).toBe(true);
+    const withoutDep: Record<string, string> = { [SHARED_PY]: PY_LOCK };
+    expect(plan(withoutDep).deletes).toContain(SHARED_PY);
   });
 
   test("a language that needs no lock is never deduplicated", () => {
-    const map: Record<string, string> = {};
-    ownLock(map, "f/a", ".sh", "some-lock");
-    ownLock(map, "f/b", ".sh", "some-lock");
+    const map = workspace("dependencies/modules.json");
+    ownLock(map, "f/a", ".ps1", "some-lock", "echo hi");
+    ownLock(map, "f/b", ".ps1", "some-lock", "echo hi");
 
-    expect(
-      isEmptySharedLockPlan(computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) })),
-    ).toBe(true);
+    expect(isEmptySharedLockPlan(plan(map))).toBe(true);
   });
 
   test("module-layout scripts share too, from their folder", () => {
-    const map: Record<string, string> = {
-      "f/a__mod/script.py": "def main(): ...",
-      "f/a__mod/script.yaml": meta("!inline f/a__mod/script.lock"),
-      "f/a__mod/script.lock": PY_LOCK,
-      "f/b__mod/script.py": "def main(): ...",
-      "f/b__mod/script.yaml": meta("!inline f/b__mod/script.lock"),
-      "f/b__mod/script.lock": PY_LOCK,
-    };
+    const map = workspace(PY_DEPS);
+    for (const base of ["f/a__mod", "f/b__mod"]) {
+      map[`${base}/script.py`] = "def main(): ...";
+      map[`${base}/script.yaml`] = meta(`!inline ${base}/script.lock`);
+      map[`${base}/script.lock`] = PY_LOCK;
+    }
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun" }));
+    applySharedLockPlanToMap(map, plan(map));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map["f/a__mod/script.lock"]).toBeUndefined();
   });
 
-  test("a script path containing dots is deduplicated like any other", () => {
-    const map: Record<string, string> = {};
+  test("a script path containing dots reads its own content file", () => {
+    const map = workspace(PY_DEPS, BUN_DEPS);
     ownLock(map, "f/a.b", ".py", PY_LOCK);
     ownLock(map, "f/c.d", ".py", PY_LOCK);
-    // `f/a` is a Go script that happens to be a prefix of `f/a.b`: its language
-    // must come from its own content file, not its neighbour's.
-    ownLock(map, "f/a", ".go", "go-lock-contents");
-    ownLock(map, "f/e", ".go", "go-lock-contents");
+    // `f/a` is a bun script whose name is a prefix of `f/a.b`: its language and
+    // its annotation must come from its own file, not its neighbour's.
+    ownLock(map, "f/a", ".ts", "bun-lock", "export async function main() {}");
+    ownLock(map, "f/e", ".ts", "bun-lock", "export async function main() {}");
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
+    applySharedLockPlanToMap(map, plan(map));
 
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(lockRefOf(map["f/a.b.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-    expect(map["locks/go.lock"]).toEqual("go-lock-contents");
-    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(
-      "!inline locks/go.lock",
-    );
+    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_BUN}`);
   });
 
   test("only the lock line of the metadata changes", () => {
-    const map: Record<string, string> = {};
+    const map = workspace(PY_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
     map["f/a.script.yaml"] = meta("!inline f/a.script.lock", "does a thing");
     const before = map["f/a.script.yaml"];
 
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
+    applySharedLockPlanToMap(map, plan(map));
 
     expect(map["f/a.script.yaml"]).toEqual(
       before.replace("f/a.script.lock", SHARED_PY),
@@ -346,98 +269,33 @@ describe("computeSharedLockPlan", () => {
   });
 });
 
-// The git-sync deploy callback pulls with `extraIncludes` scoped to the item it
-// deploys, so a map holding one script out of a thousand is the normal case,
-// not an edge one. Anything the plan does to a shared file there lands on
-// scripts it cannot see.
-describe("computeSharedLockPlan with a partial sync map", () => {
-  /** The tree: three scripts on the shared lock. The map: only one of them. */
-  function partial(inScopeLock: string) {
-    const committed: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/c"]) {
-      sharedLock(committed, base, ".py", SHARED_PY);
+describe("isSharedLockPath", () => {
+  test("claims only the names a dependency file gives", () => {
+    for (const p of [SHARED_PY, SHARED_TEAM, SHARED_BUN]) {
+      expect(isSharedLockPath(p)).toBe(true);
     }
-    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
-    const map: Record<string, string> = {};
-    ownLock(map, "f/a", ".py", inScopeLock);
-    return { map, tree };
-  }
-
-  test("keeps the shared file the scripts out of scope read", () => {
-    const { map, tree } = partial(PY_LOCK);
-    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
-    applySharedLockPlanToMap(map, plan);
-
-    expect(plan.deletes).not.toContain(SHARED_PY);
-    // Carried into the map, or the diff would delete the committed file.
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-  });
-
-  test("never rewrites the shared file from the scripts it can see", () => {
-    const { map, tree } = partial(OTHER_LOCK);
-    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
-    applySharedLockPlanToMap(map, plan);
-
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    // The one script in scope takes a lock of its own instead.
-    expect(map["f/a.script.lock"]).toEqual(OTHER_LOCK);
-    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(
-      "!inline f/a.script.lock",
-    );
-  });
-
-  test("a script added locally but not yet pushed does not break the group", () => {
-    // On a pull the map is the REMOTE, so a script that exists only on disk is
-    // absent from it while being fully in scope. Counted as an unseen reader it
-    // would veto the bump and explode the group into per-script locks.
-    const committed: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/local"]) {
-      sharedLock(committed, base, ".py", SHARED_PY);
+    // Not a dependency file's name, so a repo that already keeps lockfiles here
+    // keeps them; `modules.json` is powershell, which takes no lock.
+    for (const p of [
+      "locks/vendor.lock",
+      "locks/Cargo.lock",
+      "locks/modules.json.lock",
+      "locks/sub/requirements.in.lock",
+      "locks/../../escape.lock",
+    ]) {
+      expect(isSharedLockPath(p)).toBe(false);
     }
-    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
-
-    const remote: Record<string, string> = {};
-    ownLock(remote, "f/a", ".py", PY_LOCK_BUMPED);
-    ownLock(remote, "f/b", ".py", PY_LOCK_BUMPED);
-
-    applySharedLockPlanToMap(
-      remote,
-      computeSharedLockPlan(remote, {
-        defaultTs: "bun",
-        existing: tree,
-        inScope: (metaRef) => committed[metaRef] !== undefined,
-      }),
-    );
-
-    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
-    expect(remote["f/a.script.lock"]).toBeUndefined();
-  });
-
-  test("forms no new group it cannot see the whole of", () => {
-    const committed: Record<string, string> = {};
-    for (const base of ["f/a", "f/b", "f/c"]) {
-      ownLock(committed, base, ".py", PY_LOCK);
-    }
-    committed[SHARED_BUN] = "bun-lock-contents";
-    const tree = treeOf(committed, { [SHARED_BUN]: "bun-lock-contents" });
-
-    const map: Record<string, string> = {};
-    ownLock(map, "f/a", ".py", PY_LOCK);
-    ownLock(map, "f/b", ".py", PY_LOCK);
-
-    const plan = computeSharedLockPlan(map, { defaultTs: "bun", existing: tree });
-    expect(plan.writes[SHARED_PY]).toBeUndefined();
   });
 });
 
 describe("scriptsReferencingSharedLock", () => {
   test("finds every script on the shared lock and nothing else", () => {
-    const map: Record<string, string> = {};
+    const map = workspace(PY_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    ownLock(map, "f/odd", ".py", OTHER_LOCK);
-    applySharedLockPlanToMap(map, computeSharedLockPlan(map, { defaultTs: "bun", existing: treeOf(map) }));
+    const extra = "# extra_requirements: default\ndef main(): ...";
+    ownLock(map, "f/extra", ".py", OTHER_LOCK, extra);
+    applySharedLockPlanToMap(map, plan(map));
 
     expect(scriptsReferencingSharedLock(map, SHARED_PY).sort()).toEqual([
       "f/a.script.yaml",
@@ -445,67 +303,15 @@ describe("scriptsReferencingSharedLock", () => {
     ]);
   });
 
-  test("reports none for a shared file nothing reads", () => {
-    const map: Record<string, string> = { [SHARED_PY]: PY_LOCK };
+  test("prose naming the file is not a reference", () => {
+    const map = {
+      "f/a.py": "def main(): ...",
+      "f/a.script.yaml": yamlStringify(
+        { summary: `see !inline ${SHARED_PY}`, lock: "!inline f/a.script.lock" },
+        yamlOptions,
+      ),
+    };
     expect(scriptsReferencingSharedLock(map, SHARED_PY)).toEqual([]);
-  });
-});
-
-describe("collectExistingSharedLocks", () => {
-  test("counts every reader, and only the ones in the workspace", async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), "wmill-dedup-"));
-    try {
-      const write = async (rel: string, content: string) => {
-        const full = path.join(root, ...rel.split("/"));
-        await mkdir(path.dirname(full), { recursive: true });
-        await writeFile(full, content, "utf-8");
-      };
-      const readsShared = meta(`!inline ${SHARED_PY}`);
-      await write(SHARED_PY, PY_LOCK);
-      await write("f/team/a.script.yaml", readsShared);
-      // A folder named after a build directory is still a Windmill folder: a
-      // script hidden from this scan is the one the scan exists to protect.
-      await write("f/team/dist/b.script.yaml", readsShared);
-      // The stateful-push mirror holds copies, not scripts — counting them as
-      // readers would freeze the shared file's content.
-      await write(".wmill/f/team/a.script.yaml", readsShared);
-      await write("f/team/escape.script.yaml", meta(`!inline ${TRAVERSING_REF}`));
-      await write(
-        "f/team/prose.script.yaml",
-        yamlStringify(
-          { summary: `see !inline ${SHARED_PY}`, lock: "!inline f/team/prose.script.lock" },
-          yamlOptions,
-        ),
-      );
-      await write("docs/example.script.yaml", readsShared);
-      // Sync never descends a dot-directory, so a fixture there is a file it can
-      // never see: counted as a script it would suppress every new group.
-      await write("f/team/.fixtures/example.script.yaml", readsShared);
-
-      const existing = await collectExistingSharedLocks(root);
-
-      expect([...existing.refs.keys()].sort()).toEqual([
-        "f/team/a.script.yaml",
-        "f/team/dist/b.script.yaml",
-      ]);
-      expect(existing.contents.get(SHARED_PY)).toEqual(PY_LOCK);
-      // A reference is repo content and becomes a path this pass writes to, so
-      // one that escapes the workspace is not a reference at all.
-      expect([...existing.refs.values()]).not.toContain(TRAVERSING_REF);
-      expect(existing.refs.get("f/team/escape.script.yaml")).toBeUndefined();
-      // `!inline` in a summary is prose, not a reference: only the `lock` field
-      // decides which lockfile a script reads.
-      expect(existing.refs.get("f/team/prose.script.yaml")).toBeUndefined();
-      // And a file merely named like script metadata, outside the namespaces
-      // sync reads, is not a script — counted, it would leave the planner in
-      // conserve-only mode for good.
-      expect(existing.scripts.has("docs/example.script.yaml")).toBe(false);
-      expect(existing.scripts.has("f/team/.fixtures/example.script.yaml")).toBe(
-        false,
-      );
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
   });
 });
 
@@ -519,32 +325,22 @@ describe("sharedLockRefIn", () => {
       expect(sharedLockRefIn(meta(`!inline ${SHARED_PY}`), false, root)).toEqual(
         SHARED_PY,
       );
-      // A regenerated script must fall back to its own lock rather than point
-      // at a shared file that is not there.
-      expect(
-        sharedLockRefIn(meta("!inline locks/go.lock"), false, root),
-      ).toBeUndefined();
-      expect(
-        sharedLockRefIn(meta(`!inline ${TRAVERSING_REF}`), false, root),
-      ).toBeUndefined();
-      expect(
-        sharedLockRefIn(meta("!inline f/a.script.lock"), false, root),
-      ).toBeUndefined();
       // Flow-style YAML starts with `{` and is not JSON: deciding the format by
       // the first character would drop the reference and repoint the script.
       expect(
-        sharedLockRefIn(`{summary: x, lock: '!inline ${SHARED_PY}'}`, false, root),
-      ).toEqual(SHARED_PY);
-      // The `lock` field alone decides, whatever prose surrounds it.
-      expect(
         sharedLockRefIn(
-          yamlStringify(
-            { summary: `see !inline ${SHARED_PY}`, lock: "!inline f/a.script.lock" },
-            yamlOptions,
-          ),
+          `{summary: x, lock: '!inline ${SHARED_PY}'}`,
           false,
           root,
         ),
+      ).toEqual(SHARED_PY);
+      // A regenerated script falls back to its own lock rather than point at a
+      // shared file that is not there.
+      expect(
+        sharedLockRefIn(meta(`!inline ${SHARED_BUN}`), false, root),
+      ).toBeUndefined();
+      expect(
+        sharedLockRefIn(meta("!inline f/a.script.lock"), false, root),
       ).toBeUndefined();
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -25,6 +25,7 @@ import {
   applySharedLockPlanToMap,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
+  metadataReadsSharedLock,
   scriptsReferencingSharedLock,
   sharedLockRefIn,
 } from "../src/utils/lock_dedup.ts";
@@ -430,5 +431,33 @@ describe("sharedLockRefIn", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("metadataReadsSharedLock", () => {
+  test("a folded reference is still a reference", () => {
+    // A long enough dependency-set name pushes `lock:` past the serializer's
+    // 80-column default, which breaks the line at the space inside the value.
+    const ref = "locks/" + "very_long_set_name_".repeat(4) + "requirements.in.lock";
+    const folded = yamlStringify({ lock: `!inline ${ref}`, summary: "" }, yamlOptions);
+    expect(folded).not.toContain("!inline " + ref);
+
+    expect(metadataReadsSharedLock("f/a.script.yaml", folded, false, ref)).toBe(
+      true,
+    );
+    expect(
+      metadataReadsSharedLock("f/a.script.yaml", folded, false, SHARED_PY),
+    ).toBe(false);
+  });
+
+  test("unparseable metadata counts as a reader", () => {
+    const conflicted = `summary: ''\n<<<<<<< HEAD\nlock: '!inline ${SHARED_PY}'\n=======\nlock: '!inline ${SHARED_BUN}'\n>>>>>>> other\n`;
+    expect(
+      metadataReadsSharedLock("f/a.script.yaml", conflicted, false, SHARED_PY),
+    ).toBe(true);
+    // Nothing to read: no reference of any kind in the file.
+    expect(
+      metadataReadsSharedLock("f/a.script.yaml", "summary: ''\n", false, SHARED_PY),
+    ).toBe(false);
   });
 });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -171,6 +171,9 @@ describe("computeSharedLockPlan", () => {
     // change what it locks, so such a script cannot stand for the file's lock.
     const map = workspace(PY_DEPS, BUN_DEPS);
     ownLock(map, "f/pinned", ".py", OTHER_LOCK, "# py311\nimport requests");
+    // The interpreter pin the python import parser reads, which the annotations
+    // macro does not cover.
+    ownLock(map, "f/pyspec", ".py", OTHER_LOCK, "# py: 3.11\nimport requests");
     ownLock(map, "f/plain", ".py", PY_LOCK);
     ownLock(map, "f/plain2", ".py", PY_LOCK);
     // Only the names the worker matches count, so a documented script — or one
@@ -186,6 +189,7 @@ describe("computeSharedLockPlan", () => {
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(map["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
+    expect(map["f/pyspec.script.lock"]).toEqual(OTHER_LOCK);
     expect(lockRefOf(map["f/doc.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
     expect(map[SHARED_BUN]).toEqual("bun-lock");
     expect(map["f/npm.script.lock"]).toEqual("npm-lock");

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -17,8 +17,12 @@
 
 import { expect, test, describe } from "bun:test";
 import { stringify as yamlStringify } from "yaml";
+import * as path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import {
   applySharedLockPlanToMap,
+  collectExistingSharedLocks,
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
@@ -348,5 +352,37 @@ describe("scriptsReferencingSharedLock", () => {
   test("reports none for a shared file nothing reads", () => {
     const map: Record<string, string> = { [SHARED_PY]: PY_LOCK };
     expect(scriptsReferencingSharedLock(map, SHARED_PY)).toEqual([]);
+  });
+});
+
+describe("collectExistingSharedLocks", () => {
+  test("counts every reader, and only the ones in the workspace", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wmill-dedup-"));
+    try {
+      const write = async (rel: string, content: string) => {
+        const full = path.join(root, ...rel.split("/"));
+        await mkdir(path.dirname(full), { recursive: true });
+        await writeFile(full, content, "utf-8");
+      };
+      const readsShared = meta(`!inline ${SHARED_PY}`);
+      await write(SHARED_PY, PY_LOCK);
+      await write("f/team/a.script.yaml", readsShared);
+      // A folder named after a build directory is still a Windmill folder: a
+      // script hidden from this scan is the one the scan exists to protect.
+      await write("f/team/dist/b.script.yaml", readsShared);
+      // The stateful-push mirror holds copies, not scripts — counting them as
+      // readers would freeze the shared file's content.
+      await write(".wmill/f/team/a.script.yaml", readsShared);
+
+      const existing = await collectExistingSharedLocks(root);
+
+      expect([...existing.refs.keys()].sort()).toEqual([
+        "f/team/a.script.yaml",
+        "f/team/dist/b.script.yaml",
+      ]);
+      expect(existing.contents.get(SHARED_PY)).toEqual(PY_LOCK);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -25,6 +25,7 @@ import {
   computeSharedLockPlan,
   isEmptySharedLockPlan,
   scriptsReferencingSharedLock,
+  sharedLockRefIn,
   type ExistingSharedLocks,
 } from "../src/utils/lock_dedup.ts";
 import { yamlOptions } from "../src/commands/sync/sync.ts";
@@ -193,6 +194,40 @@ describe("computeSharedLockPlan", () => {
       );
     }
     expect(remote["f/lag.script.lock"]).toEqual(PY_LOCK);
+  });
+
+  test("two groups bumped at once each keep their own file", () => {
+    // The shape that exposed a snapshot taken after regeneration: read late, the
+    // groups' own references are gone and the two files trade contents while
+    // every script's metadata is rewritten.
+    const committed: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/c"]) {
+      sharedLock(committed, base, ".py", SHARED_PY);
+    }
+    for (const base of ["f/d", "f/e"]) {
+      sharedLock(committed, base, ".py", SHARED_PY_2);
+    }
+    const tree = treeOf(committed, {
+      [SHARED_PY]: PY_LOCK,
+      [SHARED_PY_2]: OTHER_LOCK,
+    });
+
+    const remote: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/c"]) {
+      ownLock(remote, base, ".py", PY_LOCK_BUMPED);
+    }
+    for (const base of ["f/d", "f/e"]) {
+      ownLock(remote, base, ".py", OTHER_LOCK + "click==8.1.7\n");
+    }
+    const plan = computeSharedLockPlan(remote, "bun", tree);
+    applySharedLockPlanToMap(remote, plan);
+
+    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(remote[SHARED_PY_2]).toEqual(OTHER_LOCK + "click==8.1.7\n");
+    expect(lockRefOf(remote["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+    expect(lockRefOf(remote["f/d.script.yaml"])).toEqual(
+      `!inline ${SHARED_PY_2}`,
+    );
   });
 
   test("a lone script keeps its own lock", () => {
@@ -420,6 +455,35 @@ describe("collectExistingSharedLocks", () => {
       // one that escapes the workspace is not a reference at all.
       expect([...existing.refs.values()]).not.toContain(TRAVERSING_REF);
       expect(existing.refs.get("f/team/escape.script.yaml")).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("sharedLockRefIn", () => {
+  test("returns a reference only when it is one, and it exists", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "wmill-dedup-ref-"));
+    try {
+      await mkdir(path.join(root, "dependencies", "locks"), {
+        recursive: true,
+      });
+      await writeFile(path.join(root, SHARED_PY), PY_LOCK, "utf-8");
+
+      expect(sharedLockRefIn(meta(`!inline ${SHARED_PY}`), root)).toEqual(
+        SHARED_PY,
+      );
+      // A regenerated script must fall back to its own lock rather than point
+      // at a shared file that is not there.
+      expect(
+        sharedLockRefIn(meta("!inline dependencies/locks/go.lock"), root),
+      ).toBeUndefined();
+      expect(
+        sharedLockRefIn(meta(`!inline ${TRAVERSING_REF}`), root),
+      ).toBeUndefined();
+      expect(
+        sharedLockRefIn(meta("!inline f/a.script.lock"), root),
+      ).toBeUndefined();
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -5,7 +5,7 @@
  * every Python script, so the repo carries thousands of identical
  * `.script.lock` files: a dependency bump rewrites all of them and every open
  * branch conflicts on all of them. Dedup keeps one file per group under
- * `dependencies/locks/` and points the metadata at it.
+ * `locks/` and points the metadata at it.
  *
  * What these pin, per the invariants in `lock_dedup.ts`:
  *  - a group keeps the file it already reads, so a bump is a one-file diff
@@ -33,10 +33,10 @@ import { yamlOptions } from "../src/commands/sync/sync.ts";
 const PY_LOCK = "requests==2.32.0\nurllib3==2.2.1\n";
 const PY_LOCK_BUMPED = "requests==2.32.3\nurllib3==2.2.1\n";
 const OTHER_LOCK = "requests==2.32.0\nurllib3==2.2.1\npandas==2.2.0\n";
-const SHARED_PY = "dependencies/locks/python3.lock";
-const SHARED_PY_2 = "dependencies/locks/python3-2.lock";
-const SHARED_BUN = "dependencies/locks/bun.lock";
-const TRAVERSING_REF = "dependencies/locks/../../../../tmp/escaped.lock";
+const SHARED_PY = "locks/python3.lock";
+const SHARED_PY_2 = "locks/python3-2.lock";
+const SHARED_BUN = "locks/bun.lock";
+const TRAVERSING_REF = "locks/../../../../tmp/escaped.lock";
 
 function meta(lockRef: string, summary = ""): string {
   return yamlStringify({ summary, lock: lockRef }, yamlOptions);
@@ -75,7 +75,7 @@ function treeOf(
   for (const [key, value] of Object.entries(map)) {
     if (!key.endsWith(".script.yaml")) continue;
     scripts.add(key);
-    const match = /!inline (dependencies\/locks\/[^\s'"]+\.lock)/.exec(value);
+    const match = /!inline (locks\/[^\s'"]+\.lock)/.exec(value);
     if (match) refs.set(key, match[1]);
   }
   return { refs, scripts, contents: new Map(Object.entries(contents)) };
@@ -325,9 +325,9 @@ describe("computeSharedLockPlan", () => {
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(lockRefOf(map["f/a.b.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-    expect(map["dependencies/locks/go.lock"]).toEqual("go-lock-contents");
+    expect(map["locks/go.lock"]).toEqual("go-lock-contents");
     expect(lockRefOf(map["f/a.script.yaml"])).toEqual(
-      "!inline dependencies/locks/go.lock",
+      "!inline locks/go.lock",
     );
   });
 
@@ -465,9 +465,7 @@ describe("sharedLockRefIn", () => {
   test("returns a reference only when it is one, and it exists", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "wmill-dedup-ref-"));
     try {
-      await mkdir(path.join(root, "dependencies", "locks"), {
-        recursive: true,
-      });
+      await mkdir(path.join(root, "locks"), { recursive: true });
       await writeFile(path.join(root, SHARED_PY), PY_LOCK, "utf-8");
 
       expect(sharedLockRefIn(meta(`!inline ${SHARED_PY}`), root)).toEqual(
@@ -476,7 +474,7 @@ describe("sharedLockRefIn", () => {
       // A regenerated script must fall back to its own lock rather than point
       // at a shared file that is not there.
       expect(
-        sharedLockRefIn(meta("!inline dependencies/locks/go.lock"), root),
+        sharedLockRefIn(meta("!inline locks/go.lock"), root),
       ).toBeUndefined();
       expect(
         sharedLockRefIn(meta(`!inline ${TRAVERSING_REF}`), root),

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -7,12 +7,11 @@
  * branch conflicts on all of them. Dedup keeps one file per group under
  * `dependencies/locks/` and points the metadata at it.
  *
- * What these pin:
+ * What these pin, per the invariants in `lock_dedup.ts`:
  *  - a group keeps the file it already reads, so a bump is a one-file diff
- *  - a shared file is never rewritten or deleted under scripts the sync map does
- *    not cover (the git-sync deploy callback narrows it to a single item)
- *  - the pass is idempotent: a deduplicated tree produces no further changes,
- *    which is what keeps `sync pull`/`push` from seeing a diff on every run
+ *  - nothing is rewritten or deleted under scripts the sync map does not cover
+ *  - the pass is idempotent, which is what keeps `sync pull`/`push` from seeing
+ *    a diff on every run
  */
 
 import { expect, test, describe } from "bun:test";
@@ -36,6 +35,7 @@ const OTHER_LOCK = "requests==2.32.0\nurllib3==2.2.1\npandas==2.2.0\n";
 const SHARED_PY = "dependencies/locks/python3.lock";
 const SHARED_PY_2 = "dependencies/locks/python3-2.lock";
 const SHARED_BUN = "dependencies/locks/bun.lock";
+const TRAVERSING_REF = "dependencies/locks/../../../../tmp/escaped.lock";
 
 function meta(lockRef: string, summary = ""): string {
   return yamlStringify({ summary, lock: lockRef }, yamlOptions);
@@ -169,6 +169,32 @@ describe("computeSharedLockPlan", () => {
     ]);
   });
 
+  test("the majority keeps the file when a minority lags behind", () => {
+    // The case the feature exists for: a bump that most scripts take. The one
+    // that lags must not hold the name hostage and rename the file for the rest.
+    const committed: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/c", "f/d", "f/lag"]) {
+      sharedLock(committed, base, ".py", SHARED_PY);
+    }
+    const tree = treeOf(committed, { [SHARED_PY]: PY_LOCK });
+
+    const remote: Record<string, string> = {};
+    for (const base of ["f/a", "f/b", "f/c", "f/d"]) {
+      ownLock(remote, base, ".py", PY_LOCK_BUMPED);
+    }
+    ownLock(remote, "f/lag", ".py", PY_LOCK);
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun", tree));
+
+    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(remote[SHARED_PY_2]).toBeUndefined();
+    for (const base of ["f/a", "f/b", "f/c", "f/d"]) {
+      expect(lockRefOf(remote[`${base}.script.yaml`])).toEqual(
+        `!inline ${SHARED_PY}`,
+      );
+    }
+    expect(remote["f/lag.script.lock"]).toEqual(PY_LOCK);
+  });
+
   test("a lone script keeps its own lock", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a", ".py", PY_LOCK);
@@ -255,11 +281,19 @@ describe("computeSharedLockPlan", () => {
     const map: Record<string, string> = {};
     ownLock(map, "f/a.b", ".py", PY_LOCK);
     ownLock(map, "f/c.d", ".py", PY_LOCK);
+    // `f/a` is a Go script that happens to be a prefix of `f/a.b`: its language
+    // must come from its own content file, not its neighbour's.
+    ownLock(map, "f/a", ".go", "go-lock-contents");
+    ownLock(map, "f/e", ".go", "go-lock-contents");
 
     applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun", treeOf(map)));
 
     expect(map[SHARED_PY]).toEqual(PY_LOCK);
     expect(lockRefOf(map["f/a.b.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+    expect(map["dependencies/locks/go.lock"]).toEqual("go-lock-contents");
+    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(
+      "!inline dependencies/locks/go.lock",
+    );
   });
 
   test("only the lock line of the metadata changes", () => {
@@ -373,6 +407,7 @@ describe("collectExistingSharedLocks", () => {
       // The stateful-push mirror holds copies, not scripts — counting them as
       // readers would freeze the shared file's content.
       await write(".wmill/f/team/a.script.yaml", readsShared);
+      await write("f/team/escape.script.yaml", meta(`!inline ${TRAVERSING_REF}`));
 
       const existing = await collectExistingSharedLocks(root);
 
@@ -381,6 +416,10 @@ describe("collectExistingSharedLocks", () => {
         "f/team/dist/b.script.yaml",
       ]);
       expect(existing.contents.get(SHARED_PY)).toEqual(PY_LOCK);
+      // A reference is repo content and becomes a path this pass writes to, so
+      // one that escapes the workspace is not a reference at all.
+      expect([...existing.refs.values()]).not.toContain(TRAVERSING_REF);
+      expect(existing.refs.get("f/team/escape.script.yaml")).toBeUndefined();
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -173,9 +173,12 @@ describe("computeSharedLockPlan", () => {
     ownLock(map, "f/pinned", ".py", OTHER_LOCK, "# py311\nimport requests");
     ownLock(map, "f/plain", ".py", PY_LOCK);
     ownLock(map, "f/plain2", ".py", PY_LOCK);
-    // Prose is not an annotation: a documented script still deduplicates.
-    ownLock(map, "f/doc", ".py", PY_LOCK, "# syncs users nightly\nimport requests");
+    // Only the names the worker matches count, so a documented script — or one
+    // with a `# TODO:` or a `# type: ignore` — still deduplicates.
+    ownLock(map, "f/doc", ".py", PY_LOCK, "# TODO: clean up\n# type: ignore\nimport requests");
+    // Both annotation forms the worker accepts: a bare name and `name=value`.
     ownLock(map, "f/npm", ".ts", "npm-lock", "//npm\nexport async function main() {}");
+    ownLock(map, "f/nb", ".ts", "nb-lock", "//nobundling=true\nexport async function main() {}");
     ownLock(map, "f/ts", ".ts", "bun-lock", "export async function main() {}");
     ownLock(map, "f/ts2", ".ts", "bun-lock", "export async function main() {}");
 
@@ -186,6 +189,7 @@ describe("computeSharedLockPlan", () => {
     expect(lockRefOf(map["f/doc.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
     expect(map[SHARED_BUN]).toEqual("bun-lock");
     expect(map["f/npm.script.lock"]).toEqual("npm-lock");
+    expect(map["f/nb.script.lock"]).toEqual("nb-lock");
   });
 
   test("a script whose lock is its own keeps a private lockfile", () => {

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -252,32 +252,53 @@ describe("computeSharedLockPlan", () => {
     expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
   });
 
-  test("a lone script does not move a lockfile others read", () => {
-    // It may be the one pinning a Python version rather than the first of a
-    // bump everyone took — two agreeing scripts settle it.
-    const alone = workspace(PY_DEPS);
-    ownLock(alone, "f/pinned", ".py", OTHER_LOCK);
+  test("a script that disagrees moves the lockfile only if the file moved", () => {
+    // The dependency file is unchanged, so this script pins something the
+    // worker also locks (a Python version, an `//npm` annotation). It must not
+    // hand that variant to every other script reading the file.
+    const pinned = workspace(PY_DEPS);
+    ownLock(pinned, "f/pinned", ".py", OTHER_LOCK);
     applySharedLockPlanToMap(
-      alone,
-      computeSharedLockPlan(alone, {
+      pinned,
+      computeSharedLockPlan(pinned, {
         defaultTs: "bun",
         present: { [SHARED_PY]: PY_LOCK },
       }),
     );
-    expect(alone[SHARED_PY]).toEqual(PY_LOCK);
-    expect(alone["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
+    expect(pinned[SHARED_PY]).toEqual(PY_LOCK);
+    expect(pinned["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
 
+    // The same shape, but the dependency file moved: one script is enough, or a
+    // sync narrowed to one item could never carry a bump through.
     const bumped = workspace(PY_DEPS);
     ownLock(bumped, "f/a", ".py", PY_LOCK_BUMPED);
-    ownLock(bumped, "f/b", ".py", PY_LOCK_BUMPED);
     applySharedLockPlanToMap(
       bumped,
       computeSharedLockPlan(bumped, {
         defaultTs: "bun",
         present: { [SHARED_PY]: PY_LOCK },
+        movedDepFiles: [PY_DEPS],
       }),
     );
     expect(bumped[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(bumped["f/a.script.lock"]).toBeUndefined();
+    expect(lockRefOf(bumped["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+  });
+
+  test("a dependency file with a single script can still take a bump", () => {
+    const map = workspace(PY_DEPS);
+    ownLock(map, "f/only", ".py", PY_LOCK_BUMPED);
+    applySharedLockPlanToMap(
+      map,
+      computeSharedLockPlan(map, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: PY_LOCK },
+        movedDepFiles: [PY_DEPS],
+      }),
+    );
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+    expect(map["f/only.script.lock"]).toBeUndefined();
   });
 
   test("a language that needs no lock is never deduplicated", () => {

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -285,6 +285,39 @@ describe("computeSharedLockPlan", () => {
     expect(lockRefOf(bumped["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
   });
 
+  test("a lock's own dependency stamp says whether it may move the file", () => {
+    const stamp = (dep: string, body: string) =>
+      `# workspace-dependencies-mode: manual\n# workspace-dependencies: default:${dep}\n${body}`;
+
+    // Same dependency inputs, different body: this script pinned something, and
+    // the file is not its to move — even alone, and even mid-bump.
+    const pinned = workspace(PY_DEPS);
+    ownLock(pinned, "f/pinned", ".py", stamp("aaa", OTHER_LOCK));
+    applySharedLockPlanToMap(
+      pinned,
+      computeSharedLockPlan(pinned, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: stamp("aaa", PY_LOCK) },
+        movedDepFiles: [PY_DEPS],
+      }),
+    );
+    expect(pinned[SHARED_PY]).toEqual(stamp("aaa", PY_LOCK));
+    expect(pinned["f/pinned.script.lock"]).toEqual(stamp("aaa", OTHER_LOCK));
+
+    // Different dependency inputs: the file moved, and one script is enough.
+    const bumped = workspace(PY_DEPS);
+    ownLock(bumped, "f/a", ".py", stamp("bbb", PY_LOCK_BUMPED));
+    applySharedLockPlanToMap(
+      bumped,
+      computeSharedLockPlan(bumped, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: stamp("aaa", PY_LOCK) },
+      }),
+    );
+    expect(bumped[SHARED_PY]).toEqual(stamp("bbb", PY_LOCK_BUMPED));
+    expect(bumped["f/a.script.lock"]).toBeUndefined();
+  });
+
   test("the many correct a lockfile a lone script planted its variant on", () => {
     const map = workspace(PY_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Lockfile deduplication (`dedupeLockfiles`) — WIN-1756.
+ *
+ * A workspace with one `dependencies/requirements.in` resolves the same lock for
+ * every Python script, so the repo carries thousands of identical
+ * `.script.lock` files: a dependency bump rewrites all of them and every open
+ * branch conflicts on all of them. Dedup keeps ONE
+ * `dependencies/locks/<language>.lock` and points the metadata at it.
+ *
+ * What these pin:
+ *  - the shared file is named after the language, so a bump is a one-file diff
+ *  - a script whose lock genuinely differs keeps its own, and can get it back
+ *  - the pass is idempotent: a deduped tree produces no further changes, which
+ *    is what keeps `sync pull`/`push` from seeing a diff on every run
+ */
+
+import { expect, test, describe } from "bun:test";
+import { stringify as yamlStringify } from "yaml";
+import {
+  applySharedLockPlanToMap,
+  computeSharedLockPlan,
+  isEmptySharedLockPlan,
+  scriptsReferencingSharedLock,
+} from "../src/utils/lock_dedup.ts";
+import { yamlOptions } from "../src/commands/sync/sync.ts";
+
+const PY_LOCK = "requests==2.32.0\nurllib3==2.2.1\n";
+const PY_LOCK_BUMPED = "requests==2.32.3\nurllib3==2.2.1\n";
+const OTHER_LOCK = "requests==2.32.0\nurllib3==2.2.1\npandas==2.2.0\n";
+const SHARED_PY = "dependencies/locks/python3.lock";
+const SHARED_BUN = "dependencies/locks/bun.lock";
+
+function meta(lockRef: string, summary = ""): string {
+  return yamlStringify({ summary, lock: lockRef }, yamlOptions);
+}
+
+/** A script with its own lock file, as `sync pull` writes it without dedup. */
+function ownLock(
+  map: Record<string, string>,
+  base: string,
+  ext: string,
+  lock: string,
+) {
+  map[`${base}${ext}`] = "def main(): ...";
+  map[`${base}.script.yaml`] = meta(`!inline ${base}.script.lock`);
+  map[`${base}.script.lock`] = lock;
+}
+
+/** A script already pointing at a shared lock. */
+function sharedLock(
+  map: Record<string, string>,
+  base: string,
+  ext: string,
+  shared: string,
+) {
+  map[`${base}${ext}`] = "def main(): ...";
+  map[`${base}.script.yaml`] = meta(`!inline ${shared}`);
+}
+
+function lockRefOf(metaContent: string): string {
+  return metaContent.match(/lock: '(.*)'/)![1];
+}
+
+describe("computeSharedLockPlan", () => {
+  test("collapses identical locks into one file per language", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    ownLock(map, "f/c", ".py", PY_LOCK);
+    ownLock(map, "f/ts", ".ts", "bun-lock-contents");
+    ownLock(map, "f/ts2", ".ts", "bun-lock-contents");
+
+    const plan = computeSharedLockPlan(map, "bun");
+    applySharedLockPlanToMap(map, plan);
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map[SHARED_BUN]).toEqual("bun-lock-contents");
+    for (const base of ["f/a", "f/b", "f/c"]) {
+      expect(map[`${base}.script.lock`]).toBeUndefined();
+      expect(lockRefOf(map[`${base}.script.yaml`])).toEqual(
+        `!inline ${SHARED_PY}`,
+      );
+    }
+    expect(map["f/ts.script.lock"]).toBeUndefined();
+    expect(lockRefOf(map["f/ts.script.yaml"])).toEqual(`!inline ${SHARED_BUN}`);
+  });
+
+  test("is idempotent — a deduped tree yields no further changes", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+
+    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+  });
+
+  test("a dependency bump moves only the shared file", () => {
+    const map: Record<string, string> = {};
+    sharedLock(map, "f/a", ".py", SHARED_PY);
+    sharedLock(map, "f/b", ".py", SHARED_PY);
+    map[SHARED_PY] = PY_LOCK;
+
+    // What the remote sends after the bump: one lock per script, all bumped.
+    const remote: Record<string, string> = {};
+    ownLock(remote, "f/a", ".py", PY_LOCK_BUMPED);
+    ownLock(remote, "f/b", ".py", PY_LOCK_BUMPED);
+    applySharedLockPlanToMap(remote, computeSharedLockPlan(remote, "bun"));
+
+    const changed = Object.keys(remote).filter((k) => remote[k] !== map[k]);
+    expect(changed).toEqual([SHARED_PY]);
+    expect(remote[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
+  });
+
+  test("the minority keeps its own lock; the majority shares", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    ownLock(map, "f/odd", ".py", OTHER_LOCK);
+
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map["f/odd.script.lock"]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map["f/odd.script.yaml"])).toEqual(
+      "!inline f/odd.script.lock",
+    );
+  });
+
+  test("a script that diverges from the shared lock gets its own back", () => {
+    const map: Record<string, string> = {};
+    sharedLock(map, "f/a", ".py", SHARED_PY);
+    sharedLock(map, "f/b", ".py", SHARED_PY);
+    sharedLock(map, "f/c", ".py", SHARED_PY);
+    map[SHARED_PY] = PY_LOCK;
+    // f/c grew an import: the remote now sends it a lock of its own.
+    map["f/c.script.yaml"] = meta("!inline f/c.script.lock");
+    map["f/c.script.lock"] = OTHER_LOCK;
+
+    const plan = computeSharedLockPlan(map, "bun");
+    applySharedLockPlanToMap(map, plan);
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map["f/c.script.lock"]).toEqual(OTHER_LOCK);
+    expect(map["f/a.script.lock"]).toBeUndefined();
+  });
+
+  test("a lone script is left with its own lock", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+
+    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+  });
+
+  test("a shared file nothing references any more is removed", () => {
+    const map: Record<string, string> = {};
+    sharedLock(map, "f/a", ".py", SHARED_PY);
+    map[SHARED_PY] = PY_LOCK;
+    // The one remaining script diverged, so nothing shares that lock.
+    map["f/a.script.yaml"] = meta("!inline f/a.script.lock");
+    map["f/a.script.lock"] = OTHER_LOCK;
+
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+
+    expect(map[SHARED_PY]).toBeUndefined();
+  });
+
+  test("scripts without a lock file are untouched", () => {
+    const map: Record<string, string> = {
+      "f/a.py": "def main(): ...",
+      "f/a.script.yaml": meta(""),
+      "f/b.py": "def main(): ...",
+      "f/b.script.yaml": meta(""),
+    };
+
+    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+  });
+
+  test("a language that needs no lock is never deduped", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".sh", "some-lock");
+    ownLock(map, "f/b", ".sh", "some-lock");
+
+    expect(isEmptySharedLockPlan(computeSharedLockPlan(map, "bun"))).toBe(true);
+  });
+
+  test("module-layout scripts share too, from their folder", () => {
+    const map: Record<string, string> = {
+      "f/a__mod/script.py": "def main(): ...",
+      "f/a__mod/script.yaml": meta("!inline f/a__mod/script.lock"),
+      "f/a__mod/script.lock": PY_LOCK,
+      "f/b__mod/script.py": "def main(): ...",
+      "f/b__mod/script.yaml": meta("!inline f/b__mod/script.lock"),
+      "f/b__mod/script.lock": PY_LOCK,
+    };
+
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map["f/a__mod/script.lock"]).toBeUndefined();
+    expect(lockRefOf(map["f/a__mod/script.yaml"])).toEqual(
+      `!inline ${SHARED_PY}`,
+    );
+  });
+
+  test("only the lock line of the metadata changes", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    map["f/a.script.yaml"] = meta("!inline f/a.script.lock", "does a thing");
+    const before = map["f/a.script.yaml"];
+
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+
+    expect(map["f/a.script.yaml"]).toEqual(
+      before.replace("f/a.script.lock", SHARED_PY),
+    );
+  });
+});
+
+describe("scriptsReferencingSharedLock", () => {
+  test("finds every script on the shared lock and nothing else", () => {
+    const map: Record<string, string> = {};
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    ownLock(map, "f/odd", ".py", OTHER_LOCK);
+    applySharedLockPlanToMap(map, computeSharedLockPlan(map, "bun"));
+
+    expect(scriptsReferencingSharedLock(map, SHARED_PY).sort()).toEqual([
+      "f/a.script.yaml",
+      "f/b.script.yaml",
+    ]);
+  });
+});

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -318,6 +318,27 @@ describe("computeSharedLockPlan", () => {
     expect(bumped["f/a.script.lock"]).toBeUndefined();
   });
 
+  test("a dependency file that re-resolves without changing still moves", () => {
+    // An unpinned `requirements.in` picking up a new patch release: same stamp,
+    // new bodies. Read as variants, the whole group would fork to private locks.
+    const stamp = (body: string) =>
+      `# workspace-dependencies: default:aaa\n${body}`;
+    const map = workspace(PY_DEPS);
+    ownLock(map, "f/a", ".py", stamp(PY_LOCK_BUMPED));
+    ownLock(map, "f/b", ".py", stamp(PY_LOCK_BUMPED));
+
+    applySharedLockPlanToMap(
+      map,
+      computeSharedLockPlan(map, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: stamp(PY_LOCK) },
+      }),
+    );
+
+    expect(map[SHARED_PY]).toEqual(stamp(PY_LOCK_BUMPED));
+    expect(map["f/a.script.lock"]).toBeUndefined();
+  });
+
   test("the many correct a lockfile a lone script planted its variant on", () => {
     const map = workspace(PY_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -510,19 +510,35 @@ describe("sharedLockRefIn", () => {
       await mkdir(path.join(root, "locks"), { recursive: true });
       await writeFile(path.join(root, SHARED_PY), PY_LOCK, "utf-8");
 
-      expect(sharedLockRefIn(meta(`!inline ${SHARED_PY}`), root)).toEqual(
+      expect(sharedLockRefIn(meta(`!inline ${SHARED_PY}`), false, root)).toEqual(
         SHARED_PY,
       );
       // A regenerated script must fall back to its own lock rather than point
       // at a shared file that is not there.
       expect(
-        sharedLockRefIn(meta("!inline locks/go.lock"), root),
+        sharedLockRefIn(meta("!inline locks/go.lock"), false, root),
       ).toBeUndefined();
       expect(
-        sharedLockRefIn(meta(`!inline ${TRAVERSING_REF}`), root),
+        sharedLockRefIn(meta(`!inline ${TRAVERSING_REF}`), false, root),
       ).toBeUndefined();
       expect(
-        sharedLockRefIn(meta("!inline f/a.script.lock"), root),
+        sharedLockRefIn(meta("!inline f/a.script.lock"), false, root),
+      ).toBeUndefined();
+      // Flow-style YAML starts with `{` and is not JSON: deciding the format by
+      // the first character would drop the reference and repoint the script.
+      expect(
+        sharedLockRefIn(`{summary: x, lock: '!inline ${SHARED_PY}'}`, false, root),
+      ).toEqual(SHARED_PY);
+      // The `lock` field alone decides, whatever prose surrounds it.
+      expect(
+        sharedLockRefIn(
+          yamlStringify(
+            { summary: `see !inline ${SHARED_PY}`, lock: "!inline f/a.script.lock" },
+            yamlOptions,
+          ),
+          false,
+          root,
+        ),
       ).toBeUndefined();
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -285,6 +285,23 @@ describe("computeSharedLockPlan", () => {
     expect(lockRefOf(bumped["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
   });
 
+  test("the many correct a lockfile a lone script planted its variant on", () => {
+    const map = workspace(PY_DEPS);
+    ownLock(map, "f/a", ".py", PY_LOCK);
+    ownLock(map, "f/b", ".py", PY_LOCK);
+    applySharedLockPlanToMap(
+      map,
+      // The file holds a variant, and its dependency file has not moved.
+      computeSharedLockPlan(map, {
+        defaultTs: "bun",
+        present: { [SHARED_PY]: OTHER_LOCK },
+      }),
+    );
+
+    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map["f/a.script.lock"]).toBeUndefined();
+  });
+
   test("a dependency file with a single script can still take a bump", () => {
     const map = workspace(PY_DEPS);
     ownLock(map, "f/only", ".py", PY_LOCK_BUMPED);

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -275,7 +275,7 @@ describe("getTypeStrFromPath", () => {
   test("a shared lockfile is its own type, not a workspace dependency", () => {
     // A repo-side artifact with no object on the server: classified as a
     // workspace dependency, `sync push` would try to deploy it as one.
-    expect(getTypeStrFromPath("locks/python3.lock")).toBe(
+    expect(getTypeStrFromPath("locks/requirements.in.lock")).toBe(
       "shared_lock",
     );
     expect(getTypeStrFromPath("dependencies/requirements.in")).toBe(

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -273,14 +273,17 @@ describe("getTypeStrFromPath", () => {
   });
 
   test("a shared lockfile is its own type, not a workspace dependency", () => {
-    // It lives under dependencies/ but has no object on the server: classified
-    // as one, `sync push` would try to deploy it as a dependency file.
+    // A repo-side artifact with no object on the server: classified as a
+    // workspace dependency, `sync push` would try to deploy it as one.
     expect(getTypeStrFromPath("locks/python3.lock")).toBe(
       "shared_lock",
     );
     expect(getTypeStrFromPath("dependencies/requirements.in")).toBe(
       "workspace_dependencies",
     );
+    // `locks/` is an ordinary word: only the names Windmill writes are claimed,
+    // so a repo that already keeps its own lockfiles there keeps them.
+    expect(() => getTypeStrFromPath("locks/vendor.lock")).toThrow();
   });
 
   test("detects metadata types by name suffix", () => {

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -275,7 +275,7 @@ describe("getTypeStrFromPath", () => {
   test("a shared lockfile is its own type, not a workspace dependency", () => {
     // It lives under dependencies/ but has no object on the server: classified
     // as one, `sync push` would try to deploy it as a dependency file.
-    expect(getTypeStrFromPath("dependencies/locks/python3.lock")).toBe(
+    expect(getTypeStrFromPath("locks/python3.lock")).toBe(
       "shared_lock",
     );
     expect(getTypeStrFromPath("dependencies/requirements.in")).toBe(

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -272,6 +272,17 @@ describe("getTypeStrFromPath", () => {
     expect(getTypeStrFromPath("f/test/my_script.rs")).toBe("script");
   });
 
+  test("a shared lockfile is its own type, not a workspace dependency", () => {
+    // It lives under dependencies/ but has no object on the server: classified
+    // as one, `sync push` would try to deploy it as a dependency file.
+    expect(getTypeStrFromPath("dependencies/locks/python3.lock")).toBe(
+      "shared_lock",
+    );
+    expect(getTypeStrFromPath("dependencies/requirements.in")).toBe(
+      "workspace_dependencies",
+    );
+  });
+
   test("detects metadata types by name suffix", () => {
     expect(getTypeStrFromPath("f/test/my_var.variable.yaml")).toBe("variable");
     expect(getTypeStrFromPath("f/test/my_res.resource.yaml")).toBe("resource");

--- a/cli/wmill.schema.json
+++ b/cli/wmill.schema.json
@@ -107,7 +107,7 @@
     },
     "dedupeLockfiles": {
       "type": "boolean",
-      "description": "Share one lockfile per language in locks/, instead of an identical .script.lock per script"
+      "description": "Share one lockfile per workspace dependency file (locks/<depfile>.lock), instead of an identical .script.lock per script"
     },
     "lint": {
       "type": "boolean",

--- a/cli/wmill.schema.json
+++ b/cli/wmill.schema.json
@@ -107,7 +107,7 @@
     },
     "dedupeLockfiles": {
       "type": "boolean",
-      "description": "Share one lockfile per language in dependencies/locks/, instead of an identical .script.lock per script"
+      "description": "Share one lockfile per language in locks/, instead of an identical .script.lock per script"
     },
     "lint": {
       "type": "boolean",

--- a/cli/wmill.schema.json
+++ b/cli/wmill.schema.json
@@ -24,7 +24,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Additional glob patterns merged with includes (useful in branch overrides)"
+      "description": "Additional glob patterns merged with includes (useful in workspace overrides)"
     },
     "excludes": {
       "type": "array",
@@ -69,6 +69,10 @@
       "type": "boolean",
       "description": "Skip syncing workspace dependencies"
     },
+    "skipDatatableMigrations": {
+      "type": "boolean",
+      "description": "Skip syncing data table SQL migrations"
+    },
     "includeSchedules": {
       "type": "boolean",
       "description": "Include schedules in sync"
@@ -101,6 +105,10 @@
       "type": "boolean",
       "description": "Require lock files for all scripts"
     },
+    "dedupeLockfiles": {
+      "type": "boolean",
+      "description": "Share one lockfile per language in dependencies/locks/, instead of an identical .script.lock per script"
+    },
     "lint": {
       "type": "boolean",
       "description": "Run linting before push"
@@ -124,6 +132,10 @@
     "nonDottedPaths": {
       "type": "boolean",
       "description": "Use __flow/__app/__raw_app suffixes instead of .flow/.app/.raw_app"
+    },
+    "syncBehavior": {
+      "type": "string",
+      "description": "Sync behavior version — controls ownership handling during push/pull (v1: preserve permissioned_as on update, strip on_behalf_of_email on pull)"
     },
     "codebases": {
       "type": "array",


### PR DESCRIPTION
## Summary

A workspace whose dependencies come from a `dependencies/<file>` resolves to the same lock for every script of that language, so the repo carries thousands of byte-identical `.script.lock` files. One dependency bump rewrites all of them, and every open branch then conflicts on all of them.

`dedupeLockfiles: true` in `wmill.yaml` (opt-in, default off) stores that lock once, in a file named after the dependency file it came from, referenced from each `.script.yaml` through the `!inline` indirection the metadata already uses:

```
dependencies/requirements.in         ->  locks/requirements.in.lock
dependencies/team_a.requirements.in  ->  locks/team_a.requirements.in.lock
dependencies/package.json            ->  locks/package.json.lock
```

A dependency bump becomes a one-file diff. Fixes WIN-1756.

## Design

**Identity comes from the dependency file** — never from the lock's content, and never from which scripts happen to be in view. That is what makes the pass stateless: a sync narrowed to a single script (which is what the git-sync deploy callback does, via per-item `extraIncludes`) computes the same name as a full one, because the lock that script holds *is* that dependency file's lock — the worker resolves it from the file alone and ignores the script body.

Two consequences worth knowing:

- **A lockfile lives exactly as long as its dependency file.** Asking that, rather than "does any script still read it", is what lets a narrowed sync leave the rest of the workspace alone.
- **Two cases keep a private `.script.lock`**: a script whose annotation is `extra_` or carries inline dependencies (its lock folds in its own imports), and one naming several dependency files at once (its lock is no single file's). Scripts with no workspace dependency file behind them are untouched.

The name is a suffix append rather than an extension swap, so the mapping is reversible: strip `.lock` and you have the dependency filename, which is how `isSharedLockPath` decides whether a file is Windmill's. `locks/vendor.lock` names no dependency file, so a repo that already keeps lockfiles there keeps them, and with the option off `locks/` is ignored entirely.

## Changes

- `cli/src/utils/lock_dedup.ts` (new): the pure planner (`computeSharedLockPlan` → `{writes, deletes}`, applied to a sync map or to the working tree).
- `compareDynFSElement` collapses the **remote** map in both directions, so local and remote stay comparable and neither pull nor push sees a phantom diff.
- `sync push` fans a shared-lock change out to the scripts that read it (nothing else queues them — their own metadata is identical on both sides), after `buildTracker` so `--auto-metadata` does not regenerate their locks.
- `updateScriptLock` writes a regenerated lock straight to the shared file, so a bump never lands a private copy that a later pass has to collapse.
- `generate-metadata` and `push --auto-metadata` run a whole-tree normalization pass, re-hashing what they rewrite (never a script whose generation failed) so nothing reads as stale next run; it also runs on the up-to-date path, which is the state a repo is in when the option is first turned on, and reports instead of writing under `--dry-run`.
- A script lockfile deletion is deferred to the end of a pull and skipped if the metadata on disk still reads it — a conflict resolved as "preserve local" must not be left with a dangling `!inline`.
- Workspace-dependency vocabulary (`workspaceDependenciesPathToLanguageAndFilename`, the annotation parser) moves to `script_common.ts`, beside the languages it describes; `metadata.ts` re-exports it.
- `wmill.yaml` option + regenerated `wmill.schema.json`; `wmill lint --locks-required` resolves a shared reference from the sync root.

Scope: standalone scripts (flat and `__mod` layouts). Flow and app inline-script locks use folder-relative references and are untouched; dbt is excluded. `locks/` is created lazily — a workspace with nothing to share never grows the directory.

## Test plan

Unit (`cli/test/lock_dedup_unit.test.ts`, `UNIT_ONLY=1 bun test test/*_unit*.test.ts` — 1085 pass):

- [x] the scripts of a dependency file collapse into its lockfile; each named set gets its own
- [x] a bump changes exactly one file; the pass is idempotent
- [x] one script in view reaches the same answer as the whole workspace
- [x] `extra_`/inline annotations and multi-file scripts keep a private lock; a stale committed lock is outvoted
- [x] a shared lockfile outlives its scripts but not its dependency file
- [x] `isSharedLockPath` claims only names a dependency file gives (`locks/vendor.lock` is not ours)
- [x] dotted script paths, module layout, `lock: ''`, languages that need no lock

Exercised against a running backend (workspace with two bun dependency sets, python scripts, one divergent):

- [x] `sync pull` writes one lockfile per dependency file and removes the duplicates; a second pull and a push both report 0 changes
- [x] bumping one dependency set touches that set's lockfile only — no `.script.yaml` changes
- [x] editing a shared lockfile and pushing deploys it to exactly the scripts that read it (verified on the server)
- [x] narrow pull (`--extra-includes`, the git-deploy shape) is a no-op and leaves the shared files intact
- [x] `generate-metadata` on an up-to-date tree converts it and is a no-op on the next run; `--dry-run` leaves every file byte-identical
- [x] `push --auto-metadata` with a bumped shared lock runs 0 dependency jobs
- [x] a stateful pull with a conflict resolved as "preserve local" keeps the lockfile that metadata still references
- [x] with the option off, `locks/*.lock` files are left untouched by pull and push
