### PR TITLE
fix: require an unscoped token to reach the workspace encryption key

### DIFF
--- a/backend/tests/workspace_encryption_key_scope.rs
+++ b/backend/tests/workspace_encryption_key_scope.rs
@@ -1,0 +1,92 @@
+//! The workspace encryption key must never reach a scope-restricted token.
+//!
+//! The route that serves it and the tarball export that embeds it both resolve
+//! to `workspaces:read`, while the key decrypts every secret variable of the
+//! workspace offline — so a `workspaces:read` token would recover, past its own
+//! scopes, what `variables:read` gates on the same handler (GHSA-g3x2-mwm6-jrc3).
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+const ADMIN_TOKEN: &str = "SECRET_TOKEN";
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+/// Mint an API token for test-user (a workspace admin) restricted to `scopes`.
+async fn mint_scoped_token(port: u16, scopes: Vec<&str>) -> anyhow::Result<String> {
+    let resp = authed(
+        client().post(format!("http://localhost:{port}/api/users/tokens/create")),
+        ADMIN_TOKEN,
+    )
+    .json(&json!({ "label": "scoped", "scopes": scopes, "workspace_id": "test-workspace" }))
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 201, "mint scoped token");
+    Ok(resp.text().await?)
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_workspace_key_denied_to_scoped_token(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let ws = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let scoped = mint_scoped_token(port, vec!["workspaces:read"]).await?;
+
+    let resp = authed(
+        client().get(format!("{ws}/workspaces/encryption_key")),
+        &scoped,
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        403,
+        "workspaces:read token must not read the encryption key: {}",
+        resp.text().await.unwrap_or_default()
+    );
+
+    let resp = authed(
+        client().get(format!(
+            "{ws}/workspaces/tarball?archive_type=tar&include_key=true"
+        )),
+        &scoped,
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        403,
+        "workspaces:read token must not export the encryption key: {}",
+        resp.text().await.unwrap_or_default()
+    );
+
+    // The same admin's unscoped token keeps both paths working.
+    let resp = authed(
+        client().get(format!("{ws}/workspaces/encryption_key")),
+        ADMIN_TOKEN,
+    )
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 200, "unscoped admin token reads the key");
+
+    let resp = authed(
+        client().get(format!(
+            "{ws}/workspaces/tarball?archive_type=tar&include_key=true"
+        )),
+        ADMIN_TOKEN,
+    )
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 200, "unscoped admin token exports the key");
+
+    Ok(())
+}

--- a/backend/tests/workspace_encryption_key_scope.rs
+++ b/backend/tests/workspace_encryption_key_scope.rs
@@ -4,6 +4,7 @@
 //! to `workspaces:read`, while the key decrypts every secret variable of the
 //! workspace offline — so a `workspaces:read` token would recover, past its own
 //! scopes, what `variables:read` gates on the same handler (GHSA-g3x2-mwm6-jrc3).
+//! Replacing the key reaches the same secrets, so it is held to the same bar.
 
 use serde_json::json;
 use sqlx::{Pool, Postgres};
@@ -69,7 +70,28 @@ async fn test_workspace_key_denied_to_scoped_token(db: Pool<Postgres>) -> anyhow
         resp.text().await.unwrap_or_default()
     );
 
