### PR TITLE
fix(api): report the EE gate instead of a 500 on restart flow at step

### DIFF
--- a/backend/windmill-api-integration-tests/tests/jobs_authed.rs
+++ b/backend/windmill-api-integration-tests/tests/jobs_authed.rs
@@ -286,13 +286,24 @@ async fn test_jobs_authed_reachability(db: Pool<Postgres>) -> anyhow::Result<()>
         "GET /jobs/result_by_id",
     );
 
+    // Sent the way the generated client sends it. A handler whose `Path` tuple has drifted from
+    // the route is rejected by axum before it runs, which surfaces as a routing error rather
+    // than the handler's own answer, so reaching the handler is what this pins.
     let resp = authed(client().post(format!("{base}/restart/f/{fake}")))
+        .json(&json!({ "step_id": "a" }))
         .send()
         .await?;
-    assert_route_reachable(
-        resp.status().as_u16(),
-        &resp.text().await?,
-        "POST /jobs/restart/f",
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    assert_route_reachable(status, &body, "POST /jobs/restart/f");
+    assert!(
+        !body.contains("path arguments"),
+        "POST /jobs/restart/f never reached its handler: {status} {body}",
+    );
+    #[cfg(not(feature = "enterprise"))]
+    assert!(
+        body.contains("only available in enterprise version"),
+        "POST /jobs/restart/f must report the enterprise gate outside EE: {status} {body}",
     );
 
     let resp = authed(client().post(format!("{base}/run/workflow_as_code/{fake}/main")))

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -6559,17 +6559,18 @@ pub async fn run_flow_by_version_inner(
     Ok((uuid, early_return, has_failure_module))
 }
 
+/// Path parameters of `POST /w/{workspace}/jobs/restart/f/{job_id}`, shared by the CE and EE
+/// handlers. Axum only checks the tuple against the route at request time and rejects a
+/// mismatch with an opaque 500 before the handler runs, so both must be declared from here:
+/// an arity that drifts from the route hides the handler behind what reads as a broken route.
+type RestartFlowPath = Path<(String, Uuid)>;
+
 #[cfg(not(feature = "enterprise"))]
 pub async fn restart_flow(
     _authed: ApiAuthed,
     Extension(_db): Extension<DB>,
     Extension(_user_db): Extension<UserDB>,
-    Path((_w_id, _job_id, _step_id, _branch_or_iteration_n)): Path<(
-        String,
-        Uuid,
-        String,
-        Option<usize>,
-    )>,
+    Path((_w_id, _job_id)): RestartFlowPath,
     Query(_run_query): Query<RunJobQuery>,
 ) -> error::Result<(StatusCode, String)> {
     return Err(Error::BadRequest(
@@ -6798,7 +6799,7 @@ pub async fn restart_flow(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
-    Path((w_id, job_id)): Path<(String, Uuid)>,
+    Path((w_id, job_id)): RestartFlowPath,
     Query(run_query): Query<RunJobQuery>,
     Json(RestartFlowRequestBody {
         step_id,


### PR DESCRIPTION
## Summary

On a community build, `POST /w/{workspace}/jobs/restart/f/{job_id}` answered every call with

```
500 Wrong number of path arguments for `Path`. Expected 4 but got 2
```

so the route the OpenAPI spec declares, the generated client, and the CLI's `restartFlowAtStep` all looked broken rather than license-gated.

#7409 moved `step_id` / `branch_or_iteration_n` out of the path and into the request body, shortening the route to `/restart/f/{job_id}`, but only the `#[cfg(feature = "enterprise")]` handler was updated. The community stub kept its 4-element `Path` tuple, and axum checks that tuple against the route at request time, rejecting the mismatch before the handler runs. The license gate the stub exists to report therefore never executed.

Restarting a completed flow at a step stays enterprise-only: this is a build gate, not a change of what is offered. The run page's restart button is already disabled with an "(EE)" hint outside EE, and community builds now get the intended `400 Restarting a flow is a feature only available in enterprise version`.

Fixes GIT-981.

## Changes

- `backend/windmill-api/src/jobs.rs`: both `restart_flow` handlers now declare their path parameters from a single `RestartFlowPath` alias, so the arity cannot drift from the route again. The community stub's tuple goes from 4 elements back to the route's 2.
- `backend/windmill-api-integration-tests/tests/jobs_authed.rs`: `test_jobs_authed_reachability` now posts the body the generated client posts and asserts the request reached its handler instead of only checking for a router-level 404. Outside EE it also asserts the enterprise gate is what comes back.

## Test plan

- [x] Reproduced on this worktree's CE backend (`--features quickjs`): `POST /api/w/admins/jobs/restart/f/<uuid>` with `{"step_id":"a"}` returned `500 Wrong number of path arguments for Path. Expected 4 but got 2`; after the fix the same call returns `400 Bad request: Restarting a flow is a feature only available in enterprise version` (with and without a request body).
- [x] `cargo test -p windmill-api-integration-tests --test jobs_authed test_jobs_authed_reachability` passes with default features and with `--features enterprise,private`, and fails on the pre-fix handler with exactly the reported error.
- [x] EE backend (`--features quickjs,enterprise,private,license`): ran a 3-step flow whose last step throws, then restarted it at `b` and at `c` through the documented route. Both returned `201` and re-ran only the steps from the restart point; the preserved steps kept their original job ids, and `restarted_from` recorded the step.
- [x] Same restart driven through the UI: run page → select step `b` → "Re-start from b" → Restart. It navigated to the new run, which kept step `a`'s original job and re-ran `b` and `c`.

## Note on CI coverage

`backend-test.yml` runs `cargo test --features enterprise,… --all`, and `windmill-api-integration-tests` forwards its own `enterprise` feature down to `windmill-api`, so the `#[cfg(not(feature = "enterprise"))]` half of the new assertion does not execute in CI. It was run locally against a default-feature build (see the test plan), and the `RestartFlowPath` alias is what structurally prevents the arity from drifting again. The un-gated half of the assertion does run in CI and guards the enterprise handler against the same drift.
