### PR TITLE
fix: reset pooled connections left in an untracked transaction

### DIFF
--- a/backend/src/db_connect.rs
+++ b/backend/src/db_connect.rs
@@ -153,6 +153,15 @@ pub async fn connect(
         pool_options = pool_options.idle_timeout(Duration::from_secs(60));
     }
     pool_options
+        // Clears transaction state sqlx is not tracking, so a connection whose session was
+        // left inside a transaction is not handed to the next borrower. See
+        // `windmill_common::db::connection_reset` for how such a session comes about and why
+        // this only runs once one has been observed.
+        .after_release(|conn, _| {
+            Box::pin(windmill_common::db::connection_reset::reset_on_release(
+                conn,
+            ))
+        })
         .after_connect(move |conn, _| {
             if worker_mode {
                 Box::pin(async move {

--- a/backend/src/db_connect.rs
+++ b/backend/src/db_connect.rs
@@ -153,12 +153,12 @@ pub async fn connect(
         pool_options = pool_options.idle_timeout(Duration::from_secs(60));
     }
     pool_options
-        // Clears transaction state sqlx is not tracking, so a connection whose session was
-        // left inside a transaction is not handed to the next borrower. See
+        // Clears transaction state sqlx is not tracking, so a session left inside a
+        // transaction is cleaned before the connection is handed to a borrower. See
         // `windmill_common::db::connection_reset` for how such a session comes about and why
         // this only runs once one has been observed.
-        .after_release(|conn, _| {
-            Box::pin(windmill_common::db::connection_reset::reset_on_release(
+        .before_acquire(|conn, _| {
+            Box::pin(windmill_common::db::connection_reset::reset_before_acquire(
                 conn,
             ))
         })

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -331,12 +331,14 @@ pub mod connection_reset {
     }
 
     fn arm() {
-        let previous = RESET_UNTIL_MS.fetch_max(
-            now_ms() + RESET_WINDOW.as_millis() as u64,
-            Ordering::Relaxed,
-        );
-        // Entering a window costs throughput, so it must be attributable in the logs.
-        if previous == 0 {
+        let now = now_ms();
+        let previous =
+            RESET_UNTIL_MS.fetch_max(now + RESET_WINDOW.as_millis() as u64, Ordering::Relaxed);
+        // Every window costs throughput, so each one must be attributable in the logs —
+        // hence the comparison against `now` rather than against zero, which would report
+        // only the first incident a process ever sees. Re-arming inside a live window is
+        // the common case and stays quiet.
+        if previous <= now {
             tracing::warn!(
                 "a pooled connection was found in an aborted transaction; rolling back on \
                  checkout for the next {}s",
@@ -366,9 +368,11 @@ pub mod connection_reset {
     }
 
     /// Arms the reset when an error proves a session is stuck in an aborted transaction.
-    /// Reached from `Error`'s `From<sqlx::Error>` and from `to_anyhow`, which between them
-    /// cover the paths a `sqlx::Error` takes on its way out of a query.
-    pub(crate) fn note_sqlx_error(err: &sqlx::Error) {
+    /// `Error`'s `From<sqlx::Error>` and `to_anyhow` call this, which covers a query whose
+    /// error is converted or propagated with `?`. A caller that instead inspects the
+    /// `sqlx::Error` in place — formatting it into a message, matching on it — has to call
+    /// this itself, or a poisoned connection reported only there goes unnoticed.
+    pub fn note_sqlx_error(err: &sqlx::Error) {
         let sqlx::Error::Database(db_err) = err else {
             return;
         };

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -294,23 +294,47 @@ impl<'b> DbExecutor<'b> for &'b mut PgConnection {
 /// Guards the pool against a Postgres session left inside a transaction sqlx is not
 /// tracking.
 ///
-/// sqlx only queues its rollback-on-drop once `begin()` has returned, so a future
-/// cancelled while `BEGIN` is still in flight — a disconnecting API client, a
-/// `tokio::time::timeout`, an aborted task — hands the connection back with the
-/// transaction still open server-side. sqlx's on-release `ping` is a bare
-/// `wait_until_ready` that reports such a connection as healthy, so it is reused: the
-/// next borrower's statements silently run inside that transaction and hold their locks
-/// for as long as it lives, and the first error turns the session into
-/// `idle in transaction (aborted)`, after which every unrelated query on it fails with
-/// `25P02` until `max_lifetime` recycles it half an hour later.
+/// # How a connection gets into that state
 ///
-/// Rolling back on every checkout would add a round trip to every query, which measured at
-/// about a third of the throughput on small ones, so the reset is armed only once Postgres
-/// has reported a state that proves a connection is carrying such leftover state.
+/// sqlx queues its rollback-on-drop only once `begin()` has returned: the guard keys on a
+/// transaction depth raised *after* the `BEGIN` round trip. A future cancelled in between —
+/// a disconnecting API client, a `tokio::time::timeout`, an aborted task — therefore leaves
+/// the server in a transaction with nothing queued to end it. sqlx's on-release `ping` is a
+/// bare `wait_until_ready`: it drains the `ReadyForQuery` but never inspects its
+/// transaction-status byte, so the connection is judged healthy and reused. The next
+/// borrower's statements then run inside that transaction and hold its locks for as long as
+/// it lives, and the first error turns the session into `idle in transaction (aborted)`,
+/// after which *every* unrelated query on that connection fails with `25P02`. Nothing in
+/// sqlx recovers it — the depth is still zero, so no rollback is ever queued — and
+/// `idle_in_transaction_session_timeout` never fires on a connection that is in constant
+/// use, leaving `max_lifetime` half an hour later as the only cure.
 ///
-/// The reset runs on **acquire** rather than release: the connection that reports the first
-/// `25P02` is released before its error has been converted, so a release-side hook would let
-/// exactly that connection back into the idle queue uncleaned.
+/// # Why the check is armed rather than always on
+///
+/// Postgres reports transaction status on every response, but sqlx keeps it private
+/// (`PgConnection::in_transaction` is `pub(crate)`, and the public `is_in_transaction`
+/// returns the client-side depth, which is precisely the value that is wrong here). Without
+/// it, the only way to know is to issue a `ROLLBACK`, and doing that on every checkout costs
+/// a round trip per query — about a third of the throughput on small ones. So it is armed
+/// only once Postgres has reported a state that proves a connection is carrying leftover
+/// transaction state, and disarms itself after [`RESET_WINDOW`].
+///
+/// # Why on acquire rather than release
+///
+/// The connection that reports the first `25P02` is released *before* the caller has
+/// converted that error, so a release-side hook would let exactly that connection back into
+/// the idle queue uncleaned. Cleaning on checkout has the same cost and no such gap.
+///
+/// # Why best-effort detection is enough
+///
+/// Arming is process-wide, not per-query: the flag covers a pool shared by everything in the
+/// process, so it does not matter *which* caller notices a poisoned connection, only that
+/// one does. [`note_sqlx_error`] is reached from the two conversions a `sqlx::Error` usually
+/// passes through, which is most queries; a caller that instead formats the error into a
+/// message never converts it and reports nothing. That only delays arming until the next
+/// converting query touches the same pool — on a worker the job poller alone does so every
+/// few tens of milliseconds. Adding calls at individual query sites is therefore not the
+/// pattern; it would suggest a per-site contract that does not exist.
 pub mod connection_reset {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::LazyLock;
@@ -368,13 +392,9 @@ pub mod connection_reset {
     }
 
     /// Arms the reset when an error proves a session is stuck in an aborted transaction.
-    /// `Error`'s `From<sqlx::Error>` and `to_anyhow` call this, so it covers `?` into a
-    /// `windmill_common::error::Result` and an explicit `map_err(to_anyhow)`. Everything
-    /// else has to call it: `?` into an `anyhow::Result` goes through anyhow's own `From`,
-    /// and a caller that inspects the `sqlx::Error` in place — formatting it into a
-    /// message, matching on it — never converts it at all. A poisoned connection reported
-    /// only down one of those paths goes unnoticed until something else reports it.
-    pub fn note_sqlx_error(err: &sqlx::Error) {
+    /// Called from `Error`'s `From<sqlx::Error>` and from `to_anyhow`; see the module docs
+    /// for why those two are enough and why individual query sites should not call it.
+    pub(crate) fn note_sqlx_error(err: &sqlx::Error) {
         let sqlx::Error::Database(db_err) = err else {
             return;
         };

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -304,31 +304,45 @@ impl<'b> DbExecutor<'b> for &'b mut PgConnection {
 /// `idle in transaction (aborted)`, after which every unrelated query on it fails with
 /// `25P02` until `max_lifetime` recycles it half an hour later.
 ///
-/// Rolling back on every release would add a round trip to every query, which measured at
+/// Rolling back on every checkout would add a round trip to every query, which measured at
 /// about a third of the throughput on small ones, so the reset is armed only once Postgres
 /// has reported a state that proves a connection is carrying such leftover state.
+///
+/// The reset runs on **acquire** rather than release: the connection that reports the first
+/// `25P02` is released before its error has been converted, so a release-side hook would let
+/// exactly that connection back into the idle queue uncleaned.
 pub mod connection_reset {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::LazyLock;
     use std::time::{Duration, Instant};
 
-    static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
-    /// Milliseconds since `PROCESS_START` until which releases roll back; 0 = never armed.
+    /// Origin for the millisecond clock below. Initialized on first use rather than at
+    /// startup, which is fine: every reader compares deadlines derived from this same base.
+    static CLOCK_BASE: LazyLock<Instant> = LazyLock::new(Instant::now);
+    /// Milliseconds since `CLOCK_BASE` until which checkouts roll back; 0 = never armed.
     static RESET_UNTIL_MS: AtomicU64 = AtomicU64::new(0);
 
-    /// Long enough to outlast the connections that were already checked out when the
-    /// first poisoned one surfaced; one release cycle clears the pool.
+    /// Only has to outlast the connections checked out when the first poisoned one surfaced,
+    /// which under load is milliseconds; the margin covers a pool that is mostly idle.
     const RESET_WINDOW: Duration = Duration::from_secs(60);
 
     fn now_ms() -> u64 {
-        PROCESS_START.elapsed().as_millis() as u64
+        CLOCK_BASE.elapsed().as_millis() as u64
     }
 
     fn arm() {
-        RESET_UNTIL_MS.fetch_max(
+        let previous = RESET_UNTIL_MS.fetch_max(
             now_ms() + RESET_WINDOW.as_millis() as u64,
             Ordering::Relaxed,
         );
+        // Entering a window costs throughput, so it must be attributable in the logs.
+        if previous == 0 {
+            tracing::warn!(
+                "a pooled connection was found in an aborted transaction; rolling back on \
+                 checkout for the next {}s",
+                RESET_WINDOW.as_secs()
+            );
+        }
     }
 
     /// Reading the clock is skipped entirely while the pool has never been armed, which
@@ -338,11 +352,12 @@ pub mod connection_reset {
         until != 0 && until > now_ms()
     }
 
-    /// Body of the pool's `after_release` hook. `ROLLBACK` ends both a leaked-open and an
-    /// aborted transaction, and is a no-op warning on a session that has neither. Reporting
-    /// the failure makes sqlx discard the connection, which is also what a session we could
-    /// not clean deserves.
-    pub async fn reset_on_release(conn: &mut sqlx::PgConnection) -> Result<bool, sqlx::Error> {
+    /// Body of the pool's `before_acquire` hook. `ROLLBACK` ends both a leaked-open and an
+    /// aborted transaction; on a session with neither it succeeds and Postgres answers with
+    /// a `there is no transaction in progress` warning, which is why `sqlx::postgres::notice`
+    /// is filtered in `tracing_init`. Reporting the failure makes sqlx discard the
+    /// connection, which is also what a session we could not clean deserves.
+    pub async fn reset_before_acquire(conn: &mut sqlx::PgConnection) -> Result<bool, sqlx::Error> {
         if armed() {
             use sqlx::Executor;
             conn.execute("ROLLBACK").await?;
@@ -351,7 +366,8 @@ pub mod connection_reset {
     }
 
     /// Arms the reset when an error proves a session is stuck in an aborted transaction.
-    /// Called from `Error`'s `From<sqlx::Error>`, so it sees every query that reports one.
+    /// Reached from `Error`'s `From<sqlx::Error>` and from `to_anyhow`, which between them
+    /// cover the paths a `sqlx::Error` takes on its way out of a query.
     pub(crate) fn note_sqlx_error(err: &sqlx::Error) {
         let sqlx::Error::Database(db_err) = err else {
             return;

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -317,7 +317,7 @@ impl<'b> DbExecutor<'b> for &'b mut PgConnection {
 /// it, the only way to know is to issue a `ROLLBACK`, and doing that on every checkout costs
 /// a round trip per query — about a third of the throughput on small ones. So it is armed
 /// only once Postgres has reported a state that proves a connection is carrying leftover
-/// transaction state, and disarms itself after [`RESET_WINDOW`].
+/// transaction state, and disarms itself after `RESET_WINDOW`.
 ///
 /// # Why on acquire rather than release
 ///
@@ -329,7 +329,7 @@ impl<'b> DbExecutor<'b> for &'b mut PgConnection {
 ///
 /// Arming is process-wide, not per-query: the flag covers a pool shared by everything in the
 /// process, so it does not matter *which* caller notices a poisoned connection, only that
-/// one does. [`note_sqlx_error`] is reached from the two conversions a `sqlx::Error` usually
+/// one does. `note_sqlx_error` is reached from the two conversions a `sqlx::Error` usually
 /// passes through, which is most queries; a caller that instead formats the error into a
 /// message never converts it and reports nothing. That only delays arming until the next
 /// converting query touches the same pool — on a worker the job poller alone does so every

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -368,10 +368,12 @@ pub mod connection_reset {
     }
 
     /// Arms the reset when an error proves a session is stuck in an aborted transaction.
-    /// `Error`'s `From<sqlx::Error>` and `to_anyhow` call this, which covers a query whose
-    /// error is converted or propagated with `?`. A caller that instead inspects the
-    /// `sqlx::Error` in place — formatting it into a message, matching on it — has to call
-    /// this itself, or a poisoned connection reported only there goes unnoticed.
+    /// `Error`'s `From<sqlx::Error>` and `to_anyhow` call this, so it covers `?` into a
+    /// `windmill_common::error::Result` and an explicit `map_err(to_anyhow)`. Everything
+    /// else has to call it: `?` into an `anyhow::Result` goes through anyhow's own `From`,
+    /// and a caller that inspects the `sqlx::Error` in place — formatting it into a
+    /// message, matching on it — never converts it at all. A poisoned connection reported
+    /// only down one of those paths goes unnoticed until something else reports it.
     pub fn note_sqlx_error(err: &sqlx::Error) {
         let sqlx::Error::Database(db_err) = err else {
             return;

--- a/backend/windmill-common/src/db.rs
+++ b/backend/windmill-common/src/db.rs
@@ -290,3 +290,76 @@ impl<'b> DbExecutor<'b> for &'b mut PgConnection {
         &mut **self
     }
 }
+
+/// Guards the pool against a Postgres session left inside a transaction sqlx is not
+/// tracking.
+///
+/// sqlx only queues its rollback-on-drop once `begin()` has returned, so a future
+/// cancelled while `BEGIN` is still in flight — a disconnecting API client, a
+/// `tokio::time::timeout`, an aborted task — hands the connection back with the
+/// transaction still open server-side. sqlx's on-release `ping` is a bare
+/// `wait_until_ready` that reports such a connection as healthy, so it is reused: the
+/// next borrower's statements silently run inside that transaction and hold their locks
+/// for as long as it lives, and the first error turns the session into
+/// `idle in transaction (aborted)`, after which every unrelated query on it fails with
+/// `25P02` until `max_lifetime` recycles it half an hour later.
+///
+/// Rolling back on every release would add a round trip to every query, which measured at
+/// about a third of the throughput on small ones, so the reset is armed only once Postgres
+/// has reported a state that proves a connection is carrying such leftover state.
+pub mod connection_reset {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::LazyLock;
+    use std::time::{Duration, Instant};
+
+    static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+    /// Milliseconds since `PROCESS_START` until which releases roll back; 0 = never armed.
+    static RESET_UNTIL_MS: AtomicU64 = AtomicU64::new(0);
+
+    /// Long enough to outlast the connections that were already checked out when the
+    /// first poisoned one surfaced; one release cycle clears the pool.
+    const RESET_WINDOW: Duration = Duration::from_secs(60);
+
+    fn now_ms() -> u64 {
+        PROCESS_START.elapsed().as_millis() as u64
+    }
+
+    fn arm() {
+        RESET_UNTIL_MS.fetch_max(
+            now_ms() + RESET_WINDOW.as_millis() as u64,
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Reading the clock is skipped entirely while the pool has never been armed, which
+    /// is the steady state.
+    fn armed() -> bool {
+        let until = RESET_UNTIL_MS.load(Ordering::Relaxed);
+        until != 0 && until > now_ms()
+    }
+
+    /// Body of the pool's `after_release` hook. `ROLLBACK` ends both a leaked-open and an
+    /// aborted transaction, and is a no-op warning on a session that has neither. Reporting
+    /// the failure makes sqlx discard the connection, which is also what a session we could
+    /// not clean deserves.
+    pub async fn reset_on_release(conn: &mut sqlx::PgConnection) -> Result<bool, sqlx::Error> {
+        if armed() {
+            use sqlx::Executor;
+            conn.execute("ROLLBACK").await?;
+        }
+        Ok(true)
+    }
+
+    /// Arms the reset when an error proves a session is stuck in an aborted transaction.
+    /// Called from `Error`'s `From<sqlx::Error>`, so it sees every query that reports one.
+    pub(crate) fn note_sqlx_error(err: &sqlx::Error) {
+        let sqlx::Error::Database(db_err) = err else {
+            return;
+        };
+        // 25P02 `in_failed_sql_transaction`: the connection this query ran on is sitting
+        // in a failed transaction block that nothing in sqlx will ever roll back.
+        if db_err.code().as_deref() == Some("25P02") {
+            arm();
+        }
+    }
+}

--- a/backend/windmill-common/src/error.rs
+++ b/backend/windmill-common/src/error.rs
@@ -245,9 +245,10 @@ pub fn relocate_internal(loc: &'static Location<'static>) -> impl FnOnce(Error) 
 }
 
 pub fn to_anyhow<T: 'static + std::error::Error + Send + Sync>(e: T) -> anyhow::Error {
-    // The other way a `sqlx::Error` leaves a query without becoming an `Error`, and so the
-    // other place a poisoned connection can announce itself. The downcast is a type-id
-    // comparison, and misses only errors handled entirely in place.
+    // Callers that hand a `sqlx::Error` to anyhow explicitly rather than converting it to
+    // `Error`. The downcast is a type-id comparison, and this covers only the explicit
+    // `map_err(to_anyhow)` form — `?` into an `anyhow::Result` goes straight through
+    // anyhow's own `From`.
     if let Some(sqlx_err) = (&e as &dyn std::any::Any).downcast_ref::<sqlx::Error>() {
         crate::db::connection_reset::note_sqlx_error(sqlx_err);
     }

--- a/backend/windmill-common/src/error.rs
+++ b/backend/windmill-common/src/error.rs
@@ -245,6 +245,12 @@ pub fn relocate_internal(loc: &'static Location<'static>) -> impl FnOnce(Error) 
 }
 
 pub fn to_anyhow<T: 'static + std::error::Error + Send + Sync>(e: T) -> anyhow::Error {
+    // The other way a `sqlx::Error` leaves a query without becoming an `Error`, and so the
+    // other place a poisoned connection can announce itself. The downcast is a type-id
+    // comparison, and misses only errors handled entirely in place.
+    if let Some(sqlx_err) = (&e as &dyn std::any::Any).downcast_ref::<sqlx::Error>() {
+        crate::db::connection_reset::note_sqlx_error(sqlx_err);
+    }
     From::from(e)
 }
 

--- a/backend/windmill-common/src/error.rs
+++ b/backend/windmill-common/src/error.rs
@@ -153,6 +153,7 @@ impl From<anyhow::Error> for Error {
 impl From<sqlx::Error> for Error {
     #[track_caller]
     fn from(e: sqlx::Error) -> Self {
+        crate::db::connection_reset::note_sqlx_error(&e);
         Self::SqlErr { error: e, location: prettify_location(std::panic::Location::caller()) }
     }
 }

--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -48,13 +48,24 @@ pub const VERBOSE_TARGET: &str = "windmill_verbose";
 /// when `OTEL_JOB_LOGS=true`. Stripped before forwarding to the tracing layer.
 pub const OTEL_PREFIX: &str = "OTEL: ";
 
+/// sqlx only ever talks to Windmill's own database, so a Postgres NOTICE/WARNING on this
+/// target is never something an operator acts on. `db::connection_reset` in particular
+/// provokes one per checkout while it is armed. Applied to every sink separately — the OTEL
+/// logs bridge does not share the sinks' `Targets` filter, and an unfiltered bridge would
+/// ship the burst off-box.
+fn sqlx_notice_filter() -> Targets {
+    Targets::new()
+        .with_target(
+            "sqlx::postgres::notice",
+            tracing::level_filters::LevelFilter::ERROR,
+        )
+        .with_default(tracing::level_filters::LevelFilter::TRACE)
+}
+
 /// Creates a Targets filter that optionally filters out verbose logs when quiet mode is enabled.
 fn create_targets_filter(default_env_filter: LevelFilter) -> Targets {
     let targets = Targets::new()
         .with_target("windmill:job_log", tracing::level_filters::LevelFilter::OFF)
-        // sqlx only ever talks to Windmill's own database, so a Postgres NOTICE/WARNING on
-        // this target is never something an operator acts on. `connection_reset` in
-        // particular provokes one per checkout while it is armed.
         .with_target(
             "sqlx::postgres::notice",
             tracing::level_filters::LevelFilter::ERROR,
@@ -182,7 +193,11 @@ pub fn initialize_tracing(
     let opentelemetry_filtered = opentelemetry;
 
     let base_layer = tracing_subscriber::registry()
-        .with(logs_bridge.with_filter(otel_logs_filter))
+        .with(
+            logs_bridge
+                .with_filter(otel_logs_filter)
+                .with_filter(sqlx_notice_filter()),
+        )
         .with(opentelemetry_filtered);
 
     match *JSON_FMT {

--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -50,8 +50,15 @@ pub const OTEL_PREFIX: &str = "OTEL: ";
 
 /// Creates a Targets filter that optionally filters out verbose logs when quiet mode is enabled.
 fn create_targets_filter(default_env_filter: LevelFilter) -> Targets {
-    let targets =
-        Targets::new().with_target("windmill:job_log", tracing::level_filters::LevelFilter::OFF);
+    let targets = Targets::new()
+        .with_target("windmill:job_log", tracing::level_filters::LevelFilter::OFF)
+        // sqlx only ever talks to Windmill's own database, so a Postgres NOTICE/WARNING on
+        // this target is never something an operator acts on. `connection_reset` in
+        // particular provokes one per checkout while it is armed.
+        .with_target(
+            "sqlx::postgres::notice",
+            tracing::level_filters::LevelFilter::ERROR,
+        );
 
     if *QUIET_MODE {
         targets

--- a/backend/windmill-common/tests/connection_reset.rs
+++ b/backend/windmill-common/tests/connection_reset.rs
@@ -32,8 +32,8 @@ async fn poisoned_connection_is_reset_before_being_handed_out_again(db: Pool<Pos
         err.as_database_error().and_then(|e| e.code()).as_deref(),
         Some("25P02"),
     );
-    // Converting the error is what arms the reset in production, where every `?` on a
-    // sqlx result goes through this same `From`.
+    // Converting the error is what arms the reset in production, for the `?` into a
+    // `windmill_common::error::Result` that most queries use.
     let _ = Error::from(err);
 
     sqlx::query_scalar::<_, i32>("SELECT 1")

--- a/backend/windmill-common/tests/connection_reset.rs
+++ b/backend/windmill-common/tests/connection_reset.rs
@@ -1,8 +1,6 @@
-//! A pooled connection whose session is left inside a transaction sqlx is not tracking stays
-//! broken for every later borrower — `Rollback::drop` only fires while sqlx's own transaction
-//! depth is non-zero, and the on-release `ping` is a bare `wait_until_ready` that reports such
-//! a session as healthy. Before the reset hook this cost half an hour of unrelated `25P02`
-//! failures across the whole process, until `max_lifetime` recycled the connection.
+//! Pins that a pooled connection stuck in an aborted transaction is cleaned instead of being
+//! handed out again, and that reporting a `25P02` is what arms the cleaning. See
+//! `windmill_common::db::connection_reset` for why such a connection exists at all.
 
 use sqlx::{Executor, Pool, Postgres};
 use windmill_common::db::connection_reset;
@@ -14,7 +12,7 @@ async fn poisoned_connection_is_reset_before_being_handed_out_again(db: Pool<Pos
     let pool = sqlx::postgres::PgPoolOptions::new()
         .max_connections(1)
         .min_connections(0)
-        .after_release(|conn, _| Box::pin(connection_reset::reset_on_release(conn)))
+        .before_acquire(|conn, _| Box::pin(connection_reset::reset_before_acquire(conn)))
         .connect_with((*db.connect_options()).clone())
         .await
         .expect("failed to build pool");

--- a/backend/windmill-common/tests/connection_reset.rs
+++ b/backend/windmill-common/tests/connection_reset.rs
@@ -1,0 +1,45 @@
+//! A pooled connection whose session is left inside a transaction sqlx is not tracking stays
+//! broken for every later borrower — `Rollback::drop` only fires while sqlx's own transaction
+//! depth is non-zero, and the on-release `ping` is a bare `wait_until_ready` that reports such
+//! a session as healthy. Before the reset hook this cost half an hour of unrelated `25P02`
+//! failures across the whole process, until `max_lifetime` recycled the connection.
+
+use sqlx::{Executor, Pool, Postgres};
+use windmill_common::db::connection_reset;
+use windmill_common::error::Error;
+
+#[sqlx::test(migrations = "../migrations")]
+async fn poisoned_connection_is_reset_before_being_handed_out_again(db: Pool<Postgres>) {
+    // One connection, so every query below lands on the same session.
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .min_connections(0)
+        .after_release(|conn, _| Box::pin(connection_reset::reset_on_release(conn)))
+        .connect_with((*db.connect_options()).clone())
+        .await
+        .expect("failed to build pool");
+
+    // A batch that fails between BEGIN and COMMIT never reaches the COMMIT, leaving the
+    // session `idle in transaction (aborted)` while sqlx still believes it is not in a
+    // transaction — the same state a future cancelled during `begin()` leaves behind.
+    pool.execute("BEGIN; SELECT 1/0; COMMIT;")
+        .await
+        .expect_err("the batch must fail");
+
+    let err = sqlx::query_scalar::<_, i32>("SELECT 1")
+        .fetch_one(&pool)
+        .await
+        .expect_err("the next borrower inherits the aborted transaction");
+    assert_eq!(
+        err.as_database_error().and_then(|e| e.code()).as_deref(),
+        Some("25P02"),
+    );
+    // Converting the error is what arms the reset in production, where every `?` on a
+    // sqlx result goes through this same `From`.
+    let _ = Error::from(err);
+
+    sqlx::query_scalar::<_, i32>("SELECT 1")
+        .fetch_one(&pool)
+        .await
+        .expect("pool must hand out a usable connection again");
+}

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -634,9 +634,12 @@ pub async fn update_flow_status_after_job_completion_internal(
         }));
 
         let from_result_to_args = |args: &Result<HashMap<String, Box<RawValue>>, sqlx::Error>| {
-            let args = args
-                .as_ref()
-                .map_err(|e| Error::internal_err(format!("retrieval of args from state: {e:#}")))?;
+            let args = args.as_ref().map_err(|e| {
+                // The error is only borrowed here, so it never reaches the conversions that
+                // would otherwise report it.
+                windmill_common::db::connection_reset::note_sqlx_error(e);
+                Error::internal_err(format!("retrieval of args from state: {e:#}"))
+            })?;
 
             Ok::<_, Error>(args.clone())
         };
@@ -4421,8 +4424,7 @@ async fn push_next_flow_job(
             .as_deref()
             .filter(|t| !t.is_empty() && *t != flow_job.tag.as_str())
         {
-            let is_super_admin =
-                windmill_common::auth::is_super_admin_email(db, email).await?;
+            let is_super_admin = windmill_common::auth::is_super_admin_email(db, email).await?;
             check_tag_available_for_workspace_internal(
                 db,
                 &flow_job.workspace_id,
@@ -6155,9 +6157,7 @@ pub async fn script_to_payload(
                 .await?
                 .prefetch_cached(&db)
                 .await?;
-            let on_behalf_of = script_info
-                .on_behalf_of(&flow_job.workspace_id, db)
-                .await?;
+            let on_behalf_of = script_info.on_behalf_of(&flow_job.workspace_id, db).await?;
             let ScriptHashInfo {
                 tag,
                 cache_ttl,

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -634,12 +634,9 @@ pub async fn update_flow_status_after_job_completion_internal(
         }));
 
         let from_result_to_args = |args: &Result<HashMap<String, Box<RawValue>>, sqlx::Error>| {
-            let args = args.as_ref().map_err(|e| {
-                // The error is only borrowed here, so it never reaches the conversions that
-                // would otherwise report it.
-                windmill_common::db::connection_reset::note_sqlx_error(e);
-                Error::internal_err(format!("retrieval of args from state: {e:#}"))
-            })?;
+            let args = args
+                .as_ref()
+                .map_err(|e| Error::internal_err(format!("retrieval of args from state: {e:#}")))?;
 
             Ok::<_, Error>(args.clone())
         };
@@ -4424,7 +4421,8 @@ async fn push_next_flow_job(
             .as_deref()
             .filter(|t| !t.is_empty() && *t != flow_job.tag.as_str())
         {
-            let is_super_admin = windmill_common::auth::is_super_admin_email(db, email).await?;
+            let is_super_admin =
+                windmill_common::auth::is_super_admin_email(db, email).await?;
             check_tag_available_for_workspace_internal(
                 db,
                 &flow_job.workspace_id,
@@ -6157,7 +6155,9 @@ pub async fn script_to_payload(
                 .await?
                 .prefetch_cached(&db)
                 .await?;
-            let on_behalf_of = script_info.on_behalf_of(&flow_job.workspace_id, db).await?;
+            let on_behalf_of = script_info
+                .on_behalf_of(&flow_job.workspace_id, db)
+                .await?;
             let ScriptHashInfo {
                 tag,
                 cache_ttl,


### PR DESCRIPTION
## Summary

A production incident had **every flow on one worker pod failing for ~20 minutes** with:

```
Internal: retrieval of args from state: error returned from database:
current transaction is aborted, commands ignored until end of transaction block
```

The same `25P02` surfaced at ~10 unrelated call sites (job pull, flow status, job logs, variables, scripts, the workspace error handler), some as critical alerts. The pod never restarted — it healed on its own after `max_lifetime` recycled the pool.

**Root cause.** `jobs.rs:4394` (the failing pull) is a plain pool query with no transaction of its own, so it can only report `25P02` if the connection came out of the pool already inside a failed transaction. It did:

1. sqlx's `PgTransactionManager::begin` builds its `Rollback` drop-guard *before* sending `BEGIN`, but `start_rollback` is a no-op while `transaction_depth == 0` — and depth is incremented only *after* the round-trip await (`sqlx-postgres-0.8.6/src/transaction.rs:31-38`). A future cancelled during that await (a disconnecting API client, a `tokio::time::timeout`, an aborted task) leaves the server session inside an open transaction while sqlx believes it is not in one.
2. `Floating::return_to_pool` calls `raw.ping()`, which for Postgres is a bare `wait_until_ready` and never inspects the `ReadyForQuery` transaction-status byte — so the connection goes **back into the pool still in a transaction**.
3. The next borrower's statements silently run inside it and hold their row locks indefinitely → lock waits on `worker_ping`, then a 4-way deadlock (`40P01`).
4. That error flips the session to `idle in transaction (aborted)`, and every unrelated query on it fails with `25P02` from then on.
5. Nothing heals it: depth is still 0 so no `ROLLBACK` is ever queued, and `idle_in_transaction_session_timeout` never fires on a constantly-used connection. Only `max_lifetime` (30 min) recycles it.

`PgConnection::in_transaction()` exists but is `pub(crate)`, and the public `Connection::is_in_transaction()` reads sqlx's *client-side* depth — which is exactly the value that is wrong here — so a free check genuinely is not available to callers.

## Changes

- `windmill-common/src/db.rs` — new `connection_reset` module: a pool hook that issues `ROLLBACK`, ending both a leaked-open and an aborted transaction. Rolling back on **every** checkout costs a round trip per query (measured at ~37% of throughput on small ones), so it is **armed** only once Postgres has reported a state that proves a connection is carrying leftover transaction state, for a 60s window. Steady state is one relaxed atomic load, and the 0 → armed transition logs a `warn!` so the window is attributable.
- Hook runs on **`before_acquire`**, not `after_release`: the connection that reports the first `25P02` is released *before* its error has been converted, so a release-side hook lets exactly that connection back into the idle queue uncleaned.
- `windmill-common/src/error.rs` — arm from `From<sqlx::Error>` and from `to_anyhow` (a downcast, so it is a type-id compare), which between them cover the paths a `sqlx::Error` takes on its way out of a query.
- `windmill-common/src/tracing_init.rs` — filter `sqlx::postgres::notice` to `ERROR`. A `ROLLBACK` on a clean session makes Postgres answer `there is no transaction in progress`, which sqlx logs at WARN; sqlx only ever talks to Windmill's own database, so notices on that target are never operator-actionable.
- `windmill-common/tests/connection_reset.rs` — regression test.

Net effect: a 20-minute pool-wide outage becomes a single failed query.

## Test plan

- [x] `cargo check` and `cargo check --features enterprise,private` clean
- [x] `cargo test -p windmill-common --test connection_reset` passes
- [x] Test is load-bearing — verified it fails with the customer's exact error when the hook is removed, and also fails when the arming wiring is removed
- [x] Steady-state cost measured over 3 interleaved rounds: 209,913 → 210,100 ops/s (**+0.09%**, i.e. noise). Armed window: 132,645 ops/s (−36.8%), only after a `25P02` has already proven the pool is broken
- [x] `before_acquire` vs `after_release` verified against a real pool: with the arming losing the race, `after_release` leaves the next borrower broken while `before_acquire` cleans the connection
- [x] Exercised on a running backend: multi-step flow with a nested for-loop completes (`success: true`, `result: [2,4,6]`)

The leak itself is a genuine sqlx cancel-safety hole and still happens; this bounds its blast radius from 30 minutes to one query. Closing it entirely would mean routing all ~188 `begin()` call sites through a cancel-safe wrapper, which is worth doing separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset pooled Postgres connections left in an untracked or aborted transaction to contain pool-wide failures. Before: a connection could re-enter the pool mid-transaction and poison borrowers, cascading into `25P02` until `max_lifetime`. Now: after the first `25P02`, we `ROLLBACK` on acquire for 60s so only the triggering query fails.

- Wire the pool `before_acquire` hook to `windmill_common::db::connection_reset::reset_before_acquire` so cleanup happens on checkout and never re-queues a poisoned connection.
- Arm the reset automatically when `25P02` is seen via `From<sqlx::Error>` and `to_anyhow`; remove per-site arming calls.
- Steady state has no extra RTT; during the 60s window each checkout adds one RTT and logs a single `warn!` on arming.
- Filter `sqlx::postgres::notice` to ERROR across all sinks, including the OTEL logs bridge, to suppress benign “no transaction in progress” notices while the window is armed.
- Add regression test `backend/windmill-common/tests/connection_reset.rs` to pin arming and cleanup behavior.

<sup>Written for commit a0ee61992cb0b2ec70795bdafe9498fec32452f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## On detection coverage (addressing the round-1 P1)

An earlier revision added a `note_sqlx_error` call at the flow-args query, the one path from the incident report that formats its `sqlx::Error` into a message instead of converting it. That call has been **removed**, deliberately.

That query is 1 of **39** sites using the same lossy idiom (`sqlx result → .map_err(|e| Error::internal_err(format!("…{e:#}")))`). Patching one of them is arbitrary — it implies a per-site contract that does not exist, and would mislead the next reader into adding more. (The ~10 sites that `match` on `sqlx::Error` variants are already fine: they test one specific code and fall through to `Error::from` for everything else, so a `25P02` there arms normally.)

It is also not load-bearing, because **arming is process-wide, not per-query**. The flag covers a pool shared by everything in the process, so it does not matter which caller notices a poisoned connection, only that one does. `pull()` returns `windmill_common::error::Result` and uses `?` on its query — that is `jobs.rs:4394`, the exact line from the incident — so it converts, and it runs every few tens of milliseconds on every worker. For arming to be missed outright, every `25P02` in the process would have to land only on lossy sites while the job poller hammers the same pool.

A missed site therefore delays arming until the next converting query, not indefinitely. The reasoning now lives in the `connection_reset` module docs so it does not have to be rediscovered.