### PR TITLE
fix: require admin on workspace tarball settings export

### DIFF
--- a/backend/tests/workspace_export.rs
+++ b/backend/tests/workspace_export.rs
@@ -309,10 +309,10 @@ async fn test_tarball_export_settings_are_admin_only(db: Pool<Postgres>) -> anyh
     .execute(&db)
     .await?;
 
-    let export = async |token: &str, version: &str| -> anyhow::Result<(u16, String)> {
+    let export = async |token: &str| -> anyhow::Result<(u16, String)> {
         let resp = reqwest::Client::new()
             .get(format!(
-                "{base_url}/api/w/test-workspace/workspaces/tarball?include_settings=true&settings_version={version}"
+                "{base_url}/api/w/test-workspace/workspaces/tarball?include_settings=true&settings_version=v2"
             ))
             .bearer_auth(token)
             .send()
@@ -326,21 +326,15 @@ async fn test_tarball_export_settings_are_admin_only(db: Pool<Postgres>) -> anyh
     };
 
     // SECRET_TOKEN_2 belongs to test-user-2, a non-admin member of test-workspace.
-    for version in ["v1", "v2"] {
-        let (status, body) = export("SECRET_TOKEN_2", version).await?;
-        assert_eq!(status, 403, "non-admin exported {version} settings: {body}");
-        assert!(
-            !body.contains("WEBHOOK_SECRET") && !body.contains("AI_CONFIG_SECRET"),
-            "non-admin leaked {version} settings"
-        );
+    let (status, body) = export("SECRET_TOKEN_2").await?;
+    assert_eq!(status, 403, "non-admin exported settings: {body}");
 
-        let (status, body) = export("SECRET_TOKEN", version).await?;
-        assert_eq!(status, 200, "admin denied {version} settings: {body}");
-        assert!(
-            body.contains("WEBHOOK_SECRET") && body.contains("AI_CONFIG_SECRET"),
-            "admin got no {version} settings"
-        );
-    }
+    let (status, body) = export("SECRET_TOKEN").await?;
+    assert_eq!(status, 200, "admin denied settings: {body}");
+    assert!(
+        body.contains("WEBHOOK_SECRET") && body.contains("AI_CONFIG_SECRET"),
+        "admin got no settings"
+    );
 
     // Git sync pushes the workspace to the repo by exporting it under
     // `superadmin_sync@windmill.dev`, which belongs to no workspace: the job token
@@ -358,7 +352,7 @@ async fn test_tarball_export_settings_are_admin_only(db: Pool<Postgres>) -> anyh
         None,
     )
     .await?;
-    let (status, body) = export(&sync_token, "v2").await?;
+    let (status, body) = export(&sync_token).await?;
     assert_eq!(status, 200, "git-sync identity denied settings: {body}");
     assert!(
         body.contains("WEBHOOK_SECRET"),

--- a/backend/tests/workspace_export.rs
+++ b/backend/tests/workspace_export.rs
@@ -1,6 +1,6 @@
 use sqlx::postgres::Postgres;
 use sqlx::Pool;
-use windmill_test_utils::{initialize_tracing, ApiServer};
+use windmill_test_utils::{initialize_tracing, set_jwt_secret, ApiServer};
 
 /// Integration test: exercises every explicit-column query in `tarball_workspace`.
 ///
@@ -284,6 +284,86 @@ async fn test_tarball_export_gates_values_on_item_scopes(db: Pool<Postgres>) -> 
             "{token} exported no values"
         );
     }
