### PR TITLE
feat: upgrade bun to 1.4.0 and demote deno in the language picker

### DIFF
--- a/.github/DockerfileBackendTests
+++ b/.github/DockerfileBackendTests
@@ -42,7 +42,7 @@ RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VER
 RUN /usr/local/bin/python3 -m pip install pip-tools
 
 # Bun
-COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.4.0 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI
 RUN bun install -g windmill-cli \

--- a/.github/workflows/ai-agent-tests.yml
+++ b/.github/workflows/ai-agent-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ai-evals-test.yml
+++ b/.github/workflows/ai-evals-test.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -58,7 +58,7 @@ jobs:
           go-version: 1.21.5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.4.0
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/git-sync-test.yml
+++ b/.github/workflows/git-sync-test.yml
@@ -133,7 +133,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.4.0
 
       - uses: denoland/setup-deno@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ COPY --from=windmill_duckdb_ffi_internal_builder /windmill-duckdb-ffi-internal/t
 
 COPY --from=denoland/deno:2.2.1 --chmod=755 /usr/bin/deno /usr/bin/deno
 
-COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.4.0 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI
 RUN bun install -g windmill-cli \

--- a/backend/windmill-common/src/min_version.rs
+++ b/backend/windmill-common/src/min_version.rs
@@ -12,6 +12,12 @@ pub const MIN_VERSION_SUPPORTS_ON_BEHALF_OF_PRINCIPAL: VC = vc(1, 776, 0, "On-be
 // already-deployed hash (duplicate git-sync commit, duplicate fork tally, a re-triggered
 // relative-import cascade). Must name the release this ships in.
 pub const MIN_VERSION_SUPPORTS_BINARY_PREBUILD: VC = vc(1, 789, 0, "Auto-build binary on deploy");
+// The release that ships bun 1.4, which writes `bun.lock` v2. Bun 1.3 reports
+// `error: Unknown lockfile version`, then installs anyway from `package.json` alone — and the
+// dependency job writes every dependency as `"latest"`, so the lockfile is the only pin and an
+// older worker resolves whatever is newest instead. Below this version the stored lockfile is
+// stamped back to v1, which bun 1.3 and 1.4 both honour. Must name the release this ships in.
+pub const MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2: VC = vc(1, 794, 0, "Bun v2 lockfiles");
 pub const MIN_VERSION_SUPPORTS_NODE_DEBOUNCING: VC = vc(1, 658, 0, "Flow node debouncing");
 pub const MIN_VERSION_SUPPORTS_TOKEN_HASH: VC = vc(1, 659, 0, "Token hash storage");
 pub const MIN_VERSION_SUPPORTS_SYNC_JOBS_DEBOUNCING: VC = vc(1, 602, 0, "Sync jobs debouncing");

--- a/backend/windmill-common/src/min_version.rs
+++ b/backend/windmill-common/src/min_version.rs
@@ -12,11 +12,12 @@ pub const MIN_VERSION_SUPPORTS_ON_BEHALF_OF_PRINCIPAL: VC = vc(1, 776, 0, "On-be
 // already-deployed hash (duplicate git-sync commit, duplicate fork tally, a re-triggered
 // relative-import cascade). Must name the release this ships in.
 pub const MIN_VERSION_SUPPORTS_BINARY_PREBUILD: VC = vc(1, 789, 0, "Auto-build binary on deploy");
-// The release that ships bun 1.4, which writes `bun.lock` v2. Bun 1.3 reports
-// `error: Unknown lockfile version`, then installs anyway from `package.json` alone — and the
-// dependency job writes every dependency as `"latest"`, so the lockfile is the only pin and an
-// older worker resolves whatever is newest instead. Below this version the stored lockfile is
-// stamped back to v1, which bun 1.3 and 1.4 both honour. Must name the release this ships in.
+// The release that ships bun 1.4, which writes `bun.lock` v2 (v3 with overrides or catalogs).
+// Bun 1.3 reports `error: Unknown lockfile version`, then installs anyway from `package.json`
+// alone — and the dependency job writes every dependency as `"latest"`, so the lockfile is the
+// only pin and an older worker resolves whatever is newest instead. Below this version the
+// dependency job asks bun for a v1 lockfile, and refuses to store one bun raised anyway.
+// Must name the release this ships in.
 pub const MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2: VC = vc(1, 794, 0, "Bun v2 lockfiles");
 pub const MIN_VERSION_SUPPORTS_NODE_DEBOUNCING: VC = vc(1, 658, 0, "Flow node debouncing");
 pub const MIN_VERSION_SUPPORTS_TOKEN_HASH: VC = vc(1, 659, 0, "Token hash storage");

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -586,13 +586,23 @@ pub async fn gen_bun_lockfile(
                         // dependencies cannot be expressed in one. Storing it anyway would not
                         // fail on an older worker — it would install from package.json alone and
                         // silently resolve different versions.
-                        if let Some(v) = bun_lockfile_version(&buf).filter(|v| *v > 1) {
-                            return Err(error::Error::ExecutionErr(format!(
-                                "bun produced a v{v} lockfile, which workers older than {} \
-                                 cannot read. Finish upgrading every worker before deploying \
-                                 dependencies that need it (overrides, catalogs).",
-                                MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2.version()
-                            )));
+                        match bun_lockfile_version(&buf) {
+                            Some(1) => {}
+                            Some(v) => {
+                                return Err(error::Error::ExecutionErr(format!(
+                                    "bun produced a v{v} lockfile, which workers older than {} \
+                                     cannot read. Finish upgrading every worker before deploying \
+                                     dependencies that need it (overrides, catalogs).",
+                                    MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2.version()
+                                )));
+                            }
+                            // The guard cannot classify this one, so it must not pass silently:
+                            // a bun that stops writing the header would reopen the drift hole
+                            // with nothing in the logs.
+                            None => tracing::warn!(
+                                "bun wrote a lockfile with no readable lockfileVersion; storing \
+                                 it unchecked for job {job_id}"
+                            ),
                         }
                     }
                     content.push_str(&buf);
@@ -2952,8 +2962,9 @@ pub async fn handle_wac_v2_output(
                                     version: flow_info.version,
                                     labels: flow_info.labels.clone(),
                                 };
-                                let on_behalf_of =
-                                    flow_info.on_behalf_of(&job.workspace_id, db).await?;
+                                let on_behalf_of = flow_info
+                                    .on_behalf_of(&job.workspace_id, db)
+                                    .await?;
                                 let step_args: HashMap<String, Box<RawValue>> = step
                                     .args
                                     .iter()
@@ -4187,8 +4198,7 @@ mod tests {
             bun_lockfile_version("{\n  \"lockfileVersion\": 2,\n  \"packages\": {}\n}"),
             Some(2)
         );
-        // bun raises the version on its own for overrides/catalogs; anything above 1 has to be
-        // recognised, not just the version that happened to exist when this was written
+        // bun raises the version on its own for overrides/catalogs, so any version has to parse
         assert_eq!(bun_lockfile_version("{\"lockfileVersion\":3}"), Some(3));
         assert_eq!(
             bun_lockfile_version("{ \"lockfileVersion\" : 42 }"),

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -35,6 +35,7 @@ use windmill_common::{
     cache,
     client::AuthedClient,
     jobs::JobKind,
+    min_version::MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2,
     scripts::{id_to_codebase_info, CodebaseInfo, ScriptHash, ScriptLang},
     utils::WarnAfterExt,
     workspace_dependencies::WorkspaceDependenciesPrefetched,
@@ -377,6 +378,27 @@ pub(crate) fn split_lockfile(lockfile: &str) -> (&str, Option<&str>, bool, bool)
     }
 }
 
+/// Stamp a bun 1.4 text lockfile back to `lockfileVersion: 1`.
+///
+/// Only the header distinguishes the two for the flat `{"dependencies": {...}}` the dependency
+/// job writes: no overrides, catalogs or workspaces, so nothing needs v2 syntax. Both bun
+/// versions honour the result. Gated on [`MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2`] so the fleet
+/// stops paying for this once every worker can read v2.
+fn downgrade_bun_lockfile_v2(lockfile: String) -> String {
+    const V2: &str = "\"lockfileVersion\": 2";
+    const V1: &str = "\"lockfileVersion\": 1";
+    match lockfile.find(V2) {
+        Some(i) => {
+            let mut out = String::with_capacity(lockfile.len());
+            out.push_str(&lockfile[..i]);
+            out.push_str(V1);
+            out.push_str(&lockfile[i + V2.len()..]);
+            out
+        }
+        None => lockfile,
+    }
+}
+
 pub async fn gen_bun_lockfile(
     mem_peak: &mut i32,
     canceled_by: &mut Option<CanceledBy>,
@@ -539,6 +561,9 @@ pub async fn gen_bun_lockfile(
                     let mut file = File::open(&file).await?;
                     let mut buf = String::default();
                     file.read_to_string(&mut buf).await?;
+                    if !MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2.met_conservatively() {
+                        buf = downgrade_bun_lockfile_v2(buf);
+                    }
                     content.push_str(&buf);
                 } else {
                     content.push_str(&EMPTY_FILE);
@@ -2896,9 +2921,8 @@ pub async fn handle_wac_v2_output(
                                     version: flow_info.version,
                                     labels: flow_info.labels.clone(),
                                 };
-                                let on_behalf_of = flow_info
-                                    .on_behalf_of(&job.workspace_id, db)
-                                    .await?;
+                                let on_behalf_of =
+                                    flow_info.on_behalf_of(&job.workspace_id, db).await?;
                                 let step_args: HashMap<String, Box<RawValue>> = step
                                     .args
                                     .iter()
@@ -4124,6 +4148,20 @@ pub async fn start_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_downgrade_bun_lockfile_v2() {
+        let v2 = "{\n  \"lockfileVersion\": 2,\n  \"packages\": { \"a\": [\"a@1.0.0\"] }\n}";
+        let downgraded = downgrade_bun_lockfile_v2(v2.to_string());
+        assert!(downgraded.contains("\"lockfileVersion\": 1,"));
+        // everything but the header survives verbatim: the pins are the whole point
+        assert!(downgraded.contains("\"a@1.0.0\""));
+        assert_eq!(downgraded.len(), v2.len());
+
+        // a lockfile bun already wrote as v1 is left exactly as-is
+        let v1 = "{\n  \"lockfileVersion\": 1,\n  \"packages\": {}\n}";
+        assert_eq!(downgrade_bun_lockfile_v2(v1.to_string()), v1);
+    }
 
     #[test]
     fn test_split_lockfile_text_unix() {

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -378,25 +378,42 @@ pub(crate) fn split_lockfile(lockfile: &str) -> (&str, Option<&str>, bool, bool)
     }
 }
 
-/// Stamp a bun 1.4 text lockfile back to `lockfileVersion: 1`.
+/// An empty `lockfileVersion: 1` lockfile, planted before `bun install` so bun writes v1.
 ///
-/// Only the header distinguishes the two for the flat `{"dependencies": {...}}` the dependency
-/// job writes: no overrides, catalogs or workspaces, so nothing needs v2 syntax. Both bun
-/// versions honour the result. Gated on [`MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2`] so the fleet
-/// stops paying for this once every worker can read v2.
-fn downgrade_bun_lockfile_v2(lockfile: String) -> String {
-    const V2: &str = "\"lockfileVersion\": 2";
-    const V1: &str = "\"lockfileVersion\": 1";
-    match lockfile.find(V2) {
-        Some(i) => {
-            let mut out = String::with_capacity(lockfile.len());
-            out.push_str(&lockfile[..i]);
-            out.push_str(V1);
-            out.push_str(&lockfile[i + V2.len()..]);
-            out
-        }
-        None => lockfile,
+/// bun keeps whichever version the lockfile it found already had, and only raises it when the
+/// dependencies genuinely need newer syntax. Seeding therefore gets a real v1 lockfile — written
+/// by bun, not rewritten by us — whenever v1 can express the resolution, and lets bun escalate
+/// when it cannot. [`bun_lockfile_version`] catches the escalation afterwards.
+const EMPTY_V1_BUN_LOCK: &str = r#"{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {},
+  },
+  "packages": {}
+}"#;
+
+async fn seed_v1_bun_lockfile(job_dir: &str) -> Result<()> {
+    let path = format!("{job_dir}/bun.lock");
+    if tokio::fs::metadata(&path).await.is_ok() {
+        return Ok(());
     }
+    write_file(job_dir, "bun.lock", EMPTY_V1_BUN_LOCK)?;
+    Ok(())
+}
+
+/// The `lockfileVersion` a bun text lockfile declares, if it declares one.
+fn bun_lockfile_version(lockfile: &str) -> Option<u32> {
+    let i = lockfile.find("\"lockfileVersion\"")?;
+    let rest = &lockfile[i + "\"lockfileVersion\"".len()..];
+    let digits = rest
+        .trim_start()
+        .strip_prefix(':')?
+        .trim_start()
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>();
+    digits.parse().ok()
 }
 
 pub async fn gen_bun_lockfile(
@@ -518,6 +535,9 @@ pub async fn gen_bun_lockfile(
     }
 
     if !empty_deps {
+        if !npm_mode && !MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2.met_conservatively() {
+            seed_v1_bun_lockfile(job_dir).await?;
+        }
         install_bun_lockfile(
             mem_peak,
             canceled_by,
@@ -562,7 +582,18 @@ pub async fn gen_bun_lockfile(
                     let mut buf = String::default();
                     file.read_to_string(&mut buf).await?;
                     if !MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2.met_conservatively() {
-                        buf = downgrade_bun_lockfile_v2(buf);
+                        // Seeding asked bun for v1; a higher version back means these
+                        // dependencies cannot be expressed in one. Storing it anyway would not
+                        // fail on an older worker — it would install from package.json alone and
+                        // silently resolve different versions.
+                        if let Some(v) = bun_lockfile_version(&buf).filter(|v| *v > 1) {
+                            return Err(error::Error::ExecutionErr(format!(
+                                "bun produced a v{v} lockfile, which workers older than {} \
+                                 cannot read. Finish upgrading every worker before deploying \
+                                 dependencies that need it (overrides, catalogs).",
+                                MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2.version()
+                            )));
+                        }
                     }
                     content.push_str(&buf);
                 } else {
@@ -4150,17 +4181,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_downgrade_bun_lockfile_v2() {
-        let v2 = "{\n  \"lockfileVersion\": 2,\n  \"packages\": { \"a\": [\"a@1.0.0\"] }\n}";
-        let downgraded = downgrade_bun_lockfile_v2(v2.to_string());
-        assert!(downgraded.contains("\"lockfileVersion\": 1,"));
-        // everything but the header survives verbatim: the pins are the whole point
-        assert!(downgraded.contains("\"a@1.0.0\""));
-        assert_eq!(downgraded.len(), v2.len());
-
-        // a lockfile bun already wrote as v1 is left exactly as-is
-        let v1 = "{\n  \"lockfileVersion\": 1,\n  \"packages\": {}\n}";
-        assert_eq!(downgrade_bun_lockfile_v2(v1.to_string()), v1);
+    fn test_bun_lockfile_version() {
+        assert_eq!(bun_lockfile_version(EMPTY_V1_BUN_LOCK), Some(1));
+        assert_eq!(
+            bun_lockfile_version("{\n  \"lockfileVersion\": 2,\n  \"packages\": {}\n}"),
+            Some(2)
+        );
+        // bun raises the version on its own for overrides/catalogs; anything above 1 has to be
+        // recognised, not just the version that happened to exist when this was written
+        assert_eq!(bun_lockfile_version("{\"lockfileVersion\":3}"), Some(3));
+        assert_eq!(
+            bun_lockfile_version("{ \"lockfileVersion\" : 42 }"),
+            Some(42)
+        );
+        assert_eq!(bun_lockfile_version("{\"packages\":{}}"), None);
     }
 
     #[test]

--- a/debugger/Dockerfile
+++ b/debugger/Dockerfile
@@ -19,7 +19,7 @@
 FROM ghcr.io/windmill-labs/windmill-ee:main AS windmill-source
 
 # Stage 2: Build the debug service
-FROM oven/bun:1 AS runtime
+FROM oven/bun:1.4.0 AS runtime
 
 # Install Python and required system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -70,7 +70,7 @@ RUN mkdir -p /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv
 
-COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.4.0 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI (node symlink needed for bun install)
 RUN ln -s /usr/bin/bun /usr/bin/node \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -70,7 +70,7 @@ RUN mkdir -p /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv
 
-COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.4.0 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI (node symlink needed for bun install)
 RUN ln -s /usr/bin/bun /usr/bin/node \

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineLanguages.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineLanguages.ts
@@ -4,7 +4,7 @@ import type { ScriptLang } from '$lib/gen'
 // actually reach for first: duckdb for in-place SQL on parquet/s3 (the
 // default), bun for ergonomic data wrangling, python for ML/pandas, then
 // the sql dialects for warehouse-resident transforms. Everything else
-// (deno/bash/go) sits below — still creatable, just not the default
+// (bash/go/deno) sits below — still creatable, just not the default
 // suggestion.
 export const PIPELINE_LANGUAGES: Array<{ label: string; lang: ScriptLang }> = [
 	{ label: 'DuckDB', lang: 'duckdb' },
@@ -15,7 +15,7 @@ export const PIPELINE_LANGUAGES: Array<{ label: string; lang: ScriptLang }> = [
 	{ label: 'Snowflake', lang: 'snowflake' },
 	{ label: 'MySQL', lang: 'mysql' },
 	{ label: 'MS SQL', lang: 'mssql' },
-	{ label: 'Deno', lang: 'deno' },
 	{ label: 'Bash', lang: 'bash' },
-	{ label: 'Go', lang: 'go' }
+	{ label: 'Go', lang: 'go' },
+	{ label: 'Deno', lang: 'deno' }
 ]

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineLanguages.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineLanguages.ts
@@ -15,7 +15,7 @@ export const PIPELINE_LANGUAGES: Array<{ label: string; lang: ScriptLang }> = [
 	{ label: 'Snowflake', lang: 'snowflake' },
 	{ label: 'MySQL', lang: 'mysql' },
 	{ label: 'MS SQL', lang: 'mssql' },
-	{ label: 'TypeScript (Deno)', lang: 'deno' },
+	{ label: 'Deno', lang: 'deno' },
 	{ label: 'Bash', lang: 'bash' },
 	{ label: 'Go', lang: 'go' }
 ]

--- a/frontend/src/lib/scripts.ts
+++ b/frontend/src/lib/scripts.ts
@@ -152,7 +152,6 @@ export function flowPathToHref(path: string, hubBaseUrl: string = get(hubBaseUrl
 const scriptLanguagesArray: [SupportedLanguage | 'docker' | 'bunnative', string][] = [
 	['bun', 'TypeScript (Bun)'],
 	['python3', 'Python'],
-	['deno', 'TypeScript (Deno)'],
 	['bash', 'Bash'],
 	['go', 'Go'],
 	['nativets', 'REST'],
@@ -175,7 +174,10 @@ const scriptLanguagesArray: [SupportedLanguage | 'docker' | 'bunnative', string]
 	['duckdb', 'DuckDB'],
 	['ruby', 'Ruby'],
 	['rlang', 'R'],
-	['dbt', 'dbt']
+	['dbt', 'dbt'],
+	// Deno is on the way out: it sits last so the picker stops steering new
+	// scripts towards it. Existing deno scripts keep working.
+	['deno', 'Deno']
 	// for related places search: ADD_NEW_LANG
 ]
 /**

--- a/frontend/src/lib/scripts.ts
+++ b/frontend/src/lib/scripts.ts
@@ -175,8 +175,8 @@ const scriptLanguagesArray: [SupportedLanguage | 'docker' | 'bunnative', string]
 	['ruby', 'Ruby'],
 	['rlang', 'R'],
 	['dbt', 'dbt'],
-	// Deno is de-emphasized: keep it last so the picker stops surfacing it as an
-	// early option for new scripts.
+	// This array's order is the picker order. Deno is de-emphasized ahead of
+	// deprecation, so it stays last.
 	['deno', 'Deno']
 	// for related places search: ADD_NEW_LANG
 ]

--- a/frontend/src/lib/scripts.ts
+++ b/frontend/src/lib/scripts.ts
@@ -175,8 +175,8 @@ const scriptLanguagesArray: [SupportedLanguage | 'docker' | 'bunnative', string]
 	['ruby', 'Ruby'],
 	['rlang', 'R'],
 	['dbt', 'dbt'],
-	// Deno is on the way out: it sits last so the picker stops steering new
-	// scripts towards it. Existing deno scripts keep working.
+	// Deno is de-emphasized: keep it last so the picker stops surfacing it as an
+	// early option for new scripts.
 	['deno', 'Deno']
 	// for related places search: ADD_NEW_LANG
 ]


### PR DESCRIPTION
## Summary

Two independent changes:

1. **Bun 1.3.10 → 1.4.0** in every image that ships a bun binary, plus the CI pins so tests run against the bun we ship.
2. **Deno demoted in the language picker** — moved from position 3 to last, and relabelled `TypeScript (Deno)` → `Deno`, ahead of eventual deprecation.

Bun 1.4.0 is a full Zig→Rust rewrite of the runtime and was released 2026-08-20, so there is no patch release behind it yet. It was exercised end-to-end against a live worker before opening this (see Test plan).

## Changes

**Bun pins**
- `Dockerfile`, `docker/DockerfileSlim`, `docker/DockerfileSlimEe`, `.github/DockerfileBackendTests`: `oven/bun:1.3.10` → `oven/bun:1.4.0`
- `bun-version: 1.3.10` → `1.4.0` in `backend-test.yml`, `backend-test-windows.yml`, `git-sync-test.yml`, `ai-evals-test.yml`, `ai-agent-tests.yml`. Without this CI would keep testing 1.3.10 while the images ship 1.4.0, so a 1.4-specific regression would escape CI.
- `debugger/Dockerfile`: `oven/bun:1` → `oven/bun:1.4.0`. This image drives `prepare-deps` against the same DB-stored lockfiles as the workers, so a floating tag there is exactly where version skew would bite.
- `docker/DockerfileCli` (`oven/bun:slim`) and the `bun-version: latest` pins in `cli-tests.yml`, `sdk-tests.yml`, `npm_on_release.yml`, `publish_extra.yml` are left floating — pre-existing, and out of scope here.

**Deno demotion**
- `frontend/src/lib/scripts.ts`: `deno` moved to the end of `scriptLanguagesArray` and relabelled `Deno`. That array is the default picker order for every surface that falls back to `Object.keys(defaultScriptLanguages)` (script editor, flow step, app inline script). Workspaces with a saved `$defaultScripts.order` keep their own order, unchanged.
- `frontend/src/lib/components/assets/AssetGraph/pipelineLanguages.ts`: same relabel, and moved after Go so the pipeline picker matches.

## Compatibility notes

- **Lockfiles.** Bun 1.4 writes `bun.lock` v2, or **v3** when `package.json` carries nested or
  version-scoped overrides. Bun 1.3 does not fail on either: it prints
  `error: Unknown lockfile version`, then installs from `package.json` alone. Because the
  dependency job writes every dependency as `"latest"`, the lockfile is the *only* pin, so an
  older worker reading a newer lock resolves whatever is newest rather than drifting inside a
  range.

  **This PR closes that.** Below `MIN_VERSION_SUPPORTS_BUN_LOCKFILE_V2` (1.794.0) `gen_bun_lockfile`
  plants an empty `lockfileVersion: 1` lockfile before `bun install` (so the runtime "no lockfile
  found" path seeds one too, though that copy is discarded with the job dir — only the dependency
  job stores anything). Bun keeps the version
  the lockfile already had and raises it only when the dependencies genuinely need newer syntax —
  so the stored lockfile is a real v1 written by bun, not a header rewritten by us. If bun raises
  it anyway, the job fails with an actionable error instead of storing a lock older workers would
  silently misread. Once every worker is on 1.794.0+ the seeding stops and v2/v3 flow through
  untouched, with no follow-up change.

  Verified end-to-end on a bun 1.4.0 worker with the fleet below the gate:

  | case | outcome |
  |---|---|
  | flat deps | stored lock is `lockfileVersion: 1`, script runs green |
  | workspace deps with a nested override | deploy refused: *"bun produced a v3 lockfile, which workers older than 1.794.0 cannot read…"* |
  | gate temporarily lowered below the fleet | stored lock is `lockfileVersion: 2` — seeding correctly disengages |
  | existing v1 lock + bun 1.4 | pins honoured exactly, lock left at v1 (no mass re-lock on upgrade) |

- All bun flags this codebase passes still exist in 1.4: `install --save-text-lockfile --no-cache`,
  `run --preserve-symlinks -i --prefer-offline -r`, `--config=<bunfig>`, `--minimum-release-age`.

## Screenshots

Script settings language picker — Deno no longer at position 3:

![language-picker-top](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/update-bun-1-4-e2e-test/1787258787-language-picker-top.png)

…and now last, labelled `Deno`:

![language-picker-deno-last](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/update-bun-1-4-e2e-test/1787258770-language-picker-deno-last.png)

## Test plan

Exercised on a live worker by pointing `BUN_PATH` at a 1.4.0 binary and re-running the same suites against the same database on both versions.

- [x] 18-case runtime suite (npm deps incl. pinned versions, `windmill-client` SDK, `node:*` builtins, `Bun.*` APIs, web streams, worker_threads, TS syntax, CJS interop, large results, args/env): identical 15/18 on 1.3.11 and 1.4.0 — same three failures on both, none introduced by 1.4
- [x] Deployed scripts: relative imports (`./dep`, `./nested/deep`), absolute windmill imports (`/f/.../dep`), and a two-step flow passing data between bun steps — 5/5 on both versions. This is what exercises the `loader.bun.js` `onResolve`/`onLoad` plugin, which behaves identically.
- [x] Lockfile compatibility in both directions, using a lockfile pulled from app.windmill.dev, with version-drift detection; both branches of the version gate exercised through the real dependency job (see above)
- [x] Job latency improves — median `duration_ms` over 9 runs: trivial job 31→23ms, `node:*` builtins 32→25ms, `windmill-client` SDK 52→37ms, 3 npm deps 64→61ms
- [x] Deno picker verified in a running browser: absent from position 3, last in the list, labelled `Deno`
- [ ] Docker images build and the CI workflows pass on 1.4.0
- [ ] Not exercised: raw-app/browser `bun build`, codebase-bundle scripts, dedicated workers, and the 1.4 `trustedDependencies`/`nativeDependencies` change (packages with postinstall scripts)

### Pre-existing failures, confirmed not caused by this bump

Both reproduce identically on bun 1.3.x and are **not** regressions from 1.4:

- `//nodejs` scripts mis-bundle certain npm import shapes. `import { chunk } from "lodash"` produces a bundle ending `…process.exit(1)} = pkg;` which node's ESM loader rejects; `import * as _ from "lodash"` bundles but yields `G.chunk is not a function`. `import _ from "lodash"` (default) works, as do dayjs, zod, uuid and mime-types in both named and default form — so this is specific to certain package/import-shape combinations, not to npm deps in general. Reproduced on app.windmill.dev (bun 1.3.10, node v20.20.2) and locally on 1.3.11 and 1.4.0 (node v26.4.0), so it is independent of both the bun and node version.
- `better-sqlite3` crashes bun with `NAPI FATAL ERROR: Error::New napi_get_last_error_info` on x64 — same panic on 1.3.11 and 1.4.0.

### Not yet verified

- Legacy binary `bun.lockb` scripts (the `write_lock` branch in `bun_executor.rs`) under 1.4's
  narrowed `trustedDependencies` matching, which no longer trusts truncated-name-hash entries —
  postinstall lifecycle scripts for those packages may stop running.
- A real two-worker skew test on one instance (re-lock on 1.4, run from a 1.3 worker). The
  isolated `bun install` measurement above predicts silent drift; it has not been reproduced
  through the full dependency-job path.

## Release note

Two things worth calling out to operators:

- **During rollout**, a bun script whose dependencies need overrides or catalogs will *hard-fail to
  deploy* until every worker is on 1.794.0, where it previously succeeded. That is deliberate — the
  alternative is silently resolving different dependency versions on the older workers — and the
  error says what to do. Note that an instance which deliberately pins a worker group to an older
  release never crosses the gate, so for them the failure is indefinite rather than transient.
- **Once the gate opens**, the next re-lock of each bun script rewrites its `bun.lock` as v2, so
  git-sync users see a lockfile format churn across the repo at that point rather than now.
