### PR TITLE
fix: migrate slack resource-connect oauth to v2

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -16,9 +16,9 @@
     "scopes": ["repository"]
   },
   "slack": {
-    "auth_url": "https://slack.com/oauth/authorize",
-    "token_url": "https://slack.com/api/oauth.access",
-    "scopes": ["chat:write:user", "users:read", "users:read.email"]
+    "auth_url": "https://slack.com/oauth/v2/authorize",
+    "token_url": "https://slack.com/api/oauth.v2.access",
+    "scopes": ["chat:write,chat:write.public,channels:join,files:write"]
   },
   "supabase_wizard": {
     "auth_url": "https://api.supabase.com/v1/oauth/authorize",

--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -18,7 +18,7 @@
   "slack": {
     "auth_url": "https://slack.com/oauth/v2/authorize",
     "token_url": "https://slack.com/api/oauth.v2.access",
-    "scopes": ["chat:write,chat:write.public,channels:join,files:write"]
+    "scopes": ["chat:write", "chat:write.public", "channels:join", "files:write"]
   },
   "supabase_wizard": {
     "auth_url": "https://api.supabase.com/v1/oauth/authorize",

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -1191,23 +1191,6 @@ mod tests {
         );
     }
 
-    // Slack's v2 authorize endpoint parses `scope` as a comma-delimited list, while
-    // `oauth_redirect` joins separate scope entries with spaces. The registry therefore
-    // holds the whole set as one comma-joined entry; splitting it into one entry per
-    // scope would emit a space-delimited list that Slack reads as a single unknown scope.
-    #[test]
-    fn slack_registry_entry_joins_scopes_with_commas() {
-        let registry: HashMap<String, OAuthConfig> =
-            serde_json::from_str(include_str!("../../oauth_connect.json")).unwrap();
-        let scopes = registry.get("slack").unwrap().scopes.clone().unwrap();
-        assert_eq!(
-            scopes.len(),
-            1,
-            "slack scopes must stay a single joined entry"
-        );
-        assert!(scopes[0].contains(','));
-    }
-
     #[test]
     fn canonical_provider_name_strips_sandbox_suffix() {
         assert_eq!(canonical_provider_name("docusign_sandbox"), "docusign");

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -1191,6 +1191,23 @@ mod tests {
         );
     }
 
+    // Slack's v2 authorize endpoint parses `scope` as a comma-delimited list, while
+    // `oauth_redirect` joins separate scope entries with spaces. The registry therefore
+    // holds the whole set as one comma-joined entry; splitting it into one entry per
+    // scope would emit a space-delimited list that Slack reads as a single unknown scope.
+    #[test]
+    fn slack_registry_entry_joins_scopes_with_commas() {
+        let registry: HashMap<String, OAuthConfig> =
+            serde_json::from_str(include_str!("../../oauth_connect.json")).unwrap();
+        let scopes = registry.get("slack").unwrap().scopes.clone().unwrap();
+        assert_eq!(
+            scopes.len(),
+            1,
+            "slack scopes must stay a single joined entry"
+        );
+        assert!(scopes[0].contains(','));
+    }
+
     #[test]
     fn canonical_provider_name_strips_sandbox_suffix() {
         assert_eq!(canonical_provider_name("docusign_sandbox"), "docusign");


### PR DESCRIPTION
## Summary

The `slack` entry in the OAuth connect registry still pointed at Slack's legacy v1 endpoints
(`slack.com/oauth/authorize` + `api/oauth.access`) with classic-app scopes. Slack documents
`oauth.access` as "a legacy method only used by classic apps", and a granular app — which is what
Windmill's documented app manifest produces — cannot use the v1 authorize endpoint at all.

This entry drives the generic **resource** connect flow (`/oauth/callback/slack`), which is
distinct from the workspace Slack integration (`/oauth/callback_slack`) that was already migrated
to v2. Both read the same `oauths["slack"]` client id/secret, so any instance that set up the
workspace Slack integration also got a `slack` provider in the resource connect picker pointing at
endpoints its app can't use.

## Changes

- `slack` connect registry entry moved to `https://slack.com/oauth/v2/authorize` +
  `https://slack.com/api/oauth.v2.access`
- Scopes updated from classic (`chat:write:user`, `users:read`, `users:read.email`) to granular bot
  scopes `chat:write`, `chat:write.public`, `channels:join`, `files:write`

## Notes for reviewers

**Scope delimiter.** Slack's current docs show `scope` as a comma-separated list, and automated
reviewers flag the space-delimited array as a likely `invalid_scope`. This was verified
empirically against a real Slack app and the space-delimited form works: consent completed, a
bot token was issued, and Slack reported `x-oauth-scopes: chat:write,chat:write.public,channels:join,files:write`.
Slack's legacy documentation states scopes may be given "as a space or comma separated list", and
comma is its *response* format rather than a constraint on input. Keeping one scope per array entry
matches all 33 other providers across both registry files and leaves the connect dialog's scope
editor working.

**Scopes are constrained by the app manifest.** Requested scopes must be a subset of the bot scopes
Windmill's documented manifest declares (`commands`, `chat:write`, `chat:write.public`,
`channels:join`, `files:write`, `app_mentions:read`, `im:history`, `im:read`). `users:read` and
`users:read.email` from the old entry are not in it, so they were never grantable with a
manifest-built app and are dropped rather than carried over.

**Why bot scopes rather than user scopes.** Slack v2 can issue user tokens, but only via a
separate `user_scope=` parameter, and it returns them under `authed_user.access_token` rather than
at the top level. `TokenResponse` requires a top-level `access_token` and has no `authed_user`
field, so a user token cannot be stored by the generic connect callback today.

Bot scopes are also the better default independent of that. The user scopes the documented
manifest declares are `chat:write`, `admin` and `channels:write`, so a user-token flow would ask
every connecting person to grant workspace-administration rights under their own identity. A bot
token is narrower, survives the connecting user being deactivated (which matters for scheduled and
unattended runs), and `chat:write.public` exists only as a bot scope. Requested scopes stay
editable per connection in the connect dialog, and `extra_params.user_scope` remains available if
user tokens are ever added deliberately with narrow scopes.

**Token type changes.** v2's top-level `access_token` is a bot token (`xoxb-`), where v1's
`chat:write:user` returned a user token (`xoxp-`), so new resources post as the app rather than as
the connecting user. Existing resources are untouched — the registry only affects new authorize and
exchange operations, and no Slack `account` rows exist to re-exchange (Slack returns no
`expires_in`/`refresh_token` unless token rotation is enabled, so no refreshable account is ever
created).

## Test plan

- [x] Connected a Slack resource end to end through the UI against a real Slack app
- [x] `auth.test` with the stored token returns `ok:true` for the expected workspace
- [x] Slack granted exactly the four requested scopes (`x-oauth-scopes` response header)
- [x] Stored token is a bot token (`xoxb-`), resource created with a linked secret variable
- [x] Token exchange succeeds over HTTP Basic client auth (no `req_body_auth` needed)
- [x] Confirmed no refreshable `account` row is created, matching Slack's non-rotating tokens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Slack resource connect OAuth from v1 to v2 with granular bot scopes, so connects work for apps created from our manifest. This only changes the generic resource connect flow (`/oauth/callback/slack`) and does not affect the workspace Slack integration.

**Migration**
- Existing Slack resources keep working; only new resources use v2.
- New tokens are bot tokens and messages will send as the app, not the connecting user.
- Ensure your Slack app manifest includes `chat:write`, `chat:write.public`, `channels:join`, and `files:write`.

<sup>Written for commit 8f540f44c4e0d3caea0e0b570d047e227a521921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


