### PR TITLE
fix(frontend): key the GitHub App installation selector on installation_id

### DIFF
--- a/frontend/src/lib/components/GitHubAppIntegration.svelte
+++ b/frontend/src/lib/components/GitHubAppIntegration.svelte
@@ -55,6 +55,19 @@
 			)
 	)
 
+	// Org names that appear on more than one installation, so the dropdown can
+	// tell those entries apart.
+	let duplicatedAccountIds = $derived(
+		new Set(
+			githubState.workspaceGithubInstallations
+				.filter(
+					(installation, _, array) =>
+						array.filter((other) => other.account_id === installation.account_id).length > 1
+				)
+				.map((installation) => installation.account_id)
+		)
+	)
+
 	let showGitHubApp = $derived(
 		resourceType === 'git_repository' &&
 			$workspaceStore &&
@@ -205,29 +218,47 @@
 								<div class="flex flex-row gap-2 w-full">
 									<div class="flex flex-col gap-1 flex-1">
 										<p class="text-sm font-semibold text-secondary">GitHub Account ID</p>
-										<select bind:value={githubState.selectedGHAppAccountId}>
-											<option value="" disabled>Select GitHub Account ID</option>
+										<select
+											bind:value={githubState.selectedGHAppInstallationId}
+											onchange={() => (githubState.selectedGHAppRepository = undefined)}
+										>
+											<option value={undefined} disabled>Select GitHub Account ID</option>
 											{#each githubState.workspaceGithubInstallations as installation (`select-${installation.installation_id}-${installation.workspace_id}`)}
-												<option value={installation.account_id} disabled={!!installation.error}>
-													{installation.account_id}{installation.error ? ' (token error)' : ''}
+												{@const details = [
+													duplicatedAccountIds.has(installation.account_id)
+														? `installation ${installation.installation_id}`
+														: undefined,
+													installation.error ? 'token error' : undefined
+												].filter(Boolean)}
+												<option
+													value={installation.installation_id}
+													disabled={!!installation.error}
+												>
+													{installation.account_id}{details.length
+														? ` (${details.join(', ')})`
+														: ''}
 												</option>
 											{/each}
 										</select>
 									</div>
-									{#if githubState.selectedGHAppAccountId}
+									{#if githubState.selectedGHAppInstallationId !== undefined}
 										{@const selectedInstallation = githubState.workspaceGithubInstallations.find(
-											(inst) => inst.account_id === githubState.selectedGHAppAccountId
+											(inst) => inst.installation_id === githubState.selectedGHAppInstallationId
 										)}
 										{#if selectedInstallation}
 											<div class="flex flex-col gap-1 flex-1">
 												<p class="text-sm font-semibold text-secondary">Repository</p>
-												<RepositorySelector
-													bind:selectedRepository={githubState.selectedGHAppRepository}
-													accountId={githubState.selectedGHAppAccountId}
-													initialRepositories={selectedInstallation.repositories}
-													totalCount={selectedInstallation.total_count}
-													perPage={selectedInstallation.per_page}
-												/>
+												<!-- RepositorySelector snapshots its repositories and page cursor at
+												     mount, so switching installation has to remount it. -->
+												{#key selectedInstallation.installation_id}
+													<RepositorySelector
+														bind:selectedRepository={githubState.selectedGHAppRepository}
+														installationId={selectedInstallation.installation_id}
+														initialRepositories={selectedInstallation.repositories}
+														totalCount={selectedInstallation.total_count}
+														perPage={selectedInstallation.per_page}
+													/>
+												{/key}
 											</div>
 										{/if}
 									{/if}

--- a/frontend/src/lib/components/GitHubAppIntegration.svelte
+++ b/frontend/src/lib/components/GitHubAppIntegration.svelte
@@ -226,7 +226,7 @@
 											{#each githubState.workspaceGithubInstallations as installation (`select-${installation.installation_id}-${installation.workspace_id}`)}
 												{@const details = [
 													duplicatedAccountIds.has(installation.account_id)
-														? `installation ${installation.installation_id}`
+														? `${installation.installation_id}`
 														: undefined,
 													installation.error ? 'token error' : undefined
 												].filter(Boolean)}

--- a/frontend/src/lib/components/RepositorySelector.svelte
+++ b/frontend/src/lib/components/RepositorySelector.svelte
@@ -11,7 +11,7 @@
 	interface Props {
 		disabled?: boolean
 		selectedRepository?: string | undefined
-		accountId: string
+		installationId: number
 		initialRepositories: Repository[]
 		totalCount: number
 		perPage: number
@@ -23,7 +23,7 @@
 	let {
 		disabled = false,
 		selectedRepository = $bindable(),
-		accountId,
+		installationId,
 		initialRepositories,
 		totalCount,
 		perPage,
@@ -67,8 +67,8 @@
 				page: nextPage
 			})
 
-			// Find the matching installation and get its repositories
-			const installation = installations.find((inst) => inst.account_id === accountId)
+			// Match on installation_id: several installations can share one account_id
+			const installation = installations.find((inst) => inst.installation_id === installationId)
 
 			if (installation?.repositories) {
 				// Append new repos to existing ones
@@ -95,8 +95,8 @@
 				}))}
 				placeholder="Select repository..."
 				clearable
-				disabled={disabled}
-				bind:filterText={filterText}
+				{disabled}
+				bind:filterText
 				bind:value={selectedRepository}
 			/>
 			{#if hasMoreRepos}

--- a/frontend/src/lib/githubApp.ts
+++ b/frontend/src/lib/githubApp.ts
@@ -10,7 +10,12 @@ export interface GitHubAppState {
 	loadingGithubInstallations: boolean
 	githubInstallations: GetGlobalConnectedRepositoriesResponse
 	workspaceGithubInstallations: GetGlobalConnectedRepositoriesResponse
-	selectedGHAppAccountId: string | undefined
+	/**
+	 * Installations are keyed by `installation_id`, never by `account_id`: an org
+	 * can be installed more than once (re-installed, or added from another
+	 * workspace), and matching on the org name resolves to the wrong one.
+	 */
+	selectedGHAppInstallationId: number | undefined
 	selectedGHAppRepository: string | undefined
 	githubInstallationUrl: string | undefined
 	installationCheckInterval: number | undefined
@@ -23,11 +28,6 @@ export interface GitHubAppState {
 	 * github.com-pointed installs.
 	 */
 	isGhesSelfManaged: boolean
-}
-
-export interface GitHubRepository {
-	name: string
-	url: string
 }
 
 export interface GitHubAppError extends Error {
@@ -101,7 +101,7 @@ export function createGitHubAppState(): GitHubAppState {
 		loadingGithubInstallations: false,
 		githubInstallations: [],
 		workspaceGithubInstallations: [],
-		selectedGHAppAccountId: undefined,
+		selectedGHAppInstallationId: undefined,
 		selectedGHAppRepository: undefined,
 		githubInstallationUrl: undefined,
 		installationCheckInterval: undefined,
@@ -239,18 +239,6 @@ export function stopInstallationCheck(state: GitHubAppState): void {
 		state.installationCheckInterval = undefined
 	}
 	state.isCheckingInstallation = false
-}
-
-/**
- * Gets repositories for a specific GitHub account
- */
-export function getRepositories(state: GitHubAppState, accountId: string): GitHubRepository[] {
-	if (!accountId) return []
-
-	return (
-		state.githubInstallations.find((installation) => installation.account_id === accountId)
-			?.repositories || []
-	)
 }
 
 /**


### PR DESCRIPTION
## Summary

A workspace can hold several GitHub App installations for the same org: `install_from_workspace` and the GHES assign path dedup on `installation_id` only, so re-installing an app or pulling one in from another workspace leaves two entries sharing an `account_id`.

The GitHub Account ID dropdown used `account_id` as the `<option>` value **and** as the `.find()` key, so both entries were indistinguishable. Picking the live installation resolved to whichever came first, which could be a stale, token-errored one whose `repositories` array is empty, leaving the repository dropdown with nothing in it. `RepositorySelector`'s "load more" pagination matched the same way and appended the wrong installation's page.

Everything now keys on `installation_id`, which is unique per installation. The label still shows the org name, with the installation id appended only for orgs that appear more than once.

Fixes WIN-2448

## Changes

- `frontend/src/lib/githubApp.ts`: `selectedGHAppAccountId: string` → `selectedGHAppInstallationId: number`. Dropped `getRepositories()` and the `GitHubRepository` type it returned — both unreferenced, and `getRepositories()` carried a third copy of the same `account_id` lookup.
- `frontend/src/lib/components/GitHubAppIntegration.svelte`: the select binds and looks up by `installation_id`; the placeholder option now actually shows when nothing is selected (it was `value=""` against an `undefined` state, so the browser fell through to the first enabled installation); duplicated org names get ` (<installation id>)` appended so the two entries are distinguishable.
- `frontend/src/lib/components/RepositorySelector.svelte`: `accountId: string` prop → `installationId: number`, and `loadMoreRepositories` matches on it.
- Switching installation now remounts `RepositorySelector` (`{#key}`) and clears the selected repository. `RepositorySelector` snapshots `initialRepositories` into local state at mount and tracks its own page cursor, so without the remount a switch kept showing the previous org's repositories and a stale "Loaded N of M" count.

## Test plan

Exercised against a local instance with the installations endpoint stubbed to return two installations for one org (`acme-corp`: `111111` token-errored with no repos, `222222` healthy) plus a second org:

- [x] Options carry unique values; the duplicated org reads `acme-corp (111111, token error)` / `acme-corp (222222)`, the unique org stays plain `other-org`
- [x] Nothing preselected on open — the placeholder shows instead of the errored installation
- [x] Selecting the healthy duplicate populates the repository dropdown (this is the reported bug; before the fix it was empty)
- [x] Switching org refreshes the repository list and clears the previous selection, re-disabling Apply
- [x] "load more" with `total_count` 5 / `per_page` 3 appends the right installation's page 2 (3 of 5 → all 5); under the old lookup it would have hit the empty errored installation and appended nothing
- [x] Apply writes `url` + `is_github_app` onto the resource
- [x] `svelte-check`: 0 errors

## Screenshots

Two installations for `acme-corp`, the live one selected.

Before — the errored installation is picked up and the repository dropdown is empty:

![before-duplicate-org](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2448-fix-github-app-installation-selector-using-non-unique/1787653053-before-duplicate-org.png)

After — the two entries are distinguishable and the repositories load:

![after-duplicate-org](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2448-fix-github-app-installation-selector-using-non-unique/1787662501-after-duplicate-org-v2.png)

## Not in scope

Local review surfaced an adjacent pre-existing backend issue, left alone here because it is EE backend behaviour rather than a regression from this diff: `installation_callback` (`git_sync_ee.rs`) upserts by replacing **every** array element whose `account_id` matches. A workspace that already holds two entries for one org and then receives a fresh callback for that org would collapse both onto the same `installation_id`, which duplicates the `{#each}` key. That key expression is unchanged by this PR, but this PR is what makes `installation_id` the identity of the selection, so it is worth a separate look.
