### PR TITLE
docs: warn that pinning back to postgres 16 needs the mount reverted too

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,10 @@ services:
   ## its RLS policies to cluster-level roles, and a single-database dump loses both
   ## silently. Full procedure, and why 16 is still a valid choice until Nov 2028:
   ## https://www.windmill.dev/docs/advanced/self_host#upgrade-postgresql-to-18
+  ## Pinning back to postgres:16 means reverting the mount below as well. 16 against
+  ## the 18-style mount initdbs a fresh cluster into a subdirectory of db_data and
+  ## comes up blank, the one path here that fails quietly instead of loudly. The
+  ## original cluster is still at the volume root, unread, so it is recoverable.
   db:
     deploy:
       # To use an external database, set replicas to 0 and set DATABASE_URL to the external database url in the .env file


### PR DESCRIPTION
## Summary

Four-line follow-up to #10827. That PR merged at a head one commit behind this warning, so main is
currently missing it.

#10827 was built so every failure path is loud: bump the tag without migrating and the container
exits with an explanation, data untouched. A review round found the one exception, and it is the
revert path.

## The failure

An operator who decides to stay on 16 changes `image: postgres:18` back to `postgres:16` and stops
there, leaving the new mount in place. 16 then runs with `PGDATA` at
`/var/lib/postgresql/data`, which under the 18-style mount is a *subdirectory* of the volume
rather than its root. It finds nothing there, initdbs a fresh cluster, and starts cleanly.

Verified end to end:

```
before:            USER DATA THAT MUST NOT VANISH
volume root:       PG_VERSION = 16

after reverting only the image tag:
  container state: running exit=0
  data_directory:  /var/lib/postgresql/data
  select v from important:  ERROR: relation "important" does not exist
```

Windmill comes up blank and looks wiped. The original cluster is intact at the volume root and is
recoverable, but nothing says so, and this is the only path in the change that does not announce
itself.

## Changes

Four comment lines pairing "staying on 16 is valid" with "revert the mount too", and saying the
data is still there. No behaviour change.

The same warning is already in the companion docs page, windmill-labs/windmilldocs#1704, but the
compose file is where someone doing the revert is actually looking.

## Test plan

- [x] failure reproduced and confirmed on real containers (above)
- [x] `docker compose config` validates
- [x] diff against main is the 4 comment lines and nothing else

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comment warning that reverting to `postgres:16` also requires reverting the mount, since 16 against the 18-style mount initdbs a fresh cluster into a subdirectory and comes up blank while the original cluster stays recoverable at the volume root.

<sup>Written for commit 352c23dafbb886b1c982aa655138b08ec990f989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

