### PR TITLE
fix: build the global chat's prompt identity from the operating workspace

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -117,6 +117,8 @@ import {
 	globalToolsFor,
 	loadWorkspaceSkills,
 	prepareGlobalSystemMessage,
+	resolveGlobalPromptIdentity,
+	type GlobalPromptIdentity,
 	prepareGlobalUserMessage,
 	type AiSkillListItem,
 	type ChatCommandItem,
@@ -1081,6 +1083,12 @@ export class AIChatManager {
 	mcpServers = $state<McpServer[]>([])
 	private mcpServersRefreshId = 0
 
+	// The GLOBAL prompt's path conventions and folder ACLs, for this chat's operating
+	// workspace (`GlobalPromptIdentity`). Resolved asynchronously alongside skills, never
+	// read from the ambient user store.
+	private globalIdentity = $state<GlobalPromptIdentity | undefined>(undefined)
+	private globalIdentityRefreshId = 0
+
 	// Built-in session-chat slash commands, listed in the command picker
 	// alongside workspace skills. Unlike a skill, these run locally and never
 	// reach the model; the submit path intercepts them first, so they shadow any
@@ -1954,6 +1962,7 @@ export class AIChatManager {
 			this.helpers = {}
 		} else if (mode === AIMode.GLOBAL) {
 			this.configureGlobalMode()
+			void this.refreshGlobalIdentity()
 			void this.refreshGlobalSkills()
 			void this.refreshMcpServers()
 		} else if (mode === AIMode.APP) {
@@ -1974,6 +1983,7 @@ export class AIChatManager {
 	private configureGlobalMode = () => {
 		const systemMessage = prepareGlobalSystemMessage(getCustomPromptParts(AIMode.GLOBAL), {
 			previewTools: this.isSessionChat,
+			user: this.globalIdentity,
 			skills: this.globalSkills,
 			mcpServers: this.mcpServers
 		})
@@ -2039,6 +2049,20 @@ export class AIChatManager {
 		}
 	}
 
+	// Same shape as refreshGlobalSkills. An identity that resolves after the operating
+	// workspace moved describes the workspace left behind, so it is dropped, not installed.
+	refreshGlobalIdentity = async (workspace = this.operatingWorkspace ?? '') => {
+		const refreshId = ++this.globalIdentityRefreshId
+		const identity = await resolveGlobalPromptIdentity(workspace)
+		if (refreshId !== this.globalIdentityRefreshId) {
+			return
+		}
+		this.globalIdentity = workspace === (this.operatingWorkspace ?? '') ? identity : undefined
+		if (this.mode === AIMode.GLOBAL) {
+			this.configureGlobalMode()
+		}
+	}
+
 	// Same shape as refreshGlobalSkills: rebuild GLOBAL mode once the connected
 	// MCP servers resolve so the next chat-loop iteration advertises their tools,
 	// ignoring stale resolves so a workspace change cannot overwrite newer ones.
@@ -2085,6 +2109,7 @@ export class AIChatManager {
 		}
 		const systemMessage = prepareGlobalSystemMessage(getCustomPromptParts(AIMode.GLOBAL), {
 			previewTools: this.isSessionChat,
+			user: this.globalIdentity,
 			skills: this.globalSkills,
 			mcpServers: this.mcpServers
 		})
@@ -2914,10 +2939,13 @@ export class AIChatManager {
 				return false
 			}
 		}
-		// Session chats commit their workspace in beforeSend; skills and MCP servers
-		// must match the committed workspace before the system prompt is sent.
+		// Session chats commit their workspace in beforeSend; the identity, skills and
+		// MCP servers must all match the committed workspace before the system prompt is
+		// sent. Settling them here rather than mid-turn also keeps the prompt — the
+		// cached prefix of every iteration — stable for the whole request.
 		if (this.mode === AIMode.GLOBAL) {
 			await Promise.all([
+				this.refreshGlobalIdentity(this.operatingWorkspace ?? ''),
 				this.refreshGlobalSkills(this.operatingWorkspace ?? ''),
 				this.refreshMcpServers(this.operatingWorkspace ?? '')
 			])

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -9,6 +9,7 @@ import { AIChatManager, AIMode, AIAutonomyMode } from './AIChatManager.svelte'
 import { chatState } from './sharedChatState.svelte'
 import { PLAN_MODE_MESSAGES } from './planModeMessages'
 import { runChatLoop } from './chatLoop'
+import { clearWorkspaceRoleCache } from '$lib/user'
 
 // This suite forces esm-env BROWSER=true (below). That makes @sveltejs/kit's
 // client runtime (pulled transitively via $lib/navigation) evaluate browser-only
@@ -33,7 +34,11 @@ const mocks = vi.hoisted(() => ({
 	runChatLoop: vi.fn(),
 	listAiSkills: vi.fn(),
 	getJob: vi.fn(),
-	workspace: 'test_workspace' as string | undefined
+	whoami: vi.fn(),
+	workspace: 'test_workspace' as string | undefined,
+	// The workspace being browsed, which a session chat's own workspace need not be.
+	navWorkspace: undefined as string | undefined,
+	userWorkspaces: [] as unknown[]
 }))
 
 vi.mock('monaco-editor', () => ({
@@ -48,6 +53,9 @@ vi.mock('$lib/gen', () => ({
 	},
 	ScriptService: {},
 	FlowService: {},
+	UserService: {
+		whoami: mocks.whoami
+	},
 	JobService: {
 		getJob: mocks.getJob
 	}
@@ -73,15 +81,15 @@ vi.mock('$lib/stores', () => {
 				return () => undefined
 			}
 		},
-		// `workspace_id` tracks the mocked active workspace: allowedOpenPages compares the
-		// two, and on a mismatch fetches `whoami` for the workspace it gates.
+		// `workspace_id` is the workspace being browsed; consumers compare it against the
+		// workspace they are asked about and fetch `whoami` for the latter on a mismatch.
 		userStore: {
 			subscribe: (run: (value: unknown) => void) => {
 				run({
 					username: 'admin',
 					email: 'admin@test',
 					is_admin: true,
-					workspace_id: mocks.workspace
+					workspace_id: mocks.navWorkspace ?? mocks.workspace
 				})
 				return () => undefined
 			}
@@ -91,7 +99,16 @@ vi.mock('$lib/stores', () => {
 		// tools are built.
 		superadmin: readable(false),
 		devopsRole: readable(false),
-		userWorkspaces: readable([] as unknown[]),
+		userWorkspaces: {
+			subscribe: (run: (value: unknown[]) => void) => {
+				run(mocks.userWorkspaces)
+				return () => undefined
+			}
+		},
+		// Read by roleForWorkspace (global/core.ts), which may only settle a
+		// non-membership once this has resolved.
+		usersWorkspaceStore: readable({ workspaces: [] as unknown[] }),
+		NON_MEMBER_USERNAME: 'superadmin',
 		enterpriseLicense: readable(undefined)
 	}
 })
@@ -376,6 +393,63 @@ describe('AIChatManager global skills', () => {
 		await manager.sendRequest({ instructions: '/review-code find bugs', mode: AIMode.GLOBAL })
 
 		expect(manager.displayMessages[0]?.content).toBe('/review-code find bugs')
+	})
+})
+
+describe('AIChatManager global prompt identity', () => {
+	const model = { provider: 'openai', model: 'gpt-4o' }
+
+	beforeEach(() => {
+		localStorage.clear()
+		mocks.getCurrentModel.mockReturnValue(model)
+		mocks.tryGetCurrentModel.mockReturnValue(model)
+		mocks.listAiSkills.mockResolvedValue([])
+	})
+
+	afterEach(() => {
+		mocks.navWorkspace = undefined
+		mocks.userWorkspaces = []
+		clearWorkspaceRoleCache()
+	})
+
+	// The identity must be settled before the first request, not after the model has
+	// already been told to write to a `u/<username>/...` that does not exist there.
+	it('resolves the identity for the workspace beforeSend commits, not the browsed one', async () => {
+		mocks.workspace = 'parent'
+		mocks.navWorkspace = 'parent'
+		mocks.userWorkspaces = [{ id: 'parent' }, { id: 'child' }]
+		mocks.whoami.mockImplementation(async ({ workspace }: { workspace: string }) => ({
+			username: `${workspace}_user`,
+			email: 'admin@test',
+			is_admin: false,
+			operator: false,
+			groups: [],
+			folders: [`${workspace}_folder`],
+			folders_read: [`${workspace}_folder`]
+		}))
+		mocks.runChatLoop.mockImplementation(async (config: any) => {
+			expect(config.systemMessage.content).toContain('workspace username is "child_user"')
+			expect(config.systemMessage.content).toContain('`f/child_folder`')
+			expect(config.systemMessage.content).not.toContain('parent_folder')
+			const message = { role: 'assistant' as const, content: 'done' }
+			config.addedMessages?.push(message)
+			return {
+				addedMessages: [message],
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		const manager = new AIChatManager()
+		manager.isSessionChat = true
+		manager.beforeSend = () => {
+			mocks.workspace = 'child'
+		}
+
+		await manager.sendRequest({ instructions: 'first', mode: AIMode.GLOBAL })
+
+		expect(mocks.whoami).toHaveBeenCalledWith({ workspace: 'child' })
+		expect(manager.systemMessage.content).toContain('workspace username is "child_user"')
 	})
 })
 

--- a/frontend/src/lib/components/copilot/chat/flow/aiAgentProviderCatalog.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/aiAgentProviderCatalog.ts
@@ -9,7 +9,9 @@ import {
 	type AiAgentProviderOption
 } from './aiAgentProviders'
 
-const AI_RESOURCE_TYPES = Object.keys(AI_PROVIDERS) as AIProvider[]
+// Read lazily: evaluating this at module scope makes `AI_PROVIDERS` a load-time requirement
+// for everything that reaches this module, the whole global chat included.
+const aiResourceTypes = () => Object.keys(AI_PROVIDERS) as AIProvider[]
 
 /** Kinds whose model listing `fetchAvailableModels` narrows before returning it: OpenAI and Azure
  * OpenAI keep only `gpt-`/`o`/`codex` ids (so a fine-tune never appears), Bedrock keeps text
@@ -121,7 +123,7 @@ async function loadCatalog(workspace: string): Promise<AiAgentProviderCatalog> {
 	const [resources, aiConfig] = await Promise.all([
 		ResourceService.listResource({
 			workspace,
-			resourceType: AI_RESOURCE_TYPES.join(',')
+			resourceType: aiResourceTypes().join(',')
 		}).catch((err) => {
 			console.error('Could not list AI provider resources', err)
 			// The catalog no longer knows the workspace's resources, so nothing may be rejected for
@@ -148,7 +150,7 @@ async function loadCatalog(workspace: string): Promise<AiAgentProviderCatalog> {
 		resources,
 		new Set(configuredByPath.keys()),
 		aiConfig.default_model?.provider,
-		(resourceType) => AI_RESOURCE_TYPES.includes(resourceType as AIProvider)
+		(resourceType) => aiResourceTypes().includes(resourceType as AIProvider)
 	) as { kind: AIProvider; resourcePath: string }[]
 
 	const kept = candidates.slice(0, MAX_PROVIDER_RESOURCES)

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -346,7 +346,7 @@ import {
 	UserService,
 	VariableService
 } from '$lib/gen'
-import { userStore, usersWorkspaceStore } from '$lib/stores'
+import { superadmin, userStore, usersWorkspaceStore } from '$lib/stores'
 import { clearWorkspaceRoleCache } from '$lib/user'
 import { get } from 'svelte/store'
 import type { Tool, ToolCallbacks } from '../shared'
@@ -5797,6 +5797,8 @@ describe('open_page workspace gating', () => {
 		// Admin of the workspace being browsed, plain member of the one a session operates on.
 		userStore.set({ username: 'bob', workspace_id: NAV, is_admin: true } as any)
 		usersWorkspaceStore.set({ workspaces: [{ id: NAV }, { id: SESSION }, { id: FLAKY }] } as any)
+		// A non-membership is only pronounced once both of these have resolved.
+		superadmin.set(false)
 		whoamiByWorkspace.set(SESSION, {
 			username: 'bob',
 			email: 'bob@windmill.dev',
@@ -5809,6 +5811,7 @@ describe('open_page workspace gating', () => {
 	afterEach(() => {
 		userStore.set(undefined)
 		usersWorkspaceStore.set(undefined)
+		superadmin.set(undefined)
 		whoamiByWorkspace.clear()
 		clearWorkspaceRoleCache()
 		openPage().def = pristineDef
@@ -5858,5 +5861,16 @@ describe('open_page workspace gating', () => {
 		expect(UserService.whoami).not.toHaveBeenCalledWith(
 			expect.objectContaining({ workspace: 'unreachable_ws' })
 		)
+	})
+
+	// An unloaded list is indistinguishable from an empty one, and the layout may never
+	// finish loading it, so reading it as settled would deny the workspace permanently.
+	it('asks whoami while the workspace list is still unresolved', async () => {
+		usersWorkspaceStore.set(undefined)
+
+		await openPage().setSchema?.({ operatingWorkspace: SESSION })
+
+		expect(UserService.whoami).toHaveBeenCalledWith(expect.objectContaining({ workspace: SESSION }))
+		expect(advertisedPages()).not.toEqual([])
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -313,6 +313,7 @@ import {
 	globalTools,
 	globalToolsFor,
 	prepareGlobalSystemMessage,
+	resolveGlobalPromptIdentity,
 	getSessionContextPromptSection,
 	prepareGlobalUserMessage,
 	setDeployedInSessionHandler,
@@ -4830,7 +4831,14 @@ describe('folder tools', () => {
 	})
 
 	it('create_folder creates the folder and reflects it in the path context', async () => {
-		userStore.set({ username: 'bob', is_admin: false, folders: ['existing'] } as any)
+		// `workspace_id` is what makes the ambient store the identity for WORKSPACE — the
+		// tool credits the workspace it created the folder in, not whoever is browsing.
+		userStore.set({
+			username: 'bob',
+			workspace_id: WORKSPACE,
+			is_admin: false,
+			folders: ['existing']
+		} as any)
 		const raw = await callGlobalTool('create_folder', { name: 'analytics', summary: 'team data' })
 
 		expect(vi.mocked(FolderService.createFolder)).toHaveBeenCalledWith({
@@ -5063,6 +5071,14 @@ describe('prepareGlobalSystemMessage', () => {
 			expect(content).toContain(
 				'- As a workspace admin you can write to any existing folder. If the user names a folder, use it; if they explicitly ask for a new folder, create it with `create_folder`; otherwise ask them which folder to use rather than guessing or creating one unprompted.'
 			)
+			expect(content).not.toContain('Folders here include')
+		})
+
+		// Admin guidance asserts nothing about the folder list, so unknown ACLs must not
+		// silence it the way they silence the non-admin bullets.
+		it('keeps the admin guidance when the folder sets are unknown', () => {
+			const content = guidanceOf({ username: 'admin', is_admin: true })
+			expect(content).toContain('As a workspace admin you can write to any existing folder.')
 			expect(content).not.toContain('Folders here include')
 		})
 
@@ -5872,5 +5888,91 @@ describe('open_page workspace gating', () => {
 
 		expect(UserService.whoami).toHaveBeenCalledWith(expect.objectContaining({ workspace: SESSION }))
 		expect(advertisedPages()).not.toEqual([])
+	})
+})
+
+describe('global prompt identity', () => {
+	const NAV = 'nav_ws'
+	const SESSION = 'session_ws'
+
+	beforeEach(() => {
+		// Browsing NAV as `alice` with a folder of her own; the session operates on
+		// SESSION, where she is a different user with different folders.
+		userStore.set({
+			username: 'alice',
+			workspace_id: NAV,
+			is_admin: false,
+			folders: ['alice_stuff'],
+			folders_read: ['alice_stuff']
+		} as any)
+		usersWorkspaceStore.set({
+			workspaces: [
+				{ id: NAV, username: 'alice' },
+				{ id: SESSION, username: 'a_smith' }
+			]
+		} as any)
+		superadmin.set(false)
+		whoamiByWorkspace.set(SESSION, {
+			username: 'a_smith',
+			email: 'alice@windmill.dev',
+			is_admin: false,
+			operator: false,
+			groups: [],
+			folders: ['team_etl'],
+			folders_read: ['team_etl', 'readonly_reports']
+		})
+	})
+
+	afterEach(() => {
+		userStore.set(undefined)
+		usersWorkspaceStore.set(undefined)
+		superadmin.set(undefined)
+		whoamiByWorkspace.clear()
+		clearWorkspaceRoleCache()
+	})
+
+	// Reading the ambient store instead tells the model to write to `u/alice/...` and
+	// offers `f/alice_stuff`, neither of which exists in the workspace it writes to.
+	it('describes the operating workspace, not the one being browsed', async () => {
+		const identity = await resolveGlobalPromptIdentity(SESSION)
+		const content = prepareGlobalSystemMessage(undefined, { user: identity }).content as string
+
+		expect(content).toContain('workspace username is "a_smith"')
+		expect(content).toContain('`f/team_etl`')
+		expect(content).toContain('You can see but NOT write to: `f/readonly_reports`')
+		expect(content).not.toContain('alice_stuff')
+		expect(content).not.toContain('u/alice/')
+	})
+
+	// The username cannot be dropped the way the folder sets can — it renders into
+	// `u/<username>/...`, and an empty one yields `u//`.
+	it('keeps the username but drops folder guidance when the role cannot be resolved', async () => {
+		whoamiByWorkspace.delete(SESSION)
+		const identity = await resolveGlobalPromptIdentity(SESSION)
+		const content = prepareGlobalSystemMessage(undefined, { user: identity }).content as string
+
+		expect(identity).toEqual({ username: 'a_smith' })
+		expect(content).toContain('workspace username is "a_smith"')
+		expect(content).not.toContain('u//')
+		expect(content).not.toContain('Folders you can write to')
+		// Unknown ACLs must not be rendered as known-empty ones: this bullet is the
+		// no-writable-folders claim, and it is false in a workspace we never resolved.
+		expect(content).not.toContain('You have no shared folders you can write to')
+		expect(content).not.toContain('alice_stuff')
+	})
+
+	it('credits a created folder to the workspace it was created in', async () => {
+		await getGlobalTool('create_folder').fn({
+			args: { name: 'analytics' },
+			workspace: SESSION,
+			helpers: {},
+			toolCallbacks,
+			toolId: 'test-create-folder-cross-workspace'
+		})
+
+		expect(await resolveGlobalPromptIdentity(SESSION)).toMatchObject({
+			folders: ['team_etl', 'analytics']
+		})
+		expect(get(userStore)?.folders).toEqual(['alice_stuff'])
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -153,6 +153,7 @@ import {
 	enterpriseLicense,
 	userWorkspaces,
 	usersWorkspaceStore,
+	NON_MEMBER_USERNAME,
 	workspaceStore
 } from '$lib/stores'
 import { getWorkspaceRole, type RoleLookup } from '$lib/user'
@@ -1181,7 +1182,9 @@ const createFolderSchema = z.object({
 	summary: z.string().optional().describe('Optional human-readable description of the folder.')
 })
 
-type FolderPromptContext = { folders: string[]; foldersRead: string[]; isAdmin: boolean }
+// `folders`/`foldersRead` are undefined when the user's role in this workspace could not
+// be resolved.
+type FolderPromptContext = { folders?: string[]; foldersRead?: string[]; isAdmin: boolean }
 
 // Renders the folders the current user can act on into the system prompt so the
 // model can pick an `f/<folder>/...` path without a discovery round-trip (there
@@ -1210,6 +1213,11 @@ function buildFolderGuidance(username: string, ctx?: FolderPromptContext): strin
 				: ''
 		return `- As a workspace admin you can write to any existing folder.${known} If the user names a folder, use it; if they explicitly ask for a new folder, create it with \`create_folder\`; otherwise ask them which folder to use rather than guessing or creating one unprompted.`
 	}
+	// Everything below states the writable set as fact, including the empty case, so an
+	// unresolved role has to say nothing at all: "you have no shared folders" is a claim,
+	// and a wrong one steers shared work into personal paths. The admin branch above
+	// asserts nothing about the list, so it stands whether or not the ACLs are known.
+	if (!ctx.folders) return ''
 	const readOnly = (ctx.foldersRead ?? []).filter((f) => !writable.includes(f))
 	const lines: string[] = []
 	if (writable.length > 0) {
@@ -2454,6 +2462,47 @@ async function roleForWorkspace(
 	return getWorkspaceRole(workspaceId)
 }
 
+// Who the user is in the workspace the chat operates on, for the prompt's path-convention
+// and folder guidance. Both are per-workspace: usernames come from that workspace's `usr`
+// row, and the writable/readable folder sets are its own ACLs.
+export type GlobalPromptIdentity = {
+	username: string
+	is_admin?: boolean
+	folders?: string[]
+	folders_read?: string[]
+}
+
+// `userWorkspaces` carries the real per-workspace username for every membership at no
+// request cost; the ambient store's belongs to the workspace being browsed, so it is the
+// last resort. Undefined rather than empty when neither names anybody — the prompt would
+// otherwise render `u//<name>`.
+function fallbackUsername(workspaceId: string): string | undefined {
+	const listed = get(userWorkspaces).find((w) => w.id === workspaceId)?.username
+	if (listed && listed !== NON_MEMBER_USERNAME) return listed
+	return get(userStore)?.username || undefined
+}
+
+export async function resolveGlobalPromptIdentity(
+	workspaceId: string | undefined
+): Promise<GlobalPromptIdentity | undefined> {
+	const role = await roleForWorkspace(workspaceId)
+	if (role.kind === 'resolved') {
+		const u = role.user
+		return {
+			username: u.username,
+			is_admin: u.is_admin,
+			folders: u.folders,
+			folders_read: u.folders_read
+		}
+	}
+	// Headless callers (the eval harness) hold no workspace and pass their own identity.
+	if (role.kind === 'no_workspace_context') return undefined
+	// The role is the only source for the folder sets, so an unresolved one leaves them out:
+	// the browsed workspace's would name folders that may not exist where the chat writes.
+	const username = fallbackUsername(workspaceId!)
+	return username ? { username } : undefined
+}
+
 // Which pages the user can actually reach in `workspaceId` — mirrors the sidebar's gating.
 // `workspaceId` is the chat's operating workspace, defaulting to the navigation workspace
 // for the global side-panel chat. The tool only ever advertises, and only ever acts on,
@@ -3352,10 +3401,12 @@ export const globalTools: Tool<{}>[] = [
 					workspace,
 					requestBody: { name: parsed.name, summary: parsed.summary }
 				})
-				// Reflect the new folder in the path-convention context for the rest of this
-				// session, matching FolderPicker's local update (avoids userStore.set()).
-				const user = get(userStore)
-				if (user) {
+				// Reflect the new folder for the rest of the session without a refetch, crediting
+				// the workspace it was created in: crediting the ambient one instead would hide
+				// it from the prompt that needs it.
+				const role = await roleForWorkspace(workspace)
+				if (role.kind === 'resolved') {
+					const user = role.user
 					if (!user.folders) user.folders = []
 					if (!user.folders.includes(parsed.name)) user.folders.push(parsed.name)
 				}
@@ -7643,10 +7694,11 @@ export function prepareGlobalSystemMessage(
 	instructions?: { workspace?: string; user?: string },
 	opts?: {
 		previewTools?: boolean
-		// Identity the path-convention guidance is built from. Production omits it
-		// (read from userStore); callers that must not touch the process-global
-		// store (the eval harness) pass it explicitly instead.
-		user?: { username: string; is_admin?: boolean; folders?: string[]; folders_read?: string[] }
+		// Identity the path-convention guidance is built from (`GlobalPromptIdentity`); the
+		// eval harness seeds its own. The `userStore` fallback below is the browsed
+		// workspace's, and answers whenever no identity has been resolved yet — including
+		// before the first `refreshGlobalIdentity` settles, which is why `beforeSend` awaits it.
+		user?: GlobalPromptIdentity
 		skills?: AiSkillListItem[]
 		mcpServers?: McpServer[]
 	}
@@ -7655,8 +7707,8 @@ export function prepareGlobalSystemMessage(
 	const username = user?.username ?? ''
 	const folderCtx: FolderPromptContext | undefined = user
 		? {
-				folders: user.folders ?? [],
-				foldersRead: user.folders_read ?? user.folders ?? [],
+				folders: user.folders,
+				foldersRead: user.folders_read ?? user.folders,
 				isAdmin: user.is_admin ?? false
 			}
 		: undefined

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -152,6 +152,7 @@ import {
 	devopsRole,
 	enterpriseLicense,
 	userWorkspaces,
+	usersWorkspaceStore,
 	workspaceStore
 } from '$lib/stores'
 import { getWorkspaceRole, type RoleLookup } from '$lib/user'
@@ -2107,9 +2108,12 @@ ${getScriptPrompt(selected)}`
 }
 
 async function getFlowInstructions(workspace: string | undefined): Promise<string> {
-	const aiAgentProviders = formatAiAgentProvidersPrompt(await getAiAgentProviderCatalog(workspace), {
-		canAskUser: true
-	})
+	const aiAgentProviders = formatAiAgentProvidersPrompt(
+		await getAiAgentProviderCatalog(workspace),
+		{
+			canAskUser: true
+		}
+	)
 	return `# Global draft flow instructions
 
 - Global mode writes complete draft payloads only; it does not save, deploy, run, scaffold local files, or generate metadata.
@@ -2436,7 +2440,15 @@ async function roleForWorkspace(
 	// `whoami` would reject it every time. Settle it here: the rejection is a bare 401,
 	// which cannot be told apart from an expired session, and a superadmin resolves on a
 	// workspace they are not a member of, so neither the status nor the list alone decides.
-	if (!get(superadmin) && !get(userWorkspaces).some((w) => w.id === workspaceId)) {
+	// Both stores start undefined and load asynchronously, and the list can exhaust its
+	// retries for good, so an unloaded one must never read as an empty one: that denies
+	// every other workspace, permanently. Unknown membership means ask `whoami`.
+	const membershipKnown = get(usersWorkspaceStore) != undefined && get(superadmin) != undefined
+	if (
+		membershipKnown &&
+		!get(superadmin) &&
+		!get(userWorkspaces).some((w) => w.id === workspaceId)
+	) {
 		return { kind: 'not_a_member' }
 	}
 	return getWorkspaceRole(workspaceId)

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -112,6 +112,10 @@ export const maybePremium: Readable<boolean> = derived(
 // polling or owning its own invalidation.
 export const workspaceMembershipVersion = writable<number>(0)
 export const usersWorkspaceStore = writable<UserWorkspaceList | undefined>(undefined)
+// Stands in for `UserWorkspace.username` on entries with no `usr` row behind them. It
+// names nobody, so anything that would address a user by it (a `u/<username>/...` path)
+// must treat it as "no username here" rather than render it.
+export const NON_MEMBER_USERNAME = 'superadmin'
 export const superadmin = writable<string | false | undefined>(undefined)
 export const devopsRole = writable<string | false | undefined>(undefined)
 export const lspTokenStore = writable<string | undefined>(undefined)
@@ -142,7 +146,7 @@ export function setNonMemberWorkspaces(forWorkspace: string, workspaces: Workspa
 				name: w.name,
 				// No `usr` row here, hence no per-workspace username — same stand-in as the
 				// synthetic `admins` entry below.
-				username: 'superadmin',
+				username: NON_MEMBER_USERNAME,
 				color: w.color,
 				parent_workspace_id: w.parent_workspace_id,
 				is_dev_workspace: w.is_dev_workspace,
@@ -171,7 +175,7 @@ export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(
 					{
 						id: 'admins',
 						name: 'Admins',
-						username: 'superadmin',
+						username: NON_MEMBER_USERNAME,
 						color: undefined,
 						operator_settings: undefined,
 						disabled: false


### PR DESCRIPTION
## Summary

The global chat's system prompt built its path-convention and folder guidance from the ambient `userStore`, which describes the workspace the user is **browsing** — not the workspace the session actually **operates** on (`AIChatManager.operatingWorkspace`). Three of those fields are genuinely per-workspace and wrong whenever the two differ:

- `username` — comes from that workspace's own `usr` row
- `folders` / `folders_read` — per-workspace ACLs
- `is_admin` — decides whether the folder list is presented as exhaustive

This is prompt quality, not authorization (the backend enforces folder ACLs), so the symptom is the model proposing `u/<wrong-user>/…` or `f/<folder-that-does-not-exist-here>/…` paths, hitting a 403, and recovering. Same root cause as WIN-2390, which fixed only the `open_page` gate.

The chat now resolves the identity for its operating workspace and feeds *that* to the prompt.

Fixes WIN-2440

## Changes

**Identity resolved from the operating workspace**
- `resolveGlobalPromptIdentity(workspaceId)` in `global/core.ts` returns the username and folder ACLs as they exist in the workspace the chat writes to.
- `AIChatManager` holds it as `globalIdentity` and refreshes it alongside skills and MCP servers — with the same monotonic refresh-id guard and workspace re-check, so a stale resolve can't overwrite a newer one. It settles in `beforeSend` before the first request, keeping the cached system-prompt prefix stable across a turn.
- `configureGlobalMode` stays synchronous on purpose: making it async ripples into `changeMode` and opens a window where `this.tools` / `this.helpers` are stale with three concurrent callers racing.

**Cold-load race (edge case found in the WIN-2390 code, not previously shipped)**
- `roleForWorkspace` read an unloaded `userWorkspaces` as proof of non-membership. The root layout loads that list asynchronously and gives up after its retries, so a session targeting another workspace could advertise no pages and report an access denial — permanently, if the load failed. It now only settles `not_a_member` once both `usersWorkspaceStore` and `superadmin` have resolved, and otherwise falls through to `whoami`.

**Unknown ACLs are no longer rendered as known-empty ones**
- An unresolved role leaves the folder sets `undefined`. That used to be laundered into `[]`, which the prompt stated as fact: *"You have no shared folders you can write to in this workspace"* — false in a workspace we never resolved, and it steers shared work into personal paths. The non-admin guidance is now omitted entirely when the sets are unknown. Admin guidance is unaffected, since it asserts nothing about the list.

**Misattributed folder creation**
- `create_folder` credited the browsed workspace, which both hid the new folder from the prompt that needed it and offered the rest of the UI one that isn't there. It now patches the workspace it actually wrote to.

**Supporting**
- `NON_MEMBER_USERNAME` in `stores.ts` names the `'superadmin'` placeholder carried by entries with no `usr` row behind them, so the fallback refuses to render it into a `u/<username>/…` path.

## Test plan

- [x] `npm run check` — 0 errors (72 pre-existing warnings)
- [x] Unit tests — `global/core.test.ts` and `AIChatManager.test.ts` both pass (see the note on
  `AI_RESOURCE_TYPES` below for why the manager suite needed a fix to load at all)
- [x] Both guards mutation-verified: dropping `user: this.globalIdentity` fails the manager test; dropping the `membershipKnown` guard makes the cold-load test resolve the browsed username instead of the operating one; dropping the unknown-ACL guard reproduces the false "no shared folders" bullet
- [x] End-to-end with three real model round-trips in a session operating on a fork while browsing its parent. The captured request to `/api/w/<fork>/ai/proxy/v1/messages` carried the fork's username and `f/fork_only_etl`, with the parent's username and folders absent — while the ambient `userStore` in the same page state still described the parent
- [x] `ai_evals` global path-selection cases (`global-path1`..`global-path5`) run against a live backend
- [x] No eval fixture can reach the changed folder branch: all 6 fixtures with a `user` block either define `folders` or set `is_admin: true`, so the prompts those cases see are byte-identical before and after

## Why this PR also touches `aiAgentProviderCatalog.ts`

`AIChatManager.test.ts` could not load on `main`. `aiAgentProviderCatalog.ts` evaluated
`Object.keys(AI_PROVIDERS)` at module scope, and `global/core.ts` imports that module, so every
importer of the chat manager needed `AI_PROVIDERS` present at load time — which the suite's
long-standing `vi.mock('../lib', …)` does not provide. The suite has been unloadable since
#10774; nothing caught it because no CI workflow runs vitest, so `main` stays green while the
file never executes.

This blocks the manager test added here, so the commit makes that constant lazy: it is read in
exactly two places, both inside functions, and deferring it removes the load-time dependency
without changing behaviour. Fixing it in the mock instead would have left the real trap in
place for the next importer.

It is deliberately a separate commit so it can be split out or cherry-picked to `main` on its
own.

## Screenshots

No visible UI effect — the change is entirely in the system prompt sent to the model, plus one store constant. Evidence is the outgoing request payload, described in the test plan above.

