### PR TITLE
fix: force HTTP router rebuild on trigger-change notification

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1825,14 +1825,12 @@ async fn process_notify_event(
         #[cfg(feature = "http_trigger")]
         "notify_http_trigger_change" => {
             tracing::info!("HTTP trigger change detected: {}", payload);
-            match windmill_api::triggers::http::refresh_routers(db).await {
-                Ok((true, _)) => {
+            // The notify event is only readable once the writing transaction has committed, so
+            // the trigger rows are guaranteed visible here: force past the version check, which
+            // a concurrent refresh may already have satisfied with pre-commit rows.
+            match windmill_api::triggers::http::refresh_routers(db, true).await {
+                Ok(_) => {
                     tracing::info!("Refreshed HTTP routers (trigger change)");
-                }
-                Ok((false, _)) => {
-                    tracing::warn!(
-                        "Should have refreshed HTTP routers (trigger change) but did not"
-                    );
                 }
                 Err(err) => {
                     tracing::error!("Error refreshing HTTP routers (trigger change): {err:#}");
@@ -2059,7 +2057,7 @@ async fn process_notify_event(
                         tracing::error!(error = %e, "Could not reload http route workspaced route setting");
                     }
                     #[cfg(feature = "http_trigger")]
-                    match windmill_api::triggers::http::refresh_routers(db).await {
+                    match windmill_api::triggers::http::refresh_routers(db, false).await {
                         Ok((true, _)) => {
                             tracing::info!(
                                 "Refreshed HTTP routers (http workspaced route setting change)"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1843,6 +1843,7 @@ async fn process_notify_event(
                 }
                 Err(err) => {
                     tracing::error!("Error refreshing HTTP routers (trigger change): {err:#}");
+                    windmill_api::triggers::http::invalidate_routers_version().await;
                     return false;
                 }
             };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1439,13 +1439,13 @@ Windmill Community Edition {GIT_VERSION}
                                                 if !*windmill_common::QUIET_LOGS {
                                                     tracing::info!("Processing notify event: channel={}, payload={}", event.channel, event.payload);
                                                 }
-                                                // Every changed http_trigger row emits its own event, and each one
-                                                // forces a full router rebuild. The first rebuild of the batch reads
-                                                // every row the batch committed, so the rest would be pure repeats.
-                                                let redundant = event.channel == "notify_http_trigger_change"
-                                                    && std::mem::replace(&mut http_trigger_change_handled, true);
-                                                if !redundant {
-                                                    process_notify_event(
+                                                let is_http_trigger_change = event.channel == "notify_http_trigger_change";
+                                                // Every changed http_trigger row emits its own event and each one forces
+                                                // a full router rebuild, but the batch's first successful rebuild already
+                                                // read every row the batch committed. A failed rebuild leaves the flag
+                                                // clear so the next event in the batch retries it.
+                                                if !(is_http_trigger_change && http_trigger_change_handled) {
+                                                    let handled = process_notify_event(
                                                         &event.channel,
                                                         &event.payload,
                                                         &db,
@@ -1456,6 +1456,7 @@ Windmill Community Edition {GIT_VERSION}
                                                         #[cfg(feature = "parquet")]
                                                         disable_s3_store,
                                                     ).await;
+                                                    http_trigger_change_handled |= is_http_trigger_change && handled;
                                                 }
                                                 last_event_id = last_event_id.max(event.id);
                                             }
@@ -1678,6 +1679,9 @@ Windmill Community Edition {GIT_VERSION}
 
 /// Process a single notify event from the polling-based event system.
 /// This replaces the old PgListener notification handling.
+///
+/// Returns `false` when the event still needs handling. Only the HTTP router rebuild reports
+/// that, because the poll loop coalesces those events and must not swallow the retry.
 #[allow(unused_variables)]
 async fn process_notify_event(
     channel: &str,
@@ -1688,7 +1692,7 @@ async fn process_notify_event(
     server_mode: bool,
     worker_mode: bool,
     #[cfg(feature = "parquet")] disable_s3_store: bool,
-) {
+) -> bool {
     match channel {
         "notify_config_change" => {
             if payload == "server" && server_mode {
@@ -1839,6 +1843,7 @@ async fn process_notify_event(
                 }
                 Err(err) => {
                     tracing::error!("Error refreshing HTTP routers (trigger change): {err:#}");
+                    return false;
                 }
             };
         }
@@ -2182,6 +2187,7 @@ async fn process_notify_event(
             tracing::warn!("Unknown notification channel: {}", channel);
         }
     }
+    true
 }
 
 fn display_config(envs: &[&str]) {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1843,7 +1843,7 @@ async fn process_notify_event(
                 }
                 Err(err) => {
                     tracing::error!("Error refreshing HTTP routers (trigger change): {err:#}");
-                    windmill_api::triggers::http::invalidate_routers_version().await;
+                    windmill_api::triggers::http::invalidate_routers();
                     return false;
                 }
             };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1434,21 +1434,29 @@ Windmill Community Edition {GIT_VERSION}
                                     // Poll for new events from notify_event table
                                     match windmill_common::notify_events::poll_notify_events(&db, last_event_id).await {
                                         Ok(events) => {
+                                            let mut http_trigger_change_handled = false;
                                             for event in events {
                                                 if !*windmill_common::QUIET_LOGS {
                                                     tracing::info!("Processing notify event: channel={}, payload={}", event.channel, event.payload);
                                                 }
-                                                process_notify_event(
-                                                    &event.channel,
-                                                    &event.payload,
-                                                    &db,
-                                                    &conn,
-                                                    &tx,
-                                                    server_mode,
-                                                    worker_mode,
-                                                    #[cfg(feature = "parquet")]
-                                                    disable_s3_store,
-                                                ).await;
+                                                // Every changed http_trigger row emits its own event, and each one
+                                                // forces a full router rebuild. The first rebuild of the batch reads
+                                                // every row the batch committed, so the rest would be pure repeats.
+                                                let redundant = event.channel == "notify_http_trigger_change"
+                                                    && std::mem::replace(&mut http_trigger_change_handled, true);
+                                                if !redundant {
+                                                    process_notify_event(
+                                                        &event.channel,
+                                                        &event.payload,
+                                                        &db,
+                                                        &conn,
+                                                        &tx,
+                                                        server_mode,
+                                                        worker_mode,
+                                                        #[cfg(feature = "parquet")]
+                                                        disable_s3_store,
+                                                    ).await;
+                                                }
                                                 last_event_id = last_event_id.max(event.id);
                                             }
                                         }
@@ -1825,9 +1833,6 @@ async fn process_notify_event(
         #[cfg(feature = "http_trigger")]
         "notify_http_trigger_change" => {
             tracing::info!("HTTP trigger change detected: {}", payload);
-            // The notify event is only readable once the writing transaction has committed, so
-            // the trigger rows are guaranteed visible here: force past the version check, which
-            // a concurrent refresh may already have satisfied with pre-commit rows.
             match windmill_api::triggers::http::refresh_routers(db, true).await {
                 Ok(_) => {
                     tracing::info!("Refreshed HTTP routers (trigger change)");

--- a/backend/windmill-api/src/triggers/http/handler.rs
+++ b/backend/windmill-api/src/triggers/http/handler.rs
@@ -123,7 +123,7 @@ async fn get_http_route_trigger(
 
     let routers_cache = if routers_cache.routers.is_empty() {
         tracing::warn!("HTTP routers are not loaded, loading from db");
-        let (_, routers_cache) = refresh_routers(db).await?;
+        let (_, routers_cache) = refresh_routers(db, false).await?;
         routers_cache
     } else {
         routers_cache

--- a/backend/windmill-api/src/triggers/http/handler.rs
+++ b/backend/windmill-api/src/triggers/http/handler.rs
@@ -123,6 +123,8 @@ async fn get_http_route_trigger(
 
     let routers_cache = if routers_cache.routers.is_empty() {
         tracing::warn!("HTTP routers are not loaded, loading from db");
+        // refresh_routers takes the write lock, so holding this read guard across it deadlocks.
+        drop(routers_cache);
         let (_, routers_cache) = refresh_routers(db, false).await?;
         routers_cache
     } else {

--- a/backend/windmill-trigger-http/src/lib.rs
+++ b/backend/windmill-trigger-http/src/lib.rs
@@ -281,7 +281,8 @@ pub async fn refresh_routers(
             .await?;
 
             let mut router = matchit::Router::new();
-            let http_route_workspaced = HTTP_ROUTE_WORKSPACED_ROUTE.load(std::sync::atomic::Ordering::Relaxed);
+            let http_route_workspaced =
+                HTTP_ROUTE_WORKSPACED_ROUTE.load(std::sync::atomic::Ordering::Relaxed);
 
             for trigger in triggers {
                 let full_path =
@@ -320,6 +321,13 @@ pub async fn refresh_routers(
         tracing::debug!("No HTTP routers refresh needed");
         Ok((false, routers_cache))
     }
+}
+
+/// Withdraw the cache's claim that it covers the current version, so the next version-gated
+/// refresh rebuilds. The routes already loaded keep being served in the meantime. Use after a
+/// forced refresh fails: its change is inside the cached version, so nothing else would retry.
+pub async fn invalidate_routers_version() {
+    HTTP_ROUTERS_CACHE.write().await.version = 0;
 }
 
 pub async fn refresh_routers_loop(

--- a/backend/windmill-trigger-http/src/lib.rs
+++ b/backend/windmill-trigger-http/src/lib.rs
@@ -223,12 +223,21 @@ pub fn validate_authentication_method(
     }
 }
 
-pub async fn refresh_routers(db: &DB) -> Result<(bool, RwLockReadGuard<'_, RoutersCache>)> {
+/// `force` skips the version comparison and always rebuilds from the database.
+/// `http_trigger_version_seq` is bumped with `nextval` inside the writing transaction, and
+/// sequences are non-transactional, so the bumped version is visible to other sessions before
+/// the trigger row is. A refresh landing in that window caches the new version with the old
+/// rows, after which every version-gated refresh is a no-op and the route stays missing. Any
+/// caller that only observes the change after the transaction commits must force.
+pub async fn refresh_routers(
+    db: &DB,
+    force: bool,
+) -> Result<(bool, RwLockReadGuard<'_, RoutersCache>)> {
     let version = sqlx::query_scalar!("SELECT last_value FROM http_trigger_version_seq",)
         .fetch_one(db)
         .await?;
     let routers_cache = HTTP_ROUTERS_CACHE.read().await;
-    if routers_cache.version == 0 || version > routers_cache.version {
+    if force || routers_cache.version == 0 || version > routers_cache.version {
         drop(routers_cache);
         let mut routers = HashMap::new();
 
@@ -319,7 +328,7 @@ pub async fn refresh_routers_loop(
     db: &DB,
     mut killpill_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> () {
-    match refresh_routers(db).await {
+    match refresh_routers(db, false).await {
         Ok(_) => {
             tracing::info!("Loaded HTTP routers");
         }
@@ -335,7 +344,7 @@ pub async fn refresh_routers_loop(
                     break;
                 }
                 _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
-                    match refresh_routers(&db).await {
+                    match refresh_routers(&db, false).await {
                         Ok((true, _)) => {
                             tracing::info!("Refreshed HTTP routers");
                         }

--- a/backend/windmill-trigger-http/src/lib.rs
+++ b/backend/windmill-trigger-http/src/lib.rs
@@ -223,12 +223,10 @@ pub fn validate_authentication_method(
     }
 }
 
-/// `force` skips the version comparison and always rebuilds from the database.
-/// `http_trigger_version_seq` is bumped with `nextval` inside the writing transaction, and
-/// sequences are non-transactional, so the bumped version is visible to other sessions before
-/// the trigger row is. A refresh landing in that window caches the new version with the old
-/// rows, after which every version-gated refresh is a no-op and the route stays missing. Any
-/// caller that only observes the change after the transaction commits must force.
+/// `force` rebuilds unconditionally. `nextval` on `http_trigger_version_seq` runs inside the
+/// writing transaction and sequences are non-transactional, so a version-gated refresh can cache
+/// the bumped version against pre-commit rows and then skip forever after. A caller reacting to
+/// another session's committed change must force; one that bumped the sequence itself need not.
 pub async fn refresh_routers(
     db: &DB,
     force: bool,

--- a/backend/windmill-trigger-http/src/lib.rs
+++ b/backend/windmill-trigger-http/src/lib.rs
@@ -224,9 +224,9 @@ pub fn validate_authentication_method(
 }
 
 /// `force` rebuilds unconditionally. `nextval` on `http_trigger_version_seq` runs inside the
-/// writing transaction and sequences are non-transactional, so a version-gated refresh can cache
-/// the bumped version against pre-commit rows and then skip forever after. A caller reacting to
-/// another session's committed change must force; one that bumped the sequence itself need not.
+/// writing transaction and sequences are non-transactional, so another session can cache the
+/// bumped version against still-uncommitted rows, after which every version-gated refresh is a
+/// no-op. Force when reacting to a bump that could have been observed before its own rows were.
 pub async fn refresh_routers(
     db: &DB,
     force: bool,

--- a/backend/windmill-trigger-http/src/lib.rs
+++ b/backend/windmill-trigger-http/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use quick_cache::sync::Cache;
 use serde::{Deserialize, Serialize};
@@ -27,8 +28,11 @@ lazy_static::lazy_static! {
     pub static ref HTTP_ROUTERS_CACHE: RwLock<RoutersCache> = RwLock::new(RoutersCache {
         routers: HashMap::new(),
         version: 0,
+        invalidations: 0,
     });
 }
+
+static HTTP_ROUTERS_INVALIDATIONS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct TriggerRoute {
@@ -56,6 +60,10 @@ pub struct TriggerRoute {
 pub struct RoutersCache {
     pub routers: HashMap<HttpMethod, matchit::Router<TriggerRoute>>,
     pub version: i64,
+    /// `HTTP_ROUTERS_INVALIDATIONS` as of the moment these rows were read. A rebuild that
+    /// started before an invalidation publishes a count behind the current one, which is what
+    /// stops it from passing its own stale rows off as covering that invalidation.
+    invalidations: u64,
 }
 
 #[derive(Serialize, Deserialize, sqlx::Type, Debug, Clone, Copy, Hash, Eq, PartialEq)]
@@ -231,11 +239,16 @@ pub async fn refresh_routers(
     db: &DB,
     force: bool,
 ) -> Result<(bool, RwLockReadGuard<'_, RoutersCache>)> {
+    let invalidations = HTTP_ROUTERS_INVALIDATIONS.load(Ordering::Relaxed);
     let version = sqlx::query_scalar!("SELECT last_value FROM http_trigger_version_seq",)
         .fetch_one(db)
         .await?;
     let routers_cache = HTTP_ROUTERS_CACHE.read().await;
-    if force || routers_cache.version == 0 || version > routers_cache.version {
+    if force
+        || routers_cache.version == 0
+        || version > routers_cache.version
+        || invalidations != routers_cache.invalidations
+    {
         drop(routers_cache);
         let mut routers = HashMap::new();
 
@@ -314,7 +327,7 @@ pub async fn refresh_routers(
         }
 
         let mut routers_cache = HTTP_ROUTERS_CACHE.write().await;
-        *routers_cache = RoutersCache { routers, version };
+        *routers_cache = RoutersCache { routers, version, invalidations };
 
         Ok((true, routers_cache.downgrade()))
     } else {
@@ -323,11 +336,12 @@ pub async fn refresh_routers(
     }
 }
 
-/// Withdraw the cache's claim that it covers the current version, so the next version-gated
-/// refresh rebuilds. The routes already loaded keep being served in the meantime. Use after a
-/// forced refresh fails: its change is inside the cached version, so nothing else would retry.
-pub async fn invalidate_routers_version() {
-    HTTP_ROUTERS_CACHE.write().await.version = 0;
+/// Record that the cache no longer covers everything committed, so the next refresh rebuilds
+/// whatever the version says. The routes already loaded keep being served in the meantime. Use
+/// after a forced refresh fails: its change is inside the cached version, so nothing else would
+/// retry it.
+pub fn invalidate_routers() {
+    HTTP_ROUTERS_INVALIDATIONS.fetch_add(1, Ordering::Relaxed);
 }
 
 pub async fn refresh_routers_loop(

--- a/backend/windmill-trigger-http/tests/refresh_routers.rs
+++ b/backend/windmill-trigger-http/tests/refresh_routers.rs
@@ -1,5 +1,5 @@
 use sqlx::{Pool, Postgres};
-use windmill_trigger_http::{refresh_routers, HttpMethod, RoutersCache};
+use windmill_trigger_http::{invalidate_routers, refresh_routers, HttpMethod, RoutersCache};
 
 async fn insert_trigger(db: &Pool<Postgres>, path: &str, route_path: &str) {
     sqlx::query(
@@ -22,10 +22,10 @@ fn routes(cache: &RoutersCache, path: &str) -> bool {
 }
 
 // A trigger row can commit without advancing http_trigger_version_seq past what the cache
-// already holds, because `nextval` runs ahead of the commit it belongs to. Only a forced
-// refresh recovers the route from there.
+// already holds, because `nextval` runs ahead of the commit it belongs to. The version gate
+// cannot see such a row; only forcing, or an invalidation, recovers the route.
 #[sqlx::test(migrations = "../migrations")]
-async fn refresh_routers_force_rebuilds_on_an_unchanged_version(db: Pool<Postgres>) {
+async fn rebuilds_a_change_the_cached_version_does_not_cover(db: Pool<Postgres>) {
     insert_trigger(&db, "f/test/first", "first").await;
     let (rebuilt, cache) = refresh_routers(&db, false).await.unwrap();
     assert!(rebuilt);
@@ -42,4 +42,21 @@ async fn refresh_routers_force_rebuilds_on_an_unchanged_version(db: Pool<Postgre
     let (rebuilt, cache) = refresh_routers(&db, true).await.unwrap();
     assert!(rebuilt, "force must rebuild whatever the version says");
     assert!(routes(&cache, "/second"));
+    drop(cache);
+
+    // A forced refresh that failed leaves its change inside the cached version, so the periodic
+    // version-gated refresh has to rebuild on the invalidation alone.
+    insert_trigger(&db, "f/test/third", "third").await;
+    invalidate_routers();
+
+    let (rebuilt, cache) = refresh_routers(&db, false).await.unwrap();
+    assert!(
+        rebuilt,
+        "an invalidation must rebuild through the version gate"
+    );
+    assert!(routes(&cache, "/third"));
+    drop(cache);
+
+    let (rebuilt, _) = refresh_routers(&db, false).await.unwrap();
+    assert!(!rebuilt, "a served invalidation must not rebuild forever");
 }

--- a/backend/windmill-trigger-http/tests/refresh_routers.rs
+++ b/backend/windmill-trigger-http/tests/refresh_routers.rs
@@ -1,0 +1,45 @@
+use sqlx::{Pool, Postgres};
+use windmill_trigger_http::{refresh_routers, HttpMethod, RoutersCache};
+
+async fn insert_trigger(db: &Pool<Postgres>, path: &str, route_path: &str) {
+    sqlx::query(
+        "INSERT INTO http_trigger (
+            path, route_path, route_path_key, script_path, is_flow, workspace_id, edited_by,
+            permissioned_as, http_method, authentication_method, request_type, is_static_website,
+            workspaced_route, wrap_body, raw_string, mode
+        ) VALUES ($1, $2, $2, 'f/test/handler', false, 'test-workspace', 'test-user',
+            'u/test-user', 'get', 'none', 'async', false, false, false, false, 'enabled')",
+    )
+    .bind(path)
+    .bind(route_path)
+    .execute(db)
+    .await
+    .expect("insert http_trigger");
+}
+
+fn routes(cache: &RoutersCache, path: &str) -> bool {
+    cache.routers[&HttpMethod::Get].at(path).is_ok()
+}
+
+// A trigger row can commit without advancing http_trigger_version_seq past what the cache
+// already holds, because `nextval` runs ahead of the commit it belongs to. Only a forced
+// refresh recovers the route from there.
+#[sqlx::test(migrations = "../migrations")]
+async fn refresh_routers_force_rebuilds_on_an_unchanged_version(db: Pool<Postgres>) {
+    insert_trigger(&db, "f/test/first", "first").await;
+    let (rebuilt, cache) = refresh_routers(&db, false).await.unwrap();
+    assert!(rebuilt);
+    assert!(routes(&cache, "/first"));
+    drop(cache);
+
+    insert_trigger(&db, "f/test/second", "second").await;
+
+    let (rebuilt, cache) = refresh_routers(&db, false).await.unwrap();
+    assert!(!rebuilt, "an unchanged version must not rebuild");
+    assert!(!routes(&cache, "/second"));
+    drop(cache);
+
+    let (rebuilt, cache) = refresh_routers(&db, true).await.unwrap();
+    assert!(rebuilt, "force must rebuild whatever the version says");
+    assert!(routes(&cache, "/second"));
+}


### PR DESCRIPTION
## Summary

Fixes WIN-2452.

The HTTP trigger router cache detects changes with a PostgreSQL sequence, `http_trigger_version_seq`. `increase_trigger_version` calls `nextval` on the writing transaction, and sequences are non-transactional: the bumped version is visible to every other session as soon as it runs, while the trigger row is not visible until commit.

If a refresh lands in that window — the 60s background loop, or the empty-cache fallback — it caches the *new* version against the *old* rows. When the transaction then commits and `notify_http_trigger_change` is processed, `refresh_routers` sees `version == cached_version` and skips. Every later version-gated refresh skips too, so the new route returns 404 until a pod restart or an unrelated version bump.

`refresh_routers` now takes a `force` flag. The notify handler passes `force = true`: the notify event is only readable after the writing transaction commits, so the rows are guaranteed visible there. The 60s loop, the workspaced-route setting handler and the on-demand fallback keep the version-check optimization (`force = false`) — the setting handler is safe because it bumps the sequence itself, in autocommit, after swapping the atomic.

**Not one rebuild per row.** Every changed row emits its own notify event, so forcing per event would turn a bulk trigger change into one full rebuild per row, where the version gate previously collapsed them into one. The poll loop coalesces `notify_http_trigger_change` events within a batch: the first *successful* forced rebuild reads every row the batch committed, so the rest are dropped.

**A failed forced rebuild keeps its retry.** Its change is already inside the cached version, so nothing version-gated would rebuild. Within the batch, the coalescing flag stays clear and the next event retries immediately. Across batches — the common one-trigger-one-event-one-batch shape — `invalidate_routers` bumps a counter that the periodic refresh compares against the count the cache was built with. A rebuild that started *before* the invalidation publishes the older count, so it cannot pass its own stale rows off as covering that invalidation; the next refresh still rebuilds. Routes already loaded keep being served throughout.

Also fixes a latent deadlock on a line this PR already touches: the empty-cache fallback in `get_http_route_trigger` held its read guard across `refresh_routers`, which takes the write lock. Reachable only when the startup load errored, where it would hang the request instead of erroring.

## Changes

- `refresh_routers(db, force)` skips the version comparison when `force` is set (`backend/windmill-trigger-http/src/lib.rs`)
- `notify_http_trigger_change` handler forces the rebuild; the other three call sites stay version-gated (`backend/src/main.rs`, `backend/windmill-api/src/triggers/http/handler.rs`)
- The notify poll loop processes at most one *successful* `notify_http_trigger_change` per batch; `process_notify_event` reports whether the rebuild succeeded (`backend/src/main.rs`)
- `invalidate_routers` records a rebuild the cache still owes, as a counter the cache stores alongside its version so an older in-flight rebuild cannot clear it (`backend/windmill-trigger-http/src/lib.rs`)
- Drop the read guard before the write-locking refresh in the empty-cache fallback (`backend/windmill-api/src/triggers/http/handler.rs`)
- Regression test covering both recovery paths (`backend/windmill-trigger-http/tests/refresh_routers.rs`)

## Test plan

- [x] `cargo check` and `cargo check --features http_trigger`, both warning-free
- [x] `cargo test -p windmill-trigger-http --test refresh_routers`. Both guards are load-bearing: dropping `force ||` fails it at the force assertion, dropping the invalidation comparison fails it at the invalidation assertion.
- [x] End-to-end against a backend built with `--features quickjs,http_trigger`, poisoning the cache the way the race does (bump the sequence with no row, let the 60s loop cache that version, then commit a trigger row without a further bump). Pre-fix binary: `404 Trigger not found` indefinitely. With the fix: `Refreshed HTTP routers (trigger change)` and the route answers `201`.
- [x] Three rows committed at once: three `notify_http_trigger_change` events, one rebuild, all three routes answer `201`.
- [x] In-batch retry after a failed rebuild: renamed `http_trigger_version_seq` away so every rebuild errors, then committed two rows — both events attempted the rebuild (2 attempts / 2 errors), so a failure does not consume the batch's retries. Restoring the sequence and committing a third row recovered all three routes.
- [x] Cross-batch recovery after a failed rebuild: same break, single row (single-event batch). The rebuild failed and the route 404'd; restoring the sequence with **no further trigger change** healed it in ~54s via the backstop, and the backstop then went quiet rather than rebuilding on every tick. The build without the invalidation stayed 404 past two backstop ticks.
- [x] Delete propagation in the poisoned state: deleting one of three triggers without a sequence bump took that route to `404` while the other two stayed `201`.
- [x] Workspaced-route setting change still rebuilds through the version gate: flipping `http_route_workspaced_route` moved the live route from `/api/r/test/racy` to `/api/r/admins/test/racy`.

Not exercised: the exact interleaving where an in-flight rebuild publishes after an invalidation. It needs a pause inside the build, so it is covered by construction (the published count is captured before the rows are read) and by the test's invalidation assertions rather than by a timed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)