### PR TITLE
fix: make named and namespace npm imports work under //nodejs

### DIFF
--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -1284,8 +1284,10 @@ fn test_generate_bun_bundle_propagates_exit_status() {
 /// see the named exports of a CommonJS package that builds `module.exports`
 /// dynamically (lodash & co.), so a named import fails to instantiate and a
 /// namespace import yields nothing but `default`. The bundle must import such a
-/// package as a namespace and read the names off `default` instead — while
-/// leaving an ESM package's named imports as the live bindings node gives it.
+/// package as a namespace and read the names off `default` instead, while
+/// leaving alone anything node loads as ESM — including a package whose
+/// conditional exports hand bun a different file than they hand node — so its
+/// named imports stay the live bindings node gives them.
 #[test]
 fn test_node_loader_cjs_named_export_interop() {
     use std::process::Command;
@@ -1294,39 +1296,63 @@ fn test_node_loader_cjs_named_export_interop() {
     let temp_dir = tempfile::tempdir().unwrap();
     let dir = temp_dir.path();
     let dir_str = dir.to_str().unwrap();
+    let write_pkg = |name: &str, files: &[(&str, &str)]| {
+        let pkg_dir = dir.join("node_modules").join(name);
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        for (file, content) in files {
+            std::fs::write(pkg_dir.join(file), content).unwrap();
+        }
+    };
 
     // A CommonJS package whose exports only exist once it has run, which is
     // what defeats the lexer.
-    let pkg_dir = dir.join("node_modules").join("dyn-cjs-pkg");
-    std::fs::create_dir_all(&pkg_dir).unwrap();
-    std::fs::write(
-        pkg_dir.join("package.json"),
-        r#"{ "name": "dyn-cjs-pkg", "version": "1.0.0", "main": "index.js" }"#,
-    )
-    .unwrap();
-    std::fs::write(
-        pkg_dir.join("index.js"),
-        r#"
+    write_pkg(
+        "dyn-cjs-pkg",
+        &[
+            (
+                "package.json",
+                r#"{ "name": "dyn-cjs-pkg", "version": "1.0.0", "main": "index.js" }"#,
+            ),
+            (
+                "index.js",
+                r#"
 const api = {};
 ["greet"].forEach((k) => { api[k] = (s) => k + " " + s; });
 module.exports = api;
 "#,
-    )
-    .unwrap();
+            ),
+        ],
+    );
 
     // An ESM package whose exported binding changes after evaluation.
-    let esm_dir = dir.join("node_modules").join("live-esm-pkg");
-    std::fs::create_dir_all(&esm_dir).unwrap();
-    std::fs::write(
-        esm_dir.join("package.json"),
-        r#"{ "name": "live-esm-pkg", "version": "1.0.0", "type": "module", "main": "index.js" }"#,
-    )
-    .unwrap();
-    std::fs::write(
-        esm_dir.join("index.js"),
-        "export let count = 0;\nexport function bump() { count++; }\n",
-    )
-    .unwrap();
+    write_pkg(
+        "live-esm-pkg",
+        &[
+            (
+                "package.json",
+                r#"{ "name": "live-esm-pkg", "version": "1.0.0", "type": "module", "main": "index.js" }"#,
+            ),
+            ("index.js", "export let count = 0;\nexport function bump() { count++; }\n"),
+        ],
+    );
+
+    // Conditional exports that give bun CommonJS and node ESM: only node's
+    // answer says whether the bundle may snapshot the bindings.
+    write_pkg(
+        "dual-cond-pkg",
+        &[
+            (
+                "package.json",
+                r#"{ "name": "dual-cond-pkg", "version": "1.0.0",
+                     "exports": { ".": { "bun": "./bun-cjs.js", "node": "./node-esm.mjs", "default": "./node-esm.mjs" } } }"#,
+            ),
+            ("bun-cjs.js", "module.exports = { count: 0, bump() {} };\n"),
+            (
+                "node-esm.mjs",
+                "export let count = 0;\nexport function bump() { count++; }\n",
+            ),
+        ],
+    );
 
     std::fs::write(
         dir.join("main.ts"),
@@ -1334,7 +1360,12 @@ module.exports = api;
 import { greet } from "dyn-cjs-pkg";
 import * as pkg from "dyn-cjs-pkg";
 import { count, bump } from "live-esm-pkg";
-export function main() { bump(); return [greet("a"), pkg.greet("b"), count]; }
+import { count as dual, bump as bumpDual } from "dual-cond-pkg";
+export function main() {
+    bump();
+    bumpDual();
+    return [greet("a"), pkg.greet("b"), { ...pkg }.greet("c"), count, dual];
+}
 "#,
     )
     .unwrap();
@@ -1386,7 +1417,7 @@ console.log(JSON.stringify(Main.main()));
         "node rejected the bundle:\nstdout:\n{stdout}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stderr)
     );
-    assert_eq!(stdout.trim(), r#"["greet a","greet b",1]"#);
+    assert_eq!(stdout.trim(), r#"["greet a","greet b","greet c",1,1]"#);
 }
 
 /// Regression test for the install_bun_lockfile no-DB path: same code shape as

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -1279,6 +1279,100 @@ fn test_generate_bun_bundle_propagates_exit_status() {
     );
 }
 
+/// `//nodejs` bundles keep the packages installed under `node_modules` external,
+/// so node — not bun — resolves them at runtime. Node's cjs-module-lexer cannot
+/// see the named exports of a CommonJS package that builds `module.exports`
+/// dynamically (lodash & co.), so a named import fails to instantiate and a
+/// namespace import yields nothing but `default`. The bundle must import such a
+/// package as a namespace and read the names off `default` instead.
+#[test]
+fn test_node_loader_cjs_named_export_interop() {
+    use std::process::Command;
+    use windmill_worker::{build_loader, LoaderMode, BUN_PATH, NODE_BIN_PATH};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dir = temp_dir.path();
+    let dir_str = dir.to_str().unwrap();
+
+    // A CommonJS package whose exports only exist once it has run, which is
+    // what defeats the lexer.
+    let pkg_dir = dir.join("node_modules").join("dyn-cjs-pkg");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("package.json"),
+        r#"{ "name": "dyn-cjs-pkg", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        pkg_dir.join("index.js"),
+        r#"
+const api = {};
+["greet"].forEach((k) => { api[k] = (s) => k + " " + s; });
+module.exports = api;
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        dir.join("main.ts"),
+        r#"
+import { greet } from "dyn-cjs-pkg";
+import * as pkg from "dyn-cjs-pkg";
+export function main() { return [greet("a"), pkg.greet("b")]; }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("wrapper.mjs"),
+        r#"
+import * as Main from "./main.ts";
+console.log(JSON.stringify(Main.main()));
+"#,
+    )
+    .unwrap();
+
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(build_loader(
+            dir_str,
+            "http://localhost:8000",
+            "test_token",
+            "test-workspace",
+            "f/test/script",
+            LoaderMode::Node,
+            &None,
+        ))
+        .expect("build_loader failed");
+
+    let build = Command::new(BUN_PATH.as_str())
+        .args(["run", "node_builder.ts"])
+        .current_dir(dir)
+        .output()
+        .expect("Failed to run bun");
+    assert!(
+        build.status.success(),
+        "node_builder.ts failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stdout),
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    // Same hand-off as generate_wrapper_mjs: the bundle replaces its entrypoint.
+    std::fs::rename(dir.join("wrapper.js"), dir.join("wrapper.mjs")).unwrap();
+
+    let run = Command::new(NODE_BIN_PATH.as_str())
+        .arg("wrapper.mjs")
+        .current_dir(dir)
+        .output()
+        .expect("Failed to run node");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success(),
+        "node rejected the bundle:\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(stdout.trim(), r#"["greet a","greet b"]"#);
+}
+
 /// Regression test for the install_bun_lockfile no-DB path: same code shape as
 /// `generate_bun_bundle` (site 3 of the original bug) — `wait().await?` ignored
 /// non-zero bun exits. A `bun install` failure (e.g. malformed package.json)

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -1279,15 +1279,10 @@ fn test_generate_bun_bundle_propagates_exit_status() {
     );
 }
 
