### PR TITLE
fix: keep the thrown value identifiable in the bun and deno error wrappers

### DIFF
--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -414,9 +414,9 @@ async fn test_bun_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()>
     }
 
     // An HTTP client links its errors both ways, which is what a plain JSON.stringify
-    // could not serialize. `extra` is reported only when it serializes on its own, so the
-    // request the client hangs off the error, credentials included, stays out of the
-    // result exactly as it did when the wrapper crashed.
+    // could not serialize. Only that same stringify reports `extra`, so the request the
+    // client hangs off the error, credentials included, stays out of the result exactly as
+    // it did when the wrapper crashed.
     {
         let job = bun_job(
             r#"

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -436,6 +436,40 @@ export function main() {
         );
     }
 
+    // Serializing a cycle is what first brings an HTTP client's whole request into
+    // `extra`, so the transport credentials on it must not reach the stored result.
+    {
+        let job = bun_job(
+            r#"
+export function main() {
+    const config: any = { url: "/x", headers: { Authorization: "Bearer sentinel-tkn" } };
+    const request: any = { path: "/x", _header: "GET /x HTTP/1.1\r\nAuthorization: Bearer sentinel-tkn\r\n\r\n" };
+    const response: any = { status: 401, config, request };
+    request.res = response;
+    const e: any = new Error("Request failed with status code 401");
+    e.name = "AxiosError";
+    e.config = config;
+    e.request = request;
+    e.response = response;
+    throw e;
+}
+"#,
+        );
+        let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
+        assert!(!completed.success);
+        let result = completed.json_result().unwrap();
+        let error = &result["error"];
+        assert_eq!(
+            error["message"],
+            serde_json::json!("Request failed with status code 401")
+        );
+        assert_eq!(error["extra"]["response"]["status"], serde_json::json!(401));
+        assert!(
+            !error.to_string().contains("sentinel-tkn"),
+            "credential reached the result: {error}"
+        );
+    }
+
     Ok(())
 }
 

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -442,7 +442,11 @@ export function main() {
         let job = bun_job(
             r#"
 export function main() {
-    const config: any = { url: "/x", headers: { Authorization: "Bearer sentinel-tkn" } };
+    const config: any = {
+        url: "/x",
+        headers: { Authorization: "Bearer sentinel-tkn" },
+        auth: { username: "svc", password: "sentinel-tkn" },
+    };
     const request: any = { path: "/x", _header: "GET /x HTTP/1.1\r\nAuthorization: Bearer sentinel-tkn\r\n\r\n" };
     const response: any = { status: 401, config, request };
     request.res = response;

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -401,29 +401,6 @@ async fn test_bun_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()>
         assert_eq!(result["error"]["message"], serde_json::json!("null"));
     }
 
-    // Circular object: several HTTP clients throw errors that link two objects
-    // both ways, which a plain JSON.stringify cannot serialize.
-    {
-        let job = bun_job(
-            r#"
-export function main() {
-    const a: any = { name: "circular", message: "boom" };
-    a.self = a;
-    throw a;
-}
-"#,
-        );
-        let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
-        assert!(!completed.success);
-        let result = completed.json_result().unwrap();
-        let error = &result["error"];
-        assert_eq!(error["message"], serde_json::json!("boom"));
-        assert_eq!(
-            error["extra"]["self"]["self"],
-            serde_json::json!("[Circular]")
-        );
-    }
-
     // A thrown string is a string, not an index map of its characters.
     {
         let job = bun_job(r#"export function main() { throw "nur ein string"; }"#);
@@ -436,8 +413,10 @@ export function main() {
         );
     }
 
-    // Serializing a cycle is what first brings an HTTP client's whole request into
-    // `extra`, so the transport credentials on it must not reach the stored result.
+    // An HTTP client links its errors both ways, which is what a plain JSON.stringify
+    // could not serialize. `extra` is reported only when it serializes on its own, so the
+    // request the client hangs off the error, credentials included, stays out of the
+    // result exactly as it did when the wrapper crashed.
     {
         let job = bun_job(
             r#"
@@ -446,6 +425,7 @@ export function main() {
         url: "/x",
         headers: { Authorization: "Bearer sentinel-tkn" },
         auth: { username: "svc", password: "sentinel-tkn" },
+        httpsAgent: { options: { key: "-----BEGIN PRIVATE KEY-----sentinel-tkn" } },
     };
     const request: any = { path: "/x", _header: "GET /x HTTP/1.1\r\nAuthorization: Bearer sentinel-tkn\r\n\r\n" };
     const response: any = { status: 401, config, request };
@@ -467,10 +447,26 @@ export function main() {
             error["message"],
             serde_json::json!("Request failed with status code 401")
         );
-        assert_eq!(error["extra"]["response"]["status"], serde_json::json!(401));
+        assert_eq!(error["name"], serde_json::json!("AxiosError"));
+        assert_eq!(
+            error["extra"],
+            serde_json::json!("[extra omitted: not serializable]")
+        );
         assert!(
             !error.to_string().contains("sentinel-tkn"),
             "credential reached the result: {error}"
+        );
+    }
+
+    // An acyclic thrown object still reports its own properties, unchanged.
+    {
+        let job = bun_job(r#"export function main() { throw { code: 42, hint: "kein Error" }; }"#);
+        let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
+        assert!(!completed.success);
+        let result = completed.json_result().unwrap();
+        assert_eq!(
+            result["error"]["extra"],
+            serde_json::json!({ "code": 42, "hint": "kein Error" })
         );
     }
 

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -364,6 +364,81 @@ export function main() {
     Ok(())
 }
 
+/// A script can throw a non-object, or an object with a reference cycle. The error the
+/// job reports must still identify what was thrown, never the wrapper's own failure to
+/// read or serialize it.
+#[sqlx::test(fixtures("base"))]
+async fn test_bun_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    fn bun_job(content: &str) -> JobPayload {
+        JobPayload::Code(RawCode {
+            hash: None,
+            content: content.to_owned(),
+            path: None,
+            language: ScriptLang::Bun,
+            lock: None,
+            concurrency_settings: windmill_common::runnable_settings::ConcurrencySettings::default(
+            )
+            .into(),
+            debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
+            cache_ttl: None,
+            cache_ignore_s3_path: None,
+            dedicated_worker: None,
+            modules: None,
+            tag: None,
+        })
+    }
+
+    // `throw null`: the wrapper must not dereference the thrown value.
+    {
+        let job = bun_job("export function main() { throw null; }");
+        let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
+        assert!(!completed.success);
+        let result = completed.json_result().unwrap();
+        assert_eq!(result["error"]["message"], serde_json::json!("null"));
+    }
+
+    // Circular object: several HTTP clients throw errors that link two objects
+    // both ways, which a plain JSON.stringify cannot serialize.
+    {
+        let job = bun_job(
+            r#"
+export function main() {
+    const a: any = { name: "circular", message: "boom" };
+    a.self = a;
+    throw a;
+}
+"#,
+        );
+        let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
+        assert!(!completed.success);
+        let result = completed.json_result().unwrap();
+        let error = &result["error"];
+        assert_eq!(error["message"], serde_json::json!("boom"));
+        assert_eq!(
+            error["extra"]["self"]["self"],
+            serde_json::json!("[Circular]")
+        );
+    }
+
+    // A thrown string is a string, not an index map of its characters.
+    {
+        let job = bun_job(r#"export function main() { throw "nur ein string"; }"#);
+        let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
+        assert!(!completed.success);
+        let result = completed.json_result().unwrap();
+        assert_eq!(
+            result["error"]["message"],
+            serde_json::json!("nur ein string")
+        );
+    }
+
+    Ok(())
+}
+
 #[sqlx::test(fixtures("base"))]
 async fn test_bun_job_missing_main_function(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -458,7 +458,8 @@ export function main() {
         );
     }
 
-    // An acyclic thrown object still reports its own properties, unchanged.
+    // An acyclic thrown object still reports its own properties, unchanged. Carrying
+    // `extra` does not stand in for identifying the throw, so the type tag reports it too.
     {
         let job = bun_job(r#"export function main() { throw { code: 42, hint: "kein Error" }; }"#);
         let completed = run_job_in_new_worker_until_complete(&db, false, job, port).await;
@@ -468,6 +469,11 @@ export function main() {
             result["error"]["extra"],
             serde_json::json!({ "code": 42, "hint": "kein Error" })
         );
+        assert_eq!(
+            result["error"]["message"],
+            serde_json::json!("[object Object]")
+        );
+        assert_eq!(result["error"]["name"], serde_json::json!("ThrownValue"));
     }
 
     Ok(())

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -3277,8 +3277,7 @@ async fn test_deno_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()
         json!("null")
     );
 
-    // A thrown string reaches the result as a string; reading `message` off it yields
-    // nothing, which used to leave an empty error object.
+    // A thrown string reaches the result as a string, not an empty error object.
     let job = RunJob::from(deno_job(
         r#"export function main() { throw "nur ein string"; }"#,
     ))
@@ -3288,6 +3287,19 @@ async fn test_deno_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()
     assert_eq!(
         job.json_result().unwrap()["error"]["message"],
         json!("nur ein string")
+    );
+
+    // An object carrying none of message/name/stack is described by its contents rather
+    // than collapsing to an empty error object.
+    let job = RunJob::from(deno_job(
+        r#"export function main() { throw { code: 42, hint: "kein Error" }; }"#,
+    ))
+    .run_until_complete(&db, false, port)
+    .await;
+    assert!(!job.success);
+    assert_eq!(
+        job.json_result().unwrap()["error"]["message"],
+        json!(r#"{"code":42,"hint":"kein Error"}"#)
     );
 
     // Deno reports only message/name/stack. Collecting the thrown value's own properties

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -3289,17 +3289,32 @@ async fn test_deno_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()
         json!("nur ein string")
     );
 
-    // An object carrying none of message/name/stack is described by its contents rather
-    // than collapsing to an empty error object.
+    // Wrapping a library error (`catch (e) { throw { cause: e } }`) leaves a thrown object
+    // with none of message/name/stack. Reporting it must stay a type tag: rendering its
+    // contents would carry the wrapped client's credentials into the only record Deno
+    // keeps, since these wrappers have no `console.error`.
     let job = RunJob::from(deno_job(
-        r#"export function main() { throw { code: 42, hint: "kein Error" }; }"#,
+        r#"
+export function main() {
+    const config: any = { headers: { Authorization: "Bearer sentinel-tkn" } };
+    const request: any = { path: "/x" };
+    const response: any = { status: 401, config, request };
+    request.res = response;
+    const inner: any = new Error("Request failed with status code 401");
+    inner.config = config;
+    inner.response = response;
+    throw { cause: inner };
+}
+"#,
     ))
     .run_until_complete(&db, false, port)
     .await;
     assert!(!job.success);
-    assert_eq!(
-        job.json_result().unwrap()["error"]["message"],
-        json!(r#"{"code":42,"hint":"kein Error"}"#)
+    let error = job.json_result().unwrap()["error"].clone();
+    assert_eq!(error["message"], json!("[object Object]"));
+    assert!(
+        !error.to_string().contains("sentinel-tkn"),
+        "credential reached the result: {error}"
     );
 
     // Deno reports only message/name/stack. Collecting the thrown value's own properties

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -3240,6 +3240,75 @@ export async function main(a: Date) {
     Ok(())
 }
 
+/// A script can throw a non-object. The error the job reports must still identify what
+/// was thrown, never the wrapper's own failure to read it.
+#[sqlx::test(fixtures("base"))]
+async fn test_deno_job_non_error_throws(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let deno_job = |content: &str| {
+        JobPayload::Code(RawCode {
+            hash: None,
+            content: content.to_owned(),
+            path: None,
+            lock: None,
+            language: ScriptLang::Deno,
+            cache_ttl: None,
+            cache_ignore_s3_path: None,
+            dedicated_worker: None,
+            concurrency_settings: windmill_common::runnable_settings::ConcurrencySettings::default(
+            )
+            .into(),
+            debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
+            modules: None,
+            tag: None,
+        })
+    };
+
+    // `throw null`: the wrapper must not dereference the thrown value.
+    let job = RunJob::from(deno_job("export function main() { throw null; }"))
+        .run_until_complete(&db, false, port)
+        .await;
+    assert!(!job.success);
+    assert_eq!(
+        job.json_result().unwrap()["error"]["message"],
+        json!("null")
+    );
+
+    // A thrown string reaches the result as a string; reading `message` off it yields
+    // nothing, which used to leave an empty error object.
+    let job = RunJob::from(deno_job(
+        r#"export function main() { throw "nur ein string"; }"#,
+    ))
+    .run_until_complete(&db, false, port)
+    .await;
+    assert!(!job.success);
+    assert_eq!(
+        job.json_result().unwrap()["error"]["message"],
+        json!("nur ein string")
+    );
+
+    // Deno reports only message/name/stack. Collecting the thrown value's own properties
+    // would persist whatever an HTTP client hangs off its errors, auth headers included.
+    let job = RunJob::from(deno_job(
+        r#"
+export function main() {
+    throw Object.assign(new Error("boom"), { authorization: "Bearer secret" });
+}
+"#,
+    ))
+    .run_until_complete(&db, false, port)
+    .await;
+    assert!(!job.success);
+    let error = job.json_result().unwrap()["error"].clone();
+    assert_eq!(error["message"], json!("boom"));
+    assert!(error.get("extra").is_none(), "unexpected extra: {error}");
+
+    Ok(())
+}
+
 /// Test that full .npmrc content works for deno jobs with private registries.
 /// Requires:
 /// - `TEST_NPMRC` environment variable set to the full .npmrc content

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -22,7 +22,7 @@ use crate::{
         build_command_with_isolation, create_args_and_out_file, get_reserved_variables,
         parse_npm_config, read_file, read_file_content, read_result, resolve_nsjail_timeout,
         resolve_nsjail_tmp_mount_block, start_child_process, write_file_binary, MaybeLock,
-        OccupancyMetrics, StreamNotifier, DEV_CONF_NSJAIL,
+        OccupancyMetrics, StreamNotifier, DEV_CONF_NSJAIL, JS_ERROR_SERIALIZER,
     },
     get_proxy_envs_for_lang,
     handle_child::handle_child,
@@ -235,6 +235,7 @@ import * as Readline from "node:readline"
 BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
+{JS_ERROR_SERIALIZER}
 
 const scripts = new Map();
 {functions}
@@ -266,7 +267,7 @@ for await (const line of Readline.createInterface({{ input: process.stdin }})) {
             const res = await entry.module.main(...mainArgs);
             console.log("wm_res[success]:" + JSON.stringify(res ?? null, (key, value) => typeof value === 'undefined' ? null : value));
         }} catch (e) {{
-            console.log("wm_res[error]:" + JSON.stringify({{ message: e.message, name: e.name, stack: e.stack, line: argsJson }}));
+            console.log("wm_res[error]:" + wmSerializeError(Object.assign(wmToErrorObject(e, false), {{ line: argsJson }})));
         }}
         continue;
     }}
@@ -280,7 +281,7 @@ for await (const line of Readline.createInterface({{ input: process.stdin }})) {
             const res = await entry.module.main(...args);
             console.log("wm_res[success]:" + JSON.stringify(res ?? null, (key, value) => typeof value === 'undefined' ? null : value));
         }} catch (e) {{
-            console.log("wm_res[error]:" + JSON.stringify({{ message: e.message, name: e.name, stack: e.stack, line: argsJson }}));
+            console.log("wm_res[error]:" + wmSerializeError(Object.assign(wmToErrorObject(e, false), {{ line: argsJson }})));
         }}
         continue;
     }}
@@ -314,7 +315,7 @@ for await (const line of Readline.createInterface({{ input: process.stdin }})) {
             const res = await entry.module.main(...mainArgs);
             console.log("wm_res[success]:" + JSON.stringify(res ?? null, (key, value) => typeof value === 'undefined' ? null : value));
         }} catch (e) {{
-            console.log("wm_res[error]:" + JSON.stringify({{ message: e.message, name: e.name, stack: e.stack, line: argsJson }}));
+            console.log("wm_res[error]:" + wmSerializeError(Object.assign(wmToErrorObject(e, false), {{ line: argsJson }})));
         }}
         continue;
     }}
