### PR TITLE
fix: refuse an MCP endpoint call whose required request body is empty

### DIFF
--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -147,7 +147,16 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
                 else:
                     # Log warning when a required field is missing from schema properties
                     print(f"Warning: Required field '{field}' not found in body schema properties", file=sys.stderr)
-    
+
+        # An operation declaring `requestBody: required: true` cannot be called without a
+        # body: axum's Json extractor rejects the bodyless request with 415 before the
+        # handler runs. Carry that over so the MCP layer can refuse a call whose arguments
+        # produce no body instead of dispatching one that cannot succeed. A pass-through
+        # body (no declared properties, e.g. runScriptByPath) is excluded: `{}` is a valid
+        # body there, for a runnable that takes no arguments.
+        if body_schema and request_body.get('required') and body_schema.get('properties'):
+            body_schema['minProperties'] = 1
+
     # Sanitize empty schemas for JSON Schema draft 2020-12 compliance
     path_params_schema = sanitize_empty_schemas(path_params_schema)
     query_params_schema = sanitize_empty_schemas(query_params_schema)

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -148,12 +148,10 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
                     # Log warning when a required field is missing from schema properties
                     print(f"Warning: Required field '{field}' not found in body schema properties", file=sys.stderr)
 
-        # An operation declaring `requestBody: required: true` cannot be called without a
-        # body: axum's Json extractor rejects the bodyless request with 415 before the
-        # handler runs. Carry that over so the MCP layer can refuse a call whose arguments
-        # produce no body instead of dispatching one that cannot succeed. A pass-through
-        # body (no declared properties, e.g. runScriptByPath) is excluded: `{}` is a valid
-        # body there, for a runnable that takes no arguments.
+        # Marks a body the MCP layer must refuse to leave empty (see non_empty_body_fields
+        # in windmill-mcp). A pass-through body (no declared properties, e.g.
+        # runScriptByPath) is excluded: `{}` is a valid body there, for a runnable that
+        # takes no arguments.
         if body_schema and request_body.get('required') and body_schema.get('properties'):
             body_schema['minProperties'] = 1
 

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -162,7 +162,8 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 "value",
                 "is_secret",
                 "description"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -244,7 +245,8 @@ pub fn all_tools() -> Vec<EndpointTool> {
                         "type": "string",
                         "description": "The path to the variable (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
-        }
+        },
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -392,7 +394,8 @@ pub fn all_tools() -> Vec<EndpointTool> {
                 "path",
                 "value",
                 "resource_type"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -464,7 +467,8 @@ pub fn all_tools() -> Vec<EndpointTool> {
                         "type": "string",
                         "description": "The path to the resource (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
-        }
+        },
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -719,7 +723,8 @@ Creates a new version of an existing script when called with the same path and t
                 "summary",
                 "content",
                 "language"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -980,7 +985,8 @@ Creates a new version of an existing script when called with the same path and t
                 "value",
                 "path"
         ],
-        "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
+        "description": "Top-level flow definition containing metadata, configuration, and the flow structure",
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -1035,7 +1041,8 @@ Creates a new version of an existing script when called with the same path and t
                 "summary",
                 "value"
         ],
-        "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
+        "description": "Top-level flow definition containing metadata, configuration, and the flow structure",
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -1226,7 +1233,8 @@ Creates a new version of an existing script when called with the same path and t
                 "value",
                 "summary",
                 "policy"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -1341,7 +1349,8 @@ Creates a new version of an existing script when called with the same path and t
         },
         "required": [
                 "value"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: Some(serde_json::json!({
@@ -1463,7 +1472,8 @@ Creates a new version of an existing script when called with the same path and t
                 "args",
                 "content",
                 "language"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -2034,7 +2044,8 @@ You should get the schema of the script or flow before creating the schedule to 
                 "script_path",
                 "is_flow",
                 "args"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,
@@ -2239,7 +2250,8 @@ You should get the schema of the script or flow before updating the schedule to 
                 "schedule",
                 "timezone",
                 "args"
-        ]
+        ],
+        "minProperties": 1
 })),
         query_field_renames: None,
         body_field_renames: None,

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -291,14 +291,7 @@ impl McpBackend for WindmillBackend {
         );
 
         // Prepare request body