-    // The same admin's unscoped token keeps both paths working.
+    // Replacing the key is the same capability: the server re-encrypts every secret
+    // under a key the caller chose. `workspaces:write` reaches the route, so a 403 here
+    // is the guard rather than the route's own scope check.
+    let scoped_write = mint_scoped_token(port, vec!["workspaces:write"]).await?;
+    let resp = authed(
+        client().post(format!("{ws}/workspaces/encryption_key")),
+        &scoped_write,
+    )
+    .json(&json!({ "new_key": "a".repeat(64) }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        403,
+        "workspaces:write token must not replace the encryption key"
+    );
+    assert!(
+        resp.text().await?.contains("without scopes"),
+        "the 403 must come from the encryption-key guard"
+    );
+
+    // The same admin's unscoped token keeps both read paths working.
     let resp = authed(
         client().get(format!("{ws}/workspaces/encryption_key")),
         ADMIN_TOKEN,

--- a/backend/tests/workspace_encryption_key_scope.rs
+++ b/backend/tests/workspace_encryption_key_scope.rs
@@ -42,17 +42,18 @@ async fn test_workspace_key_denied_to_scoped_token(db: Pool<Postgres>) -> anyhow
 
     let scoped = mint_scoped_token(port, vec!["workspaces:read"]).await?;
 
+    // 403 has other producers on these routes (`require_admin`, a route-scope denial),
+    // so every case pins the guard's own message rather than the status alone.
     let resp = authed(
         client().get(format!("{ws}/workspaces/encryption_key")),
         &scoped,
     )
     .send()
     .await?;
-    assert_eq!(
-        resp.status(),
-        403,
-        "workspaces:read token must not read the encryption key: {}",
-        resp.text().await.unwrap_or_default()
+    assert_eq!(resp.status(), 403, "workspaces:read must not read the key");
+    assert!(
+        resp.text().await?.contains("without scopes"),
+        "the 403 must come from the encryption-key guard"
     );
 
     let resp = authed(
@@ -66,8 +67,11 @@ async fn test_workspace_key_denied_to_scoped_token(db: Pool<Postgres>) -> anyhow
     assert_eq!(
         resp.status(),
         403,
-        "workspaces:read token must not export the encryption key: {}",
-        resp.text().await.unwrap_or_default()
+        "workspaces:read must not export the key"
+    );
+    assert!(
+        resp.text().await?.contains("without scopes"),
+        "the 403 must come from the encryption-key guard"
     );
 
     // Replacing the key is the same capability: the server re-encrypts every secret

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -463,6 +463,12 @@ pub fn is_effectively_unscoped(scopes: Option<&[String]>) -> bool {
 /// decrypt them all. No scope grants either, so any scope-restricted token is
 /// refused. An admin check is not a substitute — it answers for the user behind the
 /// token, not for the token's own scopes.
+///
+/// This bounds the token making the request, not every route to the key. A job token
+/// is minted unscoped from its owner's privileges, so a `jobs:run` token still reaches
+/// the key indirectly by running a job as a workspace admin — the same property that
+/// lets git-sync export it. Confining that means not inheriting unscoped privilege
+/// into job tokens, which is a far wider change than this guard.
 pub fn forbid_scoped_token_workspace_key(authed: &ApiAuthed) -> error::Result<()> {
     if is_effectively_unscoped(authed.scopes.as_deref()) {
         return Ok(());

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -454,6 +454,25 @@ pub fn is_effectively_unscoped(scopes: Option<&[String]>) -> bool {
     scope_restrictions(scopes).is_none()
 }
 
+/// Forbid disclosing the workspace encryption key to a scope-restricted token.
+///
+/// The key is not the read of any one domain: it decrypts every secret variable
+/// offline, outliving the token that fetched it, and it mints the secrets that
+/// unlock public apps. No scope grants that, so any scope-restricted token is
+/// refused. An admin check is not a substitute — it answers for the user behind
+/// the token, not for the token's own scopes.
+pub fn forbid_scoped_token_workspace_key(authed: &ApiAuthed) -> error::Result<()> {
+    if is_effectively_unscoped(authed.scopes.as_deref()) {
+        return Ok(());
+    }
+    Err(Error::PermissionDenied(
+        "The workspace encryption key cannot be read with a scoped token: it decrypts every \
+         secret of the workspace offline, past the scopes and the lifetime of the token that \
+         fetched it. Use a token created without scopes."
+            .to_string(),
+    ))
+}
+
 /// Enforce monotonic privilege when a token lifecycle endpoint mints or rescopes
 /// a credential on behalf of `authed`: the resulting credential must never be
 /// more privileged than the caller's own token.

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -454,21 +454,23 @@ pub fn is_effectively_unscoped(scopes: Option<&[String]>) -> bool {
     scope_restrictions(scopes).is_none()
 }
 
-/// Forbid disclosing the workspace encryption key to a scope-restricted token.
+/// Forbid reaching the workspace encryption key with a scope-restricted token.
 ///
-/// The key is not the read of any one domain: it decrypts every secret variable
-/// offline, outliving the token that fetched it, and it mints the secrets that
-/// unlock public apps. No scope grants that, so any scope-restricted token is
-/// refused. An admin check is not a substitute — it answers for the user behind
-/// the token, not for the token's own scopes.
+/// The key is not the read or the write of any one domain: it decrypts every secret
+/// variable offline, outliving the token that reached it, and it mints the secrets
+/// that unlock public apps. Replacing it is the same capability — the server
+/// re-encrypts every secret under the new key, so a caller that chooses the key can
+/// decrypt them all. No scope grants either, so any scope-restricted token is
+/// refused. An admin check is not a substitute — it answers for the user behind the
+/// token, not for the token's own scopes.
 pub fn forbid_scoped_token_workspace_key(authed: &ApiAuthed) -> error::Result<()> {
     if is_effectively_unscoped(authed.scopes.as_deref()) {
         return Ok(());
     }
     Err(Error::PermissionDenied(
-        "The workspace encryption key cannot be read with a scoped token: it decrypts every \
-         secret of the workspace offline, past the scopes and the lifetime of the token that \
-         fetched it. Use a token created without scopes."
+        "The workspace encryption key cannot be read or replaced with a scoped token: it \
+         decrypts every secret of the workspace offline, past the scopes and the lifetime of \
+         the token that reached it. Use a token created without scopes."
             .to_string(),
     ))
 }

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4796,6 +4796,7 @@ async fn set_encryption_key(
     Json(request): Json<SetEncryptionKeyRequest>,
 ) -> Result<()> {
     require_super_admin(&db, &authed).await?;
+    windmill_api_auth::forbid_scoped_token_workspace_key(&authed)?;
 
     if !WORKSPACE_KEY_REGEXP.is_match(request.new_key.as_str()) {
         return Err(Error::BadRequest(

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4759,6 +4759,18 @@ async fn get_encryption_key(
     Path(w_id): Path<String>,
 ) -> JsonResult<GetEncryptionKeyResponse> {
     require_admin(authed.is_admin, &authed.username)?;
+    windmill_api_auth::forbid_scoped_token_workspace_key(&authed)?;
+
+    audit_log(
+        &db,
+        &authed,
+        "workspaces.read_encryption_key",
+        ActionKind::Execute,
+        &w_id,
+        None,
+        None,
+    )
+    .await?;
 
     let encryption_key_opt = sqlx::query_scalar!(
         "SELECT key FROM workspace_key WHERE workspace_id = $1",

--- a/backend/windmill-api/openapi-deref.json
+++ b/backend/windmill-api/openapi-deref.json
@@ -39499,6 +39499,7 @@
               "igroup.adduser",
               "igroup.removeuser",
               "variables.decrypt_secret",
+              "workspaces.read_encryption_key",
               "workspaces.edit_command_script",
               "workspaces.edit_deploy_to",
               "workspaces.edit_auto_invite_domain",

--- a/backend/windmill-api/openapi-deref.yaml
+++ b/backend/windmill-api/openapi-deref.yaml
@@ -500,6 +500,7 @@ paths:
                       - igroup.adduser
                       - igroup.removeuser
                       - variables.decrypt_secret
+                      - workspaces.read_encryption_key
                       - workspaces.edit_command_script
                       - workspaces.edit_deploy_to
                       - workspaces.edit_auto_invite_domain

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -28052,6 +28052,7 @@ components:
             - "igroup.adduser"
             - "igroup.removeuser"
             - "variables.decrypt_secret"
+            - "workspaces.read_encryption_key"
             - "workspaces.edit_command_script"
             - "workspaces.edit_deploy_to"
             - "workspaces.edit_auto_invite_domain"

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -638,12 +638,17 @@ pub(crate) async fn tarball_workspace(
     // variable-read capability beyond workspace metadata. Require variables:read
     // only on the plaintext-secret path: ordinary tarball pulls (structure and
     // encrypted-only values) keep working with workspaces:read, and the workspace
-    // key itself stays admin-only (include_key). No-op for unscoped tokens.
+    // key itself takes an admin *and* an unscoped token (include_key), since it
+    // decrypts those same secrets offline. No-op for unscoped tokens.
     if plain_secret.or(plain_secrets).unwrap_or(false)
         && !skip_secrets.unwrap_or(false)
         && !skip_variables.unwrap_or(false)
     {
         check_scopes(&authed, || "variables:read".to_string())?;
+    }
+    if include_key.unwrap_or(false) {
+        require_admin(authed.is_admin, &authed.username)?;
+        windmill_api_auth::forbid_scoped_token_workspace_key(&authed)?;
     }
 
     // Opt-in behavior for surfacing per-resource ACLs on flow/app rows.
@@ -671,12 +676,14 @@ pub(crate) async fn tarball_workspace(
 
     // Exporting decrypted secrets in bulk is the same capability as a per-item
     // secret read, so record it for parity with variables.decrypt_secret.
+    // Audit entries go to the pool, not `tx`: that transaction is a read-only RLS
+    // scope the handler never commits, so anything written through it is rolled back.
     if plain_secret.or(plain_secrets).unwrap_or(false)
         && !skip_variables.unwrap_or(false)
         && !skip_secrets.unwrap_or(false)
     {
         windmill_audit::audit_oss::audit_log(
-            &mut *tx,
+            &db,
             &authed,
             "variables.decrypt_secret",
             windmill_audit::ActionKind::Execute,
@@ -1681,7 +1688,16 @@ pub(crate) async fn tarball_workspace(
     }
 
     if include_key.unwrap_or(false) {
-        require_admin(authed.is_admin, &authed.username)?;
+        windmill_audit::audit_oss::audit_log(
+            &db,
+            &authed,
+            "workspaces.read_encryption_key",
+            windmill_audit::ActionKind::Execute,
+            &w_id,
+            Some("workspace_tarball_export"),
+            None,
+        )
+        .await?;
 
         let key = sqlx::query_scalar!(
             "SELECT key FROM workspace_key WHERE workspace_id = $1",

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -640,15 +640,41 @@ pub(crate) async fn tarball_workspace(
     // encrypted-only values) keep working with workspaces:read, and the workspace
     // key itself takes an admin *and* an unscoped token (include_key), since it
     // decrypts those same secrets offline. No-op for unscoped tokens.
+    //
+    // Both branches also record what they are about to disclose, on the pool and
+    // before the RLS transaction opens: `tx` is never committed, so an entry
+    // written through it is rolled back with it.
     if plain_secret.or(plain_secrets).unwrap_or(false)
         && !skip_secrets.unwrap_or(false)
         && !skip_variables.unwrap_or(false)
     {
         check_scopes(&authed, || "variables:read".to_string())?;
+        // Exporting decrypted secrets in bulk is the same capability as a per-item
+        // secret read, so record it for parity with variables.decrypt_secret.
+        windmill_audit::audit_oss::audit_log(
+            &db,
+            &authed,
+            "variables.decrypt_secret",
+            windmill_audit::ActionKind::Execute,
+            &w_id,
+            Some("workspace_tarball_export"),
+            None,
+        )
+        .await?;
     }
     if include_key.unwrap_or(false) {
         require_admin(authed.is_admin, &authed.username)?;
         windmill_api_auth::forbid_scoped_token_workspace_key(&authed)?;
+        windmill_audit::audit_oss::audit_log(
+            &db,
+            &authed,
+            "workspaces.read_encryption_key",
+            windmill_audit::ActionKind::Execute,
+            &w_id,
+            Some("workspace_tarball_export"),
+            None,
+        )
+        .await?;
     }
 
     // Opt-in behavior for surfacing per-resource ACLs on flow/app rows.
@@ -673,26 +699,6 @@ pub(crate) async fn tarball_workspace(
     };
 
     let mut tx = user_db.begin(&authed).await?;
-
-    // Exporting decrypted secrets in bulk is the same capability as a per-item
-    // secret read, so record it for parity with variables.decrypt_secret.
-    // Audit entries go to the pool, not `tx`: that transaction is a read-only RLS
-    // scope the handler never commits, so anything written through it is rolled back.
-    if plain_secret.or(plain_secrets).unwrap_or(false)
-        && !skip_variables.unwrap_or(false)
-        && !skip_secrets.unwrap_or(false)
-    {
-        windmill_audit::audit_oss::audit_log(
-            &db,
-            &authed,
-            "variables.decrypt_secret",
-            windmill_audit::ActionKind::Execute,
-            &w_id,
-            Some("workspace_tarball_export"),
-            None,
-        )
-        .await?;
-    }
 
     // Source-of-truth for fork-ness: the workspace's parent_workspace_id column.
     // The wm-fork-* prefix is a creation-time naming convention that could in
@@ -1688,17 +1694,6 @@ pub(crate) async fn tarball_workspace(
     }
 
     if include_key.unwrap_or(false) {
-        windmill_audit::audit_oss::audit_log(
-            &db,
-            &authed,
-            "workspaces.read_encryption_key",
-            windmill_audit::ActionKind::Execute,
-            &w_id,
-            Some("workspace_tarball_export"),
-            None,
-        )
-        .await?;
-
         let key = sqlx::query_scalar!(
             "SELECT key FROM workspace_key WHERE workspace_id = $1",
             &w_id

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -640,41 +640,15 @@ pub(crate) async fn tarball_workspace(
     // encrypted-only values) keep working with workspaces:read, and the workspace
     // key itself takes an admin *and* an unscoped token (include_key), since it
     // decrypts those same secrets offline. No-op for unscoped tokens.
-    //
-    // Both branches also record what they are about to disclose, on the pool and
-    // before the RLS transaction opens: `tx` is never committed, so an entry
-    // written through it is rolled back with it.
-    if plain_secret.or(plain_secrets).unwrap_or(false)
+    let export_plain_secrets = plain_secret.or(plain_secrets).unwrap_or(false)
         && !skip_secrets.unwrap_or(false)
-        && !skip_variables.unwrap_or(false)
-    {
+        && !skip_variables.unwrap_or(false);
+    if export_plain_secrets {
         check_scopes(&authed, || "variables:read".to_string())?;
-        // Exporting decrypted secrets in bulk is the same capability as a per-item
-        // secret read, so record it for parity with variables.decrypt_secret.
-        windmill_audit::audit_oss::audit_log(
-            &db,
-            &authed,
-            "variables.decrypt_secret",
-            windmill_audit::ActionKind::Execute,
-            &w_id,
-            Some("workspace_tarball_export"),
-            None,
-        )
-        .await?;
     }
     if include_key.unwrap_or(false) {
         require_admin(authed.is_admin, &authed.username)?;
         windmill_api_auth::forbid_scoped_token_workspace_key(&authed)?;
-        windmill_audit::audit_oss::audit_log(
-            &db,
-            &authed,
-            "workspaces.read_encryption_key",
-            windmill_audit::ActionKind::Execute,
-            &w_id,
-            Some("workspace_tarball_export"),
-            None,
-        )
-        .await?;
     }
 
     // Opt-in behavior for surfacing per-resource ACLs on flow/app rows.
@@ -698,21 +672,6 @@ pub(crate) async fn tarball_workspace(
         None
     };
 
-    let mut tx = user_db.begin(&authed).await?;
-
-    // Source-of-truth for fork-ness: the workspace's parent_workspace_id column.
-    // The wm-fork-* prefix is a creation-time naming convention that could in
-    // principle drift (rename, manual SQL); the column is the contract that
-    // matches what the conflict-warning gates read. The id is also the workspace
-    // whose trigger `mode` / schedule `enabled` a fork export defers to.
-    let parent_workspace_id: Option<String> = sqlx::query_scalar::<_, Option<String>>(
-        "SELECT parent_workspace_id FROM workspace WHERE id = $1",
-    )
-    .bind(&w_id)
-    .fetch_optional(&mut *tx)
-    .await?
-    .flatten();
-
     let tmp_dir = TempDir::new_in(&*WINDMILL_DIR)?;
 
     let name = match archive_type.as_deref() {
@@ -735,6 +694,54 @@ pub(crate) async fn tarball_workspace(
         }
         Some(t) => Err(Error::BadRequest(format!("Invalid Archive Type {t}"))),
     }?;
+
+    // Record what the export is about to disclose, once nothing left can reject the
+    // request: an entry written before the gates above would claim a disclosure that
+    // a 403 or an invalid archive type then prevented. On the pool and before the RLS
+    // transaction opens — `tx` is never committed, so a write through it is rolled
+    // back with it, and holding both at once would take two connections.
+    if export_plain_secrets {
+        // Exporting decrypted secrets in bulk is the same capability as a per-item
+        // secret read, so record it for parity with variables.decrypt_secret.
+        windmill_audit::audit_oss::audit_log(
+            &db,
+            &authed,
+            "variables.decrypt_secret",
+            windmill_audit::ActionKind::Execute,
+            &w_id,
+            Some("workspace_tarball_export"),
+            None,
+        )
+        .await?;
+    }
+    if include_key.unwrap_or(false) {
+        windmill_audit::audit_oss::audit_log(
+            &db,
+            &authed,
+            "workspaces.read_encryption_key",
+            windmill_audit::ActionKind::Execute,
+            &w_id,
+            Some("workspace_tarball_export"),
+            None,
+        )
+        .await?;
+    }
+
+    let mut tx = user_db.begin(&authed).await?;
+
+    // Source-of-truth for fork-ness: the workspace's parent_workspace_id column.
+    // The wm-fork-* prefix is a creation-time naming convention that could in
+    // principle drift (rename, manual SQL); the column is the contract that
+    // matches what the conflict-warning gates read. The id is also the workspace
+    // whose trigger `mode` / schedule `enabled` a fork export defers to.
+    let parent_workspace_id: Option<String> = sqlx::query_scalar::<_, Option<String>>(
+        "SELECT parent_workspace_id FROM workspace WHERE id = $1",
+    )
+    .bind(&w_id)
+    .fetch_optional(&mut *tx)
+    .await?
+    .flatten();
+
     {
         let folders = sqlx::query_as::<_, Folder>("SELECT name, workspace_id, display_name, owners, extra_perms, summary, edited_at, created_by, default_permissioned_as, labels FROM folder WHERE workspace_id = $1")
             .bind(&w_id)
@@ -1693,6 +1700,7 @@ pub(crate) async fn tarball_workspace(
             .await?;
     }
 
+    // Gated in the pre-flight block above: admin plus an unscoped token, audited there.
     if include_key.unwrap_or(false) {
         let key = sqlx::query_scalar!(
             "SELECT key FROM workspace_key WHERE workspace_id = $1",

--- a/frontend/src/lib/components/auditLogs/AuditLogsFilters.svelte
+++ b/frontend/src/lib/components/auditLogs/AuditLogsFilters.svelte
@@ -217,6 +217,7 @@
 		INSTANCE_GROUPS_SCIM_DELETE: 'instance_groups.scim_delete',
 		INSTANCE_GROUPS_SCIM_UPDATE: 'instance_groups.scim_update',
 		VARIABLES_DECRYPT_SECRET: 'variables.decrypt_secret',
+		WORKSPACES_READ_ENCRYPTION_KEY: 'workspaces.read_encryption_key',
 		WORKSPACES_EDIT_COMMAND_SCRIPT: 'workspaces.edit_command_script',
 		WORKSPACES_EDIT_DEPLOY_TO: 'workspaces.edit_deploy_to',
 		WORKSPACES_EDIT_AUTO_INVITE_DOMAIN: 'workspaces.edit_auto_invite_domain',


### PR DESCRIPTION
## Summary

The workspace encryption key was gated only by an admin check. That check answers for the user behind a token, not for the token's own scopes, so a restricted API token could still reach the key. Reaching it now additionally requires a token created without scopes.

The key is not the read or the write of a single domain: it decrypts secret variables offline, outliving the token that reached it, and it mints the secrets that unlock public apps. Replacing it lands in the same place, since the server re-encrypts every secret under the new key. No scope grants that, so the guard refuses any scope-restricted token rather than gating on one scope.

Unscoped tokens, cookie sessions and job tokens (`$WM_TOKEN`, unscoped aside from `if_jobs:filter_tags:`) are unaffected, so the workspace-settings UI, `wmill sync pull` / `instance pull`, and git-sync with `includeKey` all keep working.

## Changes

- `forbid_scoped_token_workspace_key` in `windmill-api-auth`, called from the three routes that reach the key: `GET` and `POST /w/{workspace}/workspaces/encryption_key`, and the tarball export's `include_key=true`.
- The tarball's `include_key` permission checks moved to the handler's pre-flight block, so a refused request no longer builds the whole archive first.
- Both key reads are audit-logged as `workspaces.read_encryption_key`, added to the `AuditLog.operation` enum and the audit-log filter dropdown.
- Audit entries in the tarball handler now write on the pool before the RLS transaction opens. They were written through a transaction the handler never commits, which discarded them — so this also restores the existing `variables.decrypt_secret` entry.

## Test plan

- [x] `backend/tests/workspace_encryption_key_scope.rs`: a `workspaces:read` token gets 403 on both read paths, a `workspaces:write` token gets 403 on the write path, and the same admin's unscoped token still gets 200
- [x] Both read paths and the write path exercised against a running instance; the ciphertext-plus-key archive a scoped token could previously pull is now refused
- [x] A job running with `$WM_TOKEN` still exports the tarball with `include_key` (the git-sync path)
- [x] Workspace settings, Encryption, "Load current key" still loads the key over a normal session
- [x] On an EE build with a license, all three audit entries land in `audit_partitioned`
- [x] `cargo check` clean on `quickjs` and on `enterprise,private`; `npm run check:fast` clean

Not covered by a committed test: that a job token still reaches the key. It is verified above by hand, but a future tightening of this guard would break git-sync's key sync silently, so it may be worth a case in `wm_token_confinement.rs` later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an unscoped token to read or replace the workspace encryption key and to include it in exports. Previously admin-only checks let scope-restricted tokens reach the key; now scoped tokens get 403 to prevent offline decryption of all secrets.

- Enforce `forbid_scoped_token_workspace_key` in `GET /w/{workspace}/workspaces/encryption_key`, `POST /w/{workspace}/workspaces/encryption_key`, and tarball export with `include_key=true` (`windmill-api-auth`, `windmill-api-workspaces`, `windmill-api`).
- Tarball checks run in a pre-flight block; refused requests no longer build the archive. Audit entries write only after all pre-flight gates and archive-type validation, on the pool before the RLS transaction; restores `variables.decrypt_secret` logging for tarball exports.
- Audit key reads as `workspaces.read_encryption_key`; carried into the served OpenAPI spec (`openapi.yaml` and `openapi-deref.*`) and the audit log filter UI.
- Tests cover 403s for scoped `workspaces:read`/`workspaces:write` tokens and 200 for the same admin’s unscoped token.
- Unaffected: cookie sessions, unscoped tokens, and job tokens (`$WM_TOKEN`) including git-sync with `includeKey`.
- Migration: if you used a scoped API token for the key endpoints or `include_key=true` exports, switch to an unscoped token, a session, or a job token.

<sup>Written for commit 8e9016b2c38071aba277b1ad40efc4855615531b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

