### PR TITLE
style(frontend): tighten spacing between login email and password fields

### DIFF
--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -732,7 +732,7 @@
 						contact@windmill.dev
 					</p>
 				{/if}
-				<div bind:this={fieldsEl} class="space-y-6 {shake ? 'motion-safe:animate-shake' : ''}">
+				<div bind:this={fieldsEl} class="space-y-2 {shake ? 'motion-safe:animate-shake' : ''}">
 					<div class="space-y-1">
 						<label for={emailId} class="block text-xs font-semibold text-emphasis"> Email </label>
 						<div>


### PR DESCRIPTION
## Summary

The email and password fields on the login form sat 48px apart, which read as two
unrelated sections rather than one credential pair. Each field already reserves a 20px
line below it for its error message (`min-h-5`), and the container added another 24px on
top of that.

Dropping the container from `space-y-6` to `space-y-2` brings the gap to 32px, with the
reserved error line still carrying most of the separation — so a failed attempt still
renders its message without shifting the layout.

## Changes

- `frontend/src/lib/components/Login.svelte`: fields container `space-y-6` → `space-y-2`

## Screenshots

Before (48px):

![login-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/login-nit/1787558204-login-before.png)

After (32px):

![login-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/login-nit/1787558207-login-space2.png)

## Test plan

- [ ] Open `/user/login` with password login enabled — email and password read as one pair
- [ ] Submit bad credentials — the error message renders in the reserved slot under the
      password field with no layout shift and no overlap of the neighbouring field