### PR TITLE
chore: emit only line tables for workspace crates in dev builds

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -179,15 +179,14 @@ jobs:
           # binary link spikes several hundred MB of transient I/O. Capping at
           # 8 trades ~25% wall time for headroom on the ~75GB runner disk.
           CARGO_BUILD_JOBS: 8
-          # backend/Cargo.toml leaves profile.dev at the default debug = 2 for
-          # the (large) windmill workspace crates; that debuginfo is emitted
-          # into every object file and embedded in each test binary, and on
-          # windows-msvc also spawns the mspdbsrv.exe PDB type server. Across a
-          # full --all --features build it is the dominant consumer of the
-          # ~63GB free on the runner disk (LNK1180 / disk-full during linking).
-          # CI needs no debug info, so drop it entirely for the dev/test
-          # profiles here. debug = 0 supersedes the previous split-debuginfo=off
-          # knob (no debuginfo => no .pdb and no LNK1318 type-server limit).
+          # backend/Cargo.toml keeps line tables on profile.dev for the (large)
+          # windmill workspace crates; that debuginfo is emitted into every
+          # object file and embedded in each test binary, and on windows-msvc
+          # also spawns the mspdbsrv.exe PDB type server. Across a full
+          # --all --features build it drives the peak on the ~63GB free of the
+          # runner disk (LNK1180 / disk-full during linking). CI reads no
+          # backtraces, so drop it entirely for the dev/test profiles here:
+          # debug = 0 means no .pdb and no LNK1318 type-server limit.
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_TEST_DEBUG: "0"
           # Tests' poll-time stack frames (deep nested async fn chains in

--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -182,8 +182,8 @@ jobs:
           # backend/Cargo.toml keeps line tables on profile.dev for the (large)
           # windmill workspace crates; that debuginfo is emitted into every
           # object file and embedded in each test binary, and on windows-msvc
-          # also spawns the mspdbsrv.exe PDB type server. Across a full
-          # --all --features build it drives the peak on the ~63GB free of the
+          # also spawns the mspdbsrv.exe PDB type server. Across the worker
+          # crates' test build it drives the peak on the ~63GB free of the
           # runner disk (LNK1180 / disk-full during linking). CI reads no
           # backtraces, so drop it entirely for the dev/test profiles here:
           # debug = 0 means no .pdb and no LNK1318 type-server limit.

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -268,13 +268,13 @@ jobs:
           # overhead and extra disk. Off here (kept on for local dev via
           # .cargo/config.toml). Matches backend-test-windows.yml.
           CARGO_INCREMENTAL: "0"
-          # backend/Cargo.toml leaves profile.dev at the default debug = 2 for
-          # the (large) windmill workspace crates; that debug info is emitted
-          # into every object file and embedded in each test binary. Across the
-          # full --all --features build it is the dominant memory/disk consumer
-          # when mold links the windmill-api-integration-tests binary, tipping
-          # the runner over (lost runner reported as a canceled step). CI needs
-          # no debug info, so drop it entirely for the dev/test profiles here.
+          # backend/Cargo.toml keeps line tables on profile.dev for the (large)
+          # windmill workspace crates; that debug info is emitted into every
+          # object file and embedded in each test binary. Across the full
+          # --all --features build it drives the memory/disk peak when mold
+          # links the windmill-api-integration-tests binary, tipping the runner
+          # over (lost runner reported as a canceled step). CI reads no
+          # backtraces, so drop it entirely for the dev/test profiles here.
           # (test profile inherits dev, but the workspace crates link in as
           # dev-profile deps, so both must be set.) CI-only; local dev builds
           # are unaffected.

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -100,6 +100,10 @@ path = "./src/main.rs"
 opt-level = 0
 incremental = true
 split-debuginfo = "unpacked"
+# Type and variable DWARF is the single largest thing in target/ and nothing in the dev loop
+# reads it; backtraces only need the line tables, which this keeps. Raise to `true` when you
+# actually need to inspect variables in gdb/lldb.
+debug = "line-tables-only"
 
 [profile.dev.package."*"]
 debug = false


### PR DESCRIPTION
## Summary

