### PR TITLE
fix: make //nodejs scripts import CommonJS npm packages correctly

### DIFF
--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -540,7 +540,9 @@ export function main() {
 }
 
 /// Node's ESM loader cannot see the named exports of a CommonJS package that cjs-module-lexer
-/// fails to analyze, so `//nodejs` scripts must not leave such packages as plain externals.
+/// fails to analyze, so `//nodejs` scripts must not leave such packages as plain externals. The
+/// ESM-only import guards the other half: those must stay external, since `require`ing one throws
+/// on the node versions without require(esm).
 #[sqlx::test(fixtures("base"))]
 async fn test_bun_nodejs_cjs_named_and_namespace_import(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;
@@ -550,9 +552,10 @@ async fn test_bun_nodejs_cjs_named_and_namespace_import(db: Pool<Postgres>) -> a
     let content = r#"//nodejs
 import { chunk } from "lodash";
 import * as lodash from "lodash";
+import { nanoid } from "nanoid";
 
 export function main() {
-    return [chunk([1, 2, 3, 4], 2), lodash.chunk([1, 2], 1)];
+    return [chunk([1, 2, 3, 4], 2), lodash.chunk([1, 2], 1), typeof nanoid()];
 }
 "#
     .to_owned();
@@ -578,7 +581,10 @@ export function main() {
         .json_result()
         .unwrap();
 
-    assert_eq!(result, serde_json::json!([[[1, 2], [3, 4]], [[1], [2]]]));
+    assert_eq!(
+        result,
+        serde_json::json!([[[1, 2], [3, 4]], [[1], [2]], "string"])
+    );
     Ok(())
 }
 

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -2515,6 +2515,65 @@ export function main(name: string) {
     Ok(())
 }
 
+/// A shimmed package is reached by `require()`, so the shim is only safe when nothing can make
+/// node's `require` land on a different entry than the `import` the classifier looked at. Bun's
+/// own conditions, `import`/`require`, and `--conditions` in the job's NODE_OPTIONS can each do
+/// that, so any condition at all disqualifies a manifest.
+#[test]
+fn test_node_externals_refuses_conditional_exports() {
+    use std::process::Command;
+    use windmill_worker::{BUN_PATH, NODE_EXTERNALS_PLUGIN};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let dir = temp_dir.path();
+    let plugin = NODE_EXTERNALS_PLUGIN.replace("JOB_DIR", &dir.to_string_lossy());
+    std::fs::write(dir.join("externals.js"), plugin).unwrap();
+    std::fs::write(
+        dir.join("probe.js"),
+        r#"
+import { entryDependsOnCondition } from "./externals.js";
+const manifests = JSON.parse(await Bun.file("manifests.json").text());
+console.log(JSON.stringify(manifests.map((m) => entryDependsOnCondition(m))));
+"#,
+    )
+    .unwrap();
+    // Every entry a shimmable package may have, then every way one can vary by condition.
+    let manifests = serde_json::json!([
+        serde_json::Value::Null,
+        "./index.js",
+        { ".": "./index.js" },
+        { ".": { "default": "./index.js" }, "./sub": "./sub.js" },
+        { ".": { "bun": "./bun.js", "default": "./index.js" } },
+        { ".": { "import": "./esm.js", "require": "./cjs.js" } },
+        { ".": { "development": "./dev.js", "default": "./index.js" } },
+        { "./sub": { "node": "./node.js", "default": "./index.js" } },
+        { ".": [{ "browser": "./browser.js" }, "./index.js"] },
+    ]);
+    std::fs::write(
+        dir.join("manifests.json"),
+        serde_json::to_string(&manifests).unwrap(),
+    )
+    .unwrap();
+
+    let output = Command::new(BUN_PATH.as_str())
+        .args(["run", "probe.js"])
+        .current_dir(dir)
+        .output()
+        .expect("failed to run bun");
+    assert!(
+        output.status.success(),
+        "probe failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let verdicts: Vec<bool> =
+        serde_json::from_slice(String::from_utf8_lossy(&output.stdout).trim().as_bytes()).unwrap();
+    assert_eq!(
+        verdicts,
+        vec![false, false, false, false, true, true, true, true, true]
+    );
+}
+
 /// Tests for RELATIVE_BUN_BUILDER (loader_builder.bun.js)
 /// These tests verify Bun's behavior for import scanning and package.json generation.
 /// Purpose: Catch regressions when upgrading Bun versions.

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -539,6 +539,49 @@ export function main() {
     Ok(())
 }
 
+/// Node's ESM loader cannot see the named exports of a CommonJS package that cjs-module-lexer
+/// fails to analyze, so `//nodejs` scripts must not leave such packages as plain externals.
+#[sqlx::test(fixtures("base"))]
+async fn test_bun_nodejs_cjs_named_and_namespace_import(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let content = r#"//nodejs
+import { chunk } from "lodash";
+import * as lodash from "lodash";
+
+export function main() {
+    return [chunk([1, 2, 3, 4], 2), lodash.chunk([1, 2], 1)];
+}
+"#
+    .to_owned();
+
+    let job = JobPayload::Code(RawCode {
+        hash: None,
+        content,
+        path: None,
+        language: ScriptLang::Bun,
+        lock: None,
+        concurrency_settings: windmill_common::runnable_settings::ConcurrencySettings::default()
+            .into(),
+        debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
+        cache_ttl: None,
+        cache_ignore_s3_path: None,
+        dedicated_worker: None,
+        modules: None,
+        tag: None,
+    });
+
+    let result = run_job_in_new_worker_until_complete(&db, false, job, port)
+        .await
+        .json_result()
+        .unwrap();
+
+    assert_eq!(result, serde_json::json!([[[1, 2], [3, 4]], [[1], [2]]]));
+    Ok(())
+}
+
 #[sqlx::test(fixtures("base"))]
 async fn test_bun_nobundling_mode(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;

--- a/backend/windmill-worker/node_externals.bun.js
+++ b/backend/windmill-worker/node_externals.bun.js
@@ -89,7 +89,9 @@ function cjsShim(specifier) {
       ".cjs";
     mkdirSync(cjsShimDir, { recursive: true });
     // The local binding is load-bearing: bun collapses a bare `module.exports = require(x)` back
-    // into a passthrough external import, which is the shape that breaks node.
+    // into a passthrough external import, which is the shape that breaks node. A shimmed package
+    // is reached by `require`, so node's async ESM hooks (`register()`) no longer see it; its
+    // sync `registerHooks()` and `--require` interception still do.
     writeFileSync(
       shim,
       "const mod = require(" + JSON.stringify(specifier) + ");\nmodule.exports = mod;\n"

--- a/backend/windmill-worker/node_externals.bun.js
+++ b/backend/windmill-worker/node_externals.bun.js
@@ -10,13 +10,10 @@ try {
   installedPackages = readdirSync(nodeModulesDir);
 } catch (e) {}
 
-// The shim reaches the package through require(), the classifier through bun's resolution, and the
-// two only ever agree on a manifest that cannot select a different entry for either of them. Which
-// conditions are live is not knowable here: bun applies its own, `import`/`require` split node's
-// two ways in, and `--conditions` in the job's NODE_OPTIONS adds arbitrary more at runtime. So a
-// condition of any name disqualifies the package. Subpaths and `default` always select the same
-// entry, and a package with no `exports` at all resolves through `main`, which conditions never
-// reach.
+// The shim reaches the package by require() and the classifier by bun's resolution, which agree
+// only where no condition can steer them apart. Which conditions are live is unknowable here (bun
+// applies its own, and NODE_OPTIONS `--conditions` adds any name at runtime), so any condition at
+// all disqualifies the package; subpaths and `default` select one entry whatever is live.
 export function entryDependsOnCondition(exports) {
   if (Array.isArray(exports)) {
     return exports.some(entryDependsOnCondition);
@@ -103,11 +100,9 @@ function cjsShim(specifier) {
 }
 
 // Node only sees the named exports of a CommonJS dependency that cjs-module-lexer finds
-// statically, which fails on packages such as lodash, so leaving those as plain externals breaks
-// `import { x } from "pkg"` and `import * as pkg from "pkg"`. A generated CommonJS shim makes bun
-// synthesize the interop while the package itself is still required at runtime. Only a package
-// proven CommonJS gets one: requiring an ESM entry throws on the node versions without
-// require(esm), so everything else keeps the plain external it would have had.
+// statically, which fails on lodash and the like, so a plain external breaks `import { x }` and
+// `import * as x` from it. Routing it through a CommonJS shim makes bun synthesize the interop.
+// Only proven-CommonJS packages get one: requiring an ESM entry throws without require(esm).
 export const nodeExternals = {
   name: "windmill-node-externals",
   setup(build) {

--- a/backend/windmill-worker/node_externals.bun.js
+++ b/backend/windmill-worker/node_externals.bun.js
@@ -1,0 +1,127 @@
+import { dirname } from "node:path";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+
+const jobDir = "JOB_DIR";
+const nodeModulesDir = jobDir + "/node_modules";
+const cjsShimDir = jobDir + "/.wm_node_cjs";
+
+let installedPackages = [];
+try {
+  installedPackages = readdirSync(nodeModulesDir);
+} catch (e) {}
+
+// The shim reaches the package through require(), the classifier through bun's resolution, and the
+// two only ever agree on a manifest that cannot select a different entry for either of them. Which
+// conditions are live is not knowable here: bun applies its own, `import`/`require` split node's
+// two ways in, and `--conditions` in the job's NODE_OPTIONS adds arbitrary more at runtime. So a
+// condition of any name disqualifies the package. Subpaths and `default` always select the same
+// entry, and a package with no `exports` at all resolves through `main`, which conditions never
+// reach.
+export function entryDependsOnCondition(exports) {
+  if (Array.isArray(exports)) {
+    return exports.some(entryDependsOnCondition);
+  }
+  if (exports && typeof exports === "object") {
+    return Object.keys(exports).some(
+      (key) =>
+        (key !== "default" && !key.startsWith(".")) ||
+        entryDependsOnCondition(exports[key])
+    );
+  }
+  return false;
+}
+
+const shimmable = new Map();
+function isShimmableCjs(specifier) {
+  if (!shimmable.has(specifier)) {
+    shimmable.set(specifier, classifyAsCjs(specifier));
+  }
+  return shimmable.get(specifier);
+}
+
+function classifyAsCjs(specifier) {
+  const segments = specifier.split("/");
+  const pkg = specifier.startsWith("@")
+    ? segments.slice(0, 2).join("/")
+    : segments[0];
+  try {
+    const manifest = JSON.parse(
+      readFileSync(nodeModulesDir + "/" + pkg + "/package.json", "utf8")
+    );
+    if (manifest.bun !== undefined || entryDependsOnCondition(manifest.exports)) {
+      return false;
+    }
+    const file = Bun.resolveSync(specifier, jobDir);
+    if (file.endsWith(".cjs") || file.endsWith(".node")) {
+      return true;
+    }
+    if (file.endsWith(".js")) {
+      // Same nearest-package.json walk node does to decide how to load a bare .js
+      for (let dir = dirname(file); dir !== dirname(dir); dir = dirname(dir)) {
+        try {
+          return (
+            JSON.parse(readFileSync(dir + "/package.json", "utf8")).type !==
+            "module"
+          );
+        } catch (e) {}
+      }
+    }
+    return false;
+  } catch (e) {
+    console.log(
+      "could not inspect '" +
+        specifier +
+        "' to pick its module format, leaving it external: " +
+        e
+    );
+    return false;
+  }
+}
+
+const cjsShims = new Map();
+function cjsShim(specifier) {
+  if (!cjsShims.has(specifier)) {
+    // Truncated so that a deep subpath cannot flatten into a basename over the filesystem's
+    // limit; the hash is what keeps two specifiers from sharing a shim.
+    const shim =
+      cjsShimDir +
+      "/" +
+      specifier.replace(/[^a-zA-Z0-9]/g, "_").slice(0, 64) +
+      "_" +
+      Bun.hash(specifier).toString(36) +
+      ".cjs";
+    mkdirSync(cjsShimDir, { recursive: true });
+    // The local binding is load-bearing: bun collapses a bare `module.exports = require(x)` back
+    // into a passthrough external import, which is the shape that breaks node.
+    writeFileSync(
+      shim,
+      "const mod = require(" + JSON.stringify(specifier) + ");\nmodule.exports = mod;\n"
+    );
+    cjsShims.set(specifier, shim);
+  }
+  return cjsShims.get(specifier);
+}
+
+// Node only sees the named exports of a CommonJS dependency that cjs-module-lexer finds
+// statically, which fails on packages such as lodash, so leaving those as plain externals breaks
+// `import { x } from "pkg"` and `import * as pkg from "pkg"`. A generated CommonJS shim makes bun
+// synthesize the interop while the package itself is still required at runtime. Only a package
+// proven CommonJS gets one: requiring an ESM entry throws on the node versions without
+// require(esm), so everything else keeps the plain external it would have had.
+export const nodeExternals = {
+  name: "windmill-node-externals",
+  setup(build) {
+    build.onResolve({ filter: /^[^./]/ }, (args) => {
+      if (args.importer.replace(/\\/g, "/").includes("/.wm_node_cjs/")) {
+        return { path: args.path, external: true };
+      }
+      if (!installedPackages.includes(args.path.split("/")[0])) {
+        return undefined;
+      }
+      if (!isShimmableCjs(args.path)) {
+        return { path: args.path, external: true };
+      }
+      return { path: cjsShim(args.path) };
+    });
+  },
+};

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -878,6 +878,8 @@ pub async fn build_loader(
 {loader}
 
 import {{ readdir }} from "node:fs/promises";
+import {{ dirname }} from "node:path";
+import {{ mkdirSync, readFileSync, writeFileSync }} from "node:fs";
 
 let fileNames = []
 try {{
@@ -885,14 +887,68 @@ try {{
 }} catch (e) {{
 }}
 
+const cjsShimDir = "{job_dir_js}/.wm_node_cjs";
+
+// Node only sees the named exports of a CommonJS dependency that cjs-module-lexer finds
+// statically, which fails on packages such as lodash, so leaving those as plain externals breaks
+// `import {{ x }} from "pkg"` and `import * as pkg from "pkg"`. A generated CommonJS shim makes
+// bun synthesize the interop while the package itself is still required at runtime. Packages node
+// loads as ESM keep real named exports and must stay plain externals: requiring them would throw
+// on the node versions without require(esm).
+const isCjsCache = new Map();
+function isCjs(specifier) {{
+    if (!isCjsCache.has(specifier)) {{
+        let cjs = false;
+        try {{
+            const file = Bun.resolveSync(specifier, "{job_dir_js}");
+            if (file.endsWith(".cjs") || file.endsWith(".node")) {{
+                cjs = true;
+            }} else if (file.endsWith(".js")) {{
+                // Same nearest-package.json walk node does to decide how to load a bare .js
+                for (let dir = dirname(file); dir !== dirname(dir); dir = dirname(dir)) {{
+                    try {{
+                        cjs = JSON.parse(readFileSync(dir + "/package.json", "utf8")).type !== "module";
+                        break;
+                    }} catch (e) {{}}
+                }}
+            }}
+        }} catch (e) {{}}
+        isCjsCache.set(specifier, cjs);
+    }}
+    return isCjsCache.get(specifier);
+}}
+
+const nodeExternals = {{
+    name: "windmill-node-externals",
+    setup(build) {{
+        build.onResolve({{ filter: /^[^./]/ }}, (args) => {{
+            if (args.importer.replace(/\\/g, "/").includes("/.wm_node_cjs/")) {{
+                return {{ path: args.path, external: true }};
+            }}
+            if (!fileNames.includes(args.path.split("/")[0])) {{
+                return undefined;
+            }}
+            if (!isCjs(args.path)) {{
+                return {{ path: args.path, external: true }};
+            }}
+            const shim = cjsShimDir + "/" + args.path.replace(/[^a-zA-Z0-9]/g, "_")
+                + "_" + Bun.hash(args.path).toString(36) + ".cjs";
+            mkdirSync(cjsShimDir, {{ recursive: true }});
+            // The local binding is load-bearing: bun collapses a bare `module.exports = require(x)`
+            // back into a passthrough external import, which is the shape that breaks node.
+            writeFileSync(shim, "const mod = require(" + JSON.stringify(args.path) + ");\nmodule.exports = mod;\n");
+            return {{ path: shim }};
+        }});
+    }},
+}};
+
 let result;
 try {{
     result = await Bun.build({{
         entrypoints: ["{job_dir_js}/wrapper.mjs"],
         outdir: "./",
         target: "node",
-        plugins: [p],
-        external: fileNames,
+        plugins: [p, nodeExternals],
         minify: true,
     }});
 }} catch(err) {{

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -890,16 +890,18 @@ try {{
 const nodeModulesDir = "{job_dir_js}/node_modules";
 const cjsShimDir = "{job_dir_js}/.wm_node_cjs";
 
-// Bun is the only one of the two that applies a "bun" export condition, so a manifest carrying one
-// can point bun at a CommonJS entry where node loads ESM. Such a package cannot be classified from
-// bun's resolution at all.
-function usesBunCondition(exports) {{
+// The shim reaches the package through require(), and the classifier through bun's resolution, so
+// a manifest whose entry depends on which condition asks for it would let the two disagree: "bun"
+// is applied by bun and never by node, and "import"/"require" split node's own two ways in. Only a
+// package that resolves to one entry either way can be classified from bun's resolution at all.
+function entryDependsOnCondition(exports) {{
     if (Array.isArray(exports)) {{
-        return exports.some(usesBunCondition);
+        return exports.some(entryDependsOnCondition);
     }}
     if (exports && typeof exports === "object") {{
         return Object.keys(exports).some((key) =>
-            key === "bun" || key === "bun-macro" || usesBunCondition(exports[key]));
+            key === "bun" || key === "bun-macro" || key === "import" || key === "require"
+                || entryDependsOnCondition(exports[key]));
     }}
     return false;
 }}
@@ -907,47 +909,43 @@ function usesBunCondition(exports) {{
 // Node only sees the named exports of a CommonJS dependency that cjs-module-lexer finds
 // statically, which fails on packages such as lodash, so leaving those as plain externals breaks
 // `import {{ x }} from "pkg"` and `import * as pkg from "pkg"`. A generated CommonJS shim makes
-// bun synthesize the interop while the package itself is still required at runtime. Only packages
-// proven CommonJS get one: requiring an ESM entry throws on the node versions without
-// require(esm), so anything unproven keeps the plain external it had before.
-const moduleKinds = new Map();
-function moduleKind(specifier) {{
-    if (!moduleKinds.has(specifier)) {{
-        moduleKinds.set(specifier, classifyModule(specifier));
-        if (moduleKinds.get(specifier) === "unknown") {{
-            console.log("could not tell whether '" + specifier
-                + "' is CommonJS or ESM, leaving it external: named imports from it may not resolve under node");
-        }}
+// bun synthesize the interop while the package itself is still required at runtime. Only a package
+// proven CommonJS gets one: requiring an ESM entry throws on the node versions without
+// require(esm), so everything else keeps the plain external it had before.
+const shimmable = new Map();
+function isShimmableCjs(specifier) {{
+    if (!shimmable.has(specifier)) {{
+        shimmable.set(specifier, classifyAsCjs(specifier));
     }}
-    return moduleKinds.get(specifier);
+    return shimmable.get(specifier);
 }}
 
-function classifyModule(specifier) {{
+function classifyAsCjs(specifier) {{
     const segments = specifier.split("/");
     const pkg = specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
     try {{
         const manifest = JSON.parse(readFileSync(nodeModulesDir + "/" + pkg + "/package.json", "utf8"));
-        if (manifest.bun !== undefined || usesBunCondition(manifest.exports)) {{
-            return "unknown";
+        if (manifest.bun !== undefined || entryDependsOnCondition(manifest.exports)) {{
+            return false;
         }}
         const file = Bun.resolveSync(specifier, "{job_dir_js}");
-        if (file.endsWith(".mjs")) {{
-            return "esm";
-        }}
         if (file.endsWith(".cjs") || file.endsWith(".node")) {{
-            return "cjs";
+            return true;
         }}
         if (file.endsWith(".js")) {{
             // Same nearest-package.json walk node does to decide how to load a bare .js
             for (let dir = dirname(file); dir !== dirname(dir); dir = dirname(dir)) {{
                 try {{
-                    return JSON.parse(readFileSync(dir + "/package.json", "utf8")).type === "module"
-                        ? "esm" : "cjs";
+                    return JSON.parse(readFileSync(dir + "/package.json", "utf8")).type !== "module";
                 }} catch (e) {{}}
             }}
         }}
-    }} catch (e) {{}}
-    return "unknown";
+        return false;
+    }} catch (e) {{
+        console.log("could not inspect '" + specifier
+            + "' to pick its module format, leaving it external: " + e);
+        return false;
+    }}
 }}
 
 const cjsShims = new Map();
@@ -974,7 +972,7 @@ const nodeExternals = {{
             if (!fileNames.includes(args.path.split("/")[0])) {{
                 return undefined;
             }}
-            if (moduleKind(args.path) !== "cjs") {{
+            if (!isShimmableCjs(args.path)) {{
                 return {{ path: args.path, external: true }};
             }}
             return {{ path: cjsShim(args.path) }};

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -71,6 +71,8 @@ pub const RELATIVE_BUN_LOADER: &str = include_str!("../loader.bun.windows.js");
 
 pub const RELATIVE_BUN_BUILDER: &str = include_str!("../loader_builder.bun.js");
 
+pub const NODE_EXTERNALS_PLUGIN: &str = include_str!("../node_externals.bun.js");
+
 const NSJAIL_CONFIG_RUN_BUN_CONTENT: &str = include_str!("../nsjail/run.bun.config.proto");
 
 pub const BUN_LOCK_SPLIT: &str = "\n//bun.lock\n";
@@ -870,6 +872,7 @@ pub async fn build_loader(
         .replace("TEMP_SCRIPT_REFS_PLACEHOLDER", &temp_refs_json);
 
     if mode == LoaderMode::Node {
+        let node_externals = NODE_EXTERNALS_PLUGIN.replace("JOB_DIR", &job_dir_js);
         write_file(
             &job_dir,
             "node_builder.ts",
@@ -877,109 +880,7 @@ pub async fn build_loader(
                 r#"
 {loader}
 
-import {{ readdir }} from "node:fs/promises";
-import {{ dirname }} from "node:path";
-import {{ mkdirSync, readFileSync, writeFileSync }} from "node:fs";
-
-let fileNames = []
-try {{
-    fileNames = await readdir("{job_dir_js}/node_modules")
-}} catch (e) {{
-}}
-
-const nodeModulesDir = "{job_dir_js}/node_modules";
-const cjsShimDir = "{job_dir_js}/.wm_node_cjs";
-
-// The shim reaches the package through require(), and the classifier through bun's resolution, so
-// a manifest whose entry depends on which condition asks for it would let the two disagree: "bun"
-// is applied by bun and never by node, and "import"/"require" split node's own two ways in. Only a
-// package that resolves to one entry either way can be classified from bun's resolution at all.
-function entryDependsOnCondition(exports) {{
-    if (Array.isArray(exports)) {{
-        return exports.some(entryDependsOnCondition);
-    }}
-    if (exports && typeof exports === "object") {{
-        return Object.keys(exports).some((key) =>
-            key === "bun" || key === "bun-macro" || key === "import" || key === "require"
-                || entryDependsOnCondition(exports[key]));
-    }}
-    return false;
-}}
-
-// Node only sees the named exports of a CommonJS dependency that cjs-module-lexer finds
-// statically, which fails on packages such as lodash, so leaving those as plain externals breaks
-// `import {{ x }} from "pkg"` and `import * as pkg from "pkg"`. A generated CommonJS shim makes
-// bun synthesize the interop while the package itself is still required at runtime. Only a package
-// proven CommonJS gets one: requiring an ESM entry throws on the node versions without
-// require(esm), so everything else keeps the plain external it had before.
-const shimmable = new Map();
-function isShimmableCjs(specifier) {{
-    if (!shimmable.has(specifier)) {{
-        shimmable.set(specifier, classifyAsCjs(specifier));
-    }}
-    return shimmable.get(specifier);
-}}
-
-function classifyAsCjs(specifier) {{
-    const segments = specifier.split("/");
-    const pkg = specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
-    try {{
-        const manifest = JSON.parse(readFileSync(nodeModulesDir + "/" + pkg + "/package.json", "utf8"));
-        if (manifest.bun !== undefined || entryDependsOnCondition(manifest.exports)) {{
-            return false;
-        }}
-        const file = Bun.resolveSync(specifier, "{job_dir_js}");
-        if (file.endsWith(".cjs") || file.endsWith(".node")) {{
-            return true;
-        }}
-        if (file.endsWith(".js")) {{
-            // Same nearest-package.json walk node does to decide how to load a bare .js
-            for (let dir = dirname(file); dir !== dirname(dir); dir = dirname(dir)) {{
-                try {{
-                    return JSON.parse(readFileSync(dir + "/package.json", "utf8")).type !== "module";
-                }} catch (e) {{}}
-            }}
-        }}
-        return false;
-    }} catch (e) {{
-        console.log("could not inspect '" + specifier
-            + "' to pick its module format, leaving it external: " + e);
-        return false;
-    }}
-}}
-
-const cjsShims = new Map();
-function cjsShim(specifier) {{
-    if (!cjsShims.has(specifier)) {{
-        const shim = cjsShimDir + "/" + specifier.replace(/[^a-zA-Z0-9]/g, "_")
-            + "_" + Bun.hash(specifier).toString(36) + ".cjs";
-        mkdirSync(cjsShimDir, {{ recursive: true }});
-        // The local binding is load-bearing: bun collapses a bare `module.exports = require(x)`
-        // back into a passthrough external import, which is the shape that breaks node.
-        writeFileSync(shim, "const mod = require(" + JSON.stringify(specifier) + ");\nmodule.exports = mod;\n");
-        cjsShims.set(specifier, shim);
-    }}
-    return cjsShims.get(specifier);
-}}
-
-const nodeExternals = {{
-    name: "windmill-node-externals",
-    setup(build) {{
-        build.onResolve({{ filter: /^[^./]/ }}, (args) => {{
-            if (args.importer.replace(/\\/g, "/").includes("/.wm_node_cjs/")) {{
-                return {{ path: args.path, external: true }};
-            }}
-            if (!fileNames.includes(args.path.split("/")[0])) {{
-                return undefined;
-            }}
-            if (!isShimmableCjs(args.path)) {{
-                return {{ path: args.path, external: true }};
-            }}
-            return {{ path: cjsShim(args.path) }};
-        }});
-    }},
-}};
-
+{node_externals}
 let result;
 try {{
     result = await Bun.build({{

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -887,35 +887,81 @@ try {{
 }} catch (e) {{
 }}
 
+const nodeModulesDir = "{job_dir_js}/node_modules";
 const cjsShimDir = "{job_dir_js}/.wm_node_cjs";
+
+// Bun is the only one of the two that applies a "bun" export condition, so a manifest carrying one
+// can point bun at a CommonJS entry where node loads ESM. Such a package cannot be classified from
+// bun's resolution at all.
+function usesBunCondition(exports) {{
+    if (Array.isArray(exports)) {{
+        return exports.some(usesBunCondition);
+    }}
+    if (exports && typeof exports === "object") {{
+        return Object.keys(exports).some((key) =>
+            key === "bun" || key === "bun-macro" || usesBunCondition(exports[key]));
+    }}
+    return false;
+}}
 
 // Node only sees the named exports of a CommonJS dependency that cjs-module-lexer finds
 // statically, which fails on packages such as lodash, so leaving those as plain externals breaks
 // `import {{ x }} from "pkg"` and `import * as pkg from "pkg"`. A generated CommonJS shim makes
-// bun synthesize the interop while the package itself is still required at runtime. Packages node
-// loads as ESM keep real named exports and must stay plain externals: requiring them would throw
-// on the node versions without require(esm).
-const isCjsCache = new Map();
-function isCjs(specifier) {{
-    if (!isCjsCache.has(specifier)) {{
-        let cjs = false;
-        try {{
-            const file = Bun.resolveSync(specifier, "{job_dir_js}");
-            if (file.endsWith(".cjs") || file.endsWith(".node")) {{
-                cjs = true;
-            }} else if (file.endsWith(".js")) {{
-                // Same nearest-package.json walk node does to decide how to load a bare .js
-                for (let dir = dirname(file); dir !== dirname(dir); dir = dirname(dir)) {{
-                    try {{
-                        cjs = JSON.parse(readFileSync(dir + "/package.json", "utf8")).type !== "module";
-                        break;
-                    }} catch (e) {{}}
-                }}
-            }}
-        }} catch (e) {{}}
-        isCjsCache.set(specifier, cjs);
+// bun synthesize the interop while the package itself is still required at runtime. Only packages
+// proven CommonJS get one: requiring an ESM entry throws on the node versions without
+// require(esm), so anything unproven keeps the plain external it had before.
+const moduleKinds = new Map();
+function moduleKind(specifier) {{
+    if (!moduleKinds.has(specifier)) {{
+        moduleKinds.set(specifier, classifyModule(specifier));
+        if (moduleKinds.get(specifier) === "unknown") {{
+            console.log("could not tell whether '" + specifier
+                + "' is CommonJS or ESM, leaving it external: named imports from it may not resolve under node");
+        }}
     }}
-    return isCjsCache.get(specifier);
+    return moduleKinds.get(specifier);
+}}
+
+function classifyModule(specifier) {{
+    const segments = specifier.split("/");
+    const pkg = specifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+    try {{
+        const manifest = JSON.parse(readFileSync(nodeModulesDir + "/" + pkg + "/package.json", "utf8"));
+        if (manifest.bun !== undefined || usesBunCondition(manifest.exports)) {{
+            return "unknown";
+        }}
+        const file = Bun.resolveSync(specifier, "{job_dir_js}");
+        if (file.endsWith(".mjs")) {{
+            return "esm";
+        }}
+        if (file.endsWith(".cjs") || file.endsWith(".node")) {{
+            return "cjs";
+        }}
+        if (file.endsWith(".js")) {{
+            // Same nearest-package.json walk node does to decide how to load a bare .js
+            for (let dir = dirname(file); dir !== dirname(dir); dir = dirname(dir)) {{
+                try {{
+                    return JSON.parse(readFileSync(dir + "/package.json", "utf8")).type === "module"
+                        ? "esm" : "cjs";
+                }} catch (e) {{}}
+            }}
+        }}
+    }} catch (e) {{}}
+    return "unknown";
+}}
+
+const cjsShims = new Map();
+function cjsShim(specifier) {{
+    if (!cjsShims.has(specifier)) {{
+        const shim = cjsShimDir + "/" + specifier.replace(/[^a-zA-Z0-9]/g, "_")
+            + "_" + Bun.hash(specifier).toString(36) + ".cjs";
+        mkdirSync(cjsShimDir, {{ recursive: true }});
+        // The local binding is load-bearing: bun collapses a bare `module.exports = require(x)`
+        // back into a passthrough external import, which is the shape that breaks node.
+        writeFileSync(shim, "const mod = require(" + JSON.stringify(specifier) + ");\nmodule.exports = mod;\n");
+        cjsShims.set(specifier, shim);
+    }}
+    return cjsShims.get(specifier);
 }}
 
 const nodeExternals = {{
@@ -928,16 +974,10 @@ const nodeExternals = {{
             if (!fileNames.includes(args.path.split("/")[0])) {{
                 return undefined;
             }}
-            if (!isCjs(args.path)) {{
+            if (moduleKind(args.path) !== "cjs") {{
                 return {{ path: args.path, external: true }};
             }}
-            const shim = cjsShimDir + "/" + args.path.replace(/[^a-zA-Z0-9]/g, "_")
-                + "_" + Bun.hash(args.path).toString(36) + ".cjs";
-            mkdirSync(cjsShimDir, {{ recursive: true }});
-            // The local binding is load-bearing: bun collapses a bare `module.exports = require(x)`
-            // back into a passthrough external import, which is the shape that breaks node.
-            writeFileSync(shim, "const mod = require(" + JSON.stringify(args.path) + ");\nmodule.exports = mod;\n");
-            return {{ path: shim }};
+            return {{ path: cjsShim(args.path) }};
         }});
     }},
 }};

--- a/backend/windmill-worker/src/lib.rs
+++ b/backend/windmill-worker/src/lib.rs
@@ -108,8 +108,8 @@ pub use worker::*;
 pub use bun_executor::{
     build_loader, compute_bundle_local_and_remote_path, ensure_bundle_output_exists,
     generate_bun_bundle, get_common_bun_proc_envs, install_bun_lockfile, prebundle_bun_script,
-    prepare_job_dir, LoaderMode, BUN_DEDICATED_WORKER_ARGS, RELATIVE_BUN_BUILDER,
-    RELATIVE_BUN_LOADER,
+    prepare_job_dir, LoaderMode, BUN_DEDICATED_WORKER_ARGS, NODE_EXTERNALS_PLUGIN,
+    RELATIVE_BUN_BUILDER, RELATIVE_BUN_LOADER,
 };
 #[cfg(any(feature = "private", test))]
 pub use bun_executor::{


### PR DESCRIPTION
## Summary

Fixes GIT-975.

Under the `//nodejs` annotation, `import { chunk } from "lodash"` produced a bundle node's ESM loader rejects at instantiate time, and `import * as _ from "lodash"` produced a namespace object without the package's methods (`TypeError: _.chunk is not a function`).

Root cause: `LoaderMode::Node` passed `external: <every top-level directory name under <job_dir>/node_modules>` to `Bun.build`, so a bare import of an npm package survived verbatim into the ESM output that node then has to resolve at runtime. Node can only expose the named exports of a CommonJS dependency that `cjs-module-lexer` finds statically, and lodash's UMD wrapper defeats it, so the named import fails to link and the namespace object carries only `default`. `mime-types` worked because the lexer *can* see its `exports.x = ...` assignments, which is why the failure looked package-specific rather than CJS-wide.

The fix replaces the `external` option with a bun plugin that decides, per `node_modules` package, whether a CommonJS shim is provably safe:

- a package proven **CommonJS** is routed through a generated `.cjs` shim, so bun synthesizes the interop itself while the package is still `require`d from `<job_dir>/node_modules` at runtime rather than bundled;
- **everything else** stays a plain external, byte-for-byte the shape that shipped before this PR.

"Proven" means node's `import` and `require` land on the same CommonJS file no matter which export conditions are live. Since `--conditions` in a job's `NODE_OPTIONS` can enable a condition of any name, no denylist can be complete, so **any** condition disqualifies a package: only subpath keys and `default` are permitted anywhere in `exports`, plus packages with no `exports` at all, which resolve through `main`, where conditions never reach. Three review rounds each found a different condition that selected a different entry, so the rule is categorical rather than enumerated. The worst case is "not fixed for that package", never "a package that worked now breaks".

Nothing is newly bundled into the output, so native addons and packages that read their own files at runtime keep working the same way.

## Changes

- `backend/windmill-worker/node_externals.bun.js` (new) — the `windmill-node-externals` bun plugin: leaves every `node_modules` package external except the ones it can prove CommonJS, which resolve to a generated `<job_dir>/.wm_node_cjs/*.cjs` shim. CommonJS-ness comes from the resolved file extension plus the same nearest-`package.json` `type` walk node performs, and only for manifests whose entry cannot vary by condition. It lives in its own file, interpolated like the existing `RELATIVE_BUN_BUILDER`, so the rule can be unit-tested and so the block stops needing `format!` brace escaping.
- `backend/windmill-worker/src/bun_executor.rs` — `build_loader`'s `LoaderMode::Node` branch drops `external: fileNames` and registers that plugin instead.
- `backend/tests/bun_jobs.rs` — a job-level regression test (`//nodejs` script with a named and a namespace import of lodash, plus a named import from ESM-only `nanoid` to pin the stays-external branch), and a unit test running `entryDependsOnCondition` under bun against a table of manifest shapes.

## Test plan

- [x] `cargo test --test bun_jobs` — 36/36 pass; the new `test_bun_nodejs_cjs_named_and_namespace_import` fails on `main`'s builder and passes with the fix.
- [x] `cargo test --features quickjs,private,enterprise --test dedicated_workers test_dedicated_flow_bun_nodejs` — the dedicated-worker `//nodejs` path also builds through `LoaderMode::Node`.
- [x] Real jobs on a local instance, before and after. Before: `import { chunk } from "lodash"` fails with the reported `… = pkg;` ESM-loader error, `import * as _ from "lodash"` fails with `TypeError: G.chunk is not a function`. After: `[[1,2],[3,4]]` and `[[1],[2]]`.
- [x] Real jobs for the shapes that already worked: lodash default and `lodash/chunk.js` subpath, `mime-types`, `dayjs`, `zod`, `uuid`, `axios`, ESM-only `nanoid`, `windmill-client` (namespace and named imports, plus a real `setVariable`/`getVariable` roundtrip), a `/f/...`-imported windmill script that itself imports lodash, `//nodejs //nobundling`, and a deployed `//nodejs` script (the `NodeBundle` path, unchanged).
- [x] A 25-shape matrix built through the real generated builder and executed under node, across **node v20.20.0** (the managed instance's version, no `require(esm)`) and **v26.4.0**, with **bun 1.3.11** and **bun 1.4.0** (the version #10784 upgrades to) as the builder. All pass in every combination.
- [x] Fixtures for each way the classifier can be fooled, each compared against `main`: a `{"bun": …, "node": …}` package (shimming it gave `ERR_REQUIRE_ASYNC_MODULE`), a `{"import": "./import.cjs", "require": "./require.cjs"}` package whose entries return different values (shimming it silently returned the `require` entry), a `{"development": "./dev.mjs", "default": "./index.cjs"}` package run under `NODE_OPTIONS=--conditions=development` (shimming it gave `ERR_REQUIRE_ASYNC_MODULE`), a CJS subpath long enough that the flattened shim basename exceeded the filesystem limit (`ENAMETOOLONG`, a hard build failure), a symlinked `node_modules` package, and `main` (CJS) + `module` (ESM) with no `exports`. Every one now matches or improves on `main`.
- [x] Dynamic `await import("lodash")` — also broken before this change, fixed by it.

Not verified: a `//nodejs` job on a **Windows** worker. The generated builder transpiles against `loader.bun.windows.js` and the path handling is drive-letter safe by construction, but no job was run there.

## Known limitation: a shimmed package is invisible to async ESM loader hooks

A shimmed package is reached by `require()`, so node's **async** ESM hooks
(`module.register()` / `--experimental-loader`, reachable because a script's `envs` can set
`NODE_OPTIONS` off `CLOUD_HOSTED`) no longer see it. Measured on node v26.4.0 with a hook
redirecting `lodash`, against `import _ from "lodash"` built both ways:

| interception mechanism | before | after |
| -- | -- | -- |
| `register()` / `--experimental-loader` (async, ESM-only) | intercepted | **not intercepted** |
| `module.registerHooks()` (sync, node >= 22.15) | intercepted | intercepted |
| `--require` + `Module.prototype.require` patch (what APM auto-instrumentation uses) | intercepted | intercepted |

This is a property of the mechanism, not an oversight, and neither remedy is available:

- **Preserving ESM resolution cannot fix the bug.** Node's ESM loader cannot expose lodash's
  named exports at all — that *is* the root cause. Any fix must obtain the CommonJS exports
  object through `require`, and node does not route `require` through async ESM hooks by design.
- **Refusing the shim when hooks are configured is not soundly detectable.** The bundler runs
  with `env_clear()` and only `common_bun_proc_envs` (`bun_executor.rs:1032-1037`), so it never
  sees the job's `NODE_OPTIONS`; and the bundle cache key is content + lock + transitive import
  versions with no env component (`bun_executor.rs:1367`), so a bundle built for a job without
  `NODE_OPTIONS` is reused verbatim by a later job that sets it. A build-time gate would be
  silently stale — the same class of bug rounds 1-3 were about.

Narrowing the shim to only the import shapes that are broken today (leaving default-only imports
external, so nothing that works today changes) would bound this to scripts that currently crash.
It needs an import-clause classifier — `Bun.Transpiler.scan()` reports specifiers but not clauses,
so it would be hand-rolled — and a mis-parse re-breaks the bug on the common path to protect an
exotic one. Recorded as a deliberate call for the human review this PR is waiting on, not done.

**Left in draft deliberately.** Round 6 is clean on all three reviewers (Codex, Claude, Pi all "good to merge" at `d767b1c3d0`), round 5's Codex P1 being the loader-hook trade-off documented above. It is left in draft anyway because this changes how every non-cached `//nodejs` job links its npm dependencies, which is shared worker infrastructure rather than a self-contained fix. Three earlier rounds each found a real regression in this same classifier, so it wants a human look before it goes ready rather than an automatic flip on a clean round.


