### PR TITLE
fix(frontend): mint string password secrets in the operating workspace

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -841,6 +841,7 @@
 							{disablePortal}
 							{disabled}
 							{prettifyHeader}
+							{workspace}
 							{schema}
 							bind:args={value}
 						/>
@@ -983,6 +984,7 @@
 															{disablePortal}
 															{disabled}
 															{prettifyHeader}
+															{workspace}
 															schema={getSchemaFromProperties(itemsType?.properties)}
 															bind:args={value[i]}
 														/>
@@ -1150,6 +1152,7 @@
 											{disablePortal}
 											{disabled}
 											{prettifyHeader}
+											{workspace}
 											bind:schema={
 												() => ({
 													properties: obj.properties ?? {},
@@ -1186,6 +1189,7 @@
 											{disabled}
 											{prettifyHeader}
 											{chatInputEnabled}
+											{workspace}
 											hiddenArgs={['label', 'kind']}
 											schema={{
 												properties: obj.properties,
@@ -1270,6 +1274,7 @@
 							{disablePortal}
 							{disabled}
 							{prettifyHeader}
+							{workspace}
 							schema={{
 								properties,
 								$schema: '',
@@ -1301,6 +1306,7 @@
 							{disablePortal}
 							{disabled}
 							{prettifyHeader}
+							{workspace}
 							schema={{
 								properties,
 								order,
@@ -1471,7 +1477,7 @@
 								/>
 							{/if}
 						{:else}
-							<PasswordArgInput {disabled} minRows={extra?.['minRows']} bind:value />
+							<PasswordArgInput {disabled} minRows={extra?.['minRows']} {workspace} bind:value />
 						{/if}
 					{:else}
 						{#key extra?.['minRows']}

--- a/frontend/src/lib/components/ArrayTypeNarrowing.svelte
+++ b/frontend/src/lib/components/ArrayTypeNarrowing.svelte
@@ -25,13 +25,15 @@
 			  }
 			| undefined
 		nonEmpty?: boolean | undefined
+		workspace?: string | undefined
 	}
 
 	let {
 		canEditResourceType = false,
 		originalType = undefined,
 		itemsType = $bindable(),
-		nonEmpty = $bindable()
+		nonEmpty = $bindable(),
+		workspace
 	}: Props = $props()
 
 	let selected:
@@ -199,6 +201,7 @@
 	/>
 	{#if itemsType?.properties != undefined}
 		<EditableSchemaDrawer
+			{workspace}
 			bind:schema={
 				() => {
 					return {

--- a/frontend/src/lib/components/EditableSchemaForm.svelte
+++ b/frontend/src/lib/components/EditableSchemaForm.svelte
@@ -124,6 +124,8 @@
 		workspace = undefined
 	}: Props = $props()
 
+	let ws = $derived(workspace ?? $workspaceStore)
+
 	$effect.pre(() => {
 		if (args == undefined) {
 			args = {}
@@ -914,7 +916,7 @@
 		documentationLink="https://www.windmill.dev/docs/core_concepts/variables_and_secrets"
 		extraField="path"
 		loadItems={async () =>
-			(await VariableService.listVariable({ workspace: $workspaceStore ?? '' })).map((x) => ({
+			(await VariableService.listVariable({ workspace: ws ?? '' })).map((x) => ({
 				name: x.path,
 				...x
 			}))}
@@ -933,7 +935,7 @@
 		{/snippet}
 	</ItemPicker>
 
-	<VariableEditor bind:this={variableEditor} />
+	<VariableEditor bind:this={variableEditor} workspace={ws} />
 {/if}
 
 <style>

--- a/frontend/src/lib/components/EditableSchemaForm.svelte
+++ b/frontend/src/lib/components/EditableSchemaForm.svelte
@@ -82,6 +82,7 @@
 		extraTab?: import('svelte').Snippet
 		schemaFormClassName?: string
 		onChange?: (args: Record<string, any>) => void
+		workspace?: string | undefined
 	}
 
 	let {
@@ -119,7 +120,8 @@
 		runButton,
 		extraTab,
 		schemaFormClassName = undefined,
-		onChange = undefined
+		onChange = undefined,
+		workspace = undefined
 	}: Props = $props()
 
 	$effect.pre(() => {
@@ -437,6 +439,7 @@
 							{hiddenArgs}
 							{disableDnd}
 							{onlyMaskPassword}
+							{workspace}
 							bind:args
 							on:click={(e) => {
 								opened = e.detail
@@ -682,6 +685,7 @@
 															{isFlowInput}
 															{isAppInput}
 															{showSensitiveToggle}
+															{workspace}
 														>
 															{#snippet typeeditor()}
 																{#if isFlowInput || isAppInput}
@@ -809,6 +813,7 @@
 
 															{#if isFlowInput || isAppInput}
 																<FlowPropertyEditor
+																	{workspace}
 																	onDrawerClose={() => {
 																		dndType = generateRandomString()
 																	}}

--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -94,6 +94,7 @@
 		allowedAiTransforms?: string[] | undefined
 		s3StorageConfigured?: boolean
 		chatInputEnabled?: boolean
+		workspace?: string | undefined
 	}
 
 	let {
@@ -131,7 +132,8 @@
 		isAgentTool = false,
 		allowedAiTransforms = isAgentTool ? undefined : [],
 		s3StorageConfigured = true,
-		chatInputEnabled = false
+		chatInputEnabled = false,
+		workspace
 	}: Props = $props()
 
 	let monaco: SimpleEditor | undefined = $state(undefined)
@@ -882,6 +884,7 @@
 							{:else if (propertyType === undefined || propertyType == 'static') && schema?.properties?.[argName]}
 								<ArgInput
 									{resourceTypes}
+									{workspace}
 									noMargin
 									compact
 									on:focus={onFocus}

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -28,6 +28,7 @@
 		isAgentTool?: boolean
 		allowedAiTransforms?: string[] | undefined
 		chatInputEnabled?: boolean
+		workspace?: string | undefined
 	}
 
 	let {
@@ -44,7 +45,8 @@
 		helperScript = undefined,
 		isAgentTool = false,
 		allowedAiTransforms = isAgentTool ? undefined : [],
-		chatInputEnabled = false
+		chatInputEnabled = false,
+		workspace
 	}: Props = $props()
 
 	let inputCheck: { [id: string]: boolean } = $state({})
@@ -146,6 +148,7 @@
 						{allowedAiTransforms}
 						{s3StorageConfigured}
 						{chatInputEnabled}
+						{workspace}
 						otherArgs={Object.fromEntries(
 							Object.entries(args ?? {}).filter(([key]) => key !== argName)
 						)}

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -49,6 +49,8 @@
 		workspace
 	}: Props = $props()
 
+	let ws = $derived(workspace ?? $workspaceStore)
+
 	let inputCheck: { [id: string]: boolean } = $state({})
 
 	$effect(() => {
@@ -83,8 +85,8 @@
 
 	async function checkS3Storage() {
 		try {
-			if ($workspaceStore) {
-				const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore })
+			if (ws) {
+				const settings = await WorkspaceService.getPublicSettings({ workspace: ws })
 				s3StorageConfigured = settings.large_file_storage?.s3_resource_path !== undefined
 			}
 		} catch (error) {
@@ -171,7 +173,7 @@
 	itemName="Variable"
 	extraField="path"
 	loadItems={async () =>
-		(await VariableService.listVariable({ workspace: $workspaceStore ?? '' })).map((x) => ({
+		(await VariableService.listVariable({ workspace: ws ?? '' })).map((x) => ({
 			name: x.path,
 			...x
 		}))}
@@ -192,4 +194,4 @@
 	{/snippet}
 </ItemPicker>
 
-<VariableEditor bind:this={variableEditor} />
+<VariableEditor bind:this={variableEditor} workspace={ws} />

--- a/frontend/src/lib/components/ModulePreviewForm.svelte
+++ b/frontend/src/lib/components/ModulePreviewForm.svelte
@@ -13,6 +13,7 @@
 	import type SimpleEditor from './SimpleEditor.svelte'
 	import { getResourceTypes } from './resourceTypesStore'
 	import { twMerge } from 'tailwind-merge'
+	import { workspaceStore } from '$lib/stores'
 
 	interface Props {
 		schema: Schema | { properties?: Record<string, any>; required?: string[] }
@@ -32,8 +33,10 @@
 		focusArg = undefined
 	}: Props = $props()
 
-	const { stepsInputArgs, flowStateStore, flowStore, previewArgs } =
+	const { stepsInputArgs, flowStateStore, flowStore, previewArgs, opWorkspace } =
 		getContext<FlowEditorContext>('FlowEditorContext')
+
+	let opWs = $derived(opWorkspace?.() ?? $workspaceStore)
 
 	let inputCheck: { [id: string]: boolean } = $state({})
 	$effect(() => {
@@ -152,6 +155,7 @@
 								nullable={schema.properties[argName].nullable}
 								title={schema.properties[argName].title}
 								placeholder={schema.properties[argName].placeholder}
+								workspace={opWs}
 							>
 								{#snippet fieldHeaderActions()}
 									{#if stepsInputArgs?.isArgManuallySet(mod.id, argName)}

--- a/frontend/src/lib/components/PasswordArgInput.svelte
+++ b/frontend/src/lib/components/PasswordArgInput.svelte
@@ -2,6 +2,7 @@
 	import { VariableService } from '$lib/gen'
 	import { userStore, workspaceStore } from '$lib/stores'
 	import { generateRandomString } from '$lib/utils'
+	import { sendUserToast } from '$lib/toast'
 	import { Button } from './common'
 	import Password from './Password.svelte'
 	import { untrack } from 'svelte'
@@ -10,11 +11,18 @@
 		value?: string | undefined
 		disabled: boolean
 		minRows?: number
+		/** Workspace the ephemeral secret is minted in; defaults to the nav workspace.
+		 * Session editors pass their acting workspace. */
+		workspace?: string | undefined
 	}
 
-	let { value = $bindable(undefined), disabled, minRows }: Props = $props()
+	let { value = $bindable(undefined), disabled, minRows, workspace }: Props = $props()
+
+	let ws = $derived(workspace ?? $workspaceStore)
 
 	let path = $state('')
+	// Workspace the variable at `path` actually lives in; `ws` can move away from it.
+	let mintedIn = $state<string | undefined>(undefined)
 	let password = $state(
 		value && typeof value === 'string' && !value.startsWith('$var:') ? value : ''
 	)
@@ -27,11 +35,12 @@
 	async function generateValue() {
 		if (isGenerating) return
 		isGenerating = true
+		const mintWs = ws!
 		try {
 			let npath = userPrefix + generateRandomString(12)
 			let nvalue = '$var:' + npath
 			await VariableService.createVariable({
-				workspace: $workspaceStore!,
+				workspace: mintWs,
 				requestBody: {
 					value: password,
 					is_secret: true,
@@ -41,6 +50,7 @@
 				}
 			})
 			path = npath
+			mintedIn = mintWs
 			console.log('generated', nvalue)
 			value = nvalue
 			debouncedUpdate()
@@ -52,7 +62,7 @@
 	async function updateValue() {
 		try {
 			await VariableService.updateVariable({
-				workspace: $workspaceStore!,
+				workspace: mintedIn ?? ws!,
 				path: path,
 				requestBody: {
 					value: password
@@ -74,11 +84,25 @@
 	})
 
 	$effect(() => {
-		$workspaceStore &&
+		ws &&
 			($userStore?.username || $userStore?.email) &&
 			path == '' &&
 			password != '' &&
 			untrack(() => generateValue())
+	})
+
+	// The operating workspace can move after minting (a session forking, say), leaving the
+	// variable behind where the job will not find it: mint a fresh one in the new workspace.
+	// Bounded to a live instance: a field mounted onto an existing `$var:` holds neither the
+	// plaintext nor the workspace it was minted in, so it can only be moved by retyping it.
+	$effect(() => {
+		const cur = ws
+		if (!cur || path === '' || password === '' || mintedIn === cur) return
+		untrack(() =>
+			generateValue().catch((e) =>
+				sendUserToast(`Could not create the secret in ${cur}: ${e?.body ?? e?.message ?? e}`, true)
+			)
+		)
 	})
 </script>
 

--- a/frontend/src/lib/components/PasswordArgInput.svelte
+++ b/frontend/src/lib/components/PasswordArgInput.svelte
@@ -23,9 +23,16 @@
 	let path = $state('')
 	// Workspace the variable at `path` actually lives in; `ws` can move away from it.
 	let mintedIn = $state<string | undefined>(undefined)
-	let password = $state(
-		value && typeof value === 'string' && !value.startsWith('$var:') ? value : ''
-	)
+	// What the field mints from: an argument already holding a `$var:` ref has nothing to mint.
+	function plaintextOf(v: unknown): string {
+		return typeof v === 'string' && v !== '' && !v.startsWith('$var:') ? v : ''
+	}
+	let password = $state(plaintextOf(value))
+
+	// The argument no longer holds what this field would mint from — a parent can replace the whole
+	// args object without remounting it (previewing a saved input, say). Minting now would describe a
+	// secret the argument does not point at, and binding it would discard the replacement.
+	let argReplaced = $derived(path !== '' && value !== '$var:' + path)
 
 	let isGenerating = false
 
@@ -33,9 +40,10 @@
 		'u/' + ($userStore?.username ?? $userStore?.email)?.split('@')[0] + '/secret_arg/'
 	)
 	async function generateValue() {
-		if (isGenerating) return
+		if (isGenerating || argReplaced) return
 		isGenerating = true
 		const mintWs = ws!
+		const boundBefore = value
 		try {
 			let npath = userPrefix + generateRandomString(12)
 			let nvalue = '$var:' + npath
@@ -49,17 +57,33 @@
 					expires_at: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString()
 				}
 			})
+			// The arg can be replaced the same way while the create is in flight. Nothing ever
+			// referenced the variable just minted, so delete it; it expires on its own if that fails.
+			if (value !== boundBefore) {
+				VariableService.deleteVariable({ workspace: mintWs, path: npath }).catch(() => {})
+				return
+			}
 			path = npath
 			mintedIn = mintWs
 			console.log('generated', nvalue)
 			value = nvalue
 			debouncedUpdate()
 		} finally {
+			// Ended without binding: discarded just above, or the create failed after the argument
+			// moved. The field would otherwise keep showing a secret the argument does not hold, and
+			// the mint effect tracks `ws` — a workspace move would bind that stale plaintext over the
+			// replacement. Re-seeding leaves the field describing the argument again.
+			if (path === '' && value !== boundBefore) {
+				password = plaintextOf(value)
+			}
 			isGenerating = false
 		}
 	}
 
 	async function updateValue() {
+		// The first keystroke queues an update before anything is minted: letting it run would 404 and
+		// retry the mint, binding over an argument that was replaced while the first mint was in flight.
+		if (path === '') return
 		try {
 			await VariableService.updateVariable({
 				workspace: mintedIn ?? ws!,
@@ -88,7 +112,13 @@
 			($userStore?.username || $userStore?.email) &&
 			path == '' &&
 			password != '' &&
-			untrack(() => generateValue())
+			untrack(() =>
+				// A failed mint leaves the plaintext bound to nothing and the argument empty. Only a
+				// further keystroke re-runs this, so say so rather than submitting the job without it.
+				generateValue().catch((e) =>
+					sendUserToast(`Could not create the secret: ${e?.body ?? e?.message ?? e}`, true)
+				)
+			)
 	})
 
 	// The operating workspace can move after minting (a session forking, say), leaving the
@@ -97,7 +127,7 @@
 	// plaintext nor the workspace it was minted in, so it can only be moved by retyping it.
 	$effect(() => {
 		const cur = ws
-		if (!cur || path === '' || password === '' || mintedIn === cur) return
+		if (!cur || path === '' || password === '' || mintedIn === cur || argReplaced) return
 		untrack(() =>
 			generateValue().catch((e) =>
 				sendUserToast(`Could not create the secret in ${cur}: ${e?.body ?? e?.message ?? e}`, true)

--- a/frontend/src/lib/components/PasswordArgInput.svelte
+++ b/frontend/src/lib/components/PasswordArgInput.svelte
@@ -84,6 +84,7 @@
 		// The first keystroke queues an update before anything is minted: letting it run would 404 and
 		// retry the mint, binding over an argument that was replaced while the first mint was in flight.
 		if (path === '') return
+		const updating = path
 		try {
 			await VariableService.updateVariable({
 				workspace: mintedIn ?? ws!,
@@ -93,7 +94,12 @@
 				}
 			})
 		} catch (e) {
-			generateValue()
+			// A re-mint can bind a fresh variable while this update is in flight; recovering then
+			// would orphan the one it just bound.
+			if (path !== updating) return
+			generateValue().catch((e) =>
+				sendUserToast(`Could not create the secret: ${e?.body ?? e?.message ?? e}`, true)
+			)
 		}
 	}
 

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -2019,6 +2019,7 @@
 									<ScriptSchema
 										bind:schema={script.schema}
 										customUi={customUi?.settingsPanel?.metadata?.editableSchemaForm}
+										workspace={opWorkspace}
 									/>
 								</TabContent>
 							{/if}

--- a/frontend/src/lib/components/ScriptSchema.svelte
+++ b/frontend/src/lib/components/ScriptSchema.svelte
@@ -7,9 +7,17 @@
 	interface Props {
 		schema: Schema | any
 		customUi?: EditableSchemaFormUi | undefined
+		workspace?: string | undefined
 	}
 
-	let { schema = $bindable(), customUi = undefined }: Props = $props()
+	let { schema = $bindable(), customUi = undefined, workspace = undefined }: Props = $props()
 </script>
 
-<EditableSchemaForm bind:schema uiOnly {customUi} editTab="inputEditor" showSensitiveToggle />
+<EditableSchemaForm
+	bind:schema
+	uiOnly
+	{customUi}
+	{workspace}
+	editTab="inputEditor"
+	showSensitiveToggle
+/>

--- a/frontend/src/lib/components/argInputWorkspaceForwarding.test.ts
+++ b/frontend/src/lib/components/argInputWorkspaceForwarding.test.ts
@@ -26,12 +26,11 @@ function formMounts(source: string): { tag: string; line: number; block: string 
 	for (let i = 0; i < lines.length; i++) {
 		const open = lines[i].trim().match(new RegExp(`^${OPENING.source}`))
 		if (!open) continue
-		// A mount that already closes on its opening line holds all of its props there. Scanning on
-		// for a lone `>` would run into the next component and read its props as this one's.
+		// Requiring a lone `>` would run past a mount whose last prop shares the closing line, into
+		// the next component, and read its `workspace` as this one's — a false pass on exactly the
+		// regression this guards.
 		let end = i
-		if (!lines[i].trim().endsWith('>')) {
-			while (end < lines.length && !['>', '/>'].includes(lines[end].trim())) end++
-		}
+		while (end < lines.length && !lines[end].trim().endsWith('>')) end++
 		// Running off the end means the props were never delimited, so the block would swallow the
 		// rest of the file and match any `workspace` in it — a false pass, not a failure.
 		if (end >= lines.length) {

--- a/frontend/src/lib/components/argInputWorkspaceForwarding.test.ts
+++ b/frontend/src/lib/components/argInputWorkspaceForwarding.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const TAGS = [
+	'SchemaFormDnd',
+	'SchemaForm',
+	'PasswordArgInput',
+	'ArgInput',
+	'FlowPropertyEditor',
+	'PropertyEditor',
+	'EditableSchemaForm',
+	'EditableSchemaDrawer',
+	'ArrayTypeNarrowing',
+	'InputTransformSchemaForm',
+	'InputTransformForm',
+	'ScriptSchema'
+]
+// `SchemaFormDnd` precedes `SchemaForm` so the longer tag is not matched as the shorter one.
+const OPENING = new RegExp(`<(${TAGS.join('|')})(?=[\\s/>]|$)`, 'g')
+
+function formMounts(source: string): { tag: string; line: number; block: string }[] {
+	const lines = source.split('\n')
+	const mounts: { tag: string; line: number; block: string }[] = []
+	for (let i = 0; i < lines.length; i++) {
+		const open = lines[i].trim().match(new RegExp(`^${OPENING.source}`))
+		if (!open) continue
+		// A mount that already closes on its opening line holds all of its props there. Scanning on
+		// for a lone `>` would run into the next component and read its props as this one's.
+		let end = i
+		if (!lines[i].trim().endsWith('>')) {
+			while (end < lines.length && !['>', '/>'].includes(lines[end].trim())) end++
+		}
+		// Running off the end means the props were never delimited, so the block would swallow the
+		// rest of the file and match any `workspace` in it — a false pass, not a failure.
+		if (end >= lines.length) {
+			throw new Error(`unterminated <${open[1]}> mount at line ${i + 1}`)
+		}
+		mounts.push({ tag: open[1], line: i + 1, block: lines.slice(i, end + 1).join('\n') })
+		i = end
+	}
+	return mounts
+}
+
+// `workspace={$workspaceStore}` and `workspace={undefined}` are the nav-workspace fallback this
+// guards against, so presence of the prop is not enough.
+function forwardsWorkspace(block: string): boolean {
+	const m = block.match(/\{workspace\}|workspace=\{([^{}]*)\}/)
+	if (!m) return false
+	const expr = m[1]?.trim()
+	return expr === undefined || (expr !== 'undefined' && expr !== '$workspaceStore')
+}
+
+function read(relPath: string): string {
+	return readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), relPath), 'utf-8')
+}
+
+// Every hop between the form a caller mounts and the PasswordArgInput that mints the secret, plus
+// the entry points that supply the workspace in the first place. A hop that drops `workspace` falls
+// back to the navigation workspace, so the secret lands where the job will not run — while the
+// top-level case keeps passing.
+describe.each([
+	['ArgInput.svelte', 7],
+	['schema/SchemaFormDND.svelte', 1],
+	['SchemaForm.svelte', 2],
+	['EditableSchemaForm.svelte', 3],
+	['schema/FlowPropertyEditor.svelte', 3],
+	['schema/EditableSchemaDrawer.svelte', 2],
+	['schema/PropertyEditor.svelte', 3],
+	['ArrayTypeNarrowing.svelte', 1],
+	['InputTransformSchemaForm.svelte', 1],
+	['InputTransformForm.svelte', 1],
+	['ScriptSchema.svelte', 1],
+	['ScriptBuilder.svelte', 1],
+	['flows/content/FlowInput.svelte', 2],
+	['flows/content/FlowModuleComponent.svelte', 1],
+	['flows/content/AgentToolBindings.svelte', 1],
+	['ModulePreviewForm.svelte', 1],
+	['dbt/DbtEditor.svelte', 1]
+	// `flows/content/FlowModuleSuspend.svelte` stays out: its two unthreaded mounts render the
+	// locally built `groups` schema and a preview whose args stay empty, so neither can mint.
+])('%s nested forms', (relPath, minMounts) => {
+	it('forwards workspace to every nested form', () => {
+		const source = read(relPath)
+		const mounts = formMounts(source)
+		expect(mounts.length).toBeGreaterThanOrEqual(minMounts)
+		// The scan only recognises a mount opening its own line, so one written inline would be
+		// skipped and silently unguarded. Every opening tag in the file has to be accounted for.
+		expect(mounts.length).toBe(source.match(OPENING)?.length ?? 0)
+		expect(
+			mounts.filter((m) => !forwardsWorkspace(m.block)).map((m) => `${m.tag}:${m.line}`)
+		).toEqual([])
+	})
+})

--- a/frontend/src/lib/components/dbt/DbtEditor.svelte
+++ b/frontend/src/lib/components/dbt/DbtEditor.svelte
@@ -370,7 +370,13 @@
 					{/snippet}
 					{#snippet content()}
 						{#if schema}
-							<SchemaForm {schema} bind:args noVariablePicker={false} showSchemaExplorer />
+							<SchemaForm
+								{schema}
+								bind:args
+								workspace={opWs}
+								noVariablePicker={false}
+								showSchemaExplorer
+							/>
 						{:else}
 							<p class="text-2xs text-tertiary">This descriptor takes no arguments.</p>
 						{/if}

--- a/frontend/src/lib/components/flows/content/AgentToolBindings.svelte
+++ b/frontend/src/lib/components/flows/content/AgentToolBindings.svelte
@@ -151,6 +151,7 @@
 						schema={schemas[tool.id]}
 						{pickableProperties}
 						{extraLib}
+						{workspace}
 						isAgentTool
 						bind:args={
 							() => localArgs[tool.id],

--- a/frontend/src/lib/components/flows/content/FlowInput.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInput.svelte
@@ -712,6 +712,7 @@
 								hiddenArgs={['user_message']}
 								isFlowInput
 								showSensitiveToggle
+								workspace={opWs}
 								editTab={chatInputsEditTab ? 'inputEditor' : undefined}
 								showDynOpt
 								bind:dynCode
@@ -768,6 +769,7 @@
 						bind:schema={flowStore.val.schema}
 						isFlowInput
 						showSensitiveToggle
+						workspace={opWs}
 						on:delete={(e) => {
 							addPropertyV2?.handleDeleteArgument([e.detail])
 						}}

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -1208,6 +1208,7 @@
 														: undefined}
 													helperScript={retrieveDynCodeAndLang(flowModule.value)}
 													chatInputEnabled={flowStore.val.value?.chat_input_enabled ?? false}
+													workspace={opWs}
 												/>
 												{#if agentLinked}
 													<!-- Linked agent: the resource's tools with their inputs rebindable to this

--- a/frontend/src/lib/components/flows/content/FlowModuleSuspend.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleSuspend.svelte
@@ -278,6 +278,7 @@
 
 					<EditableSchemaDrawer
 						bind:this={formEditor}
+						workspace={opWs}
 						bind:schema={
 							() => flowModule.suspend?.resume_form?.schema ?? draftFormSchema,
 							(v) => {

--- a/frontend/src/lib/components/schema/EditableSchemaDrawer.svelte
+++ b/frontend/src/lib/components/schema/EditableSchemaDrawer.svelte
@@ -57,13 +57,15 @@
 		/** Render only the editing drawer: the caller shows its own view of the schema and
 		 *  opens the drawer through `openDrawer()`. */
 		drawerOnly?: boolean
+		workspace?: string | undefined
 	}
 
 	let {
 		schema = $bindable(),
 		jsonView = $bindable(false),
 		hiddenArgs = undefined,
-		drawerOnly = false
+		drawerOnly = false,
+		workspace
 	}: Props = $props()
 
 	export function openDrawer() {
@@ -99,6 +101,7 @@
 					schemaFormClassName="min-h-full"
 					bind:this={editableSchemaForm}
 					bind:schema
+					{workspace}
 					isAppInput
 					on:delete={(e) => {
 						;(addPropertyComponent ?? drawerAddProperty)?.handleDeleteArgument([e.detail])
@@ -211,7 +214,10 @@
 								{#if schema.properties[item.value]?.type === 'object' && !(schema.properties[item.value].oneOf && schema.properties[item.value].oneOf.length >= 2)}
 									<div class="flex flex-col w-full mt-2">
 										<Label label="Nested properties">
-											<EditableSchemaDrawer bind:schema={schema.properties[item.value]} />
+											<EditableSchemaDrawer
+												bind:schema={schema.properties[item.value]}
+												{workspace}
+											/>
 										</Label>
 									</div>
 								{/if}

--- a/frontend/src/lib/components/schema/FlowPropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/FlowPropertyEditor.svelte
@@ -51,6 +51,7 @@
 		onDrawerClose?: () => void
 		hideCatalogPicker?: boolean | undefined
 		hideRawInput?: boolean | undefined
+		workspace?: string | undefined
 	}
 
 	let {
@@ -77,7 +78,8 @@
 		displayWebhookWarning = true,
 		onDrawerClose = undefined,
 		hideCatalogPicker = $bindable(undefined),
-		hideRawInput = $bindable(undefined)
+		hideRawInput = $bindable(undefined),
+		workspace = undefined
 	}: Props = $props()
 
 	let isS3Field = $derived(
@@ -272,6 +274,7 @@
 				{@const idx = oneOf.findIndex((obj) => obj.title === oneOfSelected)}
 				<div class="ml-1">
 					<EditableSchemaDrawer
+						{workspace}
 						onClose={() => {
 							onDrawerClose?.()
 						}}
@@ -317,6 +320,7 @@
 				</ToggleButtonGroup>
 				{#if customObjectSelected === 'editor'}
 					<EditableSchemaDrawer
+						{workspace}
 						bind:schema={
 							() => {
 								return {
@@ -379,6 +383,7 @@
 				{disabled}
 				{nullable}
 				{variableEditor}
+				{workspace}
 				compact
 				noMargin
 			/>

--- a/frontend/src/lib/components/schema/PropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/PropertyEditor.svelte
@@ -49,6 +49,7 @@
 			| undefined
 		typeeditor?: import('svelte').Snippet
 		children?: import('svelte').Snippet
+		workspace?: string | undefined
 	}
 
 	let {
@@ -72,7 +73,8 @@
 		order = $bindable(),
 		itemsType = $bindable(undefined),
 		typeeditor,
-		children
+		children,
+		workspace
 	}: Props = $props()
 
 	$effect.pre(() => {
@@ -225,6 +227,7 @@
 				bind:itemsType
 				canEditResourceType={isFlowInput || isAppInput}
 				bind:nonEmpty
+				{workspace}
 			/>
 		{:else if type == 'string' || ['number', 'integer'].includes(type ?? '')}
 			<div>
@@ -276,6 +279,7 @@
 						uiOnly
 						jsonEnabled={false}
 						editTab="inputEditor"
+						{workspace}
 					/>
 				</div>
 			{/if}
@@ -288,6 +292,7 @@
 					uiOnly
 					jsonEnabled={false}
 					editTab="inputEditor"
+					{workspace}
 				/>
 			</div>
 		{/if}

--- a/frontend/src/lib/components/schema/SchemaFormDND.svelte
+++ b/frontend/src/lib/components/schema/SchemaFormDND.svelte
@@ -26,6 +26,7 @@
 		className?: string
 		dndType?: string
 		lightHeaderFont?: boolean
+		workspace?: string | undefined
 	}
 
 	let {
@@ -46,7 +47,8 @@
 		noVariablePicker = false,
 		className = '',
 		dndType = generateRandomString(),
-		lightHeaderFont
+		lightHeaderFont,
+		workspace = undefined
 	}: Props = $props()
 
 	$effect.pre(() => {
@@ -155,6 +157,7 @@
 	bind:isValid
 	{noVariablePicker}
 	{lightHeaderFont}
+	{workspace}
 >
 	{#snippet actions()}
 		{#if !disableDnd}


### PR DESCRIPTION
## Summary

A `password: true` string argument is rendered by `PasswordArgInput`. On the first keystroke it mints an ephemeral secret variable and rebinds the arg to `$var:<path>`. It created that variable in `$workspaceStore` — the globally-active navigation workspace.

Session editors operate on a different, possibly forked workspace without switching `$workspaceStore`, and thread the operating workspace explicitly as a `workspace` prop. When the two diverge the secret landed in the workspace the user is merely viewing while the job ran elsewhere, and the backend failed with `Variable not found` (`variables.rs` matches `WHERE path = $1 AND workspace_id = $2`, no parent fallback).

`PasswordArgInput` had no `workspace` prop and `ArgInput` mounted it without one — even though `ArgInput` already declares the prop and `SchemaForm` already forwards it. The object-typed half of this was fixed the same way in c000bbca28 (#10015), which added `forceWorkspace?` to `processSecretArgs`; this closes the remaining string half.

## Changes

The branch is three commits, one per concern. The diff shows which files moved; what follows is why.

**Mint in the operating workspace.** `PasswordArgInput` takes a `workspace?` prop, resolved as `ws = workspace ?? $workspaceStore` so every existing caller keeps today's behaviour. The prop then has to reach it, which is what the other eighteen files are: ten components in the chain declared no `workspace` prop at all, and seven callers that do hold an operating workspace were not feeding one in. A component that holds the prop uses it for everything workspace-scoped, not only the forms it mounts: `EditableSchemaForm` and `InputTransformSchemaForm` now list and create variables — and read S3 settings — in the workspace they forward, which is what `SchemaForm` already did on `main`. Otherwise picking an existing variable in the Flow Input panel binds a `$var:` from the navigation workspace and fails at execution exactly like the mint did. `mintedIn` records the workspace a live `path` was actually minted in, so an update targets where the variable lives; and when the operating workspace moves after a path exists — a session forking — the field re-mints rather than leaving the argument pointing at a workspace the job cannot read.

**Keep the field consistent with its argument.** A parent can replace the whole args object without remounting the field — selecting a saved input does exactly this (`FlowPreviewContent.svelte:256` does not bump `renderCount`, so the `{#key}` at `:534` holds the field). That leaves `path` and `password` describing a secret the argument no longer points at, and minting from them copies the old plaintext into the new workspace over the replacement. One `argReplaced` derived states that rule and gates every way into `generateValue`, including the re-mint retry inside `updateValue`'s `catch`. The replacement can also land while the create is in flight, so the same thing is checked after `createVariable` resolves, against the value captured before the request — capturing the bound value rather than re-testing `'$var:' + path` is what makes that check cover the initial mint too, where the argument is not a `$var:` yet. A mint that ends without binding re-seeds `password` from what the argument now holds, by the same rule that seeds it on mount: otherwise the field goes on displaying a secret that is not bound, and — since the discard leaves `path === ''` where `argReplaced` cannot see it, while the mint effect tracks `ws` — an operating-workspace change alone would bind that stale plaintext over the replacement with no user action. Re-seeding removes the thing that effect would have minted instead of adding a third guard. Finally, `updateValue` returns early when nothing has been minted yet: the update the first keystroke queues would otherwise 404 and re-mint, re-reading an argument that may have been replaced meanwhile.

**Guard the threading.** A lexical test asserts that every hop *and every entry point* forwards `workspace`. Entry points matter as much as hops: every hop below `ScriptSchema` already forwarded correctly and the script editor's Generated UI tab still minted into the navigation workspace, because the entry point fed the chain `undefined`. The test checks the forwarded expression rather than the prop's presence, since `workspace={$workspaceStore}` and `workspace={undefined}` are the fallback this whole PR is about. It also asserts the two ways its own scan could stop guarding without failing: an unterminated mount raises instead of swallowing the rest of the file, and the number of mounts parsed must equal the number of tag occurrences, so a mount written inline is a failure rather than a silent skip. A mount ends at the first line that closes it rather than at a line holding nothing but `>`; ending only on the latter walks a mount whose last prop shares the closing line into the next component, where a sibling's `workspace` reads as its own. `FlowModuleSuspend.svelte` is deliberately excluded and says so in the file — its two unthreaded mounts render a locally built `groups` schema and a preview whose args stay empty, so neither can carry a user-defined password field.

Threading `workspace` through `ArgInput`'s nested forms also moves the **resource, S3 and JSON-schema pickers** in nested fields onto the operating workspace, which previously listed the navigation workspace's entries even inside a session editor. That is wider than the password path, and intended: it is the direction the top-level `ArgInput` already took, and a nested picker offering resources the job cannot reach was a bug of the same shape.

Re-minting is bounded to a live component instance. A field mounted onto an argument that already holds a `$var:` has neither the plaintext nor a record of the workspace it was minted in, so a later workspace move cannot be followed — retyping the value re-mints it. That gap predates this PR and closing it would need a probe request per password field on mount; the boundary is recorded in a comment above the effect instead. A caller passing no prop resolves `ws` to `$workspaceStore`, so a workspace switch that left such a field mounted would re-mint where `main` did nothing — every surface threaded here navigates on switch, and I did not find one that does not.

The variable left behind in the old workspace after a re-mint is an orphan that expires on its existing 7-day `expires_at`. Eager deletion was considered and rejected: `$var:` is resolved at job execution time, so deleting it could break a job already queued in the old workspace. A mint discarded because the argument was replaced mid-create is the opposite case — it was never bound anywhere, so nothing can resolve it — and is deleted outright; a failed delete falls back on the same expiry.

## Flow argument surfaces

Every form in the flow editor that can mint a secret is covered. One surface deliberately gets no change, checked in the browser rather than inferred:

- **Flow Input panel** (`FlowInput` → `EditableSchemaForm` → `SchemaFormDnd`) — fixed. Reproduced end to end before the fix: the minted variable landed in the nav workspace and the run failed with `execution error: Not found: Variable u/admin/secret_arg/... not found for 'pw'`.
- **Flow input property editor** (`FlowInput` → `EditableSchemaForm` → `FlowPropertyEditor` → `ArgInput`) — fixed. The drawer's "Default" field mints just like the panel does, and the default becomes the arg value when the flow runs without one supplied.
- **Nested-schema drawers** (`… → EditableSchemaDrawer → EditableSchemaForm isAppInput → FlowPropertyEditor → ArgInput`) — fixed. The drawer's `isAppInput` gives every nested property the same "Default" field, so a `password: true` string inside an object, inside an array of objects, inside a one-of variant, or inside a nested object two levels down all mint. Reproduced in the flow editor with a diverged operating workspace, on the nested-object path: **before**, the drawer's default minted `navws | u/admin/secret_arg/2XYIxe4lgsPJ`; **after**, the same six clicks mint `opws | u/admin/secret_arg/LQENWJ2fKyeD`.
- **Approval/resume form** (`FlowModuleSuspend` → `EditableSchemaDrawer`) — fixed, same drawer, reached from a step's Suspend tab.
- **Step test form** (`ModulePreview` → `ModulePreviewForm`) — fixed. It mounts `<ArgInput>` directly, so a `password: true` step arg does render `PasswordArgInput` there and did mint into the navigation workspace.
- **Step inputs panel** (`FlowModuleComponent` → `InputTransformSchemaForm` → `InputTransformForm`) — fixed for **object and array** arguments; a plain `password: true` **string** argument is genuinely unreachable there and needs nothing. `isStaticTemplate(inputCat)` is true for a string (`setInputCat` never looks at `password`), so `InputTransformForm.svelte:854` renders a `TemplateEditor` ahead of the `<ArgInput>` branch; only `noDynamicToggle` gets past it, and that is set solely by the fixed-schema flow settings (retries, loop, early stop, skip, branch predicate), none of which carries a user-defined password field. An object argument is `inputCat: 'object'`, which is not a static template, so the `ArgInput` branch is taken and its nested `SchemaForm` renders the nested password field. Reproduced with a diverged operating workspace on a step whose argument is `obj: { pw: password }`: **before**, `POST /api/w/navws/variables/create` → `navws | u/admin/secret_arg/HYs03J1exllO`; **after**, `POST /api/w/opws/variables/create` → `opws | u/admin/secret_arg/EPOtxGVuIRSo`. The panel's own variable picker now lists the operating workspace too.

One surface outside the flow editor is fixed too:

- **Script editor, Generated UI tab** (`ScriptBuilder` → `ScriptSchema` → `EditableSchemaForm uiOnly` → … → `EditableSchemaDrawer` → `FlowPropertyEditor` → `ArgInput`) — fixed. The tab's own top-level preview cannot mint (its inputs are disabled), but the nested "UI Customisation" drawer's Default field is live. Reproduced with `arr: list[dict]` → Custom Object → a nested `secret` string marked "Is Password/Sensitive", its Default typed, operating workspace forced to `opws` while navigating `navws`: **before** (entry-point prop dropped), `navws | u/admin/secret_arg/Y8Lug4IrclSB`; **after**, `opws | u/admin/secret_arg/uwQIR1HyewTM`.

None of these callers needed a new source of truth: `FlowEditorContext.opWorkspace` already carries the acting workspace and is read the same way by a dozen other components.

## Decisions

The boundary of this PR sits on a seam worth stating explicitly.

**Taken: a discarded mint cannot re-mint on its own, and the field re-seeds rather than locking.** The discard is this PR's own construct, so the window it opens is this PR's to close. Reproduced end to end: with the create held open, a saved input applied mid-flight, and then nothing but an operating-workspace change, the field minted the stale plaintext into the new workspace and bound it over the replacement — the flow ran `got:STALE-SECRET` instead of the saved input's value. Re-seeding closes that window and the display divergence at once, and it deletes state instead of adding a guard. Blocking on the discarded plaintext instead was tried and is worse: keyed on the value rather than on whether the argument is still replaced, it never lifts when the user re-enters the same secret, and never lifts when the parent restores the original argument — verified on the real UI, where clicking "Reset variable link" left the field displaying `hunter2` with no create issued, so Run would have submitted an empty argument. The divergence itself is new here rather than pre-existing: on `main` the mint completes and clobbers the replacement, so the field and the argument agree — wrongly, but visibly. This PR is right to keep the replacement; it should not also leave the field lying about it.

**Taken: the step-inputs object path and the script editor's Generated UI tab.** Both are pre-existing rather than introduced here, and both are the same bug class on plumbing this PR had already built — for the Generated UI tab, every hop below the entry point forwarded correctly and only `ScriptBuilder` → `ScriptSchema` was missing. Leaving it would have meant shipping a guard test asserting "every hop forwards" while an entry point fed it `undefined`, which is why the test covers entry points too.

**Taken: a failed mint toasts, wherever it is raised.** Removing `main`'s accidental recovery is what makes the silence consequential. The exposure is narrow — `password` is a dependency of the mint effect, so any further keystroke retries — but a failure on the *last* keystroke leaves the user looking at their typed secret with nothing bound, and pressing Run submits the argument empty. The initial mint and the recovery mint inside `updateValue`'s `catch` both report now, which is every call site, and leaves the component with no unhandled rejection.

**Taken: only the update that still describes the argument may recover.** An update can reject after a re-mint has already bound a fresh variable — the workspace it was addressed to is often the one that just went away — and recovering from it would mint a third variable and orphan the second. Capturing the path the update was issued for separates the two cases; a recovery that is still current behaves exactly as before, re-minting and rebinding when the variable is deleted underneath a bound field.

**Taken: the pickers in the components this threads.** `EditableSchemaForm` and `InputTransformSchemaForm` gained a `workspace` prop here and would otherwise have kept listing and creating variables in the navigation workspace while the forms below them minted into the operating one. `SchemaForm` on `main` already passes its own `ws` to both `listVariable` and `VariableEditor`, and `VariableEditor` already takes the prop for this reason, so the inconsistency would have been introduced by this PR rather than inherited. `PropPicker`'s variables tree is a different component with no `workspace` prop and no caller threading one; it stays on the navigation workspace.

**Not taken: re-deriving `path` / `password` / `mintedIn` when a parent replaces `value`.** This is the root cause behind several reported symptoms — after a replacement the field still shows the old plaintext, and typing edits the orphaned variable instead of binding a new one. It reproduces identically on `main` (verified by running the same sequence against `main`'s component: both issue only an update to the orphan, neither rebinds), so it is pre-existing rather than introduced here. Fixing it properly means reworking the component's initialization and mint lifecycle — deciding what a mounted password field owns, when it may claim an argument, and how it recovers when the argument moves. That is a change of a different shape from threading a workspace prop, and it belongs in its own PR where it can be designed and reviewed as such rather than as a fourth guard bolted onto the same function.

**Not taken: `main`'s post-failure mint retry.** It was never designed recovery — a failed create left `path === ''`, the queued update 404'd, and the catch re-minted. Restoring it would re-create exactly the state that produced the clobber above. A further keystroke already retries, since `password` drives the mint effect. What that recovery was really compensating for — a failed initial mint passing silently — is fixed directly instead, with a toast.

**Not taken: an emptied field clearing its argument.** Emptying a password field leaves the argument bound to the variable still holding the last non-empty text — `password` gates the update effect on `main` exactly as it does here — so field and argument disagree until something rebinds. A workspace move cannot follow that reference either, since the re-mint has no plaintext to mint from. Both are the same initialization-and-lifecycle question as the item above, and belong with it rather than as another guard.

**Not taken: the app editor** (`StaticInputEditor.svelte:320`). Nothing in the app editor threads `workspace`, so there is no operating workspace to forward.


## Screenshots

The UI is visually unchanged — this threads an existing prop. The screenshot documents the exercised path: a `password: true` string arg in the script editor test panel, minted and resolved successfully.

![pwtest-plain-case](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/string-password-workspace-mint/1787577368-pwtest-plain-case.png)

## Test plan

Exercised on a running instance with two workspaces (`navws` as navigation, `opws` as operating):

- [x] With `workspace="opws"` and nav workspace `navws`, a top-level **and** a nested-in-object password arg both mint into `opws` (404 in `navws`).
- [x] With no `workspace` prop, both mint into `navws` — plain case unchanged.
- [x] Running a job in `opws` with the `opws`-minted `$var:` succeeds; with the `navws`-minted one it fails with `Not found: Variable ... not found for 'pw'` — the reported bug.
- [x] Moving the operating workspace after minting re-mints both fields into the new workspace and rewrites the bound args; a subsequent keystroke updates the new variable in place rather than creating another.
- [x] Real UI, argument replaced between mint and workspace move: typed a secret in the Test flow drawer (minted in `opws`), selected a saved input replacing that argument, then moved the operating workspace to `navws`. The field still showed the original plaintext, confirming it had not remounted. **Before** (guard removed): a second variable was minted in `navws` holding the *old* plaintext and the argument was rebound to it, discarding the saved input. **After:** no re-mint, replacement intact. A workspace move with no replacement still re-mints (`opws` → `navws`), so the guard does not disable the case above.
- [x] Real UI, argument replaced *while the mint is in flight*: with the create response held open, moved the operating workspace to start a re-mint, then applied the saved input before the response landed. **Before** (post-await check removed): the argument was rebound to the newly minted `$var:`, discarding the replacement. **After:** one mint instead of two, and the argument still reads `REPLACED-BY-SAVED-INPUT`. A workspace move with no replacement still mints and rebinds in both orderings.
- [x] Real UI, same race on the **initial** mint (create held 300ms, saved input applied 80ms in): the discarded variable is deleted (`DELETE .../variables/delete/...` → 200, and gone from the `variable` table) and the replacement stands. Since the field now re-seeds, a mint *does* follow when the replacement is a plaintext — of the replacement's own value, not the discarded one, which is what a fresh mount would have done with the same argument. Corroborated on `u/admin/dpw` with a `from-saved-input` plaintext in `password`: `create u/admin/secret_arg/RODCgIssH7Wr {value: "hunter2"}` → `DELETE …/RODCgIssH7Wr`, then `create u/admin/secret_arg/wDUrCDPAhefo {value: "from-saved-input"}`, and running the script with the resulting `$var:` returned `"got:from-saved-input"`. **Before** (`updateValue`'s guard removed): the pre-mint update fired against an empty path, 404'd, and its retry minted a second variable and bound the argument to it — the same argument loss `main` produces, verified by running the identical race against `main`'s component, where the first mint binds over the replacement directly.
- [x] Real UI, the field stays usable after a discard: typing again mints and rebinds the argument, so the guards cost a retype rather than making the input inert.
- [x] Real UI, variable deleted underneath a **bound** field: the update 404s and the recovery re-mints and rebinds — unchanged.
- [x] Real UI, variable deleted underneath a **replaced** field: the update 404s and no re-mint follows, where `main` minted over the replacement.
- [x] Real UI, argument restored to the minted `$var:` after the operating workspace moved: the re-mint fires and rebinds into the new workspace — the case that needs the re-mint effect to keep reading `value`, not just `generateValue` to refuse.
- [x] A re-mint into an unreachable workspace raises an error toast (no unhandled rejection) and retries on the next edit; recovering to a valid workspace re-mints with the latest typed value.
- [x] Real UI, Flow Input panel: flow in `navws` with `autosaveWorkspace="opws"`, a `password: true` flow input wired to the step arg. **Before:** minted in `navws` (404 in `opws`), run in `opws` failed with `Not found: Variable ... not found for 'pw'`. **After:** minted in `opws` (404 in `navws`), run returned `"got:flowinput-fixed"` — the real secret value resolved.
- [x] Real UI, flow input property editor: same setup — a default value typed into the `password: true` flow input's property drawer minted into `opws`, and the Flow Input panel then showed that argument linked to the `opws` variable, so the default is what the flow would run with. **Before** (the drawer's `ArgInput` left unthreaded): the identical edit minted into `navws`.
- [x] Real UI, step forms: same setup — a `password: true` step arg typed in "Test this step" minted into `opws` (404 in `navws`); the same arg in the step-inputs panel renders a template editor, not a password field.
- [x] Real UI, nested-schema drawer: a `password: true` string nested inside an object flow input, its default typed in the "Nested properties" drawer. **Before:** `POST /api/w/navws/variables/create` → `navws | u/admin/secret_arg/2XYIxe4lgsPJ`. **After:** `POST /api/w/opws/variables/create` → `opws | u/admin/secret_arg/LQENWJ2fKyeD`, same clicks, same diverged operating workspace.
- [x] Real UI, step-inputs panel with an object argument (`obj: { pw: password }`): **before**, `POST /api/w/navws/variables/create` → `navws | u/admin/secret_arg/HYs03J1exllO`; **after**, `POST /api/w/opws/variables/create` → `opws | u/admin/secret_arg/EPOtxGVuIRSo`. A `password: true` string argument in the same panel renders a template editor, not a password field, in both.
- [x] Real UI, discarded mint then an operating-workspace move with **no typing** — the sequence that needed the new guard. Setup logged as `create 201 @1518 → DELETE 200 @1529` (discard), then `__setOpWs('opws')`. **Before:** `POST /api/w/opws/variables/create`, the argument rebound, and running the flow returned `got:STALE-SECRET`. **After:** the run returns `got:REPLACED-BY-SAVED-INPUT` — the saved input stands. Where the replacement is a plaintext a create does follow, carrying the *replacement's* value; where it is a `$var:` ref the field re-seeds to empty and no request is made at all.
- [x] Real UI, typing after that discard still works: one `POST /api/w/opws/variables/create`, the argument rebinds, and the run returns `got:RETYPED-SECRET`. The guard costs a retype, it does not make the field inert.
- [x] Real UI, script editor Generated UI tab with a diverged operating workspace: `arr: list[dict]` → Custom Object → nested `secret` string marked "Is Password/Sensitive" → Default typed in the "UI Customisation" drawer. **Before** (entry-point prop dropped): `navws | u/admin/secret_arg/Y8Lug4IrclSB`. **After:** `opws | u/admin/secret_arg/uwQIR1HyewTM` — same clicks, same forced operating workspace. The tab's top-level preview field is disabled and cannot mint, so the drawer is the reachable path.
- [x] Real UI, failed initial mint: `/variables/create` stubbed to a 400 with the plain-text body the API actually returns (`Bad request: …`, verified against the live endpoint) — one create attempt, error toast `Could not create the secret: Bad request: simulated backend refusal`, and no unhandled rejection. **Before:** the rejection passed silently with nothing bound.
- [x] Real UI: `/scripts/edit/...` test panel in `navws` — variable minted in `navws`, job succeeded.
- [x] Real UI, discarded mint then the argument restored. Script editor test panel, operating workspace `opws`: typed `hunter2` with the create held open, replaced the argument mid-flight with the variable picker (`u/admin/picked_static`), released, then clicked "Reset variable link". **Before:** the discarded variable was deleted correctly, but the field still read `hunter2` and no create was issued — the argument sat empty behind a field showing a secret. **After:** the field re-seeds to empty, and re-entering the *same* `hunter2` mints `u/admin/secret_arg/ivcb6qML1LGp`, whose stored value reads back as `"hunter2"`; the discarded `…/9ePh5SzIkoNX` is gone (404).
- [x] Real UI, variable pickers with a diverged operating workspace (`navws` navigation, `opws` operating): the Flow Input property drawer's picker and the step-inputs panel's picker both request `/api/w/opws/variables/list` and list `u/admin/marker_opws`. With the prop removed the same two request `/api/w/navws/variables/list` and list `u/admin/marker_navws` — the no-prop fallback is unchanged. `PropPicker`'s variables tree stays on `navws` in both, as intended.
- [x] Real UI, recovery mint after the bound variable is deleted underneath the field: the update 404s, one create follows, and the argument rebinds (`…/cftEm9KJNA2j` → `…/j2O0GkXhehp5`) — the path guard does not block a recovery that is still current.
- [x] Real UI, recovery mint that fails: variable deleted and `/variables/create` stubbed to a 400 carrying the API's plain-text body — one create attempt, toast `Could not create the secret: Bad request: simulated backend refusal`, and `unhandledrejection` fires zero times. **Before:** silent.
- [x] Guard-test scanner: reproduced the false pass the exact-`>` terminator allowed — a mount that drops `workspace`, written with its last prop on the closing line, followed by an untracked sibling carrying `workspace={opWs}`, was reported as forwarding. It fails after the change, as do the same case with a guarded sibling and with nothing following; a mount that legitimately forwards still passes. All 17 real files still pass and their mount counts stay exact.
- [x] `npm run check` (0 errors, 72 warnings — unchanged), prettier clean, guard test green (17 tests over 17 files) — negative-checked by dropping the prop from each of the five entry points added this round (`FlowInput.svelte` fails `EditableSchemaForm:710`, `FlowModuleComponent.svelte` fails `InputTransformSchemaForm:1180`, `AgentToolBindings.svelte` fails `InputTransformSchemaForm:149`, `ModulePreviewForm.svelte` fails `ArgInput:131`, `DbtEditor.svelte` fails `SchemaForm:373`), from the `ScriptBuilder` → `ScriptSchema` entry point (fails `ScriptSchema:2019`), the `ScriptSchema` → `EditableSchemaForm` hop (fails `EditableSchemaForm:16`), and from a multi-line mount, a single-line self-closing mount, the `SchemaFormDND` hop, the `SchemaForm` → `ArgInput` hop, the `EditableSchemaForm` → `SchemaFormDnd` hop, the `ArgInput` → `PasswordArgInput` minting hop, the `EditableSchemaForm` → `FlowPropertyEditor` hop, the recursive `EditableSchemaDrawer` → `EditableSchemaDrawer` hop, the `InputTransformSchemaForm` → `InputTransformForm` hop and the `InputTransformForm` → `ArgInput` hop (each fails naming the offending mount); by replacing a forwarded `{workspace}` with `workspace={$workspaceStore}` (fails, where the presence-only check passed); by removing a mount's closing delimiter (raises `unterminated <SchemaForm> mount`); and by moving a mount inline so the line-start scan would skip it (fails the mount-count assertion).

