### PR TITLE
fix: let MCP createScript create a script without a parent hash

### DIFF
--- a/backend/generate_mcp_endpoints_tools/README.md
+++ b/backend/generate_mcp_endpoints_tools/README.md
@@ -36,11 +36,12 @@ To mark an endpoint as an MCP tool, add `x-mcp-tool: true` to the operation in t
 
 ### Body fields the agent never sees
 
-`x-mcp-tool-body-constants` sets body fields on every call to the tool. They stay out of
-the tool's input schema, so use it for a field whose only correct value over MCP is fixed —
-exposing such a field earns nothing and invites a model to fill it with a placeholder the
-API then rejects. A constant must name a real body property and must not also appear in
-`x-mcp-tool-include-fields`; the generator fails otherwise.
+`x-mcp-tool-body-constants` sets body fields on every call that carries a body. They stay
+out of the tool's input schema, so use it for a field whose only correct value over MCP is
+fixed — exposing such a field earns nothing and invites a model to fill it with a
+placeholder the API then rejects. A constant must name a real body property, must not also
+appear in `x-mcp-tool-include-fields`, and cannot cover every exposed property (a body made
+of constants alone is never sent); the generator fails otherwise.
 
 ```yaml
 /w/{workspace}/scripts/create:

--- a/backend/generate_mcp_endpoints_tools/README.md
+++ b/backend/generate_mcp_endpoints_tools/README.md
@@ -33,3 +33,19 @@ To mark an endpoint as an MCP tool, add `x-mcp-tool: true` to the operation in t
     operationId: listScripts
     # ... rest of endpoint definition
 ```
+
+### Body fields the agent never sees
+
+`x-mcp-tool-body-constants` sets body fields on every call to the tool. They stay out of
+the tool's input schema, so use it for a field whose only correct value over MCP is fixed —
+exposing such a field earns nothing and invites a model to fill it with a placeholder the
+API then rejects. A constant must name a real body property and must not also appear in
+`x-mcp-tool-include-fields`; the generator fails otherwise.
+
+```yaml
+/w/{workspace}/scripts/create:
+  post:
+    x-mcp-tool: true
+    x-mcp-tool-body-constants:
+      auto_parent: true
+```

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -61,7 +61,7 @@ def flatten_allof_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
 
     return merged
 
-def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Optional[Dict[str, Any]], spec: Dict[str, Any], required_fields: Optional[List[str]] = None, base_path: str = "", include_fields: Optional[List[str]] = None, opaque_fields: Optional[List[str]] = None, include_query_params: Optional[List[str]] = None) -> tuple:
+def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Optional[Dict[str, Any]], spec: Dict[str, Any], required_fields: Optional[List[str]] = None, base_path: str = "", include_fields: Optional[List[str]] = None, opaque_fields: Optional[List[str]] = None, include_query_params: Optional[List[str]] = None, body_constants: Optional[Dict[str, Any]] = None) -> tuple:
     """Extract separate schemas for path parameters, query parameters, and request body."""
     path_params_schema = {
         "type": "object",
@@ -114,8 +114,16 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
         body_schema = extract_request_body_schema(request_body, spec, base_path)
 
         # Flatten allOf schemas into a single object schema for filtering
-        if body_schema and (include_fields is not None or opaque_fields):
+        if body_schema and (include_fields is not None or opaque_fields or body_constants):
             body_schema = flatten_allof_schema(body_schema)
+
+        # A constant is sent under the agent's back, so it must name a real body field
+        # and must not also be exposed as an argument the agent can contradict.
+        for field in (body_constants or {}):
+            if field not in (body_schema or {}).get('properties', {}):
+                raise ValueError(f"x-mcp-tool-body-constants field '{field}' is not a body property")
+            if include_fields is not None and field in include_fields:
+                raise ValueError(f"x-mcp-tool-body-constants field '{field}' is also in x-mcp-tool-include-fields")
 
         # Apply include_fields filter: only keep listed top-level properties
         if body_schema and include_fields is not None and 'properties' in body_schema:
@@ -448,6 +456,10 @@ def find_mcp_tools(spec: Dict[str, Any]) -> List[Dict[str, Any]]:
                     'include_fields': operation.get('x-mcp-tool-include-fields'),
                     'opaque_fields': operation.get('x-mcp-tool-opaque-fields'),
                     'include_query_params': operation.get('x-mcp-tool-include-query-params'),
+                    # Body fields the MCP layer fills in itself, invisible to the agent.
+                    # For a field whose only correct value is fixed, this is what keeps it
+                    # out of the tool schema, where a model would fill it with a placeholder.
+                    'body_constants': operation.get('x-mcp-tool-body-constants'),
                 }
                 tools.append(tool)
 
@@ -494,7 +506,8 @@ export const mcpEndpointTools: EndpointTool[] = [];
         # Generate separate schemas
         path_params_schema, query_params_schema, body_schema, query_field_renames, body_field_renames = extract_separate_schemas(
             tool['parameters'], tool['requestBody'], spec, tool['required_fields'], base_path,
-            tool.get('include_fields'), tool.get('opaque_fields'), tool.get('include_query_params')
+            tool.get('include_fields'), tool.get('opaque_fields'), tool.get('include_query_params'),
+            tool.get('body_constants')
         )
 
         # Convert schemas to TypeScript - use 'as const' for better type inference