@@ -340,7 +341,7 @@ for await (const line of Readline.createInterface({{ input: process.stdin }})) {
             const res = await entry.module.main(...args);
             console.log("wm_res[success]:" + JSON.stringify(res ?? null, (key, value) => typeof value === 'undefined' ? null : value));
         }} catch (e) {{
-            console.log("wm_res[error]:" + JSON.stringify({{ message: e.message, name: e.name, stack: e.stack, line: argsJson }}));
+            console.log("wm_res[error]:" + wmSerializeError(Object.assign(wmToErrorObject(e, false), {{ line: argsJson }})));
         }}
         continue;
     }}
@@ -1912,6 +1913,7 @@ function argsObjToArr({{ {spread} }}) {{
 BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
+{JS_ERROR_SERIALIZER}
 
 // Find the workflow entrypoint (export default)
 let workflowFn = Main.default;
@@ -1990,22 +1992,12 @@ try {{
     process.exit(0);
 }} catch(e) {{
     console.error(e);
-    let err = {{ message: e.message, name: e.name, stack: e.stack }};
-    let step_id = process.env.WM_FLOW_STEP_ID;
+    const err = wmToErrorObject(e, true);
+    const step_id = process.env.WM_FLOW_STEP_ID;
     if (step_id) {{
         err["step_id"] = step_id;
     }}
-    const extra = {{}};
-    Object.getOwnPropertyNames(e).forEach((key) => {{
-        if (['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'].includes(key)) {{
-            return;
-        }}
-        extra[key] = e[key];
-    }});
-    if (Object.keys(extra).length > 0) {{
-        err["extra"] = extra;
-    }}
-    await fs.writeFile("result.json", JSON.stringify(err));
+    await fs.writeFile("result.json", wmSerializeError(err));
     process.exit(1);
 }}
     "#,
@@ -2030,6 +2022,7 @@ function isAsyncIterable(obj) {{
 BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
+{JS_ERROR_SERIALIZER}
 
 async function run() {{
     {dates}
@@ -2056,22 +2049,12 @@ try {{
     await run();
 }} catch(e) {{
     console.error(e);
-    let err = {{ message: e.message, name: e.name, stack: e.stack }};
-    let step_id = process.env.WM_FLOW_STEP_ID;
+    const err = wmToErrorObject(e, true);
+    const step_id = process.env.WM_FLOW_STEP_ID;
     if (step_id) {{
         err["step_id"] = step_id;
     }}
-    const extra = {{}};
-    Object.getOwnPropertyNames(e).forEach((key) => {{
-        if (['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'].includes(key)) {{
-            return;
-        }}
-        extra[key] = e[key];
-    }});
-    if (Object.keys(extra).length > 0) {{
-        err["extra"] = extra;
-    }}
-    await fs.writeFile("result.json", JSON.stringify(err));
+    await fs.writeFile("result.json", wmSerializeError(err));
     process.exit(1);
 }}
     "#,

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -91,7 +91,7 @@ pub const DEV_CONF_NSJAIL: &str = "";
 /// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
 const wmErrOwnKeys = ['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'];
-const wmErrSecretKeys = /^(authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[-_]?key|_header)$/i;
+const wmErrSecretKeys = /^(authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[-_]?key|auth|passphrase|_header)$/i;
 const wmErrMaxExtra = 100000;
 
 function wmErrString(v) {

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -79,15 +79,11 @@ pub const DEV_CONF_NSJAIL: &str = "";
 /// Enabling it there would newly persist whatever an HTTP client hangs off its errors,
 /// credential-bearing headers included, into existing scripts' run history.
 ///
-/// `extra` is reported only when it serializes on its own, which is exactly when the
-/// pre-existing bare `JSON.stringify` would have succeeded. Anything else is what used to
-/// crash, so persisting it now would be new exposure: an HTTP client hangs its whole
-/// request off a cyclic error, credentials and mTLS keys included, and no blocklist of key
-/// names can be complete. Keeping the condition rather than the key list is what bounds it.
-///
-/// `wmErrDescribe` also renders a thrown object's contents, so it stays behind the same
-/// line: it fills a message only for a value that yielded no field at all, never for one
-/// carrying `message`/`name`/`stack` or reportable `extra`.
+/// What a thrown object holds is reported only through the one plain `JSON.stringify`
+/// the wrappers already did, so it reaches a result exactly when it did before. What used
+/// to crash instead reports the thrown value's own strings and a marker: an HTTP client
+/// hangs its whole request off a cyclic error, credentials and mTLS keys included, and
+/// nothing may render that graph, no blocklist of key names being complete enough to.
 ///
 /// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
@@ -110,24 +106,6 @@ function wmErrProp(e, key) {
     }
 }
 
-function wmErrSerializable(v) {
-    try {
-        return JSON.stringify(v) !== undefined;
-    } catch (_) {
-        return false;
-    }
-}
-
-function wmErrDescribe(v) {
-    if (v === null || typeof v !== 'object') return wmErrString(v);
-    let s;
-    try {
-        s = wmSerializeError(v);
-    } catch (_) {}
-    if (s === undefined || s === '{}') return wmErrString(v);
-    return s.length > 10000 ? s.slice(0, 10000) + '...[truncated]' : s;
-}
-
 function wmToErrorObject(e, collectExtra) {
     if (e === null || typeof e !== 'object') {
         return { message: wmErrString(e), name: 'ThrownValue' };
@@ -148,29 +126,34 @@ function wmToErrorObject(e, collectExtra) {
             const v = wmErrProp(e, key);
             if (v !== undefined) extra[key] = v;
         }
-        if (Object.keys(extra).length > 0) {
-            err.extra = wmErrSerializable(extra) ? extra : '[extra omitted: not serializable]';
-        }
+        if (Object.keys(extra).length > 0) err.extra = extra;
     }
     if (Object.keys(err).length === 0) {
-        err.message = wmErrDescribe(e);
         err.name = 'ThrownValue';
+        try {
+            err.message = Object.prototype.toString.call(e);
+        } catch (_) {
+            err.message = '[unstringifiable object]';
+        }
     }
     return err;
 }
 
 function wmSerializeError(err) {
-    const ancestors = [];
     try {
-        return JSON.stringify(err, function (key, v) {
-            if (v === null || typeof v !== 'object') return v;
-            while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) ancestors.pop();
-            if (ancestors.indexOf(v) !== -1) return '[Circular]';
-            ancestors.push(v);
-            return v;
-        });
-    } catch (_) {
+        const s = JSON.stringify(err);
+        if (s !== undefined) return s;
+    } catch (_) {}
+    if (err !== null && typeof err === 'object' && err.extra !== undefined) {
+        try {
+            const s = JSON.stringify(Object.assign({}, err, { extra: '[extra omitted: not serializable]' }));
+            if (s !== undefined) return s;
+        } catch (_) {}
+    }
+    try {
         return JSON.stringify({ message: err.message, name: err.name, stack: err.stack, step_id: err.step_id, line: err.line });
+    } catch (_) {
+        return JSON.stringify({ message: '[unserializable error]', name: 'ThrownValue' });
     }
 }
 "#;

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -79,20 +79,19 @@ pub const DEV_CONF_NSJAIL: &str = "";
 /// Enabling it there would newly persist whatever an HTTP client hangs off its errors,
 /// credential-bearing headers included, into existing scripts' run history.
 ///
-/// `wmErrDescribe` renders a thrown object's contents, so it stays behind the same line:
-/// it runs only for a value exposing none of message/name/stack, which an HTTP client's
-/// error never is, and only to fill a message that would otherwise be `[object Object]`.
+/// `extra` is reported only when it serializes on its own, which is exactly when the
+/// pre-existing bare `JSON.stringify` would have succeeded. Anything else is what used to
+/// crash, so persisting it now would be new exposure: an HTTP client hangs its whole
+/// request off a cyclic error, credentials and mTLS keys included, and no blocklist of key
+/// names can be complete. Keeping the condition rather than the key list is what bounds it.
 ///
-/// Making a cyclic graph serializable is what puts an HTTP client's whole request under
-/// `extra` for the first time, so the replacer drops transport-credential keys and the
-/// walk is capped: `console.error` prints those nested objects as `[Object ...]`, and the
-/// crash kept them out of the result entirely, so neither had reached a stored result.
+/// `wmErrDescribe` also renders a thrown object's contents, so it stays behind the same
+/// line: it fills a message only for a value that yielded no field at all, never for one
+/// carrying `message`/`name`/`stack` or reportable `extra`.
 ///
 /// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
 const wmErrOwnKeys = ['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'];
-const wmErrSecretKeys = /^(authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[-_]?key|auth|passphrase|_header)$/i;
-const wmErrMaxExtra = 100000;
 
 function wmErrString(v) {
     if (typeof v === 'string') return v;
@@ -108,6 +107,14 @@ function wmErrProp(e, key) {
         return e[key];
     } catch (_) {
         return undefined;
+    }
+}
+
+function wmErrSerializable(v) {
+    try {
+        return JSON.stringify(v) !== undefined;
+    } catch (_) {
+        return false;
     }
 }
 
@@ -142,8 +149,7 @@ function wmToErrorObject(e, collectExtra) {
             if (v !== undefined) extra[key] = v;
         }
         if (Object.keys(extra).length > 0) {
-            const s = wmSerializeError(extra);
-            err.extra = s !== undefined && s.length <= wmErrMaxExtra ? extra : '[extra omitted: too large]';
+            err.extra = wmErrSerializable(extra) ? extra : '[extra omitted: not serializable]';
         }
     }
     if (Object.keys(err).length === 0) {
@@ -157,7 +163,6 @@ function wmSerializeError(err) {
     const ancestors = [];
     try {
         return JSON.stringify(err, function (key, v) {
-            if (wmErrSecretKeys.test(key)) return '[redacted]';
             if (v === null || typeof v !== 'object') return v;
             while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) ancestors.pop();
             if (ancestors.indexOf(v) !== -1) return '[Circular]';

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -79,6 +79,10 @@ pub const DEV_CONF_NSJAIL: &str = "";
 /// Enabling it there would newly persist whatever an HTTP client hangs off its errors,
 /// credential-bearing headers included, into existing scripts' run history.
 ///
+/// `wmErrDescribe` renders a thrown object's contents, so it stays behind the same line:
+/// it runs only for a value exposing none of message/name/stack, which an HTTP client's
+/// error never is, and only to fill a message that would otherwise be `[object Object]`.
+///
 /// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
 const wmErrOwnKeys = ['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'];
@@ -101,19 +105,18 @@ function wmErrProp(e, key) {
 }
 
 function wmErrDescribe(v) {
+    if (v === null || typeof v !== 'object') return wmErrString(v);
     let s;
-    if (v !== null && typeof v === 'object') {
-        try {
-            s = wmSerializeError(v);
-        } catch (_) {}
-    }
-    if (s === undefined || s === '{}') s = wmErrString(v);
+    try {
+        s = wmSerializeError(v);
+    } catch (_) {}
+    if (s === undefined || s === '{}') return wmErrString(v);
     return s.length > 10000 ? s.slice(0, 10000) + '...[truncated]' : s;
 }
 
 function wmToErrorObject(e, collectExtra) {
     if (e === null || typeof e !== 'object') {
-        return { message: wmErrDescribe(e), name: 'ThrownValue' };
+        return { message: wmErrString(e), name: 'ThrownValue' };
     }
     const err = {};
     for (const field of ['message', 'name', 'stack']) {

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -67,22 +67,19 @@ mount {
 #[cfg(not(debug_assertions))]
 pub const DEV_CONF_NSJAIL: &str = "";
 
-/// Helpers the Bun/Deno wrappers use to turn a thrown value into the error object
-/// they report, injected into the generated wrapper source.
+/// Error-serialization helpers injected into every generated Bun/Deno wrapper.
 ///
-/// A script can throw anything, so neither reading `e.message` nor calling
-/// `JSON.stringify` on the result is safe: `throw null`, and errors that link two
-/// objects both ways (an axios error hangs `response` off `request` and back), both
-/// abort the wrapper itself, and the job then reports a stack trace from the wrapper
-/// instead of what the script threw.
+/// A script can throw anything, so neither reading `e.message` nor a bare
+/// `JSON.stringify` is safe: `throw null` and errors that link two objects both ways
+/// (axios hangs `response` off `request` and back) abort the wrapper itself, and the
+/// job then reports the wrapper's own stack instead of what the script threw.
 ///
-/// `collectExtra` is true only where the wrapper already reported the thrown value's own
-/// properties, which is the Bun main and Bun WAC v2 wrappers alone. Turning it on for the
-/// other three would newly persist whatever an HTTP client hangs off its errors,
-/// credential-bearing headers included, into the run history of every existing script on
-/// those paths; that parity is its own decision, not part of stopping a crash.
+/// `collectExtra` must stay false on every wrapper that did not already report the
+/// thrown value's own properties, which is all of them but the two Bun script wrappers.
+/// Enabling it there would newly persist whatever an HTTP client hangs off its errors,
+/// credential-bearing headers included, into existing scripts' run history.
 ///
-/// Kept comment-free, since it is written out per job.
+/// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
 const wmErrOwnKeys = ['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'];
 
@@ -103,9 +100,20 @@ function wmErrProp(e, key) {
     }
 }
 
+function wmErrDescribe(v) {
+    let s;
+    if (v !== null && typeof v === 'object') {
+        try {
+            s = wmSerializeError(v);
+        } catch (_) {}
+    }
+    if (s === undefined || s === '{}') s = wmErrString(v);
+    return s.length > 10000 ? s.slice(0, 10000) + '...[truncated]' : s;
+}
+
 function wmToErrorObject(e, collectExtra) {
     if (e === null || typeof e !== 'object') {
-        return { message: wmErrString(e), name: 'ThrownValue' };
+        return { message: wmErrDescribe(e), name: 'ThrownValue' };
     }
     const err = {};
     for (const field of ['message', 'name', 'stack']) {
@@ -120,12 +128,13 @@ function wmToErrorObject(e, collectExtra) {
         const extra = {};
         for (const key of keys) {
             if (wmErrOwnKeys.includes(key)) continue;
-            extra[key] = wmErrProp(e, key);
+            const v = wmErrProp(e, key);
+            if (v !== undefined) extra[key] = v;
         }
         if (Object.keys(extra).length > 0) err.extra = extra;
     }
     if (Object.keys(err).length === 0) {
-        err.message = wmErrString(e);
+        err.message = wmErrDescribe(e);
         err.name = 'ThrownValue';
     }
     return err;

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -67,6 +67,86 @@ mount {
 #[cfg(not(debug_assertions))]
 pub const DEV_CONF_NSJAIL: &str = "";
 
+/// Helpers the Bun/Deno wrappers use to turn a thrown value into the error object
+/// they report, injected into the generated wrapper source.
+///
+/// A script can throw anything, so neither reading `e.message` nor calling
+/// `JSON.stringify` on the result is safe: `throw null`, and errors that link two
+/// objects both ways (an axios error hangs `response` off `request` and back), both
+/// abort the wrapper itself, and the job then reports a stack trace from the wrapper
+/// instead of what the script threw.
+///
+/// `collectExtra` is true only where the wrapper already reported the thrown value's own
+/// properties, which is the Bun main and Bun WAC v2 wrappers alone. Turning it on for the
+/// other three would newly persist whatever an HTTP client hangs off its errors,
+/// credential-bearing headers included, into the run history of every existing script on
+/// those paths; that parity is its own decision, not part of stopping a crash.
+///
+/// Kept comment-free, since it is written out per job.
+pub const JS_ERROR_SERIALIZER: &str = r#"
+const wmErrOwnKeys = ['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'];
+
+function wmErrString(v) {
+    if (typeof v === 'string') return v;
+    try {
+        return String(v);
+    } catch (_) {
+        return '[unstringifiable ' + typeof v + ']';
+    }
+}
+
+function wmErrProp(e, key) {
+    try {
+        return e[key];
+    } catch (_) {
+        return undefined;
+    }
+}
+
+function wmToErrorObject(e, collectExtra) {
+    if (e === null || typeof e !== 'object') {
+        return { message: wmErrString(e), name: 'ThrownValue' };
+    }
+    const err = {};
+    for (const field of ['message', 'name', 'stack']) {
+        const v = wmErrProp(e, field);
+        if (v != null) err[field] = wmErrString(v);
+    }
+    if (collectExtra) {
+        let keys = [];
+        try {
+            keys = Object.getOwnPropertyNames(e);
+        } catch (_) {}
+        const extra = {};
+        for (const key of keys) {
+            if (wmErrOwnKeys.includes(key)) continue;
+            extra[key] = wmErrProp(e, key);
+        }
+        if (Object.keys(extra).length > 0) err.extra = extra;
+    }
+    if (Object.keys(err).length === 0) {
+        err.message = wmErrString(e);
+        err.name = 'ThrownValue';
+    }
+    return err;
+}
+
+function wmSerializeError(err) {
+    const ancestors = [];
+    try {
+        return JSON.stringify(err, function (key, v) {
+            if (v === null || typeof v !== 'object') return v;
+            while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) ancestors.pop();
+            if (ancestors.indexOf(v) !== -1) return '[Circular]';
+            ancestors.push(v);
+            return v;
+        });
+    } catch (_) {
+        return JSON.stringify({ message: err.message, name: err.name, stack: err.stack, step_id: err.step_id, line: err.line });
+    }
+}
+"#;
+
 /// Turn a JSON value into the string a shell/CLI arg should receive: a JSON string
 /// becomes its inner value, anything else is re-serialized compactly.
 pub(crate) fn raw_to_string(x: &str) -> String {

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -79,11 +79,11 @@ pub const DEV_CONF_NSJAIL: &str = "";
 /// Enabling it there would newly persist whatever an HTTP client hangs off its errors,
 /// credential-bearing headers included, into existing scripts' run history.
 ///
-/// What a thrown object holds is reported only through the one plain `JSON.stringify`
-/// the wrappers already did, so it reaches a result exactly when it did before. What used
-/// to crash instead reports the thrown value's own strings and a marker: an HTTP client
-/// hangs its whole request off a cyclic error, credentials and mTLS keys included, and
-/// nothing may render that graph, no blocklist of key names being complete enough to.
+/// What a thrown object holds is reported only through the one plain `JSON.stringify` the
+/// wrappers already did, so nothing reaches a result that the bare call did not already put
+/// there. What used to crash reports the thrown value's own strings and a marker instead:
+/// an HTTP client hangs its whole request off a cyclic error, credentials and mTLS keys
+/// included, and no blocklist of key names is complete enough to render that graph safely.
 ///
 /// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
@@ -111,9 +111,21 @@ function wmToErrorObject(e, collectExtra) {
         return { message: wmErrString(e), name: 'ThrownValue' };
     }
     const err = {};
+    let identified = false;
     for (const field of ['message', 'name', 'stack']) {
         const v = wmErrProp(e, field);
-        if (v != null) err[field] = wmErrString(v);
+        if (v != null) {
+            err[field] = wmErrString(v);
+            identified = true;
+        }
+    }
+    if (!identified) {
+        err.name = 'ThrownValue';
+        try {
+            err.message = Object.prototype.toString.call(e);
+        } catch (_) {
+            err.message = '[unstringifiable object]';
+        }
     }
     if (collectExtra) {
         let keys = [];
@@ -127,14 +139,6 @@ function wmToErrorObject(e, collectExtra) {
             if (v !== undefined) extra[key] = v;
         }
         if (Object.keys(extra).length > 0) err.extra = extra;
-    }
-    if (Object.keys(err).length === 0) {
-        err.name = 'ThrownValue';
-        try {
-            err.message = Object.prototype.toString.call(e);
-        } catch (_) {
-            err.message = '[unstringifiable object]';
-        }
     }
     return err;
 }

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -83,9 +83,16 @@ pub const DEV_CONF_NSJAIL: &str = "";
 /// it runs only for a value exposing none of message/name/stack, which an HTTP client's
 /// error never is, and only to fill a message that would otherwise be `[object Object]`.
 ///
+/// Making a cyclic graph serializable is what puts an HTTP client's whole request under
+/// `extra` for the first time, so the replacer drops transport-credential keys and the
+/// walk is capped: `console.error` prints those nested objects as `[Object ...]`, and the
+/// crash kept them out of the result entirely, so neither had reached a stored result.
+///
 /// Comment-free on purpose: it is written into each job's wrapper source.
 pub const JS_ERROR_SERIALIZER: &str = r#"
 const wmErrOwnKeys = ['line', 'name', 'stack', 'column', 'message', 'sourceURL', 'originalLine', 'originalColumn'];
+const wmErrSecretKeys = /^(authorization|proxy-authorization|cookie|set-cookie|x-api-key|api[-_]?key|_header)$/i;
+const wmErrMaxExtra = 100000;
 
 function wmErrString(v) {
     if (typeof v === 'string') return v;
@@ -134,7 +141,10 @@ function wmToErrorObject(e, collectExtra) {
             const v = wmErrProp(e, key);
             if (v !== undefined) extra[key] = v;
         }
-        if (Object.keys(extra).length > 0) err.extra = extra;
+        if (Object.keys(extra).length > 0) {
+            const s = wmSerializeError(extra);
+            err.extra = s !== undefined && s.length <= wmErrMaxExtra ? extra : '[extra omitted: too large]';
+        }
     }
     if (Object.keys(err).length === 0) {
         err.message = wmErrDescribe(e);
@@ -147,6 +157,7 @@ function wmSerializeError(err) {
     const ancestors = [];
     try {
         return JSON.stringify(err, function (key, v) {
+            if (wmErrSecretKeys.test(key)) return '[redacted]';
             if (v === null || typeof v !== 'object') return v;
             while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) ancestors.pop();
             if (ancestors.indexOf(v) !== -1) return '[Circular]';

--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -9,7 +9,7 @@ use crate::{
     common::{
         build_command_with_isolation, create_args_and_out_file, get_reserved_variables,
         parse_npm_config, read_file, read_result, start_child_process, OccupancyMetrics,
-        StreamNotifier,
+        StreamNotifier, JS_ERROR_SERIALIZER,
     },
     get_proxy_envs_for_lang,
     handle_child::handle_child,
@@ -342,6 +342,7 @@ function argsObjToArr({{ {spread} }}) {{
 BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
+{JS_ERROR_SERIALIZER}
 
 function isAsyncIterable(obj) {{
     return obj != null && typeof obj[Symbol.asyncIterator] === 'function';
@@ -368,12 +369,12 @@ async function run() {{
 try {{
     await run();
 }} catch(e) {{
-    let err = {{ message: e.message, name: e.name, stack: e.stack }};
-    let step_id = Deno.env.get("WM_FLOW_STEP_ID");
+    const err = wmToErrorObject(e, false);
+    const step_id = Deno.env.get("WM_FLOW_STEP_ID");
     if (step_id) {{
         err["step_id"] = step_id;
     }}
-    await Deno.writeTextFile("result.json", JSON.stringify(err));
+    await Deno.writeTextFile("result.json", wmSerializeError(err));
     Deno.exit(1);
 }}
     "#,
@@ -662,7 +663,7 @@ pub fn generate_dedicated_worker_wrapper(inner_content: &str) -> Result<String> 
                 let res: any = await main(...[ {spread} ]);
                 console.log("wm_res[success]:" + JSON.stringify(res ?? null, (key, value) => typeof value === 'undefined' ? null : value) + '\n');
             }} catch (e) {{
-                console.log("wm_res[error]:" + JSON.stringify({{ message: e.message, name: e.name, stack: e.stack, line: line }}) + '\n');
+                console.log("wm_res[error]:" + wmSerializeError(Object.assign(wmToErrorObject(e, false), {{ line: line }})) + '\n');
             }}
             continue;
         }}"#
@@ -679,6 +680,7 @@ import {{ main }} from "./main.ts";
 BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
+{JS_ERROR_SERIALIZER}
 
 console.log('start\n');
 
@@ -705,7 +707,7 @@ for await (const chunk of Deno.stdin.readable) {{
                 let res: any = await main(...[ {spread} ]);
                 console.log("wm_res[success]:" + JSON.stringify(res ?? null, (key, value) => typeof value === 'undefined' ? null : value) + '\n');
             }} catch (e) {{
-                console.log("wm_res[error]:" + JSON.stringify({{ message: e.message, name: e.name, stack: e.stack, line: argsJson }}) + '\n');
+                console.log("wm_res[error]:" + wmSerializeError(Object.assign(wmToErrorObject(e, false), {{ line: argsJson }})) + '\n');
             }}
             continue;
         }}


### PR DESCRIPTION
## Summary

The Bun wrapper that turns a thrown value into a job error was not defensive about what a script actually threw:

- `throw null` crashed it on `e.message`.
- A thrown object with a reference cycle crashed the `JSON.stringify` that writes `result.json`. This is the practically important case: several widely used HTTP clients throw errors with circular references (an axios error hangs `response` off `request` and back), so any adapter that lets one propagate lost it entirely.
- `throw "a string"` survived, but was spread into a character index map (`{"0":"n","1":"u",...}`).

The blast radius is error *reporting*, not correctness: the job still fails, nothing is lost or corrupted, no worker dies. What is lost is why it failed, since the result carries a stack trace from Windmill's own wrapper instead of the script's error. That makes the real cause unrecoverable from run history and leaves a flow error handler unable to branch on the error class.

The Deno wrappers share the same unguarded `e.message` read, so `throw null` crashed them too, and a thrown non-object produced an empty `{}`.

Fixes GIT-984.

## Changes

A shared `JS_ERROR_SERIALIZER` const in `backend/windmill-worker/src/common.rs`, injected into all five generated wrapper templates (Bun main, Bun WAC v2, Bun dedicated worker / runner group, Deno main, Deno dedicated worker):

- `wmToErrorObject` reads `message` / `name` / `stack` behind a guard, so a non-object throw cannot crash the wrapper, and it no longer spreads a non-object's indices into `extra`. A thrown non-object becomes `{ message: <string form>, name: "ThrownValue" }`, so `throw null` reports `null` and `throw "boom"` reports `boom` verbatim, at any length.
- `wmSerializeError` attempts the plain `JSON.stringify` the wrappers already did, and only if that throws retries with `extra` replaced by `"[extra omitted: not serializable]"`, falling back to the thrown value's own string fields. So the output is byte-identical wherever the old wrapper produced one, and the job reports the script's error instead of the wrapper's stack wherever it did not.
- A thrown object exposing none of `message` / `name` / `stack` reports `Object.prototype.toString.call(e)`, a type tag with no contents, where Deno previously stored a bare `{}`. It fires whether or not `extra` is present, so a cyclic object thrown on Bun still carries an identifying field rather than the marker alone.
- `extra` skips properties that read back `undefined`, so a thrown object whose getters throw still reports an identifiable error rather than an empty `{"extra":{}}`.
- `collectExtra` is true only for the two wrappers that already collected the thrown value's own properties: the Bun main wrapper and Bun WAC v2. The Bun dedicated worker / runner group and both Deno wrappers emitted `{ message, name, stack }` and keep doing so. Giving them `extra` would newly persist whatever an HTTP client hangs off its errors, credential-bearing headers included, into the run history of every existing script on those paths. That parity is a separate decision, not part of stopping the wrapper from crashing.

A thrown `Error`, and a thrown object carrying its own `message`, are reported exactly as before. What changes is only what used to be unreportable: a value that crashed the wrapper now yields the fields it does expose, and one exposing none of them gains the type tag rather than an empty object.

The helper adds ~2 KB to the per-job `wrapper.mjs` in the job's temp directory, and nothing else. It does not reach the cached bundle: that is built from `main.ts` alone (`bun_executor.rs:1003`) and the wrapper imports it, which is why `bun_executor.rs:2194` rewrites the wrapper's import to `./main.js` afterwards. Verified by grepping the on-disk bundle cache. The helpers are function declarations that only run inside `catch`, so the success path is unaffected; parse cost measured against bun startup is below the noise floor.

## Test plan

- [x] `cargo test -p windmill --test bun_jobs --test worker` (68 tests, all pass) plus `wac_approval_resume` / `wac_approval_urls`. Two regression tests, `test_bun_job_non_error_throws` and `test_deno_job_non_error_throws`, pin the throws each runtime actually got wrong, including the Deno no-`extra` invariant, a real-shaped cyclic `AxiosError` carrying sentinels in a header, in `config.auth` and in an mTLS private key, and on Deno a `throw { cause: axiosErr }` wrapper, none of which may appear in the result.
- [x] Ran real jobs against this worktree's backend for `throw null`, a thrown string, a thrown plain object, `throw { cause: axiosErr }`, a cyclic `AxiosError`, a thrown `Error` and a successful return, on **bun** and on **deno**, plus the cyclic cases through a **WAC v2** workflow. Every case reports the script's own value; none reports the wrapper, and the success path is unchanged. The sentinel credential appears zero times in every stored result, on all three paths.
- [x] Generated the **dedicated worker** wrappers (Bun and Deno) from the real codegen functions and drove them over their `execd:` line protocol for the same cases: each `wm_res[error]:` line stays a single line and carries the thrown value.
- [x] Ran the pre-fix wrapper logic and the new one side by side, in both `collectExtra` modes, asserting `extra` parity on every acyclic shape and no sentinel on every previously-crashing one: plain objects, errors with scalar and with nested-acyclic properties, the cyclic `AxiosError`, `throw { cause: axiosErr }`, a cyclic secret-bearing plain object, an array cycle, a BigInt property, a function property, and a key-sensitive `toJSON`. Also the awkward primitives: symbol, bigint, `Object.create(null)`, a getter that throws, a `toString` that throws. All three runtimes agree byte for byte.

Not exercised: the `dedicated_workers` integration suite, which needs `--features private,enterprise`. The local EE worktree sits one commit ahead of the `backend/ee-repo-ref.txt` pin, and that extra commit calls a `windmill-common` helper this branch does not have, so the EE build fails before reaching any test. That is local worktree state, unrelated to this change, which touches no EE file. The two dedicated-worker wrappers were verified instead by generating them from their real codegen functions and driving the line protocol directly, as above.

## On the credential findings

Four review rounds each found a different credential reachable once cyclic graphs serialize: an `Authorization` header, then structured `config.auth = { username, password }`, then an mTLS private key under `config.httpsAgent.options.key`, then a `wmErrDescribe` helper of mine rendering a `throw { cause: err }` wrapper's whole contents into `message` on the paths that collect no `extra`. The first two I answered by extending a blocklist of key names. That was the wrong shape: a blocklist over a library's internal object graph can never be complete, and each round produced the next key name.

The blocklist, the size cap and `wmErrDescribe` are all gone, replaced by a condition that is checkable rather than enumerable:

> A thrown object's contents reach the result only through the one plain `JSON.stringify` the wrappers already did.

That makes the exposure question decidable instead of a matter of coverage, and it closes both routes that could carry contents. Where the old wrapper produced a result, the output is byte-identical. Where it crashed, the job reports the thrown value's own `message` / `name` / `stack` plus the marker. A thrown object with none of those fields reports a type tag. So this PR persists nothing that `main` did not, for any thrown value, whatever its keys are named.

I checked that as a property rather than by example, running the pre-fix wrapper logic and the new one side by side in both `collectExtra` modes over: plain objects, errors with scalar and with nested-acyclic properties, a real-shaped cyclic `AxiosError` carrying sentinels in a header, in `config.auth` and in an mTLS key, a `throw { cause: axiosErr }` wrapper, a cyclic secret-bearing plain object, an array cycle, a BigInt property, a function property, and a key-sensitive `toJSON` returning a different graph for the `"extra"` key than for the root. Every acyclic case is byte-identical; every previously-crashing case yields the marker; the sentinel count is zero throughout, under bun, node and deno alike.

Two notes behind that:

- `wmSerializeError` does not probe and then re-serialize. A probe in a separate context can disagree with the real serialization, because `toJSON` receives the key it is being serialized under.
- The pre-existing exposure is untouched, deliberately: an *acyclic* HTTP error already serialized `config` / `request` / `response` into `extra` on `main`, credentials included. Redacting that applies to results, logs and returned values alike, changes what existing scripts read out of `extra`, and wants its own change rather than the blocklist that failed to converge here.

The cost is that an axios error no longer carries `extra.response.status`. That is parity with `main`, which carried nothing at all for those errors, and `message` / `name` / `stack` still identify the failure. A bounded, cycle-safe projection of transport errors would be a genuine improvement, but it is an enrichment rather than part of stopping a crash.

## Left in draft

This regenerates the wrapper for every Bun and Deno job, so the blast radius is wider than the two-file diff suggests. Per the repo's PR policy that is a change to shared worker infrastructure and wants a human look before it goes ready, so it stays a clean draft rather than flipping on a green round.
