### PR TITLE
chore: move the compose stack to postgres 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,15 +8,46 @@ x-logging: &default-logging
     compress: "true"
 
 services:
+  ## UPGRADING AN EXISTING STACK: a db_data volume written by postgres:16 holds a
+  ## cluster that 18 cannot read. The container exits with an explanatory error
+  ## instead of coming up blank, so nothing is lost before you migrate. Postgres 16
+  ## is supported upstream until Nov 2028, so staying on `image: postgres:16` with
+  ## the old `db_data:/var/lib/postgresql/data` mount remains a valid option.
+  ##
+  ## To move the data across, dump first while the old 16 container is still the
+  ## one running (git checkout the previous docker-compose.yml if you already
+  ## replaced it), with only db up:
+  ##   docker compose stop windmill_server windmill_worker windmill_worker_native
+  ##   docker compose exec -T db pg_dumpall -U postgres --globals-only --no-role-passwords > globals.sql
+  ##   docker compose exec -T db pg_dump -U postgres -Fc windmill > windmill.dump
+  ## Check both files, then switch to this file and start 18 on an empty volume:
+  ##   docker compose down
+  ##   docker volume ls | grep db_data     # then remove the one this project owns
+  ##   docker volume rm <that_volume>
+  ##   docker compose up -d db
+  ##   docker compose exec -T db psql -U postgres -d postgres < globals.sql
+  ##   docker compose exec -T db pg_restore -U postgres -d windmill --no-owner --exit-on-error < windmill.dump
+  ##   docker compose up -d
+  ## Loading globals.sql is not optional. Windmill grants its row-level security
+  ## policies to the cluster-level windmill_admin and windmill_user roles, which a
+  ## database-only dump does not carry, and pg_restore silently drops every policy
+  ## whose grantee role is missing. The one error to expect is psql reporting
+  ## `role "postgres" already exists`, which the fresh cluster bootstraps itself.
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file
       replicas: 1
-    image: postgres:16
+    image: postgres:18
     shm_size: 1g
     restart: unless-stopped
     volumes:
-      - db_data:/var/lib/postgresql/data
+      # From 18 on the official image keeps the cluster in a major-version
+      # subdirectory (/var/lib/postgresql/18/docker), so the mount has to be the
+      # parent directory: that is what lets pg_upgrade see an old and a new
+      # cluster inside a single mount point. Mounting the pre-18 .../data path
+      # instead makes the image exit rather than start, which is what turns a
+      # stale 16 cluster into a loud failure instead of an empty instance.
+      - db_data:/var/lib/postgresql
     expose:
       - 5432
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,15 +27,19 @@ services:
   ##   docker volume ls | grep db_data     # then remove the one this project owns
   ##   docker volume rm <that_volume>
   ##   docker compose up --wait db
-  ##   docker compose exec -T db psql -U postgres -d postgres < cluster.sql
-  ##   docker compose exec -T db psql -U postgres -d windmill -c ANALYZE
+  ##   docker compose exec -T db psql -U postgres -d postgres < cluster.sql > restore.log 2>&1
+  ##   grep -i '^ERROR' restore.log      # only the two expected ones, see below
+  ##   docker compose exec -T db vacuumdb -U postgres --all --analyze-in-stages
   ##   docker compose up -d
-  ## `database "windmill" already exists` and `role "postgres" already exists` are
-  ## expected; the fresh cluster bootstraps both, and psql carries on to load into
-  ## them. ANALYZE is not optional: a restored cluster starts with no planner
-  ## statistics, which reads as "the upgrade made Windmill slow" until autovacuum
-  ## catches up. `up --wait` rather than `up -d` because psql would otherwise race
-  ## initdb on a fresh volume.
+  ## `up --wait` because psql would otherwise race initdb on a fresh volume. psql
+  ## does not stop on error and the old volume is already gone by then, so grep the
+  ## log rather than trust its exit code; `database "windmill" already exists` and
+  ## `role "postgres" already exists` are the two the fresh cluster causes itself.
+  ## vacuumdb spans every restored database, which a plain ANALYZE would not: each
+  ## comes back with no planner statistics, and a fork database is where the stall
+  ## shows. Postgres triggers reading a database in this cluster come back disabled
+  ## with "replication slot ... no longer exists", since slots are never dumped;
+  ## re-saving the trigger recreates the slot.
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   ## Windmill keeps datatable, DuckLake and wm_fork_* databases beside it and grants
   ## its RLS policies to cluster-level roles, and a single-database dump loses both
   ## silently. Full procedure, and why 16 is still a valid choice until Nov 2028:
-  ## https://gist.github.com/rubenfiszel/4f2807b0fc685865f6e97d352681b9a8
+  ## https://www.windmill.dev/docs/advanced/self_host#upgrade-postgresql-to-18
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,19 +27,23 @@ services:
   ##   docker volume ls | grep db_data     # then remove the one this project owns
   ##   docker volume rm <that_volume>
   ##   docker compose up --wait db
+  ##   docker compose exec -T db psql -U postgres -d postgres -c 'DROP DATABASE windmill'
   ##   docker compose exec -T db psql -U postgres -d postgres < cluster.sql > restore.log 2>&1
-  ##   grep -i '^ERROR' restore.log      # only the two expected ones, see below
+  ##   grep -i '^ERROR' restore.log      # only `role "postgres" already exists`
   ##   docker compose exec -T db vacuumdb -U postgres --all --analyze-in-stages
   ##   docker compose up -d
-  ## `up --wait` because psql would otherwise race initdb on a fresh volume. psql
-  ## does not stop on error and the old volume is already gone by then, so grep the
-  ## log rather than trust its exit code; `database "windmill" already exists` and
-  ## `role "postgres" already exists` are the two the fresh cluster causes itself.
-  ## vacuumdb spans every restored database, which a plain ANALYZE would not: each
-  ## comes back with no planner statistics, and a fork database is where the stall
-  ## shows. Postgres triggers reading a database in this cluster come back disabled
-  ## with "replication slot ... no longer exists", since slots are never dumped;
-  ## re-saving the trigger recreates the slot.
+  ## `up --wait` because psql would otherwise race initdb on a fresh volume. The
+  ## DROP is what lets the dump's own `CREATE DATABASE windmill` run: POSTGRES_DB
+  ## has already made an empty one, and loading into it would keep the new cluster's
+  ## encoding and collation instead of the dumped ones, for that database only.
+  ## psql does not stop on error and the old volume is already gone by then, so grep
+  ## the log rather than trust its exit code; the fresh cluster bootstraps `postgres`
+  ## itself, so that role is the one error left. vacuumdb spans every restored
+  ## database, which a plain ANALYZE would not: each comes back with no planner
+  ## statistics, and a fork database is where the stall shows. Postgres triggers
+  ## reading a database in this cluster come back disabled with "replication slot
+  ## ... no longer exists", since slots are never dumped; re-saving the trigger
+  ## recreates the slot, then re-enable it.
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,25 +14,28 @@ services:
   ## is supported upstream until Nov 2028, so staying on `image: postgres:16` with
   ## the old `db_data:/var/lib/postgresql/data` mount remains a valid option.
   ##
-  ## To move the data across, dump first while the old 16 container is still the
-  ## one running (git checkout the previous docker-compose.yml if you already
-  ## replaced it), with only db up:
-  ##   docker compose stop windmill_server windmill_worker windmill_worker_native
-  ##   docker compose exec -T db pg_dumpall -U postgres --globals-only --no-role-passwords > globals.sql
-  ##   docker compose exec -T db pg_dump -U postgres -Fc windmill > windmill.dump
-  ## Check both files, then switch to this file and start 18 on an empty volume:
+  ## Migrating means moving the WHOLE CLUSTER, not the windmill database. Windmill
+  ## creates instance datatable, DuckLake and wm_fork_* databases alongside it, and
+  ## grants its row-level security policies to cluster-level roles; a single-database
+  ## pg_dump carries neither, and the volume is gone before anyone notices. Dump
+  ## while the 16 container is still the one running (git checkout the previous
+  ## docker-compose.yml if you already replaced it):
+  ##   docker compose down && docker compose up --wait db
+  ##   docker compose exec -T db pg_dumpall -U postgres > cluster.sql
+  ## Check cluster.sql lists every database, then switch to this file:
   ##   docker compose down
   ##   docker volume ls | grep db_data     # then remove the one this project owns
   ##   docker volume rm <that_volume>
