### PR TITLE
fix(frontend): operator menu opens on hover, pins on click

### DIFF
--- a/frontend/src/lib/components/meltComponents/Menu.svelte
+++ b/frontend/src/lib/components/meltComponents/Menu.svelte
@@ -31,6 +31,12 @@
 		// on it clips submenus that open to the side. Opt in only when using a submenu — the
 		// default keeps the existing single-element markup untouched for every other menu.
 		submenuSafe?: boolean
+		// Open on hover without pinning, so the menu closes again once the pointer leaves.
+		// A click then pins it open until a click outside or on the trigger.
+		openOnHover?: boolean
+		// Grace period before a hover-opened menu closes, so the pointer can travel from
+		// the trigger to the content.
+		debounceDelay?: number
 		classNames?: string
 		triggr?: import('svelte').Snippet<[any]>
 		children?: import('svelte').Snippet<[any]>
@@ -50,6 +56,8 @@
 		open = $bindable(false),
 		renderContent = false,
 		submenuSafe = false,
+		openOnHover = false,
+		debounceDelay = 150,
 		class: classNames = '',
 		triggr,
 		children
@@ -99,6 +107,77 @@
 		open = false
 	}
 
+	// A hover-opened menu is unpinned; a click pins it until a click outside or on the trigger.
+	let pinned = $state(false)
+	let closeTimeout: ReturnType<typeof setTimeout> | undefined
+	let triggerEl: HTMLElement | undefined = $state()
+	let clickingTrigger = false
+
+	watch(
+		() => open,
+		() => {
+			if (!open) {
+				pinned = false
+				cancelPendingClose()
+			}
+		}
+	)
+
+	// Setting `open` doesn't open a menubar menu: melt shows the content only once the
+	// trigger's own click handler has registered it as the active trigger. So every
+	// hover-driven open and close goes through a click on the trigger instead.
+	function toggleViaTrigger() {
+		const el = triggerEl?.querySelector('[data-melt-menubar-trigger]')
+		if (!(el instanceof HTMLElement)) return
+		// click() dispatches synchronously, so the flag only covers our own event.
+		clickingTrigger = true
+		try {
+			el.click()
+		} finally {
+			clickingTrigger = false
+		}
+	}
+
+	function cancelPendingClose() {
+		if (closeTimeout != undefined) {
+			clearTimeout(closeTimeout)
+			closeTimeout = undefined
+		}
+	}
+
+	function handleHoverEnter() {
+		if (!openOnHover) return
+		cancelPendingClose()
+		if (!open) toggleViaTrigger()
+	}
+
+	function scheduleClose() {
+		if (!openOnHover) return
+		cancelPendingClose()
+		if (pinned) return
+		// The content is portaled away from the trigger, so moving between the two fires a
+		// leave on the one being left; the delay lets the matching enter cancel it.
+		closeTimeout = setTimeout(() => {
+			closeTimeout = undefined
+			if (open && !pinned) toggleViaTrigger()
+		}, debounceDelay)
+	}
+
+	function handleTriggerClick(e: MouseEvent) {
+		if (!openOnHover || clickingTrigger) return
+		cancelPendingClose()
+		if (open && !pinned) {
+			// Hover already opened it: swallow the click before melt's trigger handler
+			// toggles it shut, and pin it instead.
+			e.preventDefault()
+			e.stopPropagation()
+			pinned = true
+			return
+		}
+		// Melt handles the toggle itself: closed becomes open and pinned, pinned closes.
+		pinned = !open
+	}
+
 	async function getMenuElements(): Promise<HTMLElement[]> {
 		// Tooltip content counts as menu territory for the same reason as the
 		// onOutsideClick veto above.
@@ -112,8 +191,12 @@
 	<ResolveOpen {open} on:open on:close />
 
 	<button
+		bind:this={triggerEl}
 		class={twMerge('w-full h-full', justifyEnd ? 'flex justify-end' : '')}
 		{disabled}
+		onmouseenter={handleHoverEnter}
+		onmouseleave={scheduleClose}
+		onclickcapture={handleTriggerClick}
 		use:pointerDownOutside={{
 			capture: true,
 			stopPropagation: false,
@@ -135,6 +218,8 @@
 		<div
 			use:melt={$menuElement}
 			data-menu
+			onmouseenter={cancelPendingClose}
+			onmouseleave={scheduleClose}
 			transition:placementFly={{ duration: 100, placement }}
 			class={twMerge(
 				'z-[6000] border w-56 origin-top-right rounded-md shadow-md focus:outline-none',

--- a/frontend/src/lib/components/meltComponents/Menu.svelte
+++ b/frontend/src/lib/components/meltComponents/Menu.svelte
@@ -108,6 +108,7 @@
 	}
 
 	// A hover-opened menu is unpinned; a click pins it until a click outside or on the trigger.
+	// Handed to the triggr snippet so the trigger can show the pinned state.
 	let pinned = $state(false)
 	let closeTimeout: ReturnType<typeof setTimeout> | undefined
 	let triggerEl: HTMLElement | undefined = $state()
@@ -210,7 +211,7 @@
 		}}
 		data-menu
 	>
-		{@render triggr?.({ trigger })}
+		{@render triggr?.({ trigger, pinned })}
 	</button>
 
 	<!--svelte-ignore a11y_no_static_element_interactions-->

--- a/frontend/src/lib/components/meltComponents/Menu.svelte
+++ b/frontend/src/lib/components/meltComponents/Menu.svelte
@@ -8,7 +8,7 @@
 	import { melt, createSync } from '@melt-ui/svelte'
 	import type { MenubarBuilders } from '@melt-ui/svelte'
 	import type { Placement } from '@floating-ui/core'
-	import { pointerDownOutside } from '$lib/utils'
+	import { debounce, pointerDownOutside } from '$lib/utils'
 
 	import { twMerge } from 'tailwind-merge'
 	import ResolveOpen from '$lib/components/common/menu/ResolveOpen.svelte'
@@ -110,7 +110,6 @@
 	// A hover-opened menu is unpinned; a click pins it until a click outside or on the trigger.
 	// Handed to the triggr snippet so the trigger can show the pinned state.
 	let pinned = $state(false)
-	let closeTimeout: ReturnType<typeof setTimeout> | undefined
 	let triggerEl: HTMLElement | undefined = $state()
 	let clickingTrigger = false
 
@@ -139,12 +138,12 @@
 		}
 	}
 