+
+    Ok(())
+}
+
+/// `settings.json` carries the admin-managed integration config that `get_settings`
+/// is admin-only for (the webhook URL, ai_config, git_sync, handler extra_args), so
+/// `include_settings` takes the same admin check as `get_settings` rather than
+/// riding on the route's `workspaces:read`. Git sync exports settings through the
+/// same route, so the gate must still admit its system identity.
+#[sqlx::test(fixtures("base"))]
+async fn test_tarball_export_settings_are_admin_only(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    set_jwt_secret().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let base_url = format!("http://localhost:{}", server.addr.port());
+
+    sqlx::query(
+        r#"UPDATE workspace_settings
+              SET webhook = 'https://hook.example/?token=WEBHOOK_SECRET',
+                  ai_config = '{"providers":{"openai":{"api_key":"AI_CONFIG_SECRET"}}}'::jsonb
+            WHERE workspace_id = 'test-workspace'"#,
+    )
+    .execute(&db)
+    .await?;
+
+    let export = async |token: &str, version: &str| -> anyhow::Result<(u16, String)> {
+        let resp = reqwest::Client::new()
+            .get(format!(
+                "{base_url}/api/w/test-workspace/workspaces/tarball?include_settings=true&settings_version={version}"
+            ))
+            .bearer_auth(token)
+            .send()
+            .await?;
+        let status = resp.status().as_u16();
+        // Lossy: a successful export is a tar, not UTF-8. Only the values matter here.
+        Ok((
+            status,
+            String::from_utf8_lossy(&resp.bytes().await?).into_owned(),
+        ))
+    };
+
+    // SECRET_TOKEN_2 belongs to test-user-2, a non-admin member of test-workspace.
+    for version in ["v1", "v2"] {
+        let (status, body) = export("SECRET_TOKEN_2", version).await?;
+        assert_eq!(status, 403, "non-admin exported {version} settings: {body}");
+        assert!(
+            !body.contains("WEBHOOK_SECRET") && !body.contains("AI_CONFIG_SECRET"),
+            "non-admin leaked {version} settings"
+        );
+
+        let (status, body) = export("SECRET_TOKEN", version).await?;
+        assert_eq!(status, 200, "admin denied {version} settings: {body}");
+        assert!(
+            body.contains("WEBHOOK_SECRET") && body.contains("AI_CONFIG_SECRET"),
+            "admin got no {version} settings"
+        );
+    }
+
+    // Git sync pushes the workspace to the repo by exporting it under
+    // `superadmin_sync@windmill.dev`, which belongs to no workspace: the job token
+    // it runs with is the export's only admin claim.
+    let sync_email = windmill_common::users::SUPERADMIN_SYNC_EMAIL;
+    let sync_token = windmill_common::auth::create_token_for_owner(
+        &db,
+        "test-workspace",
+        sync_email,
+        "git-sync",
+        300,
+        sync_email,
+        &uuid::Uuid::new_v4(),
+        None,
+        None,
+    )
+    .await?;
+    let (status, body) = export(&sync_token, "v2").await?;
+    assert_eq!(status, 200, "git-sync identity denied settings: {body}");
+    assert!(
+        body.contains("WEBHOOK_SECRET"),
+        "git-sync identity got no settings"
+    );
 
     Ok(())
 }

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -643,6 +643,14 @@ pub(crate) async fn tarball_workspace(
         windmill_api_auth::forbid_scoped_token_workspace_key(&authed)?;
     }
 
+    // settings.json carries the admin-managed integration config that `get_settings`
+    // is admin-only for (ai_config, the webhook URL, git_sync, handler extra_args),
+    // so it takes the same check. Not a per-field redaction: fields silently dropped
+    // from settings.json come back as null on the next `wmill sync push`.
+    if include_settings.unwrap_or(false) {
+        require_admin(authed.is_admin, &authed.username)?;
+    }
+
     // The route is gated by workspaces:read, but the tarball also carries the item
     // values that the per-item routes gate on their own domain (get_resource_value,
     // get_variable). A whole-workspace export cannot be confined to a path, so it