-/// `//nodejs` bundles keep the packages installed under `node_modules` external,
-/// so node — not bun — resolves them at runtime. Node's cjs-module-lexer cannot
-/// see the named exports of a CommonJS package that builds `module.exports`
-/// dynamically (lodash & co.), so a named import fails to instantiate and a
-/// namespace import yields nothing but `default`. The bundle must import such a
-/// package as a namespace and read the names off `default` instead, while
-/// leaving alone anything node loads as ESM — including a package whose
-/// conditional exports hand bun a different file than they hand node — so its
-/// named imports stay the live bindings node gives them.
+/// Pins the two halves of the `//nodejs` CommonJS interop: a package whose
+/// exports only exist once it has run must resolve through `default`, and one
+/// node loads as ESM — including through conditional exports that hand bun a
+/// different file — must keep its named imports as live bindings.
 #[test]
 fn test_node_loader_cjs_named_export_interop() {
     use std::process::Command;

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -1284,7 +1284,8 @@ fn test_generate_bun_bundle_propagates_exit_status() {
 /// see the named exports of a CommonJS package that builds `module.exports`
 /// dynamically (lodash & co.), so a named import fails to instantiate and a
 /// namespace import yields nothing but `default`. The bundle must import such a
-/// package as a namespace and read the names off `default` instead.
+/// package as a namespace and read the names off `default` instead — while
+/// leaving an ESM package's named imports as the live bindings node gives it.
 #[test]
 fn test_node_loader_cjs_named_export_interop() {
     use std::process::Command;
@@ -1313,12 +1314,27 @@ module.exports = api;
     )
     .unwrap();
 
+    // An ESM package whose exported binding changes after evaluation.
+    let esm_dir = dir.join("node_modules").join("live-esm-pkg");
+    std::fs::create_dir_all(&esm_dir).unwrap();
+    std::fs::write(
+        esm_dir.join("package.json"),
+        r#"{ "name": "live-esm-pkg", "version": "1.0.0", "type": "module", "main": "index.js" }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        esm_dir.join("index.js"),
+        "export let count = 0;\nexport function bump() { count++; }\n",
+    )
+    .unwrap();
+
     std::fs::write(
         dir.join("main.ts"),
         r#"
 import { greet } from "dyn-cjs-pkg";
 import * as pkg from "dyn-cjs-pkg";
-export function main() { return [greet("a"), pkg.greet("b")]; }
+import { count, bump } from "live-esm-pkg";
+export function main() { bump(); return [greet("a"), pkg.greet("b"), count]; }
 "#,
     )
     .unwrap();
@@ -1370,7 +1386,7 @@ console.log(JSON.stringify(Main.main()));
         "node rejected the bundle:\nstdout:\n{stdout}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stderr)
     );
-    assert_eq!(stdout.trim(), r#"["greet a","greet b"]"#);
+    assert_eq!(stdout.trim(), r#"["greet a","greet b",1]"#);
 }
 
 /// Regression test for the install_bun_lockfile no-DB path: same code shape as

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -1281,8 +1281,8 @@ fn test_generate_bun_bundle_propagates_exit_status() {
 
 /// Pins the two halves of the `//nodejs` CommonJS interop: a package whose
 /// exports only exist once it has run must resolve through `default`, and one
-/// node loads as ESM — including through conditional exports that hand bun a
-/// different file — must keep its named imports as live bindings.
+/// node loads as ESM — through conditional exports that hand bun a different
+/// file, or an extensionless entry — must keep its named imports as live bindings.
 #[test]
 fn test_node_loader_cjs_named_export_interop() {
     use std::process::Command;
@@ -1349,6 +1349,18 @@ module.exports = api;
         ],
     );
 
+    // An extensionless entry, which takes its format from the package scope too.
+    write_pkg(
+        "extless-esm-pkg",
+        &[
+            (
+                "package.json",
+                r#"{ "name": "extless-esm-pkg", "version": "1.0.0", "type": "module", "exports": "./entry" }"#,
+            ),
+            ("entry", "export let count = 0;\nexport function bump() { count++; }\n"),
+        ],
+    );
+
     std::fs::write(
         dir.join("main.ts"),
         r#"
@@ -1356,10 +1368,12 @@ import { greet } from "dyn-cjs-pkg";
 import * as pkg from "dyn-cjs-pkg";
 import { count, bump } from "live-esm-pkg";
 import { count as dual, bump as bumpDual } from "dual-cond-pkg";
+import { count as extless, bump as bumpExtless } from "extless-esm-pkg";
 export function main() {
     bump();
     bumpDual();
-    return [greet("a"), pkg.greet("b"), { ...pkg }.greet("c"), count, dual];
+    bumpExtless();
+    return [greet("a"), pkg.greet("b"), { ...pkg }.greet("c"), count, dual, extless];
 }
 "#,
     )
@@ -1412,7 +1426,7 @@ console.log(JSON.stringify(Main.main()));
         "node rejected the bundle:\nstdout:\n{stdout}\nstderr:\n{}",
         String::from_utf8_lossy(&run.stderr)
     );
-    assert_eq!(stdout.trim(), r#"["greet a","greet b","greet c",1,1]"#);
+    assert_eq!(stdout.trim(), r#"["greet a","greet b","greet c",1,1,1]"#);
 }
 
 /// Regression test for the install_bun_lockfile no-DB path: same code shape as

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -161,7 +161,7 @@ function wmCommonJsSpecs(specs, jobDir, nodePath) {
       } catch (err) {
         continue;
       }
-    } else if (resolved[spec] != null) {
+    } else if (resolved[spec]?.startsWith("file:")) {
       file = fileURLToPath(resolved[spec]);
     } else {
       continue;

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -12,6 +12,7 @@
 
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const WM_IDENT = "[A-Za-z_$][A-Za-z0-9_$]*";
 const WM_NS_CLAUSE = `\\*\\s*as\\s+${WM_IDENT}`;
@@ -20,21 +21,12 @@ const WM_CLAUSE = `(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}|${WM_IDENT}(?:\\s*,\\s*
 const WM_ATTRS = "\\s*(?:with|assert)\\s*\\{[^{}]*\\}";
 const WM_IMPORT = `(^|[;}\\n])import\\s*(?:(${WM_CLAUSE})\\s*from\\s*)?(?:"([^"\\n]*)"|'([^'\\n]*)')(${WM_ATTRS})?`;
 
