### PR TITLE
fix(ci): unbreak the windows test jobs and the discord comment relay

### DIFF
--- a/.github/workflows/shareable-discord-notification.yml
+++ b/.github/workflows/shareable-discord-notification.yml
@@ -150,13 +150,21 @@ jobs:
           COMMENT_URL: ${{ inputs.COMMENT_URL }}
           COMMENT_IS_EDIT: ${{ inputs.COMMENT_IS_EDIT }}
         run: |
-          # 1) Find the thread by PR number
+          # 1) Find the thread by PR number. A rate-limited or unauthorized
+          # response carries no thread list at all, which under `bash -e` aborts
+          # the step (jq cannot iterate null, nor parse an HTML error page)
+          # rather than reaching the skip below. It is also not the same thing as
+          # this PR having no thread, so it is reported rather than swallowed.
           threads=$(curl -s -H "Authorization: Bot $BOT_TOKEN" \
             "https://discord.com/api/v10/guilds/${GUILD_ID}/threads/active")
+          if ! echo "$threads" | jq -e 'has("threads")' >/dev/null 2>&1; then
+            echo "::warning::Discord returned no thread list; the comment on PR #${PR_NUMBER} was not relayed: ${threads:0:200}"
+            exit 0
+          fi
           thread_id=$(echo "$threads" | jq -r \
             --arg cid "$CHANNEL_ID" \
             --arg pref "#${PR_NUMBER}:" \
-            '.threads[] | select(.parent_id == $cid and (.name | startswith($pref))) | .id')
+            '(.threads // [])[] | select(.parent_id == $cid and (.name | startswith($pref))) | .id')
 
           if [ -z "$thread_id" ]; then
             echo "Thread not found for PR #${PR_NUMBER}, skipping"

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -2486,10 +2486,12 @@ mod tests {
         std::fs::create_dir(&target).unwrap();
 
         unpack_repo_archive(&path, &target, &no_abort()).unwrap();
-        assert_eq!(
-            std::fs::read_to_string(target.join("docs/link")).unwrap(),
-            "hi\n"
-        );
+        let link = target.join("docs").join("link");
+        assert!(std::fs::symlink_metadata(&link).unwrap().is_symlink());
+        // Windows stores a symlink's target verbatim and its object manager
+        // rejects the `/` in a POSIX one, so only here does the link resolve.
+        #[cfg(unix)]
+        assert_eq!(std::fs::read_to_string(&link).unwrap(), "hi\n");
     }
 
     #[test]

--- a/cli/test/lock_dedup_unit.test.ts
+++ b/cli/test/lock_dedup_unit.test.ts
@@ -43,6 +43,12 @@ const SHARED_PY = "locks/requirements.in.lock";
 const SHARED_TEAM = "locks/team_a.requirements.in.lock";
 const SHARED_BUN = "locks/package.json.lock";
 
+/** A sync map is keyed with the platform separator — `sync.ts` walks the tree
+ *  with `path.join` — while an `!inline` reference is always forward-slash.
+ *  The fixtures speak both, or on Windows they would pin a map shape the CLI
+ *  never builds. */
+const k = (p: string) => p.replaceAll("/", path.sep);
+
 function meta(lockRef: string, summary = ""): string {
   return yamlStringify({ summary, lock: lockRef }, yamlOptions);
 }
