### PR TITLE
fix(debugger): parse bun 1.4's UUID inspector token

### DIFF
--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -1652,8 +1652,12 @@ export class DebugSession {
 			await this.startBunProcess(cwd)
 		} catch (error) {
 			this.sendEvent('output', { category: 'stderr', output: `Failed to start Bun: ${error}\n` })
-			this.terminatedSent = true
-			this.sendEvent('terminated', { error: String(error) })
+			// A socket that drops mid-handshake reports the termination from onclose and fails the
+			// launch; that first event carries the result, so it must not be overwritten here.
+			if (!this.terminatedSent) {
+				this.terminatedSent = true
+				this.sendEvent('terminated', { error: String(error) })
+			}
 			// --inspect-wait blocks until a debugger attaches, so a bun we failed to attach to
 			// waits forever unless it is reaped here.
 			await this.cleanup()

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -1652,7 +1652,11 @@ export class DebugSession {
 			await this.startBunProcess(cwd)
 		} catch (error) {
 			this.sendEvent('output', { category: 'stderr', output: `Failed to start Bun: ${error}\n` })
+			this.terminatedSent = true
 			this.sendEvent('terminated', { error: String(error) })
+			// --inspect-wait blocks until a debugger attaches, so a bun we failed to attach to
+			// waits forever unless it is reaped here.
+			await this.cleanup()
 		}
 	}
 