-	function cancelPendingClose() {
-		if (closeTimeout != undefined) {
-			clearTimeout(closeTimeout)
-			closeTimeout = undefined
-		}
-	}
+	const { debounced: debounceClose, clearDebounce: cancelPendingClose } = debounce(
+		() => {
+			if (open && !pinned) toggleViaTrigger()
+		},
+		untrack(() => debounceDelay)
+	)
 
 	function handleHoverEnter() {
 		if (!openOnHover) return
@@ -158,10 +157,7 @@
 		if (pinned) return
 		// The content is portaled away from the trigger, so moving between the two fires a
 		// leave on the one being left; the delay lets the matching enter cancel it.
-		closeTimeout = setTimeout(() => {
-			closeTimeout = undefined
-			if (open && !pinned) toggleViaTrigger()
-		}, debounceDelay)
+		debounceClose()
 	}
 
 	function handleTriggerClick(e: MouseEvent) {

--- a/frontend/src/lib/components/sidebar/MenuButton.svelte
+++ b/frontend/src/lib/components/sidebar/MenuButton.svelte
@@ -2,12 +2,10 @@
 	export const sidebarClasses = {
 		text: 'text-secondary text-xs font-normal',
 		iconText: 'text-hint',
-		selectedText: 'text-accent text-xs font-semibold',
+		selectedText: 'text-emphasis text-xs font-semibold',
 		sublabelText: 'text-secondary text-2xs font-normal',
 		hoverBg: 'transition-colors hover:bg-surface-hover',
-		// The accent tint keeps the current page distinguishable from the hover and
-		// keyboard-highlight states, which both paint bg-surface-hover.
-		selectedBg: 'bg-surface-accent-selected'
+		selectedBg: 'bg-surface-hover'
 	}
 </script>
 

--- a/frontend/src/lib/components/sidebar/MenuButton.svelte
+++ b/frontend/src/lib/components/sidebar/MenuButton.svelte
@@ -2,10 +2,12 @@
 	export const sidebarClasses = {
 		text: 'text-secondary text-xs font-normal',
 		iconText: 'text-hint',
-		selectedText: 'text-emphasis text-xs font-semibold',
+		selectedText: 'text-accent text-xs font-semibold',
 		sublabelText: 'text-secondary text-2xs font-normal',
 		hoverBg: 'transition-colors hover:bg-surface-hover',
-		selectedBg: 'bg-surface-hover'
+		// The accent tint keeps the current page distinguishable from the hover and
+		// keyboard-highlight states, which both paint bg-surface-hover.
+		selectedBg: 'bg-surface-accent-selected'
 	}
 </script>
 

--- a/frontend/src/lib/components/sidebar/MenuLink.svelte
+++ b/frontend/src/lib/components/sidebar/MenuLink.svelte
@@ -62,10 +62,11 @@
 			{onclick}
 			class={twMerge(
 				'group flex items-center px-2 py-2 text-sm font-light rounded-md h-8 gap-2',
-				isSelected
-					? sidebarClasses.selectedBg
-					: sidebarClasses.hoverBg,
+				isSelected ? sidebarClasses.selectedBg : sidebarClasses.hoverBg,
 				isSelected ? sidebarClasses.selectedText : sidebarClasses.text,
+				// Keyboard navigation marks the current row with data-highlighted; without this
+				// it moves invisibly, since sidebarClasses.hoverBg only reacts to the pointer.
+				item ? 'data-[highlighted]:bg-surface-hover' : '',
 				classNames
 			)}
 			data-light-mode={lightMode}
@@ -77,7 +78,13 @@
 		>
 			{#if icon}
 				{@const SvelteComponent = icon}
-				<SvelteComponent size={16} class={twMerge('flex-shrink-0 transition-all', isSelected ? sidebarClasses.selectedText : sidebarClasses.iconText)} />
+				<SvelteComponent
+					size={16}
+					class={twMerge(
+						'flex-shrink-0 transition-all',
+						isSelected ? sidebarClasses.selectedText : sidebarClasses.iconText
+					)}
+				/>
 			{/if}
 
 			{#if !isCollapsed}

--- a/frontend/src/lib/components/sidebar/MenuLink.svelte
+++ b/frontend/src/lib/components/sidebar/MenuLink.svelte
@@ -62,11 +62,15 @@
 			{onclick}
 			class={twMerge(
 				'group flex items-center px-2 py-2 text-sm font-light rounded-md h-8 gap-2',
-				isSelected ? sidebarClasses.selectedBg : sidebarClasses.hoverBg,
-				isSelected ? sidebarClasses.selectedText : sidebarClasses.text,
-				// Keyboard navigation marks the current row with data-highlighted; without this
-				// it moves invisibly, since sidebarClasses.hoverBg only reacts to the pointer.
+				isSelected
+					? sidebarClasses.selectedBg
+					: item
+						? 'transition-colors'
+						: sidebarClasses.hoverBg,
+				// Inside a menu, melt moves data-highlighted with both the keyboard and the
+				// pointer, so it is the only pointer state: a hover rule as well lights two rows.
 				item ? 'data-[highlighted]:bg-surface-hover' : '',
+				isSelected ? sidebarClasses.selectedText : sidebarClasses.text,
 				classNames
 			)}
 			data-light-mode={lightMode}

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -344,11 +344,13 @@
 								{#if extraTriggerLinks.length}<div>
 										<!-- svelte-ignore a11y_no_static_element_interactions -->
 										<div
+											role="none"
 											onclickcapture={(e) => {
 												// This row expands the list below it instead of acting on the selection, and
 												// melt keeps the menu open only for a click it sees as defaultPrevented.
 												// Svelte delegates onclick to the root, which runs after melt's own listener,
-												// so the capture phase on this wrapper is what gets there first.
+												// and a capture listener on the item itself would be ordered only by
+												// registration, so an ancestor's capture phase is what reliably wins.
 												e.preventDefault()
 												showExtraTriggers = !showExtraTriggers
 											}}

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -179,9 +179,14 @@
 			usePointerDownOutside
 			on:close={() => (showExtraTriggers = false)}
 		>
-			{#snippet triggr({ trigger })}
+			{#snippet triggr({ trigger, pinned })}
 				<MenuButton
-					class="!text-xs bg-surface !pl-3.5 !pr-2 !w-auto"
+					class={twMerge(
+						'!text-xs bg-surface !pl-3.5 !pr-2 !w-auto',
+						// A hover-opened menu leaves the button plain once the pointer moves on;
+						// keeping the tint is what tells you the click pinned it.
+						pinned ? sidebarClasses.selectedBg : ''
+					)}
 					icon={MenuIcon}
 					isCollapsed={false}
 					lightMode

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -40,66 +40,6 @@
 	import type { FavoriteKind } from './FavoriteMenu.svelte'
 	let darkMode: boolean = $state(false)
 	let showExtraTriggers = $state(false)
-	// Mirrors melt's own open state. Writing it doesn't open the menu — melt's menubar
-	// only shows the content once the trigger's click handler has registered it as the
-	// active trigger — so every open and close goes through a click on the trigger.
-	let open = $state(false)
-	// A click pins the menu: it then stays open until a click outside or on the trigger.
-	// Hover opens it without pinning, so it closes again once the pointer leaves.
-	let pinned = $state(false)
-	let closeTimeout: ReturnType<typeof setTimeout> | undefined
-	let wrapperEl: HTMLElement | undefined = $state()
-	let clickingTrigger = false
-
-	function toggleViaTrigger() {
-		const el = wrapperEl?.querySelector('[data-melt-menubar-trigger]')
-		if (!(el instanceof HTMLElement)) return
-		// click() dispatches synchronously, so the flag only covers our own event.
-		clickingTrigger = true
-		try {
-			el.click()
-		} finally {
-			clickingTrigger = false
-		}
-	}
-
-	function cancelPendingClose() {
-		if (closeTimeout != undefined) {
-			clearTimeout(closeTimeout)
-			closeTimeout = undefined
-		}
-	}
-
-	function openOnHover() {
-		cancelPendingClose()
-		if (!open) toggleViaTrigger()
-	}
-
-	function scheduleClose() {
-		cancelPendingClose()
-		if (pinned) return
-		// The menu content is portaled away from the trigger, so moving between the two
-		// fires a leave on the one being left; the delay lets the matching enter cancel it.
-		closeTimeout = setTimeout(() => {
-			closeTimeout = undefined
-			if (open && !pinned) toggleViaTrigger()
-		}, 150)
-	}
-
-	function onTriggerClick(e: MouseEvent) {
-		if (clickingTrigger) return
-		cancelPendingClose()
-		if (open && !pinned) {
-			// Hover already opened it: swallow the click before melt's trigger handler
-			// toggles it shut, and pin it instead.
-			e.preventDefault()
-			e.stopPropagation()
-			pinned = true
-			return
-		}
-		// Melt handles the toggle itself: closed becomes open and pinned, pinned closes.
-		pinned = !open
-	}
 
 	interface Props {
 		isCollapsed?: boolean
@@ -230,222 +170,203 @@
 	)
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-	bind:this={wrapperEl}
-	onmouseenter={openOnHover}
-	onmouseleave={scheduleClose}
-	onclickcapture={onTriggerClick}
->
-	<Menubar>
-		{#snippet children({ createMenu })}
-			<Menu
-				{createMenu}
-				bind:open
-				usePointerDownOutside
-				on:close={() => {
-					showExtraTriggers = false
-					pinned = false
-					cancelPendingClose()
-				}}
-			>
-				{#snippet triggr({ trigger })}
-					<MenuButton
-						class="!text-xs bg-surface !pl-3.5 !pr-2 !w-auto"
-						icon={MenuIcon}
-						isCollapsed={false}
-						lightMode
-						label={undefined}
-						{trigger}
-					/>
-				{/snippet}
-				{#snippet children({ item })}
-					<!-- svelte-ignore a11y_no_static_element_interactions -->
-					<div onmouseenter={cancelPendingClose} onmouseleave={scheduleClose}>
-						<div class="w-full max-w-full">
-							{#each favoriteLinks ?? [] as favorite (favorite.href)}
-								<MenuItem
-									href={favorite.href}
-									{item}
-									class={twMerge(
-										'w-full inline-flex flex-row px-2 py-2 hover:bg-surface-hover',
-										'data-[highlighted]:bg-surface-hover'
-									)}
-								>
-									<span class="center-center">
-										{#if favorite.kind == 'script'}
-											<Code2 size={16} />
-										{:else if favorite.kind == 'flow'}
-											<BarsStaggered size={16} />
-										{:else if favorite.kind == 'app' || favorite.kind == 'raw_app'}
-											<LayoutDashboard size={16} />
-										{:else if favorite.kind == 'asset'}
-											<Table2 size={16} />
-										{/if}
-									</span>
-									<span class="text-primary ml-2 grow min-w-0 text-xs truncate">
-										{favorite.label}
-									</span>
-								</MenuItem>
-							{/each}
-						</div>
-
-						{#each mainMenuLinks as menuLink (menuLink.href ?? menuLink.label)}
-							<MenuLink class="!text-xs" {...menuLink} {isCollapsed} {item} lightMode />
-						{/each}
-
-						<div class="divide-y" role="none">
-							<div role="none">
-								<MenuItem
-									href={USER_SETTINGS_HASH}
-									class={twMerge(
-										'flex flex-row gap-3.5 items-center px-2 py-2',
-										sidebarClasses.text,
-										sidebarClasses.hoverBg
-									)}
-									lightMode
-									{item}
-								>
-									<Settings size={14} />
-									Account settings
-								</MenuItem>
-							</div>
-
-							<div role="none">
-								<MenuItem
-									onClick={() => {
-										if (!document.documentElement.classList.contains('dark')) {
-											document.documentElement.classList.add('dark')
-											window.localStorage.setItem('dark-mode', 'dark')
-										} else {
-											document.documentElement.classList.remove('dark')
-											window.localStorage.setItem('dark-mode', 'light')
-										}
-									}}
-									lightMode
-									class={twMerge(
-										'w-full flex gap-3.5 px-2 py-2',
-										sidebarClasses.hoverBg,
-										sidebarClasses.text
-									)}
-									{item}
-								>
-									{#if darkMode}
-										<Sun size={14} />
-									{:else}
-										<Moon size={14} />
-									{/if}
-									Switch theme
-								</MenuItem>
-								<MenuItem
-									href="{base}/user/workspaces"
-									onClick={() => clearWorkspaceFromStorage()}
-									lightMode
-									class={twMerge(
-										'flex gap-3.5 px-2 py-2',
-										sidebarClasses.hoverBg,
-										sidebarClasses.text
-									)}
-									{item}
-								>
-									<Building size={14} />
-									All workspaces
-								</MenuItem>
-
-								{#if $superadmin}
-									<MenuItem
-										href="#superadmin-settings"
-										class={twMerge(
-											'flex flex-row gap-3.5 items-center px-2 py-2 ',
-											'text-secondary text-xs',
-											'hover:bg-surface-hover hover:text-primary cursor-pointer',
-											'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
-										)}
-										{item}
-									>
-										<ServerCog size={14} />
-										Instance settings
-									</MenuItem>
+<Menubar>
+	{#snippet children({ createMenu })}
+		<Menu
+			{createMenu}
+			openOnHover
+			usePointerDownOutside
+			on:close={() => (showExtraTriggers = false)}
+		>
+			{#snippet triggr({ trigger })}
+				<MenuButton
+					class="!text-xs bg-surface !pl-3.5 !pr-2 !w-auto"
+					icon={MenuIcon}
+					isCollapsed={false}
+					lightMode
+					label={undefined}
+					{trigger}
+				/>
+			{/snippet}
+			{#snippet children({ item })}
+				<div class="w-full max-w-full">
+					{#each favoriteLinks ?? [] as favorite (favorite.href)}
+						<MenuItem
+							href={favorite.href}
+							{item}
+							class={twMerge(
+								'w-full inline-flex flex-row px-2 py-2 hover:bg-surface-hover',
+								'data-[highlighted]:bg-surface-hover'
+							)}
+						>
+							<span class="center-center">
+								{#if favorite.kind == 'script'}
+									<Code2 size={16} />
+								{:else if favorite.kind == 'flow'}
+									<BarsStaggered size={16} />
+								{:else if favorite.kind == 'app' || favorite.kind == 'raw_app'}
+									<LayoutDashboard size={16} />
+								{:else if favorite.kind == 'asset'}
+									<Table2 size={16} />
 								{/if}
+							</span>
+							<span class="text-primary ml-2 grow min-w-0 text-xs truncate">
+								{favorite.label}
+							</span>
+						</MenuItem>
+					{/each}
+				</div>
 
+				{#each mainMenuLinks as menuLink (menuLink.href ?? menuLink.label)}
+					<MenuLink class="!text-xs" {...menuLink} {isCollapsed} {item} lightMode />
+				{/each}
+
+				<div class="divide-y" role="none">
+					<div role="none">
+						<MenuItem
+							href={USER_SETTINGS_HASH}
+							class={twMerge(
+								'flex flex-row gap-3.5 items-center px-2 py-2',
+								sidebarClasses.text,
+								sidebarClasses.hoverBg
+							)}
+							lightMode
+							{item}
+						>
+							<Settings size={14} />
+							Account settings
+						</MenuItem>
+					</div>
+
+					<div role="none">
+						<MenuItem
+							onClick={() => {
+								if (!document.documentElement.classList.contains('dark')) {
+									document.documentElement.classList.add('dark')
+									window.localStorage.setItem('dark-mode', 'dark')
+								} else {
+									document.documentElement.classList.remove('dark')
+									window.localStorage.setItem('dark-mode', 'light')
+								}
+							}}
+							lightMode
+							class={twMerge(
+								'w-full flex gap-3.5 px-2 py-2',
+								sidebarClasses.hoverBg,
+								sidebarClasses.text
+							)}
+							{item}
+						>
+							{#if darkMode}
+								<Sun size={14} />
+							{:else}
+								<Moon size={14} />
+							{/if}
+							Switch theme
+						</MenuItem>
+						<MenuItem
+							href="{base}/user/workspaces"
+							onClick={() => clearWorkspaceFromStorage()}
+							lightMode
+							class={twMerge('flex gap-3.5 px-2 py-2', sidebarClasses.hoverBg, sidebarClasses.text)}
+							{item}
+						>
+							<Building size={14} />
+							All workspaces
+						</MenuItem>
+
+						{#if $superadmin}
+							<MenuItem
+								href="#superadmin-settings"
+								class={twMerge(
+									'flex flex-row gap-3.5 items-center px-2 py-2 ',
+									'text-secondary text-xs',
+									'hover:bg-surface-hover hover:text-primary cursor-pointer',
+									'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+								)}
+								{item}
+							>
+								<ServerCog size={14} />
+								Instance settings
+							</MenuItem>
+						{/if}
+
+						<MenuItem
+							onClick={() => logout()}
+							class={twMerge(
+								'flex flex-row gap-3.5  items-center px-2 py-2 w-full',
+								'text-primary text-xs',
+								'hover:bg-surface-hover cursor-pointer',
+								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+							)}
+							{item}
+						>
+							<LogOut size={14} />
+							Sign out
+						</MenuItem>
+					</div>
+					<div role="none">
+						{#snippet renderSecondMenuLinks(menuLinks: SecondMenuLink[])}
+							{#each menuLinks as menuLink (menuLink.href ?? menuLink.label)}
 								<MenuItem
-									onClick={() => logout()}
+									href={menuLink.href}
 									class={twMerge(
-										'flex flex-row gap-3.5  items-center px-2 py-2 w-full',
-										'text-primary text-xs',
-										'hover:bg-surface-hover cursor-pointer',
+										'flex flex-row gap-3.5 items-center px-2 py-2 text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
 										'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 									)}
 									{item}
 								>
-									<LogOut size={14} />
-									Sign out
+									{menuLink.label}
 								</MenuItem>
-							</div>
-							<div role="none">
-								{#snippet renderSecondMenuLinks(menuLinks: SecondMenuLink[])}
-									{#each menuLinks as menuLink (menuLink.href ?? menuLink.label)}
-										<MenuItem
-											href={menuLink.href}
-											class={twMerge(
-												'flex flex-row gap-3.5 items-center px-2 py-2 text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
-												'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
-											)}
-											{item}
+							{/each}
+						{/snippet}
+						{#if secondMenuLinks.length || secondMenuTriggerLinks.length || extraTriggerLinks.length}
+							<div class="divide-y">
+								{#if secondMenuLinks.length}<div
+										>{@render renderSecondMenuLinks(secondMenuLinks)}</div
+									>{/if}
+								{#if secondMenuTriggerLinks.length}<div
+										>{@render renderSecondMenuLinks(secondMenuTriggerLinks)}</div
+									>{/if}
+								{#if extraTriggerLinks.length}<div>
+										<!-- svelte-ignore a11y_no_static_element_interactions -->
+										<div
+											class="flex flex-row gap-3.5 items-center px-2 py-2 w-full text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer"
+											role="button"
+											tabindex="0"
+											onclick={(e) => {
+												e.stopPropagation()
+												showExtraTriggers = !showExtraTriggers
+											}}
 										>
-											{menuLink.label}
-										</MenuItem>
-									{/each}
-								{/snippet}
-								{#if secondMenuLinks.length || secondMenuTriggerLinks.length || extraTriggerLinks.length}
-									<div class="divide-y">
-										{#if secondMenuLinks.length}<div
-												>{@render renderSecondMenuLinks(secondMenuLinks)}</div
-											>{/if}
-										{#if secondMenuTriggerLinks.length}<div
-												>{@render renderSecondMenuLinks(secondMenuTriggerLinks)}</div
-											>{/if}
-										{#if extraTriggerLinks.length}<div>
-												<!-- svelte-ignore a11y_no_static_element_interactions -->
-												<div
-													class="flex flex-row gap-3.5 items-center px-2 py-2 w-full text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer"
-													role="button"
-													tabindex="0"
-													onclick={(e) => {
-														e.stopPropagation()
-														showExtraTriggers = !showExtraTriggers
-													}}
+											<Plus size={12} />
+											<span class="text-2xs">More triggers</span>
+										</div>
+										{#if showExtraTriggers}
+											{#each extraTriggerLinks as menuLink (menuLink.href)}
+												<MenuItem
+													href={menuLink.href}
+													class={twMerge(
+														'flex flex-row gap-3.5 items-center px-2 py-2 pl-6 text-tertiary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
+														'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+													)}
+													{item}
 												>
-													<Plus size={12} />
-													<span class="text-2xs">More triggers</span>
-												</div>
-												{#if showExtraTriggers}
-													{#each extraTriggerLinks as menuLink (menuLink.href)}
-														<MenuItem
-															href={menuLink.href}
-															class={twMerge(
-																'flex flex-row gap-3.5 items-center px-2 py-2 pl-6 text-tertiary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
-																'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
-															)}
-															{item}
-														>
-															{menuLink.label}
-														</MenuItem>
-													{/each}
-												{/if}
-											</div>{/if}
-									</div>
-								{/if}
-								{#if $enterpriseLicense}
-									<MultiplayerMenu />
-								{/if}
+													{menuLink.label}
+												</MenuItem>
+											{/each}
+										{/if}
+									</div>{/if}
 							</div>
-						</div>
+						{/if}
+						{#if $enterpriseLicense}
+							<MultiplayerMenu />
+						{/if}
 					</div>
-				{/snippet}
-			</Menu>
-		{/snippet}
-	</Menubar>
-</div>
+				</div>
+			{/snippet}
+		</Menu>
+	{/snippet}
+</Menubar>
 
 <DarkModeObserver bind:darkMode />

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -338,16 +338,25 @@
 								{#if extraTriggerLinks.length}<div>
 										<!-- svelte-ignore a11y_no_static_element_interactions -->
 										<div
-											class="flex flex-row gap-3.5 items-center px-2 py-2 w-full text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer"
-											role="button"
-											tabindex="0"
-											onclick={(e) => {
-												e.stopPropagation()
+											onclickcapture={(e) => {
+												// This row expands the list below it instead of acting on the selection, and
+												// melt keeps the menu open only for a click it sees as defaultPrevented.
+												// Svelte delegates onclick to the root, which runs after melt's own listener,
+												// so the capture phase on this wrapper is what gets there first.
+												e.preventDefault()
 												showExtraTriggers = !showExtraTriggers
 											}}
 										>
-											<Plus size={12} />
-											<span class="text-2xs">More triggers</span>
+											<MenuItem
+												class={twMerge(
+													'flex flex-row gap-3.5 items-center px-2 py-2 w-full text-secondary text-2xs cursor-pointer',
+													'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+												)}
+												{item}
+											>
+												<Plus size={12} />
+												<span class="text-2xs">More triggers</span>
+											</MenuItem>
 										</div>
 										{#if showExtraTriggers}
 											{#each extraTriggerLinks as menuLink (menuLink.href)}

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -174,6 +174,7 @@
 	{#snippet children({ createMenu })}
 		<Menu
 			{createMenu}
+			placement="bottom-start"
 			openOnHover
 			usePointerDownOutside
 			on:close={() => (showExtraTriggers = false)}

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -40,7 +40,66 @@
 	import type { FavoriteKind } from './FavoriteMenu.svelte'
 	let darkMode: boolean = $state(false)
 	let showExtraTriggers = $state(false)
-	let menubarEl: HTMLElement | undefined = $state()
+	// Mirrors melt's own open state. Writing it doesn't open the menu — melt's menubar
+	// only shows the content once the trigger's click handler has registered it as the
+	// active trigger — so every open and close goes through a click on the trigger.
+	let open = $state(false)
+	// A click pins the menu: it then stays open until a click outside or on the trigger.
+	// Hover opens it without pinning, so it closes again once the pointer leaves.
+	let pinned = $state(false)
+	let closeTimeout: ReturnType<typeof setTimeout> | undefined
+	let wrapperEl: HTMLElement | undefined = $state()
+	let clickingTrigger = false
+
+	function toggleViaTrigger() {
+		const el = wrapperEl?.querySelector('[data-melt-menubar-trigger]')
+		if (!(el instanceof HTMLElement)) return
+		// click() dispatches synchronously, so the flag only covers our own event.
+		clickingTrigger = true
+		try {
+			el.click()
+		} finally {
+			clickingTrigger = false
+		}
+	}
+
+	function cancelPendingClose() {
+		if (closeTimeout != undefined) {
+			clearTimeout(closeTimeout)
+			closeTimeout = undefined
+		}
+	}
+
+	function openOnHover() {
+		cancelPendingClose()
+		if (!open) toggleViaTrigger()
+	}
+
+	function scheduleClose() {
+		cancelPendingClose()
+		if (pinned) return
+		// The menu content is portaled away from the trigger, so moving between the two
+		// fires a leave on the one being left; the delay lets the matching enter cancel it.
+		closeTimeout = setTimeout(() => {
+			closeTimeout = undefined
+			if (open && !pinned) toggleViaTrigger()
+		}, 150)
+	}
+
+	function onTriggerClick(e: MouseEvent) {
+		if (clickingTrigger) return
+		cancelPendingClose()
+		if (open && !pinned) {
+			// Hover already opened it: swallow the click before melt's trigger handler
+			// toggles it shut, and pin it instead.
+			e.preventDefault()
+			e.stopPropagation()
+			pinned = true
+			return
+		}
+		// Melt handles the toggle itself: closed becomes open and pinned, pinned closes.
+		pinned = !open
+	}
 
 	interface Props {
 		isCollapsed?: boolean
@@ -173,15 +232,23 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	bind:this={menubarEl}
-	onmouseenter={() => {
-		const btn = menubarEl?.querySelector('[data-melt-menubar-trigger]')
-		if (btn instanceof HTMLElement) btn.click()
-	}}
+	bind:this={wrapperEl}
+	onmouseenter={openOnHover}
+	onmouseleave={scheduleClose}
+	onclickcapture={onTriggerClick}
 >
 	<Menubar>
 		{#snippet children({ createMenu })}
-			<Menu {createMenu} usePointerDownOutside on:close={() => (showExtraTriggers = false)}>
+			<Menu
+				{createMenu}
+				bind:open
+				usePointerDownOutside
+				on:close={() => {
+					showExtraTriggers = false
+					pinned = false
+					cancelPendingClose()
+				}}
+			>
 				{#snippet triggr({ trigger })}
 					<MenuButton
 						class="!text-xs bg-surface !pl-3.5 !pr-2 !w-auto"
@@ -193,183 +260,186 @@
 					/>
 				{/snippet}
 				{#snippet children({ item })}
-					<div class="w-full max-w-full">
-						{#each favoriteLinks ?? [] as favorite (favorite.href)}
-							<MenuItem
-								href={favorite.href}
-								{item}
-								class={twMerge(
-									'w-full inline-flex flex-row px-2 py-2 hover:bg-surface-hover',
-									'data-[highlighted]:bg-surface-hover'
-								)}
-							>
-								<span class="center-center">
-									{#if favorite.kind == 'script'}
-										<Code2 size={16} />
-									{:else if favorite.kind == 'flow'}
-										<BarsStaggered size={16} />
-									{:else if favorite.kind == 'app' || favorite.kind == 'raw_app'}
-										<LayoutDashboard size={16} />
-									{:else if favorite.kind == 'asset'}
-										<Table2 size={16} />
-									{/if}
-								</span>
-								<span class="text-primary ml-2 grow min-w-0 text-xs truncate">
-									{favorite.label}
-								</span>
-							</MenuItem>
-						{/each}
-					</div>
-
-					{#each mainMenuLinks as menuLink (menuLink.href ?? menuLink.label)}
-						<MenuLink class="!text-xs" {...menuLink} {isCollapsed} {item} lightMode />
-					{/each}
-
-					<div class="divide-y" role="none">
-						<div role="none">
-							<MenuItem
-								href={USER_SETTINGS_HASH}
-								class={twMerge(
-									'flex flex-row gap-3.5 items-center px-2 py-2',
-									sidebarClasses.text,
-									sidebarClasses.hoverBg
-								)}
-								lightMode
-								{item}
-							>
-								<Settings size={14} />
-								Account settings
-							</MenuItem>
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<div onmouseenter={cancelPendingClose} onmouseleave={scheduleClose}>
+						<div class="w-full max-w-full">
+							{#each favoriteLinks ?? [] as favorite (favorite.href)}
+								<MenuItem
+									href={favorite.href}
+									{item}
+									class={twMerge(
+										'w-full inline-flex flex-row px-2 py-2 hover:bg-surface-hover',
+										'data-[highlighted]:bg-surface-hover'
+									)}
+								>
+									<span class="center-center">
+										{#if favorite.kind == 'script'}
+											<Code2 size={16} />
+										{:else if favorite.kind == 'flow'}
+											<BarsStaggered size={16} />
+										{:else if favorite.kind == 'app' || favorite.kind == 'raw_app'}
+											<LayoutDashboard size={16} />
+										{:else if favorite.kind == 'asset'}
+											<Table2 size={16} />
+										{/if}
+									</span>
+									<span class="text-primary ml-2 grow min-w-0 text-xs truncate">
+										{favorite.label}
+									</span>
+								</MenuItem>
+							{/each}
 						</div>
 
-						<div role="none">
-							<MenuItem
-								onClick={() => {
-									if (!document.documentElement.classList.contains('dark')) {
-										document.documentElement.classList.add('dark')
-										window.localStorage.setItem('dark-mode', 'dark')
-									} else {
-										document.documentElement.classList.remove('dark')
-										window.localStorage.setItem('dark-mode', 'light')
-									}
-								}}
-								lightMode
-								class={twMerge(
-									'w-full flex gap-3.5 px-2 py-2',
-									sidebarClasses.hoverBg,
-									sidebarClasses.text
-								)}
-								{item}
-							>
-								{#if darkMode}
-									<Sun size={14} />
-								{:else}
-									<Moon size={14} />
-								{/if}
-								Switch theme
-							</MenuItem>
-							<MenuItem
-								href="{base}/user/workspaces"
-								onClick={() => clearWorkspaceFromStorage()}
-								lightMode
-								class={twMerge(
-									'flex gap-3.5 px-2 py-2',
-									sidebarClasses.hoverBg,
-									sidebarClasses.text
-								)}
-								{item}
-							>
-								<Building size={14} />
-								All workspaces
-							</MenuItem>
+						{#each mainMenuLinks as menuLink (menuLink.href ?? menuLink.label)}
+							<MenuLink class="!text-xs" {...menuLink} {isCollapsed} {item} lightMode />
+						{/each}
 
-							{#if $superadmin}
+						<div class="divide-y" role="none">
+							<div role="none">
 								<MenuItem
-									href="#superadmin-settings"
+									href={USER_SETTINGS_HASH}
 									class={twMerge(
-										'flex flex-row gap-3.5 items-center px-2 py-2 ',
-										'text-secondary text-xs',
-										'hover:bg-surface-hover hover:text-primary cursor-pointer',
-										'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+										'flex flex-row gap-3.5 items-center px-2 py-2',
+										sidebarClasses.text,
+										sidebarClasses.hoverBg
+									)}
+									lightMode
+									{item}
+								>
+									<Settings size={14} />
+									Account settings
+								</MenuItem>
+							</div>
+
+							<div role="none">
+								<MenuItem
+									onClick={() => {
+										if (!document.documentElement.classList.contains('dark')) {
+											document.documentElement.classList.add('dark')
+											window.localStorage.setItem('dark-mode', 'dark')
+										} else {
+											document.documentElement.classList.remove('dark')
+											window.localStorage.setItem('dark-mode', 'light')
+										}
+									}}
+									lightMode
+									class={twMerge(
+										'w-full flex gap-3.5 px-2 py-2',
+										sidebarClasses.hoverBg,
+										sidebarClasses.text
 									)}
 									{item}
 								>
-									<ServerCog size={14} />
-									Instance settings
+									{#if darkMode}
+										<Sun size={14} />
+									{:else}
+										<Moon size={14} />
+									{/if}
+									Switch theme
 								</MenuItem>
-							{/if}
+								<MenuItem
+									href="{base}/user/workspaces"
+									onClick={() => clearWorkspaceFromStorage()}
+									lightMode
+									class={twMerge(
+										'flex gap-3.5 px-2 py-2',
+										sidebarClasses.hoverBg,
+										sidebarClasses.text
+									)}
+									{item}
+								>
+									<Building size={14} />
+									All workspaces
+								</MenuItem>
 
-							<MenuItem
-								onClick={() => logout()}
-								class={twMerge(
-									'flex flex-row gap-3.5  items-center px-2 py-2 w-full',
-									'text-primary text-xs',
-									'hover:bg-surface-hover cursor-pointer',
-									'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
-								)}
-								{item}
-							>
-								<LogOut size={14} />
-								Sign out
-							</MenuItem>
-						</div>
-						<div role="none">
-							{#snippet renderSecondMenuLinks(menuLinks: SecondMenuLink[])}
-								{#each menuLinks as menuLink (menuLink.href ?? menuLink.label)}
+								{#if $superadmin}
 									<MenuItem
-										href={menuLink.href}
+										href="#superadmin-settings"
 										class={twMerge(
-											'flex flex-row gap-3.5 items-center px-2 py-2 text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
+											'flex flex-row gap-3.5 items-center px-2 py-2 ',
+											'text-secondary text-xs',
+											'hover:bg-surface-hover hover:text-primary cursor-pointer',
 											'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 										)}
 										{item}
 									>
-										{menuLink.label}
+										<ServerCog size={14} />
+										Instance settings
 									</MenuItem>
-								{/each}
-							{/snippet}
-							{#if secondMenuLinks.length || secondMenuTriggerLinks.length || extraTriggerLinks.length}
-								<div class="divide-y">
-									{#if secondMenuLinks.length}<div
-											>{@render renderSecondMenuLinks(secondMenuLinks)}</div
-										>{/if}
-									{#if secondMenuTriggerLinks.length}<div
-											>{@render renderSecondMenuLinks(secondMenuTriggerLinks)}</div
-										>{/if}
-									{#if extraTriggerLinks.length}<div>
-											<!-- svelte-ignore a11y_no_static_element_interactions -->
-											<div
-												class="flex flex-row gap-3.5 items-center px-2 py-2 w-full text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer"
-												role="button"
-												tabindex="0"
-												onclick={(e) => {
-													e.stopPropagation()
-													showExtraTriggers = !showExtraTriggers
-												}}
-											>
-												<Plus size={12} />
-												<span class="text-2xs">More triggers</span>
-											</div>
-											{#if showExtraTriggers}
-												{#each extraTriggerLinks as menuLink (menuLink.href)}
-													<MenuItem
-														href={menuLink.href}
-														class={twMerge(
-															'flex flex-row gap-3.5 items-center px-2 py-2 pl-6 text-tertiary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
-															'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
-														)}
-														{item}
-													>
-														{menuLink.label}
-													</MenuItem>
-												{/each}
-											{/if}
-										</div>{/if}
-								</div>
-							{/if}
-							{#if $enterpriseLicense}
-								<MultiplayerMenu />
-							{/if}
+								{/if}
+
+								<MenuItem
+									onClick={() => logout()}
+									class={twMerge(
+										'flex flex-row gap-3.5  items-center px-2 py-2 w-full',
+										'text-primary text-xs',
+										'hover:bg-surface-hover cursor-pointer',
+										'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+									)}
+									{item}
+								>
+									<LogOut size={14} />
+									Sign out
+								</MenuItem>
+							</div>
+							<div role="none">
+								{#snippet renderSecondMenuLinks(menuLinks: SecondMenuLink[])}
+									{#each menuLinks as menuLink (menuLink.href ?? menuLink.label)}
+										<MenuItem
+											href={menuLink.href}
+											class={twMerge(
+												'flex flex-row gap-3.5 items-center px-2 py-2 text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
+												'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+											)}
+											{item}
+										>
+											{menuLink.label}
+										</MenuItem>
+									{/each}
+								{/snippet}
+								{#if secondMenuLinks.length || secondMenuTriggerLinks.length || extraTriggerLinks.length}
+									<div class="divide-y">
+										{#if secondMenuLinks.length}<div
+												>{@render renderSecondMenuLinks(secondMenuLinks)}</div
+											>{/if}
+										{#if secondMenuTriggerLinks.length}<div
+												>{@render renderSecondMenuLinks(secondMenuTriggerLinks)}</div
+											>{/if}
+										{#if extraTriggerLinks.length}<div>
+												<!-- svelte-ignore a11y_no_static_element_interactions -->
+												<div
+													class="flex flex-row gap-3.5 items-center px-2 py-2 w-full text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer"
+													role="button"
+													tabindex="0"
+													onclick={(e) => {
+														e.stopPropagation()
+														showExtraTriggers = !showExtraTriggers
+													}}
+												>
+													<Plus size={12} />
+													<span class="text-2xs">More triggers</span>
+												</div>
+												{#if showExtraTriggers}
+													{#each extraTriggerLinks as menuLink (menuLink.href)}
+														<MenuItem
+															href={menuLink.href}
+															class={twMerge(
+																'flex flex-row gap-3.5 items-center px-2 py-2 pl-6 text-tertiary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
+																'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+															)}
+															{item}
+														>
+															{menuLink.label}
+														</MenuItem>
+													{/each}
+												{/if}
+											</div>{/if}
+									</div>
+								{/if}
+								{#if $enterpriseLicense}
+									<MultiplayerMenu />
+								{/if}
+							</div>
 						</div>
 					</div>
 				{/snippet}

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -228,7 +228,8 @@
 							class={twMerge(
 								'flex flex-row gap-3.5 items-center px-2 py-2',
 								sidebarClasses.text,
-								sidebarClasses.hoverBg
+								sidebarClasses.hoverBg,
+								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 							)}
 							lightMode
 							{item}
@@ -253,7 +254,8 @@
 							class={twMerge(
 								'w-full flex gap-3.5 px-2 py-2',
 								sidebarClasses.hoverBg,
-								sidebarClasses.text
+								sidebarClasses.text,
+								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 							)}
 							{item}
 						>
@@ -268,7 +270,12 @@
 							href="{base}/user/workspaces"
 							onClick={() => clearWorkspaceFromStorage()}
 							lightMode
-							class={twMerge('flex gap-3.5 px-2 py-2', sidebarClasses.hoverBg, sidebarClasses.text)}
+							class={twMerge(
+								'flex gap-3.5 px-2 py-2',
+								sidebarClasses.hoverBg,
+								sidebarClasses.text,
+								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
+							)}
 							{item}
 						>
 							<Building size={14} />

--- a/frontend/src/lib/components/sidebar/OperatorMenu.svelte
+++ b/frontend/src/lib/components/sidebar/OperatorMenu.svelte
@@ -195,7 +195,7 @@
 							href={favorite.href}
 							{item}
 							class={twMerge(
-								'w-full inline-flex flex-row px-2 py-2 hover:bg-surface-hover',
+								'w-full inline-flex flex-row px-2 py-2',
 								'data-[highlighted]:bg-surface-hover'
 							)}
 						>
@@ -228,7 +228,7 @@
 							class={twMerge(
 								'flex flex-row gap-3.5 items-center px-2 py-2',
 								sidebarClasses.text,
-								sidebarClasses.hoverBg,
+								'transition-colors',
 								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 							)}
 							lightMode
@@ -253,7 +253,7 @@
 							lightMode
 							class={twMerge(
 								'w-full flex gap-3.5 px-2 py-2',
-								sidebarClasses.hoverBg,
+								'transition-colors',
 								sidebarClasses.text,
 								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 							)}
@@ -272,7 +272,7 @@
 							lightMode
 							class={twMerge(
 								'flex gap-3.5 px-2 py-2',
-								sidebarClasses.hoverBg,
+								'transition-colors',
 								sidebarClasses.text,
 								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 							)}
@@ -288,7 +288,7 @@
 								class={twMerge(
 									'flex flex-row gap-3.5 items-center px-2 py-2 ',
 									'text-secondary text-xs',
-									'hover:bg-surface-hover hover:text-primary cursor-pointer',
+									'cursor-pointer',
 									'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 								)}
 								{item}
@@ -303,7 +303,7 @@
 							class={twMerge(
 								'flex flex-row gap-3.5  items-center px-2 py-2 w-full',
 								'text-primary text-xs',
-								'hover:bg-surface-hover cursor-pointer',
+								'cursor-pointer',
 								'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 							)}
 							{item}
@@ -318,7 +318,7 @@
 								<MenuItem
 									href={menuLink.href}
 									class={twMerge(
-										'flex flex-row gap-3.5 items-center px-2 py-2 text-secondary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
+										'flex flex-row gap-3.5 items-center px-2 py-2 text-secondary text-2xs cursor-pointer',
 										'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 									)}
 									{item}
@@ -354,7 +354,7 @@
 												<MenuItem
 													href={menuLink.href}
 													class={twMerge(
-														'flex flex-row gap-3.5 items-center px-2 py-2 pl-6 text-tertiary text-2xs hover:bg-surface-hover hover:text-primary cursor-pointer',
+														'flex flex-row gap-3.5 items-center px-2 py-2 pl-6 text-tertiary text-2xs cursor-pointer',
 														'data-[highlighted]:bg-surface-hover data-[highlighted]:text-primary'
 													)}
 													{item}


### PR DESCRIPTION
## Problem

The operator hamburger menu synthesized a trigger click on every `mouseenter`, so melt *toggled* it instead of opening it: re-entering an already-open menu closed it, and a real click after a hover-open closed it too.

Fixing that surfaced two more bugs in the same menu: keyboard navigation moved through it invisibly on several rows, and once those rows were fixed, two rows lit at once.

## Change

### Hover opens, click pins

Now lives in `meltComponents/Menu.svelte` behind an `openOnHover` prop, named to match the one `meltComponents/Popover.svelte` already has. `Menu.svelte` owns both the trigger wrapper and the content div, so it is the right home:

- Hover opens the menu only when it is closed, and closes it after `debounceDelay` (150ms) once the pointer leaves. The content is portaled away from the trigger, so both carry the enter/leave handlers — crossing from the button to the list cancels the pending close.
- A click is intercepted in the capture phase. If hover already opened the menu, the click is swallowed (melt's trigger would otherwise toggle it shut) and the menu is pinned: it stays open through `mouseleave` and closes on a click outside or a second click on the trigger. The pin clears whenever `open` goes false.

Opening and closing both go through a synthetic click on `[data-melt-menubar-trigger]`, guarded by a flag so the capture handler ignores it. Setting `open` alone cannot open the menu: melt's menubar renders content only when `rootOpen && rootActiveTrigger`, and only the trigger's own click handler sets `rootActiveTrigger` — writing `open = true` left the trigger reporting `data-state="open"` while the menu stayed `display: none`.

`Menu` hands `pinned` to the `triggr` snippet so the trigger can show the state. The operator hamburger keeps `sidebarClasses.selectedBg` while it holds — the same tint hover gives it, now persisting after the pointer leaves, which is what tells you the click registered.

All of it is behind `openOnHover`, which defaults to false, so the other five `Menubar` users (`SidebarContent`, `TriggersBadge`, `SessionPicker`, `AppMenu`, `FlowJobsMenu`) are unchanged.

`OperatorMenu.svelte` is back to its pre-hack markup plus `openOnHover`; the large diff there is the dedent from dropping the wrapper `<div>` that only existed to host the old `mouseenter` handler. Review it with `-w`.

### One highlight state per row

`sidebarClasses.hoverBg` only reacts to the pointer, so rows styled with it alone stayed transparent while melt moved `data-highlighted` through them — arrow keys walked the menu with nothing to show for it. Affected Home, Runs, Schedules and Tutorials (via `MenuLink`), plus Account settings, Switch theme and All workspaces.

Adding a `data-[highlighted]:` rule alongside the existing `hover:` rule then gave every row two independent states. Melt's `pointermove` handler calls `handleRovingFocus`, so `data-highlighted` already follows the pointer: with both rules, the row under the pointer and the row the arrow keys had reached lit up together. Menu rows now style `data-highlighted` only.

### "More triggers" is now a real menu item

It was a hand-rolled `<div role="button" tabindex="0">`. Melt collects the rows arrow keys walk with `querySelectorAll('[data-melt-menu-id="<menuId>"]')` — an attribute only the `item` builder stamps on — so the row was skipped, and its `tabindex` was no help either since Tab inside an open menu is intercepted to close it.

It is now a `MenuItem`, which also gives it the same highlight styling as every other row. Melt closes the menu on item click unless the click is `defaultPrevented`, and Svelte delegates `onclick` to the root, which runs after melt's own listener — so the toggle sits in a capture handler on a wrapper, where it reaches the event first.

`MenuLink` drops the hover rule only when it is rendered as a menu item (`item` is passed). `SettingsMenu`, `SidebarContent` and `+layout.svelte` pass no `item`, so the sidebar keeps its hover affordance.

### Opens below the trigger

`Menu` defaults to `placement="right-start"`, which put the operator menu alongside the hamburger and over the page header. It now passes `bottom-start`, so the menu drops under the trigger, left-aligned with it. Set on this menu only — the shared default is unchanged.

## Screenshots

Operator menu opening below the hamburger, with "Schedules" as the keyboard-highlighted row:

![operator-menu-bottom-start](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-operator-opening/1787648739-operator-menu-bottom-start.png)

Pinned, with the pointer parked far away — the hamburger holds the selected tint:

![operator-menu-pinned-trigger](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-operator-opening/1787648994-operator-menu-pinned-trigger.png)

## Testing

Exercised in Chromium as an operator user on a dev instance:

- hover the trigger → opens (unpinned), below the trigger and left-aligned with it
- move pointer away → closes after the grace delay
- trigger → list → trigger round trip → stays open
- click while hover-opened → pinned; pointer far away → still open, and the trigger holds `rgba(207, 207, 226, 0.2)` instead of falling back to `rgb(251, 251, 253)`
- a cold click (no prior hover) pins and tints the trigger the same way
- click outside → closes and un-pins, and the trigger returns to `rgb(251, 251, 253)` (a following hover-out closes again)
- second click on the trigger while pinned → closes
- "More triggers" is reachable by arrow keys; Enter and mouse click both expand and collapse it in place without closing the menu, and the revealed "Kafka triggers" link navigates
- "Audit logs" navigates to `/audit_logs?page=1&perPage=100` and the menu closes
- ArrowDown walks all 15 rows and every one paints the highlight
- pointer resting on one row while the arrow keys sit on another: exactly one row lit

Regression check on a `Menu` without `openOnHover` (the sidebar workspace menu, as admin): hover does not open, click opens, second click closes.

`npm run check:fast` is clean.

## Note on Popover

`meltComponents/Popover.svelte` keeps its own `openOnHover`: it is built on `createPopover`, not the menubar, so it needs neither the trigger-click detour nor a shared implementation. It has no pin — clicking a hover-opened Popover still closes it — but fixing that touches every `openOnHover` consumer (`DraftBadge`, `FilterSearchbar`, `TagList`, `RunsQueue`, `StorageSettings`, …) and is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwLAoY7s9iPkYPGcmnw6UC



