### PR TITLE
fix: patch sqlx so a cancelled BEGIN cannot poison a pooled connection

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -11849,8 +11849,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -11862,8 +11861,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
@@ -11901,8 +11899,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11914,8 +11911,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros-core"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "dotenvy",
  "either",
@@ -11939,8 +11935,7 @@ dependencies = [
 [[package]]
 name = "sqlx-mysql"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -11984,8 +11979,7 @@ dependencies = [
 [[package]]
 name = "sqlx-postgres"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -12025,8 +12019,7 @@ dependencies = [
 [[package]]
 name = "sqlx-sqlite"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+source = "git+https://github.com/windmill-labs/sqlx?rev=6bdaee94fa62a01561125646da3f99eb341f2457#6bdaee94fa62a01561125646da3f99eb341f2457"
 dependencies = [
  "atoi",
  "chrono",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -214,6 +214,23 @@ all_sqlx_features = ["all_languages", "enterprise", "enterprise_saml", "embeddin
    "windmill-git-sync/all_sqlx_features"]
 
 [patch.crates-io]
+# v0.8.6 plus one commit: `Pool::begin` is not cancel-safe on Postgres. sqlx raises the
+# transaction depth its rollback-on-drop guard keys on only *after* the BEGIN round trip, so
+# a cancelled caller (a disconnecting API client, a `timeout`, an aborted task) leaves the
+# session in a transaction nothing will end, and the pool hands that connection out again —
+# every later query on it fails with 25P02 until max_lifetime recycles it 30 minutes on.
+# Reported upstream in 2022 (launchbadge/sqlx#2054), fixed for SQLite only, and still present
+# in 0.9.0. Drop this the moment upstream carries the fix.
+# The whole family has to move together: `sqlx-postgres` depends on `sqlx-core` by path
+# inside the sqlx workspace, so patching it alone leaves two incompatible `sqlx-core`s and
+# `Postgres` stops implementing the `Database` the macros expect.
+sqlx = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
+sqlx-core = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
+sqlx-macros = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
+sqlx-macros-core = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
+sqlx-postgres = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
+sqlx-mysql = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
+sqlx-sqlite = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
 object_store = { git = "https://github.com/apache/arrow-rs-object-store", rev = "36752c975d4f29e20b57c91f81a10872dcd48ae7" }
 # Use tiberius main branch for libgssapi 0.8.1 fix (https://github.com/prisma/tiberius/issues/343)
 tiberius = { git = "https://github.com/prisma/tiberius", rev = "59db57960a14b422fb3a1309aa4aa47880896ff8" }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -224,6 +224,9 @@ all_sqlx_features = ["all_languages", "enterprise", "enterprise_saml", "embeddin
 # The whole family has to move together: `sqlx-postgres` depends on `sqlx-core` by path
 # inside the sqlx workspace, so patching it alone leaves two incompatible `sqlx-core`s and
 # `Postgres` stops implementing the `Database` the macros expect.
+# Changing any of this — a bump, a rebase of the fork, dropping these lines — still compiles
+# clean, so run the guard that actually checks the behaviour is still there:
+#   cargo test -p windmill-common --test sqlx_begin_cancel_safe -- --ignored
 sqlx = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
 sqlx-core = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }
 sqlx-macros = { git = "https://github.com/windmill-labs/sqlx", rev = "6bdaee94fa62a01561125646da3f99eb341f2457" }

--- a/backend/windmill-common/tests/sqlx_begin_cancel_safe.rs
+++ b/backend/windmill-common/tests/sqlx_begin_cancel_safe.rs
@@ -1,16 +1,10 @@
-//! Guards the `sqlx` entries in `[patch.crates-io]`.
-//!
-//! Upstream `Pool::begin` raises the transaction depth its rollback-on-drop guard keys on
-//! only *after* the `BEGIN` round trip, so a cancelled caller leaves the session inside a
-//! transaction nothing will end — and the pool hands that connection to the next borrower,
-//! whose statements run inside it until an error turns every later query on it into `25P02`.
-//! Dropping the patch (an sqlx bump that forgets to rebase it, or a deleted `Cargo.toml`
-//! line) still compiles, so this is what notices.
+//! Guards the `sqlx` entries in `[patch.crates-io]` — `backend/Cargo.toml` carries the why.
+//! Dropping the patch still compiles, so a test is what notices.
 
 use sqlx::{Connection, PgConnection, Pool, Postgres};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-#[sqlx::test(migrations = "../migrations")]
+#[sqlx::test]
 async fn begin_cancelled_mid_round_trip_leaves_no_open_transaction(db: Pool<Postgres>) {
     // One connection, so the session inspected below is the one the cancelled begin used.
     let pool = sqlx::postgres::PgPoolOptions::new()
@@ -25,8 +19,8 @@ async fn begin_cancelled_mid_round_trip_leaves_no_open_transaction(db: Pool<Post
         .unwrap();
 
     // A plain `BEGIN` answers in well under a millisecond, which is too narrow to cancel
-    // reliably; appending a sleep widens the round trip the way a degraded database does,
-    // and it runs through the same `PgTransactionManager::begin` the patch fixes.
+    // reliably; appending a sleep widens the round trip and runs through the same
+    // `PgTransactionManager::begin` the patch fixes.
     let cancelled = tokio::time::timeout(
         Duration::from_millis(300),
         pool.begin_with("BEGIN; SELECT pg_sleep(2);"),
@@ -34,25 +28,32 @@ async fn begin_cancelled_mid_round_trip_leaves_no_open_transaction(db: Pool<Post
     .await;
     assert!(cancelled.is_err(), "the begin must not have completed");
 
-    // Outlast the sleep: sqlx only flushes the queued ROLLBACK once the abandoned statement
-    // has answered and the connection is on its way back to the pool.
-    tokio::time::sleep(Duration::from_millis(3500)).await;
-
     let mut admin = PgConnection::connect_with(&(*db.connect_options()).clone())
         .await
         .expect("failed to open an observing connection");
-    let state: Option<String> =
-        sqlx::query_scalar("SELECT state FROM pg_stat_activity WHERE pid = $1")
+
+    // sqlx only flushes the queued ROLLBACK once the abandoned statement has answered, so
+    // wait for the session to stop running rather than sleeping a fixed time a loaded runner
+    // could overshoot.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let state = loop {
+        let state: String = sqlx::query_scalar("SELECT state FROM pg_stat_activity WHERE pid = $1")
             .bind(pid)
             .fetch_optional(&mut admin)
             .await
             .unwrap()
-            .flatten();
-    assert_eq!(
-        state.as_deref(),
-        Some("idle"),
-        "connection returned to the pool still inside a transaction — is the sqlx patch in \
-         backend/Cargo.toml still applied?"
+            .flatten()
+            .unwrap_or_default();
+        if state != "active" || Instant::now() >= deadline {
+            break state;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+
+    assert!(
+        !state.starts_with("idle in transaction"),
+        "connection returned to the pool still inside a transaction (state {state:?}) — is \
+         the sqlx patch in backend/Cargo.toml still applied?"
     );
 
     sqlx::query_scalar::<_, i32>("SELECT 1")

--- a/backend/windmill-common/tests/sqlx_begin_cancel_safe.rs
+++ b/backend/windmill-common/tests/sqlx_begin_cancel_safe.rs
@@ -1,0 +1,62 @@
+//! Guards the `sqlx` entries in `[patch.crates-io]`.
+//!
+//! Upstream `Pool::begin` raises the transaction depth its rollback-on-drop guard keys on
+//! only *after* the `BEGIN` round trip, so a cancelled caller leaves the session inside a
+//! transaction nothing will end — and the pool hands that connection to the next borrower,
+//! whose statements run inside it until an error turns every later query on it into `25P02`.
+//! Dropping the patch (an sqlx bump that forgets to rebase it, or a deleted `Cargo.toml`
+//! line) still compiles, so this is what notices.
+
+use sqlx::{Connection, PgConnection, Pool, Postgres};
+use std::time::Duration;
+
+#[sqlx::test(migrations = "../migrations")]
+async fn begin_cancelled_mid_round_trip_leaves_no_open_transaction(db: Pool<Postgres>) {
+    // One connection, so the session inspected below is the one the cancelled begin used.
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .min_connections(0)
+        .connect_with((*db.connect_options()).clone())
+        .await
+        .expect("failed to build pool");
+    let pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    // A plain `BEGIN` answers in well under a millisecond, which is too narrow to cancel
+    // reliably; appending a sleep widens the round trip the way a degraded database does,
+    // and it runs through the same `PgTransactionManager::begin` the patch fixes.
+    let cancelled = tokio::time::timeout(
+        Duration::from_millis(300),
+        pool.begin_with("BEGIN; SELECT pg_sleep(2);"),
+    )
+    .await;
+    assert!(cancelled.is_err(), "the begin must not have completed");
+
+    // Outlast the sleep: sqlx only flushes the queued ROLLBACK once the abandoned statement
+    // has answered and the connection is on its way back to the pool.
+    tokio::time::sleep(Duration::from_millis(3500)).await;
+
+    let mut admin = PgConnection::connect_with(&(*db.connect_options()).clone())
+        .await
+        .expect("failed to open an observing connection");
+    let state: Option<String> =
+        sqlx::query_scalar("SELECT state FROM pg_stat_activity WHERE pid = $1")
+            .bind(pid)
+            .fetch_optional(&mut admin)
+            .await
+            .unwrap()
+            .flatten();
+    assert_eq!(
+        state.as_deref(),
+        Some("idle"),
+        "connection returned to the pool still inside a transaction — is the sqlx patch in \
+         backend/Cargo.toml still applied?"
+    );
+
+    sqlx::query_scalar::<_, i32>("SELECT 1")
+        .fetch_one(&pool)
+        .await
+        .expect("pool must still serve queries");
+}

--- a/backend/windmill-common/tests/sqlx_begin_cancel_safe.rs
+++ b/backend/windmill-common/tests/sqlx_begin_cancel_safe.rs
@@ -1,10 +1,19 @@
 //! Guards the `sqlx` entries in `[patch.crates-io]` — `backend/Cargo.toml` carries the why.
 //! Dropping the patch still compiles, so a test is what notices.
+//!
+//! Ignored by default: it only has something to say when the sqlx dependency moves, and it
+//! spends a couple of seconds waiting on a deliberately slow round trip. Run it whenever you
+//! touch sqlx — a version bump, a change to the patch entries, a fork rebase:
+//!
+//! ```text
+//! cargo test -p windmill-common --test sqlx_begin_cancel_safe -- --ignored
+//! ```
 
 use sqlx::{Connection, PgConnection, Pool, Postgres};
 use std::time::{Duration, Instant};
 
 #[sqlx::test]
+#[ignore = "run with --ignored after any sqlx bump or change to [patch.crates-io]"]
 async fn begin_cancelled_mid_round_trip_leaves_no_open_transaction(db: Pool<Postgres>) {
     // One connection, so the session inspected below is the one the cancelled begin used.
     let pool = sqlx::postgres::PgPoolOptions::new()

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -16,6 +16,7 @@ After making changes, run the appropriate checks and fix all errors before consi
 | Multiple gated modules | `cargo check --features enterprise,parquet` | Combine only the flags you need |
 | API route changes | `cargo check` | Then update `openapi.yaml` and run `npm run generate-backend-client` |
 | Database migrations | `cargo check` | Test migration applies cleanly with `sqlx migrate run` |
+| The `sqlx` dependency (version bump, `[patch.crates-io]` entries, fork rebase) | `cargo test -p windmill-common --test sqlx_begin_cancel_safe -- --ignored` | Windmill runs a patched `sqlx`: upstream's `Pool::begin` is not cancel-safe on Postgres, and a cancelled one poisons the pooled connection for 30 minutes. Losing the patch still compiles, so this ignored test is the only thing that notices. `backend/Cargo.toml` has the detail |
 
 **Never** use `--features all_sqlx_features` — it compiles everything and is very slow. Check `backend/Cargo.toml` `[features]` to find the right flags.
 


### PR DESCRIPTION
## Summary

A production incident had **every flow on one worker pod failing for ~20 minutes** with `current transaction is aborted, commands ignored until end of transaction block` (`25P02`), surfacing at ~10 unrelated call sites at once — job pull, flow status, job logs, variables, scripts, the workspace error handler. The pod never restarted; it healed on its own once `max_lifetime` recycled the pool.

**Root cause is upstream.** `Pool::begin` is not cancel-safe on Postgres:

1. `PgTransactionManager::begin` raises the `transaction_depth` its rollback-on-drop guard keys on only *after* the `BEGIN` round trip. A future cancelled in between — a disconnecting API client, a `tokio::time::timeout`, an aborted task — leaves the session inside a transaction with nothing queued to end it. (Normally that window is sub-millisecond; a degraded database widens it, and the pod logged `db_latency=8315ms`.)
2. `Floating::return_to_pool` calls `ping()`, which on Postgres is a bare `wait_until_ready`: it drains the `ReadyForQuery` but never inspects its transaction-status byte. So the connection is judged healthy and returned to the pool.
3. The next borrower's statements run inside that transaction and hold its locks indefinitely → lock waits on `worker_ping` → a 4-way deadlock (`40P01`).
4. That error turns the session into `idle in transaction (aborted)`, and every unrelated query on the connection fails with `25P02` from then on.
5. Nothing recovers it: the depth is still zero so no rollback is ever queued, and `idle_in_transaction_session_timeout` never fires on a connection in constant use. Only `max_lifetime` (30 min) does — which matches the ~20 minutes observed.

Upstream has known since 2022 ([launchbadge/sqlx#2054](https://github.com/launchbadge/sqlx/issues/2054), labeled `bug`), fixed it for **SQLite only** and closed it. #2819 later added the Postgres `Rollback` guard, but it is a no-op at depth 0 — the pool case. #3980 (shipped in 0.9.0, titled *"Correctly `ROLLBACK` transaction when dropped during `BEGIN`"*) restructures the generic `Transaction::begin`, but for Postgres it still funnels into the same depth-gated `start_rollback`. **I tested 0.9.0 directly: it still leaks**, so bumping does not fix this.

## Changes

- `backend/Cargo.toml` — point the `sqlx` family at [windmill-labs/sqlx@6bdaee94](https://github.com/windmill-labs/sqlx/commit/6bdaee94fa62a01561125646da3f99eb341f2457), which is `v0.8.6` plus one commit: claim the transaction depth *before* the `BEGIN` round trip and unwind it if the `BEGIN` did not take, so the drop-guard has something to act on.

  The whole family moves together deliberately. `sqlx-postgres` depends on `sqlx-core` by path inside the sqlx workspace, so patching it alone yields two incompatible `sqlx-core`s and `Postgres` stops implementing the `Database` the macros expect. The lock still resolves to exactly one `sqlx-core`.
- `backend/windmill-common/tests/sqlx_begin_cancel_safe.rs` — guards the patch. Dropping it (an sqlx bump that forgets to rebase, a deleted `Cargo.toml` line) still compiles, so a test is what notices.

This is the same mechanism already used for `tokio-postgres`/`postgres-types`/`postgres-protocol`, which are pinned to the MaterializeInc fork for a change upstream declined to merge.

## Test plan

- [x] `cargo check` and `cargo check --features enterprise,private` clean
- [x] `cargo test -p windmill-common` — 531 unit + all integration tests pass
- [x] New test is load-bearing: with the patch entries removed it fails with `left: Some("idle in transaction")`, `right: Some("idle")`
- [x] `cargo tree` confirms `sqlx-postgres` resolves to the fork, and the lock has exactly one `sqlx-core` (unchanged count from main)
- [x] Patch verified not to alter transaction semantics: commit persists, drop rolls back, explicit rollback works, nested savepoint rolls back inside a committing outer transaction
- [x] Exercised on a running backend: script deploy, group create, script run (`27`), multi-step flow with a nested for-loop (`[2,4,6]`)

## Follow-ups

- Upstream report filed with the reproduction; drop this patch the moment upstream carries the fix — it is one line in `Cargo.toml` plus the test.
- Bumping to sqlx 0.9 is worth doing on its own merits (`sqlx.toml`, advisory-lock cancel-safety) but is deliberately **not** coupled here: it does not fix this bug, and it needs 114 `AssertSqlSafe` call sites plus a Postgres connection-option escaping change that wants its own testing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches the `sqlx` family to a fork so a cancelled `Pool::begin` on Postgres no longer leaves the session in an open transaction and poisons a pooled connection. Previously, cancelling `BEGIN` could return a connection still in a transaction; later queries deadlocked or failed with `25P02` until the pool recycled it.

- backend/Cargo.toml: patches all `sqlx` crates (`sqlx`, `sqlx-core`, `sqlx-postgres`, `sqlx-macros`, `sqlx-macros-core`, `sqlx-mysql`, `sqlx-sqlite`) to the `windmill-labs/sqlx` fork that claims transaction depth before the `BEGIN` round trip; `Cargo.lock` reflects git sources and keeps a single `sqlx-core`.
- Adds `backend/windmill-common/tests/sqlx_begin_cancel_safe.rs` to guard the patch; the test is ignored by default. When changing `sqlx`, run: cargo test -p windmill-common --test sqlx_begin_cancel_safe -- --ignored. Updates `docs/validation.md` to point to this.
- No schema or app code changes. Remove the patch once upstream ships a fix; the test will catch regressions.

<sup>Written for commit 7cb7941d0f13743c7eac3d192818449fa9f9b74c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Fixes WIN-2444