@@ -1956,9 +1960,12 @@ export class DebugSession {
 				const text = decoder.decode(value)
 				buffer += text
 
-				// Look for the WebSocket URL in Bun's inspector output
-				// Format: "ws://127.0.0.1:9229/xxxxx"
-				const wsMatch = buffer.match(/ws:\/\/[\d.]+:\d+\/[a-z0-9]+/i)
+				// Look for the WebSocket URL in Bun's inspector banner, e.g.
+				// "  ws://127.0.0.1:9229/848c719d-a52e-4610-8e94-99cd60f34af9".
+				// The token's alphabet is Bun's to change (it became a hyphenated UUID in 1.4),
+				// so take the whole path, and only once the line is terminated: a stderr chunk can
+				// end mid-URL, and connecting to a truncated path gets a 404 from the inspector.
+				const wsMatch = buffer.match(/ws:\/\/[\d.]+:\d+\/\S+(?=\r?\n)/)
 				if (wsMatch && this.inspectorWsUrlPromise) {
 					const wsUrl = wsMatch[0]
 					logger.info(`Found inspector WebSocket URL in stderr: ${wsUrl}`)
@@ -1988,12 +1995,18 @@ export class DebugSession {
 		return new Promise((resolve, reject) => {
 			this.inspectorWs = new WebSocket(wsUrl)
 
+			// A close before the handshake succeeds is a failed connection, not a finished
+			// script, and the two are reported to the client in opposite ways.
+			let opened = false
+			let handshakeError: string | null = null
+
 			const timeout = setTimeout(() => {
 				reject(new Error('Inspector connection timeout'))
 			}, 5000)
 
 			this.inspectorWs.onopen = async () => {
 				clearTimeout(timeout)
+				opened = true
 				logger.info('Connected to inspector')
 
 				try {
@@ -2042,11 +2055,24 @@ export class DebugSession {
 
 			this.inspectorWs.onerror = (error) => {
 				logger.error('Inspector WebSocket error:', error)
+				if (!opened) {
+					handshakeError = (error as ErrorEvent)?.message || String(error)
+				}
 			}
 
 			this.inspectorWs.onclose = () => {
 				logger.info('Inspector WebSocket closed')
 				this.inspectorWs = null
+
+				if (!opened) {
+					clearTimeout(timeout)
+					reject(
+						new Error(
+							`Inspector connection failed: ${handshakeError ?? 'closed before the handshake completed'}`
+						)
+					)
+					return
+				}
 
 				// When inspector closes, the script has ended - send terminated event
 				if (!this.terminatedSent) {

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -1651,9 +1651,9 @@ export class DebugSession {
 		try {
 			await this.startBunProcess(cwd)
 		} catch (error) {
-			// Reachable after a successful run: a command still in flight when the script ended
-			// rejects on its own timer, long after onclose reported the termination. Saying the
-			// launch failed at that point contradicts the result the client already has.
+			// A launch failure is reported here, a finished script from onclose; whichever gets
+			// there first owns the terminated event, so a client that already has a result is
+			// never told afterwards that the launch failed.
 			if (!this.terminatedSent) {
 				this.terminatedSent = true
 				this.sendEvent('output', { category: 'stderr', output: `Failed to start Bun: ${error}\n` })
@@ -2046,12 +2046,16 @@ export class DebugSession {
 					await this.applyBreakpointsByUrl()
 
 					this.running = true
-					executionStarted = true
 
 					// CRITICAL: Call Inspector.initialized to start script execution
 					// Without this, Bun waits indefinitely with --inspect-wait
 					logger.info('Starting script execution with Inspector.initialized...')
 					await this.sendInspectorCommand('Inspector.initialized', {})
+
+					// Only past its reply is a later close a finished script rather than a lost
+					// connection. The reply precedes any close on this socket, so the continuation
+					// runs first and a real run is never misread as a failure.
+					executionStarted = true
 
 					resolve()
 				} catch (error) {

--- a/debugger/dap_websocket_server_bun.ts
+++ b/debugger/dap_websocket_server_bun.ts
@@ -1651,11 +1651,12 @@ export class DebugSession {
 		try {
 			await this.startBunProcess(cwd)
 		} catch (error) {
-			this.sendEvent('output', { category: 'stderr', output: `Failed to start Bun: ${error}\n` })
-			// A socket that drops mid-handshake reports the termination from onclose and fails the
-			// launch; that first event carries the result, so it must not be overwritten here.
+			// Reachable after a successful run: a command still in flight when the script ended
+			// rejects on its own timer, long after onclose reported the termination. Saying the
+			// launch failed at that point contradicts the result the client already has.
 			if (!this.terminatedSent) {
 				this.terminatedSent = true
+				this.sendEvent('output', { category: 'stderr', output: `Failed to start Bun: ${error}\n` })
 				this.sendEvent('terminated', { error: String(error) })
 			}
 			// --inspect-wait blocks until a debugger attaches, so a bun we failed to attach to
@@ -1966,10 +1967,10 @@ export class DebugSession {
 
 				// Look for the WebSocket URL in Bun's inspector banner, e.g.
 				// "  ws://127.0.0.1:9229/848c719d-a52e-4610-8e94-99cd60f34af9".
-				// The token's alphabet is Bun's to change (it became a hyphenated UUID in 1.4),
-				// so take the whole path, and only once the line is terminated: a stderr chunk can
-				// end mid-URL, and connecting to a truncated path gets a 404 from the inspector.
-				const wsMatch = buffer.match(/ws:\/\/[\d.]+:\d+\/\S+(?=\r?\n)/)
+				// The token's alphabet is Bun's to change (it became a hyphenated UUID in 1.4), so
+				// take the whole path, and only once whitespace proves it complete: a stderr chunk
+				// can end mid-URL, and connecting to a truncated path gets a 404 from the inspector.
+				const wsMatch = buffer.match(/ws:\/\/[\d.]+:\d+\/\S+(?=\s)/)
 				if (wsMatch && this.inspectorWsUrlPromise) {
 					const wsUrl = wsMatch[0]
 					logger.info(`Found inspector WebSocket URL in stderr: ${wsUrl}`)
@@ -1999,9 +2000,13 @@ export class DebugSession {
 		return new Promise((resolve, reject) => {
 			this.inspectorWs = new WebSocket(wsUrl)
 
-			// A close before the handshake succeeds is a failed connection, not a finished
-			// script, and the two are reported to the client in opposite ways.
+			// A close before the script is running is a failed connection, not a finished script,
+			// and the two are reported to the client in opposite ways. The socket opening is not
+			// the line: the setup commands below run over an open socket and none of them reject
+			// when it drops (sendInspectorCommand only has its own timer), so a drop mid-setup
+			// would otherwise be indistinguishable from a clean exit.
 			let opened = false
+			let executionStarted = false
 			let handshakeError: string | null = null
 
 			const timeout = setTimeout(() => {
@@ -2041,6 +2046,7 @@ export class DebugSession {
 					await this.applyBreakpointsByUrl()
 
 					this.running = true
+					executionStarted = true
 
 					// CRITICAL: Call Inspector.initialized to start script execution
 					// Without this, Bun waits indefinitely with --inspect-wait
@@ -2068,11 +2074,11 @@ export class DebugSession {
 				logger.info('Inspector WebSocket closed')
 				this.inspectorWs = null
 
-				if (!opened) {
+				if (!executionStarted) {
 					clearTimeout(timeout)
 					reject(
 						new Error(
-							`Inspector connection failed: ${handshakeError ?? 'closed before the handshake completed'}`
+							`Inspector connection failed: ${handshakeError ?? (opened ? 'closed before setup completed' : 'closed before the handshake completed')}`
 						)
 					)
 					return

--- a/docker/test_windmill_extra.ts
+++ b/docker/test_windmill_extra.ts
@@ -206,7 +206,11 @@ class DAPTestClient {
 	private events: DAPMessage[] = []
 	private output: string[] = []
 	private result: unknown = undefined
-	private eventHandlers = new Map<string, ((event: DAPMessage) => void)[]>()
+	private eventWaiters = new Map<string, ((event: DAPMessage) => void)[]>()
+	// An event that arrives before its waiter is registered is queued rather than dropped: the
+	// server sends 'initialized' right behind the 'initialize' response, and 'terminated' can
+	// land before the launch call the test awaits has even returned.
+	private bufferedEvents = new Map<string, DAPMessage[]>()
 
 	async connect(endpoint: string): Promise<void> {
 		const url = `ws://${HOST}:${DEBUGGER_PORT}${endpoint}`
@@ -273,9 +277,13 @@ class DAPTestClient {
 					this.result = msg.body.result
 				}
 
-				const handlers = this.eventHandlers.get(msg.event!) || []
-				for (const handler of handlers) {
-					handler(msg)
+				const waiters = this.eventWaiters.get(msg.event!)
+				if (waiters && waiters.length > 0) {
+					waiters.shift()!(msg)
+				} else {
+					const buffered = this.bufferedEvents.get(msg.event!) || []
+					buffered.push(msg)
+					this.bufferedEvents.set(msg.event!, buffered)
 				}
 			}
 		} catch {
@@ -313,23 +321,27 @@ class DAPTestClient {
 	}
 
 	waitForEvent(eventName: string, timeout = 10000): Promise<DAPMessage> {
+		const buffered = this.bufferedEvents.get(eventName)
+		if (buffered && buffered.length > 0) {
+			return Promise.resolve(buffered.shift()!)
+		}
+
 		return new Promise((resolve, reject) => {
+			const waiters = this.eventWaiters.get(eventName) || []
+			this.eventWaiters.set(eventName, waiters)
+
 			const timer = setTimeout(() => {
+				const idx = waiters.indexOf(handler)
+				if (idx >= 0) waiters.splice(idx, 1)
 				reject(new Error(`Timeout waiting for event: ${eventName}`))
 			}, timeout)
 
 			const handler = (event: DAPMessage) => {
 				clearTimeout(timer)
-				const handlers = this.eventHandlers.get(eventName) || []
-				const idx = handlers.indexOf(handler)
-				if (idx >= 0) handlers.splice(idx, 1)
 				resolve(event)
 			}
 
-			if (!this.eventHandlers.has(eventName)) {
-				this.eventHandlers.set(eventName, [])
-			}
-			this.eventHandlers.get(eventName)!.push(handler)
+			waiters.push(handler)
 		})
 	}
 
@@ -379,6 +391,7 @@ class DAPTestClient {
 		this.output = []
 		this.result = undefined
 		this.events = []
+		this.bufferedEvents.clear()
 	}
 }
 


### PR DESCRIPTION
## Summary

The `test_extra` job in `publish_extra.yml` has failed on every run since the bun 1.4.0 bump (`d85050f505`) — 1.794.1, 1.795.0 and 1.796.0 all fail with the same two cases:

```
- Debugger TypeScript execution: Missing expected output. Got: ["Preparing dependencies..."]
- Debugger breakpoint support: Timeout waiting for event: stopped
```

Bun 1.4 changed the inspector URL's token from an alphanumeric string to a hyphenated UUID. The debugger scrapes that URL out of bun's stderr banner with `/ws:\/\/[\d.]+:\d+\/[a-z0-9]+/i`, which stops at the first hyphen:

```
banner:    ws://127.0.0.1:9742/848c719d-a52e-4610-8e94-99cd60f34af9
scraped:   ws://127.0.0.1:9742/848c719d          -> HTTP 404
```

The inspector answers the truncated path with a 404, so the WebSocket handshake fails with *"Expected 101 status code"* and no TypeScript debug session has been able to attach since. Both failing tests are that one cause: execution never starts, so there is no output and no `stopped` event.

Two things kept it from being diagnosable from the CI log. A close before the script was running was reported as a normal script termination, so the client saw a plausible `terminated` and never learned the connection had failed. And the debuggee was never reaped — `--inspect-wait` blocks until a debugger attaches, so each failed attach leaked a bun process.

## Changes

- Match the whole URL path, and only once whitespace proves it complete. A stderr chunk can end mid-URL, which would otherwise be read as a complete but truncated URL — the same 404, arrived at a different way. Backward-compatible with bun 1.3's token format.
- Report any close before execution starts as the connection failure it is, naming the handshake error. The socket opening is not the dividing line: the setup commands run over an open socket and none of them reject when it drops (`sendInspectorCommand` only has its own timer), so `Inspector.initialized` being answered is what separates a finished script from a lost connection.
- Reap the debuggee when the launch fails.
- Pair the `Failed to start Bun` output with the `terminated` event it explains, so a run that already reported its result cannot afterwards be told it failed to launch.
- `docker/test_windmill_extra.ts`: queue events that arrive before their waiter registers. The server sends `initialized` immediately behind the `initialize` response, so the client could drop it and then time out waiting for it — a latent flake independent of the bun bug, which I hit locally.

No new test: `docker/test_windmill_extra.ts` is already the regression guard for this, and it is the suite that was failing.

## Test plan

Verified locally by running the CI suite against the debug service with the image's exact bun (1.4.0), `REQUIRE_SIGNED_DEBUG_REQUESTS=false` as CI passes, and a real `windmill` binary so the `prepare-deps` path runs:

- [x] All 4 debugger tests pass, 16 consecutive runs (was 2/4 failing deterministically)
- [x] Reproduced the root cause first: 40/40 handshake failures under bun 1.4.0, 0/40 under 1.3.11
- [x] Backward compatible — suite green with bun 1.3.11's non-hyphenated token
- [x] Close before open (the 404 path), via a stub advertising an unreachable inspector: exactly one `terminated` carrying the real error, and the process reaped
- [x] Close mid-setup, via a stub that answers `Inspector.enable` then drops: one `terminated` with the connection error, immediately rather than on a 10s timer
- [x] Close during `Inspector.initialized`, via a stub that answers every setup command then drops: one `terminated` with the connection error. Confirmed this is a real regression detector — with the flag set one line earlier the same stub yields a silent `terminated {}`

**`test_extra` cannot run on this PR.** `publish_extra.yml` triggers only on `v*` tags and `workflow_dispatch`, so the job will first execute on the next release tag after merge. Note for anyone tempted to dispatch it on this branch to check: `publish_extra` has no branch guard and would push the branch build to `ghcr.io/windmill-labs/windmill-extra:latest`.

LSP and multiplayer tests went unexercised locally (building the image pulls `windmill-ee-slim` and installs Go/gopls/pyright, which would risk filling this box's root partition); they pass in CI today and nothing here touches them.