### PR TITLE
fix: allow job tokens to read the automate_username_creation setting

### DIFF
--- a/backend/tests/wm_token_confinement.rs
+++ b/backend/tests/wm_token_confinement.rs
@@ -318,8 +318,9 @@ async fn test_wm_token_is_confined_to_its_workspace(db: Pool<Postgres>) -> anyho
             resp.text().await?
         );
     }
-    // ...and the single `settings/global` key the handler itself leaves ungated, which the
-    // CLI reads before creating a user on a git-sync push. Every other key stays out.
+    // ...and the one `settings/global` key on the allowlist, which the CLI reads before
+    // creating a user on a git-sync push. `ws_base_url` is the control: the handler leaves
+    // it as ungated as `automate_username_creation`, so only the allowlist stops it.
     let resp = authed(
         client().get(format!("{api}/settings/global/automate_username_creation")),
         &user_wm,
@@ -333,7 +334,7 @@ async fn test_wm_token_is_confined_to_its_workspace(db: Pool<Postgres>) -> anyho
         resp.text().await?
     );
     let resp = authed(
-        client().get(format!("{api}/settings/global/base_url")),
+        client().get(format!("{api}/settings/global/ws_base_url")),
         &user_wm,
     )
     .send()

--- a/backend/tests/wm_token_confinement.rs
+++ b/backend/tests/wm_token_confinement.rs
@@ -318,6 +318,32 @@ async fn test_wm_token_is_confined_to_its_workspace(db: Pool<Postgres>) -> anyho
             resp.text().await?
         );
     }
+    // ...and the single `settings/global` key the handler itself leaves ungated, which the
+    // CLI reads before creating a user on a git-sync push. Every other key stays out.
+    let resp = authed(
+        client().get(format!("{api}/settings/global/automate_username_creation")),
+        &user_wm,
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "WM_TOKEN must still read automate_username_creation: {}",
+        resp.text().await?
+    );
+    let resp = authed(
+        client().get(format!("{api}/settings/global/base_url")),
+        &user_wm,
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        403,
+        "WM_TOKEN must not read any other global setting: {}",
+        resp.text().await?
+    );
     let resp = authed(client().post(format!("{api}/schedules/preview")), &user_wm)
         .json(&json!({ "schedule": "0 0 12 * * *", "timezone": "UTC" }))
         .send()

--- a/backend/windmill-api-auth/src/scopes.rs
+++ b/backend/windmill-api-auth/src/scopes.rs
@@ -996,11 +996,12 @@ fn scope_grants_access(
 /// the caller's own row; `email` and `allowed_domain_auto_invite` are derived from the
 /// token itself and touch no table.
 ///
-/// `settings/global/automate_username_creation` is the one instance setting on the list:
-/// `get_global_setting` exempts that key from its own super-admin gate, so the boolean is
-/// already readable by every authenticated user, and the CLI reads it before creating a
-/// user during a git-sync push, which runs as a job. No other `settings/global` key
-/// qualifies — the rest of that route stays confined.
+/// `settings/global/automate_username_creation` is the one instance setting on the list.
+/// `get_global_setting` exempts a handful of keys from its own super-admin gate, that one
+/// among them, so the boolean is already readable by every authenticated user; it is here
+/// because the CLI reads it before creating a user during a git-sync push, which runs as a
+/// job. The other ungated keys have no such caller, so they stay confined — being ungated
+/// earns a key nothing on its own.
 ///
 /// Deliberately absent, as each crosses that line: `users/list_invites` (returns the
 /// workspace ids the identity was invited to), `users/tokens/list` (credential metadata

--- a/backend/windmill-api-auth/src/scopes.rs
+++ b/backend/windmill-api-auth/src/scopes.rs
@@ -996,6 +996,12 @@ fn scope_grants_access(
 /// the caller's own row; `email` and `allowed_domain_auto_invite` are derived from the
 /// token itself and touch no table.
 ///
+/// `settings/global/automate_username_creation` is the one instance setting on the list:
+/// `get_global_setting` exempts that key from its own super-admin gate, so the boolean is
+/// already readable by every authenticated user, and the CLI reads it before creating a
+/// user during a git-sync push, which runs as a job. No other `settings/global` key
+/// qualifies — the rest of that route stays confined.
+///
 /// Deliberately absent, as each crosses that line: `users/list_invites` (returns the
 /// workspace ids the identity was invited to), `users/tokens/list` (credential metadata
 /// of the borrowed identity), `users/exists/{email}` (an oracle over arbitrary
@@ -1011,6 +1017,7 @@ fn is_global_read_open_to_job_token(route_path: &str) -> bool {
             | "/api/users/usage"
             | "/api/users/tutorial_progress"
             | "/api/workspaces/allowed_domain_auto_invite"
+            | "/api/settings/global/automate_username_creation"
             | "/api/docs/search"
             | "/api/docs/page"
             | "/api/integrations/hub/list"


### PR DESCRIPTION
## Summary

Fixes WIN-2459.

The `is_global_read_open_to_job_token` allowlist that confines a job token (`$WM_TOKEN`) to
workspace-scoped routes did not include `/api/settings/global/automate_username_creation`.
The CLI reads that setting before creating a user (`cli/src/commands/user/user.ts:197`), and
during a git-sync push it runs as a job, so the read returned `403` and aborted the whole
push.

`get_global_setting` already exempts that key from its own super-admin gate, so the boolean is
readable by any authenticated user with an ordinary API token. A job token borrows an
authenticated identity, so granting it the same read discloses nothing new.

## Changes

- `backend/windmill-api-auth/src/scopes.rs`: add `/api/settings/global/automate_username_creation`
  to `is_global_read_open_to_job_token`, as an exact match rather than a prefix, so no adjacent
  `settings/global` key is reachable. The grant is read-only by construction — the `POST` on the
  same axum route maps to `ScopeAction::Write` and stays denied.
- `backend/tests/wm_token_confinement.rs`: extend `test_wm_token_is_confined_to_its_workspace`
  with the positive case and a control. The control key is `ws_base_url`, which the handler
  leaves as ungated as `automate_username_creation`, so its `403` proves the allowlist is what
  blocks it rather than the handler's own super-admin gate.

## Test plan

- [x] `cargo test --test wm_token_confinement --features quickjs,enterprise,private` — all 11 tests pass.
- [x] Exercised end to end on a running instance: a real `bash` job read
      `GET /api/settings/global/automate_username_creation` with its `$WM_TOKEN` and got
      `HTTP 200 : true`; the same job reading `ws_base_url` still got `403` from the
      confinement middleware, while a plain user token reads `ws_base_url` with `200`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes job tokens being denied read access to the `automate_username_creation` setting, which aborted git-sync pushes when the CLI reads it before creating a user. The exact route is now allowlisted for job-token reads; all other global settings stay confined, and the write action on the same route remains denied.

- Adds `/api/settings/global/automate_username_creation` as an exact-match entry in the job-token read allowlist.
- Extends the confinement test with a positive case and a `ws_base_url` control to prove the allowlist, not the handler, gates it.

<sup>Written for commit e4d86d69b45027c03969a3a8ad498e082e8580bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

Review round clean at `e4d86d69b45027c03969a3a8ad498e082e8580bc` (codex: Good to merge, claude: Good to merge). Left in draft anyway: it widens the job-token confinement allowlist, so it wants a human look at the auth boundary before ready.
