### PR TITLE
feat(frontend): flag the fork-compare datatable schema diff as legacy

### DIFF
--- a/frontend/src/lib/components/DatatableSchemaDiff.svelte
+++ b/frontend/src/lib/components/DatatableSchemaDiff.svelte
@@ -41,7 +41,9 @@
 	// migrations, its changes flow through the normal item diff instead, so it is
 	// excluded here and the whole section hides once none remain.
 	let applicableCount = $state(0)
-	let applicableLabel = $derived(applicableCount === 1 ? 'this data table' : 'these data tables')
+	let applicableLabel = $derived(
+		applicableCount === 1 ? 'this data table has' : 'these data tables have'
+	)
 	let expandedDatatables: Set<string> = $state(new Set())
 
 	// Drawer state
@@ -285,10 +287,10 @@
 	<div class="bg-surface-tertiary p-4 rounded-md border">
 		<h3 class="text-sm font-semibold">Datatable schema changes</h3>
 		<Alert type="warning" size="xs" title="Legacy schema comparison" class="mt-2">
-			This section diffs data table schemas directly because migrations are disabled on {applicableLabel}.
-			With migrations enabled, schema changes are tracked as migrations and deployed like any other
-			item. Enable them in the parent workspace's data table settings: a fork inherits the flag from
-			its parent when it is created.
+			This section diffs data table schemas directly because {applicableLabel} not opted in to migrations.
+			With migrations enabled, schema changes are tracked as migrations and deployed like any other item.
+			Opt in from the parent workspace's data table settings — a fork only inherits the flag when it
+			is created, so this fork keeps using the legacy diff.
 		</Alert>
 		{#if loading}
 			<div class="flex items-center gap-2 text-xs text-tertiary py-2">

--- a/frontend/src/lib/components/DatatableSchemaDiff.svelte
+++ b/frontend/src/lib/components/DatatableSchemaDiff.svelte
@@ -41,6 +41,7 @@
 	// migrations, its changes flow through the normal item diff instead, so it is
 	// excluded here and the whole section hides once none remain.
 	let applicableCount = $state(0)
+	let applicableLabel = $derived(applicableCount === 1 ? 'this data table' : 'these data tables')
 	let expandedDatatables: Set<string> = $state(new Set())
 
 	// Drawer state
@@ -283,6 +284,12 @@
 {#if applicableCount > 0}
 	<div class="bg-surface-tertiary p-4 rounded-md border">
 		<h3 class="text-sm font-semibold">Datatable schema changes</h3>
+		<Alert type="warning" size="xs" title="Legacy schema comparison" class="mt-2">
+			This section diffs data table schemas directly because migrations are disabled on {applicableLabel}.
+			With migrations enabled, schema changes are tracked as migrations and deployed like any other
+			item. Enable them in the parent workspace's data table settings: a fork inherits the flag from
+			its parent when it is created.
+		</Alert>
 		{#if loading}
 			<div class="flex items-center gap-2 text-xs text-tertiary py-2">
 				<Loader2 class="w-4 h-4 animate-spin" /> Loading datatable diffs...


### PR DESCRIPTION
## Summary

On the fork compare page, the "Datatable schema changes" section only appears for forked data tables that have **not** opted in to migrations — it is the legacy fallback that diffs schemas directly instead of tracking them as migrations. Nothing on screen said so, so the section read like a normal part of the compare flow.

This adds a warning `Alert` at the top of that section explaining why it is showing.

## Changes

- `DatatableSchemaDiff.svelte`: render a warning `Alert` ("Legacy schema comparison") above the diff list, stating that the section shows because the affected data table(s) have not opted in to migrations, that migrations track schema changes as regular deployable items, and that the opt-in belongs in the parent workspace — with the caveat that a fork inherits the flag only at creation, so the current fork keeps using the legacy diff.
- Added an `applicableLabel` `$derived` for the singular/plural wording, driven by the existing `applicableCount`.

No behavior change: the section's visibility condition (`applicableCount > 0`) and every diff/migration action are untouched.

## Screenshots

![fork-compare legacy datatable alert](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-datatable-alert/1787653154-legacy-alert.png)

## Test plan

- [ ] On a fork whose data table has not opted in to migrations, open Compare & Deploy and confirm the warning renders above the diff list
- [ ] Opt that data table in to migrations in the fork and confirm the whole section (alert included) disappears
- [ ] With two or more applicable data tables, confirm the copy reads "these data tables have"