### PR TITLE
fix: make workspace preprocessor scripts selectable in flow preprocessor steps

### DIFF
--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -94,7 +94,7 @@
 		// editor). `undefined` = not applicable; `false` makes the badge red
 		// even if the main function parses.
 		validAssets?: boolean | undefined
-		kind?: 'script' | 'trigger' | 'approval'
+		kind?: 'script' | 'trigger' | 'approval' | 'preprocessor'
 		template?:
 			| 'pgsql'
 			| 'mysql'
@@ -580,7 +580,13 @@
 <Drawer bind:this={scriptPicker} size="900px">
 	<DrawerContent title="Code" on:close={scriptPicker.closeDrawer}>
 		{#if pick_existing == 'hub'}
-			<PickHubScript bind:filter {kind} on:pick={onScriptPick}>
+			<!-- The hub publishes no preprocessor script, so that kind falls back to the action list
+			     rather than showing an empty hub. -->
+			<PickHubScript
+				bind:filter
+				kind={kind == 'preprocessor' ? 'script' : kind}
+				on:pick={onScriptPick}
+			>
 				<ToggleHubWorkspace bind:selected={pick_existing} />
 			</PickHubScript>
 		{:else}

--- a/frontend/src/lib/components/flows/content/FlowInputs.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInputs.svelte
@@ -44,6 +44,11 @@
 					? 'approval'
 					: 'script'
 	)
+	// The preprocessor slot shows no kind toggle, so `kind` stays 'script' there. Everything that
+	// tags a script (inline template, pre-made list) must key off this, never off `kind`.
+	let scriptKind: 'script' | 'failure' | 'approval' | 'trigger' | 'preprocessor' = $derived(
+		preprocessorModule ? 'preprocessor' : kind
+	)
 	let pick_existing: 'workspace' | 'hub' = $state('hub')
 	let filter = $state('')
 
