### PR TITLE
fix: keep ai chat messages when leaving the page mid-generation

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -612,8 +612,8 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 									{#each pastChats as chat (chat.id)}
 										<button
 											class="text-left flex flex-row items-center gap-2 justify-between hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md p-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent dark:disabled:hover:bg-transparent"
-											disabled={aiChatManager.loading}
-											title={aiChatManager.loading
+											disabled={aiChatManager.loading || aiChatManager.sendInFlight}
+											title={aiChatManager.loading || aiChatManager.sendInFlight
 												? 'Stop the current answer to switch conversation'
 												: undefined}
 											onclick={() => {

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -611,7 +611,11 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 								<div class="flex flex-col">
 									{#each pastChats as chat (chat.id)}
 										<button
-											class="text-left flex flex-row items-center gap-2 justify-between hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md p-1"
+											class="text-left flex flex-row items-center gap-2 justify-between hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md p-1 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent dark:disabled:hover:bg-transparent"
+											disabled={aiChatManager.loading}
+											title={aiChatManager.loading
+												? 'Stop the current answer to switch conversation'
+												: undefined}
 											onclick={() => {
 												loadPastChat(chat.id)
 												close()

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -2282,9 +2282,6 @@ export class AIChatManager {
 		snapshot?: {
 			/** Result to synthesize for the calls of a batch caught mid-execution. */
 			interruptedToolContent: string
-			/** True when partialReply has not been folded into a message yet, so it
-			 *  cannot be the stale duplicate the dedup below exists to drop. */
-			textIsLive: boolean
 			/** Images a tool has produced that the turn has not yet turned into a
 			 *  message (see appendPendingToolImages). */
 			bufferedImages?: ChatCompletionMessageParam
@@ -2294,8 +2291,9 @@ export class AIChatManager {
 			? closeInterruptedToolBatch(collectedMessages, snapshot.interruptedToolContent)
 			: truncateToToolPairedPrefix(collectedMessages)
 		// partialReply can be stale — equal to text already committed inside the
-		// prefix — so only append when new. Live text is exempt: identical text can
-		// legitimately recur across iterations, so content alone cannot judge it.
+		// prefix — so only append when new. A snapshot is exempt: it passes only
+		// live streaming text, which is never in the prefix, and identical text can
+		// legitimately recur across iterations where content alone cannot judge it.
 		const lastCommittedText = [...prefix]
 			.reverse()
 			.find(
@@ -2303,7 +2301,7 @@ export class AIChatManager {
 					m.role === 'assistant' && typeof m.content === 'string' && !!m.content.trim()
 			)?.content
 		const keptPartialReply =
-			!!partialReply.trim() && (!!snapshot?.textIsLive || partialReply !== lastCommittedText)
+			!!partialReply.trim() && (!!snapshot || partialReply !== lastCommittedText)
 		// Images sit between the batch that produced them and whatever the model
 		// said next, matching where appendPendingToolImages puts them live.
 		const tail = snapshot?.bufferedImages ? [...prefix, snapshot.bufferedImages] : prefix
@@ -3025,10 +3023,6 @@ export class AIChatManager {
 		// that never became one.
 		const collectedMessages: ChatCompletionMessageParam[] = []
 		let partialReply = ''
-		// Whether partialReply is already in collectedMessages. Parsers call
-		// onMessageEnd both before pushing (text giving way to a tool call) and
-		// after (a finished message), so only the capture site can tell.
-		let partialReplyCommitted = false
 		// Once an outcome branch (commit/restore) took over, a later throw (e.g.
 		// from saveChat) must not make the catch commit the turn a second time.
 		let turnOutcomeHandled = false
@@ -3052,12 +3046,15 @@ export class AIChatManager {
 			// nothing and the rate follows steps taken rather than time.
 			const shape = `${collectedMessages.length}:${this.displayMessages.length}:${streaming.length}`
 			if (!force && shape === checkpointedShape) return
+			// Live text only. Text the parsers have flushed is theirs to push, and
+			// they do so before the tool execution a checkpoint is likely to land in
+			// — so reading it here would mean re-appending what the transcript
+			// already holds. The abort path still recovers it via partialReply.
 			const { messages, keptPartialReply } = this.interruptedTurnMessages(
 				collectedMessages,
-				streaming || partialReply,
+				streaming,
 				{
 					interruptedToolContent: INTERRUPTED_TOOL_RESULT,
-					textIsLive: !!streaming || !partialReplyCommitted,
 					// A screenshot's image becomes a message only once its whole batch
 					// does, so a batch closed mid-flight would restore a result
 					// announcing a screenshot the model cannot see. Read without
@@ -3410,8 +3407,6 @@ export class AIChatManager {
 						// deduped in commitInterruptedTurn.
 						if (this.currentReply) {
 							partialReply = this.currentReply
-							const last = collectedMessages[collectedMessages.length - 1]
-							partialReplyCommitted = last?.role === 'assistant' && last.content === partialReply
 						}
 						if (this.currentReply || this.currentReasoning) {
 							this.displayMessages = [

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -159,6 +159,11 @@ function prefersInstantReveal(): boolean {
 // schema changes from mode switches, and the estimate's chars/4 error.
 const COMPACTION_TRIGGER_RATIO = 0.8
 const COMPACTION_TARGET_RATIO = 0.7
+// How often a running turn is offered to the mid-turn checkpoint (see
+// sendRequest). The whole transcript is rewritten on each accepted checkpoint,
+// so this bounds the write rate; it also bounds how much of a turn a tab
+// closed without warning can lose.
+const CHECKPOINT_INTERVAL_MS = 2000
 // Flat per-image token estimate for a downscaled (≤1568px) vision image. Used instead
 // of chars/4 on the base64 data URL, which would overcount by ~50x.
 const IMAGE_TOKEN_ESTIMATE = 1200
@@ -2258,16 +2263,16 @@ export class AIChatManager {
 		}
 	}
 
-	// Commit an interrupted turn's usable output as context for a follow-up:
-	// the tool-paired prefix of completed steps (a dangling tool call would
-	// make providers reject the next request) plus the partial answer text.
-	// A reasoning-only interrupt instead drops its stuck-open bubble.
-	private commitInterruptedTurn = (
+	// The transcript an interrupted turn leaves behind: the stored history, the
+	// tool-paired prefix of the turn's completed steps (a dangling tool call
+	// would make providers reject the next request), and the partial answer text
+	// when it isn't already inside that prefix. Pure — the caller decides whether
+	// this becomes the live transcript or only a persisted checkpoint.
+	private interruptedTurnMessages = (
 		collectedMessages: ChatCompletionMessageParam[],
 		partialReply: string
-	) => {
+	): { messages: ChatCompletionMessageParam[]; keptPartialReply: boolean } => {
 		const prefix = truncateToToolPairedPrefix(collectedMessages)
-		this.messages = [...this.messages, ...prefix]
 		// partialReply can be stale — equal to text already committed inside the
 		// prefix (see its capture in onMessageEnd) — so only append when new.
 		const lastCommittedText = [...prefix]
@@ -2276,9 +2281,27 @@ export class AIChatManager {
 				(m): m is ChatCompletionMessageParam & { content: string } =>
 					m.role === 'assistant' && typeof m.content === 'string' && !!m.content.trim()
 			)?.content
-		if (partialReply.trim() && partialReply !== lastCommittedText) {
-			this.messages = [...this.messages, { role: 'assistant', content: partialReply }]
-		} else {
+		const keptPartialReply = !!partialReply.trim() && partialReply !== lastCommittedText
+		return {
+			messages: keptPartialReply
+				? [...this.messages, ...prefix, { role: 'assistant', content: partialReply }]
+				: [...this.messages, ...prefix],
+			keptPartialReply
+		}
+	}
+
+	// Commit an interrupted turn's usable output as context for a follow-up.
+	// A reasoning-only interrupt instead drops its stuck-open bubble.
+	private commitInterruptedTurn = (
+		collectedMessages: ChatCompletionMessageParam[],
+		partialReply: string
+	) => {
+		const { messages, keptPartialReply } = this.interruptedTurnMessages(
+			collectedMessages,
+			partialReply
+		)
+		this.messages = messages
+		if (!keptPartialReply) {
 			const last = this.displayMessages[this.displayMessages.length - 1]
 			if (last?.role === 'assistant' && !last.content.trim() && !!last.reasoning) {
 				this.displayMessages = this.displayMessages.slice(0, -1)
@@ -2977,6 +3000,53 @@ export class AIChatManager {
 		// that never became one.
 		const collectedMessages: ChatCompletionMessageParam[] = []
 		let partialReply = ''
+		// A turn's output only reaches history when the turn ends, so a tab closed or
+		// reloaded mid-turn would lose every step it had already taken. Persist what
+		// has landed so far WITHOUT committing it: the outcome branches below still
+		// need `this.messages` unmodified to roll the turn back. Whatever the
+		// outcome, their own save overwrites the last checkpoint.
+		let checkpointedShape = ''
+		const checkpointTurn = async (force = false) => {
+			// Polled, but written only when the turn actually advanced — a message
+			// collected, or a card appearing (a tool starting, a confirmation staged).
+			// So an answer streaming for minutes and a turn parked on a confirmation
+			// both cost nothing, and the write rate follows steps taken, not time.
+			const shape = `${collectedMessages.length}:${this.displayMessages.length}`
+			if (!force && shape === checkpointedShape) return
+			// currentReply holds the answer text streaming right now; partialReply is
+			// the last text onMessageEnd flushed (already inside the prefix unless the
+			// turn ended on it), so it only stands in when nothing is streaming.
+			const { messages } = this.interruptedTurnMessages(
+				collectedMessages,
+				this.currentReply || partialReply
+			)
+			if (messages.length === this.messages.length) return
+			checkpointedShape = shape
+			// Best-effort: the turn-end save is the authoritative one, so a failed
+			// checkpoint must never break the turn it is only shadowing.
+			try {
+				await this.historyManager.saveChat(
+					this.settledToolDisplay(this.displayMessages, 'Interrupted'),
+					messages,
+					this.contextUsage,
+					this.modifiedItems ? [...this.modifiedItems] : undefined
+				)
+			} catch (e) {
+				console.error('Failed to checkpoint chat mid-turn', e)
+			}
+		}
+		const checkpointTimer = setInterval(() => void checkpointTurn(), CHECKPOINT_INTERVAL_MS)
+		// Leaving the page is the one moment worth a forced write, streamed text and
+		// all. `hidden` precedes pagehide on close, reload and navigation and, unlike
+		// pagehide, still runs a live document — though a navigation can still outrun
+		// the IndexedDB write, which is why the poll above carries the guarantee and
+		// this only narrows the gap. `document` is absent under SSR and the node test
+		// env, where a turn has no page to leave.
+		const hideTarget = typeof document !== 'undefined' ? document : undefined
+		const checkpointOnHide = () => {
+			if (hideTarget?.visibilityState === 'hidden') void checkpointTurn(true)
+		}
+		hideTarget?.addEventListener('visibilitychange', checkpointOnHide)
 		// Once an outcome branch (commit/restore) took over, a later throw (e.g.
 		// from saveChat) must not make the catch commit the turn a second time.
 		let turnOutcomeHandled = false
@@ -3525,6 +3595,8 @@ export class AIChatManager {
 			sendUserToast(getSendRequestErrorMessage(err, webSearchUnavailable), true)
 		} finally {
 			this.loading = false
+			clearInterval(checkpointTimer)
+			hideTarget?.removeEventListener('visibilitychange', checkpointOnHide)
 			// Turn teardown: cancel any in-flight reveal frame and drop leftover
 			// backlog. onMessageEnd already flushed on every outcome, so this only
 			// releases the loop; it never discards uncommitted text.
@@ -4104,13 +4176,26 @@ export class AIChatManager {
 		}
 	}
 
-	cancelLoadingTools = (messageText: 'Canceled' | 'Error' = 'Canceled') => {
-		this.displayMessages = this.displayMessages.map((message) => {
+	// In-flight and queued tool cards settled into a terminal state. Persisting
+	// one as-is restores a card that spins forever, and an unanswered question
+	// keeps the composer disabled (see isActiveUserQuestion) with nothing left
+	// running to answer it — so every transcript that outlives its turn goes
+	// through here first.
+	private settledToolDisplay = (
+		messages: DisplayMessage[],
+		messageText: string
+	): DisplayMessage[] =>
+		messages.map((message) => {
 			if (message.role === 'tool' && (message.isLoading || message.isQueued)) {
 				return {
 					...message,
 					isLoading: false,
 					isQueued: false,
+					// Both render live affordances on their own, without consulting
+					// isLoading: a Run/Reject footer for a call nothing is waiting on,
+					// and a card that hides its result as still-streaming.
+					needsConfirmation: false,
+					isStreamingArguments: false,
 					// A question's card disappears once canceled, so keep the question
 					// itself readable in the collapsed header.
 					content: message.userQuestion
@@ -4124,6 +4209,9 @@ export class AIChatManager {
 			}
 			return message
 		})
+
+	cancelLoadingTools = (messageText: 'Canceled' | 'Error' = 'Canceled') => {
+		this.displayMessages = this.settledToolDisplay(this.displayMessages, messageText)
 	}
 }
 

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -99,7 +99,7 @@ import {
 import type { Selection } from 'monaco-editor'
 import type AIChatInput from './AIChatInput.svelte'
 import { prepareApiSystemMessage, prepareApiUserMessage } from './api/core'
-import { runChatLoop, truncateToToolPairedPrefix } from './chatLoop'
+import { closeInterruptedToolBatch, runChatLoop, truncateToToolPairedPrefix } from './chatLoop'
 import { sanitizeToolCallArguments } from './toolCallArguments'
 import { normalizeContextUsage } from './tokenUsage'
 import type { ReviewChangesOpts } from './monaco-adapter'
@@ -161,9 +161,13 @@ const COMPACTION_TRIGGER_RATIO = 0.8
 const COMPACTION_TARGET_RATIO = 0.7
 // How often a running turn is offered to the mid-turn checkpoint (see
 // sendRequest). The whole transcript is rewritten on each accepted checkpoint,
-// so this bounds the write rate; it also bounds how much of a turn a tab
-// closed without warning can lose.
+// so this bounds the write rate; it also bounds how much of a turn a tab that
+// dies without warning can lose.
 const CHECKPOINT_INTERVAL_MS = 2000
+// Stands in for the result of a tool call that had not finished when the
+// transcript was checkpointed — still running, or still waiting to be confirmed.
+// The model reads the step as unfinished, which is what the card tells the reader.
+const INTERRUPTED_TOOL_RESULT = 'Interrupted: the chat was closed before this tool finished'
 // Flat per-image token estimate for a downscaled (≤1568px) vision image. Used instead
 // of chars/4 on the base64 data URL, which would overcount by ~50x.
 const IMAGE_TOKEN_ESTIMATE = 1200
@@ -2270,9 +2274,16 @@ export class AIChatManager {
 	// this becomes the live transcript or only a persisted checkpoint.
 	private interruptedTurnMessages = (
 		collectedMessages: ChatCompletionMessageParam[],
-		partialReply: string
+		partialReply: string,
+		// Content for the synthesized results of a batch caught mid-execution. Only
+		// a snapshot that has to outlive its turn passes it: a turn committed for a
+		// follow-up is better off truncating the batch so the model reruns it, since
+		// it is still live and nothing has been lost yet.
+		interruptedToolContent?: string
 	): { messages: ChatCompletionMessageParam[]; keptPartialReply: boolean } => {
-		const prefix = truncateToToolPairedPrefix(collectedMessages)
+		const prefix = interruptedToolContent
+			? closeInterruptedToolBatch(collectedMessages, interruptedToolContent)
+			: truncateToToolPairedPrefix(collectedMessages)
 		// partialReply can be stale — equal to text already committed inside the
 		// prefix (see its capture in onMessageEnd) — so only append when new.
 		const lastCommittedText = [...prefix]
@@ -3016,18 +3027,24 @@ export class AIChatManager {
 		let checkpointedShape = ''
 		const checkpointTurn = async (force = false) => {
 			// Polled, but written only when the turn actually advanced — a message
-			// collected, or a card appearing (a tool starting, a confirmation staged).
-			// So an answer streaming for minutes and a turn parked on a confirmation
-			// both cost nothing, and the write rate follows steps taken, not time.
-			const shape = `${collectedMessages.length}:${this.displayMessages.length}`
+			// collected, a card appearing, or the answer growing. A turn parked on a
+			// confirmation therefore costs nothing, while a long streamed answer keeps
+			// being captured as it grows rather than freezing at its first slice.
+			const shape = `${collectedMessages.length}:${this.displayMessages.length}:${this.currentReply.length}`
 			if (!force && shape === checkpointedShape) return
+			// The reveal animation holds received-but-unshown text, and currentReply is
+			// only what it has released, so the leaving path has to drain it or persist
+			// a truncated answer. The polled path deliberately does not: flushing would
+			// snap the typewriter to the end on a page the reader is still watching.
+			if (force) this.replyReveal.flush()
 			// partialReply is the last text onMessageEnd flushed, already inside the
 			// prefix unless the turn ended on it; currentReply is the answer streaming
 			// right now, which onMessageEnd has not turned into a message yet.
 			const streaming = this.currentReply
 			const { messages, keptPartialReply } = this.interruptedTurnMessages(
 				collectedMessages,
-				streaming || partialReply
+				streaming || partialReply,
+				INTERRUPTED_TOOL_RESULT
 			)
 			if (messages.length === this.messages.length) return
 			checkpointedShape = shape

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -2276,10 +2276,9 @@ export class AIChatManager {
 	private interruptedTurnMessages = (
 		collectedMessages: ChatCompletionMessageParam[],
 		partialReply: string,
-		// Passed only by the mid-turn checkpoint, whose snapshot has to outlive its
-		// turn. A turn being committed for a follow-up wants neither: it is still
-		// live, so it is better off truncating a half-run batch and letting the
-		// model rerun it than reading results nothing produced.
+		// Passed only by the mid-turn checkpoint, whose result must outlive its turn.
+		// A turn committed for a follow-up is still live, so it would rather truncate
+		// a half-run batch and rerun it than read results nothing produced.
 		snapshot?: {
 			/** Result to synthesize for the calls of a batch caught mid-execution. */
 			interruptedToolContent: string
@@ -2295,9 +2294,8 @@ export class AIChatManager {
 			? closeInterruptedToolBatch(collectedMessages, snapshot.interruptedToolContent)
 			: truncateToToolPairedPrefix(collectedMessages)
 		// partialReply can be stale — equal to text already committed inside the
-		// prefix (see its capture in onMessageEnd) — so only append when new. Live
-		// text is exempt: it provably is not in the prefix yet, and two iterations
-		// around a tool call can legitimately produce the same sentence twice.
+		// prefix — so only append when new. Live text is exempt: identical text can
+		// legitimately recur across iterations, so content alone cannot judge it.
 		const lastCommittedText = [...prefix]
 			.reverse()
 			.find(
@@ -3027,11 +3025,10 @@ export class AIChatManager {
 		// that never became one.
 		const collectedMessages: ChatCompletionMessageParam[] = []
 		let partialReply = ''
-		// How much had been collected when partialReply was captured. The parser
-		// pushes that text as a message right after, so an unchanged count means it
-		// is still uncommitted — which is what tells a checkpoint the text is new
-		// rather than a stale copy of what the transcript already holds.
-		let partialReplyCollectedLen = -1
+		// Whether partialReply is already in collectedMessages. Parsers call
+		// onMessageEnd both before pushing (text giving way to a tool call) and
+		// after (a finished message), so only the capture site can tell.
+		let partialReplyCommitted = false
 		// Once an outcome branch (commit/restore) took over, a later throw (e.g.
 		// from saveChat) must not make the catch commit the turn a second time.
 		let turnOutcomeHandled = false
@@ -3040,48 +3037,40 @@ export class AIChatManager {
 		// auto-sends the next queued message. Cancel, error, and empty-response
 		// rollbacks leave it false so queued text is restored to the input.
 		let turnCommittedCleanly = false
-		// A turn's output only reaches history when the turn ends, so a tab closed or
-		// reloaded mid-turn would lose every step it had already taken. Persist what
-		// has landed so far WITHOUT committing it: the outcome branches below still
-		// need `this.messages` unmodified to roll the turn back. Whatever the
-		// outcome, their own save overwrites the last checkpoint.
+		// A turn's output only reaches history when the turn ends, so a tab closed
+		// mid-turn loses every step it had taken. Persist progress WITHOUT
+		// committing it: the outcome branches still need `this.messages`
+		// unmodified to roll the turn back, and their save overwrites this.
 		let checkpointedShape = ''
 		const checkpointTurn = async (force = false) => {
-			// Polled, but written only when the turn actually advanced — a message
-			// collected, a card appearing, or the answer growing. A turn parked on a
-			// confirmation therefore costs nothing, while a long streamed answer keeps
-			// being captured as it grows rather than freezing at its first slice.
-			// The whole answer as received, not as painted: currentReply is only what
-			// the reveal has released, and a hidden tab pauses that loop while text
-			// keeps arriving — fingerprinting the painted text would stall the poll
-			// exactly when nobody is watching to notice. Reading `pending` leaves the
-			// animation alone, so no path here ever disturbs the typewriter.
+			// Text as received, not as painted: a hidden tab pauses the reveal loop
+			// while text keeps arriving, so fingerprinting painted text would stall
+			// the poll exactly when nobody is watching. `pending` reads it without
+			// disturbing the animation.
 			const streaming = this.currentReply + this.replyReveal.pending
+			// Write only when the turn advanced, so a parked confirmation costs
+			// nothing and the rate follows steps taken rather than time.
 			const shape = `${collectedMessages.length}:${this.displayMessages.length}:${streaming.length}`
 			if (!force && shape === checkpointedShape) return
 			const { messages, keptPartialReply } = this.interruptedTurnMessages(
 				collectedMessages,
-				// `streaming` is the answer arriving right now; partialReply is the last
-				// text onMessageEnd flushed, which the parser folds into a message a tick
-				// later — until it has, that text is as uncommitted as streaming text.
 				streaming || partialReply,
 				{
 					interruptedToolContent: INTERRUPTED_TOOL_RESULT,
-					textIsLive: !!streaming || collectedMessages.length === partialReplyCollectedLen,
-					// A screenshot tool completes inside its batch but its image only
-					// becomes a message once the whole batch does, so a batch closed
-					// mid-flight would otherwise restore a result announcing a screenshot
-					// the model cannot see. Read the buffer without draining it.
+					textIsLive: !!streaming || !partialReplyCommitted,
+					// A screenshot's image becomes a message only once its whole batch
+					// does, so a batch closed mid-flight would restore a result
+					// announcing a screenshot the model cannot see. Read without
+					// draining: the live turn still owns the buffer.
 					bufferedImages: pendingToolImagesMessage([...this.pendingToolImages.values()].flat())
 				}
 			)
 			if (messages.length === this.messages.length) return
 			checkpointedShape = shape
 			const display = this.settledToolDisplay(this.displayMessages, 'Interrupted')
-			// onMessageEnd is what appends the bubble for streamed text, and it resets
-			// currentReply when it does — so text still sitting there has no bubble yet
-			// and a checkpoint has to add one, or the reply comes back as context the
-			// reader cannot see.
+			// onMessageEnd is what gives streamed text its bubble, and it clears
+			// currentReply doing so — text still there has none, and without one the
+			// reply returns as context the reader cannot see.
 			const withStreamed =
 				streaming && keptPartialReply
 					? [...display, { role: 'assistant' as const, content: streaming }]
@@ -3105,23 +3094,19 @@ export class AIChatManager {
 			}
 		}
 		const checkpointTimer = setInterval(() => void checkpointTurn(), CHECKPOINT_INTERVAL_MS)
-		// Leaving the page is the one moment worth a forced write, streamed text and
-		// all. `hidden` precedes pagehide on close, reload and navigation and, unlike
-		// pagehide, still runs a live document — though a navigation can still outrun
-		// the IndexedDB write, which is why the poll above carries the guarantee and
-		// this only narrows the gap. `document` is absent under SSR and the node test
-		// env, where a turn has no page to leave.
+		// `hidden` precedes pagehide on close, reload and navigation and still runs a
+		// live document, so it is the last point a write can land. A navigation can
+		// outrun it — the poll, not this, carries the guarantee. `document` is absent
+		// under SSR and the node test env.
 		const hideTarget = typeof document !== 'undefined' ? document : undefined
 		const checkpointOnHide = () => {
 			if (hideTarget?.visibilityState === 'hidden') void checkpointTurn(true)
 		}
 		hideTarget?.addEventListener('visibilitychange', checkpointOnHide)
-		// Checkpointing must stop the moment the loop hands back, not in `finally`:
-		// the outcome branches merge the turn into `this.messages` and only then
-		// await their save, so a checkpoint landing in that window would append the
-		// same collected messages to an already-committed transcript and, queued
-		// behind the real save, persist the duplicate. Idempotent — every exit path
-		// calls it.
+		// Must stop when the loop hands back, not in `finally`: the outcome branches
+		// merge the turn into `this.messages` before awaiting their save, so a
+		// checkpoint there would re-append the same messages and, queued behind that
+		// save, persist the duplicate. Idempotent — every exit path calls it.
 		const stopCheckpoints = () => {
 			clearInterval(checkpointTimer)
 			hideTarget?.removeEventListener('visibilitychange', checkpointOnHide)
@@ -3425,7 +3410,8 @@ export class AIChatManager {
 						// deduped in commitInterruptedTurn.
 						if (this.currentReply) {
 							partialReply = this.currentReply
-							partialReplyCollectedLen = collectedMessages.length
+							const last = collectedMessages[collectedMessages.length - 1]
+							partialReplyCommitted = last?.role === 'assistant' && last.content === partialReply
 						}
 						if (this.currentReply || this.currentReasoning) {
 							this.displayMessages = [

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -3879,13 +3879,11 @@ export class AIChatManager {
 	}
 
 	loadPastChat = async (id: string) => {
-		// A running turn commits into whatever transcript it finds when it ends, so
-		// swapping one in underneath it either files the turn in the wrong chat or —
-		// when the loaded chat is the one it started in, already carrying the turn's
-		// own checkpoint — appends it a second time, leaving duplicate tool_call ids
-		// the provider then rejects. The History menu disables its entries while a
-		// turn runs; this guards the callers that don't.
-		if (this.loading) return
+		// A turn commits into whatever transcript it finds when it ends, so swapping
+		// one in underneath it misfiles the turn — or duplicates it, when the loaded
+		// chat already carries the turn's own checkpoint. Gated on `sendInFlight`
+		// too, for the pre-`loading` window `sendOrQueue` documents.
+		if (this.loading || this.sendInFlight) return
 		const chat = await this.historyManager.loadPastChat(id)
 		if (chat) {
 			// Drop any message queued in the current conversation so it doesn't

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -29,6 +29,7 @@ import {
 	completedJobToolStatus,
 	backgroundJobCompletionNote,
 	deriveChatJobStatus,
+	pendingToolImagesMessage,
 	trimJob
 } from './shared'
 import type {
@@ -2282,10 +2283,12 @@ export class AIChatManager {
 		snapshot?: {
 			/** Result to synthesize for the calls of a batch caught mid-execution. */
 			interruptedToolContent: string
-			/** True when partialReply is text arriving right now rather than the last
-			 *  text onMessageEnd flushed. Only the latter can be a stale duplicate of
-			 *  what the prefix already holds, so only it may be deduped away. */
+			/** True when partialReply has not been folded into a message yet, so it
+			 *  cannot be the stale duplicate the dedup below exists to drop. */
 			textIsLive: boolean
+			/** Images a tool has produced that the turn has not yet turned into a
+			 *  message (see appendPendingToolImages). */
+			bufferedImages?: ChatCompletionMessageParam
 		}
 	): { messages: ChatCompletionMessageParam[]; keptPartialReply: boolean } => {
 		const prefix = snapshot
@@ -2303,10 +2306,13 @@ export class AIChatManager {
 			)?.content
 		const keptPartialReply =
 			!!partialReply.trim() && (!!snapshot?.textIsLive || partialReply !== lastCommittedText)
+		// Images sit between the batch that produced them and whatever the model
+		// said next, matching where appendPendingToolImages puts them live.
+		const tail = snapshot?.bufferedImages ? [...prefix, snapshot.bufferedImages] : prefix
 		return {
 			messages: keptPartialReply
-				? [...this.messages, ...prefix, { role: 'assistant', content: partialReply }]
-				: [...this.messages, ...prefix],
+				? [...this.messages, ...tail, { role: 'assistant', content: partialReply }]
+				: [...this.messages, ...tail],
 			keptPartialReply
 		}
 	}
@@ -3021,6 +3027,11 @@ export class AIChatManager {
 		// that never became one.
 		const collectedMessages: ChatCompletionMessageParam[] = []
 		let partialReply = ''
+		// How much had been collected when partialReply was captured. The parser
+		// pushes that text as a message right after, so an unchanged count means it
+		// is still uncommitted — which is what tells a checkpoint the text is new
+		// rather than a stale copy of what the transcript already holds.
+		let partialReplyCollectedLen = -1
 		// Once an outcome branch (commit/restore) took over, a later throw (e.g.
 		// from saveChat) must not make the catch commit the turn a second time.
 		let turnOutcomeHandled = false
@@ -3050,11 +3061,19 @@ export class AIChatManager {
 			if (!force && shape === checkpointedShape) return
 			const { messages, keptPartialReply } = this.interruptedTurnMessages(
 				collectedMessages,
-				// partialReply is the last text onMessageEnd flushed, already inside the
-				// prefix unless the turn ended on it; `streaming` is the answer arriving
-				// right now, which onMessageEnd has not turned into a message yet.
+				// `streaming` is the answer arriving right now; partialReply is the last
+				// text onMessageEnd flushed, which the parser folds into a message a tick
+				// later — until it has, that text is as uncommitted as streaming text.
 				streaming || partialReply,
-				{ interruptedToolContent: INTERRUPTED_TOOL_RESULT, textIsLive: !!streaming }
+				{
+					interruptedToolContent: INTERRUPTED_TOOL_RESULT,
+					textIsLive: !!streaming || collectedMessages.length === partialReplyCollectedLen,
+					// A screenshot tool completes inside its batch but its image only
+					// becomes a message once the whole batch does, so a batch closed
+					// mid-flight would otherwise restore a result announcing a screenshot
+					// the model cannot see. Read the buffer without draining it.
+					bufferedImages: pendingToolImagesMessage([...this.pendingToolImages.values()].flat())
+				}
 			)
 			if (messages.length === this.messages.length) return
 			checkpointedShape = shape
@@ -3406,6 +3425,7 @@ export class AIChatManager {
 						// deduped in commitInterruptedTurn.
 						if (this.currentReply) {
 							partialReply = this.currentReply
+							partialReplyCollectedLen = collectedMessages.length
 						}
 						if (this.currentReply || this.currentReasoning) {
 							this.displayMessages = [

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -3000,6 +3000,14 @@ export class AIChatManager {
 		// that never became one.
 		const collectedMessages: ChatCompletionMessageParam[] = []
 		let partialReply = ''
+		// Once an outcome branch (commit/restore) took over, a later throw (e.g.
+		// from saveChat) must not make the catch commit the turn a second time.
+		let turnOutcomeHandled = false
+		let webSearchUnavailable = false
+		// Gates the queued-message flush below: only a cleanly committed turn
+		// auto-sends the next queued message. Cancel, error, and empty-response
+		// rollbacks leave it false so queued text is restored to the input.
+		let turnCommittedCleanly = false
 		// A turn's output only reaches history when the turn ends, so a tab closed or
 		// reloaded mid-turn would lose every step it had already taken. Persist what
 		// has landed so far WITHOUT committing it: the outcome branches below still
@@ -3013,22 +3021,37 @@ export class AIChatManager {
 			// both cost nothing, and the write rate follows steps taken, not time.
 			const shape = `${collectedMessages.length}:${this.displayMessages.length}`
 			if (!force && shape === checkpointedShape) return
-			// currentReply holds the answer text streaming right now; partialReply is
-			// the last text onMessageEnd flushed (already inside the prefix unless the
-			// turn ended on it), so it only stands in when nothing is streaming.
-			const { messages } = this.interruptedTurnMessages(
+			// partialReply is the last text onMessageEnd flushed, already inside the
+			// prefix unless the turn ended on it; currentReply is the answer streaming
+			// right now, which onMessageEnd has not turned into a message yet.
+			const streaming = this.currentReply
+			const { messages, keptPartialReply } = this.interruptedTurnMessages(
 				collectedMessages,
-				this.currentReply || partialReply
+				streaming || partialReply
 			)
 			if (messages.length === this.messages.length) return
 			checkpointedShape = shape
+			const display = this.settledToolDisplay(this.displayMessages, 'Interrupted')
+			// onMessageEnd is what appends the bubble for streamed text, and it resets
+			// currentReply when it does — so text still sitting there has no bubble yet
+			// and a checkpoint has to add one, or the reply comes back as context the
+			// reader cannot see.
+			const withStreamed =
+				streaming && keptPartialReply
+					? [...display, { role: 'assistant' as const, content: streaming }]
+					: display
 			// Best-effort: the turn-end save is the authoritative one, so a failed
 			// checkpoint must never break the turn it is only shadowing.
 			try {
 				await this.historyManager.saveChat(
-					this.settledToolDisplay(this.displayMessages, 'Interrupted'),
+					withStreamed,
 					messages,
-					this.contextUsage,
+					// No report describes this transcript: `contextUsage` still measures
+					// the pre-turn history while these messages already carry part of the
+					// turn. Storing it would under-report a restored chat by the whole
+					// partial turn — enough to skip the compaction its next send needs.
+					// Omitting drops the field, which is the "readers estimate" fallback.
+					undefined,
 					this.modifiedItems ? [...this.modifiedItems] : undefined
 				)
 			} catch (e) {
@@ -3047,14 +3070,16 @@ export class AIChatManager {
 			if (hideTarget?.visibilityState === 'hidden') void checkpointTurn(true)
 		}
 		hideTarget?.addEventListener('visibilitychange', checkpointOnHide)
-		// Once an outcome branch (commit/restore) took over, a later throw (e.g.
-		// from saveChat) must not make the catch commit the turn a second time.
-		let turnOutcomeHandled = false
-		let webSearchUnavailable = false
-		// Gates the queued-message flush below: only a cleanly committed turn
-		// auto-sends the next queued message. Cancel, error, and empty-response
-		// rollbacks leave it false so queued text is restored to the input.
-		let turnCommittedCleanly = false
+		// Checkpointing must stop the moment the loop hands back, not in `finally`:
+		// the outcome branches merge the turn into `this.messages` and only then
+		// await their save, so a checkpoint landing in that window would append the
+		// same collected messages to an already-committed transcript and, queued
+		// behind the real save, persist the duplicate. Idempotent — every exit path
+		// calls it.
+		const stopCheckpoints = () => {
+			clearInterval(checkpointTimer)
+			hideTarget?.removeEventListener('visibilitychange', checkpointOnHide)
+		}
 		try {
 			// A queued message carries its own context snapshot (contextOverride); use
 			// it verbatim and leave the live selection alone (it belongs to whatever the
@@ -3426,6 +3451,7 @@ export class AIChatManager {
 					webSearchUnavailable = true
 				}
 			})
+			stopCheckpoints()
 			const wasAborted = this.abortController?.signal.aborted ?? false
 			// Pure reasoning doesn't count as usable: it's not replayed as context,
 			// so a reasoning-only turn is as unsent as a literally empty one.
@@ -3537,6 +3563,7 @@ export class AIChatManager {
 				}
 			}
 		} catch (err) {
+			stopCheckpoints()
 			console.error(err)
 			// Request failure: keep the usable output as context for a follow-up.
 			// Skipped when the throw came from post-outcome code (e.g. saveChat) —
@@ -3595,8 +3622,9 @@ export class AIChatManager {
 			sendUserToast(getSendRequestErrorMessage(err, webSearchUnavailable), true)
 		} finally {
 			this.loading = false
-			clearInterval(checkpointTimer)
-			hideTarget?.removeEventListener('visibilitychange', checkpointOnHide)
+			// Backstop for the paths that leave the try without reaching either call
+			// above (a pre-flight throw, an aborted compaction).
+			stopCheckpoints()
 			// Turn teardown: cancel any in-flight reveal frame and drop leftover
 			// backlog. onMessageEnd already flushed on every outcome, so this only
 			// releases the loop; it never discards uncommitted text.

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -2275,24 +2275,34 @@ export class AIChatManager {
 	private interruptedTurnMessages = (
 		collectedMessages: ChatCompletionMessageParam[],
 		partialReply: string,
-		// Content for the synthesized results of a batch caught mid-execution. Only
-		// a snapshot that has to outlive its turn passes it: a turn committed for a
-		// follow-up is better off truncating the batch so the model reruns it, since
-		// it is still live and nothing has been lost yet.
-		interruptedToolContent?: string
+		// Passed only by the mid-turn checkpoint, whose snapshot has to outlive its
+		// turn. A turn being committed for a follow-up wants neither: it is still
+		// live, so it is better off truncating a half-run batch and letting the
+		// model rerun it than reading results nothing produced.
+		snapshot?: {
+			/** Result to synthesize for the calls of a batch caught mid-execution. */
+			interruptedToolContent: string
+			/** True when partialReply is text arriving right now rather than the last
+			 *  text onMessageEnd flushed. Only the latter can be a stale duplicate of
+			 *  what the prefix already holds, so only it may be deduped away. */
+			textIsLive: boolean
+		}
 	): { messages: ChatCompletionMessageParam[]; keptPartialReply: boolean } => {
-		const prefix = interruptedToolContent
-			? closeInterruptedToolBatch(collectedMessages, interruptedToolContent)
+		const prefix = snapshot
+			? closeInterruptedToolBatch(collectedMessages, snapshot.interruptedToolContent)
 			: truncateToToolPairedPrefix(collectedMessages)
 		// partialReply can be stale — equal to text already committed inside the
-		// prefix (see its capture in onMessageEnd) — so only append when new.
+		// prefix (see its capture in onMessageEnd) — so only append when new. Live
+		// text is exempt: it provably is not in the prefix yet, and two iterations
+		// around a tool call can legitimately produce the same sentence twice.
 		const lastCommittedText = [...prefix]
 			.reverse()
 			.find(
 				(m): m is ChatCompletionMessageParam & { content: string } =>
 					m.role === 'assistant' && typeof m.content === 'string' && !!m.content.trim()
 			)?.content
-		const keptPartialReply = !!partialReply.trim() && partialReply !== lastCommittedText
+		const keptPartialReply =
+			!!partialReply.trim() && (!!snapshot?.textIsLive || partialReply !== lastCommittedText)
 		return {
 			messages: keptPartialReply
 				? [...this.messages, ...prefix, { role: 'assistant', content: partialReply }]
@@ -3030,21 +3040,21 @@ export class AIChatManager {
 			// collected, a card appearing, or the answer growing. A turn parked on a
 			// confirmation therefore costs nothing, while a long streamed answer keeps
 			// being captured as it grows rather than freezing at its first slice.
-			const shape = `${collectedMessages.length}:${this.displayMessages.length}:${this.currentReply.length}`
+			// The whole answer as received, not as painted: currentReply is only what
+			// the reveal has released, and a hidden tab pauses that loop while text
+			// keeps arriving — fingerprinting the painted text would stall the poll
+			// exactly when nobody is watching to notice. Reading `pending` leaves the
+			// animation alone, so no path here ever disturbs the typewriter.
+			const streaming = this.currentReply + this.replyReveal.pending
+			const shape = `${collectedMessages.length}:${this.displayMessages.length}:${streaming.length}`
 			if (!force && shape === checkpointedShape) return
-			// The reveal animation holds received-but-unshown text, and currentReply is
-			// only what it has released, so the leaving path has to drain it or persist
-			// a truncated answer. The polled path deliberately does not: flushing would
-			// snap the typewriter to the end on a page the reader is still watching.
-			if (force) this.replyReveal.flush()
-			// partialReply is the last text onMessageEnd flushed, already inside the
-			// prefix unless the turn ended on it; currentReply is the answer streaming
-			// right now, which onMessageEnd has not turned into a message yet.
-			const streaming = this.currentReply
 			const { messages, keptPartialReply } = this.interruptedTurnMessages(
 				collectedMessages,
+				// partialReply is the last text onMessageEnd flushed, already inside the
+				// prefix unless the turn ended on it; `streaming` is the answer arriving
+				// right now, which onMessageEnd has not turned into a message yet.
 				streaming || partialReply,
-				INTERRUPTED_TOOL_RESULT
+				{ interruptedToolContent: INTERRUPTED_TOOL_RESULT, textIsLive: !!streaming }
 			)
 			if (messages.length === this.messages.length) return
 			checkpointedShape = shape

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -3879,6 +3879,13 @@ export class AIChatManager {
 	}
 
 	loadPastChat = async (id: string) => {
+		// A running turn commits into whatever transcript it finds when it ends, so
+		// swapping one in underneath it either files the turn in the wrong chat or —
+		// when the loaded chat is the one it started in, already carrying the turn's
+		// own checkpoint — appends it a second time, leaving duplicate tool_call ids
+		// the provider then rejects. The History menu disables its entries while a
+		// turn runs; this guards the callers that don't.
+		if (this.loading) return
 		const chat = await this.historyManager.loadPastChat(id)
 		if (chat) {
 			// Drop any message queued in the current conversation so it doesn't

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1816,7 +1816,46 @@ describe('AIChatManager queued messages', () => {
 
 	// Every checkpoint test installs a fake document; leaking one would make a
 	// single failure cascade through every later test in the file.
-	afterEach(() => vi.unstubAllGlobals())
+	afterEach(() => {
+		vi.unstubAllGlobals()
+		vi.useRealTimers()
+	})
+
+	it('keeps re-checkpointing a streamed answer as it grows', async () => {
+		vi.useFakeTimers({ shouldAdvanceTime: true })
+		const manager = createManager()
+		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+		// One poll interval, per CHECKPOINT_INTERVAL_MS in AIChatManager.
+		const pastOnePoll = 2100
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			// A text-only answer: nothing lands in addedMessages and no card appears,
+			// so the growing reply is the only thing that can drive the poll.
+			for (const text of ['the first part', 'the first part and more', 'the whole answer']) {
+				manager.currentReply = text
+				await vi.advanceTimersByTimeAsync(pastOnePoll)
+			}
+			const message = { role: 'assistant' as const, content: manager.currentReply }
+			config.addedMessages.push(message)
+			return {
+				addedMessages: [message],
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'write me something long' })
+
+		// A fingerprint blind to the reply would freeze at whatever the first tick
+		// captured, so each tick must persist strictly more of the answer.
+		const persisted = saveChat.mock.calls
+			.map(([, messages]) => messages as ChatCompletionMessageParam[])
+			.map((messages) => messages[messages.length - 1])
+			.filter((m) => m?.role === 'assistant' && typeof m.content === 'string')
+			.map((m) => String(m.content))
+			.filter((c) => c.startsWith('the first part'))
+		expect(persisted).toEqual(['the first part', 'the first part and more'])
+	})
 
 	it('checkpoints a turn to history when the page is hidden mid-generation', async () => {
 		const leavePage = stubHidingPage()
@@ -1855,9 +1894,14 @@ describe('AIChatManager queued messages', () => {
 		const [display, actual] = saveChat.mock.calls.find(
 			([, messages]) => messages.length > 1
 		) as unknown as [DisplayMessage[], ChatCompletionMessageParam[]]
-		// The unanswered t2 call is cut: persisting it would make the next request
-		// 400 on a dangling tool call.
-		expect(actual.map((m) => m.role)).toEqual(['user', 'assistant', 'tool'])
+		// Both steps are kept, and the unfinished t2 call gets a synthesized result:
+		// leaving it dangling would make the next request 400, dropping it would lose
+		// the step the reader can still see on the card below.
+		expect(actual.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'assistant', 'tool'])
+		expect(actual[actual.length - 1]).toMatchObject({
+			tool_call_id: 't2',
+			content: expect.stringContaining('Interrupted')
+		})
 		// Its card is kept but settled, so reopening the chat doesn't restore a
 		// confirmation prompt with nothing behind it.
 		expect(display.find((m) => m.role === 'tool' && m.tool_call_id === 't2')).toMatchObject({

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -2273,6 +2273,37 @@ describe('AIChatManager queued messages', () => {
 		expect(manager.queuedMessage).toBe('')
 	})
 
+	it('refuses to switch conversation while a turn is running', async () => {
+		const manager = createManager(createInputMock())
+		const loadStored = vi.spyOn(manager.historyManager, 'loadPastChat').mockReturnValue({
+			id: 'chat-b',
+			title: 'Chat B',
+			displayMessages: [{ role: 'user', content: 'belongs to chat B', index: 0 }],
+			actualMessages: [{ role: 'user', content: 'belongs to chat B' }],
+			lastModified: 0
+		} as unknown as ReturnType<typeof manager.historyManager.loadPastChat>)
+		vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			// The user opens History mid-turn. Swapping the transcript in underneath
+			// the turn makes the commit below land on a foreign one — and when the
+			// loaded chat is this one, on top of its own checkpoint.
+			await manager.loadPastChat('chat-b')
+			const message = { role: 'assistant' as const, content: 'done' }
+			config.addedMessages.push(message)
+			return {
+				addedMessages: [message],
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'belongs to chat A' })
+
+		expect(loadStored).not.toHaveBeenCalled()
+		expect(manager.messages.map((m) => m.content)).toEqual(['belongs to chat A', 'done'])
+	})
+
 	it('clears attachments on New chat / load past chat (non-session), keeps them in a session', async () => {
 		const txt = (n: string) => new File(['hello\n'], n, { type: 'text/plain' })
 

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -2304,6 +2304,30 @@ describe('AIChatManager queued messages', () => {
 		expect(manager.messages.map((m) => m.content)).toEqual(['belongs to chat A', 'done'])
 	})
 
+	it('refuses to switch conversation before `loading` has risen', async () => {
+		const manager = createManager(createInputMock())
+		const loadStored = vi.spyOn(manager.historyManager, 'loadPastChat').mockReturnValue({
+			id: 'chat-b',
+			title: 'Chat B',
+			displayMessages: [{ role: 'user', content: 'belongs to chat B', index: 0 }],
+			actualMessages: [{ role: 'user', content: 'belongs to chat B' }],
+			lastModified: 0
+		} as unknown as ReturnType<typeof manager.historyManager.loadPastChat>)
+		vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+		replyWith('done')
+
+		const sent = manager.sendRequest({ instructions: 'belongs to chat A' })
+		// The send is registered but its attachment upkeep hasn't finished, so
+		// `loading` is still false — the window `sendOrQueue` also guards.
+		expect(manager.loading).toBe(false)
+		expect(manager.sendInFlight).toBe(true)
+		await manager.loadPastChat('chat-b')
+		await sent
+
+		expect(loadStored).not.toHaveBeenCalled()
+		expect(manager.messages.map((m) => m.content)).toEqual(['belongs to chat A', 'done'])
+	})
+
 	it('clears attachments on New chat / load past chat (non-session), keeps them in a session', async () => {
 		const txt = (n: string) => new File(['hello\n'], n, { type: 'text/plain' })
 

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1857,6 +1857,44 @@ describe('AIChatManager queued messages', () => {
 		expect(persisted).toEqual(['the first part', 'the first part and more'])
 	})
 
+	it('checkpoints a live reply that repeats an earlier segment verbatim', async () => {
+		const leavePage = stubHidingPage()
+		const manager = createManager()
+		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+		const repeated = 'Let me check that.'
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			// The model said the same sentence before its tool call as it is saying
+			// after it — the staleness heuristic must not read the second one as a
+			// duplicate of the first and drop it.
+			config.addedMessages.push(
+				{
+					role: 'assistant' as const,
+					content: repeated,
+					tool_calls: [
+						{ id: 't1', type: 'function' as const, function: { name: 'do_thing', arguments: '{}' } }
+					]
+				},
+				{ role: 'tool' as const, tool_call_id: 't1', content: 'ok' }
+			)
+			manager.currentReply = repeated
+			leavePage.forEach((fn) => fn())
+			return {
+				addedMessages: config.addedMessages,
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'check the thing' })
+
+		const [display, actual] = saveChat.mock.calls.find(
+			([, messages]) => messages.length > 1
+		) as unknown as [DisplayMessage[], ChatCompletionMessageParam[]]
+		expect(actual[actual.length - 1]).toMatchObject({ role: 'assistant', content: repeated })
+		expect(display[display.length - 1]).toMatchObject({ role: 'assistant', content: repeated })
+	})
+
 	it('checkpoints a turn to history when the page is hidden mid-generation', async () => {
 		const leavePage = stubHidingPage()
 		const manager = createManager()

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1857,6 +1857,63 @@ describe('AIChatManager queued messages', () => {
 		expect(persisted).toEqual(['the first part', 'the first part and more'])
 	})
 
+	it('carries a completed screenshot into a checkpoint of the batch it came from', async () => {
+		const leavePage = stubHidingPage()
+		const manager = createManager()
+		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			// take_screenshot finished and buffered its image, but the batch it belongs
+			// to has another call still pending — so the loop has not yet turned the
+			// buffer into a message.
+			config.addedMessages.push(
+				{
+					role: 'assistant' as const,
+					content: '',
+					tool_calls: [
+						{
+							id: 'shot',
+							type: 'function' as const,
+							function: { name: 'take_screenshot', arguments: '{}' }
+						},
+						{
+							id: 'next',
+							type: 'function' as const,
+							function: { name: 'do_thing', arguments: '{}' }
+						}
+					]
+				},
+				{ role: 'tool' as const, tool_call_id: 'shot', content: 'Screenshot attached below' }
+			)
+			config.callbacks.attachToolImage('shot', {
+				dataUrl: 'data:image/png;base64,iVBORw0KGgo=',
+				name: 'shot.png'
+			})
+			leavePage.forEach((fn) => fn())
+			return {
+				addedMessages: config.addedMessages,
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'look at the app' })
+
+		const [, actual] = saveChat.mock.calls.find(
+			([, messages]) => messages.length > 1
+		) as unknown as [DisplayMessage[], ChatCompletionMessageParam[]]
+		// Without the image the restored history announces a screenshot the model
+		// cannot see, so the next turn cannot answer anything about it.
+		const imageParts = actual.flatMap((m) =>
+			Array.isArray(m.content) ? m.content.filter((p: any) => p.type === 'image_url') : []
+		)
+		expect(imageParts).toHaveLength(1)
+		// And it sits after the batch that produced it, where the live path puts it.
+		const imageIdx = actual.findIndex((m) => Array.isArray(m.content))
+		const resultIdx = actual.findIndex((m) => m.role === 'tool' && m.tool_call_id === 'shot')
+		expect(imageIdx).toBeGreaterThan(resultIdx)
+	})
+
 	it('checkpoints a live reply that repeats an earlier segment verbatim', async () => {
 		const leavePage = stubHidingPage()
 		const manager = createManager()

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -4,6 +4,7 @@ import type { PipelineAIChatHelpers } from './pipeline/core'
 import type { CurrentEditor } from '$lib/components/flows/types'
 import type { ReviewChangesOpts } from './monaco-adapter'
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions.mjs'
+import type { DisplayMessage } from './shared'
 import type { AttachedImage } from './imageUtils'
 import { AIChatManager, AIMode, AIAutonomyMode } from './AIChatManager.svelte'
 import { chatState } from './sharedChatState.svelte'
@@ -1798,6 +1799,72 @@ describe('AIChatManager queued messages', () => {
 		// clean handoff: queued message sent, cancelled prompt NOT shoved back in
 		expect(manager.queuedMessage).toBe('')
 		expect(input.restoreInstructions).not.toHaveBeenCalled()
+	})
+
+	it('checkpoints a turn to history when the page is hidden mid-generation', async () => {
+		// This suite runs under the node env, so stand up the minimum document the
+		// manager needs to hear the page going away.
+		const leavePage = new Set<() => void>()
+		vi.stubGlobal('document', {
+			visibilityState: 'hidden',
+			addEventListener: (_: string, fn: () => void) => leavePage.add(fn),
+			removeEventListener: (_: string, fn: () => void) => leavePage.delete(fn)
+		})
+		const manager = createManager()
+		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+		const toolCall = (id: string, name: string) => ({
+			role: 'assistant' as const,
+			content: '',
+			tool_calls: [{ id, type: 'function' as const, function: { name, arguments: '{}' } }]
+		})
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			// One completed round-trip, then a call still waiting on the user.
+			config.addedMessages.push(
+				toolCall('t1', 'write_script'),
+				{ role: 'tool', tool_call_id: 't1', content: 'created' },
+				toolCall('t2', 'test_run_script')
+			)
+			config.callbacks.setToolStatus('t2', {
+				content: 'Waiting for confirmation...',
+				isLoading: true,
+				needsConfirmation: true
+			})
+			leavePage.forEach((fn) => fn())
+			const message = { role: 'assistant' as const, content: 'done' }
+			config.addedMessages.push({ role: 'tool', tool_call_id: 't2', content: 'ran' }, message)
+			return {
+				addedMessages: config.addedMessages,
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'write and run a script' })
+
+		const [display, actual] = saveChat.mock.calls.find(
+			([, messages]) => messages.length > 1
+		) as unknown as [DisplayMessage[], ChatCompletionMessageParam[]]
+		// The unanswered t2 call is cut: persisting it would make the next request
+		// 400 on a dangling tool call.
+		expect(actual.map((m) => m.role)).toEqual(['user', 'assistant', 'tool'])
+		// Its card is kept but settled, so reopening the chat doesn't restore a
+		// confirmation prompt with nothing behind it.
+		expect(display.find((m) => m.role === 'tool' && m.tool_call_id === 't2')).toMatchObject({
+			isLoading: false,
+			needsConfirmation: false,
+			error: 'Interrupted'
+		})
+		// The turn itself is untouched by the checkpoint and still commits in full.
+		expect(manager.messages.map((m) => m.role)).toEqual([
+			'user',
+			'assistant',
+			'tool',
+			'assistant',
+			'tool',
+			'assistant'
+		])
+		vi.unstubAllGlobals()
 	})
 
 	it('restores consumed DOM selector chips when a turn is cancelled before output', async () => {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1801,15 +1801,25 @@ describe('AIChatManager queued messages', () => {
 		expect(input.restoreInstructions).not.toHaveBeenCalled()
 	})
 
-	it('checkpoints a turn to history when the page is hidden mid-generation', async () => {
-		// This suite runs under the node env, so stand up the minimum document the
-		// manager needs to hear the page going away.
+	// This suite runs under the node env, so stand up the minimum document the
+	// manager needs to hear the page going away. Returns the registered listeners
+	// so a test can play the user leaving.
+	function stubHidingPage() {
 		const leavePage = new Set<() => void>()
 		vi.stubGlobal('document', {
 			visibilityState: 'hidden',
 			addEventListener: (_: string, fn: () => void) => leavePage.add(fn),
 			removeEventListener: (_: string, fn: () => void) => leavePage.delete(fn)
 		})
+		return leavePage
+	}
+
+	// Every checkpoint test installs a fake document; leaking one would make a
+	// single failure cascade through every later test in the file.
+	afterEach(() => vi.unstubAllGlobals())
+
+	it('checkpoints a turn to history when the page is hidden mid-generation', async () => {
+		const leavePage = stubHidingPage()
 		const manager = createManager()
 		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
 		const toolCall = (id: string, name: string) => ({
@@ -1864,7 +1874,57 @@ describe('AIChatManager queued messages', () => {
 			'tool',
 			'assistant'
 		])
-		vi.unstubAllGlobals()
+	})
+
+	it('stops checkpointing once the turn commits, so the transcript is never doubled', async () => {
+		const leavePage = stubHidingPage()
+		const manager = createManager()
+		// The turn-end save is where the race lives: the outcome branch has already
+		// merged the turn into `manager.messages` and is awaiting this call, so a
+		// checkpoint landing here would append the same messages a second time.
+		let leaveDuringFinalSave: () => void = () => {}
+		const saveChat = vi
+			.spyOn(manager.historyManager, 'saveChat')
+			.mockImplementation(async () => leaveDuringFinalSave())
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			const collected = [
+				{
+					role: 'assistant' as const,
+					content: '',
+					tool_calls: [
+						{
+							id: 't1',
+							type: 'function' as const,
+							function: { name: 'write_script', arguments: '{}' }
+						}
+					]
+				},
+				{ role: 'tool' as const, tool_call_id: 't1', content: 'created' },
+				{ role: 'assistant' as const, content: 'done' }
+			]
+			config.addedMessages.push(...collected)
+			leaveDuringFinalSave = () => leavePage.forEach((fn) => fn())
+			return {
+				addedMessages: collected,
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'write a script' })
+		await Promise.resolve()
+
+		// A duplicated transcript repeats t1, which providers reject outright — so
+		// no persisted call may carry the same tool_call_id twice.
+		for (const [, messages] of saveChat.mock.calls as unknown as [
+			unknown,
+			ChatCompletionMessageParam[]
+		][]) {
+			const toolCallIds = messages.flatMap((m: any) => m.tool_calls?.map((c: any) => c.id) ?? [])
+			expect(toolCallIds).toEqual([...new Set(toolCallIds)])
+		}
+		expect(manager.messages.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'assistant'])
 	})
 
 	it('restores consumed DOM selector chips when a turn is cancelled before output', async () => {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1914,34 +1914,30 @@ describe('AIChatManager queued messages', () => {
 		expect(imageIdx).toBeGreaterThan(resultIdx)
 	})
 
-	it('tells flushed-but-uncommitted text from text the parser already pushed', async () => {
+	it('does not repeat a preamble the parser has already pushed', async () => {
 		const leavePage = stubHidingPage()
 		const manager = createManager()
 		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
 		const preamble = 'Let me look that up.'
-		let lastSaved: ChatCompletionMessageParam[] = []
-		saveChat.mockImplementation(async (_display, messages) => {
-			lastSaved = messages as ChatCompletionMessageParam[]
-		})
-		let beforePush: ChatCompletionMessageParam[] = []
-		let afterPush: ChatCompletionMessageParam[] = []
 
 		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
-			// Parsers call onMessageEnd BEFORE pushing when text gives way to a tool
-			// call, and AFTER pushing when a message finishes. Only the second means
-			// the text is already in the transcript.
+			// A text-then-tool-call turn in parser order: the preamble is flushed when
+			// the tool call starts, pushed when the message completes, and only then
+			// do the tools run — the long window a checkpoint is most likely to land in.
 			manager.currentReply = preamble
-			config.callbacks.onMessageEnd() // pre-push flush: text is uncommitted
+			config.callbacks.onMessageEnd()
+			config.addedMessages.push(
+				{ role: 'assistant' as const, content: preamble },
+				{
+					role: 'assistant' as const,
+					content: '',
+					tool_calls: [
+						{ id: 't1', type: 'function' as const, function: { name: 'do_thing', arguments: '{}' } }
+					]
+				},
+				{ role: 'tool' as const, tool_call_id: 't1', content: 'ok' }
+			)
 			leavePage.forEach((fn) => fn())
-			beforePush = lastSaved
-
-			const answer = { role: 'assistant' as const, content: preamble }
-			config.addedMessages.push(answer)
-			manager.currentReply = preamble
-			config.callbacks.onMessageEnd() // post-push flush: text is committed
-			leavePage.forEach((fn) => fn())
-			afterPush = lastSaved
-
 			return {
 				addedMessages: config.addedMessages,
 				tokenUsage: { prompt: 0, completion: 0, total: 0 },
@@ -1951,10 +1947,12 @@ describe('AIChatManager queued messages', () => {
 
 		await manager.sendRequest({ instructions: 'look something up' })
 
-		// Uncommitted: the checkpoint has to carry it, or it is lost.
-		expect(beforePush.filter((m) => m.content === preamble)).toHaveLength(1)
-		// Committed: carrying it again would show the answer twice on reload.
-		expect(afterPush.filter((m) => m.content === preamble)).toHaveLength(1)
+		const [, actual] = saveChat.mock.calls.find(
+			([, messages]) => messages.length > 1
+		) as unknown as [DisplayMessage[], ChatCompletionMessageParam[]]
+		// Reading flushed text back would show the preamble twice on reload; the
+		// transcript already holds it, so the checkpoint must take it from there.
+		expect(actual.filter((m) => m.content === preamble)).toHaveLength(1)
 	})
 
 	it('checkpoints a live reply that repeats an earlier segment verbatim', async () => {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -1914,6 +1914,49 @@ describe('AIChatManager queued messages', () => {
 		expect(imageIdx).toBeGreaterThan(resultIdx)
 	})
 
+	it('tells flushed-but-uncommitted text from text the parser already pushed', async () => {
+		const leavePage = stubHidingPage()
+		const manager = createManager()
+		const saveChat = vi.spyOn(manager.historyManager, 'saveChat').mockResolvedValue(undefined)
+		const preamble = 'Let me look that up.'
+		let lastSaved: ChatCompletionMessageParam[] = []
+		saveChat.mockImplementation(async (_display, messages) => {
+			lastSaved = messages as ChatCompletionMessageParam[]
+		})
+		let beforePush: ChatCompletionMessageParam[] = []
+		let afterPush: ChatCompletionMessageParam[] = []
+
+		mocks.runChatLoop.mockImplementationOnce(async (config: any) => {
+			// Parsers call onMessageEnd BEFORE pushing when text gives way to a tool
+			// call, and AFTER pushing when a message finishes. Only the second means
+			// the text is already in the transcript.
+			manager.currentReply = preamble
+			config.callbacks.onMessageEnd() // pre-push flush: text is uncommitted
+			leavePage.forEach((fn) => fn())
+			beforePush = lastSaved
+
+			const answer = { role: 'assistant' as const, content: preamble }
+			config.addedMessages.push(answer)
+			manager.currentReply = preamble
+			config.callbacks.onMessageEnd() // post-push flush: text is committed
+			leavePage.forEach((fn) => fn())
+			afterPush = lastSaved
+
+			return {
+				addedMessages: config.addedMessages,
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		await manager.sendRequest({ instructions: 'look something up' })
+
+		// Uncommitted: the checkpoint has to carry it, or it is lost.
+		expect(beforePush.filter((m) => m.content === preamble)).toHaveLength(1)
+		// Committed: carrying it again would show the answer twice on reload.
+		expect(afterPush.filter((m) => m.content === preamble)).toHaveLength(1)
+	})
+
 	it('checkpoints a live reply that repeats an earlier segment verbatim', async () => {
 		const leavePage = stubHidingPage()
 		const manager = createManager()

--- a/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { randomUUID } from '$lib/utils/uuid'
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions.mjs'
-import { runChatLoop, truncateToToolPairedPrefix, type ChatLoopConfig } from './chatLoop'
+import {
+	closeInterruptedToolBatch,
+	runChatLoop,
+	truncateToToolPairedPrefix,
+	type ChatLoopConfig
+} from './chatLoop'
 import type { ReasoningProviderModel } from '../reasoningRegistry'
 
 const mocks = vi.hoisted(() => ({
@@ -552,6 +557,25 @@ const tool = (id: string): ChatCompletionMessageParam => ({
 	content: 'result'
 })
 const user = (content: string): ChatCompletionMessageParam => ({ role: 'user', content })
+
+describe('closeInterruptedToolBatch', () => {
+	it('keeps the answered half of a batch still executing, pairing the rest', () => {
+		// The model asked for two tools in one message; the first wrote a script
+		// (a real side effect) and the second is still going. Truncating would drop
+		// both, so the restored chat would not know the script exists.
+		const msgs = [assistantTools('a', 'b'), tool('a')]
+		expect(closeInterruptedToolBatch(msgs, 'stopped')).toEqual([
+			assistantTools('a', 'b'),
+			tool('a'),
+			{ role: 'tool', tool_call_id: 'b', content: 'stopped' }
+		])
+	})
+
+	it('leaves an already-paired transcript alone', () => {
+		const msgs = [assistantTools('a'), tool('a'), assistant('done')]
+		expect(closeInterruptedToolBatch(msgs, 'stopped')).toEqual(msgs)
+	})
+})
 
 describe('truncateToToolPairedPrefix', () => {
 	it('returns an empty array unchanged', () => {

--- a/frontend/src/lib/components/copilot/chat/chatLoop.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.ts
@@ -127,15 +127,9 @@ export function truncateToToolPairedPrefix(
 /**
  * Like `truncateToToolPairedPrefix`, but closes the batch it would have dropped:
  * every call in the trailing `tool_calls` message still missing a result gets one
- * saying it was interrupted.
- *
- * A model emits a whole batch as one assistant message and the parsers execute
- * its calls one at a time, so a snapshot taken mid-batch has real results for the
- * calls that finished. Truncating discards those along with the unanswered ones —
- * fine for a live turn that is about to continue, but for a transcript that has to
- * outlive its turn it throws away completed steps whose side effects (a written
- * script, a deployed flow) are already real. Synthesizing the missing results
- * keeps them as context and matches what their cards show the reader.
+ * saying it was interrupted. A batch's calls execute one at a time, so truncating
+ * it discards steps that already finished — and whose side effects are already
+ * real. For a snapshot that must outlive its turn, keeping them beats a clean cut.
  */
 export function closeInterruptedToolBatch(
 	messages: ChatCompletionMessageParam[],

--- a/frontend/src/lib/components/copilot/chat/chatLoop.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.ts
@@ -124,6 +124,44 @@ export function truncateToToolPairedPrefix(
 	return messages.slice(0, lastValidLen)
 }
 
+/**
+ * Like `truncateToToolPairedPrefix`, but closes the batch it would have dropped:
+ * every call in the trailing `tool_calls` message still missing a result gets one
+ * saying it was interrupted.
+ *
+ * A model emits a whole batch as one assistant message and the parsers execute
+ * its calls one at a time, so a snapshot taken mid-batch has real results for the
+ * calls that finished. Truncating discards those along with the unanswered ones —
+ * fine for a live turn that is about to continue, but for a transcript that has to
+ * outlive its turn it throws away completed steps whose side effects (a written
+ * script, a deployed flow) are already real. Synthesizing the missing results
+ * keeps them as context and matches what their cards show the reader.
+ */
+export function closeInterruptedToolBatch(
+	messages: ChatCompletionMessageParam[],
+	interruptedContent: string
+): ChatCompletionMessageParam[] {
+	const paired = truncateToToolPairedPrefix(messages)
+	const rest = messages.slice(paired.length)
+	const batch = rest[0]
+	if (batch?.role !== 'assistant' || !batch.tool_calls?.length) return paired
+	// Results for THIS batch only, stopping at the first non-tool message:
+	// anything past a still-pending batch was never valid context.
+	const batchIds = new Set(batch.tool_calls.map((c) => c.id))
+	const answers: ChatCompletionMessageParam[] = []
+	const answered = new Set<string>()
+	for (const m of rest.slice(1)) {
+		if (m.role !== 'tool') break
+		if (!batchIds.has(m.tool_call_id)) continue
+		answers.push(m)
+		answered.add(m.tool_call_id)
+	}
+	const interrupted = [...batchIds]
+		.filter((id) => !answered.has(id))
+		.map((id) => ({ role: 'tool' as const, tool_call_id: id, content: interruptedContent }))
+	return [...paired, batch, ...answers, ...interrupted]
+}
+
 const unsupportedWebSearchCache = new Set<string>()
 const WEB_SEARCH_UNAVAILABLE_STATUS_CODES = new Set([400, 403, 404])
 

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -1024,20 +1024,29 @@ export async function processToolCall<T>({
  * id is already answered by its tool result before this non-tool message. The image
  * parts ride the same `image_url` carrier that the provider converters translate.
  */
-export function appendPendingToolImages(
-	messages: ChatCompletionMessageParam[],
-	addedMessages: ChatCompletionMessageParam[],
-	toolCallbacks: ToolCallbacks
-): void {
-	const images = toolCallbacks.takePendingToolImages?.() ?? []
-	if (images.length === 0) return
-	const message: ChatCompletionMessageParam = {
+/** The message that hands tool-produced images to the model, or undefined when
+ *  there are none. Split out so a snapshot of a turn still buffering them can
+ *  build the same message without draining the buffer the live turn still owns. */
+export function pendingToolImagesMessage(
+	images: AttachedImage[]
+): ChatCompletionMessageParam | undefined {
+	if (images.length === 0) return undefined
+	return {
 		role: 'user',
 		content: [
 			{ type: 'text', text: 'Screenshot(s) of the app preview:' },
 			...images.map((img) => dataUrlToImagePart(img.dataUrl))
 		]
 	}
+}
+
+export function appendPendingToolImages(
+	messages: ChatCompletionMessageParam[],
+	addedMessages: ChatCompletionMessageParam[],
+	toolCallbacks: ToolCallbacks
+): void {
+	const message = pendingToolImagesMessage(toolCallbacks.takePendingToolImages?.() ?? [])
+	if (!message) return
 	messages.push(message)
 	addedMessages.push(message)
 }

--- a/frontend/src/lib/components/copilot/chat/typewriterReveal.test.ts
+++ b/frontend/src/lib/components/copilot/chat/typewriterReveal.test.ts
@@ -73,6 +73,26 @@ describe('TypewriterReveal', () => {
 		expect(revealed().length).toBeLessThan(text.length)
 	})
 
+	it('exposes un-revealed text without advancing or ending the reveal', () => {
+		const sched = new FakeScheduler()
+		const { reveal, revealed } = makeReveal(sched)
+		const text = 'x'.repeat(300)
+		reveal.push(text)
+		sched.frame(16)
+		// A hidden tab stops scheduling frames while text keeps arriving, so a
+		// caller that must account for everything received reads `pending` — and
+		// reading it must not paint or stop the animation the way flush() does.
+		expect(revealed() + reveal.pending).toBe(text)
+		expect(reveal.pending.length).toBeGreaterThan(0)
+		const paintedBefore = revealed()
+		expect(reveal.pending).toBe(text.slice(paintedBefore.length))
+		expect(revealed()).toBe(paintedBefore)
+		// Still animating: further frames keep painting, which flush() would have
+		// prevented by ending the reveal.
+		sched.frames(3, 34)
+		expect(revealed().length).toBeGreaterThan(paintedBefore.length)
+	})
+
 	it('preserves text exactly after flush (no loss, no duplication)', () => {
 		const sched = new FakeScheduler()
 		const { reveal, revealed } = makeReveal(sched)

--- a/frontend/src/lib/components/copilot/chat/typewriterReveal.ts
+++ b/frontend/src/lib/components/copilot/chat/typewriterReveal.ts
@@ -87,6 +87,15 @@ export class TypewriterReveal {
 		this.ensureRunning()
 	}
 
+	/** Text that has arrived but has not been revealed yet. Lets a caller that must
+	 *  account for everything the model has sent — not just what has been painted —
+	 *  read it without disturbing the pacing. `flush()` is the wrong tool there: it
+	 *  ends the animation. The gap it covers is unbounded, because a hidden tab
+	 *  pauses the paint loop while text keeps arriving. */
+	get pending(): string {
+		return this.buffer.slice(this.revealed)
+	}
+
 	/** Reveal everything still buffered now and stop. Call before reading the
 	 *  owner's reactive state into committed state, so the read sees the full text. */
 	flush(): void {


### PR DESCRIPTION
## What's broken

Start an AI chat turn, leave the page before it finishes, come back: everything except your first message is gone.

The chat's agent loop runs entirely in the browser tab. A turn was written to storage exactly twice: once when your message went in, once when the turn finished. Everything in between lived only in memory. Close or reload the tab in that window and the whole turn went with it.

The worst part is that the work was real. In the repro, the model had already created a script draft. After the reload that draft was sitting in the workspace, but the conversation had no idea it existed.

This is why it felt intermittent: if the turn happened to finish before you came back, the end-of-turn save caught everything and nothing looked wrong.

## What this changes

A turn is now saved *while it runs*, not just at its edges. Concretely, that means calling the same `saveChat` that already existed, at more moments, with a transcript assembled from the turn's in-flight state.

**When it runs.** A 2s timer. Each tick compares a small fingerprint (messages collected, transcript rows, answer text received) and returns immediately if nothing changed. So a turn parked on a confirmation ticks and writes nothing; an active turn writes at most once every 2s. There is also one forced write when the page goes hidden, which is the last moment a write can still complete before a close or reload.

**What it costs you.** At most a couple of seconds of a turn, instead of all of it.

## What this does *not* change

- **The generation still stops when the tab dies.** There's no server-side loop to resume. You come back to a stopped turn that you can continue by sending a message, not to one still running.
- **Navigating inside Windmill was already safe** and still is. The chat lives in a module singleton and session runtimes are cached, so switching pages or session tabs never interrupted anything.

## The details it has to get right

Each of these is small, and each one was a bug caught in review. The first is the one worth a careful look.

| | |
|---|---|
| **Stop before the commit** | The end-of-turn code merges the turn into the transcript and *then* saves. A checkpoint landing in that window would append the same messages again and, queued behind the real save, win — producing duplicate `tool_call` ids that providers reject. So checkpointing stops the moment the loop returns, not in `finally`. |
| **Settle in-flight tool cards** | A card saved mid-run restores spinning forever, and a staged confirmation restores with Run/Reject buttons nothing is listening to. This also fixes the same gap on the existing Stop path. |
| **Keep the finished half of a batch** | A model can request several tools in one message, and they run one at a time. Dropping an unfinished batch also drops the calls that already completed, whose side effects are already real. Unfinished calls get a synthesized "interrupted" result instead. |
| **Carry buffered screenshots** | A screenshot only becomes a message once its whole batch finishes, so a batch saved mid-run would otherwise reference an image the model can't see. |
| **Capture text as it arrives, not as it's painted** | A hidden tab pauses the animation frames the typewriter runs on, so painted text freezes while text keeps arriving. |
| **Don't store a stale context size** | It measures the pre-turn history, so keeping it would under-report a restored chat by the whole partial turn — enough to skip the compaction its next send needs. |
| **Don't swap the transcript mid-turn** | Switching conversation from the History menu while a turn runs made it commit onto a different transcript. The entries are now disabled while generating. |

## Screenshots

A multi-tool turn interrupted by a reload, restored in full:

![restored-transcript-top](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ai-chat-message-loss-mid-generation/1787395669-restored-transcript-top.png)

A turn that was parked on a tool confirmation when the page went away. The staged call comes back as a settled card showing what it was about to run, with no Run/Reject footer:

![restored-after-reload](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ai-chat-message-loss-mid-generation/1787395671-restored-after-reload.png)

## Test plan

Driven against Anthropic through the real `/ai/proxy` on a local instance.

- [x] Reload mid tool-batch: all 17 model messages and 3 drafts restored, and a follow-up answers from the restored history
- [x] Reload while parked on a confirmation: full transcript plus an interrupted card, no dead buttons, model correctly recalls what it had done
- [x] Reload mid streamed answer: 10,221 characters of context restored, and the visible bubble matches it exactly
- [x] Backgrounded tab with animation frames stubbed out: capture keeps advancing (5560 → 8979 chars) where it used to freeze
- [x] Clean turn with repeated hide events: no duplicated or unpaired tool calls, real context size preserved
- [x] Follow-up on a conversation restored from a synthesized batch close: provider returns 200, not a rejection
- [x] Every regression test confirmed to fail when its own fix is reverted
- [x] `npm run check` 0 errors; 1004 passing in `src/lib/components/copilot/chat/` (6 failures there are pre-existing on main, in `ContextManager.test.ts` and `app/core.test.ts`)
- [x] Write cost measured in-browser: 22 ms per checkpoint on a 1.7 MB transcript, 32x larger than the biggest real chat, capped at one write per 2s

## Note for later

The checkpoint composes a transcript rather than appending to the live one, because a turn's messages aren't committed until its outcome is known. A cleaner shape would append at tool-batch boundaries, which needs a "step completed" event from the provider parsers. That's a change to the loop's contract and is deliberately not in this PR.
