### PR TITLE
feat: make the flow graph step panel resizable and detachable

### DIFF
--- a/frontend/src/lib/components/FlowGraphViewer.svelte
+++ b/frontend/src/lib/components/FlowGraphViewer.svelte
@@ -7,6 +7,13 @@
 	import { writable } from 'svelte/store'
 	import { twMerge } from 'tailwind-merge'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
+	import { MousePointerClick } from 'lucide-svelte'
+	import Modal from './common/modal/Modal.svelte'
+	import Badge from './common/badge/Badge.svelte'
+	import FlowPanelPlacementPicker from './flows/common/FlowPanelPlacementPicker.svelte'
+	import { useFlowPanelMode } from './flows/flowPanelMode.svelte'
+	import type { FlowPanelDetachContext } from './flows/types'
+	import { stepLabel } from './flows/stepLabel'
 
 	import FlowGraphViewerStep from './FlowGraphViewerStep.svelte'
 	import FlowGraphV2 from './graph/FlowGraphV2.svelte'
@@ -55,12 +62,95 @@
 	}: Props = $props()
 
 	let availableHeight = $state(0)
-	// The step panel stays hidden below Tailwind's sm breakpoint, as it did when this was a
-	// `hidden sm:flex` grid cell: a Pane keeps its width even when its content is display:none,
-	// so the breakpoint has to decide whether the Pane exists at all.
-	let innerWidth = $state(0)
-	let showSide = $derived(
-		!noSide && !(hideDefaultInputs && stepDetail == undefined) && innerWidth >= 640
+	let availableWidth = $state(0)
+
+	// Same placement rule as the flow editor, off the same breakpoint: 'docked' puts the step
+	// panel in a pane beside the graph, 'modal' gives the graph the full width and moves the
+	// panel into a dialog opened by double-clicking a step. Measured on this component rather
+	// than the window, because the viewer is often embedded in a pane far narrower than it.
+	const panelController = useFlowPanelMode({ enabled: () => !noSide && !noGraph })
+	$effect(() => panelController.measure(availableWidth))
+	let panelMode = $derived(panelController.mode)
+	let stepModalOpen = $state(false)
+
+	// Supplying this context is what puts the Auto/Attached/Detached picker in the graph's own
+	// control bar — FlowGraphV2 renders it already and hides it wherever the context is absent.
+	setContext<FlowPanelDetachContext>('flowPanelDetach', {
+		// The viewer's panel draws no card header, so nothing claims the chrome.
+		claim: () => () => {},
+		modalOpen: () => panelMode === 'modal' && stepModalOpen,
+		close: () => (stepModalOpen = false),
+		enabled: () => !noSide && !noGraph,
+		preference: () => panelController.preference,
+		setPreference: (preference) => {
+			if (preference === panelController.preference) return
+			// Moving the panel must not lose what it was showing: docked, it is always on screen,
+			// so the dialog it becomes has to open on arrival. The reverse is handled by the
+			// effect below, which closes a dialog that is no longer rendered.
+			const wasVisible = panelMode === 'docked' || stepModalOpen
+			panelController.preference = preference
+			stepModalOpen = panelController.mode === 'modal' && wasVisible
+		}
+	})
+	// Whether the panel has anything to show. Kept apart from panelMode so the double-click
+	// gesture stays live under hideDefaultInputs, where nothing shows until a step is picked.
+	let hasSideContent = $derived(!noSide && !(hideDefaultInputs && stepDetail == undefined))
+
+	// A move back to 'docked' — the viewer got wider — would otherwise leave a dialog open
+	// over a panel that is already visible beside the graph.
+	$effect(() => {
+		if (panelMode === 'docked' && untrack(() => stepModalOpen)) {
+			stepModalOpen = false
+		}
+	})
+
+	// Asset and note nodes are deliberately unselectable, and the In/Out bar inside a node is
+	// a picker that opens and shuts on click — neither is a request to see a step's details.
+	function selectableNodeAt(e: MouseEvent): HTMLElement | null {
+		const target = e.target as HTMLElement | null
+		if (target?.closest('[data-prop-picker]')) return null
+		return target?.closest('.svelte-flow__node.selectable') ?? null
+	}
+
+	function openStepModalFromGraph(e: MouseEvent) {
+		if (selectableNodeAt(e)) stepModalOpen = true
+	}
+
+	// Clicking the step that is already selected is the second half of "select it, then show
+	// it". Read in the capture phase: once the click bubbles, the graph has applied its own
+	// selection and a first click looks identical to this one.
+	let clickStartedOnSelected = false
+	function noteSelectionBeforeClick(e: MouseEvent) {
+		clickStartedOnSelected = Boolean(selectableNodeAt(e)?.classList.contains('selected'))
+	}
+
+	function openStepModalIfReselected(e: MouseEvent) {
+		if (clickStartedOnSelected && selectableNodeAt(e)) stepModalOpen = true
+	}
+
+	let stepModalStep = $derived(
+		typeof stepDetail === 'object' && stepDetail != undefined ? stepDetail : undefined
+	)
+	// Flow-level targets ('Input', 'Result', …) reach the panel as a bare string and have no id
+	// or label of their own — the string is the name. With nothing selected the panel shows the
+	// flow's inputs, which is what detaching from an empty selection opens on.
+	let stepModalTitle = $derived(
+		stepModalStep
+			? stepLabel(stepModalStep)
+			: typeof stepDetail === 'string'
+				? stepDetail
+				: 'Flow inputs'
+	)
+	let stepModalBadge = $derived(
+		stepModalStep?.id && stepModalStep.id != 'failure' && stepModalStep.id != 'preprocessor'
+			? stepModalStep.id
+			: undefined
+	)
+
+	let stepHintText = $derived(
+		typeof stepDetail === 'object' && stepDetail != undefined
+			? 'Click the selected step to see its details'
+			: 'Double click a step to see its details'
 	)
 
 	if (provideTriggerContext && !hasContext('TriggerContext')) {
@@ -95,10 +185,12 @@
 	})
 </script>
 
