### PR TITLE
fix: recover from unresolvable AI session links instead of a dead end

### DIFF
--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -36,6 +36,7 @@
 		setNewSessionWorkspace,
 		setSessionArchived,
 		syncWorkspaceTo,
+		withOpenSessionTeardown,
 		type Session
 	} from './sessionState.svelte'
 	import { unreadCountFor } from './sessionUnread.svelte'
@@ -571,8 +572,8 @@
 
 	// After deleting the open session, land somewhere usable: the newest remaining
 	// session, else a fresh one. The page derives the visible session from the
-	// `session_name` query, so leaving the URL on a deleted session would render
-	// its not-found state instead of a ready-to-type composer.
+	// `session_name` query, so leaving the URL on a deleted session would fall
+	// through to recovery and open a blank one rather than their recent work.
 	async function openReplacementSession() {
 		const next = sessionState.sessions[0]
 		if (next) await activate(next)
@@ -590,9 +591,11 @@
 		if (ids.length === 0) return
 		const current = sessionState.currentSessionId
 		const wasActive = !!current && ids.includes(current)
-		for (const id of ids) removeSession(id)
-		exitSelectionMode()
-		if (wasActive) await openReplacementSession()
+		await withOpenSessionTeardown(async () => {
+			for (const id of ids) removeSession(id)
+			exitSelectionMode()
+			if (wasActive) await openReplacementSession()
+		})
 	}
 
 	async function handleConfirmedDelete() {
@@ -608,23 +611,25 @@
 		deleteAlsoFork = false
 		if (!session) return
 		const wasActive = sessionState.currentSessionId === session.id
-		removeSession(session.id)
-		if (forkToDelete) {
-			try {
-				await WorkspaceService.deleteWorkspace({ workspace: forkToDelete })
-				await deleteSessionsForWorkspace(forkToDelete)
-				sendUserToast(`Deleted forked workspace ${forkToDelete}`)
-				await reconcileAfterWorkspaceChange()
-			} catch (e: any) {
-				sendUserToast(`Failed to delete fork ${forkToDelete}: ${e?.body ?? e}`, true)
+		await withOpenSessionTeardown(async () => {
+			removeSession(session.id)
+			if (forkToDelete) {
+				try {
+					await WorkspaceService.deleteWorkspace({ workspace: forkToDelete })
+					await deleteSessionsForWorkspace(forkToDelete)
+					sendUserToast(`Deleted forked workspace ${forkToDelete}`)
+					await reconcileAfterWorkspaceChange()
+				} catch (e: any) {
+					sendUserToast(`Failed to delete fork ${forkToDelete}: ${e?.body ?? e}`, true)
+				}
 			}
-		}
-		// If the deleted fork was the active workspace, fall back to its parent
-		// so the user isn't stranded on a workspace that no longer exists.
-		if (forkToDelete && forkParentId && $workspaceStore === forkToDelete) {
-			syncWorkspaceTo(forkParentId)
-		}
-		if (wasActive) await openReplacementSession()
+			// If the deleted fork was the active workspace, fall back to its parent
+			// so the user isn't stranded on a workspace that no longer exists.
+			if (forkToDelete && forkParentId && $workspaceStore === forkToDelete) {
+				syncWorkspaceTo(forkParentId)
+			}
+			if (wasActive) await openReplacementSession()
+		})
 	}
 
 	function focusAt(index: number) {

--- a/frontend/src/lib/components/sessions/SessionWrapper.svelte
+++ b/frontend/src/lib/components/sessions/SessionWrapper.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setContext, untrack } from 'svelte'
+	import { onDestroy, setContext, untrack } from 'svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import AIChat from '$lib/components/copilot/chat/AIChat.svelte'
 	import SessionsBetaBanner from './SessionsBetaBanner.svelte'
@@ -21,14 +21,17 @@
 		ArrowUpRight,
 		EllipsisVertical,
 		ExternalLink,
+		MessageSquareDashed,
 		Pencil,
 		Settings,
-		Trash2
+		Trash2,
+		X
 	} from 'lucide-svelte'
 	import { type Item } from '$lib/utils'
 	import WorkspaceScopeTrigger from '$lib/components/WorkspaceScopeTrigger.svelte'
 	import SessionWorkspaceBar from './SessionWorkspaceBar.svelte'
 	import SessionChangesBar from './SessionChangesBar.svelte'