-        let body_json = build_request_body(
-            &endpoint_tool.method,
-            args_map,
-            &endpoint_tool.body_schema,
-            &endpoint_tool.body_field_renames,
-            &endpoint_tool.path_params_schema,
-            &endpoint_tool.query_params_schema,
-        );
+        let body_json = build_request_body(endpoint_tool, args_map)?;
 
         // Create and execute request
         let response = create_http_request(

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -458,9 +458,8 @@ pub fn build_request_body(
 ) -> BackendResult<Option<Value>> {
     let body = assemble_request_body(tool, args_map);
 
-    // Such a call would come back as a bare 415, leaving the caller to work out what
-    // was wrong with arguments its input schema accepted. The fields it could have
-    // filled are not expressible in that schema, so name them here.
+    // The fields that would have satisfied it are not expressible in the tool's input
+    // schema, so name them here rather than dispatching a call that cannot succeed.
     if body.is_none() {
         if let Some(fields) = non_empty_body_fields(tool) {
             return Err(ErrorData::invalid_params(

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -15,7 +15,9 @@ use windmill_common::scripts::{get_full_hub_script_by_path, Schema};
 use windmill_common::utils::{query_elems_from_hub, StripPath};
 use windmill_common::worker::to_raw_value;
 use windmill_common::{DB, HUB_BASE_URL};
-use windmill_mcp::server::{BackendResult, ErrorData, PathFilter};
+use windmill_mcp::server::{
+    non_empty_body_fields, BackendResult, EndpointTool, ErrorData, PathFilter,
+};
 use windmill_mcp::{HubResponse, HubScriptInfo, ItemSchema, ResourceInfo, ResourceType};
 
 use crate::db::ApiAuthed;
@@ -448,15 +450,45 @@ pub fn build_query_string(
     }
 }
 
-/// Build request body from arguments
+/// Build request body from arguments, refusing a call that would reach an
+/// endpoint requiring a body without one.
 pub fn build_request_body(
-    method: &str,
+    tool: &EndpointTool,
     args_map: &serde_json::Map<String, Value>,
-    body_schema: &Option<Value>,
-    body_field_renames: &Option<Value>,
-    path_params_schema: &Option<Value>,
-    query_params_schema: &Option<Value>,
+) -> BackendResult<Option<Value>> {
+    let body = assemble_request_body(tool, args_map);
+
+    // Such a call would come back as a bare 415, leaving the caller to work out what
+    // was wrong with arguments its input schema accepted. The fields it could have
+    // filled are not expressible in that schema, so name them here.
+    if body.is_none() {
+        if let Some(fields) = non_empty_body_fields(tool) {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "{} needs a request body: provide at least one of {}",
+                    tool.name,
+                    fields.join(", ")
+                ),
+                None,
+            ));
+        }
+    }
+
+    Ok(body)
+}
+
+fn assemble_request_body(
+    tool: &EndpointTool,
+    args_map: &serde_json::Map<String, Value>,
 ) -> Option<Value> {
+    let EndpointTool {
+        method,
+        body_schema,
+        body_field_renames,
+        path_params_schema,
+        query_params_schema,
+        ..
+    } = tool;
     if method == "GET" {
         return None;
     }
@@ -805,27 +837,64 @@ mod tests {
         );
     }
 
+    fn endpoint_tool(
+        method: &'static str,
+        path_params_schema: Option<Value>,
+        body_schema: Option<Value>,
+        body_field_renames: Option<Value>,
+    ) -> EndpointTool {
+        EndpointTool {
+            name: std::borrow::Cow::Borrowed("testTool"),
+            description: std::borrow::Cow::Borrowed("desc"),
+            instructions: std::borrow::Cow::Borrowed(""),
+            path: std::borrow::Cow::Borrowed("/w/{workspace}/test/{path}"),
+            method: std::borrow::Cow::Borrowed(method),
+            path_params_schema,
+            query_params_schema: None,
+            body_schema,
+            query_field_renames: None,
+            body_field_renames,
+        }
+    }
+
+    fn args_of(value: Value) -> serde_json::Map<String, Value> {
+        value.as_object().unwrap().clone()
+    }
+
+    fn path_param_schema() -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"]
+        }))
+    }
+
+    fn generated_tool(name: &str) -> EndpointTool {
+        crate::mcp::auto_generated_endpoints::all_tools()
+            .into_iter()
+            .find(|t| t.name.as_ref() == name)
+            .unwrap_or_else(|| panic!("{name} must be a generated endpoint tool"))
+    }
+
     #[test]
     fn build_request_body_passthrough_forwards_script_args_minus_path() {
         // runScriptByPath-shaped body: additionalProperties, no declared props.
         // `path` is a path param and must be excluded; the rest are the script's
         // arguments and must be forwarded verbatim.
-        let body_schema = Some(json!({ "type": "object", "additionalProperties": true }));
-        let path_schema = Some(json!({
-            "type": "object",
-            "properties": { "path": { "type": "string" } },
-            "required": ["path"]
-        }));
-        let args: serde_json::Map<String, Value> = json!({
+        let tool = endpoint_tool(
+            "POST",
+            path_param_schema(),
+            Some(json!({ "type": "object", "additionalProperties": true })),
+            None,
+        );
+        let args = args_of(json!({
             "path": "u/admin/my_script",
             "name": "alice",
             "count": 3
-        })
-        .as_object()
-        .unwrap()
-        .clone();
+        }));
 
-        let body = build_request_body("POST", &args, &body_schema, &None, &path_schema, &None)
+        let body = build_request_body(&tool, &args)
+            .unwrap()
             .expect("passthrough body should be built");
         let obj = body.as_object().unwrap();
         assert_eq!(obj.get("name"), Some(&json!("alice")));
@@ -839,16 +908,18 @@ mod tests {
     #[test]
     fn build_request_body_declared_props_only_forwards_declared() {
         // Endpoints with explicit properties keep the strict declared-only behavior.
-        let body_schema = Some(json!({
-            "type": "object",
-            "properties": { "value": { "type": "string" } },
-            "required": ["value"]
-        }));
-        let args: serde_json::Map<String, Value> = json!({ "value": "x", "sneaky": "y" })
-            .as_object()
-            .unwrap()
-            .clone();
-        let body = build_request_body("POST", &args, &body_schema, &None, &None, &None).unwrap();
+        let tool = endpoint_tool(
+            "POST",
+            None,
+            Some(json!({
+                "type": "object",
+                "properties": { "value": { "type": "string" } },
+                "required": ["value"]
+            })),
+            None,
+        );
+        let args = args_of(json!({ "value": "x", "sneaky": "y" }));
+        let body = build_request_body(&tool, &args).unwrap().unwrap();
         let obj = body.as_object().unwrap();
         assert_eq!(obj.get("value"), Some(&json!("x")));
         assert!(
@@ -859,13 +930,10 @@ mod tests {
 
     // updateFlow-shaped: `path` is both a path parameter and a body field. The path
     // parameter keeps the plain name; only the body side is mangled.
-    fn update_flow_schemas() -> (Option<Value>, Option<Value>, Option<Value>) {
-        (
-            Some(json!({
-                "type": "object",
-                "properties": { "path": { "type": "string" } },
-                "required": ["path"]
-            })),
+    fn update_flow_tool() -> EndpointTool {
+        endpoint_tool(
+            "POST",
+            path_param_schema(),
             Some(json!({
                 "type": "object",
                 "properties": {
@@ -873,7 +941,8 @@ mod tests {
                     "value": { "type": "object" },
                     "path__body": { "type": "string" }
                 },
-                "required": ["summary", "value"]
+                "required": ["summary", "value"],
+                "minProperties": 1
             })),
             Some(json!({ "path__body": "path" })),
         )
@@ -884,26 +953,16 @@ mod tests {
         // The mangled body field carries the *new* path when renaming; it must reach the
         // API under its original name `path`. (An omitted `path__body` is intentionally
         // absent from the body; the server defaults it from the URL path parameter.)
-        let (path_schema, body_schema, body_renames) = update_flow_schemas();
-        let args: serde_json::Map<String, Value> = json!({
+        let args = args_of(json!({
             "path": "f/team/my_flow",
             "path__body": "f/team/renamed_flow",
             "summary": "s",
             "value": {}
-        })
-        .as_object()
-        .unwrap()
-        .clone();
+        }));
 
-        let body = build_request_body(
-            "POST",
-            &args,
-            &body_schema,
-            &body_renames,
-            &path_schema,
-            &None,
-        )
-        .expect("body should be built");
+        let body = build_request_body(&update_flow_tool(), &args)
+            .unwrap()
+            .expect("body should be built");
         assert_eq!(
             body.as_object().unwrap().get("path"),
             Some(&json!("f/team/renamed_flow")),
@@ -913,9 +972,51 @@ mod tests {
 
     #[test]
     fn build_request_body_get_has_no_body() {
-        let body_schema = Some(json!({ "type": "object", "additionalProperties": true }));
-        let args: serde_json::Map<String, Value> = json!({ "a": 1 }).as_object().unwrap().clone();
-        assert!(build_request_body("GET", &args, &body_schema, &None, &None, &None).is_none());
+        let tool = endpoint_tool(
+            "GET",
+            None,
+            Some(json!({ "type": "object", "additionalProperties": true })),
+            None,
+        );
+        assert!(build_request_body(&tool, &args_of(json!({ "a": 1 })))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn build_request_body_refuses_bodyless_call_to_required_body_endpoint() {
+        // updateVariable's only required argument is the path parameter, so a
+        // path-only call satisfies the tool's input schema while leaving the body
+        // empty. Dispatching it would reach the API with no JSON body and come back
+        // as a 415, so it is refused here with the fields it could have set.
+        let tool = generated_tool("updateVariable");
+        let err = build_request_body(&tool, &args_of(json!({ "path": "u/admin/a_var" })))
+            .expect_err("a path-only updateVariable call must be refused");
+        assert!(
+            err.message.contains("value"),
+            "the error must name the body fields, got: {}",
+            err.message
+        );
+
+        let body = build_request_body(
+            &tool,
+            &args_of(json!({ "path": "u/admin/a_var", "value": "v" })),
+        )
+        .unwrap()
+        .expect("a call carrying an update must still build a body");
+        assert_eq!(body.as_object().unwrap().get("value"), Some(&json!("v")));
+    }
+
+    #[test]
+    fn build_request_body_allows_bodyless_run_of_a_no_arg_runnable() {
+        // The counterpart: a runnable that takes no arguments has nothing to put in
+        // the body, and the run endpoints accept an empty one.
+        let tool = generated_tool("runScriptByPath");
+        assert!(
+            build_request_body(&tool, &args_of(json!({ "path": "u/admin/no_args"})))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/backend/windmill-mcp/src/server/endpoints.rs
+++ b/backend/windmill-mcp/src/server/endpoints.rs
@@ -31,6 +31,22 @@ pub fn is_endpoint_read_only(tool: &EndpointTool) -> bool {
     tool.method.as_ref() == "GET"
 }
 
+/// The body fields of an endpoint that cannot be called with an empty body, or
+/// `None` when a bodyless call is legitimate.
+///
+/// `minProperties` on the body schema marks an operation whose OpenAPI declares
+/// `requestBody: required: true` (see `generate_mcp_tools.py`). The API answers a
+/// request carrying no JSON body with 415 before the handler runs, so a call
+/// filling none of these fields can only fail.
+pub fn non_empty_body_fields(tool: &EndpointTool) -> Option<Vec<&str>> {
+    let schema = tool.body_schema.as_ref()?;
+    if schema.get("minProperties").and_then(|m| m.as_u64())? == 0 {
+        return None;
+    }
+    let props = schema.get("properties")?.as_object()?;
+    Some(props.keys().map(|k| k.as_str()).collect())
+}
+
 /// Convert a single endpoint tool to MCP tool
 pub fn endpoint_tool_to_mcp_tool(tool: &EndpointTool) -> Tool {
     let mut combined_properties = serde_json::Map::new();
@@ -54,7 +70,23 @@ pub fn endpoint_tool_to_mcp_tool(tool: &EndpointTool) -> Tool {
     });
     make_schema_compatible(&mut combined_schema);
 
-    let description = format!("{}. {}", tool.description, tool.instructions);
+    let mut description = format!("{}. {}", tool.description, tool.instructions);
+
+    // A body that must not be empty, none of whose fields is individually required,
+    // is a requirement no `required` array can express. Spell it out, or the schema
+    // reads as if the path alone were a complete call.
+    if let Some(fields) = non_empty_body_fields(tool) {
+        if !fields
+            .iter()
+            .any(|f| combined_required.iter().any(|r| r == f))
+        {
+            description = format!(
+                "{} At least one of these arguments must be provided: {}.",
+                description.trim_end(),
+                fields.join(", ")
+            );
+        }
+    }
 
     // Create annotations based on HTTP method and endpoint characteristics
     let annotations = create_endpoint_annotations(tool);
@@ -286,6 +318,53 @@ mod tests {
         assert_eq!(
             count, 1,
             "workspace_id must appear exactly once in required"
+        );
+    }
+
+    /// updateVariable-shaped: the body must not be empty, but no single field of it
+    /// is required, so `required` cannot carry the constraint and the prose must.
+    fn update_tool(body_required: &[&str]) -> EndpointTool {
+        let mut t = tool("updateVariable", "/w/{workspace}/variables/update/{path}");
+        t.method = Cow::Borrowed("POST");
+        t.path_params_schema = Some(serde_json::json!({
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"]
+        }));
+        t.body_schema = Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string" },
+                "is_secret": { "type": "boolean" }
+            },
+            "required": body_required,
+            "minProperties": 1
+        }));
+        t
+    }
+
+    #[test]
+    fn required_body_with_no_required_field_is_stated_in_the_description() {
+        let desc = endpoint_tool_to_mcp_tool(&update_tool(&[]))
+            .description
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            desc.contains("value, is_secret"),
+            "the description must name the body fields, got: {desc}"
+        );
+    }
+
+    #[test]
+    fn required_body_with_a_required_field_keeps_its_description() {
+        // `required` already forbids the empty body here, so the sentence would be noise.
+        let desc = endpoint_tool_to_mcp_tool(&update_tool(&["value"]))
+            .description
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            !desc.contains("At least one"),
+            "no extra sentence is needed when a body field is required, got: {desc}"
         );
     }
 

--- a/backend/windmill-mcp/src/server/mod.rs
+++ b/backend/windmill-mcp/src/server/mod.rs
@@ -15,7 +15,7 @@ pub use crate::common::types::{McpToken, MultiWorkspaceMcp, WorkspaceInfo};
 pub use backend::{BackendResult, McpAuth, McpBackend, PathFilter};
 pub use endpoints::{
     endpoint_tool_to_mcp_tool, endpoint_tool_to_mcp_tool_multi, is_endpoint_read_only,
-    list_workspaces_tool, EndpointTool,
+    list_workspaces_tool, non_empty_body_fields, EndpointTool,
 };
 pub use runner::Runner;
 pub use tools::create_tool_from_item;

--- a/backend/windmill-mcp/src/server/runner.rs
+++ b/backend/windmill-mcp/src/server/runner.rs
@@ -607,12 +607,13 @@ impl<B: McpBackend> Runner<B> {
                 // including the run-by-path path check (shared with multi mode).
                 authorize_endpoint_call(scope_config, endpoint_tool, &args, read_only)?;
 
-                // This is an endpoint tool, call via backend
+                // This is an endpoint tool, call via backend. The backend's own error
+                // code is kept: a client that retries an internal error would loop on
+                // arguments the endpoint rejected.
                 let result = self
                     .backend
                     .call_endpoint(auth, workspace_id, endpoint_tool, args)
-                    .await
-                    .map_err(|e| ErrorData::internal_error(e.message, None))?;
+                    .await?;
 
                 return Ok(CallToolResult::success(vec![ContentBlock::text(
                     truncate_tool_result(
@@ -865,8 +866,7 @@ impl<B: McpBackend> Runner<B> {
         let result = self
             .backend
             .call_endpoint(&resolved_auth, &workspace_id, endpoint_tool, args)
-            .await
-            .map_err(|e| ErrorData::internal_error(e.message, None))?;
+            .await?;
 
         Ok(CallToolResult::success(vec![ContentBlock::text(
             truncate_tool_result(

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -171,7 +171,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "value",
                 "is_secret",
                 "description"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -253,7 +254,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                         "type": "string",
                         "description": "The path to the variable (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
-        }
+        },
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -401,7 +403,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "path",
                 "value",
                 "resource_type"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -473,7 +476,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                         "type": "string",
                         "description": "The path to the resource (body parameter). Defaults to `path` when omitted; set it only to change the path."
                 }
-        }
+        },
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -727,7 +731,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "summary",
                 "content",
                 "language"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -988,7 +993,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "value",
                 "path"
         ],
-        "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
+        "description": "Top-level flow definition containing metadata, configuration, and the flow structure",
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -1043,7 +1049,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "summary",
                 "value"
         ],
-        "description": "Top-level flow definition containing metadata, configuration, and the flow structure"
+        "description": "Top-level flow definition containing metadata, configuration, and the flow structure",
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -1234,7 +1241,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "value",
                 "summary",
                 "policy"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -1349,7 +1357,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         },
         "required": [
                 "value"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: {
@@ -1471,7 +1480,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "args",
                 "content",
                 "language"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -2039,7 +2049,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "script_path",
                 "is_flow",
                 "args"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined
@@ -2241,7 +2252,8 @@ export const mcpEndpointTools: EndpointTool[] = [
                 "schedule",
                 "timezone",
                 "args"
-        ]
+        ],
+        "minProperties": 1
 },
         queryFieldRenames: undefined,
         bodyFieldRenames: undefined


### PR DESCRIPTION
## Summary

Fixes GIT-971.

The MCP tool for `updateVariable` advertised `path` as its only required argument, so a call
carrying exactly that passed the tool's input schema and was dispatched to
`POST /w/{workspace}/variables/update/{path}` with no JSON body. axum's `Json` extractor rejects
a bodyless request with **415 Unsupported Media Type** before the handler runs, so the agent got
an opaque transport error for arguments the contract said were complete, and the variable was
left unchanged. `updateResource` had the same shape.

The constraint is not expressible in the tool's `required` array (any *one* of the body fields
is enough), so this fixes both halves the report asked for: the contract now states the
requirement, and the call is refused with a clear validation error before the REST request.

## Changes

- `generate_mcp_tools.py`: an operation whose OpenAPI declares `requestBody: required: true` and
  has declared body properties now emits `"minProperties": 1` on the generated body schema. A
  pass-through body (no declared properties, e.g. `runScriptByPath`) is excluded: `{}` is a valid
  body there, for a runnable that takes no arguments.
- Regenerated `auto_generated_endpoints.rs` and `mcpEndpointTools.ts` (12 tools marked).
- `non_empty_body_fields()` in `windmill-mcp`: reads that marker; `endpoint_tool_to_mcp_tool`
  appends "At least one of these arguments must be provided: ..." to the tool description when no
  body field is individually required (so tools like `createVariable`, whose `required` already
  forbids an empty body, are untouched).
- `build_request_body` takes the `EndpointTool` (dropping five derived parameters) and returns a
  result: an empty body for an endpoint that requires one is refused with `invalid_params` naming
  the fields, instead of being dispatched.
- The runner no longer rewrites a backend error into `internal_error`; the code survives, so a
  client sees `-32602` (bad arguments) rather than `-32603` (retryable internal error).

## Test plan

Unit (`cargo test -p windmill-mcp --features server`, `cargo test -p windmill-api --features mcp,quickjs --lib mcp::`):

- [x] a path-only `updateVariable` call against the real generated tool is refused, and the same
      call with `value` still builds a body
- [x] a no-arg `runScriptByPath` call still builds no body
- [x] the description states the requirement only when nothing in the body is required

Exercised live against a local instance built with `--features quickjs,mcp`, over the MCP
Streamable HTTP endpoint:

- [x] `tools/list` shows the requirement in `updateVariable` / `updateResource` descriptions
- [x] path-only `updateVariable` (the reported repro) returns
      `-32602 updateVariable needs a request body: provide at least one of value, is_secret, ...`;
      the variable is unchanged
- [x] control `{path, value}` updates the variable; same for `updateResource` with `{path, description}`
- [x] both refusal and control reproduce through the multi-workspace gateway (`/api/mcp/gateway`)
- [x] `createVariable` (required body fields) unaffected
- [x] a no-arg bun script runs to completion through `runScriptByPath` with only `path` (the
      run endpoints accept a bodyless POST, verified directly: 404 not 415)

Reviewed locally with `local-review-codex` (Good to merge, no findings). The Claude-side
`local-review` was not run: it needs a subagent, which this session was configured not to spawn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses MCP endpoint calls that require a JSON body when none of the body fields are provided, fixing GIT-971. Previously, path-only update calls were sent as bodyless POSTs and failed with 415; now they are rejected up front with -32602 invalid_params naming the allowed body fields. Pass-through calls like runScriptByPath are unchanged.

- Adds minProperties: 1 to generated body schemas when OpenAPI marks requestBody.required and the body declares properties; excludes pass-through bodies. Regenerates Rust and TS endpoint tools (~dozen affected) in `windmill-api` and `frontend`.
- Validates before dispatch: build_request_body now refuses an empty body for such endpoints and returns invalid_params listing the fields; endpoint descriptions append “At least one of…” only when no single body field is required.
- Preserves backend error codes in the `Runner` instead of rewriting to internal_error, so clients see -32602 for bad arguments.
- Documents the required-body rule once to avoid repetition.
- Required action: callers of updateVariable and updateResource must provide at least one documented body field (e.g., value, is_secret, or description).

<sup>Written for commit 696a717faed6d097e1a6446b697fd193600d880d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