`[profile.dev]` had no `debug` key, so every workspace crate compiled with full DWARF (cargo's `debug = true` default). Dependencies were already exempt via `[profile.dev.package."*"] debug = false`, so this was purely windmill's own crates — and with `split-debuginfo = "unpacked"` that type/variable info lands in `.dwo` files beside the objects, where it is the single largest thing in `backend/target`.

Nothing in the dev loop reads it. Line tables, which are what backtraces resolve against, live in the `.o`/binary and are untouched by this setting.

**On my checkout `backend/target/debug` is 430 GB, of which 192 GB (45%) is `.dwo`:**

| | size | files |
|---|---|---|
| `deps/*.dwo` | 134.6 GB | 1,011,424 |
| `incremental/**/*.dwo` | 57.7 GB | 455,765 |
| `deps/*.rlib` | 81.3 GB | 8,596 |
| linked binaries | 27.3 GB | 233 |
| `deps/*.rmeta` | 24.1 GB | 17,880 |

A section dump of a 20 MB `windmill_api` `.dwo` shows why it is all droppable: 15.9 MB `.debug_str`, 3.1 MB `.debug_info`, and **zero line-table bytes**.

**Controlled A/B on the same source** (`cargo build -p windmill-common --lib`, dependencies cached, only the `debug` flag differing):

| | `debug = true` | `line-tables-only` | |
|---|---|---|---|
| `windmill_common` `.dwo` | 93.67 MB | 7.65 MB | −91.8% |
| all 6 crates rebuilt | 114.57 MB | 9.43 MB | −91.8% |
| `libwindmill_common.rlib` | 160.2 MB | 160.2 MB | unchanged |

Identical 910 `.dwo` files on both sides, so the win is entirely per-file size, and `.rlib`/`.rmeta` are unaffected. Extrapolated to the tree above that is roughly 176 GB, ~41% of `backend/target`.

**What it costs:** dev builds no longer carry variable/type info, so gdb/lldb can't inspect locals. Backtraces, `panic!` locations and profiler symbolication are unaffected. Set `debug = true` locally when you actually need a debugger.

## Changes

- `backend/Cargo.toml`: add `debug = "line-tables-only"` to `[profile.dev]`.
- `.github/workflows/backend-test.yml`, `backend-test-windows.yml`: comment-only. Both asserted "backend/Cargo.toml leaves profile.dev at the default debug = 2", which this PR falsifies. Both still set `CARGO_PROFILE_DEV_DEBUG: "0"` / `CARGO_PROFILE_TEST_DEBUG: "0"` — CI reads no backtraces and wants none at all — so no CI behaviour changes.

## Checked and deliberately left alone

- `[profile.dev.package."*"] debug = false` already zeroes every dependency, proc macros included (`libsqlx_macros.so` has no `.debug_*` sections at all).
- Workspace-member **build scripts** turn out not to follow `profile.dev`: a `windmill-api` build-script binary carries the same 3.34 MB of debug info before and after this change. Only `[profile.dev.build-override] debug = false` reaches them, and that is 0.76 GB across 200 binaries — 0.18% of the tree — in exchange for losing build-script panic backtraces. Left out as not worth the trade; trivial to add if anyone disagrees.
- `split-debuginfo = "unpacked"` already keeps DWARF out of the linker's inputs, so link time does not change either way.
- `[profile.release]` is already `debug = "line-tables-only"`; `docker-image.yml`'s `debuginfo` extraction target is unaffected.
- The Windows worker builds (`build_windows_worker_.yml`, `publish_windows_worker.yml`) are `cargo build --release`, so `profile.dev` never applies there.
- The excluded crates (`windmill-duckdb-ffi-internal`, `parsers/windmill-parser-wasm`) build `--release` with no debuginfo.
- Workflows that build the workspace without pinning `CARGO_PROFILE_DEV_DEBUG` (`ai-agent-tests.yml`, `ai-evals-test.yml`, `git-sync-test.yml`) inherit line-tables-only for free.

Note this does **not** address the other half of the 430 GB: ~8,600 stale `.rlib`s and 233 stale binaries accumulated across feature combinations that nothing garbage-collects. That needs a `cargo clean` / sweep, not a profile knob.

## Test plan

- [x] `cargo build --bin windmill` completes against the new profile.
- [x] The resulting binary still symbolises: forcing a panic yields `at /home/rfiszel/windmill/backend/src/main.rs:830:18` with `RUST_BACKTRACE=full`.
- [x] `.dwo` output for `windmill-common` drops 91.8% with byte-identical `.rlib` output (table above).
- [x] The `test` profile inherits it (probe crate: test-binary `.dwo` 144.1 KB → 34.4 KB), so `cargo test` benefits without a separate `[profile.test]` key.
- [x] Both edited workflow YAMLs still parse.