-<svelte:window bind:innerWidth />
-
-<div bind:clientHeight={availableHeight} class="w-full h-full min-h-0">
-	{#if !noGraph && showSide}
+<div
+	bind:clientHeight={availableHeight}
+	bind:clientWidth={availableWidth}
+	class="w-full h-full min-h-0 relative"
+>
+	{#if !noGraph && hasSideContent && panelMode === 'docked'}
 		<Splitpanes class="w-full h-full">
 			<Pane size={66} minSize={25}>
 				{@render graph()}
@@ -109,16 +201,54 @@
 		</Splitpanes>
 	{:else if !noGraph}
 		{@render graph()}
-	{:else if showSide}
+	{:else if hasSideContent}
 		{@render side()}
+	{/if}
+
+	{#if panelMode === 'modal' && !stepModalOpen}
+		<div
+			class="pointer-events-none absolute bottom-2 left-3 z-30 flex items-center gap-1.5 text-xs text-hint"
+		>
+			<MousePointerClick size={13} />
+			{stepHintText}
+		</div>
 	{/if}
 </div>
 
+<Modal bind:open={stepModalOpen} title={stepModalTitle} kind="X" titleBadgeFirst class="max-w-4xl">
+	{#snippet titleBadge()}
+		{#if stepModalBadge}
+			<Badge color="indigo" small class="shrink-0 !py-0 leading-4">{stepModalBadge}</Badge>
+		{/if}
+	{/snippet}
+	<!-- The picker in the graph's control bar is behind this dialog, so re-attaching needs its
+	     own way back from in here. -->
+	{#snippet settings()}
+		<FlowPanelPlacementPicker variant="header" />
+	{/snippet}
+	<!-- The dialog supplies the padding and names the step, and hugs a short step while
+	     scrolling a long one: without fillHeight it sizes to its content, which would
+	     otherwise run past the viewport on a step with a long script. -->
+	<FlowGraphViewerStep
+		schema={flow?.schema}
+		{stepDetail}
+		{hideDefaultInputs}
+		{workspace}
+		hideHeader
+		class="p-0 max-h-[70vh] overflow-y-auto"
+	/>
+</Modal>
+
 {#snippet graph()}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<div
 		class="w-full h-full min-h-0 max-h-full"
 		class:overflow-auto={overflowAuto}
 		class:border={!noBorder}
+		ondblclick={panelMode === 'modal' ? openStepModalFromGraph : undefined}
+		onpointerdowncapture={panelMode === 'modal' ? noteSelectionBeforeClick : undefined}
+		onclick={panelMode === 'modal' ? openStepModalIfReselected : undefined}
 	>
 		<FlowGraphV2
 			{triggerNode}

--- a/frontend/src/lib/components/FlowGraphViewer.svelte
+++ b/frontend/src/lib/components/FlowGraphViewer.svelte
@@ -6,6 +6,7 @@
 	import { createEventDispatcher, hasContext, setContext } from 'svelte'
 	import { writable } from 'svelte/store'
 	import { twMerge } from 'tailwind-merge'
+	import { Pane, Splitpanes } from 'svelte-splitpanes'
 
 	import FlowGraphViewerStep from './FlowGraphViewerStep.svelte'
 	import FlowGraphV2 from './graph/FlowGraphV2.svelte'
@@ -54,6 +55,13 @@
 	}: Props = $props()
 
 	let availableHeight = $state(0)
+	// The step panel stays hidden below Tailwind's sm breakpoint, as it did when this was a
+	// `hidden sm:flex` grid cell: a Pane keeps its width even when its content is display:none,
+	// so the breakpoint has to decide whether the Pane exists at all.
+	let innerWidth = $state(0)
+	let showSide = $derived(
+		!noSide && !(hideDefaultInputs && stepDetail == undefined) && innerWidth >= 640
+	)
 
 	if (provideTriggerContext && !hasContext('TriggerContext')) {
 		const triggersCount = writable<TriggersCount | undefined>(undefined)
@@ -87,55 +95,71 @@
 	})
 </script>
 
-<div bind:clientHeight={availableHeight} class="grid grid-cols-3 w-full h-full min-h-0">
-	{#if !noGraph}
-		<div
-			class="{noSide || (hideDefaultInputs && stepDetail == undefined)
-				? 'col-span-3'
-				: 'sm:col-span-2 col-span-3'} w-full h-full min-h-0 max-h-full"
-			class:overflow-auto={overflowAuto}
-			class:border={!noBorder}
-		>
-			<FlowGraphV2
-				{triggerNode}
-				earlyStop={flow?.value?.skip_expr !== undefined}
-				cache={flow?.value?.cache_ttl !== undefined}
-				path={flow?.path}
-				{download}
-				minHeight={fillAvailableHeight ? Math.max(minHeight, availableHeight) : minHeight}
-				{workspace}
-				modules={flow?.value?.modules}
-				failureModule={flow?.value?.failure_module}
-				preprocessorModule={flow?.value?.preprocessor_module}
-				notes={flow?.value?.notes}
-				groups={flow?.value?.groups}
-				onSelect={(nodeId) => {
-					if (nodeId === 'Trigger') {
-						dispatch('triggerDetail')
-						return
-					} else if (nodeId === 'failure') {
-						stepDetail = flow?.value?.failure_module
-					} else if (nodeId === 'preprocessor') {
-						stepDetail = flow?.value?.preprocessor_module
-					} else {
-						stepDetail = dfs(flow?.value?.modules ?? [], (m) => m).find((m) => m?.id === nodeId)
-					}
-					stepDetail = stepDetail ?? nodeId
-					dispatch('select', stepDetail)
-				}}
-			/>
-		</div>
-	{/if}
-	{#if !noSide && !(hideDefaultInputs && stepDetail == undefined)}
-		<div
-			class={twMerge(
-				fillAvailableHeight
-					? 'relative w-full h-full min-h-0 border-r border-b border-t p-2 pt-0 overflow-auto hidden sm:flex flex-col gap-4'
-					: 'relative w-full h-full min-h-[150px] max-h-[90vh] border-r border-b border-t p-2 pt-0 overflow-auto hidden sm:flex flex-col gap-4',
-				noGraph ? 'border-0 w-max' : ''
-			)}
-		>
-			<FlowGraphViewerStep schema={flow?.schema} {stepDetail} {hideDefaultInputs} {workspace} />
-		</div>
+<svelte:window bind:innerWidth />
+
+<div bind:clientHeight={availableHeight} class="w-full h-full min-h-0">
+	{#if !noGraph && showSide}
+		<Splitpanes class="w-full h-full">
+			<Pane size={66} minSize={25}>
+				{@render graph()}
+			</Pane>
+			<Pane size={34} minSize={15}>
+				{@render side()}
+			</Pane>
+		</Splitpanes>
+	{:else if !noGraph}
+		{@render graph()}
+	{:else if showSide}
+		{@render side()}
 	{/if}
 </div>
+
+{#snippet graph()}
+	<div
+		class="w-full h-full min-h-0 max-h-full"
+		class:overflow-auto={overflowAuto}
+		class:border={!noBorder}
+	>
+		<FlowGraphV2
+			{triggerNode}
+			earlyStop={flow?.value?.skip_expr !== undefined}
+			cache={flow?.value?.cache_ttl !== undefined}
+			path={flow?.path}
+			{download}
+			minHeight={fillAvailableHeight ? Math.max(minHeight, availableHeight) : minHeight}
+			{workspace}
+			modules={flow?.value?.modules}
+			failureModule={flow?.value?.failure_module}
+			preprocessorModule={flow?.value?.preprocessor_module}
+			notes={flow?.value?.notes}
+			groups={flow?.value?.groups}
+			onSelect={(nodeId) => {
+				if (nodeId === 'Trigger') {
+					dispatch('triggerDetail')
+					return
+				} else if (nodeId === 'failure') {
+					stepDetail = flow?.value?.failure_module
+				} else if (nodeId === 'preprocessor') {
+					stepDetail = flow?.value?.preprocessor_module
+				} else {
+					stepDetail = dfs(flow?.value?.modules ?? [], (m) => m).find((m) => m?.id === nodeId)
+				}
+				stepDetail = stepDetail ?? nodeId
+				dispatch('select', stepDetail)
+			}}
+		/>
+	</div>
+{/snippet}
+
+{#snippet side()}
+	<div
+		class={twMerge(
+			fillAvailableHeight
+				? 'relative w-full h-full min-h-0 border-r border-b border-t p-2 pt-0 overflow-auto flex flex-col gap-4'
+				: 'relative w-full h-full min-h-[150px] max-h-[90vh] border-r border-b border-t p-2 pt-0 overflow-auto flex flex-col gap-4',
+			noGraph ? 'border-0 w-max' : ''
+		)}
+	>
+		<FlowGraphViewerStep schema={flow?.schema} {stepDetail} {hideDefaultInputs} {workspace} />
+	</div>
+{/snippet}

--- a/frontend/src/lib/components/FlowGraphViewer.svelte
+++ b/frontend/src/lib/components/FlowGraphViewer.svelte
@@ -84,10 +84,11 @@
 		preference: () => panelController.preference,
 		setPreference: (preference) => {
 			if (preference === panelController.preference) return
-			// Moving the panel must not lose what it was showing: docked, it is always on screen,
-			// so the dialog it becomes has to open on arrival. The reverse is handled by the
-			// effect below, which closes a dialog that is no longer rendered.
-			const wasVisible = panelMode === 'docked' || stepModalOpen
+			// Moving the panel must not lose what it was showing, so a panel that was on screen
+			// reopens as a dialog. Docked is not enough on its own: under hideDefaultInputs with
+			// nothing selected the pane renders nothing, and detaching would open an empty dialog.
+			// The reverse is handled by the effect below, which closes a dialog no longer rendered.
+			const wasVisible = (panelMode === 'docked' && hasSideContent) || stepModalOpen
 			panelController.preference = preference
 			stepModalOpen = panelController.mode === 'modal' && wasVisible
 		}
@@ -95,6 +96,7 @@
 	// Whether the panel has anything to show. Kept apart from panelMode so the double-click
 	// gesture stays live under hideDefaultInputs, where nothing shows until a step is picked.
 	let hasSideContent = $derived(!noSide && !(hideDefaultInputs && stepDetail == undefined))
+	let panelDocked = $derived(hasSideContent && panelMode === 'docked')
 
 	// A move back to 'docked' — the viewer got wider — would otherwise leave a dialog open
 	// over a panel that is already visible beside the graph.
@@ -190,19 +192,25 @@
 	bind:clientWidth={availableWidth}
 	class="w-full h-full min-h-0 relative"
 >
-	{#if !noGraph && hasSideContent && panelMode === 'docked'}
+	{#if noGraph}
+		{#if hasSideContent}
+			{@render side()}
+		{/if}
+	{:else}
+		<!-- The graph keeps one pane across every transition, and only the step pane comes and
+		     goes. Rendering it in two branches instead would re-create FlowGraphV2 whenever the
+		     panel moves — losing pan, zoom and the selected node — and every embed under 1280
+		     would mount it twice, since width starts at 0 and 0 resolves to docked. -->
 		<Splitpanes class="w-full h-full">
-			<Pane size={66} minSize={25}>
+			<Pane size={panelDocked ? 66 : 100} minSize={25}>
 				{@render graph()}
 			</Pane>
-			<Pane size={34} minSize={15}>
-				{@render side()}
-			</Pane>
+			{#if panelDocked}
+				<Pane size={34} minSize={15}>
+					{@render side()}
+				</Pane>
+			{/if}
 		</Splitpanes>
-	{:else if !noGraph}
-		{@render graph()}
-	{:else if hasSideContent}
-		{@render side()}
 	{/if}
 
 	{#if panelMode === 'modal' && !stepModalOpen}
@@ -215,7 +223,13 @@
 	{/if}
 </div>
 
-<Modal bind:open={stepModalOpen} title={stepModalTitle} kind="X" titleBadgeFirst class="max-w-4xl">
+<Modal
+	bind:open={stepModalOpen}
+	title={stepModalTitle}
+	kind="X"
+	titleBadgeFirst
+	class="sm:max-w-4xl"
+>
 	{#snippet titleBadge()}
 		{#if stepModalBadge}
 			<Badge color="indigo" small class="shrink-0 !py-0 leading-4">{stepModalBadge}</Badge>

--- a/frontend/src/lib/components/FlowGraphViewer.svelte
+++ b/frontend/src/lib/components/FlowGraphViewer.svelte
@@ -196,6 +196,11 @@
 		{#if hasSideContent}
 			{@render side()}
 		{/if}
+	{:else if noSide}
+		<!-- No step pane can ever appear here, so there is no transition to protect against and
+		     the graph keeps its plain container — svelte-splitpanes measures, and several of these
+		     embeds sit in an ancestor with no definite height. -->
+		{@render graph()}
 	{:else}
 		<!-- The graph keeps one pane across every transition, and only the step pane comes and
 		     goes. Rendering it in two branches instead would re-create FlowGraphV2 whenever the

--- a/frontend/src/lib/components/FlowGraphViewerStep.svelte
+++ b/frontend/src/lib/components/FlowGraphViewerStep.svelte
@@ -16,6 +16,7 @@
 
 	import { twMerge } from 'tailwind-merge'
 	import FlowModuleScript from './flows/content/FlowModuleScript.svelte'
+	import { stepLabel } from './flows/stepLabel'
 	import { Copy, Expand } from 'lucide-svelte'
 	import HighlightTheme from './HighlightTheme.svelte'
 	import LanguageIcon from './common/languageIcons/LanguageIcon.svelte'
@@ -28,6 +29,10 @@
 		// The workspace the viewed flow belongs to (differs from the nav workspace in fork/session
 		// editors); used to qualify resource links.
 		workspace?: string
+		/** Overrides the root's padding and scrolling, for hosts that pad and scroll themselves. */
+		class?: string
+		/** Drops the id + label strip, for a host that already names the step in its own chrome. */
+		hideHeader?: boolean
 	}
 
 	let {
@@ -35,7 +40,9 @@
 		stepDetail = undefined,
 		jobScriptHash = undefined,
 		hideDefaultInputs = false,
-		workspace = undefined
+		workspace = undefined,
+		class: className = '',
+		hideHeader = false
 	}: Props = $props()
 	let ws = $derived(workspace ?? $workspaceStore)
 	let codeViewer: Drawer | undefined = $state()
@@ -94,12 +101,16 @@
 	</DrawerContent>
 </Drawer>
 
-<div class={twMerge('p-2 overflow-y-scroll')}>
+<div class={twMerge('p-2 overflow-y-scroll', className)}>
 	{#if stepDetail == undefined}
 		<div>
-			<p class="text-secondary text-xs italic px-2 pt-2"> Click on a step to see its details </p>
+			{#if !hideHeader}
+				<p class="text-secondary text-xs italic px-2 pt-2"> Click on a step to see its details </p>
+			{/if}
 			{#if schema && !hideDefaultInputs}
-				<h3 class="mb-2 font-semibold">Flow Inputs</h3>
+				{#if !hideHeader}
+					<h3 class="mb-2 font-semibold">Flow Inputs</h3>
+				{/if}
 				<SchemaViewer {schema} />
 			{/if}
 		</div>
@@ -113,48 +124,23 @@
 		<p class="font-medium text-secondary text-center pt-4 pb-8"> End of the flow </p>
 	{:else if typeof stepDetail != 'string' && stepDetail.value}
 		<div class="">
-			<div class="sticky top-0 bg-surface w-full flex items-center py-2">
-				{#if stepDetail.id && stepDetail.id != 'failure' && stepDetail.id != 'preprocessor'}
-					<Badge color="indigo">
-						{stepDetail.id}
-					</Badge>
-				{/if}
-				<span
-					class={twMerge(
-						'font-semibold text-emphasis text-sm',
-						stepDetail.id !== 'failure' && stepDetail.id !== 'preprocessor' ? 'ml-2' : ''
-					)}
-				>
-					{#if stepDetail.summary}
-						{stepDetail.summary}
-					{:else if stepDetail.value.type == 'identity'}
-						Identity
-					{:else if stepDetail.value.type == 'forloopflow'}
-						For loop {#if stepDetail.value.parallel}(parallel){/if}
-						{#if stepDetail.value.skip_failures}(skip failures){/if}
-						{#if stepDetail.value.squash}(squash){/if}
-					{:else if stepDetail.value.type == 'branchall'}
-						Run all branches {#if stepDetail.value.parallel}(parallel){/if}
-					{:else if stepDetail.value.type == 'branchone'}
-						Run one branch
-					{:else if stepDetail.value.type == 'flow'}
-						Inner flow
-					{:else if stepDetail.value.type == 'whileloopflow'}
-						While loop {#if stepDetail.value.skip_failures}(skip failures){/if}
-						{#if stepDetail.value.squash}(squash){/if}
-					{:else if stepDetail.id === 'failure'}
-						Error handler
-					{:else if stepDetail.id === 'preprocessor'}
-						Preprocessor
-					{:else if stepDetail.value.type == 'rawscript'}
-						Inline {stepDetail.value.language} script
-					{:else if stepDetail.value.type == 'script'}
-						Workspace script
-					{:else if stepDetail.value.type == 'aiagent'}
-						AI Agent
+			{#if !hideHeader}
+				<div class="sticky top-0 bg-surface w-full flex items-center py-2">
+					{#if stepDetail.id && stepDetail.id != 'failure' && stepDetail.id != 'preprocessor'}
+						<Badge color="indigo">
+							{stepDetail.id}
+						</Badge>
 					{/if}
-				</span>
-			</div>
+					<span
+						class={twMerge(
+							'font-semibold text-emphasis text-sm',
+							stepDetail.id !== 'failure' && stepDetail.id !== 'preprocessor' ? 'ml-2' : ''
+						)}
+					>
+						{stepLabel(stepDetail)}
+					</span>
+				</div>
+			{/if}
 			{#if stepDetail.value.type == 'script'}
 				<div class="pb-2">
 					<a

--- a/frontend/src/lib/components/common/modal/Modal.svelte
+++ b/frontend/src/lib/components/common/modal/Modal.svelte
@@ -50,6 +50,9 @@
 		/** Rendered against the dialog's own name, before any level below it: what it marks is the
 		 * dialog rather than wherever in it you have navigated to. */
 		titleBadge?: import('svelte').Snippet
+		/** Puts the badge ahead of the title, for a badge that identifies the subject rather than
+		 * qualifying it — an id reads before the name it belongs to, a "Beta" tag reads after. */
+		titleBadgeFirst?: boolean
 		settings?: import('svelte').Snippet
 		children?: import('svelte').Snippet
 		actions?: import('svelte').Snippet
@@ -67,6 +70,7 @@
 		fillHeight = false,
 		minZIndex: minZIndexProp = undefined,
 		titleBadge,
+		titleBadgeFirst = false,
 		settings,
 		children: children_render,
 		actions
@@ -259,14 +263,26 @@
 												{@render settings?.()}
 											</div>
 										{:else}
-											<div class="flex flex-row items-center justify-between">
+											<!-- pr-8 under `kind="X"`: the close button is absolutely positioned, so a long
+											     title or anything in `settings` would otherwise run under it. -->
+											<div
+												class="flex flex-row items-center justify-between gap-2 min-w-0 {kind ===
+												'X'
+													? 'pr-8'
+													: ''}"
+											>
 												<h3
 													class="text-emphasis text-lg font-semibold {titleBadge
-														? 'flex items-center gap-1'
+														? 'flex items-center gap-1.5 min-w-0'
 														: ''}"
 												>
-													{title}
-													{@render titleBadge?.()}
+													{#if titleBadgeFirst}
+														{@render titleBadge?.()}
+														<span class="truncate">{title}</span>
+													{:else}
+														{title}
+														{@render titleBadge?.()}
+													{/if}
 												</h3>
 												{@render settings?.()}
 											</div>

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -1077,7 +1077,7 @@
 							{/if}
 						{:else if flowModule.value.type === 'flow'}
 							{#key forceReload}
-								<FlowPathViewer path={flowModule.value.path} />
+								<FlowPathViewer noSide path={flowModule.value.path} />
 							{/key}
 						{/if}
 					{/snippet}

--- a/frontend/src/lib/components/flows/stepLabel.test.ts
+++ b/frontend/src/lib/components/flows/stepLabel.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import type { FlowModule } from '$lib/gen'
+import { stepLabel } from './stepLabel'
+
+function mod(id: string, value: any, summary?: string): FlowModule {
+	return { id, value, ...(summary ? { summary } : {}) } as FlowModule
+}
+
+describe('stepLabel', () => {
+	it('prefers the summary over every derived label', () => {
+		expect(stepLabel(mod('a', { type: 'forloopflow', parallel: true }, 'Per line item'))).toBe(
+			'Per line item'
+		)
+		expect(stepLabel(mod('failure', { type: 'rawscript', language: 'bun' }, 'Tell Slack'))).toBe(
+			'Tell Slack'
+		)
+	})
+
+	// The ordering that a reorder would silently break: the id checks sit between the composite
+	// types and the leaf script types, so these keep their role rather than reading as their body.
+	it('names the failure and preprocessor modules by their role, not their script', () => {
+		expect(stepLabel(mod('failure', { type: 'rawscript', language: 'bun' }))).toBe('Error handler')
+		expect(stepLabel(mod('preprocessor', { type: 'rawscript', language: 'python3' }))).toBe(
+			'Preprocessor'
+		)
+	})
+
+	it('lets a composite type win over the id checks', () => {
+		expect(stepLabel(mod('failure', { type: 'branchone' }))).toBe('Run one branch')
+	})
+
+	it('appends one parenthesised suffix per set flag, in order', () => {
+		expect(
+			stepLabel(
+				mod('b', { type: 'forloopflow', parallel: true, skip_failures: true, squash: true })
+			)
+		).toBe('For loop (parallel) (skip failures) (squash)')
+		expect(stepLabel(mod('b', { type: 'forloopflow' }))).toBe('For loop')
+		expect(stepLabel(mod('c', { type: 'whileloopflow', squash: true }))).toBe('While loop (squash)')
+		expect(stepLabel(mod('d', { type: 'branchall', parallel: true }))).toBe(
+			'Run all branches (parallel)'
+		)
+	})
+
+	it('names the leaf types', () => {
+		expect(stepLabel(mod('e', { type: 'rawscript', language: 'python3' }))).toBe(
+			'Inline python3 script'
+		)
+		expect(stepLabel(mod('f', { type: 'script' }))).toBe('Workspace script')
+		expect(stepLabel(mod('g', { type: 'aiagent' }))).toBe('AI Agent')
+		expect(stepLabel(mod('h', { type: 'flow' }))).toBe('Inner flow')
+		expect(stepLabel(mod('i', { type: 'identity' }))).toBe('Identity')
+	})
+
+	it('returns an empty label for an unknown type rather than throwing', () => {
+		expect(stepLabel(mod('j', { type: 'something_new' }))).toBe('')
+		expect(stepLabel(mod('k', undefined))).toBe('')
+	})
+})

--- a/frontend/src/lib/components/flows/stepLabel.ts
+++ b/frontend/src/lib/components/flows/stepLabel.ts
@@ -1,0 +1,55 @@
+import type { FlowModule } from '$lib/gen'
+
+/**
+ * What to call a step that has no summary. The id checks sit between the composite types and
+ * the leaf script types on purpose: a failure module holds a rawscript, and reading it as
+ * "Inline python3 script" loses the only thing that distinguishes it.
+ */
+export function stepLabel(step: FlowModule): string {
+	if (step.summary) return step.summary
+
+	const value = step.value as Record<string, any> | undefined
+	const suffixes = (...flags: [boolean | undefined, string][]) =>
+		flags
+			.filter(([on]) => on)
+			.map(([, label]) => ` (${label})`)
+			.join('')
+
+	switch (value?.type) {
+		case 'identity':
+			return 'Identity'
+		case 'forloopflow':
+			return (
+				'For loop' +
+				suffixes(
+					[value.parallel, 'parallel'],
+					[value.skip_failures, 'skip failures'],
+					[value.squash, 'squash']
+				)
+			)
+		case 'branchall':
+			return 'Run all branches' + suffixes([value.parallel, 'parallel'])
+		case 'branchone':
+			return 'Run one branch'
+		case 'flow':
+			return 'Inner flow'
+		case 'whileloopflow':
+			return (
+				'While loop' + suffixes([value.skip_failures, 'skip failures'], [value.squash, 'squash'])
+			)
+	}
+
+	if (step.id === 'failure') return 'Error handler'
+	if (step.id === 'preprocessor') return 'Preprocessor'
+
+	switch (value?.type) {
+		case 'rawscript':
+			return `Inline ${value.language} script`
+		case 'script':
+			return 'Workspace script'
+		case 'aiagent':
+			return 'AI Agent'
+	}
+
+	return ''
+}

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1524,6 +1524,10 @@
 		   sets a light `border-color` on every element, so whenever that base rule does not
 		   make it into the bundle alongside this one the bar draws a white outline. */
 		@apply overflow-hidden rounded-md border border-border-light;
+		/* The bar carries the opaque surface, not just the buttons: `surface-hover` is a
+		   translucent token, so a hovered button that only swaps its own background would
+		   composite that tint straight onto the graph. */
+		@apply bg-surface;
 		box-shadow: none;
 	}
 	:global(.wm-flow-controls .svelte-flow__controls-button) {

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptRunnable.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptRunnable.svelte
@@ -353,7 +353,7 @@
 						{@render inputsPanel()}
 					{:else if selectedTab == 'test'}
 						{@render testPanel()}
-					{:else}
+					{:else if isRunnableByPath(runnable)}
 						<InlineScriptRunnableByPath
 							rawApps
 							bind:runnable

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptRunnable.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptRunnable.svelte
@@ -10,7 +10,7 @@
 		type UserAppInput,
 		type CtxAppInput
 	} from '../apps/inputType'
-	import { createEventDispatcher } from 'svelte'
+	import { createEventDispatcher, untrack } from 'svelte'
 	import RawAppInlineScriptEditor from './RawAppInlineScriptEditor.svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import Tabs from '../common/tabs/Tabs.svelte'
@@ -75,7 +75,7 @@
 					}
 	}
 
-	let selectedTab = $state('test')
+	let selectedTab = $state(isRunnableByPath(runnable) ? 'view' : 'test')
 	let args = $state({})
 	let hubFlowPreview: OpenFlow | undefined = $state(undefined)
 
@@ -122,6 +122,16 @@
 	$effect(() => {
 		if (debugMode) {
 			selectedTab = 'test'
+		}
+	})
+
+	// 'view' only exists in the runnable-by-path layout: land on it there, leave it otherwise
+	let isByPath = $derived(isRunnableByPath(runnable))
+	$effect(() => {
+		if (isByPath) {
+			untrack(() => (selectedTab = 'view'))
+		} else if (untrack(() => selectedTab) == 'view') {
+			untrack(() => (selectedTab = 'test'))
 		}
 	})
 
@@ -199,41 +209,188 @@
 	bind:job={testJob}
 />
 
-{#if isRunnableByPath(runnable) || (isRunnableByName(runnable) && runnable.inlineScript)}
+{#snippet inputsPanel()}
+	{#if runnable?.fields}
+		<div class="w-full flex flex-col gap-4 p-2">
+			{#each Object.keys(runnable.fields) as k}
+				{@const meta = runnable.fields[k]}
+				<RawAppInputsSpecEditor
+					key={k}
+					bind:componentInput={runnable.fields[k]}
+					{id}
+					shouldCapitalize
+					fieldType={meta?.['fieldType']}
+					subFieldType={meta?.['subFieldType']}
+					format={meta?.['format']}
+					selectOptions={meta?.['selectOptions']}
+					tooltip={meta?.['tooltip']}
+					placeholder={meta?.['placeholder']}
+					customTitle={meta?.['customTitle']}
+					loading={meta?.['loading']}
+					documentationLink={meta?.['documentationLink']}
+					allowTypeChange={meta?.['allowTypeChange']}
+					displayType
+				/>
+			{/each}
+		</div>
+	{:else}
+		<div class="text-primary text-xs">No inputs</div>
+	{/if}
+{/snippet}
+
+{#snippet testPanel()}
+	{#if debugMode && isDebuggableScript}
+		<div transition:slide={{ duration: 200 }}>
+			<DebugToolbar
+				connected={$debugState.connected}
+				running={$debugState.running}
+				stopped={$debugState.stopped}
+				breakpointCount={editorDebugState.debugBreakpoints?.size ?? 0}
+				onStart={() => inlineScriptEditor?.startDebugging() ?? Promise.resolve()}
+				onStop={() => inlineScriptEditor?.stopDebugging() ?? Promise.resolve()}
+				onContinue={() => inlineScriptEditor?.continueExecution() ?? Promise.resolve()}
+				onStepOver={() => inlineScriptEditor?.stepOver() ?? Promise.resolve()}
+				onStepIn={() => inlineScriptEditor?.stepIn() ?? Promise.resolve()}
+				onStepOut={() => inlineScriptEditor?.stepOut() ?? Promise.resolve()}
+				onClearBreakpoints={() => inlineScriptEditor?.clearAllBreakpoints()}
+				onExitDebug={() => inlineScriptEditor?.toggleDebugMode()}
+			/>
+		</div>
+	{/if}
+	<SplitPanesWrapper>
+		<Splitpanes horizontal class="grow">
+			<Pane size={50}>
+				<div class="px-2 py-3 h-full overflow-auto">
+					<div class="mx-auto w-fit">
+						<RunButton
+							isLoading={testIsLoading}
+							onRun={testPreview}
+							onCancel={async () => {
+								if (jobLoader) {
+									await jobLoader.cancelJob()
+								}
+							}}
+							size="md"
+						/>
+					</div>
+					<SchemaForm
+						on:keydownCmdEnter={testPreview}
+						workspace={opWs}
+						disabledArgs={Object.entries(runnable?.fields ?? {})
+							.filter(([_, v]) => v.type == 'static')
+							.map(([k]) => k)}
+						schema={runnable ? getSchema(runnable) : {}}
+						bind:args
+					/>
+				</div>
+			</Pane>
+			<Pane size={50}>
+				{#if showDebugPanel || hasDebugResult}
+					<Splitpanes horizontal class="h-full">
+						<Pane size={50} minSize={15}>
+							<Splitpanes horizontal class="h-full">
+								<Pane size={50} minSize={10}>
+									<LogViewer
+										small
+										content={$debugState.logs}
+										isLoading={$debugState.running && !$debugState.stopped}
+										tag={undefined}
+									/>
+								</Pane>
+								<Pane size={50} minSize={10}>
+									{#if hasDebugResult}
+										<div class="h-full p-2 overflow-auto">
+											<DisplayResult
+												result={$debugState.result}
+												language={runnable?.inlineScript?.language}
+											/>
+										</div>
+									{:else}
+										<div class="h-full flex items-center justify-center text-sm text-tertiary">
+											{#if $debugState.running && !$debugState.stopped}
+												Running...
+											{:else if $debugState.stopped}
+												Paused at breakpoint
+											{:else}
+												Waiting for debug session
+											{/if}
+										</div>
+									{/if}
+								</Pane>
+							</Splitpanes>
+						</Pane>
+						<Pane size={50} minSize={15}>
+							<DebugPanel
+								stackFrames={$debugState.stackFrames}
+								scopes={$debugState.scopes}
+								variables={$debugState.variables}
+								client={dapClient}
+								bind:selectedFrameId={selectedDebugFrameId}
+							/>
+						</Pane>
+					</Splitpanes>
+				{:else if debugMode && isDebuggableScript}
+					<div class="h-full flex items-center justify-center text-sm text-tertiary">
+						Click "Debug" in the toolbar to start debugging
+					</div>
+				{:else}
+					<RunnableJobPanelInner frontendJob={false} {testJob} {testIsLoading} />
+				{/if}
+			</Pane>
+		</Splitpanes>
+	</SplitPanesWrapper>
+{/snippet}
+
+{#if isRunnableByPath(runnable)}
+	<div class="h-full w-full flex flex-col min-h-0">
+		<Tabs bind:selected={selectedTab}>
+			<Tab value="view" label={runnable.runType == 'flow' ? 'Flow' : 'Script'} />
+			<Tab value="test" label="Test" />
+			<Tab value="inputs" label="Inputs" />
+			{#snippet content()}
+				<div class="grow min-h-0 flex flex-col">
+					{#if selectedTab == 'inputs'}
+						{@render inputsPanel()}
+					{:else if selectedTab == 'test'}
+						{@render testPanel()}
+					{:else}
+						<InlineScriptRunnableByPath
+							rawApps
+							bind:runnable
+							bind:fields={runnable.fields}
+							bind:hubFlowPreview
+							on:fork={(e) => fork(e.detail)}
+							on:delete
+							{id}
+							isLoading={testIsLoading}
+							onRun={testPreview}
+							onCancel={async () => {
+								if (jobLoader) {
+									await jobLoader.cancelJob()
+								}
+							}}
+						/>
+					{/if}
+				</div>
+			{/snippet}
+		</Tabs>
+	</div>
+{:else if isRunnableByName(runnable) && runnable.inlineScript}
 	<Splitpanes>
 		<Pane size={55}>
-			{#if isRunnableByName(runnable)}
-				<RawAppInlineScriptEditor
-					bind:this={inlineScriptEditor}
-					on:createScriptFromInlineScript={() => dispatch('createScriptFromInlineScript', runnable)}
-					{id}
-					bind:inlineScript={runnable.inlineScript}
-					bind:name={runnable.name}
-					bind:fields={runnable.fields}
-					bind:delete_after_secs={runnable.delete_after_secs}
-					onRun={testPreview}
-					on:delete
-					path={appPath}
-					{onSelectionChange}
-				/>
-			{:else if isRunnableByPath(runnable)}
-				<InlineScriptRunnableByPath
-					rawApps
-					bind:runnable
-					bind:fields={runnable.fields}
-					bind:hubFlowPreview
-					on:fork={(e) => fork(e.detail)}
-					on:delete
-					{id}
-					isLoading={testIsLoading}
-					onRun={testPreview}
-					onCancel={async () => {
-						if (jobLoader) {
-							await jobLoader.cancelJob()
-						}
-					}}
-				/>
-			{/if}
+			<RawAppInlineScriptEditor
+				bind:this={inlineScriptEditor}
+				on:createScriptFromInlineScript={() => dispatch('createScriptFromInlineScript', runnable)}
+				{id}
+				bind:inlineScript={runnable.inlineScript}
+				bind:name={runnable.name}
+				bind:fields={runnable.fields}
+				bind:delete_after_secs={runnable.delete_after_secs}
+				onRun={testPreview}
+				on:delete
+				path={appPath}
+				{onSelectionChange}
+			/>
 		</Pane>
 		<Pane size={45}>
 			<Tabs bind:selected={selectedTab}>
@@ -241,135 +398,9 @@
 				<Tab value="inputs" label="Inputs" />
 				{#snippet content()}
 					{#if selectedTab == 'inputs'}
-						{#if runnable?.fields}
-							<div class="w-full flex flex-col gap-4 p-2">
-								{#each Object.keys(runnable.fields) as k}
-									{@const meta = runnable.fields[k]}
-									<RawAppInputsSpecEditor
-										key={k}
-										bind:componentInput={runnable.fields[k]}
-										{id}
-										shouldCapitalize
-										fieldType={meta?.['fieldType']}
-										subFieldType={meta?.['subFieldType']}
-										format={meta?.['format']}
-										selectOptions={meta?.['selectOptions']}
-										tooltip={meta?.['tooltip']}
-										placeholder={meta?.['placeholder']}
-										customTitle={meta?.['customTitle']}
-										loading={meta?.['loading']}
-										documentationLink={meta?.['documentationLink']}
-										allowTypeChange={meta?.['allowTypeChange']}
-										displayType
-									/>
-								{/each}
-							</div>
-						{:else}
-							<div class="text-primary text-xs">No inputs</div>
-						{/if}
-					{:else if selectedTab == 'test'}
-						{#if debugMode && isDebuggableScript}
-							<div transition:slide={{ duration: 200 }}>
-								<DebugToolbar
-									connected={$debugState.connected}
-									running={$debugState.running}
-									stopped={$debugState.stopped}
-									breakpointCount={editorDebugState.debugBreakpoints?.size ?? 0}
-									onStart={() => inlineScriptEditor?.startDebugging() ?? Promise.resolve()}
-									onStop={() => inlineScriptEditor?.stopDebugging() ?? Promise.resolve()}
-									onContinue={() => inlineScriptEditor?.continueExecution() ?? Promise.resolve()}
-									onStepOver={() => inlineScriptEditor?.stepOver() ?? Promise.resolve()}
-									onStepIn={() => inlineScriptEditor?.stepIn() ?? Promise.resolve()}
-									onStepOut={() => inlineScriptEditor?.stepOut() ?? Promise.resolve()}
-									onClearBreakpoints={() => inlineScriptEditor?.clearAllBreakpoints()}
-									onExitDebug={() => inlineScriptEditor?.toggleDebugMode()}
-								/>
-							</div>
-						{/if}
-						<SplitPanesWrapper>
-							<Splitpanes horizontal class="grow">
-								<Pane size={50}>
-									<div class="px-2 py-3 h-full overflow-auto">
-										<div class="mx-auto w-fit">
-											<RunButton
-												isLoading={testIsLoading}
-												onRun={testPreview}
-												onCancel={async () => {
-													if (jobLoader) {
-														await jobLoader.cancelJob()
-													}
-												}}
-												size="md"
-											/>
-										</div>
-										<SchemaForm
-											on:keydownCmdEnter={testPreview}
-											workspace={opWs}
-											disabledArgs={Object.entries(runnable?.fields ?? {})
-												.filter(([_, v]) => v.type == 'static')
-												.map(([k]) => k)}
-											schema={runnable ? getSchema(runnable) : {}}
-											bind:args
-										/>
-									</div>
-								</Pane>
-								<Pane size={50}>
-									{#if showDebugPanel || hasDebugResult}
-										<Splitpanes horizontal class="h-full">
-											<Pane size={50} minSize={15}>
-												<Splitpanes horizontal class="h-full">
-													<Pane size={50} minSize={10}>
-														<LogViewer
-															small
-															content={$debugState.logs}
-															isLoading={$debugState.running && !$debugState.stopped}
-															tag={undefined}
-														/>
-													</Pane>
-													<Pane size={50} minSize={10}>
-														{#if hasDebugResult}
-															<div class="h-full p-2 overflow-auto">
-																<DisplayResult
-																	result={$debugState.result}
-																	language={runnable?.inlineScript?.language}
-																/>
-															</div>
-														{:else}
-															<div
-																class="h-full flex items-center justify-center text-sm text-tertiary"
-															>
-																{#if $debugState.running && !$debugState.stopped}
-																	Running...
-																{:else if $debugState.stopped}
-																	Paused at breakpoint
-																{:else}
-																	Waiting for debug session
-																{/if}
-															</div>
-														{/if}
-													</Pane>
-												</Splitpanes>
-											</Pane>
-											<Pane size={50} minSize={15}>
-												<DebugPanel
-													stackFrames={$debugState.stackFrames}
-													scopes={$debugState.scopes}
-													variables={$debugState.variables}
-													client={dapClient}
-													bind:selectedFrameId={selectedDebugFrameId}
-												/>
-											</Pane>
-										</Splitpanes>
-									{:else if debugMode && isDebuggableScript}
-										<div class="h-full flex items-center justify-center text-sm text-tertiary">
-											Click "Debug" in the toolbar to start debugging
-										</div>
-									{:else}
-										<RunnableJobPanelInner frontendJob={false} {testJob} {testIsLoading} />
-									{/if}
-								</Pane>
-							</Splitpanes>
-						</SplitPanesWrapper>
+						{@render inputsPanel()}
+					{:else}
+						{@render testPanel()}
 					{/if}
 				{/snippet}
 			</Tabs>

--- a/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/+page.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import { Button } from '$lib/components/common'
+	import Toggle from '$lib/components/Toggle.svelte'
+	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
+	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
+	import FlowPathViewer from '$lib/components/flows/content/FlowPathViewer.svelte'
+	import { FlowService } from '$lib/gen'
+	import { userStore, workspaceStore } from '$lib/stores'
+	import { sendUserToast } from '$lib/toast'
+	import { untrack } from 'svelte'
+	import { fixtureFlow } from './fixtureFlow'
+
+	// FlowPathViewer takes a path and fetches, so the fixture has to exist in the workspace.
+	// Seeding on load keeps fixtureFlow.ts the single source of truth for the graph.
+	let path = $derived(`u/${$userStore?.username ?? 'admin'}/dev_flow_path_viewer`)
+
+	let seeded = $state<string | undefined>(undefined)
+	let seeding = $state(false)
+	let error = $state<string | undefined>(undefined)
+
+	let noSide = $state(false)
+	let fillAvailableHeight = $state(true)
+	let frame = $state<'full' | 'panel' | 'short'>('full')
+
+	// Inline styles rather than Tailwind classes: the arbitrary sizes are the point of this page
+	// and JIT only emits the ones it happened to scan.
+	const frameStyle = {
+		full: 'height: 100%; width: 100%',
+		panel: 'height: 520px; width: 55%',
+		short: 'height: 260px; width: 100%'
+	}
+
+	async function seed(workspace: string, p: string) {
+		seeding = true
+		error = undefined
+		try {
+			const exists = await FlowService.existsFlowByPath({ workspace, path: p })
+			if (exists) {
+				await FlowService.updateFlow({
+					workspace,
+					path: p,
+					requestBody: { path: p, ...fixtureFlow, deployment_message: 'dev fixture' }
+				})
+			} else {
+				await FlowService.createFlow({
+					workspace,
+					requestBody: { path: p, ...fixtureFlow, deployment_message: 'dev fixture' }
+				})
+			}
+			seeded = undefined
+			await new Promise((r) => setTimeout(r, 0))
+			seeded = p
+		} catch (e: any) {
+			error = e?.body ?? e?.message ?? String(e)
+			sendUserToast(`Could not seed the fixture flow: ${error}`, true)
+		} finally {
+			seeding = false
+		}
+	}
+
+	$effect(() => {
+		const workspace = $workspaceStore
+		const p = path
+		if (!workspace || !$userStore) return
+		// seed() writes seeded/seeding, so the guard has to read them outside the dependency set
+		untrack(() => {
+			if (seeded !== p && !seeding) seed(workspace, p)
+		})
+	})
+</script>
+
+<div class="h-screen w-full flex flex-col min-h-0">
+	<div class="flex flex-wrap items-center gap-4 border-b px-4 py-2 text-xs bg-surface-secondary">
+		<span class="font-semibold">FlowPathViewer</span>
+		<span class="text-tertiary font-mono">{path}</span>
+
+		<Toggle bind:checked={noSide} size="xs" options={{ right: 'noSide' }} />
+		<Toggle
+			bind:checked={fillAvailableHeight}
+			size="xs"
+			options={{ right: 'fillAvailableHeight' }}
+		/>
+
+		<ToggleButtonGroup bind:selected={frame} noWFull>
+			{#snippet children({ item })}
+				<ToggleButton value="full" label="Full page" {item} />
+				<ToggleButton value="panel" label="Raw-app pane (55%)" {item} />
+				<ToggleButton value="short" label="Short (260px)" {item} />
+			{/snippet}
+		</ToggleButtonGroup>
+
+		<Button
+			unifiedSize="xs"
+			variant="default"
+			loading={seeding}
+			onclick={() => $workspaceStore && seed($workspaceStore, path)}
+		>
+			Re-seed
+		</Button>
+	</div>
+
+	<div class="grow min-h-0 p-4">
+		<div class="border rounded min-h-0 flex flex-col overflow-hidden" style={frameStyle[frame]}>
+			{#if error}
+				<div class="p-4 text-xs text-red-600 font-mono whitespace-pre-wrap">{error}</div>
+			{:else if seeded}
+				{#key seeded}
+					<FlowPathViewer path={seeded} {noSide} {fillAvailableHeight} />
+				{/key}
+			{:else}
+				<div class="p-4 text-xs text-tertiary">Seeding the fixture flow…</div>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/+page.svelte
@@ -30,13 +30,24 @@
 		short: 'height: 260px; width: 100%'
 	}
 
+	/** Stamped on every flow this harness deploys, and checked before it overwrites one. */
+	const FIXTURE_MARK = 'Deployed by /dev/flow_path_viewer. Safe to delete.'
+
 	async function upsert(workspace: string, p: string, flow: OpenFlow) {
-		const body = { path: p, ...flow, deployment_message: 'dev fixture' }
-		if (await FlowService.existsFlowByPath({ workspace, path: p })) {
-			await FlowService.updateFlow({ workspace, path: p, requestBody: body })
-		} else {
+		const body = { path: p, ...flow, description: FIXTURE_MARK, deployment_message: 'dev fixture' }
+		if (!(await FlowService.existsFlowByPath({ workspace, path: p }))) {
 			await FlowService.createFlow({ workspace, requestBody: body })
+			return
 		}
+		// A path this harness happens to want can already hold someone's real flow. Redeploying
+		// over it would be a silent, versioned overwrite, so only ever replace our own.
+		const existing = await FlowService.getFlowByPath({ workspace, path: p })
+		if (existing.description !== FIXTURE_MARK) {
+			throw new Error(
+				`${p} already exists and was not created by this page — delete it or point the harness elsewhere`
+			)
+		}
+		await FlowService.updateFlow({ workspace, path: p, requestBody: body })
 	}
 
 	async function seed(workspace: string, p: string) {
@@ -58,10 +69,13 @@
 		}
 	}
 
+	// The page deploys flows into whatever workspace you are in, so it exists only in a dev build.
+	const enabled = import.meta.env.DEV
+
 	$effect(() => {
 		const workspace = $workspaceStore
 		const p = path
-		if (!workspace || !$userStore) return
+		if (!enabled || !workspace || !$userStore) return
 		// seed() writes seeded/seeding, so the guard has to read them outside the dependency set
 		untrack(() => {
 			if (seeded !== p && !seeding) seed(workspace, p)
@@ -69,47 +83,53 @@
 	})
 </script>
 
-<div class="h-screen w-full flex flex-col min-h-0">
-	<div class="flex flex-wrap items-center gap-4 border-b px-4 py-2 text-xs bg-surface-secondary">
-		<span class="font-semibold">FlowPathViewer</span>
-		<span class="text-tertiary font-mono">{path}</span>
-
-		<Toggle bind:checked={noSide} size="xs" options={{ right: 'noSide' }} />
-		<Toggle
-			bind:checked={fillAvailableHeight}
-			size="xs"
-			options={{ right: 'fillAvailableHeight' }}
-		/>
-
-		<ToggleButtonGroup bind:selected={frame} noWFull>
-			{#snippet children({ item })}
-				<ToggleButton value="full" label="Full page" {item} />
-				<ToggleButton value="panel" label="Raw-app pane (55%)" {item} />
-				<ToggleButton value="short" label="Short (260px)" {item} />
-			{/snippet}
-		</ToggleButtonGroup>
-
-		<Button
-			unifiedSize="xs"
-			variant="default"
-			loading={seeding}
-			onclick={() => $workspaceStore && seed($workspaceStore, path)}
-		>
-			Re-seed
-		</Button>
+{#if !enabled}
+	<div class="p-8 text-sm text-secondary">
+		This page deploys fixture flows into the current workspace, so it runs only in a dev build.
 	</div>
+{:else}
+	<div class="h-screen w-full flex flex-col min-h-0">
+		<div class="flex flex-wrap items-center gap-4 border-b px-4 py-2 text-xs bg-surface-secondary">
+			<span class="font-semibold">FlowPathViewer</span>
+			<span class="text-tertiary font-mono">{path}</span>
 
-	<div class="grow min-h-0 p-4">
-		<div class="border rounded min-h-0 flex flex-col overflow-hidden" style={frameStyle[frame]}>
-			{#if error}
-				<div class="p-4 text-xs text-red-600 font-mono whitespace-pre-wrap">{error}</div>
-			{:else if seeded}
-				{#key seeded}
-					<FlowPathViewer path={seeded} {noSide} {fillAvailableHeight} />
-				{/key}
-			{:else}
-				<div class="p-4 text-xs text-tertiary">Seeding the fixture flow…</div>
-			{/if}
+			<Toggle bind:checked={noSide} size="xs" options={{ right: 'noSide' }} />
+			<Toggle
+				bind:checked={fillAvailableHeight}
+				size="xs"
+				options={{ right: 'fillAvailableHeight' }}
+			/>
+
+			<ToggleButtonGroup bind:selected={frame} noWFull>
+				{#snippet children({ item })}
+					<ToggleButton value="full" label="Full page" {item} />
+					<ToggleButton value="panel" label="Raw-app pane (55%)" {item} />
+					<ToggleButton value="short" label="Short (260px)" {item} />
+				{/snippet}
+			</ToggleButtonGroup>
+
+			<Button
+				unifiedSize="xs"
+				variant="default"
+				loading={seeding}
+				onclick={() => $workspaceStore && seed($workspaceStore, path)}
+			>
+				Re-seed
+			</Button>
+		</div>
+
+		<div class="grow min-h-0 p-4">
+			<div class="border rounded min-h-0 flex flex-col overflow-hidden" style={frameStyle[frame]}>
+				{#if error}
+					<div class="p-4 text-xs text-red-600 font-mono whitespace-pre-wrap">{error}</div>
+				{:else if seeded}
+					{#key seeded}
+						<FlowPathViewer path={seeded} {noSide} {fillAvailableHeight} />
+					{/key}
+				{:else}
+					<div class="p-4 text-xs text-tertiary">Seeding the fixture flow…</div>
+				{/if}
+			</div>
 		</div>
 	</div>
-</div>
+{/if}

--- a/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/+page.svelte
@@ -4,11 +4,11 @@
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import FlowPathViewer from '$lib/components/flows/content/FlowPathViewer.svelte'
-	import { FlowService } from '$lib/gen'
+	import { FlowService, type OpenFlow } from '$lib/gen'
 	import { userStore, workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { untrack } from 'svelte'
-	import { fixtureFlow } from './fixtureFlow'
+	import { fixtureFlow, subFixtureFlow } from './fixtureFlow'
 
 	// FlowPathViewer takes a path and fetches, so the fixture has to exist in the workspace.
 	// Seeding on load keeps fixtureFlow.ts the single source of truth for the graph.
@@ -30,23 +30,23 @@
 		short: 'height: 260px; width: 100%'
 	}
 
+	async function upsert(workspace: string, p: string, flow: OpenFlow) {
+		const body = { path: p, ...flow, deployment_message: 'dev fixture' }
+		if (await FlowService.existsFlowByPath({ workspace, path: p })) {
+			await FlowService.updateFlow({ workspace, path: p, requestBody: body })
+		} else {
+			await FlowService.createFlow({ workspace, requestBody: body })
+		}
+	}
+
 	async function seed(workspace: string, p: string) {
 		seeding = true
 		error = undefined
 		try {
-			const exists = await FlowService.existsFlowByPath({ workspace, path: p })
-			if (exists) {
-				await FlowService.updateFlow({
-					workspace,
-					path: p,
-					requestBody: { path: p, ...fixtureFlow, deployment_message: 'dev fixture' }
-				})
-			} else {
-				await FlowService.createFlow({
-					workspace,
-					requestBody: { path: p, ...fixtureFlow, deployment_message: 'dev fixture' }
-				})
-			}
+			// Subflow first: the main fixture's step 'm' points at it, and a step whose target
+			// does not exist renders as not-found instead of a nested graph.
+			await upsert(workspace, `${p}_sub`, subFixtureFlow)
+			await upsert(workspace, p, fixtureFlow(`${p}_sub`))
 			seeded = undefined
 			await new Promise((r) => setTimeout(r, 0))
 			seeded = p

--- a/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/fixtureFlow.ts
+++ b/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/fixtureFlow.ts
@@ -17,13 +17,24 @@ function step(
 
 const js = (expr: string) => ({ type: 'javascript' as const, expr })
 
+/** Target of the fixture's subflow step, so the step panel has a nested graph to draw. */
+export const subFixtureFlow: OpenFlow = {
+	summary: 'Refund a line item (dev fixture subflow)',
+	value: {
+		modules: [
+			step('a', 'Void the charge', 'bun', 'export async function main() {}\n'),
+			step('b', 'Restock the item', 'python3', 'def main():\n    return "restocked"\n')
+		]
+	}
+}
+
 /**
  * Shape of the graph this fixture draws, so a change here can be judged against intent:
  * a straight step, a for-loop with two nested steps, a three-way branchone, a branchall
- * with a skip_failure branch, a step carrying retry/cache/early-stop badges, plus a
- * failure module, a preprocessor, a note and a group.
+ * with a skip_failure branch, a subflow, a step carrying retry/cache/early-stop badges,
+ * plus a failure module, a preprocessor, a note and a group.
  */
-export const fixtureFlow: OpenFlow = {
+export const fixtureFlow = (subflowPath: string): OpenFlow => ({
 	summary: 'Order fulfilment (dev fixture)',
 	description:
 		'Fake flow rendered by /dev/flow_path_viewer. Edit fixtureFlow.ts and hit Re-seed to change the graph.',
@@ -101,6 +112,11 @@ export const fixtureFlow: OpenFlow = {
 					]
 				}
 			},
+			{
+				id: 'm',
+				summary: 'Refund rejected items',
+				value: { type: 'flow', input_transforms: {}, path: subflowPath }
+			},
 			step('l', 'Close the order', 'python3', 'def main():\n    return "done"\n', {
 				retry: { constant: { attempts: 3, seconds: 5 } },
 				cache_ttl: 3600,
@@ -138,4 +154,4 @@ export const fixtureFlow: OpenFlow = {
 			}
 		]
 	}
-}
+})

--- a/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/fixtureFlow.ts
+++ b/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/fixtureFlow.ts
@@ -36,8 +36,6 @@ export const subFixtureFlow: OpenFlow = {
  */
 export const fixtureFlow = (subflowPath: string): OpenFlow => ({
 	summary: 'Order fulfilment (dev fixture)',
-	description:
-		'Fake flow rendered by /dev/flow_path_viewer. Edit fixtureFlow.ts and hit Re-seed to change the graph.',
 	schema: {
 		$schema: 'https://json-schema.org/draft/2020-12/schema',
 		type: 'object',

--- a/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/fixtureFlow.ts
+++ b/frontend/src/routes/(root)/(logged)/dev/flow_path_viewer/fixtureFlow.ts
@@ -1,0 +1,141 @@
+import type { FlowModule, OpenFlow } from '$lib/gen'
+
+function step(
+	id: string,
+	summary: string,
+	language: 'python3' | 'bun' | 'deno' | 'bash' | 'postgresql',
+	content: string,
+	extra: Partial<FlowModule> = {}
+): FlowModule {
+	return {
+		id,
+		summary,
+		value: { type: 'rawscript', input_transforms: {}, language, content },
+		...extra
+	}
+}
+
+const js = (expr: string) => ({ type: 'javascript' as const, expr })
+
+/**
+ * Shape of the graph this fixture draws, so a change here can be judged against intent:
+ * a straight step, a for-loop with two nested steps, a three-way branchone, a branchall
+ * with a skip_failure branch, a step carrying retry/cache/early-stop badges, plus a
+ * failure module, a preprocessor, a note and a group.
+ */
+export const fixtureFlow: OpenFlow = {
+	summary: 'Order fulfilment (dev fixture)',
+	description:
+		'Fake flow rendered by /dev/flow_path_viewer. Edit fixtureFlow.ts and hit Re-seed to change the graph.',
+	schema: {
+		$schema: 'https://json-schema.org/draft/2020-12/schema',
+		type: 'object',
+		properties: {
+			order_id: { type: 'string', description: 'Order to fulfil', default: 'ord_1234' },
+			warehouse: {
+				type: 'string',
+				description: 'Warehouse to reserve stock from',
+				enum: ['eu-west', 'us-east', 'ap-south'],
+				default: 'eu-west'
+			},
+			max_items: { type: 'integer', description: 'Cap on line items', default: 25 },
+			dry_run: { type: 'boolean', description: 'Skip every side effect', default: true }
+		},
+		required: ['order_id'],
+		order: ['order_id', 'warehouse', 'max_items', 'dry_run']
+	},
+	value: {
+		modules: [
+			step('a', 'Fetch order', 'python3', 'def main(order_id: str):\n    return {"items": []}\n'),
+			{
+				id: 'b',
+				summary: 'For each line item',
+				value: {
+					type: 'forloopflow',
+					iterator: js('results.a.items'),
+					skip_failures: false,
+					parallel: true,
+					parallelism: js('4'),
+					modules: [
+						step('c', 'Reserve stock', 'bun', 'export async function main() {}\n'),
+						step('d', 'Write warehouse ledger', 'postgresql', 'INSERT INTO ledger VALUES ($1);\n')
+					]
+				}
+			},
+			{
+				id: 'e',
+				summary: 'Route by payment status',
+				value: {
+					type: 'branchone',
+					branches: [
+						{
+							summary: 'Paid',
+							expr: 'results.a.status === "paid"',
+							modules: [step('f', 'Ship immediately', 'bun', 'export async function main() {}\n')]
+						},
+						{
+							summary: 'Awaiting capture',
+							expr: 'results.a.status === "pending"',
+							modules: [step('g', 'Hold for capture', 'bun', 'export async function main() {}\n')]
+						}
+					],
+					default: [step('h', 'Flag for review', 'bash', 'echo "manual review"\n')]
+				}
+			},
+			{
+				id: 'i',
+				summary: 'Fan out notifications',
+				value: {
+					type: 'branchall',
+					parallel: true,
+					branches: [
+						{
+							summary: 'Customer email',
+							modules: [step('j', 'Send email', 'bun', 'export async function main() {}\n')]
+						},
+						{
+							summary: 'Internal Slack',
+							skip_failure: true,
+							modules: [step('k', 'Post to Slack', 'bun', 'export async function main() {}\n')]
+						}
+					]
+				}
+			},
+			step('l', 'Close the order', 'python3', 'def main():\n    return "done"\n', {
+				retry: { constant: { attempts: 3, seconds: 5 } },
+				cache_ttl: 3600,
+				stop_after_if: { expr: 'result === "done"', skip_if_stopped: true }
+			})
+		],
+		failure_module: step(
+			'failure',
+			'Report the failure',
+			'bun',
+			'export async function main(error: any) {}\n'
+		),
+		preprocessor_module: step(
+			'preprocessor',
+			'Normalise the trigger payload',
+			'bun',
+			'export async function main(event: any) {\n\treturn event\n}\n'
+		),
+		notes: [
+			{
+				id: 'note_1',
+				type: 'free',
+				color: 'yellow',
+				text: 'Stock reservation is idempotent — replaying the loop is safe.',
+				position: { x: 420, y: 120 },
+				size: { width: 220, height: 90 }
+			}
+		],
+		groups: [
+			{
+				summary: 'Fulfilment',
+				note: 'Everything between reserving stock and routing on payment.',
+				start_id: 'b',
+				end_id: 'e'
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

The flow viewer inside the raw app editor was unusable: the graph rendered at 55% width with the Test panel glued to its right, and the step-details panel took a fixed third of what remained. This makes the step panel resizable, and below a width breakpoint moves it out of the layout entirely — the same Auto / Attached / Detached rule the flow editor already uses, off the same breakpoint.

Because the placement rule was already factored out into `flows/panelPlacement.ts` and `FlowGraphV2` already renders the placement picker, most of this is wiring the viewer into machinery that exists rather than new mechanism.

## Changes

**Raw app editor**
- The backend-runnable panel splits the viewer and the Test panel into separate full-width tabs (Flow/Script · Test · Inputs) instead of a 55/45 split. Running from the by-path toolbar switches to Test, so results appear where you are looking.

**Flow graph viewer** (`FlowGraphViewer`, shared by `/flows/get`, `FlowViewer`, `FlowStatusViewerInner` and the app/raw-app runnable panels)
- The step panel is a resizable `<Pane>` (66/34) instead of a fixed `grid-cols-3` cell.
- Below `MODAL_PANEL_BREAKPOINT` (1280) it detaches: the graph takes the full width and the panel opens in a dialog on double-click, or on a click on the already-selected step. Same gestures and the same standing hint as the editor.
- Width is measured on the component, not the window — the viewer is routinely embedded in a pane far narrower than the screen.
- Provides the `flowPanelDetach` context, which is what surfaces the Auto / Attached / Detached picker in the graph's control bar. The picker is also in the dialog header, since the control bar is behind it once detached.
- The `sm`-breakpoint gate on the step panel is gone — a `Pane` keeps its width even when its content is `display: none`, so the breakpoint now decides whether the pane exists.

**Supporting**
- `flows/stepLabel.ts`: the step's display name, previously a 25-line `{#if}` chain inside `FlowGraphViewerStep`'s markup, extracted so the panel and the dialog title can't disagree. The `failure` / `preprocessor` id checks stay between the composite types and the leaf script types, so an error handler reads "Error handler" and not "Inline bun script".
- `FlowGraphViewerStep`: `class` and `hideHeader` props, so a host that pads, scrolls and names the panel itself doesn't get it twice. Defaults are unchanged for the other four callers.
- `Modal`: `titleBadgeFirst`, for a badge that identifies the subject (a step id reads before the name) rather than qualifying it (a "Beta" tag reads after). The plain header row also gets the `pr-8` that the breadcrumb row already had under `kind="X"`, so a long title or anything in `settings` stops running under the close button.
- `FlowGraphV2`: the control bar carries the opaque surface. `surface-hover` is a translucent token, so a hovered button that only swapped its own background composited that tint straight onto the graph.
- `/dev/flow_path_viewer`: a dev harness rendering `FlowPathViewer` against a seeded fixture flow, with toggles for `noSide`, `fillAvailableHeight` and the container size, for iterating on the viewer without hunting for a flow that exercises every node type.

## Screenshots

Attached — resizable pane, picker in the control bar:

![attached](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-raw-app-flow-viewer/1787747134-pr-1-attached.png)

Detached below the breakpoint — graph full-width, standing hint bottom-left:

![detached](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-raw-app-flow-viewer/1787747134-pr-2-detached.png)

The step dialog, titled by id and summary:

![dialog](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-raw-app-flow-viewer/1787747134-pr-3-dialog.png)

## Test plan

- [ ] `/dev/flow_path_viewer` — drag the splitter; the graph re-lays out and the inputs table stops clipping its `Format` / `Required` columns.
- [ ] Same page, "Raw-app pane (55%)" — the panel detaches; double-click a step, then Escape, then single-click the selected step to reopen.
- [ ] Widen the window past 1280 with the dialog open — it closes and the pane comes back.
- [ ] Control bar picker → Detached with a step selected: the dialog opens on that step, not empty. Attached from the dialog header puts it back.
- [ ] Hover any control-bar button: the hover shade is opaque, not a window onto the graph.
- [ ] Raw app editor → a workspace-flow backend runnable: Flow / Test / Inputs are separate full-width tabs; Run from the toolbar lands on Test.
- [ ] `/flows/get/<path>` and the flow editor's subflow step still render.

## Not covered

- Two `FlowPathViewer` drawers (`ScriptPicker`, the runnable toolbar's Expand) are 900px and 1200px, both under the breakpoint, so they now open detached. Not exercised.
- No `feature_usage` instrumentation. The editor's equivalent has `useFlowPanelPlacementTelemetry`; adding it here needs a backend allowlist entry and disclosure copy, so it is left out deliberately.

## Review round 1 fixes

- **The graph is no longer re-created when the panel moves.** It was rendered from two `{#if}` branches, so every docked↔modal transition destroyed and rebuilt `FlowGraphV2` — losing pan, zoom and the selected node — and every embed under 1280 mounted it twice, since width starts at 0 and 0 resolves to docked. It now lives in one persistent `Pane` sized 100 or 66, with only the step pane conditional, matching `FlowEditor.svelte:343`. Verified by tagging the `.svelte-flow` element and watching it survive both transitions.
- **`FlowModuleComponent.svelte:1080` now passes `noSide`.** The flow editor's own subflow step was detaching and shadowing the editor's `flowPanelDetach` context — the earlier "Not covered" note wrongly claimed the nested case was unaffected, which was only true of `FlowGraphViewerStep.svelte:314`.
- **`wasVisible` no longer counts a pane that renders nothing.** Under `hideDefaultInputs` with no selection, Detached opened an empty dialog.
- **The step dialog is actually 896px wide.** `max-w-4xl` lost the cascade to `Modal`'s own `sm:max-w-lg`; `sm:max-w-4xl` wins it.
- **The dev harness can't clobber a real flow.** It stamps every flow it deploys and refuses to overwrite one it didn't create, and the whole route is behind `import.meta.env.DEV`.
- **`stepLabel.test.ts`** pins the ordering the extraction had to preserve — summary first, `failure`/`preprocessor` between the composite and leaf types, and the parenthesised suffixes.

The step dialog at its intended width:

![dialog](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-raw-app-flow-viewer/1787749279-dialog-wide.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eu85JrwsztjfXGNQAATRz
