### PR TITLE
fix: keep every value of a repeated multipart field

### DIFF
--- a/backend/windmill-api/src/args.rs
+++ b/backend/windmill-api/src/args.rs
@@ -70,6 +70,47 @@ pub struct WebhookArgs {
 // capture
 //
 
+/// One multipart part's value, kept in body order so that repeated field names
+/// can be grouped without dropping any of them.
+#[cfg(any(feature = "parquet", test))]
+enum MultipartValue {
+    Text(String),
+    File(serde_json::Value),
+}
+
+/// Collapse multipart parts into one value per field name: a name sent once
+/// stays a scalar, a name sent several times becomes an array of its values in
+/// body order. A name that carried a file is always an array, even for a single
+/// file, since that is the shape scripts have been typed against since #5002.
+#[cfg(any(feature = "parquet", test))]
+fn collapse_multipart_fields(
+    parts: Vec<(String, MultipartValue)>,
+) -> HashMap<String, Box<RawValue>> {
+    let mut grouped: HashMap<String, (Vec<serde_json::Value>, bool)> = HashMap::new();
+
+    for (name, value) in parts {
+        let (values, has_file) = grouped.entry(name).or_insert_with(|| (vec![], false));
+        match value {
+            MultipartValue::Text(text) => values.push(serde_json::Value::String(text)),
+            MultipartValue::File(file) => {
+                values.push(file);
+                *has_file = true;
+            }
+        }
+    }
+
+    grouped
+        .into_iter()
+        .map(|(name, (mut values, has_file))| {
+            let value = match (has_file, values.len()) {
+                (false, 1) => values.remove(0),
+                _ => serde_json::Value::Array(values),
+            };
+            (name, to_raw_value(&value))
+        })
+        .collect()
+}
+
 impl RawWebhookArgs {
     #[cfg(not(feature = "parquet"))]
     pub async fn process_multipart(
@@ -106,8 +147,7 @@ impl RawWebhookArgs {
         if let Some(s3_resource) = s3_resource {
             let s3_client = build_object_store_client(&s3_resource).await?;
 
-            let mut body = HashMap::new();
-            let mut files = HashMap::new();
+            let mut parts: Vec<(String, MultipartValue)> = Vec::new();
 
             while let Some(field) = multipart.next_field().await.map_err(|e| {
                 Error::BadRequest(format!("Error reading multipart field: {}", e.body_text()))
@@ -146,7 +186,8 @@ impl RawWebhookArgs {
                         // file_key is always freshly random here, so this never
                         // overwrites an existing object; the full size is the delta.
                         #[cfg(not(feature = "enterprise"))]
-                        let max_size = Some(ce_storage_quota_remaining(db, w_id, None).await? as usize);
+                        let max_size =
+                            Some(ce_storage_quota_remaining(db, w_id, None).await? as usize);
                         #[cfg(feature = "enterprise")]
                         let max_size: Option<usize> = None;
 
@@ -176,20 +217,20 @@ impl RawWebhookArgs {
                             }
                         }
 
-                        files.entry(name).or_insert(vec![]).push(serde_json::json!({
-                            "s3": &file_key
-                        }));
+                        parts.push((
+                            name,
+                            MultipartValue::File(serde_json::json!({ "s3": &file_key })),
+                        ));
                     } else {
-                        body.insert(name, to_raw_value(&field.text().await.unwrap_or_default()));
+                        parts.push((
+                            name,
+                            MultipartValue::Text(field.text().await.unwrap_or_default()),
+                        ));
                     }
                 }
             }
 
-            for (k, v) in files {
-                body.insert(k, to_raw_value(&v));
-            }
-
-            Ok(body)
+            Ok(collapse_multipart_fields(parts))
         } else {
             Err(Error::BadRequest(format!(
                 "You need to connect your workspace to an S3 bucket to use multipart/form-data"
@@ -798,5 +839,37 @@ mod tests {
             }
             _ => panic!("Expected a HashMap"),
         }
+    }
+
+    #[test]
+    fn test_collapse_multipart_fields() {
+        let file = |key: &str| MultipartValue::File(serde_json::json!({ "s3": key }));
+        let body = collapse_multipart_fields(vec![
+            ("single".to_string(), MultipartValue::Text("a".to_string())),
+            (
+                "repeated".to_string(),
+                MultipartValue::Text("a".to_string()),
+            ),
+            (
+                "repeated".to_string(),
+                MultipartValue::Text("b".to_string()),
+            ),
+            ("one_file".to_string(), file("k1")),
+            ("many_files".to_string(), file("k2")),
+            ("many_files".to_string(), file("k3")),
+            ("mixed".to_string(), MultipartValue::Text("a".to_string())),
+            ("mixed".to_string(), file("k4")),
+        ]);
+
+        let get = |k: &str| body.get(k).expect(k).get().to_string();
+
+        assert_eq!(get("single"), r#""a""#);
+        assert_eq!(get("repeated"), r#"["a","b"]"#);
+        // A lone file stays wrapped in an array: scripts are typed against it.
+        assert_eq!(get("one_file"), r#"[{"s3":"k1"}]"#);
+        assert_eq!(get("many_files"), r#"[{"s3":"k2"},{"s3":"k3"}]"#);
+        // A name used by both a text and a file part keeps both, in body order,
+        // rather than the file silently replacing the text.
+        assert_eq!(get("mixed"), r#"["a",{"s3":"k4"}]"#);
     }
 }

--- a/backend/windmill-api/src/args.rs
+++ b/backend/windmill-api/src/args.rs
@@ -868,8 +868,7 @@ mod tests {
         // A lone file stays wrapped in an array: scripts are typed against it.
         assert_eq!(get("one_file"), r#"[{"s3":"k1"}]"#);
         assert_eq!(get("many_files"), r#"[{"s3":"k2"},{"s3":"k3"}]"#);
-        // A name used by both a text and a file part keeps both, in body order,
-        // rather than the file silently replacing the text.
+        // A name used by both a text and a file part keeps both, in body order.
         assert_eq!(get("mixed"), r#"["a",{"s3":"k4"}]"#);
     }
 }


### PR DESCRIPTION
## Summary

`multipart/form-data` webhook bodies handled repeated field names two different ways. Repeated
**file** parts accumulated into an array, but repeated **non-file** parts went through a plain
`HashMap::insert` and collapsed to the last value, so every earlier value was silently dropped.
Both are appended with the same `FormData.append()` on the client, so the asymmetry is hard to
predict from the caller's side.

The array shape for files was deliberate (#5002); the collapse for text parts was never a
decision, just the default of the map it happened to be inserted into. This makes the parser
group every part by name instead.

A related bug fell out of the same structure: the `files` map was merged into the body *after*
the part loop, so a file part overwrote a same-named text part regardless of which came first in
the body.

## Behavior change

This changes an observable public surface (webhook and HTTP-trigger request bodies).

**Release note:** repeated non-file fields in a `multipart/form-data` body now arrive as an array
of every value sent, where previously only the last value was kept. Runnables that type such a
parameter as a scalar need updating.

| Body | Before | After |
|---|---|---|
| one text part `a=1` | `"1"` | `"1"` (unchanged) |
| repeated text `a=1&a=2` | `"2"` | `["1","2"]` |
| one file part | `[{"s3":…}]` | `[{"s3":…}]` (unchanged) |
| repeated file parts | `[{"s3":…},{"s3":…}]` | unchanged |
| one name as both text and file | `[{"s3":…}]` (text dropped) | `["1",{"s3":…}]` |

Only callers that repeat a name in a single body are affected. For most of them the old behavior
was silent data loss with no recovery path: `?raw=true` is ignored on the multipart branch
(`process_args` never sets `raw_string` there, unlike every other branch), so a preprocessor could
not reach the dropped values either.

One case is **not** data loss and is a real break: the HTML hidden-input + checkbox idiom
deliberately posts a name twice and relies on last-wins.

```html
<input type="hidden" name="opt_in" value="off">
<input type="checkbox" name="opt_in" value="on">
```

A browser form using `enctype="multipart/form-data"` posted to a webhook will now deliver
`["off","on"]` where a runnable typing `opt_in` as a string previously got `"on"`. That is the
most likely way someone hits this on upgrade, and it is why the release note matters even though
this lands as a `fix:`.

Single-value bodies, which are the overwhelming majority, are byte-for-byte unchanged.

## Out of scope

`application/x-www-form-urlencoded` bodies and query parameters still keep only the last
occurrence of a repeated key, since both deserialize into a `HashMap` (`args.rs`, `build_query`).
That is a separate and wider blast radius, left deliberately untouched here. It does mean the two
form encodings now differ for repeated text fields, where before they agreed on dropping them.

## Changes

- `process_multipart` accumulates parts into an ordered `Vec<(String, MultipartValue)>` instead of
  inserting into a map as it streams, so body order survives.
- New pure `collapse_multipart_fields` groups parts by name: a text name sent once stays a scalar,
  a repeated text name becomes an array in body order, and any name that carried a file stays an
  array even for a single file, preserving the shape scripts have been typed against since #5002.
- A name carrying both a text and a file part now keeps both instead of the file replacing the text.
- Both new items are gated `#[cfg(any(feature = "parquet", test))]`: consumed by `process_multipart`
  under `parquet`, exercised by the unit test otherwise, and not compiled when neither applies.

## Test plan

- [x] `cargo test -p windmill-api --lib args::tests` — 3/3, including the new
      `test_collapse_multipart_fields` pinning all four shapes above.
- [x] `cargo check` (core, live DB) and `cargo check --features parquet --tests` both clean; the
      full `quickjs,parquet,enterprise,private` binary builds and serves.
- [x] Exercised on a running instance. Multipart needs `parquet` **and** `enterprise,private` (the
      OSS `get_workspace_s3_resource` is a stub returning `None`), so with a workspace pointed at
      object storage, a `curl -F` POST repeating a text field, repeating a file field, sending a
      lone file, and sending one name as both produced:

      {"single":"a",
       "repeated":["a","b","c"],
       "onefile":[{"s3":"windmill_uploads/upload_…32654.txt"}],
       "manyfiles":[{"s3":"…62918.txt"},{"s3":"…7121.txt"}],
       "mixed":["sometext",{"s3":"…8385.txt"}]}

      All four objects landed in the bucket at the right sizes, confirming the file parts really
      uploaded rather than just minting keys.