-  ##   docker compose up -d db
-  ##   docker compose exec -T db psql -U postgres -d postgres < globals.sql
-  ##   docker compose exec -T db pg_restore -U postgres -d windmill --no-owner --exit-on-error < windmill.dump
+  ##   docker compose up --wait db
+  ##   docker compose exec -T db psql -U postgres -d postgres < cluster.sql
+  ##   docker compose exec -T db psql -U postgres -d windmill -c ANALYZE
   ##   docker compose up -d
-  ## Loading globals.sql is not optional. Windmill grants its row-level security
-  ## policies to the cluster-level windmill_admin and windmill_user roles, which a
-  ## database-only dump does not carry, and pg_restore silently drops every policy
-  ## whose grantee role is missing. The one error to expect is psql reporting
-  ## `role "postgres" already exists`, which the fresh cluster bootstraps itself.
+  ## `database "windmill" already exists` and `role "postgres" already exists` are
+  ## expected; the fresh cluster bootstraps both, and psql carries on to load into
+  ## them. ANALYZE is not optional: a restored cluster starts with no planner
+  ## statistics, which reads as "the upgrade made Windmill slow" until autovacuum
+  ## catches up. `up --wait` rather than `up -d` because psql would otherwise race
+  ## initdb on a fresh volume.
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,42 +8,13 @@ x-logging: &default-logging
     compress: "true"
 
 services:
-  ## UPGRADING AN EXISTING STACK: a db_data volume written by postgres:16 holds a
-  ## cluster that 18 cannot read. The container exits with an explanatory error
-  ## instead of coming up blank, so nothing is lost before you migrate. Postgres 16
-  ## is supported upstream until Nov 2028, so staying on `image: postgres:16` with
-  ## the old `db_data:/var/lib/postgresql/data` mount remains a valid option.
-  ##
-  ## Migrating means moving the WHOLE CLUSTER, not the windmill database. Windmill
-  ## creates instance datatable, DuckLake and wm_fork_* databases alongside it, and
-  ## grants its row-level security policies to cluster-level roles; a single-database
-  ## pg_dump carries neither, and the volume is gone before anyone notices. Dump
-  ## while the 16 container is still the one running (git checkout the previous
-  ## docker-compose.yml if you already replaced it):
-  ##   docker compose down && docker compose up --wait db
-  ##   docker compose exec -T db pg_dumpall -U postgres > cluster.sql
-  ## Check cluster.sql lists every database, then switch to this file:
-  ##   docker compose down
-  ##   docker volume ls | grep db_data     # then remove the one this project owns
-  ##   docker volume rm <that_volume>
-  ##   docker compose up --wait db
-  ##   docker compose exec -T db psql -U postgres -d postgres -c 'DROP DATABASE windmill'
-  ##   docker compose exec -T db psql -U postgres -d postgres < cluster.sql > restore.log 2>&1
-  ##   grep -i '^ERROR' restore.log      # only `role "postgres" already exists`
-  ##   docker compose exec -T db vacuumdb -U postgres --all --analyze-in-stages
-  ##   docker compose up -d
-  ## `up --wait` because psql would otherwise race initdb on a fresh volume. The
-  ## DROP is what lets the dump's own `CREATE DATABASE windmill` run: POSTGRES_DB
-  ## has already made an empty one, and loading into it would keep the new cluster's
-  ## encoding and collation instead of the dumped ones, for that database only.
-  ## psql does not stop on error and the old volume is already gone by then, so grep
-  ## the log rather than trust its exit code; the fresh cluster bootstraps `postgres`
-  ## itself, so that role is the one error left. vacuumdb spans every restored
-  ## database, which a plain ANALYZE would not: each comes back with no planner
-  ## statistics, and a fork database is where the stall shows. Postgres triggers
-  ## reading a database in this cluster come back disabled with "replication slot
-  ## ... no longer exists", since slots are never dumped; re-saving the trigger
-  ## recreates the slot, then re-enable it.
+  ## UPGRADING FROM POSTGRES 16: db_data holds a cluster 18 cannot read, so the
+  ## container exits with an explanatory error rather than coming up blank. Migrating
+  ## means dumping the WHOLE cluster (pg_dumpall), never just the windmill database:
+  ## Windmill keeps datatable, DuckLake and wm_fork_* databases beside it and grants
+  ## its RLS policies to cluster-level roles, and a single-database dump loses both
+  ## silently. Full procedure, and why 16 is still a valid choice until Nov 2028:
+  ## https://gist.github.com/rubenfiszel/4f2807b0fc685865f6e97d352681b9a8
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file