+	import { clearSessionRecovered, isSessionRecovered } from './sessionRecoveryNotice.svelte'
 	import {
 		composerFocusRequest,
 		createSession,
@@ -45,7 +48,8 @@
 		selectSession,
 		sessionState,
 		setSessionArchived,
-		syncWorkspaceTo
+		syncWorkspaceTo,
+		withOpenSessionTeardown
 	} from './sessionState.svelte'
 	import { getOrCreateRuntime, removeSession } from './sessionRuntime.svelte'
 	import { goto } from '$lib/navigation'
@@ -161,8 +165,8 @@
 		const fresh = createSession()
 		selectSession(fresh.id)
 		// The page derives the visible session from the `session_name` query, not
-		// currentSessionId — navigate so the URL leaves the deleted/archived session
-		// (else it renders the not-found state or stays on the archived one).
+		// currentSessionId: navigate so the URL leaves the deleted/archived session,
+		// which would otherwise fall through to recovery or stay on the archived one.
 		await goto(`/sessions?session_name=${encodeURIComponent(fresh.name)}`)
 	}
 
@@ -196,24 +200,26 @@
 			? $userWorkspaces.find((w) => w.id === forkToDelete)?.parent_workspace_id
 			: undefined
 		deleteAlsoFork = false
-		removeSession(sessionId)
-		if (forkToDelete) {
-			try {
-				await WorkspaceService.deleteWorkspace({ workspace: forkToDelete })
-				await deleteSessionsForWorkspace(forkToDelete)
-				sendUserToast(`Deleted forked workspace ${forkToDelete}`)
-				await reconcileAfterWorkspaceChange()
-			} catch (e: any) {
-				sendUserToast(`Failed to delete fork ${forkToDelete}: ${e?.body ?? e}`, true)
+		await withOpenSessionTeardown(async () => {
+			removeSession(sessionId)
+			if (forkToDelete) {
+				try {
+					await WorkspaceService.deleteWorkspace({ workspace: forkToDelete })
+					await deleteSessionsForWorkspace(forkToDelete)
+					sendUserToast(`Deleted forked workspace ${forkToDelete}`)
+					await reconcileAfterWorkspaceChange()
+				} catch (e: any) {
+					sendUserToast(`Failed to delete fork ${forkToDelete}: ${e?.body ?? e}`, true)
+				}
 			}
-		}
-		// If the deleted fork was the active workspace, fall back to its parent
-		// so the new session (created below) opens against a live workspace
-		// instead of the one we just removed.
-		if (forkToDelete && forkParentId && $workspaceStore === forkToDelete) {
-			syncWorkspaceTo(forkParentId)
-		}
-		await resetToNewSession()
+			// If the deleted fork was the active workspace, fall back to its parent
+			// so the new session (created below) opens against a live workspace
+			// instead of the one we just removed.
+			if (forkToDelete && forkParentId && $workspaceStore === forkToDelete) {
+				syncWorkspaceTo(forkParentId)
+			}
+			await resetToNewSession()
+		})
 	}
 
 	async function handleConfirmedArchive() {
@@ -260,6 +266,22 @@
 		runtime?.manager.displayMessages.some((m) => m.role === 'user') ?? false
 	)
 
+	// Gated on the first message, not on typing: the notice sits directly above a
+	// vertically centred composer, so dropping it mid-sentence would jump the
+	// field out from under the user's cursor.
+	const showRecoveryNotice = $derived(isSessionRecovered(sessionId) && !hasFirstUserMessage)
+
+	// The notice explains one arrival, and the arrival is exactly "this page is
+	// open, on this session, nothing sent yet". Spend the marker the moment any of
+	// those three breaks, so a later return can never replay it — masking it behind
+	// the gate above instead leaves it to resurface. Dismiss is the user's own exit.
+	$effect(() => {
+		if (hasFirstUserMessage || sessionState.currentSessionId !== sessionId) {
+			clearSessionRecovered(sessionId)
+		}
+	})
+	onDestroy(() => clearSessionRecovered(sessionId))
+
 	// Focus the chat input whenever this session is the active one.
 	// The textarea is disabled until copilotInfo loads (otherwise focus is
 	// a silent no-op), so we wait for that too. Triggers on initial mount,
