### PR TITLE
feat(sessions): batch edit, filters and grouping in the session sidebar

### DIFF
--- a/.agents/skills/svelte-frontend/SKILL.md
+++ b/.agents/skills/svelte-frontend/SKILL.md
@@ -61,7 +61,13 @@ else, go back to the barrel and grep.
 <Button startIcon={{ icon: ChevronLeft }} iconOnly onclick={prev} />
 ```
 
-Props: `variant?: 'accent' | 'accent-secondary' | 'default' | 'subtle'`, `unifiedSize?: 'sm' | 'md' | 'lg'`, `startIcon?: { icon: SvelteComponent }`, `iconOnly?: boolean`, `disabled?: boolean`
+Props: `variant?: 'accent' | 'accent-secondary' | 'default' | 'subtle'`, `unifiedSize?: '2xs' | 'xs' | 'sm' | 'md' | 'lg'`, `startIcon?: { icon: SvelteComponent }`, `iconOnly?: boolean`, `disabled?: boolean`
+
+**`size` on `<Button>` is banned** — it, `spacingSize` and `extendedSize` are the legacy sizing
+system (`xs3`/`xs2`/`xs`/…, marked `@deprecated` in `Button.svelte`). Size every button with
+`unifiedSize`, the small ones included: `2xs` and `xs` are `h-5`, `sm` is `h-7`, `md` is `h-8`,
+`lg` is `h-10`. Existing `size="xs2"` call sites are legacy, not a precedent to copy. Same for
+`variant`: `contained`/`border`/`divider` are deprecated — use the four listed above.
 
 ### Text inputs — `<TextInput>`
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -3,6 +3,7 @@
 - **Coding patterns**: MUST use the `svelte-frontend` skill when writing Svelte code
 - **Validation**: `docs/validation.md` — `npm run check:fast` (2s) for iteration, `npm run check` (50s) for final PR
 - **UI components**: use Windmill's design-system components — never raw HTML elements. Start from the barrel `src/lib/components/common/index.ts` and grep `src/lib/components/`; the component you need almost certainly exists
+- **Never pass a `@deprecated` prop.** On `<Button>` that means `size`, `spacingSize`, `extendedSize` and the `contained`/`border`/`divider` variants — size buttons with `unifiedSize` (`2xs` | `xs` | `sm` | `md` | `lg`). Deprecated props survive at old call sites; copying one forward is still a bug. Check the prop's JSDoc in the component before using it
 - **Brand/design**: `frontend/brand-guidelines.md` — read the relevant section before building UI, not after; the `svelte-frontend` skill maps which section covers what
 - **Backend API**: routes in `../backend/windmill-api/openapi.yaml`, generated types in `src/lib/gen/`
 - **Regenerate client**: `npm run generate-backend-client` after backend API changes

--- a/frontend/src/lib/components/sessions/SessionFilterMenu.svelte
+++ b/frontend/src/lib/components/sessions/SessionFilterMenu.svelte
@@ -2,9 +2,10 @@
 	import { untrack } from 'svelte'
 	import { melt } from '@melt-ui/svelte'
 	import type { MenubarMenuBuilders } from '@melt-ui/svelte'
-	import { ChevronRight, Filter } from 'lucide-svelte'
+	import { Check, ChevronRight, Filter } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import Toggle from '$lib/components/Toggle.svelte'
+	import { GROUP_BY_OPTIONS, LAST_ACTIVITY_OPTIONS, type GroupBy } from './sessionFilters'
 
 	interface Props {
 		// Submenu builders from the enclosing melt Menu — createSubmenu must be
@@ -12,9 +13,17 @@
 		builders: MenubarMenuBuilders
 		showArchived: boolean
 		archivedCount: number
+		lastActivityDays: number
+		groupBy: GroupBy
 	}
 
-	let { builders, showArchived = $bindable(), archivedCount }: Props = $props()
+	let {
+		builders,
+		showArchived = $bindable(),
+		archivedCount,
+		lastActivityDays = $bindable(),
+		groupBy = $bindable()
+	}: Props = $props()
 
 	const {
 		elements: { subTrigger, subMenu },
@@ -23,7 +32,13 @@
 
 	// Count of active (non-default) filters, surfaced as a subtle badge on the
 	// trigger so an applied filter is visible without opening the submenu.
-	let activeCount = $derived(showArchived ? 1 : 0)
+	// Grouping is left out: it reorders the list rather than hiding anything.
+	let activeCount = $derived((showArchived ? 1 : 0) + (lastActivityDays > 0 ? 1 : 0))
+
+	const optionRow = twMerge(
+		'px-3 py-1.5 w-full text-left text-xs font-normal text-secondary',
+		'flex flex-row items-center gap-2 rounded-sm hover:bg-surface-hover hover:text-primary'
+	)
 </script>
 
 <button
@@ -47,17 +62,35 @@
 		use:melt={$subMenu}
 		class="z-[6000] w-48 bg-surface dark:border rounded-md shadow-md focus:outline-none py-1"
 	>
-		<!-- Rendered as plain content (not a MenuItem) so toggling a filter keeps
-		     the submenu open instead of selecting-and-closing the whole menu. -->
-		<div class="px-3 py-1.5 flex flex-col gap-2">
-			<div class="flex flex-col gap-0.5">
-				<Toggle bind:checked={showArchived} size="xs" options={{ right: 'Show archived' }} />
-				{#if archivedCount > 0}
-					<span class="text-2xs text-tertiary pl-1">
-						{archivedCount} archived session{archivedCount === 1 ? '' : 's'}
-					</span>
-				{/if}
-			</div>
+		<!-- Rendered as plain content (not MenuItems) so picking a filter keeps the
+		     submenu open instead of selecting-and-closing the whole menu. -->
+		<div class="px-3 py-1.5 flex flex-col gap-0.5">
+			<Toggle bind:checked={showArchived} size="xs" options={{ right: 'Show archived' }} />
+			{#if archivedCount > 0}
+				<span class="text-2xs text-tertiary pl-1">
+					{archivedCount} archived session{archivedCount === 1 ? '' : 's'}
+				</span>
+			{/if}
 		</div>
+		<div class="my-1 border-t border-border-light"></div>
+		<div class="px-3 pb-0.5 text-3xs text-tertiary">Last activity</div>
+		{#each LAST_ACTIVITY_OPTIONS as option (option.days)}
+			<button type="button" class={optionRow} onclick={() => (lastActivityDays = option.days)}>
+				<span class="grow truncate">{option.label}</span>
+				{#if lastActivityDays === option.days}
+					<Check size={14} class="shrink-0 text-primary" />
+				{/if}
+			</button>
+		{/each}
+		<div class="my-1 border-t border-border-light"></div>
+		<div class="px-3 pb-0.5 text-3xs text-tertiary">Group by</div>
+		{#each GROUP_BY_OPTIONS as option (option.value)}
+			<button type="button" class={optionRow} onclick={() => (groupBy = option.value)}>
+				<span class="grow truncate">{option.label}</span>
+				{#if groupBy === option.value}
+					<Check size={14} class="shrink-0 text-primary" />
+				{/if}
+			</button>
+		{/each}
 	</div>
 {/if}

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -101,6 +101,16 @@
 	// user opted out, the sidebar section is hidden entirely.
 	const globalEnabled = isGlobalAiEnabled()
 
+	// The activity cutoff and the date buckets are wall-clock reads, which Svelte
+	// cannot track: without this the list would keep a session past its cutoff, and
+	// keep yesterday's header on today's rows, until some unrelated write forced a
+	// re-derive. Ticking a tracked timestamp bounds that staleness to a minute.
+	let clock = $state(Date.now())
+	$effect(() => {
+		const handle = setInterval(() => (clock = Date.now()), 60_000)
+		return () => clearInterval(handle)
+	})
+
 	// Only highlight the active session while the sessions page is open — elsewhere
 	// `currentSessionId` lingers but no row should appear selected.
 	const onSessionsPage = $derived(page.url.pathname.startsWith(`${base}/sessions`))
@@ -167,7 +177,7 @@
 			if (s.id === sessionState.currentSessionId) return true
 			if (s.archived && !showArchived.val) return false
 			if (lastActivityDays.val > 0) {
-				const cutoff = Date.now() - lastActivityDays.val * 24 * 60 * 60 * 1000
+				const cutoff = clock - lastActivityDays.val * 24 * 60 * 60 * 1000
 				if (sessionLastActivityAt(s) < cutoff) return false
 			}
 			// Scope to the current workspace family only.
@@ -285,7 +295,7 @@
 		const byActivity = (a: Session, b: Session) =>
 			sessionLastActivityAt(b) - sessionLastActivityAt(a)
 		if (groupBy.val === 'date') {
-			const now = Date.now()
+			const now = clock
 			const buckets = new Map<string, { label: string; rank: number; sessions: Session[] }>()
 			for (const s of visibleSessions) {
 				const b = dateBucket(sessionLastActivityAt(s), now)
@@ -339,7 +349,7 @@
 			if (!s.archived || s.transient) return false
 			if (s.id === sessionState.currentSessionId) return true
 			if (lastActivityDays.val > 0) {
-				const cutoff = Date.now() - lastActivityDays.val * 24 * 60 * 60 * 1000
+				const cutoff = clock - lastActivityDays.val * 24 * 60 * 60 * 1000
 				if (sessionLastActivityAt(s) < cutoff) return false
 			}
 			const currentRoot = $currentWorkspaceRootId
@@ -866,7 +876,11 @@
 							icon: ListChecks,
 							action: enterSelectionMode,
 							separatorTop: true,
-							hide: visibleSessions.length === 0
+							// Selection is built from `visibleSessions`, which the tree render
+							// path doesn't follow — it drops workspace-less sessions and hides
+							// rows under a collapsed workspace, so "Select all" there would
+							// reach rows that never showed a checkbox.
+							hide: visibleSessions.length === 0 || workspaceTree
 						}
 					]}
 				>

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -316,10 +316,14 @@
 		return [...byWorkspace.entries()]
 			.map(([wsId, sessions]) => {
 				sessions.sort(byActivity)
+				// Sessions on a deleted fork keep its id; only a workspace the user
+				// still has can host a new session (putSession drops the rest), so
+				// `workspaceId` — which drives the header `+` — stays unset for those.
+				const known = $userWorkspaces.find((w) => w.id === wsId)
 				return {
 					key: wsId,
-					label: $userWorkspaces.find((w) => w.id === wsId)?.name || wsId || 'No workspace yet',
-					workspaceId: wsId || undefined,
+					label: known?.name || wsId || 'No workspace yet',
+					workspaceId: known ? wsId : undefined,
 					sessions,
 					showHeader: headed
 				}
@@ -327,13 +331,19 @@
 			.sort((a, b) => sessionLastActivityAt(b.sessions[0]) - sessionLastActivityAt(a.sessions[0]))
 	})
 
+	// What "Show archived" would actually reveal: every filter the list applies
+	// except the archive one, so the count never promises rows the activity
+	// cutoff would then hide.
 	const archivedCount = $derived(
 		sessionState.sessions.filter((s) => {
 			if (!s.archived || s.transient) return false
+			if (s.id === sessionState.currentSessionId) return true
+			if (lastActivityDays.val > 0) {
+				const cutoff = Date.now() - lastActivityDays.val * 24 * 60 * 60 * 1000
+				if (sessionLastActivityAt(s) < cutoff) return false
+			}
 			const currentRoot = $currentWorkspaceRootId
-			return (
-				!currentRoot || sessionRootOf(s) === currentRoot || s.id === sessionState.currentSessionId
-			)
+			return !currentRoot || sessionRootOf(s) === currentRoot
 		}).length
 	)
 
@@ -776,13 +786,14 @@
 					class="shrink-0 !w-4 !h-4 !p-0"
 					title="Select all sessions"
 				/>
-				<button
-					type="button"
-					onclick={toggleSelectAll}
-					class="text-xs text-secondary hover:text-primary whitespace-nowrap"
+				<Button
+					unifiedSize="2xs"
+					variant="subtle"
+					on:click={toggleSelectAll}
+					btnClasses="!text-xs !h-5 w-auto !px-0 text-secondary whitespace-nowrap"
 				>
 					Select all
-				</button>
+				</Button>
 				<span class="ml-auto text-2xs text-tertiary whitespace-nowrap">
 					{selectedIds.length} selected
 				</span>
@@ -1148,8 +1159,8 @@
 							{@const groupWs = groupWsId
 								? $userWorkspaces.find((w) => w.id === groupWsId)
 								: undefined}
-							<!-- Same styling as the "AI sessions" title: a group header is the
-							     section title for the rows under it. -->
+							<!-- A group header is the section title for the rows under it:
+							     plain text, no workspace icon or chip. -->
 							<div
 								class={twMerge(
 									'group flex flex-row items-center gap-1 pl-1 pr-0.5 pt-2 pb-1 min-w-0',
@@ -1167,15 +1178,17 @@
 									</Badge>
 								{/if}
 								{#if groupWsId}
-									<button
-										type="button"
-										onclick={() => createAndOpenIn(groupWsId)}
+									<Button
+										unifiedSize="xs"
+										variant="subtle"
+										iconOnly
+										startIcon={{ icon: Plus }}
+										on:click={() => createAndOpenIn(groupWsId)}
 										title="New session in {group.label}"
 										aria-label="New session in {group.label}"
-										class="ml-auto shrink-0 inline-flex items-center justify-center w-5 h-5 rounded text-tertiary opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-surface-hover hover:text-primary"
-									>
-										<Plus size={14} />
-									</button>
+										wrapperClasses="ml-auto shrink-0"
+										btnClasses="text-tertiary opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+									/>
 								{/if}
 							</div>
 						{/if}

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -34,8 +34,8 @@
 		selectSession,
 		sessionLastActivityAt,
 		sessionState,
+		setNewSessionWorkspace,
 		setSessionArchived,
-		setSessionPendingWorkspace,
 		syncWorkspaceTo,
 		type Session
 	} from './sessionState.svelte'
@@ -63,7 +63,12 @@
 	import { page } from '$app/state'
 	import { base } from '$app/paths'
 	import { devBadgeText } from '$lib/utils/devWorkspaceLabel'
-	import { GROUP_BY_OPTIONS, LAST_ACTIVITY_OPTIONS, type GroupBy } from './sessionFilters'
+	import {
+		dateBucket,
+		GROUP_BY_OPTIONS,
+		LAST_ACTIVITY_OPTIONS,
+		type GroupBy
+	} from './sessionFilters'
 
 	// The row icon only distinguishes "the session's fork workspace no longer
 	// exists" (detached) — never the fork's ahead/behind sync state, which is
@@ -139,7 +144,6 @@
 	const showArchived = useLocalStorageValue('windmill_sessions_show_archived', false, 'boolean')
 	// Hide sessions untouched for longer than this many days. 0 = no cutoff.
 	const lastActivityDays = useLocalStorageValue('windmill_sessions_last_activity_days', 0, 'number')
-	// `hint` is the compact form shown on the collapsed submenu row.
 	// How the list is carved into groups. 'none' keeps the family grouping (headers
 	// only when a second family shows up); the others always draw headers.
 	const groupBy = useLocalStorageValue<GroupBy>('windmill_sessions_group_by', 'none', 'string')
@@ -259,20 +263,6 @@
 	// Family labels are redundant when scoped to a single family — only show them
 	// if the active-session override surfaces a second family.
 	const showGroupHeaders = $derived(sessionGroups.length > 1)
-
-	// Calendar-relative bucket for a timestamp, counted from local midnight so
-	// "Today" means today's date rather than the last 24 hours.
-	function dateBucket(ts: number, now: number): { key: string; label: string; rank: number } {
-		const midnight = new Date(now)
-		midnight.setHours(0, 0, 0, 0)
-		const startOfToday = midnight.getTime()
-		const day = 24 * 60 * 60 * 1000
-		if (ts >= startOfToday) return { key: 'today', label: 'Today', rank: 0 }
-		if (ts >= startOfToday - day) return { key: 'yesterday', label: 'Yesterday', rank: 1 }
-		if (ts >= startOfToday - 7 * day) return { key: 'week', label: 'Last 7 days', rank: 2 }
-		if (ts >= startOfToday - 30 * day) return { key: 'month', label: 'Last 30 days', rank: 3 }
-		return { key: 'older', label: 'Older', rank: 4 }
-	}
 
 	// The list as the user chose to see it. `workspaceId` is set on the groups that
 	// stand for a workspace — the ones whose header offers "new session here".
@@ -420,7 +410,7 @@
 	// workspace rather than the one currently open.
 	async function createAndOpenIn(workspaceId: string) {
 		const fresh = createSession()
-		setSessionPendingWorkspace(fresh.id, workspaceId)
+		setNewSessionWorkspace(fresh.id, workspaceId)
 		await activate(fresh)
 	}
 
@@ -540,8 +530,25 @@
 
 	function handleBatchArchive() {
 		const archive = !allSelectedArchived
-		for (const id of selectedIds) setSessionArchived(id, archive)
+		let skipped = 0
+		for (const id of selectedIds) {
+			const session = sessionState.sessions.find((s) => s.id === id)
+			if (!session) continue
+			// Unarchiving a session whose fork workspace is gone can't persist (the
+			// putSession guard drops it) and reconcile would re-archive it, so the row
+			// would silently revert. Same guard as the per-row menu.
+			if (!archive && isUnavailableFork(session)) {
+				skipped++
+				continue
+			}
+			setSessionArchived(id, archive)
+		}
 		exitSelectionMode()
+		if (skipped > 0) {
+			sendUserToast(
+				`${skipped} session${skipped === 1 ? '' : 's'} kept archived: their forked workspace no longer exists`
+			)
+		}
 	}
 
 	// After deleting the open session, land somewhere usable: the newest remaining
@@ -855,15 +862,16 @@
 					]}
 				>
 					{#snippet buttonReplacement()}
-						<span
+						<Button
+							nonCaptureEvent
+							unifiedSize="md"
+							variant="subtle"
+							iconOnly
+							startIcon={{ icon: Settings }}
 							title="Session list options"
 							aria-label="Session list options"
-							class="inline-flex items-center justify-center w-5 h-5 rounded text-tertiary hover:bg-surface-hover hover:text-primary {activeFilters
-								? 'text-emphasis'
-								: ''}"
-						>
-							<Settings size={12} />
-						</span>
+							btnClasses={activeFilters ? 'text-emphasis' : ''}
+						/>
 					{/snippet}
 				</DropdownV2>
 			</div>

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -17,7 +17,6 @@
 		PencilLine,
 		Plus,
 		Rows3,
-		Settings,
 		Trash2
 	} from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
@@ -866,7 +865,7 @@
 							unifiedSize="md"
 							variant="subtle"
 							iconOnly
-							startIcon={{ icon: Settings }}
+							startIcon={{ icon: EllipsisVertical }}
 							title="Session list options"
 							aria-label="Session list options"
 							btnClasses="text-secondary"

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
 	import ConfirmationModal from '$lib/components/common/confirmationModal/ConfirmationModal.svelte'
+	import Checkbox from '$lib/components/common/checkbox/Checkbox.svelte'
+	import { Badge, Button } from '$lib/components/common'
 	import {
 		Archive,
 		ArchiveRestore,
 		Building,
 		ChevronDown,
 		ChevronRight,
+		Clock,
 		EllipsisVertical,
-		Filter,
 		GitFork,
+		ListChecks,
 		MessageSquare,
 		Pencil,
 		PencilLine,
 		Plus,
+		Rows3,
+		Settings,
 		Trash2
 	} from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
@@ -27,13 +32,14 @@
 		reconcileAfterWorkspaceChange,
 		renameSession,
 		selectSession,
+		sessionLastActivityAt,
 		sessionState,
 		setSessionArchived,
+		setSessionPendingWorkspace,
 		syncWorkspaceTo,
 		type Session
 	} from './sessionState.svelte'
 	import { unreadCountFor } from './sessionUnread.svelte'
-	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import {
 		getOrCreateRuntime,
@@ -43,7 +49,6 @@
 		resetSessionPreviewTabs
 	} from './sessionRuntime.svelte'
 	import SessionStatusDot from './SessionStatusDot.svelte'
-	import WorkspaceIcon from '$lib/components/workspace/WorkspaceIcon.svelte'
 	import { buildWorkspaceHierarchy } from '$lib/utils/workspaceHierarchy'
 	import SessionFilterMenu from './SessionFilterMenu.svelte'
 	import { Menu, Menubar, MenuItem } from '$lib/components/meltComponents'
@@ -57,6 +62,8 @@
 	import { currentWorkspaceRootId, workspaceRootId } from './sessionScope.svelte'
 	import { page } from '$app/state'
 	import { base } from '$app/paths'
+	import { devBadgeText } from '$lib/utils/devWorkspaceLabel'
+	import { GROUP_BY_OPTIONS, LAST_ACTIVITY_OPTIONS, type GroupBy } from './sessionFilters'
 
 	// The row icon only distinguishes "the session's fork workspace no longer
 	// exists" (detached) — never the fork's ahead/behind sync state, which is
@@ -130,6 +137,13 @@
 		'boolean'
 	)
 	const showArchived = useLocalStorageValue('windmill_sessions_show_archived', false, 'boolean')
+	// Hide sessions untouched for longer than this many days. 0 = no cutoff.
+	const lastActivityDays = useLocalStorageValue('windmill_sessions_last_activity_days', 0, 'number')
+	// `hint` is the compact form shown on the collapsed submenu row.
+	// How the list is carved into groups. 'none' keeps the family grouping (headers
+	// only when a second family shows up); the others always draw headers.
+	const groupBy = useLocalStorageValue<GroupBy>('windmill_sessions_group_by', 'none', 'string')
+	const activeFilters = $derived(showArchived.val || lastActivityDays.val > 0)
 	let listRoot: HTMLDivElement | undefined = $state()
 
 	// A session's family root: the stored grouping id, else derived live.
@@ -147,9 +161,13 @@
 		sessionState.sessions.filter((s) => {
 			// Pending (unsent) sessions show like any other, so several drafts can be
 			// set up in parallel; they group by pending_workspace_id via sessionRootOf.
-			// The open session always stays in the list, ignoring both filters.
+			// The open session always stays in the list, ignoring every filter.
 			if (s.id === sessionState.currentSessionId) return true
 			if (s.archived && !showArchived.val) return false
+			if (lastActivityDays.val > 0) {
+				const cutoff = Date.now() - lastActivityDays.val * 24 * 60 * 60 * 1000
+				if (sessionLastActivityAt(s) < cutoff) return false
+			}
 			// Scope to the current workspace family only.
 			const currentRoot = $currentWorkspaceRootId
 			if (currentRoot && sessionRootOf(s) !== currentRoot) return false
@@ -242,6 +260,85 @@
 	// if the active-session override surfaces a second family.
 	const showGroupHeaders = $derived(sessionGroups.length > 1)
 
+	// Calendar-relative bucket for a timestamp, counted from local midnight so
+	// "Today" means today's date rather than the last 24 hours.
+	function dateBucket(ts: number, now: number): { key: string; label: string; rank: number } {
+		const midnight = new Date(now)
+		midnight.setHours(0, 0, 0, 0)
+		const startOfToday = midnight.getTime()
+		const day = 24 * 60 * 60 * 1000
+		if (ts >= startOfToday) return { key: 'today', label: 'Today', rank: 0 }
+		if (ts >= startOfToday - day) return { key: 'yesterday', label: 'Yesterday', rank: 1 }
+		if (ts >= startOfToday - 7 * day) return { key: 'week', label: 'Last 7 days', rank: 2 }
+		if (ts >= startOfToday - 30 * day) return { key: 'month', label: 'Last 30 days', rank: 3 }
+		return { key: 'older', label: 'Older', rank: 4 }
+	}
+
+	// The list as the user chose to see it. `workspaceId` is set on the groups that
+	// stand for a workspace — the ones whose header offers "new session here".
+	type DisplayGroup = {
+		key: string
+		label: string
+		workspaceId?: string
+		sessions: Session[]
+		showHeader: boolean
+	}
+
+	const displayGroups: DisplayGroup[] = $derived.by(() => {
+		if (groupBy.val === 'none') {
+			return sessionGroups.map((g) => ({
+				key: g.rootId,
+				label: g.name,
+				workspaceId: g.rootId || undefined,
+				sessions: g.sessions,
+				showHeader: showGroupHeaders
+			}))
+		}
+		const byActivity = (a: Session, b: Session) =>
+			sessionLastActivityAt(b) - sessionLastActivityAt(a)
+		if (groupBy.val === 'date') {
+			const now = Date.now()
+			const buckets = new Map<string, { label: string; rank: number; sessions: Session[] }>()
+			for (const s of visibleSessions) {
+				const b = dateBucket(sessionLastActivityAt(s), now)
+				const entry = buckets.get(b.key)
+				if (entry) entry.sessions.push(s)
+				else buckets.set(b.key, { label: b.label, rank: b.rank, sessions: [s] })
+			}
+			return [...buckets.entries()]
+				.sort((a, b) => a[1].rank - b[1].rank)
+				.map(([key, v]) => ({
+					key,
+					label: v.label,
+					sessions: v.sessions.sort(byActivity),
+					showHeader: true
+				}))
+		}
+		// Fork: one group per actual workspace — the root and each fork stand alone,
+		// unlike the family grouping that folds a whole fork tree into its root.
+		const byWorkspace = new Map<string, Session[]>()
+		for (const s of visibleSessions) {
+			const wsId = s.workspace_id ?? s.pending_workspace_id ?? ''
+			const arr = byWorkspace.get(wsId)
+			if (arr) arr.push(s)
+			else byWorkspace.set(wsId, [s])
+		}
+		// A lone workspace names itself — its header would label the whole list.
+		const headed = byWorkspace.size > 1
+		return [...byWorkspace.entries()]
+			.map(([wsId, sessions]) => {
+				sessions.sort(byActivity)
+				return {
+					key: wsId,
+					label: $userWorkspaces.find((w) => w.id === wsId)?.name || wsId || 'No workspace yet',
+					workspaceId: wsId || undefined,
+					sessions,
+					showHeader: headed
+				}
+			})
+			.sort((a, b) => sessionLastActivityAt(b.sessions[0]) - sessionLastActivityAt(a.sessions[0]))
+	})
+
 	const archivedCount = $derived(
 		sessionState.sessions.filter((s) => {
 			if (!s.archived || s.transient) return false
@@ -319,6 +416,14 @@
 		await activate(fresh)
 	}
 
+	// The `+` on a workspace group header: a new session parked on that group's
+	// workspace rather than the one currently open.
+	async function createAndOpenIn(workspaceId: string) {
+		const fresh = createSession()
+		setSessionPendingWorkspace(fresh.id, workspaceId)
+		await activate(fresh)
+	}
+
 	let editingId: string | undefined = $state(undefined)
 	let renameDraft = $state('')
 
@@ -342,9 +447,9 @@
 	// Default off: deleting a fork workspace is destructive and not what deleting a
 	// session implies. The user can tick it in the modal to also drop the fork.
 	let deleteAlsoFork = $state(false)
-	// Fork workspace tied to `pendingDelete`, if any, and still accessible.
-	const pendingDeleteForkId = $derived.by(() => {
-		const wsId = pendingDelete?.workspace_id
+	// Fork workspace tied to a session, if any, and still accessible.
+	function forkWorkspaceIdFor(session: Session | undefined): string | undefined {
+		const wsId = session?.workspace_id
 		if (!wsId) return undefined
 		const ws = $userWorkspaces.find((w) => w.id === wsId)
 		// Fork = prefix OR parent (so an orphaned wm-fork- fork still qualifies); exclude persistent
@@ -352,7 +457,118 @@
 		if (!ws || !workspaceIsFork(wsId, $userWorkspaces)) return undefined
 		if (ws.is_dev_workspace) return undefined
 		return wsId
+	}
+	const pendingDeleteForkId = $derived(forkWorkspaceIdFor(pendingDelete))
+
+	// Batch selection: "Edit sessions" in the header menu turns the rows into
+	// checkboxes so several sessions can be deleted in one pass.
+	let selectionMode = $state(false)
+	let selectedIds = $state<string[]>([])
+	let batchDeleteOpen = $state(false)
+
+	const selectableIds = $derived(visibleSessions.map((s) => s.id))
+	const allSelected = $derived(
+		selectableIds.length > 0 && selectedIds.length === selectableIds.length
+	)
+	const selectedForkCount = $derived(
+		selectedIds.filter((id) => forkWorkspaceIdFor(sessionState.sessions.find((s) => s.id === id)))
+			.length
+	)
+	// A mixed selection archives; only an all-archived selection reads as "undo
+	// that", so that's the single case the button flips to Unarchive.
+	const allSelectedArchived = $derived(
+		selectedIds.length > 0 &&
+			selectedIds.every((id) => sessionState.sessions.find((s) => s.id === id)?.archived)
+	)
+
+	// Drop selections that left the list (archive filter flipped, workspace family
+	// switched) so the count never claims more than the visible checkboxes.
+	$effect(() => {
+		if (!selectionMode) return
+		const visible = new Set(selectableIds)
+		const pruned = selectedIds.filter((id) => visible.has(id))
+		if (pruned.length !== selectedIds.length) selectedIds = pruned
 	})
+
+	function enterSelectionMode() {
+		selectionMode = true
+		selectedIds = []
+		// Checkboxes are unreachable while the section is folded away.
+		sectionCollapsed.val = false
+	}
+
+	function exitSelectionMode() {
+		selectionMode = false
+		selectedIds = []
+		rangeAnchorId = undefined
+	}
+
+	// A checkbox's `click` carries the modifier keys and its `change` carries the
+	// state, and only `change` may drive the value — preventing the click's default
+	// leaves the input's own checked flag out of step with the prop. So the click
+	// only records whether shift was down, for the change handler that follows it.
+	let shiftHeldOnClick = false
+
+	// Anchor for shift-click: the row whose checkbox was last set, as in a file list.
+	let rangeAnchorId: string | undefined = $state(undefined)
+
+	// Every visible row in display order, which is what a shift-range spans — it
+	// runs across group boundaries, matching what the user sees.
+	const orderedIds = $derived(displayGroups.flatMap((g) => g.sessions.map((s) => s.id)))
+
+	function toggleSelected(id: string, extendRange = false) {
+		const anchor = rangeAnchorId
+		rangeAnchorId = id
+		if (extendRange && anchor && anchor !== id) {
+			const from = orderedIds.indexOf(anchor)
+			const to = orderedIds.indexOf(id)
+			if (from !== -1 && to !== -1) {
+				const range = orderedIds.slice(Math.min(from, to), Math.max(from, to) + 1)
+				const merged = new Set([...selectedIds, ...range])
+				selectedIds = orderedIds.filter((x) => merged.has(x))
+				return
+			}
+		}
+		selectedIds = selectedIds.includes(id)
+			? selectedIds.filter((x) => x !== id)
+			: [...selectedIds, id]
+	}
+
+	function toggleSelectAll() {
+		selectedIds = allSelected ? [] : [...selectableIds]
+	}
+
+	function handleBatchArchive() {
+		const archive = !allSelectedArchived
+		for (const id of selectedIds) setSessionArchived(id, archive)
+		exitSelectionMode()
+	}
+
+	// After deleting the open session, land somewhere usable: the newest remaining
+	// session, else a fresh one. The page derives the visible session from the
+	// `session_name` query, so leaving the URL on a deleted session would render
+	// its not-found state instead of a ready-to-type composer.
+	async function openReplacementSession() {
+		const next = sessionState.sessions[0]
+		if (next) await activate(next)
+		else {
+			const fresh = createSession()
+			await goto(`/sessions?session_name=${encodeURIComponent(fresh.name)}`)
+		}
+	}
+
+	// Batch delete never touches fork workspaces — same default as the single
+	// delete, where the user has to tick the fork box explicitly.
+	async function handleConfirmedBatchDelete() {
+		const ids = selectedIds
+		batchDeleteOpen = false
+		if (ids.length === 0) return
+		const current = sessionState.currentSessionId
+		const wasActive = !!current && ids.includes(current)
+		for (const id of ids) removeSession(id)
+		exitSelectionMode()
+		if (wasActive) await openReplacementSession()
+	}
 
 	async function handleConfirmedDelete() {
 		const session = pendingDelete
@@ -383,18 +599,7 @@
 		if (forkToDelete && forkParentId && $workspaceStore === forkToDelete) {
 			syncWorkspaceTo(forkParentId)
 		}
-		if (wasActive) {
-			const next = sessionState.sessions[0]
-			if (next) await activate(next)
-			else {
-				// No sessions left — create a fresh one and navigate to it. The page
-				// derives the visible session from the `session_name` query, so just
-				// clearing currentSessionId would strand the URL on the deleted session
-				// and render its not-found state instead of a ready-to-type composer.
-				const fresh = createSession()
-				await goto(`/sessions?session_name=${encodeURIComponent(fresh.name)}`)
-			}
-		}
+		if (wasActive) await openReplacementSession()
 	}
 
 	function focusAt(index: number) {
@@ -436,6 +641,14 @@
 	     explanatory message, mirroring the sidebar AI chat. -->
 {:else if isCollapsed}
 	<div class={embedded ? '' : 'px-2 pt-3 pb-2 border-b border-light'}>
+		<MenuButton
+			stopPropagationOnClick={true}
+			on:click={createAndOpen}
+			{isCollapsed}
+			icon={Plus}
+			label="New session"
+			class="!text-xs"
+		/>
 		<Menubar>
 			{#snippet children({ createMenu })}
 				<Menu {createMenu} usePointerDownOutside submenuSafe>
@@ -470,18 +683,20 @@
 								<SessionFilterMenu
 									{builders}
 									bind:showArchived={showArchived.val}
+									bind:lastActivityDays={lastActivityDays.val}
+									bind:groupBy={groupBy.val}
 									{archivedCount}
 								/>
 							</div>
 							<div class="py-1" role="none">
-								{#each sessionGroups as group (group.rootId)}
-									{#if showGroupHeaders}
+								{#each displayGroups as group (group.key)}
+									{#if group.showHeader}
 										<div
-											class="px-3 pt-1.5 pb-0.5 text-[0.5rem] uppercase text-tertiary truncate"
+											class="px-3 pt-1.5 pb-0.5 text-3xs text-tertiary truncate"
 											role="none"
-											title={group.name}
+											title={group.label}
 										>
-											{group.name}
+											{group.label}
 										</div>
 									{/if}
 									{#each group.sessions as session (session.id)}
@@ -545,79 +760,144 @@
 			? 'border-b border-light'
 			: ''}"
 	>
-		<div class="flex flex-row items-center justify-between pl-1 pr-0.5">
-			{#if collapsible && visibleSessions.length > 0}
+		<!-- Selection mode reuses the New session row (same h-8 slot, same px-2) so
+		     the list below it never moves. -->
+		{#if selectionMode}
+			<div class="flex flex-row items-center gap-1.5 h-8 px-2">
+				<Checkbox
+					checked={allSelected}
+					indeterminate={selectedIds.length > 0 && !allSelected}
+					onChange={toggleSelectAll}
+					class="shrink-0 !w-4 !h-4 !p-0"
+					title="Select all sessions"
+				/>
+				<button
+					type="button"
+					onclick={toggleSelectAll}
+					class="text-xs text-secondary hover:text-primary whitespace-nowrap"
+				>
+					Select all
+				</button>
+				<span class="ml-auto text-2xs text-tertiary whitespace-nowrap">
+					{selectedIds.length} selected
+				</span>
+				<Button
+					unifiedSize="2xs"
+					variant="subtle"
+					btnClasses="!text-2xs !h-5 w-auto"
+					onClick={exitSelectionMode}
+				>
+					Done
+				</Button>
+			</div>
+		{:else}
+			<!-- The submenu collapses to one row, so the picked cutoff would otherwise
+			     only be visible after opening it. -->
+			{#snippet lastActivityHint()}
+				<span class="text-2xs text-tertiary whitespace-nowrap">
+					{LAST_ACTIVITY_OPTIONS.find((o) => o.days === lastActivityDays.val)?.hint ?? ''}
+				</span>
+			{/snippet}
+			{#snippet groupByHint()}
+				<span class="text-2xs text-tertiary whitespace-nowrap">
+					{GROUP_BY_OPTIONS.find((o) => o.value === groupBy.val)?.hint ?? ''}
+				</span>
+			{/snippet}
+			<div class="flex flex-row items-center gap-0.5 pr-0.5">
+				<div class="flex-1 min-w-0">
+					<MenuButton
+						stopPropagationOnClick={true}
+						on:click={createAndOpen}
+						isCollapsed={false}
+						icon={Plus}
+						label="New session"
+						class="!text-xs"
+					/>
+				</div>
+				<DropdownV2
+					fixedHeight={false}
+					placement="bottom-end"
+					enableFlyTransition
+					items={[
+						{
+							displayName: archivedCount > 0 ? `Show archived (${archivedCount})` : 'Show archived',
+							icon: Archive,
+							toggle: showArchived.val,
+							action: () => (showArchived.val = !showArchived.val)
+						},
+						{
+							displayName: 'Last activity',
+							icon: Clock,
+							extra: lastActivityHint,
+							submenuItems: LAST_ACTIVITY_OPTIONS.map((o) => ({
+								displayName: o.label,
+								selected: lastActivityDays.val === o.days,
+								action: () => (lastActivityDays.val = o.days)
+							}))
+						},
+						{
+							displayName: 'Group by',
+							icon: Rows3,
+							extra: groupByHint,
+							submenuItems: GROUP_BY_OPTIONS.map((o) => ({
+								displayName: o.label,
+								selected: groupBy.val === o.value,
+								action: () => (groupBy.val = o.value)
+							}))
+						},
+						{
+							displayName: 'Edit sessions',
+							icon: ListChecks,
+							action: enterSelectionMode,
+							separatorTop: true,
+							hide: visibleSessions.length === 0
+						}
+					]}
+				>
+					{#snippet buttonReplacement()}
+						<span
+							title="Session list options"
+							aria-label="Session list options"
+							class="inline-flex items-center justify-center w-5 h-5 rounded text-tertiary hover:bg-surface-hover hover:text-primary {activeFilters
+								? 'text-emphasis'
+								: ''}"
+						>
+							<Settings size={12} />
+						</span>
+					{/snippet}
+				</DropdownV2>
+			</div>
+		{/if}
+		{#if collapsible}
+			<!-- Only the collapsible sidebar section needs a title: it doubles as the
+			     fold toggle. In the rail the list owns the pane, so the label is noise. -->
+			<div class="flex flex-row items-center pl-1 pr-0.5">
 				<button
 					type="button"
 					onclick={() => (sectionCollapsed.val = !sectionCollapsed.val)}
 					class="text-secondary text-[0.5rem] uppercase flex flex-row items-center gap-1 rounded px-1 -mx-1 py-0.5 hover:bg-surface-hover focus:outline-none"
 					aria-expanded={!sectionCollapsed.val}
+					disabled={visibleSessions.length === 0}
 				>
 					AI sessions
-					{#if sectionCollapsed.val}
-						<ChevronRight size={10} />
-					{:else}
-						<ChevronDown size={10} />
+					{#if visibleSessions.length > 0}
+						{#if sectionCollapsed.val}
+							<ChevronRight size={10} />
+						{:else}
+							<ChevronDown size={10} />
+						{/if}
 					{/if}
 				</button>
-			{:else}
-				<!-- No sessions yet: render the label as plain text (no collapse toggle). -->
-				<span
-					class="text-secondary text-[0.5rem] uppercase flex flex-row items-center gap-1 px-1 -mx-1 py-0.5"
-				>
-					AI sessions
-				</span>
-			{/if}
-			<div class="flex flex-row items-center gap-0.5">
-				<button
-					type="button"
-					title="New session"
-					aria-label="New session"
-					onclick={createAndOpen}
-					class="inline-flex items-center justify-center w-5 h-5 rounded text-tertiary hover:bg-surface-hover hover:text-primary"
-				>
-					<Plus size={12} />
-				</button>
-				<Popover placement="bottom-end" usePointerDownOutside disableFocusTrap class="inline-flex">
-					{#snippet trigger()}
-						<button
-							type="button"
-							title="Filter sessions"
-							aria-label="Filter sessions"
-							class="inline-flex items-center justify-center w-5 h-5 rounded text-tertiary hover:bg-surface-hover hover:text-primary {showArchived.val
-								? 'text-emphasis'
-								: ''}"
-						>
-							<Filter size={12} />
-						</button>
-					{/snippet}
-					{#snippet content()}
-						<div
-							class="w-56 p-2 bg-surface-tertiary dark:border rounded-md shadow-lg flex flex-col gap-2"
-						>
-							<div class="flex flex-col gap-0.5">
-								<Toggle
-									bind:checked={showArchived.val}
-									size="xs"
-									options={{ right: 'Show archived' }}
-								/>
-								{#if archivedCount > 0}
-									<span class="text-2xs text-tertiary pl-1">
-										{archivedCount} archived session{archivedCount === 1 ? '' : 's'}
-									</span>
-								{/if}
-							</div>
-						</div>
-					{/snippet}
-				</Popover>
 			</div>
-		</div>
+		{/if}
 		{#if !collapsible || !sectionCollapsed.val}
 			<div
 				bind:this={listRoot}
 				transition:slide={{ duration: 180 }}
 				class={twMerge(
 					'flex flex-col gap-0.5 overflow-y-auto',
+					// Shift-clicking rows would otherwise paint a text selection across them.
+					selectionMode ? 'select-none' : '',
 					// In the rail the picker is the whole list and the rail scrolls;
 					// only cap height when it's one section among others (normal sidebar).
 					collapsible ? 'max-h-[40vh]' : ''
@@ -638,18 +918,36 @@
 					{@const isEditing = editingId === session.id}
 					{@const unread = unreadFor(session)}
 					{@const draft = hasDraft(session)}
+					{@const isChecked = selectedIds.includes(session.id)}
 					<div
 						class={twMerge(
 							'flex flex-row group rounded',
 							treeDepth === undefined ? 'items-center' : 'items-stretch',
 							isSelected ? sidebarClasses.selectedBg : 'hover:bg-surface-hover',
 							session.archived ? 'opacity-60' : '',
-							// Family mode indents under the header; tree mode uses guide columns.
-							treeDepth === undefined && indented ? 'pl-5' : ''
+							// Grouped rows sit slightly in from their header; tree mode uses guide columns.
+							treeDepth === undefined && indented ? 'pl-1' : ''
 						)}
 					>
 						{#if treeDepth !== undefined}
 							{#each Array(treeDepth) as _}{@render vline()}{/each}
+						{/if}
+						{#if selectionMode}
+							<!-- Takes over the status-dot slot exactly (pl-2 + 16px, the row button's
+							     own px-2 supplying the trailing gap), so entering selection mode
+							     doesn't shift a single row label sideways. -->
+							<span class="flex items-center pl-2">
+								<Checkbox
+									checked={isChecked}
+									onChange={() => {
+										toggleSelected(session.id, shiftHeldOnClick)
+										shiftHeldOnClick = false
+									}}
+									onClick={(e) => (shiftHeldOnClick = e.shiftKey)}
+									class="shrink-0 !w-4 !h-4 !p-0"
+									title={session.summary ?? 'Untitled session'}
+								/>
+							</span>
 						{/if}
 						{#if isEditing}
 							<span class="flex flex-row items-center gap-2 flex-1 px-2 py-1 min-w-0">
@@ -683,14 +981,15 @@
 								type="button"
 								data-session-button
 								role="option"
-								aria-selected={isSelected}
-								onclick={() => activate(session)}
+								aria-selected={selectionMode ? isChecked : isSelected}
+								onclick={(e) =>
+									selectionMode ? toggleSelected(session.id, e.shiftKey) : activate(session)}
 								class={twMerge(
 									'flex flex-row items-center gap-2 text-left text-xs font-normal focus:outline-none flex-1 min-w-0 px-2 py-1',
 									isSelected ? sidebarClasses.selectedText : 'text-secondary'
 								)}
 							>
-								{#if treeDepth === undefined}
+								{#if treeDepth === undefined && !selectionMode}
 									<SessionStatusDot
 										{status}
 										isFork={isForkFor(session)}
@@ -714,8 +1013,15 @@
 									</span>
 								{/if}
 							</button>
+							<!-- Hidden rather than dropped while selecting: removing it would widen
+							     every label and re-truncate the list. -->
 							<div
-								class="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity pr-0.5"
+								class={twMerge(
+									'transition-opacity pr-0.5',
+									selectionMode
+										? 'invisible pointer-events-none'
+										: 'opacity-0 group-hover:opacity-100 focus-within:opacity-100'
+								)}
 							>
 								<DropdownV2
 									fixedHeight={false}
@@ -830,27 +1136,72 @@
 						{/if}
 					{/each}
 				{:else}
-					{#each sessionGroups as group, groupIdx (group.rootId)}
-						{#if showGroupHeaders}
-							{@const groupWs = $userWorkspaces.find((w) => w.id === group.rootId)}
+					{#each displayGroups as group, groupIdx (group.key)}
+						{#if group.showHeader}
+							{@const groupWsId = group.workspaceId}
+							{@const groupWs = groupWsId
+								? $userWorkspaces.find((w) => w.id === groupWsId)
+								: undefined}
+							<!-- Same styling as the "AI sessions" title: a group header is the
+							     section title for the rows under it. -->
 							<div
 								class={twMerge(
-									'flex items-center gap-2 px-2 pt-2 pb-1 min-w-0',
-									// Space families apart so group boundaries read clearly.
+									'group flex flex-row items-center gap-1 pl-1 pr-0.5 pt-2 pb-1 min-w-0',
+									// Space groups apart so their boundaries read clearly.
 									groupIdx > 0 ? 'mt-4' : ''
 								)}
-								title={group.name}
+								title={group.label}
 							>
-								<WorkspaceIcon workspaceColor={groupWs?.color} size={12} />
-								<span class="text-xs font-medium text-secondary truncate">{group.name}</span>
+								<span class="text-secondary text-3xs truncate min-w-0">
+									{group.label}
+								</span>
+								{#if groupWs?.is_dev_workspace}
+									<Badge color="gray" small class="text-3xs px-1 py-0 shrink-0">
+										{devBadgeText(groupWs.dev_workspace_label)}
+									</Badge>
+								{/if}
+								{#if groupWsId}
+									<button
+										type="button"
+										onclick={() => createAndOpenIn(groupWsId)}
+										title="New session in {group.label}"
+										aria-label="New session in {group.label}"
+										class="ml-auto shrink-0 inline-flex items-center justify-center w-5 h-5 rounded text-tertiary opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-surface-hover hover:text-primary"
+									>
+										<Plus size={14} />
+									</button>
+								{/if}
 							</div>
 						{/if}
 						{#each group.sessions as session (session.id)}
-							{@render sessionRow(session, showGroupHeaders, undefined)}
+							{@render sessionRow(session, group.showHeader, undefined)}
 						{/each}
 					{/each}
 				{/if}
 			</div>
+			{#if selectionMode}
+				<div class="flex flex-col gap-1 px-1 pt-1.5">
+					<Button
+						unifiedSize="xs"
+						variant="default"
+						disabled={selectedIds.length === 0}
+						startIcon={{ icon: allSelectedArchived ? ArchiveRestore : Archive }}
+						onClick={handleBatchArchive}
+					>
+						{allSelectedArchived ? 'Unarchive' : 'Archive'}
+					</Button>
+					<Button
+						unifiedSize="xs"
+						variant="default"
+						destructive
+						disabled={selectedIds.length === 0}
+						startIcon={{ icon: Trash2 }}
+						onClick={() => (batchDeleteOpen = true)}
+					>
+						Delete
+					</Button>
+				</div>
+			{/if}
 		{/if}
 	</div>
 {/if}
@@ -883,6 +1234,31 @@
 					>
 				</div>
 			</div>
+		{/if}
+	</div>
+</ConfirmationModal>
+
+<ConfirmationModal
+	open={batchDeleteOpen}
+	title="Delete sessions"
+	confirmationText="Delete"
+	onConfirmed={handleConfirmedBatchDelete}
+	onCanceled={() => (batchDeleteOpen = false)}
+>
+	<div class="flex flex-col gap-3">
+		<p>
+			Delete <span class="font-medium text-primary"
+				>{selectedIds.length} session{selectedIds.length === 1 ? '' : 's'}</span
+			>? This cannot be undone.
+		</p>
+		{#if selectedForkCount > 0}
+			<p class="text-xs text-tertiary">
+				{selectedForkCount} of them {selectedForkCount === 1 ? 'has a' : 'have'} forked workspace{selectedForkCount ===
+				1
+					? ''
+					: 's'}, which {selectedForkCount === 1 ? 'is' : 'are'} kept. Delete a session on its own to
+				drop its fork too.
+			</p>
 		{/if}
 	</div>
 </ConfirmationModal>

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -823,6 +823,7 @@
 					fixedHeight={false}
 					placement="bottom-end"
 					enableFlyTransition
+					customWidth={180}
 					items={[
 						{
 							displayName: archivedCount > 0 ? `Show archived (${archivedCount})` : 'Show archived',

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -147,7 +147,6 @@
 	// How the list is carved into groups. 'none' keeps the family grouping (headers
 	// only when a second family shows up); the others always draw headers.
 	const groupBy = useLocalStorageValue<GroupBy>('windmill_sessions_group_by', 'none', 'string')
-	const activeFilters = $derived(showArchived.val || lastActivityDays.val > 0)
 	let listRoot: HTMLDivElement | undefined = $state()
 
 	// A session's family root: the stored grouping id, else derived live.
@@ -870,7 +869,7 @@
 							startIcon={{ icon: Settings }}
 							title="Session list options"
 							aria-label="Session list options"
-							btnClasses={activeFilters ? 'text-emphasis' : 'text-secondary'}
+							btnClasses="text-secondary"
 						/>
 					{/snippet}
 				</DropdownV2>

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -870,7 +870,7 @@
 							startIcon={{ icon: Settings }}
 							title="Session list options"
 							aria-label="Session list options"
-							btnClasses={activeFilters ? 'text-emphasis' : ''}
+							btnClasses={activeFilters ? 'text-emphasis' : 'text-secondary'}
 						/>
 					{/snippet}
 				</DropdownV2>

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -823,7 +823,6 @@
 					fixedHeight={false}
 					placement="bottom-end"
 					enableFlyTransition
-					customWidth={180}
 					items={[
 						{
 							displayName: archivedCount > 0 ? `Show archived (${archivedCount})` : 'Show archived',

--- a/frontend/src/lib/components/sessions/sessionFilters.test.ts
+++ b/frontend/src/lib/components/sessions/sessionFilters.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { dateBucket } from './sessionFilters'
+
+// Buckets are anchored on local midnight, so the boundaries are the part that
+// can silently drift: a timestamp must land in exactly one bucket, and the one
+// the label claims.
+describe('dateBucket', () => {
+	const now = new Date(2026, 7, 19, 14, 30).getTime()
+	const startOfToday = new Date(2026, 7, 19, 0, 0, 0, 0).getTime()
+	const day = 24 * 60 * 60 * 1000
+
+	it('splits today from yesterday at local midnight', () => {
+		expect(dateBucket(startOfToday, now).key).toBe('today')
+		expect(dateBucket(startOfToday - 1, now).key).toBe('yesterday')
+	})
+
+	it('closes each window on its own boundary', () => {
+		expect(dateBucket(startOfToday - day, now).key).toBe('yesterday')
+		expect(dateBucket(startOfToday - day - 1, now).key).toBe('week')
+		expect(dateBucket(startOfToday - 7 * day, now).key).toBe('week')
+		expect(dateBucket(startOfToday - 7 * day - 1, now).key).toBe('month')
+		expect(dateBucket(startOfToday - 30 * day, now).key).toBe('month')
+		expect(dateBucket(startOfToday - 30 * day - 1, now).key).toBe('older')
+	})
+
+	it('ranks buckets newest-first', () => {
+		const ranks = [
+			dateBucket(now, now),
+			dateBucket(startOfToday - 1, now),
+			dateBucket(startOfToday - 2 * day, now),
+			dateBucket(startOfToday - 10 * day, now),
+			dateBucket(startOfToday - 100 * day, now)
+		].map((b) => b.rank)
+		expect(ranks).toEqual([0, 1, 2, 3, 4])
+	})
+})

--- a/frontend/src/lib/components/sessions/sessionFilters.test.ts
+++ b/frontend/src/lib/components/sessions/sessionFilters.test.ts
@@ -23,6 +23,24 @@ describe('dateBucket', () => {
 		expect(dateBucket(startOfToday - 30 * day - 1, now).key).toBe('older')
 	})
 
+	// A local day is 23h long across the spring-forward transition, so boundaries
+	// derived by subtracting a fixed 24h land an hour before midnight and pull the
+	// first hour of a day into the older bucket.
+	it('keeps boundaries on local midnight across a DST change', () => {
+		const original = process.env.TZ
+		process.env.TZ = 'Europe/Paris'
+		try {
+			// Paris springs forward at 02:00 on 2026-03-29, so from the 30th a naive
+			// -24h lands at 23:00 on the 28th instead of midnight on the 29th.
+			const dstNow = new Date(2026, 2, 30, 12, 0).getTime()
+			const startOfYesterday = new Date(2026, 2, 29, 0, 0, 0, 0).getTime()
+			expect(dateBucket(startOfYesterday, dstNow).key).toBe('yesterday')
+			expect(dateBucket(startOfYesterday - 1, dstNow).key).toBe('week')
+		} finally {
+			process.env.TZ = original
+		}
+	})
+
 	it('ranks buckets newest-first', () => {
 		const ranks = [
 			dateBucket(now, now),

--- a/frontend/src/lib/components/sessions/sessionFilters.ts
+++ b/frontend/src/lib/components/sessions/sessionFilters.ts
@@ -1,0 +1,17 @@
+// Filter and grouping options for the session list, shared by the expanded
+// picker header and the collapsed rail's menu so both offer the same choices.
+
+export const LAST_ACTIVITY_OPTIONS: { days: number; label: string; hint: string }[] = [
+	{ days: 0, label: 'Any time', hint: 'Any' },
+	{ days: 7, label: 'Last 7 days', hint: '7d' },
+	{ days: 30, label: 'Last 30 days', hint: '30d' },
+	{ days: 90, label: 'Last 90 days', hint: '90d' }
+]
+
+export type GroupBy = 'none' | 'date' | 'fork'
+
+export const GROUP_BY_OPTIONS: { value: GroupBy; label: string; hint: string }[] = [
+	{ value: 'none', label: 'None', hint: 'None' },
+	{ value: 'date', label: 'Date', hint: 'Date' },
+	{ value: 'fork', label: 'Workspace fork', hint: 'Fork' }
+]

--- a/frontend/src/lib/components/sessions/sessionFilters.ts
+++ b/frontend/src/lib/components/sessions/sessionFilters.ts
@@ -15,3 +15,23 @@ export const GROUP_BY_OPTIONS: { value: GroupBy; label: string; hint: string }[]
 	{ value: 'date', label: 'Date', hint: 'Date' },
 	{ value: 'fork', label: 'Workspace fork', hint: 'Fork' }
 ]
+
+/**
+ * Calendar-relative bucket for a timestamp, counted from local midnight so
+ * "Today" means today's date rather than the last 24 hours. `rank` orders the
+ * buckets newest-first.
+ */
+export function dateBucket(
+	ts: number,
+	now: number
+): { key: string; label: string; rank: number } {
+	const midnight = new Date(now)
+	midnight.setHours(0, 0, 0, 0)
+	const startOfToday = midnight.getTime()
+	const day = 24 * 60 * 60 * 1000
+	if (ts >= startOfToday) return { key: 'today', label: 'Today', rank: 0 }
+	if (ts >= startOfToday - day) return { key: 'yesterday', label: 'Yesterday', rank: 1 }
+	if (ts >= startOfToday - 7 * day) return { key: 'week', label: 'Last 7 days', rank: 2 }
+	if (ts >= startOfToday - 30 * day) return { key: 'month', label: 'Last 30 days', rank: 3 }
+	return { key: 'older', label: 'Older', rank: 4 }
+}

--- a/frontend/src/lib/components/sessions/sessionFilters.ts
+++ b/frontend/src/lib/components/sessions/sessionFilters.ts
@@ -17,21 +17,26 @@ export const GROUP_BY_OPTIONS: { value: GroupBy; label: string; hint: string }[]
 ]
 
 /**
+ * Local midnight `daysAgo` calendar days before `now`. Stepping the date field
+ * rather than subtracting 24h keeps the boundary on midnight across a DST
+ * change, where a local day is 23 or 25 hours long.
+ */
+function startOfDayBefore(now: number, daysAgo: number): number {
+	const d = new Date(now)
+	d.setDate(d.getDate() - daysAgo)
+	d.setHours(0, 0, 0, 0)
+	return d.getTime()
+}
+
+/**
  * Calendar-relative bucket for a timestamp, counted from local midnight so
  * "Today" means today's date rather than the last 24 hours. `rank` orders the
  * buckets newest-first.
  */
-export function dateBucket(
-	ts: number,
-	now: number
-): { key: string; label: string; rank: number } {
-	const midnight = new Date(now)
-	midnight.setHours(0, 0, 0, 0)
-	const startOfToday = midnight.getTime()
-	const day = 24 * 60 * 60 * 1000
-	if (ts >= startOfToday) return { key: 'today', label: 'Today', rank: 0 }
-	if (ts >= startOfToday - day) return { key: 'yesterday', label: 'Yesterday', rank: 1 }
-	if (ts >= startOfToday - 7 * day) return { key: 'week', label: 'Last 7 days', rank: 2 }
-	if (ts >= startOfToday - 30 * day) return { key: 'month', label: 'Last 30 days', rank: 3 }
+export function dateBucket(ts: number, now: number): { key: string; label: string; rank: number } {
+	if (ts >= startOfDayBefore(now, 0)) return { key: 'today', label: 'Today', rank: 0 }
+	if (ts >= startOfDayBefore(now, 1)) return { key: 'yesterday', label: 'Yesterday', rank: 1 }
+	if (ts >= startOfDayBefore(now, 7)) return { key: 'week', label: 'Last 7 days', rank: 2 }
+	if (ts >= startOfDayBefore(now, 30)) return { key: 'month', label: 'Last 30 days', rank: 3 }
 	return { key: 'older', label: 'Older', rank: 4 }
 }

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -110,6 +110,12 @@ export type Session = {
 	// untouched draft never persists, so idle `+` clicks vanish on reload
 	// instead of littering the sidebar.
 	transient?: boolean
+	// Epoch ms of the last write to this record — typing, renaming, opening the
+	// session, archiving, changing preview tabs. Stamped by the two write funnels
+	// (persistTouched, markSessionSeen), so it tracks use rather than creation.
+	// Absent on records last written before the field existed; readers fall back
+	// to createdAt via sessionLastActivityAt.
+	lastActivityAt?: number
 	// Per-session unread watermark: the displayMessages count the last time
 	// the user was on this session's page. Compared against the runtime's
 	// current message count to derive the unread badge (see sessionUnread).
@@ -354,7 +360,14 @@ export function getSessionDraftPrompt(sessionId: string): string | undefined {
 // directly, so an untouched draft stays in memory and vanishes on reload.
 function persistTouched(s: Session): void {
 	if (s.transient) delete s.transient
+	s.lastActivityAt = Date.now()
 	void putSession(s)
+}
+
+// When the session was last used. Pre-dates-the-field records report their
+// creation time, which is the earliest activity they could have had.
+export function sessionLastActivityAt(s: Session): number {
+	return s.lastActivityAt ?? s.createdAt
 }
 
 // Sessions whose record has been removed from IndexedDB. Ids come from createLongHash

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -110,9 +110,11 @@ export type Session = {
 	// untouched draft never persists, so idle `+` clicks vanish on reload
 	// instead of littering the sidebar.
 	transient?: boolean
-	// Epoch ms of the last write to this record — typing, renaming, opening the
-	// session, archiving, changing preview tabs. Stamped by the two write funnels
-	// (persistTouched, markSessionSeen), so it tracks use rather than creation.
+	// Epoch ms of the last write to this record — typing, renaming, archiving,
+	// changing preview tabs, or catching up on new messages. Stamped by the two
+	// write funnels (persistTouched, markSessionSeen), so it tracks use rather
+	// than creation; merely opening a session without reading anything new is not
+	// a write and does not bump it.
 	// Absent on records last written before the field existed; readers fall back
 	// to createdAt via sessionLastActivityAt.
 	lastActivityAt?: number
@@ -786,6 +788,17 @@ export function setSessionPendingWorkspace(id: string, workspace_id: string) {
 	// Picking an existing workspace cancels any pending fork intent.
 	s.pending_fork = undefined
 	if (changed) persistTouched(s)
+}
+
+// Park a just-created session on a workspace. Deliberately does not persist a
+// still-transient draft: picking where it will live is part of creating it, not a
+// user touch, so an unused draft still vanishes on reload (see `transient`).
+export function setNewSessionWorkspace(id: string, workspace_id: string) {
+	const s = sessionState.sessions.find((x) => x.id === id)
+	if (!s) return
+	s.pending_workspace_id = workspace_id
+	s.pending_fork = undefined
+	if (!s.transient) persistTouched(s)
 }
 
 // Records the user's intent to create a new fork without firing the API

--- a/frontend/src/lib/components/sessions/sessionUnread.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionUnread.svelte.ts
@@ -14,6 +14,9 @@ export function markSessionSeen(sessionId: string, count: number) {
 	if (!s) return
 	if ((s.lastSeenCount ?? 0) >= count) return
 	s.lastSeenCount = count
+	// Reading a session's new messages is activity — the last-activity filter
+	// would otherwise only see edits to the record.
+	s.lastActivityAt = Date.now()
 	void putSession(s)
 }
 


### PR DESCRIPTION
## Summary

Batch editing, filtering and grouping for the AI sessions sidebar. Sessions could only be
renamed, archived or deleted one at a time from the per-row menu, and the list was a single
flat run. This adds a selection mode with batch archive/unarchive and delete, a last-activity
filter, and a Group by choice (none / date / workspace fork). Everything lives behind one
options menu next to a standalone **New session** button, and every option is also reachable
from the collapsed rail.

## Changes

- **Selection mode** ("Edit sessions" in the options menu): per-row checkboxes, select-all,
  shift-click range selection, and batch **Archive/Unarchive** + **Delete** (with a
  confirmation modal). Entering it causes no layout shift — the checkbox takes over the
  16px status-dot slot and the toolbar reuses the New session row.
- **Last activity filter** — Any time / 7 / 30 / 90 days, hiding sessions untouched for longer.
  Backed by a new `lastActivityAt` on the session record, stamped by the two write funnels
  (`persistTouched`, `markSessionSeen`) with a `createdAt` fallback for older records.
- **Group by** — None (family grouping, as before), Date buckets, or Workspace fork. Fork
  groups get a plain-text header, a gray `dev` badge for dev workspaces, and a hover `+`
  that creates a session parked on that workspace. The header is dropped when there is only
  one fork.
- **New session** is now a standalone sidebar button (`MenuButton`), present collapsed too;
  the options `⋮` sits next to it at the same 32px height.
- The collapsed rail's `SessionFilterMenu` offers the same archived / last-activity /
  group-by choices, bound to the same values.
- All three choices persist in localStorage: `windmill_sessions_show_archived`,
  `windmill_sessions_last_activity_days`, `windmill_sessions_group_by`.
- `dateBucket` moved out of the component into `sessionFilters.ts` with a unit test pinning
  the local-midnight boundaries.

## Screenshots

Grouped by workspace fork, with the New session button and options menu:

![sidebar grouped by fork](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-batch-session-handling/1787210526-grouped-crop.png)

Options menu, showing the selected last-activity and group-by values as hints:

![options menu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-batch-session-handling/1787210533-menu2-crop.png)

Selection mode after a shift-click range across two groups — rows sit at the same positions
as above:

![selection mode](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-batch-session-handling/1787210529-edit-crop.png)

## Test plan

- [ ] Sidebar → `⋮` → **Edit sessions**: select rows, shift-click to extend a range, use
      **Select all**, then **Archive** and **Delete**; **Done** exits without layout shift.
- [ ] Batch **Archive** then **Unarchive** the same selection — both persist across a reload.
- [ ] `⋮` → **Last activity** → 7 days hides older sessions; the choice survives a reload.
- [ ] `⋮` → **Group by** → Workspace fork shows one header per fork (none when a single fork);
      hovering a header shows `+`, which creates a session on that workspace — and that
      still-untouched draft disappears on reload.
- [ ] Collapse the sidebar: the same filters are reachable from the rail's filter submenu.
- [ ] `npx vitest run src/lib/components/sessions/sessionFilters.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