### PR DESCRIPTION
## Summary

Moves the `db` service in the root `docker-compose.yml` from `postgres:16` to `postgres:18`.

From 18 on, the official image stores the cluster in a major-version subdirectory
(`/var/lib/postgresql/18/docker`) and declares its volume at `/var/lib/postgresql`, so the mount
point moves with it. That is a breaking change for every existing stack. The compose file carries
only the constraint a reader needs before touching the mount; the migration runbook lives in a gist
so it can be corrected in one place:

**https://gist.github.com/rubenfiszel/4f2807b0fc685865f6e97d352681b9a8**

## Performance: PG18 removes a scalability cliff

Earlier revisions of this description reported a flat regression. That was wrong, twice, and the
corrections are worth recording because both were measurement errors rather than PostgreSQL
behaviour:

1. A first pass showed PG18 1.7-2.7x *faster*. Each postgres image ships its own `pgbench`, so
   `docker exec <pg16> pgbench` vs `docker exec <pg18> pgbench` compared **clients**, not servers.
2. A second pass showed a flat ~8-23% regression. Those runs used a queue where every row was
   runnable, which is only one of the states this query runs in.

Measured properly (identical CPU-pinned containers, one `pgbench` binary over TCP, real Windmill
schema, both clusters verified to the same physical state, `VACUUM FULL` + `FREEZE` + `REINDEX`
between runs), the worker pull query with 8 tags over 200k queued rows:

| queue state | PG16 | PG18 | ratio |
| --- | --- | --- | --- |
| 40k jobs runnable now | 48,133 | 41,167 | 0.86 |
| backlog present, nothing runnable | 4,995 | 53,590 | **10.7** |

**PG18 is ~14% slower when there is work waiting, and ~10.7x faster when the queue holds a backlog
with nothing runnable** — the state an instance with scheduled jobs, delayed retries and suspended
flow steps sits in most of the time, and the state every worker polls in a loop.

### Why, and a correction

Both effects are the same mechanism, and it is **skip scan**, which I previously reported as not
applying here. It does. `queue_sort_v2` is `(priority DESC NULLS LAST, scheduled_for, tag)` and
`priority` is NULL for ~99% of rows, so the leading column is unconstrained:

- **PG16** cannot begin the scan without it and walks the whole index — 645 buffers, 1.4ms — before
  concluding nothing is runnable. That is the 4,995 tps cliff.
- **PG18** skip-scans the two distinct `priority` values (`Index Searches: 2`) and answers in 12
  buffers, 0.024ms.

The same machinery costs a constant +6 buffers per scan when a row is available immediately, which
is the 14%. Bisected on a synthetic table, `LIMIT 1` buffers:

| index / predicates | PG16 | PG18 |
| --- | --- | --- |
| plain `(a,b)`, matching ORDER BY | 1 | 1 |
| partial `(a DESC NULLS LAST, b, c)`, no qual | 4 | 4 |
| ...+ qual on a trailing column | 4-11 | 10-17 |

Ruled out individually: plan choice, protocol overhead, row locking, `SKIP LOCKED`,
`data_checksums`, `io_method` (`worker` and `sync`), prefetch (`effective_io_concurrency=0`), and
index bloat.

### The 14% is recoverable, if we want it

An `OFFSET 0` fence keeps `tag` out of the index condition while leaving the `priority` skip scan
intact. On the real schema:

| | PG16 | PG18 |
| --- | --- | --- |
| runnable work, current query | 48,133 | 41,167 |
| runnable work, fenced | 45,153 | **47,477** |
| nothing runnable, fenced | 4,970 | 51,447 |

PG18 + fence is at or above PG16 in **every** state. Verified that the fenced form still locks
correctly: two concurrent sessions pick different rows under `FOR UPDATE SKIP LOCKED`.

It costs PG16 ~6%, so it would want gating on server version rather than applying unconditionally.
`make_pull_query` builds this SQL at runtime and the backend already reads `SELECT version()` at
startup (`backend/src/main.rs:830`), so that is mechanically straightforward. **Not proposed in this
PR** — it touches the hottest query in the system and deserves its own change with its own review.

## Changes

