### PR TITLE
fix: collapse conditionally hidden fields in schema forms

### DIFF
--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -363,127 +363,122 @@
 							/>
 						</div>
 					{/if}
-					<!-- svelte-ignore a11y_no_static_element_interactions -->
-					<div
-						class="flex flex-row items-center {largeGap ? 'pb-4' : 'pb-2'} "
-						onclick={() => {
-							dispatch('click', argName)
-						}}
-					>
-						{#if args && typeof args == 'object' && prop}
-							<!-- {argName}
-							{args == undefined}
-							{JSON.stringify(args?.[argName])} -->
-							{#if !hidden[argName]}
-								<ArgInput
-									{lightHeaderFont}
-									on:change={() => {
-										dispatch('change')
-									}}
-									on:nestedChange={() => {
-										dispatch('nestedChange')
-									}}
-									on:acceptChange={(e) => dispatch('acceptChange', e.detail)}
-									on:rejectChange={(e) => dispatch('rejectChange', e.detail)}
-									on:keydownCmdEnter={() => dispatch('keydownCmdEnter')}
-									{disablePortal}
-									{resourceTypes}
-									{prettifyHeader}
-									autofocus={i == 0 && autofocus ? true : null}
-									label={argName}
-									description={prop?.description}
-									bind:value={args[argName]}
-									type={prop?.type}
-									oneOf={prop?.oneOf}
-									required={schema?.required?.includes(argName)}
-									pattern={prop?.pattern}
-									bind:valid={inputCheck[argName]}
-									defaultValue={defaultValues?.[argName] ??
-										structuredClone($state.snapshot(prop?.default))}
-									enum_={dynamicEnums?.[argName] ?? prop?.enum}
-									format={prop?.format}
-									contentEncoding={prop?.contentEncoding}
-									customErrorMessage={prop?.customErrorMessage}
-									bind:properties={
-										() => prop?.properties,
-										(v) => {
-											if (prop) prop.properties = v
-										}
+					<!-- the padded row must stay inside this condition: rendering it for a hidden
+					     field leaves its padding behind as a gap ResizeTransitionWrapper measures -->
+					{#if args && typeof args == 'object' && prop && !hidden[argName]}
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<div
+							class="flex flex-row items-center {largeGap ? 'pb-4' : 'pb-2'} "
+							onclick={() => {
+								dispatch('click', argName)
+							}}
+						>
+							<ArgInput
+								{lightHeaderFont}
+								on:change={() => {
+									dispatch('change')
+								}}
+								on:nestedChange={() => {
+									dispatch('nestedChange')
+								}}
+								on:acceptChange={(e) => dispatch('acceptChange', e.detail)}
+								on:rejectChange={(e) => dispatch('rejectChange', e.detail)}
+								on:keydownCmdEnter={() => dispatch('keydownCmdEnter')}
+								{disablePortal}
+								{resourceTypes}
+								{prettifyHeader}
+								autofocus={i == 0 && autofocus ? true : null}
+								label={argName}
+								description={prop?.description}
+								bind:value={args[argName]}
+								type={prop?.type}
+								oneOf={prop?.oneOf}
+								required={schema?.required?.includes(argName)}
+								pattern={prop?.pattern}
+								bind:valid={inputCheck[argName]}
+								defaultValue={defaultValues?.[argName] ??
+									structuredClone($state.snapshot(prop?.default))}
+								enum_={dynamicEnums?.[argName] ?? prop?.enum}
+								format={prop?.format}
+								contentEncoding={prop?.contentEncoding}
+								customErrorMessage={prop?.customErrorMessage}
+								bind:properties={
+									() => prop?.properties,
+									(v) => {
+										if (prop) prop.properties = v
 									}
-									bind:order={
-										() => prop?.order,
-										(v) => {
-											if (prop) prop.order = v
-										}
+								}
+								bind:order={
+									() => prop?.order,
+									(v) => {
+										if (prop) prop.order = v
 									}
-									nestedRequired={prop?.required}
-									itemsType={prop?.items}
-									disabled={disabledArgs.includes(argName) || disabled || prop?.disabled}
-									{compact}
-									{variableEditor}
-									{itemPicker}
-									bind:pickForField
-									password={linkedSecrets.includes(argName)}
-									extra={prop}
-									{showSchemaExplorer}
-									simpleTooltip={schemaFieldTooltip[argName]}
-									{onlyMaskPassword}
-									nullable={prop?.nullable}
-									title={prop?.title}
-									placeholder={prop?.placeholder}
-									orderEditable={dndConfig != undefined}
-									otherArgs={{ ...args, [argName]: undefined }}
-									{helperScript}
-									{lightHeader}
-									diffStatus={diff[argName] ?? undefined}
-									{nestedParent}
-									{shouldDispatchChanges}
-									{nestedClasses}
-									{appPath}
-									{computeS3ForceViewerPolicies}
-									{workspace}
-									{css}
-									{displayType}
-								>
-									{#snippet actions()}
-										{@render actions_render?.({ item })}
-										{#if linkedSecretCandidates?.includes(argName)}
-											<div class="relative">
-												<ToggleButtonGroup
-													selected={linkedSecrets.includes(argName) ? 'secret' : 'inlined'}
-													on:selected={(e) => {
-														if (e.detail === 'secret') {
-															if (!linkedSecrets.includes(argName)) {
-																linkedSecrets = [...linkedSecrets, argName]
-															}
-														} else {
-															linkedSecrets = linkedSecrets.filter((s) => s !== argName)
+								}
+								nestedRequired={prop?.required}
+								itemsType={prop?.items}
+								disabled={disabledArgs.includes(argName) || disabled || prop?.disabled}
+								{compact}
+								{variableEditor}
+								{itemPicker}
+								bind:pickForField
+								password={linkedSecrets.includes(argName)}
+								extra={prop}
+								{showSchemaExplorer}
+								simpleTooltip={schemaFieldTooltip[argName]}
+								{onlyMaskPassword}
+								nullable={prop?.nullable}
+								title={prop?.title}
+								placeholder={prop?.placeholder}
+								orderEditable={dndConfig != undefined}
+								otherArgs={{ ...args, [argName]: undefined }}
+								{helperScript}
+								{lightHeader}
+								diffStatus={diff[argName] ?? undefined}
+								{nestedParent}
+								{shouldDispatchChanges}
+								{nestedClasses}
+								{appPath}
+								{computeS3ForceViewerPolicies}
+								{workspace}
+								{css}
+								{displayType}
+							>
+								{#snippet actions()}
+									{@render actions_render?.({ item })}
+									{#if linkedSecretCandidates?.includes(argName)}
+										<div class="relative">
+											<ToggleButtonGroup
+												selected={linkedSecrets.includes(argName) ? 'secret' : 'inlined'}
+												on:selected={(e) => {
+													if (e.detail === 'secret') {
+														if (!linkedSecrets.includes(argName)) {
+															linkedSecrets = [...linkedSecrets, argName]
 														}
-													}}
-												>
-													{#snippet children({ item })}
-														<ToggleButton
-															value="inlined"
-															label="Inlined"
-															tooltip="The value is inlined in the resource and thus has no special treatment."
-															{item}
-														/>
-														<ToggleButton
-															value="secret"
-															label="Secret"
-															tooltip="The value will be stored in a newly created linked secret variable at the same path. That variable can be permissioned differently, will be treated as a secret the UI, operators will not be able to load it and every access will generate a corresponding audit log."
-															{item}
-														/>
-													{/snippet}
-												</ToggleButtonGroup>
-											</div>{/if}
-									{/snippet}
-								</ArgInput>
-							{/if}
-							<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-							<!-- svelte-ignore a11y_no_static_element_interactions -->
-						{/if}
-					</div>
+													} else {
+														linkedSecrets = linkedSecrets.filter((s) => s !== argName)
+													}
+												}}
+											>
+												{#snippet children({ item })}
+													<ToggleButton
+														value="inlined"
+														label="Inlined"
+														tooltip="The value is inlined in the resource and thus has no special treatment."
+														{item}
+													/>
+													<ToggleButton
+														value="secret"
+														label="Secret"
+														tooltip="The value will be stored in a newly created linked secret variable at the same path. That variable can be permissioned differently, will be treated as a secret the UI, operators will not be able to load it and every access will generate a corresponding audit log."
+														{item}
+													/>
+												{/snippet}
+											</ToggleButtonGroup>
+										</div>{/if}
+								{/snippet}
+							</ArgInput>
+						</div>
+					{/if}
 				{/if}
 			</ResizeTransitionWrapper>
 		{/each}


### PR DESCRIPTION
## Summary

A schema-form field whose `showExpr` evaluates false skipped its `ArgInput` but still rendered the padded row that wraps it. `ResizeTransitionWrapper` measures that row, so each hidden field pinned the slot at 8px (16px with `largeGap`) instead of collapsing to 0.

This shows up when a `oneOf` is simulated with a selector plus one `showExpr` branch per variant: every unselected branch leaves a gap, and they stack. With six variants the form carried 40px of dead space between the selected branch and the next visible field.

`SchemaForm.svelte` backs the flow run form, the flow input editor's preview pane, and the app **Form** component (`AppSchemaForm.svelte`), so all three were affected.

## Changes

- `frontend/src/lib/components/SchemaForm.svelte`: move the `!hidden[argName]` check onto the padded row itself, so nothing renders for a hidden field and the wrapper collapses to 0px.
- Drop two `svelte-ignore` comments that sat immediately before `{/if}` and applied to nothing, plus a commented-out debug block.

The per-field `ResizeTransitionWrapper` still renders unconditionally, so dnd item identity and ordering in `SchemaFormDND` / `EditableSchemaForm` are unchanged.

Most of the raw diff is re-indentation — `git diff -w` shows the actual change.

## Screenshots

Flow run form, `kind` selector with six `showExpr` branches, variant A selected. Before, the five unselected branches leave 5 × 8px between "A Field" and "Comment":

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/flow-input-improvement/1787297236-before.png)

After:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/flow-input-improvement/1787297239-after.png)

App **Form** component with `largeGap` on, variant D selected — the five hidden branches measure 0px:

![app-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/flow-input-improvement/1787297677-app-after.png)

## Test plan

- [x] Flow run form: hidden branch rows measure 0px (were 8px); toggling the selector back and forth re-shows the branch and its input stays functional
- [x] Flow input editor preview pane: hidden rows measure 0px. That pane wraps the form in `flex flex-col gap-1`, and a flex gap still applies to a zero-height child, so 4px per hidden field remains there — see the note below.
- [x] App Form component with `largeGap: true`: hidden rows measure 0px, visible rows keep their 16px gap
- [x] `npm run check:fast` clean

No test added: this is a Svelte template change with no pure-logic utility to pin.

## Known limit: the editor preview pane

`EditableSchemaForm` passes `nestedClasses="flex flex-col gap-1"`, and a flex `gap` applies between all children regardless of height, so each hidden field still costs 4px there. Removing that residue means taking the row out of layout entirely (`display: none`), but the same rows are the `use:dragHandleZone` children that `svelte-dnd-action` reorders, and a child with no box would break its position math. 4px in an authoring preview is not worth that risk. The run form and the app Form component — the surfaces this PR is about — use a plain block container and collapse completely.
