### PR TITLE
fix: qualify foreign key targets in generated datatable migrations

### DIFF
--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/dbQueriesUtils.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/dbQueriesUtils.ts
@@ -35,11 +35,12 @@ export function renderForeignKey(
 		dbType: DbType
 		tableName: string
 		/**
-		 * Quotes each dot-separated part of the target in the REFERENCES clause, so a
+		 * Table to name in the REFERENCES clause, quoted per dot-separated part so a
 		 * schema-qualified target survives identifiers that need quoting. The constraint
-		 * name is built from the unquoted value either way.
+		 * name stays derived from `fk.targetTable`, so qualifying a target here never
+		 * renames a constraint an earlier migration created under the bare name.
 		 */
-		quoteTarget?: boolean
+		qualifiedTarget?: string
 	}
 ): string {
 	const sourceColumns = fk.columns.map((c) => c.sourceColumn).filter(Boolean)
@@ -60,13 +61,12 @@ export function renderForeignKey(
 		.join('_')
 		.replaceAll('.', '_')} `.substring(0, 60)
 
-	const targetRef =
-		options.quoteTarget && targetTable
-			? targetTable
-					.split('.')
-					.map((part) => renderDbQuotedIdentifier(part, options.dbType))
-					.join('.')
-			: targetTable
+	const targetRef = options.qualifiedTarget
+		? options.qualifiedTarget
+				.split('.')
+				.map((part) => renderDbQuotedIdentifier(part, options.dbType))
+				.join('.')
+		: targetTable
 
 	sql += ` FOREIGN KEY (${sourceColumns.join(', ')}) REFERENCES ${targetRef} (${targetColumns.join(
 		', '

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/dbQueriesUtils.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/dbQueriesUtils.ts
@@ -1,5 +1,6 @@
 import type { DbType } from '$lib/components/dbTypes'
 import type { TableEditorForeignKey, TableEditorValuesColumn } from '../tableEditor'
+import { renderDbQuotedIdentifier } from '../utils'
 
 export function formatDefaultValue(str: string, datatype: string, resourceType: DbType): string {
 	if (!str) return ''
@@ -33,6 +34,12 @@ export function renderForeignKey(
 		useSchema: boolean
 		dbType: DbType
 		tableName: string
+		/**
+		 * Quotes each dot-separated part of the target in the REFERENCES clause, so a
+		 * schema-qualified target survives identifiers that need quoting. The constraint
+		 * name is built from the unquoted value either way.
+		 */
+		quoteTarget?: boolean
 	}
 ): string {
 	const sourceColumns = fk.columns.map((c) => c.sourceColumn).filter(Boolean)
@@ -53,9 +60,17 @@ export function renderForeignKey(
 		.join('_')
 		.replaceAll('.', '_')} `.substring(0, 60)
 
-	sql += ` FOREIGN KEY (${sourceColumns.join(
+	const targetRef =
+		options.quoteTarget && targetTable
+			? targetTable
+					.split('.')
+					.map((part) => renderDbQuotedIdentifier(part, options.dbType))
+					.join('.')
+			: targetTable
+
+	sql += ` FOREIGN KEY (${sourceColumns.join(', ')}) REFERENCES ${targetRef} (${targetColumns.join(
 		', '
-	)}) REFERENCES ${targetTable} (${targetColumns.join(', ')})`
+	)})`
 	if (fk.onDelete !== 'NO ACTION') sql += ` ON DELETE ${fk.onDelete}`
 	if (fk.onUpdate !== 'NO ACTION') sql += ` ON UPDATE ${fk.onUpdate}`
 	return sql

--- a/frontend/src/lib/components/datatableSchemaSql.ts
+++ b/frontend/src/lib/components/datatableSchemaSql.ts
@@ -198,15 +198,12 @@ export function generateAddedTableSql(
 	const create = `${schemaDdl}${createKeyword} ${qualifiedName} (\n  ${colDefs}${pkLine}\n);`
 	const constraints: string[] = []
 	for (const fk of table.foreignKeys ?? []) {
-		const fkSql = renderForeignKey(
-			{ ...fk, targetTable: qualifyFkTarget(sourceSchema, fk.targetTable, change.schemaName) },
-			{
-				useSchema: true,
-				dbType: 'postgresql',
-				tableName: change.tableName,
-				quoteTarget: true
-			}
-		)
+		const fkSql = renderForeignKey(fk, {
+			useSchema: true,
+			dbType: 'postgresql',
+			tableName: change.tableName,
+			qualifiedTarget: qualifyFkTarget(sourceSchema, fk.targetTable, change.schemaName)
+		})
 		// With IF NOT EXISTS the table may pre-exist with this FK already in
 		// place; an unconditional ADD would then abort the whole transaction.
 		// The constraint name is emitted unquoted, so Postgres folds it to

--- a/frontend/src/lib/components/datatableSchemaSql.ts
+++ b/frontend/src/lib/components/datatableSchemaSql.ts
@@ -147,6 +147,27 @@ function resolveColumnType(c: TableEditorValuesColumn): {
 }
 
 /**
+ * The schema API reports a foreign key's target as a bare table name whenever it
+ * lives in the same schema as the table declaring it. Emitting that verbatim
+ * produces `REFERENCES links (id)`, which Postgres resolves against `search_path`
+ * — so a migration that just created `"bitly"."links"` fails with `relation
+ * "links" does not exist`. Qualify it: the declaring table's own schema first,
+ * then any schema that has the table, matching how the FK closure resolves it.
+ */
+function qualifyFkTarget(
+	sourceSchema: DatabaseSchema,
+	targetTable: string | undefined,
+	declaringSchema: string
+): string | undefined {
+	if (!targetTable || targetTable.includes('.')) return targetTable
+	if (sourceSchema[declaringSchema]?.[targetTable]) return `${declaringSchema}.${targetTable}`
+	for (const schemaName of Object.keys(sourceSchema)) {
+		if (sourceSchema[schemaName]?.[targetTable]) return `${schemaName}.${targetTable}`
+	}
+	return targetTable
+}
+
+/**
  * SQL for an added table, with the CREATE TABLE and the FK constraints split so
  * callers creating several tables can emit every CREATE before any constraint —
  * required for circular FKs, where no creation order satisfies inline FKs.
@@ -177,11 +198,15 @@ export function generateAddedTableSql(
 	const create = `${schemaDdl}${createKeyword} ${qualifiedName} (\n  ${colDefs}${pkLine}\n);`
 	const constraints: string[] = []
 	for (const fk of table.foreignKeys ?? []) {
-		const fkSql = renderForeignKey(fk, {
-			useSchema: true,
-			dbType: 'postgresql',
-			tableName: change.tableName
-		})
+		const fkSql = renderForeignKey(
+			{ ...fk, targetTable: qualifyFkTarget(sourceSchema, fk.targetTable, change.schemaName) },
+			{
+				useSchema: true,
+				dbType: 'postgresql',
+				tableName: change.tableName,
+				quoteTarget: true
+			}
+		)
 		// With IF NOT EXISTS the table may pre-exist with this FK already in
 		// place; an unconditional ADD would then abort the whole transaction.
 		// The constraint name is emitted unquoted, so Postgres folds it to

--- a/frontend/src/lib/components/workspaceSettings/projectMigrations.test.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectMigrations.test.ts
@@ -184,7 +184,7 @@ describe('generateDatatableMigrations', () => {
 		expect(migrations[0].sql).toContain('"public"."customers"')
 	})
 
-	it('leaves a qualified ref unresolved when its schema misses, never another schema\'s table', async () => {
+	it("leaves a qualified ref unresolved when its schema misses, never another schema's table", async () => {
 		getDatatableFullSchemaMock.mockResolvedValue(schema)
 		const usage = new Map([['main', new Set(['sales.orders'])]])
 		const migrations = await generateDatatableMigrations('ws', usage)
@@ -273,6 +273,48 @@ describe('generateDatatableMigrations', () => {
 			sql.indexOf('CREATE TABLE IF NOT EXISTS "app"."customers"')
 		)
 		expect(sql).not.toContain('CREATE SCHEMA IF NOT EXISTS "public"')
+	})
+
+	it('qualifies an FK target the schema reports bare, so it resolves outside search_path', async () => {
+		// The schema API omits the schema on an FK target that lives in the same schema
+		// as the table declaring it. Emitted verbatim it becomes `REFERENCES links (id)`,
+		// which Postgres looks up on `search_path` — and the migration's own schema is
+		// never on it, so applying it fails with `relation "links" does not exist`.
+		const bitlySchema = {
+			bitly: {
+				links: {
+					name: 'links',
+					columns: [{ name: 'id', datatype: 'uuid', primary_key: true, nullable: false }],
+					foreign_keys: []
+				},
+				clicks: {
+					name: 'clicks',
+					columns: [
+						{ name: 'id', datatype: 'uuid', primary_key: true, nullable: false },
+						{ name: 'link_id', datatype: 'uuid', nullable: false }
+					],
+					foreign_keys: [
+						{
+							target_table: 'links',
+							columns: [{ source_column: 'link_id', target_column: 'id' }],
+							on_delete: 'CASCADE',
+							on_update: 'NO ACTION'
+						}
+					]
+				}
+			}
+		}
+		getDatatableFullSchemaMock.mockResolvedValue(bitlySchema)
+		const usage = new Map([['main', new Set(['bitly.clicks'])]])
+		const migrations = await generateDatatableMigrations('ws', usage)
+		const sql = migrations[0].sql
+		expect(sql).toContain('REFERENCES "bitly"."links" (id)')
+		expect(sql).not.toMatch(/REFERENCES links\b/)
+		// The guard skips the ALTER when the constraint already exists, so the name it
+		// looks up has to be the name the ALTER creates.
+		const created = sql.match(/ADD CONSTRAINT (\S+)/)?.[1]
+		expect(created).toBeTruthy()
+		expect(sql).toContain(`conname = '${created}'`)
 	})
 
 	it('keeps same-named tables from different schemas both created', async () => {

--- a/frontend/src/lib/components/workspaceSettings/projectMigrations.test.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectMigrations.test.ts
@@ -313,8 +313,55 @@ describe('generateDatatableMigrations', () => {
 		// The guard skips the ALTER when the constraint already exists, so the name it
 		// looks up has to be the name the ALTER creates.
 		const created = sql.match(/ADD CONSTRAINT (\S+)/)?.[1]
-		expect(created).toBeTruthy()
 		expect(sql).toContain(`conname = '${created}'`)
+		// The name comes from the bare target, not the qualified one: a table created by
+		// a migration generated before this fix carries the bare-target name, and the
+		// guard has to keep matching it instead of adding a second, identical FK.
+		expect(created).toBe('fk_clicks_link_id_links_id')
+	})
+
+	it('resolves a bare FK target in the declaring schema, not a same-named table elsewhere', async () => {
+		// `public` comes first, so a first-match-across-schemas resolution creates
+		// `public.links` and points the FK at it — a silently wrong reference, and
+		// `bitly.links` never gets created.
+		const sameNameTwoSchemas = {
+			public: {
+				links: {
+					name: 'links',
+					columns: [{ name: 'id', datatype: 'integer', primary_key: true, nullable: false }],
+					foreign_keys: []
+				}
+			},
+			bitly: {
+				links: {
+					name: 'links',
+					columns: [{ name: 'id', datatype: 'uuid', primary_key: true, nullable: false }],
+					foreign_keys: []
+				},
+				clicks: {
+					name: 'clicks',
+					columns: [
+						{ name: 'id', datatype: 'uuid', primary_key: true, nullable: false },
+						{ name: 'link_id', datatype: 'uuid', nullable: false }
+					],
+					foreign_keys: [
+						{
+							target_table: 'links',
+							columns: [{ source_column: 'link_id', target_column: 'id' }],
+							on_delete: 'CASCADE',
+							on_update: 'NO ACTION'
+						}
+					]
+				}
+			}
+		}
+		getDatatableFullSchemaMock.mockResolvedValue(sameNameTwoSchemas)
+		const usage = new Map([['main', new Set(['bitly.clicks'])]])
+		const migrations = await generateDatatableMigrations('ws', usage)
+		const sql = migrations[0].sql
+		expect(sql).toContain('REFERENCES "bitly"."links" (id)')
+		expect(sql).toContain('"bitly"."links"')
+		expect(sql).not.toContain('"public"."links"')
 	})
 
 	it('keeps same-named tables from different schemas both created', async () => {

--- a/frontend/src/lib/components/workspaceSettings/projectMigrations.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectMigrations.ts
@@ -130,13 +130,21 @@ export async function detectDatatableTables(
 // still references the missing one.
 function resolveTable(
 	schema: DatabaseSchema,
-	tableRef: string
+	tableRef: string,
+	declaringSchema?: string
 ): { schemaName: string; tableName: string } | undefined {
 	const dot = tableRef.indexOf('.')
 	if (dot !== -1) {
 		const schemaName = tableRef.slice(0, dot)
 		const tableName = tableRef.slice(dot + 1)
 		return schema[schemaName]?.[tableName] ? { schemaName, tableName } : undefined
+	}
+	// A bare foreign-key target means a table in the declaring table's own schema —
+	// that is the only case the schema API drops the schema for — so resolve there
+	// first. Without it a same-named table in another schema wins, and the closure
+	// creates that one while the FK points at it.
+	if (declaringSchema && schema[declaringSchema]?.[tableRef]) {
+		return { schemaName: declaringSchema, tableName: tableRef }
 	}
 	// Bare name: find it across every schema, first match wins.
 	for (const schemaName of Object.keys(schema)) {
@@ -161,7 +169,7 @@ function expandFkClosure(schema: DatabaseSchema, seed: ResolvedTable[]): Resolve
 		const t = queue.shift()!
 		const fks = schema[t.schemaName]?.[t.tableName]?.foreignKeys ?? []
 		for (const fk of fks) {
-			const target = resolveTable(schema, fk.targetTable ?? '')
+			const target = resolveTable(schema, fk.targetTable ?? '', t.schemaName)
 			if (target && !inSet.has(tableKey(target))) {
 				inSet.set(tableKey(target), target)
 				queue.push(target)
@@ -184,7 +192,7 @@ function pruneSchemaForTables(schema: DatabaseSchema, tables: ResolvedTable[]): 
 		;(pruned[t.schemaName] ??= {})[t.tableName] = {
 			...orig,
 			foreignKeys: (orig.foreignKeys ?? []).filter((fk) => {
-				const target = resolveTable(schema, fk.targetTable ?? '')
+				const target = resolveTable(schema, fk.targetTable ?? '', t.schemaName)
 				return target != null && inSet.has(tableKey(target))
 			})
 		}
@@ -203,7 +211,7 @@ function orderByFkDependency(schema: DatabaseSchema, tables: ResolvedTable[]): R
 		const fks = schema[t.schemaName]?.[t.tableName]?.foreignKeys ?? []
 		const targets = new Set<string>()
 		for (const fk of fks) {
-			const target = resolveTable(schema, fk.targetTable ?? '')
+			const target = resolveTable(schema, fk.targetTable ?? '', t.schemaName)
 			if (target && tableKey(target) !== tableKey(t) && inSet.has(tableKey(target))) {
 				targets.add(tableKey(target))
 			}


### PR DESCRIPTION
## The bug

A generated data table migration cannot be applied. Importing a Hub project whose
schema has a foreign key fails with:

```
Failed to apply migration 20260824130235 (hub_import_helpdesk):
execution error: Error: db error: ERROR: relation "tickets" does not exist
  @pg_executor.rs:552:19 @datatable_migrations.rs:219:20 @datatable_migrations.rs:433:17
```

The published SQL for `helpdesk` says:

```sql
ALTER TABLE "helpdesk"."messages" ADD CONSTRAINT fk_messages_ticket_id_tickets_id
  FOREIGN KEY (ticket_id) REFERENCES tickets (id) ON DELETE CASCADE;
```

The table is qualified, the FK target is not. Postgres resolves a bare name against
`search_path`, and a migration's own schema is never on it. The statement is inside
`BEGIN … COMMIT`, so the whole migration rolls back — the project imports fully and
sits on top of a database with no tables in it.

`getDatatableFullSchema` omits the schema on a target that lives in the same schema as
the table declaring it, and the generator emitted that verbatim.

## The fix

`qualifyFkTarget` resolves the target the way the FK closure resolves it: the declaring
table's own schema first, then any schema that holds the table. `resolveTable` learned the
same preference, so the closure, the ordering and the pruning all pick the declaring
schema's table for a bare target instead of a same-named table in another schema.

The qualified value reaches `renderForeignKey` as a `qualifiedTarget` render option, quoted
per dot-separated part so identifiers that need quoting survive. The constraint *name* is
still derived from `fk.targetTable`, so qualifying a target never renames a constraint an
earlier migration already created — the `pg_constraint` guard keeps matching it.

`qualifiedTarget` is opt-in. `alterTable.ts`, the only other caller of `renderForeignKey`,
does not pass it and is byte-identical.

## Verified

Against a real data table, not only in unit tests:

| | result |
|---|---|
| published `helpdesk` SQL | `ERROR: relation "tickets" does not exist` |
| after the failure | 0 tables — the transaction rolled back cleanly |
| same SQL, target qualified | succeeds |
| resulting constraint | `FOREIGN KEY (ticket_id) REFERENCES helpdesk.tickets(id) ON DELETE CASCADE` |

Unit test added; confirmed it fails without the fix (`expected … to contain 'REFERENCES
"bitly"."links" (id)'`, got `REFERENCES "links" (id)`).

## Rollout

The Hub stores the SQL a project was published with, so shipping this code fixes new
publishes only. Affected projects need republishing: `helpdesk`, `lemlist`, `recruit`,
`typeform`, `uptimerobot`.

No repair step for anyone who already hit this — the failed migration rolled back, so
their schema is empty rather than half-built, and the corrected SQL is idempotent
(`CREATE TABLE IF NOT EXISTS`, plus a `pg_constraint` guard on each FK).

Split out of #10729 deliberately, so it can ship and the Hub projects can be republished
and tested ahead of the larger import-wizard change.