@@ -304,6 +326,12 @@
 		if (!session) return
 		await moveSessionToNewFork(session.id, fork)
 	}
+
+	// Chrome shared by the banners stacked above the composer, so restyling one
+	// can't leave the others behind. Each supplies its own background: two bg-*
+	// utilities on one element resolve by stylesheet order, not attribute order.
+	const bannerClass =
+		'flex flex-row items-center justify-between gap-2 py-2 px-3 text-xs border rounded-md'
 </script>
 
 {#snippet externalLinkHint()}
@@ -314,6 +342,32 @@
 	<div class="p-8 text-secondary text-sm">Session not found</div>
 {:else}
 	{#snippet inputPreface()}
+		{#if showRecoveryNotice}
+			<!-- mb-6, not the banner column's mb-1: at that gap it reads as one more
+			     row of composer chrome rather than as a message about the session. -->
+			<!-- Tinted, where the other banners are white: this one has to be spotted
+			     without being looked for, above a composer the user is already typing in. -->
+			<!-- Announced: the composer takes focus the moment this appears, so without
+			     it a screen reader lands in an empty field with no account of the swap. -->
+			<div role="status" class="{bannerClass} bg-surface-accent-selected mb-6">
+				<div class="flex flex-row items-center gap-2 min-w-0">
+					<MessageSquareDashed class="w-4 h-4 shrink-0 text-accent" />
+					<!-- Names no cause: deleted, another browser, cleared site data and a
+					     damaged link are indistinguishable from here. The empty session it
+					     landed on is on screen, so the notice doesn't describe it. -->
+					<span class="text-emphasis font-semibold">We couldn't find that session</span>
+				</div>
+				<Button
+					variant="subtle"
+					unifiedSize="2xs"
+					iconOnly
+					startIcon={{ icon: X }}
+					title="Dismiss"
+					aria-label="Dismiss"
+					onclick={() => clearSessionRecovered(sessionId)}
+				/>
+			</div>
+		{/if}
 		{#if !hasFirstUserMessage}
 			<SessionWorkspaceBar {session} />
 		{/if}
@@ -328,9 +382,7 @@
 				     and reconcile would re-archive a workspace-archived one anyway. When
 				     the workspace is unavailable the SessionChangesBar below shows the
 				     move/discard banner instead (its actions are the real recovery path). -->
-				<div
-					class="flex flex-row items-center justify-between gap-2 py-2 px-3 text-xs border rounded-md bg-surface-tertiary"
-				>
+				<div class="{bannerClass} bg-surface-tertiary">
 					<div class="flex flex-row items-center gap-2 min-w-0">
 						<Archive class="w-4 h-4 shrink-0 text-tertiary" />
 						<span class="text-primary font-medium">This session is archived</span>

--- a/frontend/src/lib/components/sessions/SessionWrapper.svelte
+++ b/frontend/src/lib/components/sessions/SessionWrapper.svelte
@@ -84,8 +84,7 @@
 	// an intent this wrapper will not claim — stale, or armed on a session the
 	// page is only keeping warm in the background — still gets a composer, whose
 	// mount-time empty draft would otherwise erase the prompt from the record.
-	const armedAtInit =
-		sessionState.currentSessionId === sessionId && peekSessionAutoSend(sessionId)
+	const armedAtInit = sessionState.currentSessionId === sessionId && peekSessionAutoSend(sessionId)
 
 	// A hand-off whose click already stated the intent asks for its prompt to be
 	// sent, not parked. Reactive rather than mount-time: `createSession` reuses an
@@ -197,7 +196,7 @@
 			? $userWorkspaces.find((w) => w.id === forkToDelete)?.parent_workspace_id
 			: undefined
 		deleteAlsoFork = false
-		removeSession(session.id)
+		removeSession(sessionId)
 		if (forkToDelete) {
 			try {
 				await WorkspaceService.deleteWorkspace({ workspace: forkToDelete })

--- a/frontend/src/lib/components/sessions/sessionRecoveryNotice.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRecoveryNotice.svelte.ts
@@ -1,0 +1,18 @@
+import { SvelteSet } from 'svelte/reactivity'
+
+// Session ids opened as a stand-in for a `session_name` this browser doesn't
+// hold. Kept in memory rather than on the Session record: persisted, the notice
+// would replay on every reload of a session the user has since made their own.
+const recovered = new SvelteSet<string>()
+
+export function markSessionRecovered(id: string): void {
+	recovered.add(id)
+}
+
+export function isSessionRecovered(id: string): boolean {
+	return recovered.has(id)
+}
+
+export function clearSessionRecovered(id: string): void {
+	recovered.delete(id)
+}

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -21,6 +21,7 @@ import {
 import { getLocalSetting, storeLocalSetting } from '$lib/utils'
 import { logFeatureUsage } from '$lib/utils/featureUsage'
 import { workspaceRootId } from './sessionScope.svelte'
+import { clearSessionRecovered } from './sessionRecoveryNotice.svelte'
 import { type DBSchema, type IDBPDatabase } from 'idb'
 import { userScopedDb } from '$lib/userScopedDb'
 import { deleteItemsForSession } from '../copilot/chat/files/attachedFilesDB'
@@ -343,8 +344,8 @@ export function setSessionDraftPrompt(sessionId: string, text: string): void {
 	if ((s.draftPrompt ?? '') === text) return
 	// Keep `transient` (means "in-memory only") set until the flush persists the
 	// draft, so hydrateSessions preserves it across a reconcile inside this window;
-	// isReusableBlank, not `transient`, is what stops createSession reusing a typed
-	// draft. Only the IndexedDB write is debounced.
+	// isDiscardableDraft, not `transient`, is what stops createSession reusing a
+	// typed draft. Only the IndexedDB write is debounced.
 	s.draftPrompt = text
 	clearTimeout(draftPromptFlushHandles.get(sessionId))
 	draftPromptFlushHandles.set(
@@ -748,12 +749,30 @@ export function requestComposerFocus(): void {
 	composerFocusRequest.nonce++
 }
 
-// An untouched in-memory blank that `+` may reuse/discard. `draftPrompt ===
-// undefined` (never edited), not falsiness: a draft typed then erased to '' still
-// has a pending flush and is a real session, so it must survive both. Every other
+// An untouched in-memory blank that `+` may reuse and createSession may silently
+// drop. `draftPrompt === undefined` (never edited), not falsiness: a draft typed
+// then erased to '' still has a pending flush and is a real session. Every other
 // touch clears `transient` synchronously, so only the draft prompt needs checking.
-function isReusableBlank(s: Session): boolean {
+function isDiscardableDraft(s: Session): boolean {
 	return !!s.transient && s.draftPrompt === undefined
+}
+
+// Somewhere empty to put the user, for a URL naming a session this browser
+// doesn't hold. Only `transient` makes "empty" trustworthy: chat seeding and
+// attached-file persistence both key off `!transient` and leave every field
+// below untouched, so a persisted session can hold a conversation regardless.
+export function findEmptyLandingSession(): Session | undefined {
+	return sessionState.sessions.find(
+		(s) =>
+			!!s.transient &&
+			!s.archived &&
+			!s.workspace_id &&
+			// Falsiness, not `=== undefined`: we only navigate into the session, so a
+			// draft erased back to '' is still an empty composer to land on.
+			!s.draftPrompt?.trim() &&
+			!s.pending_fork &&
+			sessionInCurrentFamily(s)
+	)
 }
 
 export function createSession(): Session {
@@ -762,16 +781,20 @@ export function createSession(): Session {
 	// in parallel, one touch at a time. A cross-family leftover blank is dropped
 	// instead of reused (reusing it would act on that family).
 	const reusable = sessionState.sessions.find(
-		(s) => isReusableBlank(s) && sessionInCurrentFamily(s)
+		(s) => isDiscardableDraft(s) && sessionInCurrentFamily(s)
 	)
 	if (reusable) {
 		sessionState.currentSessionId = reusable.id
+		// The blank recovery just landed on is exactly what this reuses, so `+`
+		// would otherwise hand back a session still carrying the recovery notice:
+		// asking for a new session must not be answered with "we couldn't find it".
+		clearSessionRecovered(reusable.id)
 		// Reusing an already-active draft doesn't change currentSessionId, so ask
 		// the composer to focus explicitly — the caller still navigates/redirects.
 		requestComposerFocus()
 		return reusable
 	}
-	sessionState.sessions = sessionState.sessions.filter((s) => !isReusableBlank(s))
+	sessionState.sessions = sessionState.sessions.filter((s) => !isDiscardableDraft(s))
 	const existingNumbers = sessionState.sessions
 		.map((s) => /^session-(\d+)$/.exec(s.name)?.[1])
 		.map((n) => (n ? parseInt(n, 10) : 0))
@@ -1085,6 +1108,24 @@ export function setSessionArchived(id: string, archived: boolean) {
 		delete s.archivedByWorkspace
 	}
 	persistTouched(s)
+}
+
+// A counter rather than a flag: an inner teardown finishing must not reopen the
+// gate while an outer one is still running. Released in a finally, so a delete
+// that throws can't wedge it shut.
+let openSessionTeardowns = $state(0)
+
+export function isTearingDownOpenSession(): boolean {
+	return openSessionTeardowns > 0
+}
+
+export async function withOpenSessionTeardown<T>(run: () => Promise<T>): Promise<T> {
+	openSessionTeardowns++
+	try {
+		return await run()
+	} finally {
+		openSessionTeardowns--
+	}
 }
 
 export function deleteSession(id: string) {

--- a/frontend/src/lib/components/sessions/sessionState.test.ts
+++ b/frontend/src/lib/components/sessions/sessionState.test.ts
@@ -4,14 +4,22 @@ import {
 	commitSessionWorkspace,
 	createSession,
 	decideSessionLifecycle,
+	findEmptyLandingSession,
 	isForkSession,
+	isTearingDownOpenSession,
 	renameSession,
 	sessionInCurrentFamily,
 	setGeneratedSessionSummary,
 	setSessionDraftPrompt,
 	sessionState,
+	withOpenSessionTeardown,
 	type Session
 } from './sessionState.svelte'
+import {
+	clearSessionRecovered,
+	isSessionRecovered,
+	markSessionRecovered
+} from './sessionRecoveryNotice.svelte'
 import {
 	enterpriseLicense,
 	usersWorkspaceStore,
@@ -362,6 +370,28 @@ describe('createSession — reuses an untouched draft, family-scoped', () => {
 		}
 	})
 
+	it('clears the recovery notice off the draft it reuses, so `+` is not answered with "not found"', () => {
+		const restore = withTwoFamilies('rootA')
+		const prevCurrent = sessionState.currentSessionId
+		const landed = session({
+			id: 'recovered-blank',
+			name: 'session-903',
+			pending_workspace_id: 'forkA',
+			transient: true
+		})
+		sessionState.sessions.push(landed)
+		markSessionRecovered(landed.id)
+		try {
+			expect(createSession().id).toBe('recovered-blank')
+			expect(isSessionRecovered('recovered-blank')).toBe(false)
+		} finally {
+			clearSessionRecovered('recovered-blank')
+			sessionState.sessions = sessionState.sessions.filter((s) => s.id !== 'recovered-blank')
+			sessionState.currentSessionId = prevCurrent
+			restore()
+		}
+	})
+
 	it('drops an untouched draft left over from another family and starts in the active workspace', () => {
 		const restore = withTwoFamilies('rootB')
 		const prevCurrent = sessionState.currentSessionId
@@ -486,5 +516,80 @@ describe('createSession — reuses an untouched draft, family-scoped', () => {
 			sessionState.currentSessionId = prevCurrent
 			restore()
 		}
+	})
+})
+
+describe('findEmptyLandingSession — where an unresolvable session link lands', () => {
+	it('takes an untouched draft', () => {
+		const restore = withTwoFamilies('forkA')
+		const blank = session({
+			id: 'landing-blank',
+			name: 'session-910',
+			pending_workspace_id: 'forkA',
+			transient: true
+		})
+		sessionState.sessions.push(blank)
+		try {
+			expect(findEmptyLandingSession()?.id).toBe('landing-blank')
+		} finally {
+			sessionState.sessions = sessionState.sessions.filter((s) => s.id !== 'landing-blank')
+			restore()
+		}
+	})
+
+	it('passes over a persisted session, onto which chat seeding can graft a conversation', () => {
+		const restore = withTwoFamilies('forkA')
+		// ensureChatIdsSeeded assigns untagged legacy chats to `!transient` sessions
+		// and initRuntime loads them, without touching a field checked here.
+		const abandoned = session({
+			id: 'landing-abandoned',
+			name: 'session-910',
+			pending_workspace_id: 'forkA'
+		})
+		const others = sessionState.sessions
+		sessionState.sessions = [abandoned]
+		try {
+			expect(findEmptyLandingSession()).toBeUndefined()
+		} finally {
+			sessionState.sessions = others
+			restore()
+		}
+	})
+
+	it('passes over a session that has been sent, so recovery never reopens a conversation', () => {
+		const restore = withTwoFamilies('forkA')
+		const sent = session({ id: 'landing-sent', name: 'session-911', workspace_id: 'forkA' })
+		// Sole candidate, so `undefined` pins the exclusion: `not.toBe` would also
+		// pass on any unrelated session the shared module state happens to hold.
+		const others = sessionState.sessions
+		sessionState.sessions = [sent]
+		try {
+			expect(findEmptyLandingSession()).toBeUndefined()
+		} finally {
+			sessionState.sessions = others
+			restore()
+		}
+	})
+})
+
+describe('withOpenSessionTeardown — the gate that holds recovery off during a delete', () => {
+	it('stays shut until the outermost teardown finishes', async () => {
+		let innerDone = false
+		await withOpenSessionTeardown(async () => {
+			await withOpenSessionTeardown(async () => {})
+			innerDone = true
+			expect(isTearingDownOpenSession()).toBe(true)
+		})
+		expect(innerDone).toBe(true)
+		expect(isTearingDownOpenSession()).toBe(false)
+	})
+
+	it('reopens when the teardown throws, so a failed delete cannot wedge recovery shut', async () => {
+		await expect(
+			withOpenSessionTeardown(async () => {
+				throw new Error('fork deletion failed')
+			})
+		).rejects.toThrow('fork deletion failed')
+		expect(isTearingDownOpenSession()).toBe(false)
 	})
 })

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from 'svelte'
+	import { onMount, tick, untrack } from 'svelte'
 	import { SvelteSet } from 'svelte/reactivity'
 	import { page } from '$app/state'
 	import {
@@ -26,7 +26,9 @@
 	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
 	import {
 		createSession,
+		findEmptyLandingSession,
 		getEffectiveWorkspaceId,
+		isTearingDownOpenSession,
 		selectSession,
 		sessionInCurrentFamily,
 		sessionState,
@@ -42,6 +44,7 @@
 		listRuntimes
 	} from '$lib/components/sessions/sessionRuntime.svelte'
 	import { markSessionSeen } from '$lib/components/sessions/sessionUnread.svelte'
+	import { markSessionRecovered } from '$lib/components/sessions/sessionRecoveryNotice.svelte'
 	import {
 		isGlobalAiEnabled,
 		setSessionsBetaOptOut
@@ -118,8 +121,8 @@
 
 	const sessionName = $derived(page.url.searchParams.get('session_name') ?? '')
 
-	// Unfiltered resolution by name — drives the "session not found" fallback and
-	// the active-session lookup below.
+	// Unfiltered resolution by name: drives the recovery effect below and the
+	// active-session lookup.
 	const sessionByName = $derived(
 		sessionName ? sessionState.sessions.find((s) => s.name === sessionName) : undefined
 	)
@@ -137,8 +140,8 @@
 	// link navigation keeps the route), and a chat must not bleed across
 	// families. Re-enter session mode scoped to the active family: keep the open
 	// chat when it belongs there, else its most recent active session, else a
-	// fresh one. The `session_name`-without-a-session case is left to the
-	// not-found UI below.
+	// fresh one. A `session_name` that resolves to nothing is left to the
+	// recovery effect below.
 	$effect(() => {
 		if (embedded || !sessionState.hydrated) return
 		// Family membership can't be judged before the workspace list arrives:
@@ -153,6 +156,38 @@
 		const shouldReenter = current ? !sessionInCurrentFamily(current) : !sessionName
 		if (!shouldReenter) return
 		untrack(() => void enterSessionMode({ replace: true }))
+	})
+
+	// Held across the swap so the session layout mounts once, after the navigation
+	// settles. A recovered session often takes the very name that was missing, so
+	// the URL resolves before `goto` returns; mounting the panes mid-navigation
+	// makes Splitpanes miss the collapsed pane's `maxSize: 0` and leave it open.
+	let recovering = $state(false)
+
+	// Bounds the wait for the workspace list the guard above needs. The list can
+	// fail to arrive for good, and a spinner that never resolves is a worse
+	// outcome than the spare blank that judging family membership early leaves.
+	const WORKSPACE_LIST_GRACE_MS = 3000
+	let workspaceListOverdue = $state(false)
+	onMount(() => {
+		const handle = setTimeout(() => (workspaceListOverdue = true), WORKSPACE_LIST_GRACE_MS)
+		return () => clearTimeout(handle)
+	})
+
+	// The URL names a session this browser doesn't hold. Land on an empty one,
+	// never the most recent: an existing conversation would read as a successful
+	// load. `recovering` also guards re-entry: recovery mutates the session list
+	// this effect tracks, while the URL that would stop it only updates on `goto`.
+	$effect(() => {
+		if (embedded || !globalEnabled || $userStore?.operator) return
+		if (!sessionState.hydrated || recovering) return
+		// A deliberate delete removes the open session ahead of its own navigation.
+		// Claiming that gap would take over the URL and tell the user the session
+		// they just deleted couldn't be found.
+		if (isTearingDownOpenSession()) return
+		if ($usersWorkspaceStore === undefined && !workspaceListOverdue) return
+		if (!sessionName || sessionByName) return
+		untrack(() => void recoverToNewSession())
 	})
 
 	// Touch the runtime for the active session so it gets created on first visit
@@ -203,9 +238,23 @@
 		untrack(() => markSessionSeen(id, count))
 	})
 
-	async function startNewSession() {
-		const fresh = createSession()
-		await goto(`/sessions?session_name=${encodeURIComponent(fresh.name)}`)
+	async function recoverToNewSession() {
+		recovering = true
+		try {
+			// Prefer an existing empty session over stacking another blank onto the
+			// sidebar: createSession reuses only its own in-memory drafts, so one
+			// persisted by any other touch (a workspace pick, a preview tab) would
+			// be passed over.
+			const target = findEmptyLandingSession() ?? createSession()
+			selectSession(target.id)
+			markSessionRecovered(target.id)
+			await goto(`/sessions?session_name=${encodeURIComponent(target.name)}`, {
+				replaceState: true
+			})
+			await tick()
+		} finally {
+			recovering = false
+		}
 	}
 
 	// Preview panel: a tiny tabbed browser over Windmill. Every tab stays mounted
@@ -773,24 +822,18 @@
 		</div>
 	{:else if !sessionState.hydrated}
 		<!-- Sessions hydrate from IndexedDB after the user resolves; until then an
-		     empty list means "loading", so the not-found branch below must not fire. -->
+		     empty list means "loading", so recovery below must not fire and strand
+		     the user in a new session while their own is still arriving. -->
 		<div class="flex-1 flex items-center justify-center">
 			<Loader2 class="animate-spin" />
 		</div>
 	{:else if !sessionName}
 		<div class="p-8 text-secondary">No session selected — pick one in the sidebar.</div>
-	{:else if !sessionByName}
-		<!-- A session_name is in the URL but no session by that name exists — e.g. a
-		     deleted session or a link opened in a different browser. -->
-		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
-			<div class="flex flex-col gap-1">
-				<p class="text-primary font-medium">Session not found</p>
-				<p>
-					No session named <code class="font-mono text-2xs">{sessionName}</code> exists. It may have
-					been deleted, or this link was created in a different browser.
-				</p>
-			</div>
-			<Button size="xs" startIcon={{ icon: Plus }} onclick={startNewSession}>New session</Button>
+	{:else if !sessionByName || recovering}
+		<!-- A tick while recovery swaps in an empty session, or the length of a
+		     fork teardown's HTTP round trip while a delete holds recovery off. -->
+		<div class="flex-1 flex items-center justify-center">
+			<Loader2 class="animate-spin" />
 		</div>
 	{:else}
 		<div class="flex-1 min-h-0 flex flex-row relative" use:splitterPointerCapture>


### PR DESCRIPTION
## Summary

AI sessions live only in IndexedDB, and the URL keys them by `session_name`. A link that resolves in one browser resolves to nothing in another, which landed on a dead-end "Session not found" page whose only way out was a button.

That page also caught a case that isn't a broken link at all: an untouched new session is never persisted, so reloading one hit the same dead end on the user's own machine.

Now the page recovers instead of stopping. It lands on an empty session, replaces the URL so Back doesn't return to the broken link, and explains the swap in one dismissible notice above the composer.

## Screenshots

**Before** — opening `?session_name=<unknown>`. The session list is empty too, so there is nothing to click back into:

![before-dead-end](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre-win-2454/1787758505-before-dead-end.png)

**After** — the same URL. It lands on an empty session, the URL has been replaced with the session actually opened, the composer is focused and ready, and the notice sits above it:

![after-recovery](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre-win-2454/1787758507-after-recovery.png)

## Changes

- Replace the not-found branch on `/sessions` with a recovery effect: reuse an untouched draft in the active family, else create one, then `replaceState` onto it.
- Never land on a session that could hold a conversation. Eligibility requires `transient`, because that is the only state the two mechanisms that attach content to a session both skip: `ensureChatIdsSeeded` grafts untagged legacy chats onto `!transient` sessions (setting only `chatId`, which `initRuntime` then loads), and attached files persist only when `!transient`. Neither touches the fields a `Session` record would otherwise be judged "empty" by.
- Add an in-memory, per-session recovery notice (`sessionRecoveryNotice.svelte.ts`). It is not persisted: it explains one arrival, not a property of the session.
- Spend the notice's marker when the arrival ends — first message sent, session deselected, or page left — plus the user's own dismiss. `createSession` also clears it on the draft it reuses, so `+` is never answered with "we couldn't find that session".
- Gate recovery during a deliberate teardown (`withOpenSessionTeardown`). Deleting the open session removes it before the handler's own navigation lands, and across HTTP when a fork goes with it; without the gate, recovery claims that gap and reports the session the user just deleted as missing.
- Rename `isReusableBlank` to `isDiscardableDraft`, to separate "safe to throw away" from the looser "somewhere empty to land".

## Test plan

- [ ] Open `/sessions?session_name=does-not-exist` in a browser holding no such session: it lands on an empty session, the URL is replaced (Back does not return to the bad link), the composer is focused, and the preview pane is still collapsed.
- [ ] Do the above with an untouched draft already open: it reuses that one rather than stacking another blank in the sidebar.
- [ ] Do the above with a persisted unsent session present *and* untagged legacy saved chats in history: recovery must create a fresh session rather than opening the seeded conversation.
- [ ] Do the above with a persisted unsent session carrying attached files: those chips must not appear under the notice.
- [ ] On the landing session, click `+`: the notice is gone rather than carried onto the new session.
- [ ] Type a first message: the notice clears on send, and the composer does not jump while typing.
- [ ] Switch to another session and back, and leave `/sessions` and return: the notice does not replay.
- [ ] Delete the open session from the wrapper menu and from the picker, including the "also delete fork" variant that goes across HTTP: you land on the replacement without the notice flashing and without a stuck spinner.
- [ ] Reload an untouched new session: it recovers instead of hitting the old dead end.