@@ -50,7 +56,7 @@ function meta(lockRef: string, summary = ""): string {
 /** A workspace holding the given dependency files. */
 function workspace(...depFiles: string[]): Record<string, string> {
   const map: Record<string, string> = {};
-  for (const dep of depFiles) map[dep] = "requests\n";
+  for (const dep of depFiles) map[k(dep)] = "requests\n";
   return map;
 }
 
@@ -62,9 +68,9 @@ function ownLock(
   lock: string,
   body = "def main(): ...",
 ) {
-  map[`${base}${ext}`] = body;
-  map[`${base}.script.yaml`] = meta(`!inline ${base}.script.lock`);
-  map[`${base}.script.lock`] = lock;
+  map[k(`${base}${ext}`)] = body;
+  map[k(`${base}.script.yaml`)] = meta(`!inline ${base}.script.lock`);
+  map[k(`${base}.script.lock`)] = lock;
 }
 
 /** A script already reading a shared lockfile. */
@@ -75,8 +81,8 @@ function sharedLock(
   shared: string,
   body = "def main(): ...",
 ) {
-  map[`${base}${ext}`] = body;
-  map[`${base}.script.yaml`] = meta(`!inline ${shared}`);
+  map[k(`${base}${ext}`)] = body;
+  map[k(`${base}.script.yaml`)] = meta(`!inline ${shared}`);
 }
 
 function lockRefOf(metaContent: string): string {
@@ -97,15 +103,17 @@ describe("computeSharedLockPlan", () => {
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map[SHARED_BUN]).toEqual("bun-lock");
+    expect(map[k(SHARED_PY)]).toEqual(PY_LOCK);
+    expect(map[k(SHARED_BUN)]).toEqual("bun-lock");
     for (const base of ["f/a", "f/b", "f/c"]) {
-      expect(map[`${base}.script.lock`]).toBeUndefined();
-      expect(lockRefOf(map[`${base}.script.yaml`])).toEqual(
+      expect(map[k(`${base}.script.lock`)]).toBeUndefined();
+      expect(lockRefOf(map[k(`${base}.script.yaml`)])).toEqual(
         `!inline ${SHARED_PY}`,
       );
     }
-    expect(lockRefOf(map["f/ts.script.yaml"])).toEqual(`!inline ${SHARED_BUN}`);
+    expect(lockRefOf(map[k("f/ts.script.yaml")])).toEqual(
+      `!inline ${SHARED_BUN}`,
+    );
   });
 
   test("is idempotent — a deduplicated tree yields no further changes", () => {
@@ -121,7 +129,7 @@ describe("computeSharedLockPlan", () => {
     const committed = workspace(PY_DEPS);
     sharedLock(committed, "f/a", ".py", SHARED_PY);
     sharedLock(committed, "f/b", ".py", SHARED_PY);
-    committed[SHARED_PY] = PY_LOCK;
+    committed[k(SHARED_PY)] = PY_LOCK;
 
     // What the remote sends after the bump: one lock per script, all bumped.
     const remote = workspace(PY_DEPS);
@@ -130,8 +138,8 @@ describe("computeSharedLockPlan", () => {
     applySharedLockPlanToMap(remote, plan(remote));
 
     expect(
-      Object.keys(remote).filter((k) => remote[k] !== committed[k]),
-    ).toEqual([SHARED_PY]);
+      Object.keys(remote).filter((key) => remote[key] !== committed[key]),
+    ).toEqual([k(SHARED_PY)]);
   });
 
   test("each named dependency file gets a lockfile of its own", () => {
@@ -144,9 +152,11 @@ describe("computeSharedLockPlan", () => {
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map[SHARED_TEAM]).toEqual(OTHER_LOCK);
-    expect(lockRefOf(map["f/t1.script.yaml"])).toEqual(`!inline ${SHARED_TEAM}`);
+    expect(map[k(SHARED_PY)]).toEqual(PY_LOCK);
+    expect(map[k(SHARED_TEAM)]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map[k("f/t1.script.yaml")])).toEqual(
+      `!inline ${SHARED_TEAM}`,
+    );
   });
 
   // The git-sync deploy callback narrows the sync to a single item, so this is
@@ -162,9 +172,9 @@ describe("computeSharedLockPlan", () => {
     ownLock(narrow, "f/a", ".py", PY_LOCK);
     applySharedLockPlanToMap(narrow, plan(narrow));
 
-    expect(narrow[SHARED_PY]).toEqual(full[SHARED_PY]);
-    expect(lockRefOf(narrow["f/a.script.yaml"])).toEqual(
-      lockRefOf(full["f/a.script.yaml"]),
+    expect(narrow[k(SHARED_PY)]).toEqual(full[k(SHARED_PY)]);
+    expect(lockRefOf(narrow[k("f/a.script.yaml")])).toEqual(
+      lockRefOf(full[k("f/a.script.yaml")]),
     );
   });
 
@@ -187,12 +197,14 @@ describe("computeSharedLockPlan", () => {
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map["f/pinned.script.lock"]).toEqual(OTHER_LOCK);
-    expect(lockRefOf(map["f/doc.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-    expect(map[SHARED_BUN]).toEqual("bun-lock");
-    expect(map["f/npm.script.lock"]).toEqual("npm-lock");
-    expect(map["f/nb.script.lock"]).toEqual("nb-lock");
+    expect(map[k(SHARED_PY)]).toEqual(PY_LOCK);
+    expect(map[k("f/pinned.script.lock")]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map[k("f/doc.script.yaml")])).toEqual(
+      `!inline ${SHARED_PY}`,
+    );
+    expect(map[k(SHARED_BUN)]).toEqual("bun-lock");
+    expect(map[k("f/npm.script.lock")]).toEqual("npm-lock");
+    expect(map[k("f/nb.script.lock")]).toEqual("nb-lock");
   });
 
   test("an annotated script alone in its group creates no shared lockfile", () => {
@@ -205,9 +217,9 @@ describe("computeSharedLockPlan", () => {
 
       applySharedLockPlanToMap(map, plan(map));
 
-      expect(map[SHARED_PY]).toBeUndefined();
-      expect(map["f/only.script.lock"]).toEqual(OTHER_LOCK);
-      expect(lockRefOf(map["f/only.script.yaml"])).toEqual(
+      expect(map[k(SHARED_PY)]).toBeUndefined();
+      expect(map[k("f/only.script.lock")]).toEqual(OTHER_LOCK);
+      expect(lockRefOf(map[k("f/only.script.yaml")])).toEqual(
         "!inline f/only.script.lock",
       );
     }
@@ -226,12 +238,12 @@ describe("computeSharedLockPlan", () => {
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map["f/extra.script.lock"]).toEqual(OTHER_LOCK);
-    expect(map["f/both.script.lock"]).toEqual(OTHER_LOCK);
-    expect(lockRefOf(map["f/extra.script.yaml"])).toEqual(
+    expect(map[k("f/extra.script.lock")]).toEqual(OTHER_LOCK);
+    expect(map[k("f/both.script.lock")]).toEqual(OTHER_LOCK);
+    expect(lockRefOf(map[k("f/extra.script.yaml")])).toEqual(
       "!inline f/extra.script.lock",
     );
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
+    expect(map[k(SHARED_PY)]).toEqual(PY_LOCK);
   });
 
   test("a script with no dependency file behind it is left alone", () => {
@@ -250,18 +262,18 @@ describe("computeSharedLockPlan", () => {
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map[SHARED_PY]).toEqual(PY_LOCK_BUMPED);
-    expect(map["f/stale.script.lock"]).toEqual(PY_LOCK);
+    expect(map[k(SHARED_PY)]).toEqual(PY_LOCK_BUMPED);
+    expect(map[k("f/stale.script.lock")]).toEqual(PY_LOCK);
   });
 
   test("a shared lockfile outlives its scripts but not its dependency file", () => {
     // No script in view reads it — a narrowed sync must still leave it be.
     const withDep = workspace(PY_DEPS);
-    withDep[SHARED_PY] = PY_LOCK;
-    expect(plan(withDep).deletes).not.toContain(SHARED_PY);
+    withDep[k(SHARED_PY)] = PY_LOCK;
+    expect(plan(withDep).deletes).not.toContain(k(SHARED_PY));
 
-    const withoutDep: Record<string, string> = { [SHARED_PY]: PY_LOCK };
-    expect(plan(withoutDep).deletes).toContain(SHARED_PY);
+    const withoutDep: Record<string, string> = { [k(SHARED_PY)]: PY_LOCK };
+    expect(plan(withoutDep).deletes).toContain(k(SHARED_PY));
   });
 
   // The git-sync deploy callback narrows to one item, so a dependency file with
@@ -271,14 +283,16 @@ describe("computeSharedLockPlan", () => {
     const map = workspace(PY_DEPS, BUN_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
+    // `present` is forward-slashed whatever the map's separator: `sync.ts`
+    // normalizes it out of the local map before handing it over.
     const present = { [SHARED_BUN]: "bun-lock" };
 
     const result = computeSharedLockPlan(map, { defaultTs: "bun", present });
     applySharedLockPlanToMap(map, result);
 
-    expect(result.deletes).not.toContain(SHARED_BUN);
+    expect(result.deletes).not.toContain(k(SHARED_BUN));
     // Carried into the map, or the diff reads it as a local-only deletion.
-    expect(map[SHARED_BUN]).toEqual("bun-lock");
+    expect(map[k(SHARED_BUN)]).toEqual("bun-lock");
   });
 
   test("dependency files absent from the map are not gone", () => {
@@ -295,8 +309,10 @@ describe("computeSharedLockPlan", () => {
     });
     applySharedLockPlanToMap(map, result);
 
-    expect(result.deletes).not.toContain(SHARED_PY);
-    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
+    expect(result.deletes).not.toContain(k(SHARED_PY));
+    expect(lockRefOf(map[k("f/a.script.yaml")])).toEqual(
+      `!inline ${SHARED_PY}`,
+    );
   });
 
 
@@ -315,15 +331,15 @@ describe("computeSharedLockPlan", () => {
   test("module-layout scripts share too, from their folder", () => {
     const map = workspace(PY_DEPS);
     for (const base of ["f/a__mod", "f/b__mod"]) {
-      map[`${base}/script.py`] = "def main(): ...";
-      map[`${base}/script.yaml`] = meta(`!inline ${base}/script.lock`);
-      map[`${base}/script.lock`] = PY_LOCK;
+      map[k(`${base}/script.py`)] = "def main(): ...";
+      map[k(`${base}/script.yaml`)] = meta(`!inline ${base}/script.lock`);
+      map[k(`${base}/script.lock`)] = PY_LOCK;
     }
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map[SHARED_PY]).toEqual(PY_LOCK);
-    expect(map["f/a__mod/script.lock"]).toBeUndefined();
+    expect(map[k(SHARED_PY)]).toEqual(PY_LOCK);
+    expect(map[k("f/a__mod/script.lock")]).toBeUndefined();
   });
 
   test("a script path containing dots reads its own content file", () => {
@@ -337,20 +353,24 @@ describe("computeSharedLockPlan", () => {
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(lockRefOf(map["f/a.b.script.yaml"])).toEqual(`!inline ${SHARED_PY}`);
-    expect(lockRefOf(map["f/a.script.yaml"])).toEqual(`!inline ${SHARED_BUN}`);
+    expect(lockRefOf(map[k("f/a.b.script.yaml")])).toEqual(
+      `!inline ${SHARED_PY}`,
+    );
+    expect(lockRefOf(map[k("f/a.script.yaml")])).toEqual(
+      `!inline ${SHARED_BUN}`,
+    );
   });
 
   test("only the lock line of the metadata changes", () => {
     const map = workspace(PY_DEPS);
     ownLock(map, "f/a", ".py", PY_LOCK);
     ownLock(map, "f/b", ".py", PY_LOCK);
-    map["f/a.script.yaml"] = meta("!inline f/a.script.lock", "does a thing");
-    const before = map["f/a.script.yaml"];
+    map[k("f/a.script.yaml")] = meta("!inline f/a.script.lock", "does a thing");
+    const before = map[k("f/a.script.yaml")];
 
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(map["f/a.script.yaml"]).toEqual(
+    expect(map[k("f/a.script.yaml")]).toEqual(
       before.replace("f/a.script.lock", SHARED_PY),
     );
   });
@@ -399,21 +419,21 @@ describe("scriptsReferencingSharedLock", () => {
     ownLock(map, "f/extra", ".py", OTHER_LOCK, extra);
     applySharedLockPlanToMap(map, plan(map));
 
-    expect(scriptsReferencingSharedLock(map, SHARED_PY).sort()).toEqual([
-      "f/a.script.yaml",
-      "f/b.script.yaml",
+    expect(scriptsReferencingSharedLock(map, k(SHARED_PY)).sort()).toEqual([
+      k("f/a.script.yaml"),
+      k("f/b.script.yaml"),
     ]);
   });
 
   test("prose naming the file is not a reference", () => {
     const map = {
-      "f/a.py": "def main(): ...",
-      "f/a.script.yaml": yamlStringify(
+      [k("f/a.py")]: "def main(): ...",
+      [k("f/a.script.yaml")]: yamlStringify(
         { summary: `see !inline ${SHARED_PY}`, lock: "!inline f/a.script.lock" },
         yamlOptions,
       ),
     };
-    expect(scriptsReferencingSharedLock(map, SHARED_PY)).toEqual([]);
+    expect(scriptsReferencingSharedLock(map, k(SHARED_PY))).toEqual([]);
   });
 });
 

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -275,15 +275,16 @@ describe("getTypeStrFromPath", () => {
   test("a shared lockfile is its own type, not a workspace dependency", () => {
     // A repo-side artifact with no object on the server: classified as a
     // workspace dependency, `sync push` would try to deploy it as one.
-    expect(getTypeStrFromPath("locks/requirements.in.lock")).toBe(
+    // Sync paths carry the platform separator, so these do too.
+    expect(getTypeStrFromPath(join("locks", "requirements.in.lock"))).toBe(
       "shared_lock",
     );
-    expect(getTypeStrFromPath("dependencies/requirements.in")).toBe(
+    expect(getTypeStrFromPath(join("dependencies", "requirements.in"))).toBe(
       "workspace_dependencies",
     );
     // `locks/` is an ordinary word: only the names Windmill writes are claimed,
     // so a repo that already keeps its own lockfiles there keeps them.
-    expect(() => getTypeStrFromPath("locks/vendor.lock")).toThrow();
+    expect(() => getTypeStrFromPath(join("locks", "vendor.lock"))).toThrow();
   });
 
   test("detects metadata types by name suffix", () => {


### PR DESCRIPTION
## Summary

The `v1.794.0` release CI was not all green. Three things were failing, all of them
independent of each other; this fixes each at its root.

**`Backend integration tests (Windows)` → `cargo_test_windows`** —
`ansible_executor::tests::unpack_keeps_a_link_that_stays_in_the_repo` panicked with
`Os { code: 123, kind: InvalidFilename }`. `tar-rs` unpacks the archive's symlink on Windows
via `symlink_file`, which stores the POSIX target `../README.md` verbatim; the object manager
will not resolve a `/`-separated substitute name, so reading *through* the link can never work
there. Introduced by #10765, so `v1.793.0` was red too. This job runs only on `v*` tags, so it
could not have been caught on the PR.

**`CLI Tests` → `test-windows`** — 13 failures, all separator artifacts in the fixtures. A sync
map is keyed with the *platform* separator on both sides (`FSFSElement` walks the tree with
`path.join`; the remote `ZipFSElement` roots at `"." + SEP` and joins from there), while an
`!inline` reference is always forward-slash. `lock_dedup.ts` honours that on both ends, and
`getTypeStrFromPath` matches `"dependencies" + SEP` — but the fixtures hardcoded `/` keys, i.e.
a map shape the CLI never builds. Introduced by #10769, whose own `test-windows` was red on
every run before it merged.

**`notify_discord_on_comment / post_comment`** — three failures on the same head with
`jq: Cannot iterate over null`, exit 5. A rate-limited response carries no `.threads`, and
under `bash -e` iterating null aborts the step before it reaches the "thread not found,
skipping" branch immediately below.

No production code changes: two of the three are test-only, and the third is a workflow.

## Changes

- `backend/windmill-worker/src/ansible_executor.rs`: assert on every platform that the entry was
  materialized as a symlink (which reading through it never established on its own), and resolve
  through it only under `#[cfg(unix)]`.
- `cli/test/lock_dedup_unit.test.ts`: fixtures key their maps through the platform separator via
  a `k()` helper. `!inline` references and the `present` map stay forward-slash — that is the
  shape `sync.ts` hands over (it normalizes with `key.replaceAll(SEP, "/")`).
- `cli/test/utils_unit.test.ts`: the shared-lock type test builds its paths with `join`.
- `.github/workflows/shareable-discord-notification.yml`: a response with no thread list no
  longer aborts the step, and is distinguished from a PR that genuinely has no thread — the
  former warns with the body it got (a revoked token or a sustained rate-limit window stays
  diagnosable), the latter stays quiet. Also covers the non-JSON body Cloudflare answers a 429
  with, which `jq` could not parse either.

## Test plan

- [x] `cargo test -p windmill-worker --lib --features python ansible_executor::tests` — 39 passed;
      `rustfmt --check` clean.
- [x] Windows verification of the Rust fix: `backend-test-windows.yml` dispatched manually against
      this branch, since it otherwise runs only on a `v*` tag ([run](https://github.com/windmill-labs/windmill/actions/runs/32483167771)).
- [x] Separator simulation for the CLI fix: a throwaway copy of `cli/` with `SEP` / `path.sep`
      forced to `\`. The pre-fix files fail there with exactly the 13 test names CI reported; the
      fixed files pass 144/144.
- [x] Full CLI unit suite on Linux: `UNIT_ONLY=1 bun test test/*_unit.test.ts` — 1092 pass, 0 fail.
- [x] Discord step driven against a stubbed `curl` for all five response shapes — rate-limited,
      401, Cloudflare HTML, a valid list with no thread for this PR, and the normal case. Green
      with a warning for the first three, the quiet skip for the fourth, posts for the fifth. The
      pre-fix script reproduces `Cannot iterate over null` / exit 5 on the first.
- [ ] `test-windows` green on this PR's `CLI Tests` run — that is the real-Windows confirmation
      for the fixture change (`cli-tests.yml` fires on `pull_request` with a `cli/**` filter).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Windows CI and makes the Discord comment relay resilient to API rate limits/401s. Previously, Windows tests assumed POSIX paths and symlink resolution; the Discord step aborted when the thread lookup response had no `threads`. Now tests are platform-aware and the workflow warns and exits cleanly. No production code changes.

**Review notes**
- Backend test: assert the unpacked repo entry is a symlink on all platforms; read through it only on Unix. Confines the test to what the unpack code guarantees.
- CLI tests: key sync-map fixtures with the platform separator and build paths with `join`; keep `!inline` references and the `present` map forward-slashed (matches `sync.ts` contract). Updates expected keys accordingly.
- CI workflow: before posting, check the Discord response for a `threads` list. If absent or HTML, emit a warning with a short body preview and exit 0; still skip quietly when a PR genuinely has no thread.

<sup>Written for commit 6c1d9f8d2ef662ca68438f62bfedd807a9bfae52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