-function wmRewriteExternalImports(code, externals, jobDir) {
+function wmRewriteExternalImports(code, externals, jobDir, nodePath) {
   if (!externals || externals.length === 0) {
     return code;
   }
-  const eligible = new Map();
-  const needsInterop = (spec) => {
-    let ok = eligible.get(spec);
-    if (ok === undefined) {
-      ok =
-        externals.some((name) => spec === name || spec.startsWith(name + "/")) &&
-        wmIsCommonJs(spec, jobDir);
-      eligible.set(spec, ok);
-    }
-    return ok;
-  };
+  const isExternal = (spec) =>
+    externals.some((name) => spec === name || spec.startsWith(name + "/"));
 
   // Import statements are found on a copy whose literals are blanked out, so
   // that generated code holding an import statement in a string is not touched.
@@ -43,15 +35,15 @@ function wmRewriteExternalImports(code, externals, jobDir) {
   // makes the rewrite safe — it is load-bearing, not a belt-and-braces extra.
   const masked = wmMaskLiterals(code);
   const anchored = new RegExp(WM_IMPORT);
-  const found = [];
+  const matches = [];
   for (const hit of masked.matchAll(new RegExp(WM_IMPORT, "g"))) {
     const m = code.slice(hit.index, hit.index + hit[0].length).match(anchored);
     if (m === null || m.index !== 0) {
       continue;
     }
     const spec = m[3] !== undefined ? m[3] : m[4];
-    if (needsInterop(spec)) {
-      found.push({
+    if (isExternal(spec)) {
+      matches.push({
         at: hit.index,
         len: hit[0].length,
         lead: m[1],
@@ -61,6 +53,16 @@ function wmRewriteExternalImports(code, externals, jobDir) {
       });
     }
   }
+  if (matches.length === 0) {
+    return code;
+  }
+
+  const commonjs = wmCommonJsSpecs(
+    [...new Set(matches.map((m) => m.spec))],
+    jobDir,
+    nodePath
+  );
+  const found = matches.filter((m) => commonjs.has(m.spec));
   if (found.length === 0) {
     return code;
   }
@@ -125,22 +127,55 @@ function wmRewriteExternalImports(code, externals, jobDir) {
   return (
     `var ${getHelper}=(n,k,s)=>{if(k in n)return n[k];let d=Object(n.default);if(k in d)return d[k];` +
     "throw new SyntaxError(`The requested module '${s}' does not provide an export named '${k}'`)};" +
-    `var ${nsHelper}=(n)=>{let d=n.default;return d!=null&&(typeof d==="object"||typeof d==="function")` +
-    `?new Proxy(n,{get:(t,k,r)=>k in t?Reflect.get(t,k,r):d[k]}):n};` +
+    `var ${nsHelper}=(n)=>{let d=n.default;if(d==null||typeof d!=="object"&&typeof d!=="function")return n;` +
+    `let t={},a=(o,k)=>Object.defineProperty(t,k,{get:()=>o[k],enumerable:!0,configurable:!0});` +
+    `for(let k of Object.keys(d))a(d,k);for(let k of Object.keys(n))a(n,k);return t};` +
     out +
     code.slice(cursor)
   );
 }
 
-// Node's own rule for the format of the file a specifier resolves to: the
-// extension decides, and `.js` follows the `type` of the closest package.json.
-function wmIsCommonJs(spec, jobDir) {
-  let file;
+// Node runs the bundle, and conditional exports can hand it a different file
+// than they hand bun, so ask node itself where each specifier resolves. Bun's
+// resolver is only the fallback for a node too old for `import.meta.resolve`.
+function wmCommonJsSpecs(specs, jobDir, nodePath) {
+  const commonjs = new Set();
+  let resolved = null;
+  const probe =
+    "const out={};" +
+    "for(const s of JSON.parse(process.argv[1])){try{out[s]=import.meta.resolve(s)}catch(e){out[s]=null}}" +
+    "console.log(JSON.stringify(out))";
   try {
-    file = Bun.resolveSync(spec, jobDir);
-  } catch (err) {
-    return true;
+    const run = Bun.spawnSync([nodePath, "--input-type=module", "-e", probe, JSON.stringify(specs)], {
+      cwd: jobDir,
+    });
+    if (run.success) {
+      resolved = JSON.parse(run.stdout.toString());
+    }
+  } catch (err) {}
+  for (const spec of specs) {
+    let file;
+    if (resolved === null) {
+      try {
+        file = Bun.resolveSync(spec, jobDir);
+      } catch (err) {
+        continue;
+      }
+    } else if (resolved[spec] != null) {
+      file = fileURLToPath(resolved[spec]);
+    } else {
+      continue;
+    }
+    if (wmIsCommonJsFile(file)) {
+      commonjs.add(spec);
+    }
   }
+  return commonjs;
+}
+
+// Node's own rule for a file's format: the extension decides, and `.js` follows
+// the `type` of the closest package.json.
+function wmIsCommonJsFile(file) {
   if (file.endsWith(".mjs")) {
     return false;
   }

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -6,8 +6,12 @@
 // verbatim and node hits the limitation; rewrite them to a namespace import plus
 // a lookup that falls back to `default` (i.e. `module.exports`).
 //
-// Named bindings become snapshots instead of live bindings, which only differs
-// for an ESM package that mutates an exported binding after evaluation.
+// Only packages node loads as CommonJS are rewritten: the rewrite turns named
+// imports into snapshots, which would freeze an ESM export its package mutates
+// after evaluation.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const WM_IDENT = "[A-Za-z_$][A-Za-z0-9_$]*";
 const WM_NS_CLAUSE = `\\*\\s*as\\s+${WM_IDENT}`;
@@ -15,12 +19,21 @@ const WM_NAMED_CLAUSE = "\\{[^{}]*\\}";
 const WM_CLAUSE = `(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}|${WM_IDENT}(?:\\s*,\\s*(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}))?)`;
 const WM_IMPORT = `(^|[;}\\n])import\\s*(?:(${WM_CLAUSE})\\s*from\\s*)?(?:"([^"\\n]*)"|'([^'\\n]*)')`;
 
-function wmRewriteExternalImports(code, externals) {
+function wmRewriteExternalImports(code, externals, jobDir) {
   if (!externals || externals.length === 0) {
     return code;
   }
-  const isExternal = (spec) =>
-    externals.some((name) => spec === name || spec.startsWith(name + "/"));
+  const eligible = new Map();
+  const needsInterop = (spec) => {
+    let ok = eligible.get(spec);
+    if (ok === undefined) {
+      ok =
+        externals.some((name) => spec === name || spec.startsWith(name + "/")) &&
+        wmIsCommonJs(spec, jobDir);
+      eligible.set(spec, ok);
+    }
+    return ok;
+  };
 
   // Import statements are found on a copy whose literals are blanked out, so
   // that generated code holding an import statement in a string is not touched.
@@ -34,7 +47,7 @@ function wmRewriteExternalImports(code, externals) {
       continue;
     }
     const spec = m[3] !== undefined ? m[3] : m[4];
-    if (isExternal(spec)) {
+    if (needsInterop(spec)) {
       found.push({ at: hit.index, len: hit[0].length, lead: m[1], clause: m[2], spec });
     }
   }
@@ -104,6 +117,38 @@ function wmRewriteExternalImports(code, externals) {
     out +
     code.slice(cursor)
   );
+}
+
+// Node's own rule for the format of the file a specifier resolves to: the
+// extension decides, and `.js` follows the `type` of the closest package.json.
+function wmIsCommonJs(spec, jobDir) {
+  let file;
+  try {
+    file = Bun.resolveSync(spec, jobDir);
+  } catch (err) {
+    return true;
+  }
+  if (file.endsWith(".mjs")) {
+    return false;
+  }
+  if (!file.endsWith(".js")) {
+    return true;
+  }
+  let dir = dirname(file);
+  for (;;) {
+    let pkg = null;
+    try {
+      pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+    } catch (err) {}
+    if (pkg !== null) {
+      return pkg.type !== "module";
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return true;
+    }
+    dir = parent;
+  }
 }
 
 function wmParseImportClause(clause) {

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -129,7 +129,8 @@ function wmRewriteExternalImports(code, externals, jobDir, nodePath) {
     "throw new SyntaxError(`The requested module '${s}' does not provide an export named '${k}'`)};" +
     `var ${nsHelper}=(n)=>{let d=n.default;if(d==null||typeof d!=="object"&&typeof d!=="function")return n;` +
     `let t={},a=(o,k)=>Object.defineProperty(t,k,{get:()=>o[k],enumerable:!0,configurable:!0});` +
-    `for(let k of Object.keys(d))a(d,k);for(let k of Object.keys(n))a(n,k);return t};` +
+    `for(let k of Object.keys(d))a(d,k);for(let k of Object.keys(n))a(n,k);` +
+    `return new Proxy(t,{get:(x,k,r)=>k in x?Reflect.get(x,k,r):d[k],has:(x,k)=>k in x||k in d})};` +
     out +
     code.slice(cursor)
   );
@@ -142,7 +143,7 @@ function wmCommonJsSpecs(specs, jobDir, nodePath) {
   const commonjs = new Set();
   let resolved = null;
   const probe =
-    "const out={};" +
+    "if(typeof import.meta.resolve!=='function')process.exit(3);const out={};" +
     "for(const s of JSON.parse(process.argv[1])){try{out[s]=import.meta.resolve(s)}catch(e){out[s]=null}}" +
     "console.log(JSON.stringify(out))";
   try {

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -1,0 +1,235 @@
+// Node's ESM loader only exposes the named exports of a CommonJS package that
+// cjs-module-lexer can detect statically. lodash & co. build `module.exports` at
+// runtime, so `import { chunk } from "lodash"` fails at instantiation and
+// `import * as _ from "lodash"` yields a namespace holding nothing but `default`.
+// npm packages stay external to the bundle, so Bun emits those import statements
+// verbatim and node hits the limitation; rewrite them to a namespace import plus
+// a lookup that falls back to `default` (i.e. `module.exports`).
+//
+// Named bindings become snapshots instead of live bindings, which only differs
+// for an ESM package that mutates an exported binding after evaluation.
+
+const WM_IDENT = "[A-Za-z_$][A-Za-z0-9_$]*";
+const WM_NS_CLAUSE = `\\*\\s*as\\s+${WM_IDENT}`;
+const WM_NAMED_CLAUSE = "\\{[^{}]*\\}";
+const WM_CLAUSE = `(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}|${WM_IDENT}(?:\\s*,\\s*(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}))?)`;
+const WM_IMPORT = `(^|[;}\\n])import\\s*(?:(${WM_CLAUSE})\\s*from\\s*)?(?:"([^"\\n]*)"|'([^'\\n]*)')`;
+
+function wmRewriteExternalImports(code, externals) {
+  if (!externals || externals.length === 0) {
+    return code;
+  }
+  const isExternal = (spec) =>
+    externals.some((name) => spec === name || spec.startsWith(name + "/"));
+
+  // Import statements are found on a copy whose literals are blanked out, so
+  // that generated code holding an import statement in a string is not touched.
+  // Blanking preserves offsets and can only hide matches, never invent one.
+  const masked = wmMaskLiterals(code);
+  const anchored = new RegExp(WM_IMPORT);
+  const found = [];
+  for (const hit of masked.matchAll(new RegExp(WM_IMPORT, "g"))) {
+    const m = code.slice(hit.index, hit.index + hit[0].length).match(anchored);
+    if (m === null || m.index !== 0) {
+      continue;
+    }
+    const spec = m[3] !== undefined ? m[3] : m[4];
+    if (isExternal(spec)) {
+      found.push({ at: hit.index, len: hit[0].length, lead: m[1], clause: m[2], spec });
+    }
+  }
+  if (found.length === 0) {
+    return code;
+  }
+
+  // Backstop for a literal the masking missed: if the statements found are not
+  // the ones the parser sees, leave the bundle alone rather than corrupt it.
+  const counts = new Map();
+  for (const f of found) {
+    counts.set(f.spec, (counts.get(f.spec) ?? 0) + 1);
+  }
+  for (const imp of new Bun.Transpiler({ loader: "js" }).scanImports(code)) {
+    if (imp.kind === "import-statement" && counts.has(imp.path)) {
+      counts.set(imp.path, counts.get(imp.path) - 1);
+    }
+  }
+  for (const [spec, left] of counts) {
+    if (left !== 0) {
+      console.log(
+        `Skipping CommonJS interop rewrite of "${spec}": import statements found do not match the parsed ones`
+      );
+      return code;
+    }
+  }
+
+  let prefix = "__wm_ext";
+  while (code.includes(prefix)) {
+    prefix += "_";
+  }
+  const getHelper = `${prefix}Get`;
+  const nsHelper = `${prefix}Ns`;
+  let out = "";
+  let cursor = 0;
+  let count = 0;
+  for (const f of found) {
+    const parts = f.clause === undefined ? null : wmParseImportClause(f.clause);
+    // A default-only import already resolves to `module.exports` under node.
+    if (parts === null || (parts.named.length === 0 && parts.ns === null)) {
+      continue;
+    }
+    const ns = `${prefix}${count++}`;
+    const decls = [];
+    if (parts.def !== null) {
+      decls.push(`${parts.def}=${ns}.default`);
+    }
+    if (parts.ns !== null) {
+      decls.push(`${parts.ns}=${nsHelper}(${ns})`);
+    }
+    for (const [imported, local] of parts.named) {
+      decls.push(`${local}=${getHelper}(${ns},${JSON.stringify(imported)})`);
+    }
+    out +=
+      code.slice(cursor, f.at) +
+      `${f.lead}import*as ${ns} from${JSON.stringify(f.spec)};const ${decls.join(",")};`;
+    cursor = f.at + f.len;
+  }
+  if (count === 0) {
+    return code;
+  }
+
+  return (
+    `var ${getHelper}=(n,k)=>k in n?n[k]:n.default==null?undefined:n.default[k];` +
+    `var ${nsHelper}=(n)=>{let d=n.default;return d!=null&&(typeof d==="object"||typeof d==="function")` +
+    `?new Proxy(n,{get:(t,k,r)=>k in t?Reflect.get(t,k,r):d[k]}):n};` +
+    out +
+    code.slice(cursor)
+  );
+}
+
+function wmParseImportClause(clause) {
+  let def = null;
+  let ns = null;
+  const named = [];
+  let rest = clause.trim();
+
+  if (!rest.startsWith("{") && !rest.startsWith("*")) {
+    const m = rest.match(new RegExp(`^(${WM_IDENT})\\s*(?:,([\\s\\S]*))?$`));
+    if (m === null) {
+      return null;
+    }
+    def = m[1];
+    rest = (m[2] ?? "").trim();
+  }
+
+  if (rest.startsWith("*")) {
+    const m = rest.match(new RegExp(`^\\*\\s*as\\s+(${WM_IDENT})$`));
+    if (m === null) {
+      return null;
+    }
+    ns = m[1];
+  } else if (rest.startsWith("{")) {
+    const specifier = new RegExp(
+      `^(${WM_IDENT}|"[^"]*"|'[^']*')(?:\\s+as\\s+(${WM_IDENT}))?$`
+    );
+    for (const part of rest.slice(1, rest.lastIndexOf("}")).split(",")) {
+      const trimmed = part.trim();
+      if (trimmed === "") {
+        continue;
+      }
+      const m = trimmed.match(specifier);
+      if (m === null) {
+        return null;
+      }
+      const quoted = m[1].startsWith('"') || m[1].startsWith("'");
+      if (quoted && m[2] === undefined) {
+        return null;
+      }
+      named.push([quoted ? m[1].slice(1, -1) : m[1], m[2] ?? m[1]]);
+    }
+  } else if (rest !== "") {
+    return null;
+  }
+
+  return { def, ns, named };
+}
+
+// Replaces the contents of every string, template, comment and regex literal
+// with `x`, keeping the delimiters, every newline and the total length.
+function wmMaskLiterals(code) {
+  let out = "";
+  let i = 0;
+  let cursor = 0;
+  let prev = "";
+  const blank = (from, to) => {
+    out += code.slice(cursor, from);
+    for (const c of code.slice(from, to)) {
+      out += c === "\n" ? "\n" : "x";
+    }
+    cursor = to;
+  };
+  while (i < code.length) {
+    const c = code[i];
+    if (c === '"' || c === "'" || c === "`") {
+      const start = ++i;
+      while (i < code.length) {
+        if (code[i] === "\\") {
+          i += 2;
+        } else if (code[i] === c) {
+          break;
+        } else {
+          i++;
+        }
+      }
+      blank(start, Math.min(i, code.length));
+      i++;
+      prev = "'";
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "/") {
+      const start = i + 2;
+      while (i < code.length && code[i] !== "\n") {
+        i++;
+      }
+      blank(start, i);
+      continue;
+    }
+    if (c === "/" && code[i + 1] === "*") {
+      const end = code.indexOf("*/", i + 2);
+      const start = i + 2;
+      i = end === -1 ? code.length : end + 2;
+      blank(start, Math.max(start, i - 2));
+      continue;
+    }
+    // `/` only starts a regex where an operand cannot stand; a wrong guess can
+    // only make the masking hide more than it should, which the parser
+    // cross-check catches.
+    if (c === "/" && !/[A-Za-z0-9_$)\]]/.test(prev)) {
+      const start = ++i;
+      let inClass = false;
+      while (i < code.length) {
+        if (code[i] === "\\") {
+          i += 2;
+        } else if (code[i] === "[") {
+          inClass = true;
+          i++;
+        } else if (code[i] === "]") {
+          inClass = false;
+          i++;
+        } else if (code[i] === "\n" || (code[i] === "/" && !inClass)) {
+          break;
+        } else {
+          i++;
+        }
+      }
+      blank(start, Math.min(i, code.length));
+      i++;
+      prev = "'";
+      continue;
+    }
+    if (!/\s/.test(c)) {
+      prev = c;
+    }
+    i++;
+  }
+  return out + code.slice(cursor);
+}

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -17,7 +17,8 @@ const WM_IDENT = "[A-Za-z_$][A-Za-z0-9_$]*";
 const WM_NS_CLAUSE = `\\*\\s*as\\s+${WM_IDENT}`;
 const WM_NAMED_CLAUSE = "\\{[^{}]*\\}";
 const WM_CLAUSE = `(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}|${WM_IDENT}(?:\\s*,\\s*(?:${WM_NS_CLAUSE}|${WM_NAMED_CLAUSE}))?)`;
-const WM_IMPORT = `(^|[;}\\n])import\\s*(?:(${WM_CLAUSE})\\s*from\\s*)?(?:"([^"\\n]*)"|'([^'\\n]*)')`;
+const WM_ATTRS = "\\s*(?:with|assert)\\s*\\{[^{}]*\\}";
+const WM_IMPORT = `(^|[;}\\n])import\\s*(?:(${WM_CLAUSE})\\s*from\\s*)?(?:"([^"\\n]*)"|'([^'\\n]*)')(${WM_ATTRS})?`;
 
 function wmRewriteExternalImports(code, externals, jobDir) {
   if (!externals || externals.length === 0) {
@@ -37,7 +38,9 @@ function wmRewriteExternalImports(code, externals, jobDir) {
 
   // Import statements are found on a copy whose literals are blanked out, so
   // that generated code holding an import statement in a string is not touched.
-  // Blanking preserves offsets and can only hide matches, never invent one.
+  // Blanking preserves offsets, but mis-pairing a literal's boundaries can still
+  // expose a string's contents as code, so the parser cross-check below is what
+  // makes the rewrite safe — it is load-bearing, not a belt-and-braces extra.
   const masked = wmMaskLiterals(code);
   const anchored = new RegExp(WM_IMPORT);
   const found = [];
@@ -48,15 +51,22 @@ function wmRewriteExternalImports(code, externals, jobDir) {
     }
     const spec = m[3] !== undefined ? m[3] : m[4];
     if (needsInterop(spec)) {
-      found.push({ at: hit.index, len: hit[0].length, lead: m[1], clause: m[2], spec });
+      found.push({
+        at: hit.index,
+        len: hit[0].length,
+        lead: m[1],
+        clause: m[2],
+        spec,
+        attrs: m[5] ?? "",
+      });
     }
   }
   if (found.length === 0) {
     return code;
   }
 
-  // Backstop for a literal the masking missed: if the statements found are not
-  // the ones the parser sees, leave the bundle alone rather than corrupt it.
+  // If the statements found are not the ones the parser sees, the masking
+  // mis-paired a literal somewhere: leave the bundle alone rather than corrupt it.
   const counts = new Map();
   for (const f of found) {
     counts.set(f.spec, (counts.get(f.spec) ?? 0) + 1);
@@ -99,11 +109,13 @@ function wmRewriteExternalImports(code, externals, jobDir) {
       decls.push(`${parts.ns}=${nsHelper}(${ns})`);
     }
     for (const [imported, local] of parts.named) {
-      decls.push(`${local}=${getHelper}(${ns},${JSON.stringify(imported)})`);
+      decls.push(
+        `${local}=${getHelper}(${ns},${JSON.stringify(imported)},${JSON.stringify(f.spec)})`
+      );
     }
     out +=
       code.slice(cursor, f.at) +
-      `${f.lead}import*as ${ns} from${JSON.stringify(f.spec)};const ${decls.join(",")};`;
+      `${f.lead}import*as ${ns} from${JSON.stringify(f.spec)}${f.attrs};const ${decls.join(",")};`;
     cursor = f.at + f.len;
   }
   if (count === 0) {
@@ -111,7 +123,8 @@ function wmRewriteExternalImports(code, externals, jobDir) {
   }
 
   return (
-    `var ${getHelper}=(n,k)=>k in n?n[k]:n.default==null?undefined:n.default[k];` +
+    `var ${getHelper}=(n,k,s)=>{if(k in n)return n[k];let d=Object(n.default);if(k in d)return d[k];` +
+    "throw new SyntaxError(`The requested module '${s}' does not provide an export named '${k}'`)};" +
     `var ${nsHelper}=(n)=>{let d=n.default;return d!=null&&(typeof d==="object"||typeof d==="function")` +
     `?new Proxy(n,{get:(t,k,r)=>k in t?Reflect.get(t,k,r):d[k]}):n};` +
     out +

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -11,7 +11,7 @@
 // after evaluation.
 
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const WM_IDENT = "[A-Za-z_$][A-Za-z0-9_$]*";
@@ -174,13 +174,14 @@ function wmCommonJsSpecs(specs, jobDir, nodePath) {
   return commonjs;
 }
 
-// Node's own rule for a file's format: the extension decides, and `.js` follows
-// the `type` of the closest package.json.
+// Node's own rule for a file's format: the extension decides, and `.js` — like an
+// extensionless entry — follows the `type` of the closest package.json.
 function wmIsCommonJsFile(file) {
-  if (file.endsWith(".mjs")) {
+  const ext = extname(file);
+  if (ext === ".mjs") {
     return false;
   }
-  if (!file.endsWith(".js")) {
+  if (ext !== ".js" && ext !== "") {
     return true;
   }
   let dir = dirname(file);

--- a/backend/windmill-worker/node_cjs_interop.js
+++ b/backend/windmill-worker/node_cjs_interop.js
@@ -175,14 +175,16 @@ function wmCommonJsSpecs(specs, jobDir, nodePath) {
 }
 
 // Node's own rule for a file's format: the extension decides, and `.js` — like an
-// extensionless entry — follows the `type` of the closest package.json.
+// extensionless entry — follows the `type` of the closest package.json. Only the
+// formats node loads through CommonJS qualify; a JSON module exposes `default`
+// alone and must keep that shape.
 function wmIsCommonJsFile(file) {
   const ext = extname(file);
-  if (ext === ".mjs") {
-    return false;
+  if (ext === ".cjs" || ext === ".node") {
+    return true;
   }
   if (ext !== ".js" && ext !== "") {
-    return true;
+    return false;
   }
   let dir = dirname(file);
   for (;;) {

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -71,6 +71,8 @@ pub const RELATIVE_BUN_LOADER: &str = include_str!("../loader.bun.windows.js");
 
 pub const RELATIVE_BUN_BUILDER: &str = include_str!("../loader_builder.bun.js");
 
+pub const NODE_CJS_INTEROP: &str = include_str!("../node_cjs_interop.js");
+
 const NSJAIL_CONFIG_RUN_BUN_CONTENT: &str = include_str!("../nsjail/run.bun.config.proto");
 
 pub const BUN_LOCK_SPLIT: &str = "\n//bun.lock\n";
@@ -877,6 +879,8 @@ pub async fn build_loader(
                 r#"
 {loader}
 
+{interop}
+
 import {{ readdir }} from "node:fs/promises";
 
 let fileNames = []
@@ -905,7 +909,18 @@ if (!result?.success || !(result.outputs?.length > 0)) {{
     console.log("Failed to build node bundle: success=" + result?.success + ", outputs=" + (result?.outputs?.length ?? 0));
     process.exit(1);
 }}
-"#
+try {{
+    const bundlePath = "{job_dir_js}/wrapper.js";
+    const bundle = await Bun.file(bundlePath).text();
+    const interoped = wmRewriteExternalImports(bundle, fileNames);
+    if (interoped !== bundle) {{
+        await Bun.write(bundlePath, interoped);
+    }}
+}} catch(err) {{
+    console.log("Failed to apply CommonJS interop to the node bundle: " + err);
+}}
+"#,
+                interop = NODE_CJS_INTEROP
             ),
         )?;
     } else if mode == LoaderMode::Bun {

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -912,7 +912,7 @@ if (!result?.success || !(result.outputs?.length > 0)) {{
 try {{
     const bundlePath = "{job_dir_js}/wrapper.js";
     const bundle = await Bun.file(bundlePath).text();
-    const interoped = wmRewriteExternalImports(bundle, fileNames, "{job_dir_js}");
+    const interoped = wmRewriteExternalImports(bundle, fileNames, "{job_dir_js}", {node_bin});
     if (interoped !== bundle) {{
         await Bun.write(bundlePath, interoped);
     }}
@@ -920,7 +920,9 @@ try {{
     console.log("Failed to apply CommonJS interop to the node bundle: " + err);
 }}
 "#,
-                interop = NODE_CJS_INTEROP
+                interop = NODE_CJS_INTEROP,
+                node_bin = serde_json::to_string(&*NODE_BIN_PATH)
+                    .unwrap_or_else(|_| "\"node\"".to_string())
             ),
         )?;
     } else if mode == LoaderMode::Bun {

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -912,7 +912,7 @@ if (!result?.success || !(result.outputs?.length > 0)) {{
 try {{
     const bundlePath = "{job_dir_js}/wrapper.js";
     const bundle = await Bun.file(bundlePath).text();
-    const interoped = wmRewriteExternalImports(bundle, fileNames);
+    const interoped = wmRewriteExternalImports(bundle, fileNames, "{job_dir_js}");
     if (interoped !== bundle) {{
         await Bun.write(bundlePath, interoped);
     }}


### PR DESCRIPTION
## Summary

Fixes #10785.

Under the `//nodejs` annotation the wrapper is bundled with `Bun.build({ target: "node", external: <dir names under node_modules> })`, so npm packages stay out of the bundle and **node**, not bun, resolves them at runtime. Node's ESM loader only exposes the named exports of a CommonJS package that `cjs-module-lexer` can detect statically, and lodash & co. assemble `module.exports` while they run. So:

- `import { chunk } from "lodash"` never instantiated. Node's diagnostic prints the offending source line — the whole minified bundle, on one line — followed by its `import pkg from 'lodash'; const {chunk} = pkg;` hint, which is what made the log look like a bundle ending in `= pkg;`.
- `import * as _ from "lodash"` instantiated but gave a namespace holding nothing but `default`, hence `TypeError: _.chunk is not a function`.

The bundle now imports such a package as a namespace and reads the names off `default` (i.e. `module.exports`), which is exactly what node's own error message suggests doing by hand.

Only packages node loads as CommonJS are rewritten — the classification follows node's own rule (the resolved file's extension, and for `.js` the `type` of the closest `package.json`) — so an ESM package's named imports stay the live bindings node gives them. Default-only imports (`import _ from "lodash"`) and side-effect imports are left untouched as well, since node already resolves those to `module.exports`; that keeps the clear instantiation error when an ESM package has no `default` export.

## Status

**Left in draft, and duplicated by #10792.** That PR fixes the same issue in the same `build_loader` `LoaderMode::Node` branch by routing CommonJS packages through a generated `.cjs` shim so bun synthesizes the interop, rather than rewriting the emitted bundle as this PR does. The two conflict; only one should land. The trade-off: this PR never changes which file node loads (the `import` condition still picks the entry) at the cost of a post-pass over the bundle, while #10792 is much smaller but switches shimmed packages to their `require` entry.

Independently of that, this touches shared worker infrastructure (the bun executor's node loader, on the path of every `//nodejs` job), so it wants a human look before it goes ready rather than an unattended flip.

Review rounds: the round at `b0152ef` was clean — claude and pi "Good to merge", codex nit-only (JSON modules classified as CommonJS), which `8de64d4` fixes.

## Changes

- `backend/windmill-worker/node_cjs_interop.js` (new): rewrites the import statements of external CommonJS specifiers in the emitted bundle into a namespace import plus `k in ns ? ns[k] : ns.default?.[k]` lookups; namespace imports get a proxy that falls through to `default` for keys the namespace lacks. Import statements are located on a copy of the bundle whose string/template/comment/regex literals are blanked out (offset-preserving, so generated code carrying an import statement inside a string is not rewritten), and a `Bun.Transpiler.scanImports` cross-check leaves the bundle untouched if the statements found don't match the parsed ones.
- `bun_executor.rs`: `LoaderMode::Node`'s `node_builder.ts` applies that rewrite to `wrapper.js` after `Bun.build`. A failure to rewrite logs and keeps the original bundle rather than failing the job. This is also the loader used by `//nodejs` dedicated workers and by `//nodejs //nobundling`; the deployed-script `LoaderMode::NodeBundle` path bundles its dependencies and was never affected.
- `backend/tests/bun_jobs.rs`: regression test that runs the real `LoaderMode::Node` loader over a CommonJS package whose exports only exist once it has run, then executes the bundle with node. It fails without the fix with the exact `Named export 'greet' not found` error from the issue.

## Test plan

- [x] `//nodejs` + `import { chunk } from "lodash"` returns `[[1,2],[3,4]]` as a real preview job
- [x] `//nodejs` + `import * as _ from "lodash"` returns `[[1],[2]]`
- [x] every passing case in the issue's matrix still passes as a real job: lodash default, `mime-types` named, `dayjs` default, `zod` named, `uuid` named, no imports, `node:*` only, and the same lodash named import without `//nodejs`
- [x] `import * as wmill from "windmill-client"` and `import { setState, getState } from "windmill-client"` still work under `//nodejs`
- [x] deployed `//nodejs` script (bundle cache path) and deployed `//nodejs //nobundling` script both run
- [x] ESM packages unaffected: `nanoid` named + namespace, `chalk` default, and an ESM package that mutates an exported binding still reads live through a named import (0 → frozen without the CommonJS gate, correct with it)
- [x] scoped packages fixed, `lodash/fp.js` subpath fixed
- [x] a script holding `;import{y}from"lodash";` inside a string literal is rewritten correctly rather than corrupted
- [x] `cargo test --test bun_jobs` — 35 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes named and namespace npm imports under `//nodejs` by rewriting external CommonJS imports to a namespace import with a `default` fallback and explicit missing‑export errors. Previously, named imports from CJS packages like `lodash` failed and namespace imports exposed only `default`; now both work without changing default‑only or side‑effect imports.

- Runs post‑bundle in `LoaderMode::Node` only: rewrites `wrapper.js` for externals Node loads as CommonJS; `LoaderMode::NodeBundle` is unchanged.
- Classifies targets with Node’s resolver (`import.meta.resolve`) and Node’s format rules (extensionless entries follow the nearest `package.json` `type`); falls back to Bun when needed; skips Node builtins; never rewrites JSON or other non‑CommonJS module formats.
- Preserves import attributes. CJS named bindings are snapshots; namespace imports merge keys from the namespace and `default`. Missing named exports throw a `SyntaxError` at module init.
- Masks literals and cross‑checks with `Bun.Transpiler.scanImports`; on mismatch, logs and skips to avoid corrupting the bundle.
- Adds a regression test for dynamic CJS exports, live ESM export mutation, conditional exports that hand Bun CJS but Node ESM, and an extensionless ESM entry.

<sup>Written for commit 8de64d4c4a6bc00a84ef75eb9ae48553522f7123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

