### PR TITLE
fix: apply the first script kind selection in the script editor

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1466,13 +1466,20 @@
 													corresponding action.
 												</Tooltip>
 											{/snippet}
+											<!-- A script with no kind yet runs as an action, so the group is fed 'script'
+											     rather than undefined: the toggle group reports no change out of
+											     undefined, which would swallow the first pick. Two-way so the
+											     highlight can never claim a kind the script does not have. -->
 											<ToggleButtonGroup
-												selected={script.kind}
-												on:selected={({ detail }) => {
-													template = 'script'
-													script.kind = detail
-													initContent(script.language, detail, template)
-												}}
+												bind:selected={
+													() => script.kind ?? 'script',
+													(kind) => {
+														if (kind === (script.kind ?? 'script')) return
+														template = 'script'
+														script.kind = kind as Script['kind']
+														initContent(script.language, script.kind, template)
+													}
+												}
 											>
 												{#snippet children({ item })}
 													{#each scriptKindOptions as { value, title, desc, documentationLink, Icon }}

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1474,6 +1474,8 @@
 												bind:selected={
 													() => script.kind ?? 'script',
 													(kind) => {
+														// Load-bearing: any write to script.kind echoes back through the
+														// group, and initContent replaces the editor content outright.
 														if (kind === (script.kind ?? 'script')) return
 														template = 'script'
 														script.kind = kind as Script['kind']


### PR DESCRIPTION
## Summary

On a new script, picking anything in Settings → Metadata → **Script kind** did nothing: the starter
code stayed on the action template and the script never actually got that kind. The button still lit
up, so the setting looked applied while the model disagreed.

Two things combine to produce it:

- A new script has **no** `kind`. The `/scripts/add` seed omits it (`NewScript.kind` is optional;
  only a deployed `Script.kind` is required), so `script.kind` is `undefined` and *no* kind button
  renders as selected.
- `ToggleButtonGroup` dispatches `selected` only when `curr !== next && curr !== undefined`. That
  guard is there to swallow the mount-time `createSync` write, but it cannot tell that apart from a
  genuine first click out of `undefined`. melt's own store still advances, so the button highlights
  while `script.kind = detail` and `initContent(...)` never run.

`selected={script.kind}` was also one-way, which removed the fallback path and let the highlight
drift from the model.

This was not preprocessor-specific: on a new script the **first** pick of any kind (Trigger,
Approval, Error Handler, Preprocessor) was swallowed the same way.

## Changes

- `ScriptBuilder.svelte`: the kind picker now uses a Svelte 5 function binding. The getter feeds the
  group `'script'` when `script.kind` is unset, so `curr` is always defined and the first pick
  dispatches; the setter writes back, so the highlight cannot claim a kind the script does not have.
  An early return when the incoming value equals the current effective kind keeps the mount-time
  sync from retemplating the editor.

`script.kind` still stays `undefined` on the wire until the user actually picks one (the backend
defaults it to `script`), so nothing changes about what gets deployed for an untouched new script.

**Not changed, deliberately:** the `curr !== undefined` guard in `ToggleButtonGroup`. It is
load-bearing for every toggle group in the app, and every other one-way `selected=` call site passes
a value that is never `undefined`, so none of them are exposed today. Worth a follow-up if someone
wants the shared component to stop being a trap, but that is a much wider blast radius than this bug
justifies.

## Screenshots

Before — new script, nothing selected in Script kind:

![before default](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/fix-script-kind-toggle-preprocessor/1787268612-script-kind-toggle.png)

Before — after clicking Preprocessor: highlighted, but the code is still the `main()` action template:

![before clicked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/fix-script-kind-toggle-preprocessor/1787268612-bug-repro-kind.png)

After — new script now shows Action selected, matching the kind it would deploy as:

![after default](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/fix-script-kind-toggle-preprocessor/1787268612-fixed-default-action.png)

After — clicking Preprocessor loads the preprocessor scaffold:

![after clicked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/fix-script-kind-toggle-preprocessor/1787268612-fixed-kind-preprocessor.png)

## Test plan

Exercised against a local instance (backend + frontend from this branch).

- [x] New script: Action is selected by default instead of nothing
- [x] First click on Preprocessor swaps the editor to the `preprocessor(event)` scaffold
- [x] Deploying that script stores `kind: preprocessor`, content has `preprocessor()` and no `main()`
      (checked over the API, not just the UI)
- [x] First click on Trigger on a new script loads the trigger template (same bug, also fixed)
- [x] Switching Trigger → Action retemplates back
- [x] An already-deployed preprocessor script opens with Preprocessor selected
- [x] `npm run check`: 0 errors, no new warnings

No test added: Svelte component wiring with no new pure-logic helper, which `docs/validation.md`
puts under type-checking.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the script editor so the first “Script kind” selection applies to the model and re-templates the editor. Previously, a new script had no kind, the first click highlighted a button but did not set `script.kind` or update content; now the default resolves to Action and the first pick persists and re-templates.

- Uses a Svelte 5 function binding on the kind toggle: getter maps unset `script.kind` to `'script'`; setter writes back and re-templates, with an early return to ignore mount-time sync.
- Keeps the `ToggleButtonGroup` guard unchanged; other groups are unaffected because they pass defined values.
- Wire behavior is unchanged: `script.kind` stays unset until the user picks; the backend still defaults to `script`.
- Reviewer checks: new script shows Action selected; first click on any kind (e.g., Preprocessor) updates `script.kind` and loads the correct scaffold; switching kinds re-templates as expected.

<sup>Written for commit 6833ca708056fa251846041070b042745242faef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

