### PR TITLE
docs(api): document large completed job result placeholder

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -27991,9 +27991,9 @@ components:
         args:
           $ref: "#/components/schemas/ScriptArgs"
         result:
-	   description: |
-	     For large results, this may be the placeholder string 'WINDMILL_TOO_BIG'.
-	     Use the completed job result endpoint to retrieve the full result.
+          description: |
+            For large results, this may be the placeholder string 'WINDMILL_TOO_BIG'.
+            Use the completed job result endpoint to retrieve the full result.
         logs:
           type: string
         deleted:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -27990,7 +27990,10 @@ components:
           type: string
         args:
           $ref: "#/components/schemas/ScriptArgs"
-        result: {}
+        result:
+	   description: |
+	     For large results, this may be the placeholder string 'WINDMILL_TOO_BIG'.
+	     Use the completed job result endpoint to retrieve the full result.
         logs:
           type: string
         deleted:


### PR DESCRIPTION
## Summary

Documents the `WINDMILL_TOO_BIG` placeholder returned in `CompletedJob.result` for large results.

The API already exposes a separate completed-job result endpoint for retrieving the full result, but the placeholder behavior was not documented in the OpenAPI schema.

## Why

This addresses the minimum documented-improvement path described in #10860: make the sentinel value and recovery path explicit for API consumers.

## Testing

- `git diff --check`
- Documentation-only OpenAPI change; no runtime behavior changed

Fixes #10860

I have read the CLA Document and I hereby sign the CLA.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `WINDMILL_TOO_BIG` placeholder returned in `CompletedJob.result` for large results, so API consumers know to use the completed job result endpoint to retrieve the full result. Documentation-only change without runtime behavior impact. Fixes #10860.

<sup>Written for commit c2843786f759306404959cef050126fe94bbb92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



