### PR TITLE
fix: gate the chat's open_page on the operating workspace's role

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -73,8 +73,20 @@ vi.mock('$lib/stores', () => {
 				return () => undefined
 			}
 		},
-		userStore: readable({ username: 'admin', email: 'admin@test', is_admin: true }),
-		// Read eagerly at module load by the open_page tool's allowedOpenPages /
+		// `workspace_id` tracks the mocked active workspace: allowedOpenPages compares the
+		// two, and on a mismatch fetches `whoami` for the workspace it gates.
+		userStore: {
+			subscribe: (run: (value: unknown) => void) => {
+				run({
+					username: 'admin',
+					email: 'admin@test',
+					is_admin: true,
+					workspace_id: mocks.workspace
+				})
+				return () => undefined
+			}
+		},
+		// Read eagerly at module load by the open_page tool's restrictedOpenPages /
 		// allowedTriggerKinds / allowsAllWorkspacesRuns (global/core.ts) as the manager's
 		// tools are built.
 		superadmin: readable(false),

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -30,17 +30,21 @@ vi.mock('$lib/components/vscode', () => ({}))
 // drafts through DraftService (no in-tab cell in unit tests), so this Map is the
 // source of truth the write/read tools round-trip against. `vi.hoisted` makes it
 // available inside the hoisted `vi.mock` factory and the test body alike.