@@ -56,7 +61,7 @@
 	)
 
 	function displayLang(lang: SupportedLanguage | 'docker', kind: string) {
-		if (preprocessorModule) {
+		if (kind === 'preprocessor') {
 			return canHavePreprocessor(lang as SupportedLanguage)
 		}
 
@@ -218,21 +223,23 @@
 		<h3 class="pb-2 pt-4 flex gap-x-8 flex-wrap">
 			<div>
 				Inline new <span class="text-blue-500 dark:text-blue-400"
-					>{kind == 'script' ? 'action' : kind}</span
+					>{scriptKind == 'script' ? 'action' : scriptKind}</span
 				>
 				script
 				<Tooltip
-					documentationLink={kind === 'script'
+					documentationLink={scriptKind === 'script'
 						? 'https://www.windmill.dev/docs/flows/editor_components#flow-actions'
-						: kind === 'trigger'
+						: scriptKind === 'trigger'
 							? 'https://www.windmill.dev/docs/flows/flow_trigger'
-							: kind === 'approval'
+							: scriptKind === 'approval'
 								? 'https://www.windmill.dev/docs/flows/flow_approval'
-								: 'https://www.windmill.dev/docs/getting_started/flows_quickstart#flow-editor'}
+								: scriptKind === 'preprocessor'
+									? 'https://www.windmill.dev/docs/core_concepts/preprocessors'
+									: 'https://www.windmill.dev/docs/getting_started/flows_quickstart#flow-editor'}
 				>
-					Embed <span>{kind == 'script' ? 'action' : kind}</span> script directly inside a flow instead
-					of saving the script into your workspace for reuse. You can always save an inline script to
-					your workspace later.
+					Embed <span>{scriptKind == 'script' ? 'action' : scriptKind}</span> script directly inside
+					a flow instead of saving the script into your workspace for reuse. You can always save an inline
+					script to your workspace later.
 				</Tooltip>
 			</div>
 			<DefaultScripts />
@@ -250,7 +257,7 @@
 		{/if}
 		<div class="flex flex-row flex-wrap gap-2" id="flow-editor-action-script">
 			{#each langs.filter((lang) => customUi?.languages == undefined || customUi?.languages?.includes(lang?.[1])) as [label, lang] (lang)}
-				{#if displayLang(lang, kind)}
+				{#if displayLang(lang, scriptKind)}
 					<FlowScriptPicker
 						id={`flow-editor-action-script-${lang}`}
 						disabled={noEditor && (summary == undefined || summary == '')}
@@ -259,7 +266,7 @@
 						on:click={() => {
 							dispatch('new', {
 								language: lang == 'docker' ? 'bash' : lang,
-								kind,
+								kind: scriptKind,
 								subkind: lang == 'docker' ? 'docker' : preprocessorModule ? 'preprocessor' : 'flow',
 								summary
 							})
@@ -289,10 +296,13 @@
 
 		<h3 class="mb-2 mt-6"
 			>Use pre-made <span class="text-blue-500 dark:text-blue-400"
-				>{kind == 'script' ? 'action' : kind}</span
+				>{scriptKind == 'script' ? 'action' : scriptKind}</span
 			> script</h3
 		>
-		{#if pick_existing == 'hub'}
+		{#if preprocessorModule}
+			<!-- The hub publishes no preprocessor script, so this slot only ever picks from the workspace. -->
+			<WorkspaceScriptPicker displayLock bind:filter kind="preprocessor" on:pick />
+		{:else if pick_existing == 'hub'}
 			<PickHubScript bind:filter {kind} on:pick>
 				<ToggleHubWorkspace bind:selected={pick_existing} />
 			</PickHubScript>

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -109,7 +109,7 @@
 		preprocessorModule?: boolean
 		parentModule?: FlowModule | undefined
 		previousModule: FlowModule | undefined
-		scriptKind?: 'script' | 'trigger' | 'approval'
+		scriptKind?: 'script' | 'trigger' | 'approval' | 'preprocessor'
 		scriptTemplate?: 'pgsql' | 'mysql' | 'script' | 'docker' | 'powershell'
 		noEditor: boolean
 		enableAi: boolean

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -171,6 +171,11 @@
 		shellcheck: false
 	})
 
+	// `scriptKind` only records how a step was created this session, so it is back to 'script' on
+	// any remount. Being a preprocessor is a property of the slot, and the editor bar's reset code
+	// and script library depend on it, so derive it rather than reading the stale state.
+	let editorScriptKind = $derived(preprocessorModule ? 'preprocessor' : scriptKind)
+
 	let selected = $state(untrack(() => preprocessorModule) ? 'test' : 'inputs')
 	let canShowChatTab = $derived(
 		!preprocessorModule &&
@@ -864,7 +869,7 @@
 							{websocketAlive}
 							iconOnly={width < EDITOR_BAR_WIDTH_THRESHOLD}
 							compactHelpers={width < EDITOR_BAR_HELPERS_INLINE_THRESHOLD}
-							kind={scriptKind}
+							kind={editorScriptKind}
 							template={scriptTemplate}
 							args={Object.entries(flowModule.value.input_transforms).reduce((acc, [key, obj]) => {
 								acc[key] = obj.type === 'static' ? obj.value : undefined

--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -32,7 +32,7 @@
 
 	const { triggersState, triggersCount } = getContext<TriggerContext>('TriggerContext')
 
-	let scriptKind: 'script' | 'trigger' | 'approval' = $state('script')
+	let scriptKind: 'script' | 'trigger' | 'approval' | 'preprocessor' = $state('script')
 	let scriptTemplate: 'pgsql' | 'mysql' | 'script' | 'docker' | 'powershell' = $state('script')
 
 	// These pointers are used to easily access previewArgs of parent module, and previous module

--- a/frontend/src/lib/components/flows/pickers/WorkspaceScriptPicker.svelte
+++ b/frontend/src/lib/components/flows/pickers/WorkspaceScriptPicker.svelte
@@ -122,38 +122,48 @@
 				/>
 			</div>
 		{/if}
-		{#if filter.length > 0 && filteredItems.length == 0}
-			<NoItemFound />
-		{/if}
-		<ul class="divide-y border rounded-md">
-			{#each filteredItems as { path, hash, summary, description, marked }}
-				<li class="flex flex-row w-full">
-					<button
-						class="p-4 gap-1 flex flex-row grow hover:bg-surface-hover bg-surface transition-all text-primary"
-						onclick={() => {
-							dispatch('pick', { path, hash: lockHash ? hash : undefined, summary })
-						}}
-					>
-						<div class="flex flex-col">
-							<div class="text-sm font-semibold flex flex-col">
-								<span class="mr-2 text-left">
-									{#if marked}
-										{@html marked}
-									{:else}
-										{!summary || summary.length == 0 ? path : summary}
-									{/if}</span
-								>
-								<span class="font-normal text-xs text-left italic overflow-hidden"
-									>{path ?? ''}</span
-								>
+		{#if filteredItems.length == 0}
+			{#if filter.length > 0}
+				<NoItemFound hasFilters />
+			{:else}
+				<div class="text-2xs text-primary font-light text-center py-2 px-3">No scripts found.</div>
+			{/if}
+			{#if kind == 'preprocessor'}
+				<div class="text-2xs text-hint text-center pb-2 px-3">
+					Only workspace scripts whose kind is set to Preprocessor are listed here.
+				</div>
+			{/if}
+		{:else}
+			<ul class="divide-y border rounded-md">
+				{#each filteredItems as { path, hash, summary, description, marked }}
+					<li class="flex flex-row w-full">
+						<button
+							class="p-4 gap-1 flex flex-row grow hover:bg-surface-hover bg-surface transition-all text-primary"
+							onclick={() => {
+								dispatch('pick', { path, hash: lockHash ? hash : undefined, summary })
+							}}
+						>
+							<div class="flex flex-col">
+								<div class="text-sm font-semibold flex flex-col">
+									<span class="mr-2 text-left">
+										{#if marked}
+											{@html marked}
+										{:else}
+											{!summary || summary.length == 0 ? path : summary}
+										{/if}</span
+									>
+									<span class="font-normal text-xs text-left italic overflow-hidden"
+										>{path ?? ''}</span
+									>
+								</div>
+								<div class="text-xs font-light italic text-left">{description ?? ''}</div>
 							</div>
-							<div class="text-xs font-light italic text-left">{description ?? ''}</div>
-						</div>
-						{#if lockHash}<Badge large baseClass="ml-4">{truncateHash(hash ?? '')}</Badge>{/if}
-					</button>
-				</li>
-			{/each}
-		</ul>
+							{#if lockHash}<Badge large baseClass="ml-4">{truncateHash(hash ?? '')}</Badge>{/if}
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
 	{:else}
 		<div class="mt-6"></div>
 

--- a/frontend/src/lib/components/flows/pickers/WorkspaceScriptPicker.svelte
+++ b/frontend/src/lib/components/flows/pickers/WorkspaceScriptPicker.svelte
@@ -26,7 +26,7 @@
 	const flowEditorContext = getContext<FlowEditorContext>('FlowEditorContext')
 	let opWs = $derived(flowEditorContext?.opWorkspace?.() ?? $workspaceStore)
 	interface Props {
-		kind?: 'script' | 'trigger' | 'approval' | 'failure'
+		kind?: 'script' | 'trigger' | 'approval' | 'failure' | 'preprocessor'
 		isTemplate?: boolean | undefined
 		displayLock?: boolean
 		filter?: string

--- a/frontend/src/lib/components/flows/pickers/WorkspaceScriptPickerQuick.svelte
+++ b/frontend/src/lib/components/flows/pickers/WorkspaceScriptPickerQuick.svelte
@@ -165,6 +165,11 @@
 	{#if filteredItems.length == 0}
 		<div class="text-2xs text-primary font-light text-center py-2 px-3 items-center">
 			{kind == 'flow' ? 'No flows found.' : 'No scripts found.'}
+			{#if kind == 'preprocessor'}
+				<div class="text-hint">
+					Only workspace scripts whose kind is set to Preprocessor are listed here.
+				</div>
+			{/if}
 		</div>
 	{/if}
 	<ul class="gap-1 flex flex-col">

--- a/frontend/src/lib/script_helpers.test.ts
+++ b/frontend/src/lib/script_helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { bashRunsInCustomImage } from './script_helpers'
+import { bashRunsInCustomImage, getResetCode } from './script_helpers'
 
 // bashRunsInCustomImage decides whether the +Variable/+Resource pickers insert a
 // curl/wget snippet (custom image, no wmill CLI) or the wmill CLI snippet. It must
@@ -39,5 +39,28 @@ describe('bashRunsInCustomImage', () => {
 
 	it('false for a plain script with no annotations', () => {
 		expect(bashRunsInCustomImage('# shellcheck shell=bash\necho hi')).toBe(false)
+	})
+})
+
+// getResetCode short-circuits to a per-language `main` stub before it ever looks at `kind`.
+// A preprocessor step resets through the same button, and a `main` body cannot run under the
+// preprocessor entrypoint, so every preprocessor-capable language must keep its entrypoint.
+describe('getResetCode for preprocessors', () => {
+	// The concrete `language` values a preprocessor step can carry. PREPROCESSOR_SUPPORTED_LANGUAGES
+	// also holds the 'typescript'/'python' aliases, which no script is ever stored with.
+	const langs = ['deno', 'bun', 'python3', 'php'] as const
+
+	it('keeps the preprocessor entrypoint in every language that can have one', () => {
+		for (const lang of langs) {
+			const code = getResetCode(lang, 'preprocessor', undefined)
+			expect(code, lang).toContain('preprocessor')
+			expect(code, lang).not.toContain('function main')
+			expect(code, lang).not.toContain('def main')
+		}
+	})
+
+	it('still resets action scripts to a main stub', () => {
+		expect(getResetCode('python3', 'script', undefined)).toContain('def main')
+		expect(getResetCode('bun', 'script', undefined)).toContain('function main')
 	})
 })

--- a/frontend/src/lib/script_helpers.test.ts
+++ b/frontend/src/lib/script_helpers.test.ts
@@ -42,9 +42,9 @@ describe('bashRunsInCustomImage', () => {
 	})
 })
 
-// getResetCode short-circuits to a per-language `main` stub before it ever looks at `kind`.
-// A preprocessor step resets through the same button, and a `main` body cannot run under the
-// preprocessor entrypoint, so every preprocessor-capable language must keep its entrypoint.
+// Preprocessors must bypass getResetCode's per-language `main` templates: a preprocessor step
+// resets through the same button as an action script, and a `main` body cannot run under the
+// preprocessor entrypoint.
 describe('getResetCode for preprocessors', () => {
 	// The concrete `language` values a preprocessor step can carry. PREPROCESSOR_SUPPORTED_LANGUAGES
 	// also holds the 'typescript'/'python' aliases, which no script is ever stored with.

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -1703,6 +1703,11 @@ export function getResetCode(
 		| 'ci_test_python'
 		| undefined
 ) {
+	// Every *_INIT_CODE_CLEAR below is a `main` stub, which cannot run under the preprocessor
+	// entrypoint. Preprocessors must go through initialCode to keep theirs.
+	if (kind === 'preprocessor') {
+		return initialCode(language, kind, subkind)
+	}
 	if (language === 'deno') {
 		return DENO_INIT_CODE_CLEAR
 	} else if (language === 'python3') {


### PR DESCRIPTION
## Summary

A flow's preprocessor step could not pick a workspace script, and the empty picker gave no clue why.

The classic step panel (`FlowInputs.svelte`) keeps a local `kind` that stays `'script'` for the
preprocessor slot and passed it to both pickers and to the inline-template generator. Two
consequences:

- The Workspace list showed **action** scripts and never preprocessor ones, and the panel defaulted
  to the **Hub** tab even though the hub publishes no preprocessor script (`HubScriptKind` has no
  such value).
- `initialCode()` keys the preprocessor template off `kind`, not `subkind`, so "Inline new …" seeded
  a plain `main()` action stub instead of a `preprocessor(event)` one, for every language.

That panel is reached whenever `preprocessor_module` is an `identity` step (imported flows,
CLI/YAML, AI-authored flows) rather than from the "Add preprocessor step" button.

Separately, the quick insert popover filters correctly on `kind=preprocessor` but says only "No
scripts found." when a workspace has no such script. Since a workspace script is only eligible once
its **Script kind** is set to **Preprocessor**, and nothing in either picker said so, an empty list
read as a broken feature. Both pickers now say what makes a script eligible.

## Changes

- `FlowInputs.svelte`: derive `scriptKind` (`'preprocessor'` for the preprocessor slot, else `kind`)
  and key the inline template, language filter, headings, doc link and pre-made list off it. The
  preprocessor slot renders the workspace picker directly, with no Hub toggle.
- `WorkspaceScriptPicker.svelte`: accept `'preprocessor'`; show the empty state whether or not a
  search is typed (it previously rendered an empty bordered list), and add the eligibility hint.
- `WorkspaceScriptPickerQuick.svelte`: same hint under "No scripts found.".
- `FlowModuleWrapper` / `FlowModuleComponent` / `EditorBar`: widen the `scriptKind` union to carry
  `'preprocessor'` instead of laundering it through a union that excluded it, and clamp it to
  `'script'` only at `PickHubScript`, so the step editor's Library drawer keeps a populated hub tab
  while its workspace tab correctly lists preprocessor scripts.
- `FlowModuleComponent`: derive the editor bar's kind from the preprocessor slot rather than from
  `scriptKind`, which only records how a step was created this session and is back to `'script'` on
  any remount. Without this, a reloaded inline preprocessor got an action-script Library list and,
  worse, Reset Content replaced a valid `preprocessor(...)` body with a `main()` stub that cannot run
  under the preprocessor entrypoint.
- `getResetCode()`: route preprocessors through `initialCode` before the per-language short-circuits.
  Those all return a `main` stub without ever consulting `kind`, so php was the only
  preprocessor-capable language whose reset was correct; deno, bun and python3 still produced a
  `main()` body. Pinned by a case in `script_helpers.test.ts` (verified to fail without the guard).

## Screenshots

Before — preprocessor step listing **action** scripts, Hub tab default, "action script" labels:

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787259930-classic-ws.png)

After — preprocessor labels, workspace-only picker, the preprocessor script listed:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787259930-fixed-classic.png)

Empty state in the classic panel and in the quick insert popover:

![classic empty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787259930-classic-empty-hint2.png)

![quick empty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787259930-empty-hint.png)

Reloaded (remounted) inline PHP preprocessor: Library lists preprocessor scripts, and Reset Content
keeps the preprocessor entrypoint:

![remount library](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787261292-remount-library-ws.png)

![remount reset](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787261292-remount-reset.png)

Reset Content on a reloaded **Python** preprocessor, the case the per-language short-circuit missed:

![reset python](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787262677-reset-python-preproc.png)

Inline PHP preprocessor now seeded with the preprocessor template (was the `main()` action stub):

![inline template](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-974-fix-workspace-preprocessor-scripts-not-selectable-in-flows/1787259930-fixed-inline-php.png)

## Test plan

Exercised against a local instance with a `preprocessor`-kind Python script and an action script in
one workspace, plus a second workspace with neither.

- [x] Preprocessor step's "Use pre-made preprocessor script" lists the preprocessor script, not the
      action script, and shows no Hub tab
- [x] Picking it wires the step to that path with the `preprocessor` entrypoint and a working test panel
- [x] "Inline new preprocessor script" seeds the preprocessor template (checked PHP and Python)
- [x] Empty workspace shows the eligibility hint in both the classic panel and the quick popover,
      with no empty bordered list
- [x] Step editor's Library drawer: Hub tab populated, Workspace tab filtered to preprocessor
- [x] Reload a flow with a saved inline PHP preprocessor: Library's Workspace tab lists only the
      preprocessor script, and Reset Content seeds the preprocessor template rather than `main()`
- [x] Same for a saved inline Python preprocessor (php was the only language the first pass fixed)
- [x] `npx vitest run src/lib/script_helpers.test.ts`: 9 passed
- [x] No regression on action and failure steps (kind toggle, Hub/Workspace toggle, hub list intact)
- [x] `npm run check`: 0 errors, no new warnings

One test added, in `script_helpers.test.ts`: `getResetCode` is pure logic with an existing sibling
test file, and the reset regression is exactly the kind a future language addition could reintroduce.
The Svelte wiring itself stays untested per `docs/validation.md` (pure UI, covered by type-checking).
