### PR TITLE
fix(frontend): follow the operating workspace in step input forms

### DIFF
--- a/frontend/src/lib/components/EditableSchemaForm.svelte
+++ b/frontend/src/lib/components/EditableSchemaForm.svelte
@@ -173,6 +173,12 @@
 	let itemPicker: ItemPicker | undefined = $state(undefined)
 	let variableEditor: VariableEditor | undefined = $state(undefined)
 
+	// The bare read is the dependency: `loadItems` closes over `ws`.
+	$effect(() => {
+		ws
+		untrack(() => itemPicker?.reloadItems())
+	})
+
 	let keys: string[] = $state(
 		(Array.isArray(schema?.order)
 			? [...schema.order]

--- a/frontend/src/lib/components/EditableSchemaForm.svelte
+++ b/frontend/src/lib/components/EditableSchemaForm.svelte
@@ -15,6 +15,7 @@
 	import PropertyEditor from './schema/PropertyEditor.svelte'
 	import SimpleEditor from './SimpleEditor.svelte'
 	import { createEventDispatcher, untrack } from 'svelte'
+	import { watch } from 'runed'
 	import ToggleButton from './common/toggleButton-v2/ToggleButton.svelte'
 	import ToggleButtonGroup from './common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import Label from './Label.svelte'
@@ -173,11 +174,10 @@
 	let itemPicker: ItemPicker | undefined = $state(undefined)
 	let variableEditor: VariableEditor | undefined = $state(undefined)
 
-	// The bare read is the dependency: `loadItems` closes over `ws`.
-	$effect(() => {
-		ws
-		untrack(() => itemPicker?.reloadItems())
-	})
+	watch(
+		() => ws,
+		() => itemPicker?.reloadItems()
+	)
 
 	let keys: string[] = $state(
 		(Array.isArray(schema?.order)

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -109,6 +109,7 @@
 			: true
 	})
 
+	// The bare read is the dependency: `loadItems` closes over `ws`.
 	$effect(() => {
 		ws
 		untrack(() => itemPicker?.reloadItems())

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -4,7 +4,7 @@
 	import { workspaceStore } from '$lib/stores'
 	import { allTrue, type DynamicInput as DynamicInputTypes } from '$lib/utils'
 	import { untrack } from 'svelte'
-	import { resource } from 'runed'
+	import { resource, watch } from 'runed'
 	import { Button } from './common'
 	import StepInputsGen from './copilot/StepInputsGen.svelte'
 	import type { PickableProperties } from './flows/previousResults'
@@ -109,11 +109,10 @@
 			: true
 	})
 
-	// The bare read is the dependency: `loadItems` closes over `ws`.
-	$effect(() => {
-		ws
-		untrack(() => itemPicker?.reloadItems())
-	})
+	watch(
+		() => ws,
+		() => itemPicker?.reloadItems()
+	)
 
 	let keys: string[] = $state([])
 	$effect(() => {

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import type { Schema } from '$lib/common'
-	import { VariableService, WorkspaceService, type InputTransform } from '$lib/gen'
+	import { CancelError, VariableService, WorkspaceService, type InputTransform } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { allTrue, type DynamicInput as DynamicInputTypes } from '$lib/utils'
 	import { untrack } from 'svelte'
+	import { resource } from 'runed'
 	import { Button } from './common'
 	import StepInputsGen from './copilot/StepInputsGen.svelte'
 	import type { PickableProperties } from './flows/previousResults'
@@ -81,21 +82,37 @@
 	let itemPicker: ItemPicker | undefined = $state(undefined)
 	let variableEditor: VariableEditor | undefined = $state(undefined)
 
-	let s3StorageConfigured = $state(true)
-
-	async function checkS3Storage() {
-		try {
-			if (ws) {
-				const settings = await WorkspaceService.getPublicSettings({ workspace: ws })
-				s3StorageConfigured = settings.large_file_storage?.s3_resource_path !== undefined
+	const settings = resource(
+		() => ws,
+		async (ws, _previousWs, { onCleanup }) => {
+			if (!ws) return undefined
+			const req = WorkspaceService.getPublicSettings({ workspace: ws })
+			// `resource` keeps whatever lands last: cancel a superseded request so a slow
+			// reply for a workspace we have left cannot overwrite the current one.
+			onCleanup(() => req.cancel())
+			try {
+				return { ws, settings: await req }
+			} catch (err) {
+				if (!(err instanceof CancelError)) {
+					console.error('Failed to fetch workspace settings:', err)
+				}
+				return undefined
 			}
-		} catch (error) {
-			console.error('Failed to fetch workspace settings:', error)
-			s3StorageConfigured = true
 		}
-	}
+	)
+	// Assume configured until this workspace's own answer lands: the warning must not
+	// linger from the previous workspace, nor appear merely because the fetch failed.
+	let s3StorageConfigured = $derived.by(() => {
+		const loaded = settings.current
+		return loaded && loaded.ws === ws
+			? loaded.settings.large_file_storage?.s3_resource_path !== undefined
+			: true
+	})
 
-	checkS3Storage()
+	$effect(() => {
+		ws
+		untrack(() => itemPicker?.reloadItems())
+	})
 
 	let keys: string[] = $state([])
 	$effect(() => {

--- a/frontend/src/lib/components/ItemPicker.svelte
+++ b/frontend/src/lib/components/ItemPicker.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { RotateCw } from 'lucide-svelte'
-	import { Button, Drawer, Skeleton } from './common'
+	import { Alert, Button, Drawer, Skeleton } from './common'
 	import DrawerContent from './common/drawer/DrawerContent.svelte'
 	import NoItemFound from './home/NoItemFound.svelte'
 	import IconedResourceType from './IconedResourceType.svelte'
 	import SearchItems from './SearchItems.svelte'
+	import { sendUserToast } from '$lib/toast'
 
 	type Item = Record<string, any>
 
@@ -39,20 +40,57 @@
 	}: Props = $props()
 
 	let loading = $state(false)
+	let loadError: string | undefined = $state(undefined)
 	let items: Item[] | undefined = $state([])
 	let filteredItems: Item[] | undefined = $state([])
 	let filter = $state('')
 
-	export function openDrawer() {
-		loading = true
-		loadItems()
+	// Only the newest load may write `items`: a slower earlier request can resolve last.
+	// Skeletons replace a list that is known-stale; the refresh button omits them so a
+	// known-good list does not flicker.
+	let loadSeq = 0
+	function load(showSkeleton = false): Promise<void> {
+		const seq = ++loadSeq
+		if (showSkeleton) {
+			loading = true
+		}
+		return loadItems()
 			.then((v) => {
-				items = v
+				if (seq === loadSeq) {
+					items = v
+					loadError = undefined
+				}
+			})
+			.catch((err) => {
+				// Drop the list rather than keep offering entries the failed load may have
+				// superseded — they can belong to another workspace. `loadError` then has to
+				// carry the reason, or an empty list reads as an empty workspace.
+				if (seq === loadSeq) {
+					items = []
+					loadError = err.body ?? err.message ?? String(err)
+					sendUserToast(`Failed to load ${itemName.toLowerCase()}s: ${loadError}`, true)
+				}
 			})
 			.finally(() => {
-				loading = false
+				if (seq === loadSeq) {
+					loading = false
+				}
 			})
+	}
+
+	export function openDrawer() {
+		load(true)
 		drawer?.openDrawer?.()
+	}
+
+	/** Re-runs `loadItems` against what it closes over now. No-op while closed —
+	 * opening reloads anyway. */
+	export function reloadItems() {
+		if (drawer?.isOpen()) {
+			// What is on screen came from the previous workspace: it must stop being
+			// pickable now, not once the new list lands.
+			load(true)
+		}
 	}
 
 	let drawer: Drawer | undefined = $state()
@@ -94,14 +132,9 @@
 				<Button
 					on:click={() => {
 						refreshing = true
-						loadItems()
-							.then((v) => {
-								items = v
-							})
-							.finally(() => {
-								loading = false
-								refreshing = false
-							})
+						load().finally(() => {
+							refreshing = false
+						})
 					}}
 					iconOnly
 					startIcon={{ icon: RotateCw, classes: loading || refreshing ? 'animate-spin' : '' }}
@@ -111,6 +144,10 @@
 				{#each new Array(3) as _}
 					<Skeleton layout={[[5], 0.2]} />
 				{/each}
+			{:else if loadError}
+				<Alert type="error" size="xs" title="Failed to load {itemName.toLowerCase()}s">
+					{loadError}
+				</Alert>
 			{:else if !items?.length}
 				<div class="text-center text-sm text-primary mt-2">
 					{@html noItemMessage}

--- a/frontend/src/lib/components/ItemPicker.svelte
+++ b/frontend/src/lib/components/ItemPicker.svelte
@@ -62,14 +62,19 @@
 				}
 			})
 			.catch((err) => {
+				if (seq !== loadSeq) return
 				// Drop the list rather than keep offering entries the failed load may have
-				// superseded — they can belong to another workspace. `loadError` then has to
-				// carry the reason, or an empty list reads as an empty workspace.
-				if (seq === loadSeq) {
-					items = []
-					loadError = err.body ?? err.message ?? String(err)
-					sendUserToast(`Failed to load ${itemName.toLowerCase()}s: ${loadError}`, true)
+				// superseded. `loadError` then has to carry the reason, or an empty list reads
+				// as an empty workspace. An empty body must not win over the message, or the
+				// error state is skipped for a falsy `loadError` — hence `||`, not `??`.
+				items = []
+				loadError = err.body || err.message || String(err)
+				// 401/403 are handled globally by onunhandledrejection (logout, privilege
+				// toast). No caller awaits load(), so rethrowing still reaches it.
+				if (err?.status === 401 || err?.status === 403) {
+					throw err
 				}
+				sendUserToast(`Failed to load ${itemName.toLowerCase()}s: ${loadError}`, true)
 			})
 			.finally(() => {
 				if (seq === loadSeq) {
@@ -87,8 +92,6 @@
 	 * opening reloads anyway. */
 	export function reloadItems() {
 		if (drawer?.isOpen()) {
-			// What is on screen came from the previous workspace: it must stop being
-			// pickable now, not once the new list lands.
 			load(true)
 		}
 	}

--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -15,6 +15,7 @@
 	import { Plus } from 'lucide-svelte'
 	import ArgInput from './ArgInput.svelte'
 	import { createEventDispatcher, untrack } from 'svelte'
+	import { watch } from 'runed'
 	import { deepEqual } from 'fast-equals'
 	import {
 		dragHandleZone,
@@ -155,11 +156,10 @@
 	let itemPicker: ItemPicker | undefined = $state(undefined)
 	let variableEditor: VariableEditor | undefined = $state(undefined)
 
-	// The bare read is the dependency: `loadItems` closes over `ws`.
-	$effect(() => {
-		ws
-		untrack(() => itemPicker?.reloadItems())
-	})
+	watch(
+		() => ws,
+		() => itemPicker?.reloadItems()
+	)
 
 	let resourceTypes: string[] | undefined = $state(undefined)
 

--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -155,6 +155,11 @@
 	let itemPicker: ItemPicker | undefined = $state(undefined)
 	let variableEditor: VariableEditor | undefined = $state(undefined)
 
+	$effect(() => {
+		ws
+		untrack(() => itemPicker?.reloadItems())
+	})
+
 	let resourceTypes: string[] | undefined = $state(undefined)
 
 	async function loadResourceTypes() {

--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -155,6 +155,7 @@
 	let itemPicker: ItemPicker | undefined = $state(undefined)
 	let variableEditor: VariableEditor | undefined = $state(undefined)
 
+	// The bare read is the dependency: `loadItems` closes over `ws`.
 	$effect(() => {
 		ws
 		untrack(() => itemPicker?.reloadItems())

--- a/frontend/src/lib/components/flows/content/FlowEnvironmentVariables.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEnvironmentVariables.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Alert } from '$lib/components/common'
-	import { getContext, setContext } from 'svelte'
+	import { getContext, setContext, untrack } from 'svelte'
 	import type { PropPickerWrapperContext } from '../propPicker/PropPickerWrapper.svelte'
 	import { writable } from 'svelte/store'
 	import type { FlowEditorContext } from '../types'
@@ -228,6 +228,12 @@
 
 	let variablePicker: ItemPicker | undefined = $state(undefined)
 	let pickForKey: string | undefined = $state(undefined)
+
+	// The bare read is the dependency: `loadItems` closes over `opWs`.
+	$effect(() => {
+		opWs
+		untrack(() => variablePicker?.reloadItems())
+	})
 
 	setContext<PropPickerWrapperContext>('PropPickerWrapper', {
 		inputMatches: writable(undefined),

--- a/frontend/src/lib/components/flows/content/FlowEnvironmentVariables.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEnvironmentVariables.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Alert } from '$lib/components/common'
-	import { getContext, setContext, untrack } from 'svelte'
+	import { getContext, setContext } from 'svelte'
+	import { watch } from 'runed'
 	import type { PropPickerWrapperContext } from '../propPicker/PropPickerWrapper.svelte'
 	import { writable } from 'svelte/store'
 	import type { FlowEditorContext } from '../types'
@@ -229,11 +230,10 @@
 	let variablePicker: ItemPicker | undefined = $state(undefined)
 	let pickForKey: string | undefined = $state(undefined)
 
-	// The bare read is the dependency: `loadItems` closes over `opWs`.
-	$effect(() => {
-		opWs
-		untrack(() => variablePicker?.reloadItems())
-	})
+	watch(
+		() => opWs,
+		() => variablePicker?.reloadItems()
+	)
 
 	setContext<PropPickerWrapperContext>('PropPickerWrapper', {
 		inputMatches: writable(undefined),


### PR DESCRIPTION
## Summary

Two changes to the variable `ItemPicker` and the forms that host it.

**A failed load reads as an empty workspace.** `ItemPicker` had no rejection handler: a failed
`loadItems()` left `items` untouched and fell through to *"There are no items in the list"*,
which says "this workspace has no variables" rather than "the load failed". The drawer now
clears the list and renders an error `Alert` carrying the server message. This is reachable
today from any of the nine components that mount a picker — a 500, a dropped connection, a
revoked permission.

**Forms don't re-resolve when their workspace changes.** `SchemaForm`,
`InputTransformSchemaForm`, `EditableSchemaForm` and `FlowEnvironmentVariables` each derive a
`ws` (the step's operating workspace, falling back to the navigation workspace) that the
picker's `loadItems` closure and the S3 storage warning read. Nothing re-ran them when `ws`
moved, so an open drawer would keep the previous workspace's variables pickable and the
warning would keep the previous workspace's answer.

That second one is hardening, not a reproduced bug: today every surface tears these forms down
before the change lands. `/flows/edit/` and `/apps/edit/` are in `EDIT_PAGES`, so a workspace
switch navigates home; an AI Session clears `slot.loadedPath` and unmounts the editor; and the
picker's drawer covers the sidebar switcher while it is open. None of those exist for this
form's benefit, and any one of them moving reintroduces the staleness silently — hence the
guard rather than a comment.

## Changes

- `ItemPicker` records a failed load in `loadError` and renders it as an error `Alert`
  alongside the existing toast, instead of falling through to the empty state.
- `401`/`403` are rethrown after the list is cleared, so they still reach the global
  `onunhandledrejection` handler that logs the user out or reports the missing privilege. Our
  own toast is skipped for those, leaving the global one to speak.
- `ItemPicker` gains `reloadItems()`, re-running the `loadItems` closure against what it closes
  over now. It is a no-op while the drawer is closed, since opening reloads anyway.
- `ItemPicker` loads are sequenced (`loadSeq`): only the newest load may write `items`,
  `loadError` or `loading`, so a slower earlier request resolving last cannot win.
- The four hosting forms call `reloadItems()` when their `ws` changes, wrapped in `untrack` so
  the picker's own state writes don't re-trigger the effect.
- The `getPublicSettings` fetcher cancels a superseded request via `onCleanup`, and its result
  is tagged with the workspace it was fetched for. `s3StorageConfigured` only trusts a result
  whose tag matches the current `ws`, and assumes configured otherwise — so the warning never
  lingers from the previous workspace, nor appears merely because a fetch failed. (Assuming
  configured during the transition matches the prior `checkS3Storage` default.)

## Screenshots

The new failed-load state (`variables/list` stubbed to 500), replacing the misleading
empty-state copy:

![picker-error](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-workspace-reactivity/1787666334-picker-error.png)

The same flow (`u/admin/ws_demo`), same step, same field, opened from two AI Sessions bound to
different workspaces — each picker resolves against its own session's workspace. This already
held at mount time; it is the property the reactivity guard keeps true. Session on Admins:

![session-acting-on-admins](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-workspace-reactivity/1787667626-session-acting-on-admins.png)

Session on WsB:

![session-acting-on-wsb](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-workspace-reactivity/1787667628-session-acting-on-wsb.png)

## Test plan

- [x] Stub `variables/list` to 500 and refresh: the drawer shows the error `Alert` with the
      server message plus the toast, and no stale entries remain pickable.
- [x] Unstub and refresh: the list comes back and the `Alert` clears.
- [x] Stub `variables/list` to `200 []`: the genuine empty state is still reached, so
      `loadError` is not sticky.
- [x] Stub a 500 with an **empty body**: falls through to the status message rather than a
      falsy `loadError`, so the error state is still rendered and not the empty state.
- [x] Stub `variables/list` to 403: the global privilege toast fires (not ours) and the drawer
      shows the server message.
- [x] Stub `variables/list` to 401: the app logs out to `/user/login?rd=…` as it does on `main`.
- [x] Open the same flow and step from two sessions bound to different workspaces: each
      variable picker lists its own session's workspace (screenshots above).
- [x] Open a step whose workspace has S3 storage configured and one whose workspace does not:
      the large-file warning reflects the workspace the form is mounted against.
- [x] `npx svelte-check --threshold error` — 0 errors (72 pre-existing warnings).
- [ ] Not exercised: `reloadItems()` firing from a `ws` change. Every picker state above was
      reached through `openDrawer`. Triggering the reload needs a workspace change with the
      drawer open, which the three teardowns above prevent — see the scope note in the summary.

No automated tests: frontend-only, four Svelte components, and this codebase does not test
Svelte components. The change introduces no new pure-logic utility to test in isolation.