-const { backendDrafts, serverTimestamps, failingWrites, failingReads } = vi.hoisted(() => ({
-	backendDrafts: new Map<string, unknown>(),
-	// Per-row server timestamp, only set by tests that want to simulate a
-	// concurrent writer advancing the row; otherwise empty, so the conflict
-	// branch in `updateDraft` stays inert for every pre-existing test.
-	serverTimestamps: new Map<string, string>(),
-	// Keys whose `updateDraft` / draft reads throw a non-404 (network/5xx);
-	// only set by the error-handling tests, empty otherwise.
-	failingWrites: new Set<string>(),
-	failingReads: new Set<string>()
-}))
+const { backendDrafts, serverTimestamps, failingWrites, failingReads, whoamiByWorkspace } =
+	vi.hoisted(() => ({
+		backendDrafts: new Map<string, unknown>(),
+		// What `whoami` answers with, per workspace; a workspace absent from it throws, as
+		// the API does for a non-member. Empty outside the tests that seed it.
+		whoamiByWorkspace: new Map<string, Record<string, unknown>>(),
+		// Per-row server timestamp, only set by tests that want to simulate a
+		// concurrent writer advancing the row; otherwise empty, so the conflict
+		// branch in `updateDraft` stays inert for every pre-existing test.
+		serverTimestamps: new Map<string, string>(),
+		// Keys whose `updateDraft` / draft reads throw a non-404 (network/5xx);
+		// only set by the error-handling tests, empty otherwise.
+		failingWrites: new Set<string>(),
+		failingReads: new Set<string>()
+	}))
 
 vi.mock('$lib/gen', async () => {
 	const actual = await vi.importActual<any>('$lib/gen')
@@ -219,6 +223,13 @@ vi.mock('$lib/gen', async () => {
 		FolderService: wrapService(actual.FolderService, {
 			createFolder: vi.fn(async () => 'created')
 		}),
+		UserService: wrapService(actual.UserService, {
+			whoami: vi.fn(async ({ workspace }: any) => {
+				const user = whoamiByWorkspace.get(workspace)
+				if (!user) throw new Error(`not a member of ${workspace}`)
+				return user
+			})
+		}),
 		DraftService: wrapService(actual.DraftService, {
 			updateDraft: vi.fn(async ({ kind, path, requestBody }: any) => {
 				const key = `${kind}:${path}`
@@ -335,6 +346,7 @@ import {
 	VariableService
 } from '$lib/gen'
 import { userStore } from '$lib/stores'
+import { clearWorkspaceRoleCache } from '$lib/user'
 import { get } from 'svelte/store'
 import type { Tool, ToolCallbacks } from '../shared'
 
@@ -1966,7 +1978,7 @@ describe('global AI tools', () => {
 
 	// A hybrid runnable — inline code plus a leftover runType/path — contradicts its own
 	// kind, and convertPersistedToBackendRunnable is what reports it back to the model.
-	it('drops the other kind\'s fields when a runnable changes type', async () => {
+	it("drops the other kind's fields when a runnable changes type", async () => {
 		seedBackendDraft(
 			'raw_app',
 			'u/admin/converted_app',
@@ -5767,5 +5779,62 @@ describe('buildOpenPageUrl compare selection', () => {
 		expect(
 			itemsOf(buildOpenPageUrl('compare', { page: 'compare' }, { workspaceId: 'ws' }))
 		).toBeNull()
+	})
+})
+
+describe('open_page workspace gating', () => {
+	const NAV = 'nav_ws'
+	const SESSION = 'session_ws'
+	const openPage = () => getGlobalTool('open_page')
+	const advertisedPages = () =>
+		((openPage().def.function.parameters as any)?.properties?.page?.enum ?? []) as string[]
+	const pristineDef = openPage().def
+
+	beforeEach(() => {
+		// Admin of the workspace being browsed, plain member of the one a session operates on.
+		userStore.set({ username: 'bob', workspace_id: NAV, is_admin: true } as any)
+		whoamiByWorkspace.set(SESSION, {
+			username: 'bob',
+			email: 'bob@windmill.dev',
+			is_admin: false,
+			operator: false,
+			groups: []
+		})
+	})
+
+	afterEach(() => {
+		userStore.set(undefined)
+		whoamiByWorkspace.clear()
+		clearWorkspaceRoleCache()
+		openPage().def = pristineDef
+	})
+
+	// Reading the ambient `userStore` instead offers a session the pages of the workspace
+	// the user happens to be browsing.
+	it('gates on the operating workspace, not the one userStore describes', async () => {
+		await openPage().setSchema?.({ operatingWorkspace: NAV })
+		expect(advertisedPages()).toContain('workspace_settings')
+
+		await openPage().setSchema?.({ operatingWorkspace: SESSION })
+		expect(advertisedPages()).toContain('runs')
+		expect(advertisedPages()).not.toContain('workspace_settings')
+		await expect(
+			callGlobalTool('open_page', { page: 'workspace_settings' }, toolCallbacks, {
+				operatingWorkspace: SESSION
+			})
+		).resolves.toContain("don't have access")
+	})
+
+	// Falling back to a fixed page set instead offers pages the sidebar may well hide —
+	// an operator's, most of all, whose reachable set is a fraction of the default one.
+	// The refusal must not read as a denial either: the role was never established.
+	it('advertises nothing when the role lookup fails', async () => {
+		await openPage().setSchema?.({ operatingWorkspace: 'unreachable_ws' })
+		expect(advertisedPages()).toEqual([])
+		const refusal = await callGlobalTool('open_page', { page: 'runs' }, toolCallbacks, {
+			operatingWorkspace: 'unreachable_ws'
+		})
+		expect(refusal).toContain("Couldn't check your permissions")
+		expect(refusal).not.toContain("don't have access")
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -343,9 +343,10 @@ import {
 	ResourceService,
 	ScheduleService,
 	ScriptService,
+	UserService,
 	VariableService
 } from '$lib/gen'
-import { userStore } from '$lib/stores'
+import { userStore, usersWorkspaceStore } from '$lib/stores'
 import { clearWorkspaceRoleCache } from '$lib/user'
 import { get } from 'svelte/store'
 import type { Tool, ToolCallbacks } from '../shared'
@@ -5785,14 +5786,17 @@ describe('buildOpenPageUrl compare selection', () => {
 describe('open_page workspace gating', () => {
 	const NAV = 'nav_ws'
 	const SESSION = 'session_ws'
+	// A workspace the user belongs to but whose `whoami` never answers.
+	const FLAKY = 'flaky_ws'
 	const openPage = () => getGlobalTool('open_page')
-	const advertisedPages = () =>
-		((openPage().def.function.parameters as any)?.properties?.page?.enum ?? []) as string[]
+	const pageSchema = () => (openPage().def.function.parameters as any)?.properties?.page ?? {}
+	const advertisedPages = () => (pageSchema().enum ?? []) as string[]
 	const pristineDef = openPage().def
 
 	beforeEach(() => {
 		// Admin of the workspace being browsed, plain member of the one a session operates on.
 		userStore.set({ username: 'bob', workspace_id: NAV, is_admin: true } as any)
+		usersWorkspaceStore.set({ workspaces: [{ id: NAV }, { id: SESSION }, { id: FLAKY }] } as any)
 		whoamiByWorkspace.set(SESSION, {
 			username: 'bob',
 			email: 'bob@windmill.dev',
@@ -5804,6 +5808,7 @@ describe('open_page workspace gating', () => {
 
 	afterEach(() => {
 		userStore.set(undefined)
+		usersWorkspaceStore.set(undefined)
 		whoamiByWorkspace.clear()
 		clearWorkspaceRoleCache()
 		openPage().def = pristineDef
@@ -5827,14 +5832,31 @@ describe('open_page workspace gating', () => {
 
 	// Falling back to a fixed page set instead offers pages the sidebar may well hide —
 	// an operator's, most of all, whose reachable set is a fraction of the default one.
-	// The refusal must not read as a denial either: the role was never established.
-	it('advertises nothing when the role lookup fails', async () => {
-		await openPage().setSchema?.({ operatingWorkspace: 'unreachable_ws' })
+	// Neither layer may read as a denial: the role was never established, and the model
+	// sees the schema before it can ever reach the handler's message.
+	it('advertises nothing and blames no denial when the role lookup fails', async () => {
+		await openPage().setSchema?.({ operatingWorkspace: FLAKY })
 		expect(advertisedPages()).toEqual([])
+		expect(pageSchema().description).toContain("couldn't be checked")
 		const refusal = await callGlobalTool('open_page', { page: 'runs' }, toolCallbacks, {
-			operatingWorkspace: 'unreachable_ws'
+			operatingWorkspace: FLAKY
 		})
 		expect(refusal).toContain("Couldn't check your permissions")
 		expect(refusal).not.toContain("don't have access")
+	})
+
+	// A workspace absent from `userWorkspaces` is settled, not unknown: inviting a retry
+	// would be false, and asking `whoami` at all only earns a 401 on every iteration.
+	it('reports a plain denial for a workspace the user is not a member of', async () => {
+		await openPage().setSchema?.({ operatingWorkspace: 'unreachable_ws' })
+		expect(advertisedPages()).toEqual([])
+		expect(pageSchema().description).not.toContain("couldn't be checked")
+		const refusal = await callGlobalTool('open_page', { page: 'runs' }, toolCallbacks, {
+			operatingWorkspace: 'unreachable_ws'
+		})
+		expect(refusal).toContain("don't have access")
+		expect(UserService.whoami).not.toHaveBeenCalledWith(
+			expect.objectContaining({ workspace: 'unreachable_ws' })
+		)
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2412,10 +2412,17 @@ function restrictedOpenPages(workspaceId: string | undefined): OpenPageName[] {
 // workspace's role while the new whoami is in flight.
 async function roleForWorkspace(
 	workspaceId: string | undefined
-): Promise<RoleLookup | { kind: 'no_workspace_context' }> {
+): Promise<RoleLookup | { kind: 'no_workspace_context' } | { kind: 'not_a_member' }> {
 	if (!workspaceId) return { kind: 'no_workspace_context' }
 	const u = get(userStore)
 	if (u?.workspace_id === workspaceId) return { kind: 'resolved', user: u }
+	// A workspace missing from the user's own list is one they hold no membership in, so
+	// `whoami` would reject it every time. Settle it here: the rejection is a bare 401,
+	// which cannot be told apart from an expired session, and a superadmin resolves on a
+	// workspace they are not a member of, so neither the status nor the list alone decides.
+	if (!get(superadmin) && !get(userWorkspaces).some((w) => w.id === workspaceId)) {
+		return { kind: 'not_a_member' }
+	}
 	return getWorkspaceRole(workspaceId)
 }
 
@@ -2428,9 +2435,11 @@ async function allowedOpenPages(
 ): Promise<{ pages: OpenPageName[]; roleUnverified: boolean }> {
 	const role = await roleForWorkspace(workspaceId)
 	// A failed lookup says nothing about the role, so guessing a page set can offer one the
-	// sidebar hides; advertising none is the only answer that can't. Headless callers have
-	// no workspace to resolve at all and keep the pre-resolution set.
+	// sidebar hides; advertising none is the only answer that can't. A known non-member also
+	// reaches nothing, but that is settled rather than unverified — saying "try again" about
+	// it would be false. Headless callers have no workspace and keep the pre-resolution set.
 	if (role.kind === 'lookup_failed') return { pages: [], roleUnverified: true }
+	if (role.kind === 'not_a_member') return { pages: [], roleUnverified: false }
 	if (role.kind === 'no_workspace_context') {
 		return { pages: restrictedOpenPages(workspaceId), roleUnverified: false }
 	}
@@ -2692,16 +2701,25 @@ function buildOpenPageDefSchema(
 	pages: readonly OpenPageName[],
 	triggerKinds: readonly PageTriggerKind[],
 	chatEditsTracked: boolean,
-	allWorkspacesRuns: boolean
+	allWorkspacesRuns: boolean,
+	roleUnverified = false
 ): z.ZodTypeAny {
 	const full = openPageFullSchema.shape as Record<string, z.ZodTypeAny>
 	// z.enum() rejects an empty list, and a user with no reachable pages (e.g. an operator
 	// with every operator_settings flag off) yields exactly that. Fall back to a plain
 	// string so schema-building can't throw; the handler still fails closed on every page.
+	// The model reads this before it can reach the handler's message, so an unresolved role
+	// must not be described as a denial here either.
 	const shape: Record<string, z.ZodTypeAny> = {
 		page: pages.length
 			? z.enum([...pages] as [OpenPageName, ...OpenPageName[]]).describe('Which page to open')
-			: z.string().describe('No pages are available to you in this workspace')
+			: z
+					.string()
+					.describe(
+						roleUnverified
+							? "Your permissions in this workspace couldn't be checked, so no page can be opened right now"
+							: 'No pages are available to you in this workspace'
+					)
 	}
 	for (const [field, fieldPages] of Object.entries(OPEN_PAGE_FIELD_PAGES)) {
 		if (!fieldPages.some((p) => pages.includes(p))) continue
@@ -2938,12 +2956,14 @@ export const openPageTool: Tool<{}> = {
 	// Re-narrow the advertised `page` enum to this user's permissions each iteration, so
 	// the model never sees (or suggests) a page the user can't reach.
 	setSchema: async function (helpers) {
+		const access = await allowedOpenPages(operatingWorkspaceFromHelpers(helpers))
 		this.def = createToolDef(
 			buildOpenPageDefSchema(
-				(await allowedOpenPages(operatingWorkspaceFromHelpers(helpers))).pages,
+				access.pages,
 				allowedTriggerKinds(),
 				(helpers as GlobalToolHelpers | undefined)?.getModifiedItems?.() !== undefined,
-				allowsAllWorkspacesRuns(operatingWorkspaceFromHelpers(helpers))
+				allowsAllWorkspacesRuns(operatingWorkspaceFromHelpers(helpers)),
+				access.roleUnverified
 			),
 			'open_page',
 			OPEN_PAGE_DESCRIPTION

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -146,6 +146,7 @@ import {
 	userWorkspaces,
 	workspaceStore
 } from '$lib/stores'
+import { getWorkspaceRole, type RoleLookup } from '$lib/user'
 import { get } from 'svelte/store'
 import {
 	canonicalDraftSideValue,
@@ -2369,43 +2370,86 @@ function allowedTriggerKinds(): PageTriggerKind[] {
 	return (Object.keys(TRIGGER_PAGES) as PageTriggerKind[]).filter((k) => ee || !TRIGGER_PAGES[k].ee)
 }
 
-// Which pages the current user can actually reach — mirrors the sidebar's gating.
-// Operators see exactly the pages enabled in the operating workspace's operator_settings
-// (the same source OperatorMenu gates on); a missing/false flag means no access, and
-// operators are never admins so workspace_settings is always excluded. Non-operators
-// get every page except workspace_settings, which is admin/superadmin only. `workspaceId`
-// is the chat's operating workspace (a session targets its own, possibly forked workspace);
-// it defaults to the navigation workspace for the global side-panel chat. The tool only
-// ever advertises, and only ever acts on, pages in this set.
-function allowedOpenPages(workspaceId: string | undefined = get(workspaceStore)): OpenPageName[] {
-	const u = get(userStore)
-	const isAdmin = !!u?.is_admin || !!get(superadmin)
-	if (u?.operator) {
-		const settings = get(userWorkspaces).find((w) => w.id === workspaceId)?.operator_settings
-		return OPEN_PAGE_NAMES.filter(
-			(p) =>
-				p !== 'workspace_settings' && settings?.[p as keyof NonNullable<typeof settings>] === true
-		)
+// Pages an operator may reach: exactly the ones enabled in the workspace's
+// operator_settings, the same source OperatorMenu gates on. Operators are never admins, so
+// workspace_settings is excluded whatever the settings say.
+function operatorOpenPages(workspaceId: string | undefined): OpenPageName[] {
+	const settings = get(userWorkspaces).find((w) => w.id === workspaceId)?.operator_settings
+	return OPEN_PAGE_NAMES.filter(
+		(p) =>
+			p !== 'workspace_settings' && settings?.[p as keyof NonNullable<typeof settings>] === true
+	)
+}
+
+// workspace_settings is admin/superadmin only; the rest are open to any non-operator member.
+const NON_ADMIN_OPEN_PAGES = new Set<OpenPageName>([
+	'runs',
+	'assets',
+	'schedules',
+	'variables',
+	'resources',
+	'audit_logs',
+	'folders',
+	'groups',
+	'triggers',
+	'compare'
+])
+
+// What to advertise before the role in `workspaceId` has been resolved.
+// `user_workspaces` nulls operator_settings for a workspace the user is not an operator
+// in, so a non-null value narrows an operator correctly; the converse does not hold,
+// which is why the real role is still fetched.
+function restrictedOpenPages(workspaceId: string | undefined): OpenPageName[] {
+	if (get(userWorkspaces).find((w) => w.id === workspaceId)?.operator_settings) {
+		return operatorOpenPages(workspaceId)
 	}
-	const allowed = new Set<OpenPageName>([
-		'runs',
-		'assets',
-		'schedules',
-		'variables',
-		'resources',
-		'audit_logs',
-		'folders',
-		'groups',
-		'triggers',
-		'compare'
-	])
-	if (isAdmin) allowed.add('workspace_settings')
-	return OPEN_PAGE_NAMES.filter((p) => allowed.has(p))
+	return OPEN_PAGE_NAMES.filter((p) => NON_ADMIN_OPEN_PAGES.has(p))
+}
+
+// The role to gate `workspaceId` on. `userStore` answers only when it describes that same
+// workspace: a session operates on its own, possibly forked workspace where the user's
+// role can differ, and right after a switch the store still carries the previous
+// workspace's role while the new whoami is in flight.
+async function roleForWorkspace(
+	workspaceId: string | undefined
+): Promise<RoleLookup | { kind: 'no_workspace_context' }> {
+	if (!workspaceId) return { kind: 'no_workspace_context' }
+	const u = get(userStore)
+	if (u?.workspace_id === workspaceId) return { kind: 'resolved', user: u }
+	return getWorkspaceRole(workspaceId)
+}
+
+// Which pages the user can actually reach in `workspaceId` — mirrors the sidebar's gating.
+// `workspaceId` is the chat's operating workspace, defaulting to the navigation workspace
+// for the global side-panel chat. The tool only ever advertises, and only ever acts on,
+// `pages`.
+async function allowedOpenPages(
+	workspaceId: string | undefined = get(workspaceStore)
+): Promise<{ pages: OpenPageName[]; roleUnverified: boolean }> {
+	const role = await roleForWorkspace(workspaceId)
+	// A failed lookup says nothing about the role, so guessing a page set can offer one the
+	// sidebar hides; advertising none is the only answer that can't. Headless callers have
+	// no workspace to resolve at all and keep the pre-resolution set.
+	if (role.kind === 'lookup_failed') return { pages: [], roleUnverified: true }
+	if (role.kind === 'no_workspace_context') {
+		return { pages: restrictedOpenPages(workspaceId), roleUnverified: false }
+	}
+	const u = role.user
+	if (u.operator) return { pages: operatorOpenPages(workspaceId), roleUnverified: false }
+	const isAdmin = !!u.is_admin || !!u.is_super_admin || !!get(superadmin)
+	return {
+		pages: OPEN_PAGE_NAMES.filter(
+			(p) => NON_ADMIN_OPEN_PAGES.has(p) || (isAdmin && p === 'workspace_settings')
+		),
+		roleUnverified: false
+	}
 }
 
 // The Runs page only offers its cross-workspace filter to a superadmin or devops user in
 // the admins workspace (RunsPage builds its filter schema with the same condition, and
 // without the key the page ignores the query param), so the tool mirrors that gate.
+// superadmin and devops are instance-level: they hold in whichever workspace the chat
+// operates on, so this gate needs no per-workspace role lookup.
 function allowsAllWorkspacesRuns(workspaceId: string | undefined = get(workspaceStore)): boolean {
 	return (!!get(superadmin) || !!get(devopsRole)) && workspaceId === 'admins'
 }
@@ -2874,11 +2918,11 @@ function summarizeOpenPage(url: string, page: OpenPageName): string {
 }
 
 export const openPageTool: Tool<{}> = {
-	// The initial def assumes an untracked chat; setSchema below rebuilds it with the
-	// caller's real surface before each iteration.
+	// The initial def assumes an untracked chat and no resolved role; setSchema below
+	// rebuilds it with the caller's real surface before each iteration.
 	def: createToolDef(
 		buildOpenPageDefSchema(
-			allowedOpenPages(),
+			restrictedOpenPages(get(workspaceStore)),
 			allowedTriggerKinds(),
 			false,
 			allowsAllWorkspacesRuns()
@@ -2892,12 +2936,11 @@ export const openPageTool: Tool<{}> = {
 	showDetails: true,
 	autoCollapseDetails: false,
 	// Re-narrow the advertised `page` enum to this user's permissions each iteration, so
-	// the model never sees (or suggests) a page the user can't reach. Gates on the chat's
-	// operating workspace (the session's, when different from the navigation workspace).
+	// the model never sees (or suggests) a page the user can't reach.
 	setSchema: async function (helpers) {
 		this.def = createToolDef(
 			buildOpenPageDefSchema(
-				allowedOpenPages(operatingWorkspaceFromHelpers(helpers)),
+				(await allowedOpenPages(operatingWorkspaceFromHelpers(helpers))).pages,
 				allowedTriggerKinds(),
 				(helpers as GlobalToolHelpers | undefined)?.getModifiedItems?.() !== undefined,
 				allowsAllWorkspacesRuns(operatingWorkspaceFromHelpers(helpers))
@@ -2912,9 +2955,15 @@ export const openPageTool: Tool<{}> = {
 		const page = parsed.page as OpenPageName
 		const workspaceId = operatingWorkspaceFromHelpers(ctx.helpers)
 		// Defense in depth: never act on a page the user can't reach, even if the model
-		// requests one outside the advertised enum.
-		if (!allowedOpenPages(workspaceId).includes(page)) {
-			return `You don't have access to the ${OPEN_PAGE_LABELS[page] ?? page} page in this workspace.`
+		// requests one outside the advertised enum. An unverified role means the lookup
+		// failed, not that access was denied — reporting it as denied states a falsehood
+		// about the user's permissions.
+		const access = await allowedOpenPages(workspaceId)
+		if (!access.pages.includes(page)) {
+			const label = OPEN_PAGE_LABELS[page] ?? page
+			return access.roleUnverified
+				? `Couldn't check your permissions in this workspace, so the ${label} page can't be opened right now. Try again in a moment.`
+				: `You don't have access to the ${label} page in this workspace.`
 		}
 		// Same fail-closed check for trigger_kind, which is narrowed to license-available
 		// kinds in the advertised schema: a model ignoring that narrowing must not get an

--- a/frontend/src/lib/storeUtils.ts
+++ b/frontend/src/lib/storeUtils.ts
@@ -1,5 +1,6 @@
 import { resourceTypesStore } from './components/resourceTypesStore'
 import { refreshSuperadmin } from './refreshUser'
+import { clearWorkspaceRoleCache } from './user'
 import {
 	workspaceStore,
 	userStore,
@@ -34,6 +35,7 @@ export function clearStores(): void {
 
 	resourceTypesStore.set(undefined)
 	resetProtectionRules()
+	clearWorkspaceRoleCache()
 	userStore.set(undefined)
 	workspaceStore.set(undefined)
 	usersWorkspaceStore.set(undefined)

--- a/frontend/src/lib/user.ts
+++ b/frontend/src/lib/user.ts
@@ -1,13 +1,46 @@
 import { type User, UserService } from '$lib/gen'
 import type { UserExt } from './stores.js'
 
+async function fetchUserExt(workspace: string): Promise<UserExt> {
+	return mapUserToUserExt(await UserService.whoami({ workspace }), workspace)
+}
+
 export async function getUserExt(workspace: string): Promise<UserExt | undefined> {
 	try {
-		const user = await UserService.whoami({ workspace })
-		return mapUserToUserExt(user, workspace)
+		return await fetchUserExt(workspace)
 	} catch (error) {
 		return undefined
 	}
+}
+
+// A role gate must be able to tell "not this role" from "we don't know": a lookup that
+// failed is no evidence about the user, so callers need to fall back rather than infer.
+export type RoleLookup = { kind: 'resolved'; user: UserExt } | { kind: 'lookup_failed' }
+
+// `whoami` for a workspace other than the one being browsed. Memoized because a
+// per-workspace role gate can sit on a hot path. Only successes are kept, so a transient
+// error doesn't stick, and they expire so a role edited elsewhere lands without a reload.
+const WORKSPACE_ROLE_TTL_MS = 5 * 60_000
+const workspaceRoleCache = new Map<string, { at: number; lookup: Promise<RoleLookup> }>()
+
+export function getWorkspaceRole(workspace: string): Promise<RoleLookup> {
+	const cached = workspaceRoleCache.get(workspace)
+	if (cached && Date.now() - cached.at < WORKSPACE_ROLE_TTL_MS) return cached.lookup
+	const lookup: Promise<RoleLookup> = fetchUserExt(workspace).then(
+		(user) => ({ kind: 'resolved', user }),
+		() => {
+			// Evict only our own entry: a slow failure must not drop the retry that replaced it.
+			if (workspaceRoleCache.get(workspace)?.lookup === lookup) workspaceRoleCache.delete(workspace)
+			return { kind: 'lookup_failed' }
+		}
+	)
+	workspaceRoleCache.set(workspace, { at: Date.now(), lookup })
+	return lookup
+}
+
+/** Roles are per-identity, so anything that changes who is logged in must drop this. */
+export function clearWorkspaceRoleCache(): void {
+	workspaceRoleCache.clear()
 }
 
 function mapUserToUserExt(user: User, workspace: string): UserExt {


### PR DESCRIPTION
## Summary

Fixes WIN-2390.

The AI chat's `open_page` tool decided which pages to advertise from the **navigation**
workspace's role, read out of the ambient `userStore`, rather than from the **operating**
workspace it was actually acting on. An AI session operates on its own — possibly forked —
workspace, where the user's role can differ, so a session running against a workspace where
you are a plain member would still be offered the pages of whatever workspace you happened to
be browsing. The same read also raced a workspace switch: right after one, `userStore` still
describes the previous workspace while the new `whoami` is in flight.

Impact is advertising and UX, not access: every destination page is authorized by the backend
independently. The effect is the model offering (and the tool opening) pages the sidebar hides.

`allowsAllWorkspacesRuns` next to it is deliberately left alone — superadmin and devops are
instance-level, so they hold in whichever workspace the chat operates on.

## Changes

- `user.ts`: split the `whoami` fetch from the error-swallowing wrapper. `getUserExt` keeps its
  exact previous signature and behaviour; a new `getWorkspaceRole` returns a `RoleLookup`
  (`resolved` | `lookup_failed`) so a gate can tell "not this role" from "we couldn't check".
- `user.ts`: memoized per-workspace role lookups (5 min TTL). Only successes are cached — a
  failure evicts, guarded by promise identity so a slow failure can't drop the retry that
  replaced it.
- `storeUtils.ts`: `clearStores` drops the cache, so a logout can't leak another identity's roles.
- `core.ts`: `open_page` now gates on the operating workspace. `userStore` is used only when its
  `workspace_id` matches; otherwise the role is fetched for the workspace being gated.
- `core.ts`: a failed lookup advertises nothing and acts on nothing, rather than guessing a fixed
  page set that may include pages the sidebar hides. The pre-resolution set is still used for the
  module-load def and for headless callers (the eval harness, which never populates the stores).
- `core.ts`: a refusal caused by a failed lookup no longer claims the user lacks access — it says
  the check failed and invites a retry. The advertised schema says the same thing: the empty-page
  description is chosen by `roleUnverified`, so the model can't read a denial off the schema
  before it ever reaches the handler's message.
- `core.ts`: a workspace absent from `userWorkspaces` is settled as a non-membership without
  asking `whoami` at all. Its rejection is a bare 401, indistinguishable from an expired session,
  so the status can't classify it; the membership list can, and a superadmin (who resolves on
  workspaces they aren't a member of) is excluded from the shortcut. This makes the denial
  truthful and drops a `whoami` that would otherwise fail on every chat iteration forever.

## Screenshots

Same user (`bob`), browsing a workspace where they are an **admin**, with a session acting on a
fork where they are **not**.

Navigation workspace — admin, so Workspace settings opens:

![wm-openpage-admin-workspace](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2390-open_page-gates-on-the-navigation-workspaces-role-not-the/1787246554-wm-openpage-admin-workspace-v2.png)

Session acting on the fork — plain member, so it is neither offered nor opened:

![wm-openpage-member-workspace](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2390-open_page-gates-on-the-navigation-workspaces-role-not-the/1787246554-wm-openpage-member-workspace-v2.png)

`whoami` failed for the operating workspace (fault-injected): nothing advertised, and the refusal
reports a failed check rather than a denial:

![wm-openpage-unverified-message](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2390-open_page-gates-on-the-navigation-workspaces-role-not-the/1787246298-wm-openpage-unverified-message.png)

Operator in the operating workspace with only Runs and Variables enabled — Folders refused,
Variables opened:

![wm-openpage-operator-gate](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2390-open_page-gates-on-the-navigation-workspaces-role-not-the/1787246298-wm-openpage-operator-gate.png)

## Test plan

- [x] `open_page workspace gating` unit tests: the gate follows the operating workspace rather
      than `userStore`; a failed lookup advertises nothing and neither the schema description nor
      the refusal reads as a denial; a genuine non-member gets a plain denial and fires no
      `whoami`. All assert the advertised enum *and* the handler guard, and all fail on the
      pre-fix code (verified by reverting).
- [x] Admin in the navigation workspace, plain member in the session's: Workspace settings opens
      in the former, is refused in the latter.
- [x] Fault-injected `whoami` failure for the operating workspace: refused with "couldn't check
      your permissions", then opened normally on the next turn once the injector was removed
      (failures are not cached).
- [x] Operator in the operating workspace with `operator_settings` narrowed to Runs + Variables:
      Folders refused, Variables and Runs opened.
- [x] `npm run check` clean: 0 errors over 10247 files.
- [x] Full frontend suite: 349 tests pass across the two touched suites. The suite has 11
      failures overall (`alterTable`, `ContextManager`, `app/core`, `anthropicRouting`,
      `lib.toolCalls`, `raw_apps/utils`) — verified identical, test for test, with these five
      files reverted to the base commit, so none belong to this PR.

Not exercised: I could not read the advertised `page` enum off the wire for the operator case, so
that one is evidenced by the handler refusing rather than by inspecting the request payload. Enum
narrowing itself is covered by the unit tests.

## AI evals (global mode)

All 9 `open_page` cases, `--model sonnet --runs 3`, same backend and workspace on both sides.

| | Pass rate | `openpage4-workspace-settings-tab` | `openpage8-runs-label-and-worker` |
| --- | --- | --- | --- |
| Before (`dad8fed647`) | 22/27 — 81.5% | 0/3 | 1/3 |
| After | 24/27 — 88.9% | 0/3 | 3/3 |

No regression. Average prompt tokens fell slightly (44.9k vs 46.5k across all attempts) and final
context is unchanged at ~21.3k.

`openpage4` fails identically on both sides, on the same assertion. The cause is structural and
predates this PR: the eval harness never populates `userStore` / `workspaceStore`, so `open_page`
resolves to the non-admin page set, which has never contained `workspace_settings` — the case
cannot pass under the harness as written, on either commit. Worth its own ticket.

`openpage8` moving 1/3 → 3/3 is not claimed as an improvement; nothing here touches label/worker
filter handling, and that case was already flaky on the base commit.

## Follow-up

`openPageTool` is a module-level singleton whose `def` every chat manager mutates in place. Now
that `setSchema` can await a `whoami`, the pre-existing interleaving window between concurrent
chats widens from a microtask to a network round trip. Bounded — the handler re-checks against
its own workspace and stays fail-closed — but worth its own ticket, together with the static tool
description that lists every page regardless of the narrowed enum.