@@ -503,6 +516,7 @@ export const mcpEndpointTools: EndpointTool[] = [];
         body_schema_ts = json.dumps(body_schema, indent=8) if body_schema else "undefined"
         query_field_renames_ts = json.dumps(query_field_renames, indent=8) if query_field_renames else "undefined"
         body_field_renames_ts = json.dumps(body_field_renames, indent=8) if body_field_renames else "undefined"
+        body_constants_ts = json.dumps(tool.get('body_constants'), indent=8) if tool.get('body_constants') else "undefined"
 
         # Generate tool definition
         tool_def = f"""    {{
@@ -515,7 +529,8 @@ export const mcpEndpointTools: EndpointTool[] = [];
         queryParamsSchema: {query_params_ts},
         bodySchema: {body_schema_ts},
         queryFieldRenames: {query_field_renames_ts},
-        bodyFieldRenames: {body_field_renames_ts}
+        bodyFieldRenames: {body_field_renames_ts},
+        bodyConstants: {body_constants_ts}
     }}"""
         tool_definitions.append(tool_def)
 
@@ -536,6 +551,7 @@ export interface EndpointTool {{
     bodySchema?: object;
     queryFieldRenames?: Record<string, string>;
     bodyFieldRenames?: Record<string, string>;
+    bodyConstants?: Record<string, unknown>;
 }}
 
 export const mcpEndpointTools: EndpointTool[] = [
@@ -567,7 +583,8 @@ pub fn all_tools() -> Vec<EndpointTool> {{
         # Generate separate schemas
         path_params_schema, query_params_schema, body_schema, query_field_renames, body_field_renames = extract_separate_schemas(
             tool['parameters'], tool['requestBody'], spec, tool['required_fields'], base_path,
-            tool.get('include_fields'), tool.get('opaque_fields'), tool.get('include_query_params')
+            tool.get('include_fields'), tool.get('opaque_fields'), tool.get('include_query_params'),
+            tool.get('body_constants')
         )
 
         path_params_rust = schema_to_rust_value(path_params_schema)
@@ -575,6 +592,7 @@ pub fn all_tools() -> Vec<EndpointTool> {{
         body_schema_rust = schema_to_rust_value(body_schema)
         query_field_renames_rust = schema_to_rust_value(query_field_renames if query_field_renames else None)
         body_field_renames_rust = schema_to_rust_value(body_field_renames if body_field_renames else None)
+        body_constants_rust = schema_to_rust_value(tool.get('body_constants') or None)
 
         # Generate tool definition
         tool_def = f"""    EndpointTool {{
@@ -588,6 +606,7 @@ pub fn all_tools() -> Vec<EndpointTool> {{
         body_schema: {body_schema_rust},
         query_field_renames: {query_field_renames_rust},
         body_field_renames: {body_field_renames_rust},
+        body_constants: {body_constants_rust},
     }}"""
         tool_definitions.append(tool_def)
 

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -109,6 +109,9 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
             if param_required:
                 query_params_schema['required'].append(param_name)
     
+    if body_constants and not request_body:
+        raise ValueError("x-mcp-tool-body-constants needs a request body to set them on")
+
     # Process request body if present
     if request_body:
         body_schema = extract_request_body_schema(request_body, spec, base_path)

--- a/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
+++ b/backend/generate_mcp_endpoints_tools/generate_mcp_tools.py
@@ -136,6 +136,20 @@ def extract_separate_schemas(parameters: List[Dict[str, Any]], request_body: Opt
                     r for r in body_schema['required'] if r in include_fields
                 ]
 
+        # A constant is never an argument: keep it out of the schema the agent sees,
+        # whatever the include list says.
+        if body_schema and body_constants and 'properties' in body_schema:
+            for field in body_constants:
+                body_schema['properties'].pop(field, None)
+            if 'required' in body_schema:
+                body_schema['required'] = [
+                    r for r in body_schema['required'] if r not in body_constants
+                ]
+            # Constants ride along with the caller's fields; a body made of nothing else
+            # reads as a pass-through body downstream and is sent without them.
+            if not body_schema['properties']:
+                raise ValueError("x-mcp-tool-body-constants cannot cover every exposed body property")
+
         # Apply opaque_fields: simplify listed properties to {"type": "object"}
         if body_schema and opaque_fields and 'properties' in body_schema:
             for field in opaque_fields:

--- a/backend/windmill-api-integration-tests/tests/scripts.rs
+++ b/backend/windmill-api-integration-tests/tests/scripts.rs
@@ -458,6 +458,44 @@ async fn test_auto_parent_resolves_parent_hash(db: Pool<Postgres>) -> anyhow::Re
     Ok(())
 }
 
+/// A version's hash covers the parent it was deployed onto, so it must be computed
+/// after `auto_parent` resolves that parent. Computed before, every version of a path
+/// hashes as if it were the first, and restoring content the path already held
+/// collides with the older version carrying it.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_auto_parent_can_restore_earlier_content(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace/scripts");
+    let path = "u/test-user/auto_parent_revert";
+    let first = "export async function main() { return 1; }";
+
+    for content in [first, "export async function main() { return 2; }", first] {
+        let mut script = new_script(path, "v", content);
+        script["auto_parent"] = json!(true);
+        let resp = authed(client().post(format!("{base}/create")))
+            .json(&script)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 201, "create: {}", resp.text().await?);
+    }
+
+    let body = authed_get(port, "get/p", path)
+        .await
+        .json::<serde_json::Value>()
+        .await?;
+    assert_eq!(body["content"], first, "the head must carry the restored content");
+    assert_eq!(
+        body["parent_hashes"].as_array().unwrap().len(),
+        2,
+        "the restored version chains onto the two before it"
+    );
+
+    Ok(())
+}
+
 /// Regression test for GHSA-2ppx-66jv-wpw5: a path-scoped token must only see
 /// the scripts within its scope when listing, even though the route-level scope
 /// check only validates `domain:action`. Before the fix, `list_search` (and

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1054,7 +1054,6 @@ async fn create_script_internal<'c>(
     // Caller-intent: CLI / git-sync deploys ask us to preserve any existing
     // user draft at this path instead of wiping it as part of the deploy.
     let skip_draft_deletion = ns.skip_draft_deletion.unwrap_or(false);
-    let hash = ScriptHash(hash_script(&ns));
     let authed = maybe_refresh_folders(&ns.path, &w_id, authed, &db).await;
 
     let mut tx: Transaction<'_, Postgres> = user_db.begin(&authed).await?;
@@ -1101,21 +1100,6 @@ async fn create_script_internal<'c>(
     let legacy_on_behalf_of_email =
         windmill_common::legacy_on_behalf_of_email(resolved_on_behalf_of.as_deref(), &w_id, &db)
             .await?;
-    if sqlx::query_scalar!(
-        "SELECT 1 FROM script WHERE hash = $1 AND workspace_id = $2",
-        hash.0,
-        &w_id
-    )
-    .fetch_optional(&mut *tx)
-    .await?
-    .is_some()
-    {
-        return Err(Error::BadRequest(
-            "A script with same hash (hence same path, description, summary, content) already \
-             exists!"
-                .to_owned(),
-        ));
-    };
     // When auto_parent is set, serialize concurrent creates for the same (workspace, path)
     // so the clashing_script query always sees the latest committed head.
     if ns.auto_parent.unwrap_or(false) {
@@ -1150,6 +1134,27 @@ async fn create_script_internal<'c>(
             ns.parent_hash = None;
         }
     }
+
+    // Hashed here, once the request is fully resolved: the parent an `auto_parent`
+    // caller delegated, and any identity a folder default supplied above, both belong
+    // to the version's identity. Hashing before them makes reverting a path to content
+    // it already held collide with that older version.
+    let hash = ScriptHash(hash_script(&ns));
+    if sqlx::query_scalar!(
+        "SELECT 1 FROM script WHERE hash = $1 AND workspace_id = $2",
+        hash.0,
+        &w_id
+    )
+    .fetch_optional(&mut *tx)
+    .await?
+    .is_some()
+    {
+        return Err(Error::BadRequest(
+            "A script with same hash (hence same path, description, summary, content) already \
+             exists!"
+                .to_owned(),
+        ));
+    };
 
     let parent_hashes_and_perms: Option<ParentInfo> = match (&ns.parent_hash, clashing_script) {
         (None, None) => Ok(None),

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -9449,13 +9449,18 @@ paths:
       summary: create script
       description: |
         Creates a new script when the path does not already exist.
-        Creates a new version of an existing script when called with the same path and the current `parent_hash`.
+        Creates a new version of an existing script when called with the same path.
       operationId: createScript
       x-mcp-tool: true
-      x-mcp-instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language, and leave parent_hash unset. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool with the same path and set parent_hash to the script's current hash, which you can read from the `hash` field returned by getScriptByPath. This creates a new version while preserving the script's history."
+      x-mcp-instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool again with the same path. That creates a new version while preserving the script's history; the parent version is resolved for you, so you never need a script hash."
+      # The MCP tool exposes no `parent_hash`: an agent cannot hold a hash across a
+      # concurrent deploy, and every wrong value is a hard error. `auto_parent` makes
+      # the backend resolve the current head for the path inside the transaction, so
+      # the same call creates a script or versions it.
+      x-mcp-tool-body-constants:
+        auto_parent: true
       x-mcp-tool-include-fields:
         - path
-        - parent_hash
         - content
         - language
         - summary
@@ -26521,6 +26526,9 @@ components:
           type: string
         parent_hash:
           type: string
+          description: >-
+            The version the new one builds on. A path that already holds a
+            non-archived script needs this, or auto_parent.
         auto_parent:
           type: boolean
           description: >-

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -9449,7 +9449,7 @@ paths:
       summary: create script
       description: |
         Creates a new script when the path does not already exist.
-        Creates a new version of an existing script when called with the same path.
+        Creates a new version of an existing script when called with the same path; the version it builds on comes from `parent_hash`, or from `auto_parent` resolving the current head.
       operationId: createScript
       x-mcp-tool: true
       x-mcp-instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool again with the same path. That creates a new version while preserving the script's history; the parent version is resolved for you, so you never need a script hash."

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -26102,6 +26102,10 @@ components:
           type: object
           description: JSON schema for request body
           nullable: true
+        body_constants:
+          type: object
+          description: Body fields the caller must send on top of the ones it assembles from body_schema, which does not describe them
+          nullable: true
 
     AIProvider:
       type: string

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -694,7 +694,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
     EndpointTool {
         name: Cow::Borrowed("createScript"),
         description: Cow::Borrowed("create script: Creates a new script when the path does not already exist.
-Creates a new version of an existing script when called with the same path"),
+Creates a new version of an existing script when called with the same path; the version it builds on comes from `parent_hash`, or from `auto_parent` resolving the current head"),
         instructions: Cow::Borrowed("To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool again with the same path. That creates a new version while preserving the script's history; the parent version is resolved for you, so you never need a script hash."),
         path: Cow::Borrowed("/w/{workspace}/scripts/create"),
         method: Cow::Borrowed("POST"),

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -28,6 +28,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("readDocsPage"),
@@ -55,6 +56,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listDataMetrics"),
@@ -97,6 +99,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("createVariable"),
@@ -167,6 +170,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("deleteVariable"),
@@ -189,6 +193,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("updateVariable"),
@@ -252,6 +257,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_field_renames: Some(serde_json::json!({
         "path__body": "path"
 })),
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getVariable"),
@@ -291,6 +297,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listVariable"),
@@ -344,6 +351,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("createResource"),
@@ -399,6 +407,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("deleteResource"),
@@ -421,6 +430,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("updateResource"),
@@ -474,6 +484,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_field_renames: Some(serde_json::json!({
         "path__body": "path"
 })),
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getResource"),
@@ -505,6 +516,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listResource"),
@@ -566,6 +578,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listResourceType"),
@@ -578,6 +591,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listScripts"),
@@ -675,12 +689,13 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("createScript"),
         description: Cow::Borrowed("create script: Creates a new script when the path does not already exist.
-Creates a new version of an existing script when called with the same path and the current `parent_hash`"),
-        instructions: Cow::Borrowed("To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language, and leave parent_hash unset. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool with the same path and set parent_hash to the script's current hash, which you can read from the `hash` field returned by getScriptByPath. This creates a new version while preserving the script's history."),
+Creates a new version of an existing script when called with the same path"),
+        instructions: Cow::Borrowed("To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool again with the same path. That creates a new version while preserving the script's history; the parent version is resolved for you, so you never need a script hash."),
         path: Cow::Borrowed("/w/{workspace}/scripts/create"),
         method: Cow::Borrowed("POST"),
         path_params_schema: None,
@@ -689,9 +704,6 @@ Creates a new version of an existing script when called with the same path and t
         "type": "object",
         "properties": {
                 "path": {
-                        "type": "string"
-                },
-                "parent_hash": {
                         "type": "string"
                 },
                 "summary": {
@@ -728,6 +740,9 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: Some(serde_json::json!({
+        "auto_parent": true
+})),
     },
     EndpointTool {
         name: Cow::Borrowed("deleteScriptByHash"),
@@ -750,6 +765,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("deleteScriptByPath"),
@@ -781,6 +797,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getScriptByPath"),
@@ -815,6 +832,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("runScriptByPath"),
@@ -841,6 +859,7 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listFlows"),
@@ -910,6 +929,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getFlowByPath"),
@@ -944,6 +964,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("createFlow"),
@@ -990,6 +1011,7 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("updateFlow"),
@@ -1048,6 +1070,7 @@ Creates a new version of an existing script when called with the same path and t
         body_field_renames: Some(serde_json::json!({
         "path__body": "path"
 })),
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("deleteFlowByPath"),
@@ -1079,6 +1102,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listApps"),
@@ -1108,6 +1132,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getAppByPath"),
@@ -1130,6 +1155,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("createApp"),
@@ -1238,6 +1264,7 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("updateApp"),
@@ -1356,6 +1383,7 @@ Creates a new version of an existing script when called with the same path and t
         body_field_renames: Some(serde_json::json!({
         "path__body": "path"
 })),
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("runFlowByPath"),
@@ -1382,6 +1410,7 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("runScriptPreviewAndWaitResult"),
@@ -1477,6 +1506,7 @@ Creates a new version of an existing script when called with the same path and t
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listQueue"),
@@ -1597,6 +1627,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listJobs"),
@@ -1767,6 +1798,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getJob"),
@@ -1805,6 +1837,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getJobLogs"),
@@ -1836,6 +1869,7 @@ Creates a new version of an existing script when called with the same path and t
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("createSchedule"),
@@ -2049,6 +2083,7 @@ You should get the schema of the script or flow before creating the schedule to 
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("updateSchedule"),
@@ -2255,6 +2290,7 @@ You should get the schema of the script or flow before updating the schedule to 
 })),
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("deleteSchedule"),
@@ -2277,6 +2313,7 @@ You should get the schema of the script or flow before updating the schedule to 
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("getSchedule"),
@@ -2308,6 +2345,7 @@ You should get the schema of the script or flow before updating the schedule to 
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listSchedules"),
@@ -2373,6 +2411,7 @@ You should get the schema of the script or flow before updating the schedule to 
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     },
     EndpointTool {
         name: Cow::Borrowed("listWorkers"),
@@ -2402,6 +2441,7 @@ You should get the schema of the script or flow before updating the schedule to 
         body_schema: None,
         query_field_renames: None,
         body_field_renames: None,
+        body_constants: None,
     }
     ]
 }

--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -484,6 +484,7 @@ fn assemble_request_body(
         method,
         body_schema,
         body_field_renames,
+        body_constants,
         path_params_schema,
         query_params_schema,
         ..
@@ -531,7 +532,7 @@ fn assemble_request_body(
 
     let props = schema.get("properties")?.as_object()?;
 
-    let body_map: serde_json::Map<String, Value> = props
+    let mut body_map: serde_json::Map<String, Value> = props
         .keys()
         .filter_map(|param_name| {
             args_map.get(param_name).map(|value| {
@@ -543,10 +544,18 @@ fn assemble_request_body(
         .collect();
 
     if body_map.is_empty() {
-        None
-    } else {
-        Some(Value::Object(body_map))
+        // Emptiness is judged on the caller's fields alone, so constants can't paper
+        // over a call that filled nothing (see non_empty_body_fields).
+        return None;
     }
+
+    if let Some(constants) = body_constants.as_ref().and_then(|c| c.as_object()) {
+        for (name, value) in constants {
+            body_map.insert(name.clone(), value.clone());
+        }
+    }
+
+    Some(Value::Object(body_map))
 }
 
 /// Scopes to embed in the JWT minted for a proxied MCP endpoint request. The MCP
@@ -853,6 +862,7 @@ mod tests {
             body_schema,
             query_field_renames: None,
             body_field_renames,
+            body_constants: None,
         }
     }
 
@@ -1004,6 +1014,38 @@ mod tests {
         .unwrap()
         .expect("a call carrying an update must still build a body");
         assert_eq!(body.as_object().unwrap().get("value"), Some(&json!("v")));
+    }
+
+    #[test]
+    fn build_request_body_creates_a_script_without_a_parent_hash() {
+        // An agent has no way to hold a script hash, so createScript exposes none and
+        // delegates parent resolution to the backend. Without `auto_parent` this same
+        // call creates on a fresh path but conflicts with the script already at an
+        // existing one.
+        let tool = generated_tool("createScript");
+        assert!(
+            !tool.body_schema.as_ref().unwrap()["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("parent_hash"),
+            "parent_hash must stay out of the tool's input schema"
+        );
+
+        let body = build_request_body(
+            &tool,
+            &args_of(json!({
+                "path": "u/admin/new_script",
+                "summary": "s",
+                "content": "export async function main() {}",
+                "language": "bun"
+            })),
+        )
+        .unwrap()
+        .expect("a create call must build a body");
+        assert_eq!(
+            body.as_object().unwrap().get("auto_parent"),
+            Some(&json!(true))
+        );
     }
 
     #[test]

--- a/backend/windmill-mcp/src/server/endpoints.rs
+++ b/backend/windmill-mcp/src/server/endpoints.rs
@@ -23,6 +23,12 @@ pub struct EndpointTool {
     pub body_schema: Option<serde_json::Value>,
     pub query_field_renames: Option<serde_json::Value>,
     pub body_field_renames: Option<serde_json::Value>,
+    /// Body fields the MCP layer sends itself, absent from `body_schema` and so
+    /// from the tool's input schema. They exist for a field whose only correct
+    /// value over MCP is fixed: exposing such a field earns nothing and invites a
+    /// model to fill it with a placeholder the API then rejects.
+    #[serde(default)]
+    pub body_constants: Option<serde_json::Value>,
 }
 
 /// True if this endpoint is safe to expose to a read-only token. Mirrors the
@@ -235,6 +241,7 @@ mod tests {
             body_schema: None,
             query_field_renames: None,
             body_field_renames: None,
+            body_constants: None,
         }
     }
 

--- a/backend/windmill-mcp/src/server/runner.rs
+++ b/backend/windmill-mcp/src/server/runner.rs
@@ -899,6 +899,7 @@ mod tests {
             body_schema: None,
             query_field_renames: None,
             body_field_renames: None,
+            body_constants: None,
         }
     }
 

--- a/frontend/src/lib/components/copilot/chat/api/apiTools.ts
+++ b/frontend/src/lib/components/copilot/chat/api/apiTools.ts
@@ -4,6 +4,7 @@ import { get } from 'svelte/store'
 import { workspaceStore } from '$lib/stores'
 import type { EndpointTool } from '$lib/gen/types.gen'
 import { McpService } from '$lib/gen/services.gen'
+import { withBodyConstants } from './bodyConstants'
 
 function buildApiCallTool(endpointTool: EndpointTool): ChatCompletionFunctionTool {
 	// Build the parameters schema for OpenAI function calling
@@ -74,20 +75,17 @@ function buildApiCallTool(endpointTool: EndpointTool): ChatCompletionFunctionToo
 
 function buildToolsFromEndpoints(endpointTools: EndpointTool[]): {
 	tools: ChatCompletionFunctionTool[]
-	endpointMap: Record<string, { method: string; path: string }>
+	endpointMap: Record<string, EndpointTool>
 } {
 	const tools: ChatCompletionFunctionTool[] = []
-	const endpointMap: Record<string, { method: string; path: string }> = {}
+	const endpointMap: Record<string, EndpointTool> = {}
 
 	for (const endpointTool of endpointTools) {
 		const tool = buildApiCallTool(endpointTool)
 		tools.push(tool)
 
 		// Store the endpoint info in the map
-		endpointMap[endpointTool.name] = {
-			method: endpointTool.method,
-			path: endpointTool.path
-		}
+		endpointMap[endpointTool.name] = endpointTool
 	}
 
 	return { tools, endpointMap }
@@ -95,7 +93,7 @@ function buildToolsFromEndpoints(endpointTools: EndpointTool[]): {
 
 export function createApiTools(
 	chatTools: ChatCompletionFunctionTool[],
-	endpointMap: Record<string, { method: string; path: string }> = {}
+	endpointMap: Record<string, EndpointTool> = {}
 ): Tool<{}>[] {
 	return chatTools.map((chatTool) => {
 		const toolName = chatTool.function.name
@@ -167,7 +165,7 @@ export function createApiTools(
 						fetchOptions.headers = {
 							'Content-Type': 'application/json'
 						}
-						fetchOptions.body = JSON.stringify(requestBody)
+						fetchOptions.body = JSON.stringify(withBodyConstants(endpoint, requestBody))
 					}
 
 					const response = await fetch(url, fetchOptions)

--- a/frontend/src/lib/components/copilot/chat/api/bodyConstants.ts
+++ b/frontend/src/lib/components/copilot/chat/api/bodyConstants.ts
@@ -1,0 +1,20 @@
+import type { EndpointTool } from '$lib/gen/types.gen'
+
+/**
+ * Add the body fields an endpoint fills in for its callers rather than exposing.
+ * They are deliberately absent from `body_schema` — a field whose only correct
+ * value is fixed invites a model to place a placeholder there — so a body
+ * assembled from that schema alone omits them and the call reaches the API
+ * incomplete. Mirrors what the MCP server does for its own callers.
+ */
+export function withBodyConstants(endpoint: EndpointTool, body: unknown): unknown {
+	if (
+		!endpoint.body_constants ||
+		typeof body !== 'object' ||
+		body === null ||
+		Array.isArray(body)
+	) {
+		return body
+	}
+	return { ...body, ...endpoint.body_constants }
+}

--- a/frontend/src/lib/components/copilot/chat/global/apiCatalogTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/apiCatalogTools.test.ts
@@ -103,6 +103,23 @@ const CATALOG = [
 			type: 'object',
 			properties: { args: { type: 'object' } }
 		}
+	},
+	{
+		name: 'runScriptByPath',
+		description: 'Run script by path',
+		instructions: '',
+		path: '/w/{workspace}/jobs/run/p/{path}',
+		method: 'POST',
+		path_params_schema: {
+			type: 'object',
+			properties: { workspace: { type: 'string' }, path: { type: 'string' } },
+			required: ['workspace', 'path']
+		},
+		body_schema: {
+			type: 'object',
+			properties: { args: { type: 'object' } }
+		},
+		body_constants: { invisible_flag: true }
 	}
 ]
 
@@ -243,6 +260,24 @@ describe('call_api_endpoint', () => {
 			body: JSON.stringify({ args: { n: 1 } })
 		})
 		expect(result).toEqual({ success: true, data: 'job-id-1' })
+	})
+
+	it('sends the body fields the endpoint keeps out of its schema', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			headers: new Headers({ 'content-type': 'text/plain' }),
+			text: async () => 'job-id-2'
+		})
+		vi.stubGlobal('fetch', fetchMock)
+		await run('call_api_endpoint', {
+			name: 'runScriptByPath',
+			params: { path: 'u/me/myscript' },
+			body: { args: { n: 1 } }
+		})
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+			args: { n: 1 },
+			invisible_flag: true
+		})
 	})
 
 	it('redirects GET endpoints to call_api_get', async () => {

--- a/frontend/src/lib/components/copilot/chat/global/apiCatalogTools.ts
+++ b/frontend/src/lib/components/copilot/chat/global/apiCatalogTools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { McpService, type EndpointTool } from '$lib/gen'
 import { createToolDef, type Tool } from '../shared'
+import { withBodyConstants } from '../api/bodyConstants'
 
 /**
  * Generic access to the backend's MCP endpoint catalog (the endpoints marked
@@ -195,7 +196,7 @@ async function executeEndpoint(
 	const fetchOptions: RequestInit = { method }
 	if (body !== undefined && method !== 'GET') {
 		fetchOptions.headers = { 'Content-Type': 'application/json' }
-		fetchOptions.body = JSON.stringify(body)
+		fetchOptions.body = JSON.stringify(withBodyConstants(endpoint, body))
 	}
 
 	const response = await fetch(url, fetchOptions)

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -12,6 +12,7 @@ export interface EndpointTool {
     bodySchema?: object;
     queryFieldRenames?: Record<string, string>;
     bodyFieldRenames?: Record<string, string>;
+    bodyConstants?: Record<string, unknown>;
 }
 
 export const mcpEndpointTools: EndpointTool[] = [
@@ -36,7 +37,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "readDocsPage",
@@ -63,7 +65,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listDataMetrics",
@@ -105,7 +108,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "createVariable",
@@ -175,7 +179,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "deleteVariable",
@@ -197,7 +202,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: undefined,
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "updateVariable",
@@ -260,7 +266,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryFieldRenames: undefined,
         bodyFieldRenames: {
         "path__body": "path"
-}
+},
+        bodyConstants: undefined
     },
     {
         name: "getVariable",
@@ -299,7 +306,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listVariable",
@@ -352,7 +360,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "createResource",
@@ -407,7 +416,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "deleteResource",
@@ -429,7 +439,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: undefined,
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "updateResource",
@@ -482,7 +493,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryFieldRenames: undefined,
         bodyFieldRenames: {
         "path__body": "path"
-}
+},
+        bodyConstants: undefined
     },
     {
         name: "getResource",
@@ -513,7 +525,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listResource",
@@ -574,7 +587,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listResourceType",
@@ -586,7 +600,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: undefined,
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listScripts",
@@ -683,12 +698,13 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "createScript",
-        description: "create script: Creates a new script when the path does not already exist.\nCreates a new version of an existing script when called with the same path and the current `parent_hash`",
-        instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language, and leave parent_hash unset. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool with the same path and set parent_hash to the script's current hash, which you can read from the `hash` field returned by getScriptByPath. This creates a new version while preserving the script's history.",
+        description: "create script: Creates a new script when the path does not already exist.\nCreates a new version of an existing script when called with the same path",
+        instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool again with the same path. That creates a new version while preserving the script's history; the parent version is resolved for you, so you never need a script hash.",
         path: "/w/{workspace}/scripts/create",
         method: "POST",
         pathParamsSchema: undefined,
@@ -697,9 +713,6 @@ export const mcpEndpointTools: EndpointTool[] = [
         "type": "object",
         "properties": {
                 "path": {
-                        "type": "string"
-                },
-                "parent_hash": {
                         "type": "string"
                 },
                 "summary": {
@@ -735,7 +748,10 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: {
+        "auto_parent": true
+}
     },
     {
         name: "deleteScriptByHash",
@@ -757,7 +773,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: undefined,
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "deleteScriptByPath",
@@ -788,7 +805,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "getScriptByPath",
@@ -822,7 +840,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "runScriptByPath",
@@ -848,7 +867,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "additionalProperties": true
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listFlows",
@@ -917,7 +937,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "getFlowByPath",
@@ -951,7 +972,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "createFlow",
@@ -997,7 +1019,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "updateFlow",
@@ -1055,7 +1078,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryFieldRenames: undefined,
         bodyFieldRenames: {
         "path__body": "path"
-}
+},
+        bodyConstants: undefined
     },
     {
         name: "deleteFlowByPath",
@@ -1086,7 +1110,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listApps",
@@ -1115,7 +1140,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "getAppByPath",
@@ -1137,7 +1163,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: undefined,
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "createApp",
@@ -1245,7 +1272,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "updateApp",
@@ -1363,7 +1391,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryFieldRenames: undefined,
         bodyFieldRenames: {
         "path__body": "path"
-}
+},
+        bodyConstants: undefined
     },
     {
         name: "runFlowByPath",
@@ -1389,7 +1418,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "additionalProperties": true
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "runScriptPreviewAndWaitResult",
@@ -1484,7 +1514,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listQueue",
@@ -1604,7 +1635,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listJobs",
@@ -1774,7 +1806,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "getJob",
@@ -1812,7 +1845,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "getJobLogs",
@@ -1843,7 +1877,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "createSchedule",
@@ -2053,7 +2088,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "updateSchedule",
@@ -2256,7 +2292,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         "minProperties": 1
 },
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "deleteSchedule",
@@ -2278,7 +2315,8 @@ export const mcpEndpointTools: EndpointTool[] = [
         queryParamsSchema: undefined,
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "getSchedule",
@@ -2309,7 +2347,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listSchedules",
@@ -2374,7 +2413,8 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     },
     {
         name: "listWorkers",
@@ -2403,6 +2443,7 @@ export const mcpEndpointTools: EndpointTool[] = [
 },
         bodySchema: undefined,
         queryFieldRenames: undefined,
-        bodyFieldRenames: undefined
+        bodyFieldRenames: undefined,
+        bodyConstants: undefined
     }
 ];

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -703,7 +703,7 @@ export const mcpEndpointTools: EndpointTool[] = [
     },
     {
         name: "createScript",
-        description: "create script: Creates a new script when the path does not already exist.\nCreates a new version of an existing script when called with the same path",
+        description: "create script: Creates a new script when the path does not already exist.\nCreates a new version of an existing script when called with the same path; the version it builds on comes from `parent_hash`, or from `auto_parent` resolving the current head",
         instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool again with the same path. That creates a new version while preserving the script's history; the parent version is resolved for you, so you never need a script hash.",
         path: "/w/{workspace}/scripts/create",
         method: "POST",


### PR DESCRIPTION
## Summary

Fixes GIT-973.

The MCP `createScript` tool advertised both creating and updating a script, but an agent could not create one. Its input schema exposed a `parent_hash` string; models routinely fill every property of a non-strict tool schema rather than omitting one, and every placeholder is a hard error (`""` → 422 `hex string did not decode to an u64`, `"0"` → 422 `Odd number of digits`, `"0000000000000000"` → 400 `The parent hash does not seem to exist`). Omitting it worked on a fresh path but returned `Path conflict` on an existing one, so an agent that learned to supply the hash then broke every new script.

An agent has no way to hold a script hash: it cannot keep one across a concurrent deploy, and reading it first is a round-trip that buys nothing. So the tool no longer exposes `parent_hash` at all and sends `auto_parent: true` instead, which has the backend resolve the current head for the path inside the transaction. The same call now creates a script on a fresh path and versions it on an existing one, with the lineage preserved.

`auto_parent` alone was not usable that way yet: `create_script_internal` hashed the request before resolving the parent, so under `auto_parent` every version hashed as if it were the first, and restoring content a path already held collided with the older version carrying it (`A script with same hash ... already exists!`). The hash is now computed once the request is fully resolved. The CLI never hit this because it sends `parent_hash` *and* `auto_parent`, so its hash input already carried the lineage.

To carry the flag, the generator gains `x-mcp-tool-body-constants`: body fields the MCP layer sends itself, kept out of the tool's input schema. That is what makes a field whose only correct value is fixed unreachable to a placeholder.

## Changes
- `openapi.yaml`: `createScript` drops `parent_hash` from `x-mcp-tool-include-fields`, declares `x-mcp-tool-body-constants: {auto_parent: true}`, and its MCP instructions no longer talk about hashes. Documented `NewScript.parent_hash`.
- `generate_mcp_tools.py`: new `x-mcp-tool-body-constants` extension → `body_constants` (Rust) / `bodyConstants` (TS). Constants are stripped from the exposed schema; the generator rejects a constant that is not a body property, one also listed in `x-mcp-tool-include-fields`, and a set covering every exposed property.
- `mcp/utils.rs`: `assemble_request_body` merges the constants, judging body-emptiness on the caller's fields alone so the `non_empty_body_fields` guard still fires.
- `windmill-api-scripts/src/scripts.rs`: the version hash and its duplicate check move after the `auto_parent` parent resolution.
- Regenerated `auto_generated_endpoints.rs` and `mcpEndpointTools.ts`.

Note: `openapi-deref.{yaml,json}` are regenerated on their own cadence, not per-PR, so they are untouched here.

## Test plan
- [x] `tools/list` over a real MCP endpoint: `createScript` no longer carries `parent_hash`.
- [x] `tools/call createScript` on a fresh path → created; same path again ×3 → versions, DB shows one linear chain with only the head non-archived.
- [x] Content A → B → A over MCP: the restore succeeds and chains (this was `A script with same hash ... already exists!` before the second commit).
- [x] A stale `parent_hash: ""` from an older client is dropped as an undeclared argument instead of 422-ing.
- [x] REST with an explicit `parent_hash`: a verbatim replay is still refused by the duplicate-hash guard.
- [x] `cargo test -p windmill-api --features mcp mcp::`, `cargo test -p windmill-mcp --all-features`, `--test scripts`, `--test script_auto_parent_archived`, `--test on_behalf_of`, `--test folder_default_permissioned_as`.
- [x] `npm run check:fast`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCP createScript no longer exposes parent_hash and always sends auto_parent: true, so agents can create new scripts and version existing ones without holding a hash. We now compute the version hash after resolving auto_parent to avoid duplicate-hash collisions on restores, and the chat API executors also send hidden body constants so MCP behavior matches the server.

- OpenAPI: createScript drops parent_hash from the MCP tool schema, adds x-mcp-tool-body-constants: {auto_parent: true}, updates instructions; `NewScript.parent_hash` remains documented for REST.
- Generator: supports `x-mcp-tool-body-constants`, strips those fields from the tool schema, validates misuse, and emits `bodyConstants`/`body_constants` to TS/Rust.
- MCP server: merges `body_constants` into the request body while still enforcing non-empty caller-provided fields.
- Backend: computes the script hash after resolving `auto_parent`, preserving lineage and preventing restore collisions; duplicate-hash guard stays.
- Frontend (chat executors): both `createApiTools` and global `apiCatalogTools` now include endpoint `body_constants` in POST bodies via a shared `withBodyConstants` helper; tests cover this path.
- Regenerated `auto_generated_endpoints.rs` and `mcpEndpointTools.ts`; added integration tests covering restore via `auto_parent`.

**Rollout/Migration**
- Agents: no action; do not send `parent_hash`. If present from an older client, it’s ignored.
- CLI/REST: unchanged; REST with explicit `parent_hash` still works and duplicate-hash protection is intact.
- Addresses GIT-973 by enabling a single MCP call to both create and version scripts without hashes.

<sup>Written for commit 421024b506d8f1ef9de0e9e51c4a5efacf5064d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