@@ -1626,8 +1634,9 @@ pub(crate) async fn tarball_workspace(
                 slack_name: row.slack_name.clone(),
                 slack_command_script: row.slack_command_script.clone(),
                 slack_oauth_client_id: row.slack_oauth_client_id.clone(),
-                // Mirror the non-admin redaction in `get_settings`: the OAuth
-                // client secret is admin-only and must not leak via tarball.
+                // Redundant with the admin gate on `include_settings` above, kept
+                // so the OAuth client secret still requires an admin should this
+                // branch ever be reached another way.
                 slack_oauth_client_secret: if authed.is_admin {
                     row.slack_oauth_client_secret.clone()
                 } else {

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -647,8 +647,10 @@ pub(crate) async fn tarball_workspace(
     // is admin-only for (ai_config, the webhook URL, git_sync, handler extra_args),
     // so it takes the same check. Not a per-field redaction: fields silently dropped
     // from settings.json come back as null on the next `wmill sync push`.
-    if include_settings.unwrap_or(false) {
-        require_admin(authed.is_admin, &authed.username)?;
+    if include_settings.unwrap_or(false) && !authed.is_admin {
+        return Err(Error::PermissionDenied(
+            "include_settings requires workspace admin".to_string(),
+        ));
     }
 
     // The route is gated by workspaces:read, but the tarball also carries the item
@@ -1634,14 +1636,7 @@ pub(crate) async fn tarball_workspace(
                 slack_name: row.slack_name.clone(),
                 slack_command_script: row.slack_command_script.clone(),
                 slack_oauth_client_id: row.slack_oauth_client_id.clone(),
-                // Redundant with the admin gate on `include_settings` above, kept
-                // so the OAuth client secret still requires an admin should this
-                // branch ever be reached another way.
-                slack_oauth_client_secret: if authed.is_admin {
-                    row.slack_oauth_client_secret.clone()
-                } else {
-                    None
-                },
+                slack_oauth_client_secret: row.slack_oauth_client_secret.clone(),
             };
             serde_json::to_value(settings)
                 .map(|v| serde_json::to_string_pretty(&v).ok())


### PR DESCRIPTION
## Summary

`GET /w/{workspace}/workspaces/tarball` gates `include_key` on workspace admin but did not gate `include_settings`. The `settings.json` it writes carries the same admin-managed workspace settings that `get_settings` is admin-only for, so the export now takes the same check.

Gated in the pre-flight block alongside `include_key`, before any archive work, so the request is refused rather than partially served. The error names the flag it refused (`include_settings requires workspace admin`), since `includeSettings` is persisted `wmill.yaml` config that the person running the sync may not have written.

A per-field redaction was considered and rejected. With `includeSettings: true` in `wmill.yaml` the CLI keeps `settings` in its diff scope, so a withheld or partial settings file reads as a remote deletion: `wmill sync pull` deletes the local `settings.yaml`, and the next `wmill sync push` then proposes deleting the settings on the remote. Refusing the request leaves the local file untouched.

Git sync is unaffected. Its push callbacks export the workspace under `permissioned_as = superadmin_sync@windmill.dev`, which derives `is_admin: true`.

## Changes

- `workspaces_export.rs`: `include_settings` now requires workspace admin, checked in the same pre-flight block as `include_key`
- `workspaces_export.rs`: dropped the non-admin `slack_oauth_client_secret` branch. It was not a redaction: the field is always serialized, and for those fields a `null` means "clear remote" (see the note on `SimplifiedSettings`), so it would have wiped the stored secret on the next push rather than withholding it. The gate above makes it unreachable either way.
- `workspace_export.rs`: regression test covering a non-admin member, an admin, and the git-sync system identity

## Test plan

- [x] `cargo test --test workspace_export` — 3 passed
- [x] Committed test: non-admin 403, admin 200 with settings present, git-sync job token (`create_token_for_owner` under `superadmin_sync@windmill.dev`) 200 with settings present, all at `settings_version=v2` (what the CLI sends)
- [x] Manually on a running instance: non-admin 403 at both `settings_version=v1` and `v2`; the same token still exports without settings; admin still exports settings
- [x] `wmill sync pull` as a non-admin against a repo with `includeSettings: true` aborts with the flag-naming message and leaves the local `settings.yaml` in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)