- `db` image `postgres:16` → `postgres:18`
- volume mount `db_data:/var/lib/postgresql/data` → `db_data:/var/lib/postgresql`
- 7-line comment stating the constraint and linking the runbook

The volume name is deliberately unchanged. A `db_data` holding a 16 cluster makes the 18 image exit
with an explanatory error, so an operator who bumps without migrating gets a loud failure and
untouched data, rather than Windmill booting against an empty database and looking wiped.

## The two things that make the migration non-obvious

**Windmill's data is not confined to the `windmill` database.** `create_custom_instance_database`
(`windmill-common/src/lib.rs:1425`) and the workspace-fork endpoint run `CREATE DATABASE` on the
main pool, so instance datatables, DuckLake catalogs and `wm_fork_*` databases sit in the same
cluster. `pg_dump -Fc windmill` carries none of them and nothing errors. Verified: **0** references
to the sibling databases in that dump.

**RLS policies are granted to cluster-level roles.** `windmill_admin` / `windmill_user` are not in a
database dump, and `pg_restore` skips every policy whose grantee is missing unless
`--exit-on-error` is passed. Measured: **338 policies → 0**. Those roles are live;
`windmill-queue/src/schedule.rs` does `SET LOCAL ROLE windmill_user`.

`pg_dumpall` of the whole cluster solves both and keeps role passwords.

## What was tested

- **Schema** — all 627 migrations apply cleanly on 18; `pg_dump -s` byte-identical to 16 apart from
  the version banner and 18's named-`NOT NULL` syntax.
- **Fresh stack** — real `ghcr.io/windmill-labs/windmill:main` (CE v1.796.0) server + worker on
  `postgres:18` from this file: migrations applied, worker registered, Python job ran to `success`.
- **The gist runbook, verbatim, with sibling databases present** — 16 stack on the previous compose
  file, a script, a job, plus `wm_datatables` and `wm_fork_admins_lake_deadbeef` (500 rows each).
  After: 3/3 databases, 500/500 rows each, 2 scripts, 2 completed jobs, 365 RLS policies, 4 roles
  with passwords, and the pre-upgrade script ran to `success`.
- **`vacuumdb --all --analyze-in-stages`** — user-table `pg_statistic` 0 → 314 / 0 → 2 / 0 → 2. A
  single-database `ANALYZE` left the siblings at 0.
- **Skipping the migration** — container exits 1 with the docker-library explanation,
  `depends_on: service_healthy` keeps the server from starting, `PG_VERSION` still reads 16.
- **Performance** — as above, on both a synthetic reproducer and the real schema, across queue
  depths 0 / 100 / 5k / 200k and readiness 0% / 5% / 20% / 50% / 100%.

## Other PG18 features assessed

- **`uuidv7()`** — no gain, job ids are already ULIDs.
- **`NOT NULL NOT VALID`** — useful going forward: add `NOT NULL` to a large job table without the
  validation scan under `AccessExclusiveLock`.
- **pg_upgrade carries planner statistics** — helps 18→19, not this dump/restore.
- **checksums by default / async I/O / virtual generated columns** — no measurable effect here.
- **A tag-leading index** was tested as an alternative and is catastrophic (740 tps): the ORDER BY
  then requires a sort. The current index shape is correct.

## Not in scope

`start-dev-db.sh`, `integration_tests/`, `examples/deploy/*` (14/16) and the pinned CI service
containers are untouched. `backend-test.yml` uses an unpinned `image: postgres`, today 18.6
(identical image id to `postgres:18`), so the backend suite already runs on 18. Four example stacks
are on postgres:14, EOL 2026-11-12; worth its own PR.

## Test plan

- [x] 627 migrations apply cleanly on `postgres:18`
- [x] schema dump on 18 matches 16 modulo dump syntax
- [x] fresh stack boots and runs a Python job to success
- [x] gist recipe reproduces state exactly, incl. sibling databases, 365 RLS policies, role passwords
- [x] script created pre-upgrade runs post-upgrade
- [x] `vacuumdb --all` populates statistics in every restored database
- [x] bumping without migrating fails loudly and leaves the 16 cluster intact
- [x] perf characterised across queue states on synthetic and real schema, cause bisected
- [x] fenced variant verified to preserve `FOR UPDATE SKIP LOCKED` semantics
- [x] `docker compose config` validates; gist link returns 200