### PR TITLE
docs: document DATABASE_URL_FILE in the env var help

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -568,6 +568,7 @@ fn print_help() {
     println!();
     println!("Environment variables (name = default):");
     println!("  DATABASE_URL = <required>              The Postgres database url.");
+    println!("  DATABASE_URL_FILE = None               Read the database url from a file instead, e.g. a mounted secret (takes precedence over DATABASE_URL)");
     println!("  MODE = standalone                      Mode: standalone | worker | server | agent");
     println!("  BASE_URL = http://localhost:8000       Public base URL of your instance (overridden by instance settings)");
     println!(


### PR DESCRIPTION
## Summary

`DATABASE_URL_FILE` has been supported by `get_database_url` for a long time and takes precedence over `DATABASE_URL`, but it is not mentioned in `windmill --help`, so deployments that need the connection string out of the environment cannot discover it.

It is the supported answer for the Kubernetes compliance baselines that disallow secrets in a pod spec, and the chart change in windmill-labs/windmill-helm-charts#681 builds on it.

## Changes

- One line in `print_help` documenting `DATABASE_URL_FILE` and its precedence.

## Test plan

- [x] `cargo check --features quickjs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document `DATABASE_URL_FILE` in the CLI help and state that it overrides `DATABASE_URL`, so operators can use file-based database URLs via mounted secrets. Previously the help only listed `DATABASE_URL`; now it lists `DATABASE_URL_FILE` and its precedence.

- No behavior change; `get_database_url` already preferred `DATABASE_URL_FILE`.
- Supports Kubernetes compliance baselines that avoid secrets in pod specs and aligns with `windmill-helm-charts`.

<sup>Written for commit 652c3e641207e8d5356195ac4bbd8983bb3f10dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

