### PR TITLE
fix: pre-fill the test panel JSON args editor and align its placeholder

### DIFF
--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import SchemaForm from '$lib/components/SchemaForm.svelte'
 	import JsonInputs from '$lib/components/JsonInputs.svelte'
+	import { argsToJsonPayload } from '$lib/schema'
 	import JobLoader from '$lib/components/JobLoader.svelte'
 	import { Button } from '$lib/components/common'
 	import { WindmillIcon } from '$lib/components/icons'
@@ -161,7 +162,6 @@
 	let args: Record<string, any> = $state({})
 	let isValid: boolean = $state(true)
 	let jsonView: boolean = $state(false)
-	let jsonEditor: JsonInputs | undefined = $state(undefined)
 	let schemaHeight = $state(0)
 
 	// Test
@@ -1171,20 +1171,17 @@
 									rightTooltip: 'Fill args from JSON'
 								}}
 								lightMode
-								on:change={() => {
-									jsonEditor?.setCode(JSON.stringify(args ?? {}, null, '\t'))
-								}}
 							/>
 						</div>
 						{#if jsonView}
 							<div class="py-2" style="height: {Math.max(schemaHeight, 300)}px">
 								<JsonInputs
-									bind:this={jsonEditor}
 									on:select={(e) => {
 										if (e.detail) {
 											args = e.detail
 										}
 									}}
+									initialCode={argsToJsonPayload(schema, args)}
 									updateOnBlur={false}
 									placeholder={`Write args as JSON.<br/><br/>Example:<br/><br/>{<br/>&nbsp;&nbsp;"foo": "12"<br/>}`}
 								/>

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -34,6 +34,8 @@
 	import InputSelectedBadge from './schema/InputSelectedBadge.svelte'
 	import Toggle from './Toggle.svelte'
 	import JsonInputs from './JsonInputs.svelte'
+	import { argsToJsonPayload } from '$lib/schema'
+	import type { Schema } from '$lib/common'
 	import FlowHistoryJobPicker from './FlowHistoryJobPicker.svelte'
 	import type { DurationStatus, GraphModuleState } from './graph'
 	import { getStepHistoryLoaderContext } from './stepHistoryLoader.svelte'
@@ -264,7 +266,9 @@
 			previewArgs.val = input
 			inputSelected = type
 			preventEscape = true
-			jsonEditor?.setCode(JSON.stringify(previewArgs.val ?? {}, null, '\t'))
+			jsonEditor?.setCode(
+				argsToJsonPayload(flowStore.val.schema as Schema | undefined, previewArgs.val)
+			)
 		}
 	}
 
@@ -510,8 +514,7 @@
 										rightTooltip: 'Fill args from JSON'
 									}}
 									lightMode
-									on:change={(e) => {
-										jsonEditor?.setCode(JSON.stringify(previewArgs.val ?? {}, null, '\t'))
+									on:change={() => {
 										refresh()
 									}}
 								/>
@@ -526,6 +529,10 @@
 											previewArgs.val = e.detail
 										}
 									}}
+									initialCode={argsToJsonPayload(
+										flowStore.val.schema as Schema | undefined,
+										previewArgs.val
+									)}
 									updateOnBlur={false}
 									placeholder={`Write args as JSON.<br/><br/>Example:<br/><br/>{<br/>&nbsp;&nbsp;"foo": "12"<br/>}`}
 								/>

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -266,10 +266,12 @@
 			previewArgs.val = input
 			inputSelected = type
 			preventEscape = true
-			jsonEditor?.setCode(
-				argsToJsonPayload(flowStore.val.schema as Schema | undefined, previewArgs.val)
-			)
 		}
+		// Deselecting restores the args the same way selecting replaced them, so both branches
+		// owe the editor an overwrite — it holds a payload for the input being left behind.
+		jsonEditor?.setCode(
+			argsToJsonPayload(flowStore.val.schema as Schema | undefined, previewArgs.val)
+		)
 	}
 
 	export function refresh() {

--- a/frontend/src/lib/components/JsonInputs.svelte
+++ b/frontend/src/lib/components/JsonInputs.svelte
@@ -8,8 +8,9 @@
 		updateOnBlur?: boolean
 		placeholder?: string
 		selected?: boolean
-		/** Content the editor opens with. Read once, at mount: later changes to the value it was
-		 * derived from must not overwrite what is being typed. */
+		/** Content the editor opens with, and keeps following while the buffer is untouched — so a
+		 * payload nobody has typed into tracks the schema instead of going stale. The first edit
+		 * hands the buffer to the user and later changes stop overwriting it. */
 		initialCode?: string
 	}
 
@@ -21,8 +22,28 @@
 	}: Props = $props()
 
 	let pendingJson = $state(untrack(() => initialCode))
+	// The last content this component wrote. While the buffer still equals it nobody has typed,
+	// so it is ours to refresh; once they diverge the payload is the user's.
+	let seededCode = $state(untrack(() => initialCode))
 	let simpleEditor: SimpleEditor | undefined = $state(undefined)
 	let focusTrap: HTMLElement | undefined = $state()
+
+	$effect(() => {
+		const next = initialCode
+		untrack(() => {
+			if (next !== seededCode && pendingJson === seededCode) {
+				seed(next)
+			}
+		})
+	})
+
+	// `SimpleEditor.setCode` cancels the change burst its own `setValue` opens, so reseeding
+	// never dispatches `select` — the payload reaches `args` only when the user edits it.
+	function seed(code: string) {
+		seededCode = code
+		pendingJson = code
+		simpleEditor?.setCode(code)
+	}
 
 	function updatePayloadFromJson(jsonInput: string) {
 		if (jsonInput === undefined || jsonInput === null || jsonInput.trim() === '') {
@@ -37,8 +58,10 @@
 		}
 	}
 
+	/** Authoritative overwrite: replaces the buffer whether or not it has been typed into, and
+	 * re-establishes it as the content to keep following. */
 	export function setCode(code: string) {
-		simpleEditor?.setCode(code)
+		seed(code)
 	}
 
 	export function resetSelected(dispatchEvent?: boolean) {

--- a/frontend/src/lib/components/JsonInputs.svelte
+++ b/frontend/src/lib/components/JsonInputs.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import SimpleEditor from '$lib/components/SimpleEditor.svelte'
-	import { createEventDispatcher } from 'svelte'
+	import { createEventDispatcher, untrack } from 'svelte'
 
 	const dispatch = createEventDispatcher()
 
@@ -8,15 +8,19 @@
 		updateOnBlur?: boolean
 		placeholder?: string
 		selected?: boolean
+		/** Content the editor opens with. Read once, at mount: later changes to the value it was
+		 * derived from must not overwrite what is being typed. */
+		initialCode?: string
 	}
 
 	let {
 		updateOnBlur = true,
 		placeholder = 'Write a JSON payload. The input schema will be inferred.<br/><br/>Example:<br/><br/>{<br/>&nbsp;&nbsp;"foo": "12"<br/>}',
-		selected = false
+		selected = false,
+		initialCode = ''
 	}: Props = $props()
 
-	let pendingJson = $state('')
+	let pendingJson = $state(untrack(() => initialCode))
 	let simpleEditor: SimpleEditor | undefined = $state(undefined)
 	let focusTrap: HTMLElement | undefined = $state()
 

--- a/frontend/src/lib/components/JsonInputs.svelte
+++ b/frontend/src/lib/components/JsonInputs.svelte
@@ -22,16 +22,20 @@
 	}: Props = $props()
 
 	let pendingJson = $state(untrack(() => initialCode))
-	// The last content this component wrote. While the buffer still equals it nobody has typed,
-	// so it is ours to refresh; once they diverge the payload is the user's.
-	let seededCode = $state(untrack(() => initialCode))
+	// The last content this component wrote, kept only to skip a reseed that would replace the
+	// buffer with what it already holds — `setValue` resets the cursor and the undo stack.
+	let seededCode = untrack(() => initialCode)
+	// Latched from Monaco's own change event, never from `pendingJson`: that trails the buffer by
+	// SimpleEditor's debounce, a window in which typed text still looks like the seeded payload
+	// and a reseed lands on top of it.
+	let userEdited = false
 	let simpleEditor: SimpleEditor | undefined = $state(undefined)
 	let focusTrap: HTMLElement | undefined = $state()
 
 	$effect(() => {
 		const next = initialCode
 		untrack(() => {
-			if (next !== seededCode && pendingJson === seededCode) {
+			if (next !== seededCode && !userEdited) {
 				seed(next)
 			}
 		})
@@ -41,6 +45,7 @@
 	// never dispatches `select` — the payload reaches `args` only when the user edits it.
 	function seed(code: string) {
 		seededCode = code
+		userEdited = false
 		pendingJson = code
 		simpleEditor?.setCode(code)
 	}
@@ -86,6 +91,7 @@
 <div class="h-full rounded-md border">
 	<SimpleEditor
 		bind:this={simpleEditor}
+		on:input={() => (userEdited = true)}
 		on:focus={() => {
 			if (updateOnBlur) {
 				dispatch('focus')

--- a/frontend/src/lib/components/RunForm.svelte
+++ b/frontend/src/lib/components/RunForm.svelte
@@ -19,6 +19,7 @@
 	import { page } from '$app/state'
 	import { replaceState } from '$app/navigation'
 	import JsonInputs from '$lib/components/JsonInputs.svelte'
+	import { argsToJsonPayload } from '$lib/schema'
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
 	import InputSelectedBadge from './schema/InputSelectedBadge.svelte'
 	import { untrack } from 'svelte'
@@ -199,8 +200,10 @@
 		return result
 	}
 
-	export function setCode(code: string) {
-		jsonEditor?.setCode(code)
+	/** Rewrite the open JSON editor from the current args. Only for args replaced from outside
+	 * the editor: entering the JSON view already starts from whatever `args` holds. */
+	export function syncJsonEditor() {
+		jsonEditor?.setCode(argsToJsonPayload(runnable?.schema, args))
 	}
 	$effect(() => {
 		overrideTag
@@ -320,6 +323,7 @@
 							args = enforceDisabledDefaults(e.detail)
 						}
 					}}
+					initialCode={argsToJsonPayload(runnable.schema, args)}
 					updateOnBlur={false}
 					placeholder={`Write args as JSON.<br/><br/>Example:<br/><br/>{<br/>&nbsp;&nbsp;"foo": "12"<br/>}`}
 				/>

--- a/frontend/src/lib/components/RunForm.svelte
+++ b/frontend/src/lib/components/RunForm.svelte
@@ -54,6 +54,8 @@
 		args = scriptArgs
 		psCommonParams = commonParams
 		reloadArgs++
+		// `reloadArgs` only keys the form; the JSON editor reads its payload once, at mount.
+		syncJsonEditor()
 	}
 
 	export async function run(overrideScheduledForStr?: string | undefined | null) {

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -340,6 +340,9 @@
 			moduleTestState[activeModuleTab] = { args: testPanelArgs, schema: testPanelSchema }
 		}
 		if (modules && modules[modulePath]) {
+			// Re-clicking the tab you are already on must not remount the arg views: it would
+			// throw away whatever is half-typed in the JSON editor.
+			const switched = activeModuleTab !== modulePath
 			activeModuleTab = modulePath
 			editorCode = modules[modulePath].content
 			editor?.setCode(editorCode)
@@ -358,11 +361,14 @@
 					}
 				})
 			}
-			argsRender++
+			if (switched) {
+				argsRender++
+			}
 		}
 	}
 
 	function switchToMain() {
+		const switched = activeModuleTab !== null
 		if (activeModuleTab !== null && modules) {
 			// Save current module content and test state
 			modules[activeModuleTab] = { ...modules[activeModuleTab], content: editorCode }
@@ -372,7 +378,9 @@
 		editorCode = code
 		lastSyncedCode = code
 		editor?.setCode(editorCode)
-		argsRender++
+		if (switched) {
+			argsRender++
+		}
 	}
 
 	// Whether the open file is tested as a runnable of its own. A `__mod` helper
@@ -1668,8 +1676,8 @@
 	$effect(() => {
 		!hasPreprocessor && (selectedTab = 'main')
 	})
-	// `main` and `preprocessor` describe the same args under different schemas. `diagram`
-	// leaves the schema alone, so it must not read as a switch.
+	// `main` and `preprocessor` describe the same args under different schemas; every other tab
+	// (`diagram`) runs against main's schema, so it collapses into `main` here.
 	let lastSchemaTab = untrack(() => (selectedTab === 'preprocessor' ? 'preprocessor' : 'main'))
 	$effect(() => {
 		// Only depend on selectedTab (preprocessor ↔ main toggle).
@@ -1682,9 +1690,10 @@
 				const switched = schemaTab !== lastSchemaTab
 				lastSchemaTab = schemaTab
 				if (!code) return
-				// The other tab's schema only lands once inference resolves, so reseed then.
+				// The other tab's schema only lands once inference resolves, so reseed then —
+				// unless the tab moved again while we waited, in which case a later run owns it.
 				inferSchema(code).then(() => {
-					if (switched) {
+					if (switched && lastSchemaTab === schemaTab) {
 						argsRender++
 					}
 				})

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1668,12 +1668,27 @@
 	$effect(() => {
 		!hasPreprocessor && (selectedTab = 'main')
 	})
+	// `main` and `preprocessor` describe the same args under different schemas. `diagram`
+	// leaves the schema alone, so it must not read as a switch.
+	let lastSchemaTab = untrack(() => (selectedTab === 'preprocessor' ? 'preprocessor' : 'main'))
 	$effect(() => {
 		// Only depend on selectedTab (preprocessor ↔ main toggle).
 		// Code changes are handled by the editor on:change handler and
 		// explicit inferSchema calls (initContent, onMount), so we read
 		// `code` inside untrack to avoid a redundant double-inference race.
-		selectedTab && untrack(() => code && inferSchema(code))
+		selectedTab &&
+			untrack(() => {
+				const schemaTab = selectedTab === 'preprocessor' ? 'preprocessor' : 'main'
+				const switched = schemaTab !== lastSchemaTab
+				lastSchemaTab = schemaTab
+				if (!code) return
+				// The other tab's schema only lands once inference resolves, so reseed then.
+				inferSchema(code).then(() => {
+					if (switched) {
+						argsRender++
+					}
+				})
+			})
 	})
 
 	export async function updateArgs(newArgs: Record<string, any>) {

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -356,13 +356,10 @@
 			} else {
 				testPanelArgs = {}
 				testPanelSchema = emptySchema()
-				// The schema lands asynchronously, so the bump below would leave the editor
-				// showing `{}`; reseed once inference has filled it in.
-				inferModuleSchema().then(() => {
-					if (activeModuleTab === modulePath) {
-						argsRender++
-					}
-				})
+				// Inference lands after the bump below, so the editor opens on `{}` and the arg
+				// views follow the schema in once it arrives. Remounting them again on arrival
+				// instead would discard anything typed while it was in flight.
+				inferModuleSchema()
 			}
 			argsRender++
 		}
@@ -1691,13 +1688,13 @@
 				const switched = schemaTab !== lastSchemaTab
 				lastSchemaTab = schemaTab
 				if (!code) return
-				// The other tab's schema only lands once inference resolves, so reseed then —
-				// unless the tab moved again while we waited, in which case a later run owns it.
-				inferSchema(code).then(() => {
-					if (switched && lastSchemaTab === schemaTab) {
-						argsRender++
-					}
-				})
+				// Bump on the switch itself, not on the inference it starts: the other tab's schema
+				// only lands once that resolves, and remounting the arg views then would discard
+				// anything typed while it was in flight. An untouched editor follows the schema in.
+				if (switched) {
+					argsRender++
+				}
+				inferSchema(code)
 			})
 	})
 

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -334,15 +334,18 @@
 	})
 
 	function switchToModule(modulePath: string) {
-		if (activeModuleTab !== null && modules && activeModuleTab !== modulePath) {
+		// Re-clicking the tab you are already on is a no-op. Re-running the body would reset this
+		// module's test state whenever its inference is still pending or has failed (the catch
+		// leaves `moduleTestState` unwritten), losing both the filled-in args and the arg views.
+		if (activeModuleTab === modulePath) {
+			return
+		}
+		if (activeModuleTab !== null && modules) {
 			// Switching from another module: save its content and test state
 			modules[activeModuleTab] = { ...modules[activeModuleTab], content: editorCode }
 			moduleTestState[activeModuleTab] = { args: testPanelArgs, schema: testPanelSchema }
 		}
 		if (modules && modules[modulePath]) {
-			// Re-clicking the tab you are already on must not remount the arg views: it would
-			// throw away whatever is half-typed in the JSON editor.
-			const switched = activeModuleTab !== modulePath
 			activeModuleTab = modulePath
 			editorCode = modules[modulePath].content
 			editor?.setCode(editorCode)
@@ -361,15 +364,15 @@
 					}
 				})
 			}
-			if (switched) {
-				argsRender++
-			}
+			argsRender++
 		}
 	}
 
 	function switchToMain() {
-		const switched = activeModuleTab !== null
-		if (activeModuleTab !== null && modules) {
+		if (activeModuleTab === null) {
+			return
+		}
+		if (modules) {
 			// Save current module content and test state
 			modules[activeModuleTab] = { ...modules[activeModuleTab], content: editorCode }
 			moduleTestState[activeModuleTab] = { args: testPanelArgs, schema: testPanelSchema }
@@ -378,9 +381,7 @@
 		editorCode = code
 		lastSyncedCode = code
 		editor?.setCode(editorCode)
-		if (switched) {
-			argsRender++
-		}
+		argsRender++
 	}
 
 	// Whether the open file is tested as a runnable of its own. A `__mod` helper

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -122,6 +122,7 @@
 	import { updateDelegateToGitRepoConfig, insertAdditionalInventories } from '$lib/ansibleUtils'
 	import { copilotInfo } from '$lib/aiStore'
 	import JsonInputs from '$lib/components/JsonInputs.svelte'
+	import { argsToJsonPayload } from '$lib/schema'
 	import Toggle from './Toggle.svelte'
 	import { deepEqual } from 'fast-equals'
 	import { usePreparedAssetSqlQueries } from '$lib/infer.svelte'
@@ -310,6 +311,10 @@
 	let moduleTestState: Record<string, { args: Record<string, any>; schema: Schema }> = $state({})
 	let testPanelArgs: Record<string, any> = $state({})
 	let testPanelSchema: Schema = $state(emptySchema())
+	// Bumped whenever the args under test are replaced from outside the arg panel. Both arg
+	// views key off it: without a bump the JSON editor keeps showing, and on the next
+	// keystroke commits, the payload it was seeded with for the previous args.
+	let argsRender = $state(0)
 	// editorCode is what the editor shows; code always holds the main script content
 	let editorCode: string = $state(code)
 	// Sync editorCode when code changes externally (template reset, copilot,
@@ -345,8 +350,15 @@
 			} else {
 				testPanelArgs = {}
 				testPanelSchema = emptySchema()
-				inferModuleSchema()
+				// The schema lands asynchronously, so the bump below would leave the editor
+				// showing `{}`; reseed once inference has filled it in.
+				inferModuleSchema().then(() => {
+					if (activeModuleTab === modulePath) {
+						argsRender++
+					}
+				})
 			}
+			argsRender++
 		}
 	}
 
@@ -360,6 +372,7 @@
 		editorCode = code
 		lastSyncedCode = code
 		editor?.setCode(editorCode)
+		argsRender++
 	}
 
 	// Whether the open file is tested as a runnable of its own. A `__mod` helper
@@ -854,6 +867,7 @@
 
 	export function setArgs(nargs: Record<string, any>) {
 		args = nargs
+		argsRender++
 	}
 
 	export async function runTest(opts?: { cascade?: boolean; skipDdlGuard?: boolean }) {
@@ -1662,7 +1676,6 @@
 		selectedTab && untrack(() => code && inferSchema(code))
 	})
 
-	let argsRender = $state(0)
 	export async function updateArgs(newArgs: Record<string, any>) {
 		if (Object.keys(newArgs).length > 0) {
 			args = { ...newArgs }
@@ -2299,19 +2312,24 @@
 												style="height: {!schemaHeight || schemaHeight < 600 ? 600 : schemaHeight}px"
 												data-schema-picker
 											>
-												<JsonInputs
-													on:select={(e) => {
-														if (e.detail) {
-															if (onModuleArgs) {
-																testPanelArgs = e.detail
-															} else {
-																args = e.detail
+												{#key argsRender}
+													<JsonInputs
+														on:select={(e) => {
+															if (e.detail) {
+																if (onModuleArgs) {
+																	testPanelArgs = e.detail
+																} else {
+																	args = e.detail
+																}
 															}
-														}
-													}}
-													updateOnBlur={false}
-													placeholder={`Write args as JSON.<br/><br/>Example:<br/><br/>{<br/>&nbsp;&nbsp;"foo": "12"<br/>}`}
-												/>
+														}}
+														initialCode={onModuleArgs
+															? argsToJsonPayload(testPanelSchema, testPanelArgs)
+															: argsToJsonPayload(schema, args)}
+														updateOnBlur={false}
+														placeholder={`Write args as JSON.<br/><br/>Example:<br/><br/>{<br/>&nbsp;&nbsp;"foo": "12"<br/>}`}
+													/>
+												{/key}
 											</div>
 										{:else}
 											<div class="px-4">

--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -64,6 +64,9 @@
 	const CHANGE_TIMEOUT = 200
 
 	let changeTimeoutId: number | undefined = undefined
+	// Monaco fires onDidChangeModelContent synchronously from within `setValue`, so without
+	// this an authoritative overwrite reads as a user edit on the `input` event.
+	let applyingCode = false
 
 	let divEl: HTMLDivElement | null = null
 	let editor = $state<meditor.IStandaloneCodeEditor | null>(null)
@@ -183,7 +186,12 @@
 		if (ncode != code) {
 			code = ncode
 		}
-		editor?.setValue(ncode)
+		applyingCode = true
+		try {
+			editor?.setValue(ncode)
+		} finally {
+			applyingCode = false
+		}
 		// setValue emits a change event of its own; drop the burst it opens so an edit
 		// made right after an authoritative overwrite still counts as a leading change.
 		cancelPendingChanges()
@@ -458,6 +466,12 @@
 				changeTimeoutId = undefined
 				updateCode()
 			}, CHANGE_TIMEOUT)
+			// `change` trails the buffer by CHANGE_TIMEOUT, too late for a consumer that has to
+			// know the moment the buffer stopped being the one it wrote. `input` says only that,
+			// carrying no value: read `getCode()` for what is on screen.
+			if (!applyingCode) {
+				dispatch('input')
+			}
 			if (leading) {
 				updateCode()
 			}

--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -74,6 +74,10 @@
 	let width = $state(0)
 	let initialized = $state(false)
 	let placeholderVisible = $state(false)
+	// Monaco's content origin. The placeholder is a plain overlay on the editor container, so
+	// without these it sits over the line-number gutter and off the line-1 baseline.
+	let contentLeft = $state(0)
+	let contentLineHeight = $state(0)
 	let mounted = $state(false)
 
 	let valueAfterDispose: string | undefined = undefined
@@ -533,6 +537,13 @@
 		}
 
 		if (placeholder) {
+			const syncPlaceholderOrigin = () => {
+				if (!editor) return
+				contentLeft = editor.getLayoutInfo().contentLeft
+				contentLineHeight = editor.getOption(meditor.EditorOption.lineHeight)
+			}
+			syncPlaceholderOrigin()
+			editor.onDidLayoutChange(syncPlaceholderOrigin)
 			editor.onDidChangeModelContent(() => {
 				if (!editor) return
 				const value = editor.getValue()
@@ -755,9 +766,10 @@
 	{#if placeholder}
 		<div
 			id="placeholder"
-			class="absolute text-gray-500 text-sm pointer-events-none font-mono z-10 {placeholderVisible
+			class="absolute text-tertiary pointer-events-none font-mono z-10 {placeholderVisible
 				? ''
 				: 'hidden'}"
+			style="left: {contentLeft}px; top: {yPadding}px; font-size: {fontSize}px; line-height: {contentLineHeight}px;"
 		>
 			{@html placeholder}
 		</div>

--- a/frontend/src/lib/schema.test.ts
+++ b/frontend/src/lib/schema.test.ts
@@ -24,6 +24,27 @@ describe('argsToJsonPayload', () => {
 		)
 	})
 
+	it('falls back to the schema default for an absent arg, but not over an explicit null', () => {
+		// `args` only carries defaults once a `SchemaForm` has mounted for that schema, and the
+		// JSON view alone never mounts one — seeding `null` there would commit `null` over the
+		// argument's default on the first keystroke.
+		const schema = schemaOf('a', 'b')
+		schema.properties.a.default = 'hi'
+		schema.properties.b.default = 42
+		expect(argsToJsonPayload(schema, {})).toBe(JSON.stringify({ a: 'hi', b: 42 }, null, '\t'))
+		expect(argsToJsonPayload(schema, { a: null })).toBe(
+			JSON.stringify({ a: null, b: 42 }, null, '\t')
+		)
+	})
+
+	it('keeps declared args named after Object.prototype members', () => {
+		// A plain `nargs[key]` read returns the inherited function for an unset `constructor`,
+		// and `JSON.stringify` drops function-valued properties — the argument would vanish.
+		expect(argsToJsonPayload(schemaOf('constructor', 'toString', 'ok'), {})).toBe(
+			JSON.stringify({ constructor: null, toString: null, ok: null }, null, '\t')
+		)
+	})
+
 	it('keeps undeclared args named after Object.prototype members', () => {
 		// On a plain `{}` accumulator, `'constructor' in payload` is true before anything is
 		// assigned to it.

--- a/frontend/src/lib/schema.test.ts
+++ b/frontend/src/lib/schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { argsToJsonPayload } from './schema'
+import type { Schema } from './common'
+
+const schemaOf = (...names: string[]): Schema =>
+	({
+		$schema: undefined,
+		type: 'object',
+		properties: Object.fromEntries(names.map((n) => [n, { type: 'string' }])),
+		required: []
+	}) as Schema
+
+describe('argsToJsonPayload', () => {
+	it('spells out every schema property in schema order, unset ones as null', () => {
+		// `0`, `false` and `''` are values, not gaps: only a missing arg becomes `null`.
+		expect(argsToJsonPayload(schemaOf('a', 'b', 'c'), { c: 0, a: false })).toBe(
+			JSON.stringify({ a: false, b: null, c: 0 }, null, '\t')
+		)
+	})
+
+	it('keeps args the schema does not declare, after the declared ones', () => {
+		expect(argsToJsonPayload(schemaOf('a'), { z: 9, a: 1 })).toBe(
+			JSON.stringify({ a: 1, z: 9 }, null, '\t')
+		)
+	})
+
+	it('keeps undeclared args named after Object.prototype members', () => {
+		// On a plain `{}` accumulator, `'constructor' in payload` is true before anything is
+		// assigned to it.
+		expect(argsToJsonPayload(undefined, { constructor: 'x', toString: 'y', ok: 1 })).toBe(
+			JSON.stringify({ constructor: 'x', toString: 'y', ok: 1 }, null, '\t')
+		)
+	})
+
+	it('handles a missing schema or missing args', () => {
+		expect(argsToJsonPayload(undefined, undefined)).toBe('{}')
+		expect(argsToJsonPayload(schemaOf('a'), undefined)).toBe(
+			JSON.stringify({ a: null }, null, '\t')
+		)
+	})
+})

--- a/frontend/src/lib/schema.ts
+++ b/frontend/src/lib/schema.ts
@@ -65,9 +65,15 @@ export function argsToJsonPayload(
 	// `toString`) has to be an own key here, or the `in` check below reads it as already
 	// present and its value never reaches the payload.
 	const payload: Record<string, any> = Object.create(null)
+	const props = schema?.properties ?? {}
 	// Schema order first, so the payload reads like the form it replaces.
-	for (const key of Object.keys(schema?.properties ?? {})) {
-		payload[key] = nargs[key] ?? null
+	for (const key of Object.keys(props)) {
+		// Own-property read: an arg named after an `Object.prototype` member (`constructor`,
+		// `toString`) would otherwise come back as the inherited function, which `JSON.stringify`
+		// drops. An arg that is merely absent falls back to the schema default — `args` only
+		// carries defaults once a `SchemaForm` has mounted, which the JSON view alone never does.
+		payload[key] =
+			(Object.prototype.hasOwnProperty.call(nargs, key) ? nargs[key] : props[key]?.default) ?? null
 	}
 	for (const [key, value] of Object.entries(nargs)) {
 		if (!(key in payload)) {

--- a/frontend/src/lib/schema.ts
+++ b/frontend/src/lib/schema.ts
@@ -52,3 +52,27 @@ export function schemaToObject(schema: Schema, args: Record<string, any>): Objec
 	})
 	return object
 }
+
+/** Args as the JSON payload the JSON editor starts from. Every schema property is spelled out,
+ * so an argument with no value yet still shows its name; args the schema does not declare are
+ * kept, since what the editor holds replaces the args wholesale on the next keystroke. */
+export function argsToJsonPayload(
+	schema: Schema | undefined,
+	args: Record<string, any> | undefined
+): string {
+	const nargs = args ?? {}
+	// Null prototype: an arg named after an `Object.prototype` member (`constructor`,
+	// `toString`) has to be an own key here, or the `in` check below reads it as already
+	// present and its value never reaches the payload.
+	const payload: Record<string, any> = Object.create(null)
+	// Schema order first, so the payload reads like the form it replaces.
+	for (const key of Object.keys(schema?.properties ?? {})) {
+		payload[key] = nargs[key] ?? null
+	}
+	for (const [key, value] of Object.entries(nargs)) {
+		if (!(key in payload)) {
+			payload[key] = value
+		}
+	}
+	return JSON.stringify(payload, null, '\t')
+}

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -732,9 +732,6 @@
 													rightTooltip: 'Fill args from JSON'
 												}}
 												lightMode
-												on:change={(e) => {
-													runForm?.setCode(JSON.stringify(args ?? {}, null, '\t'))
-												}}
 											/>
 										{/if}
 									</div>
@@ -817,7 +814,7 @@
 				const nargs = JSON.parse(JSON.stringify(e.detail))
 				args = nargs
 				if (jsonView) {
-					runForm?.setCode(JSON.stringify(args ?? {}, null, '\t'))
+					runForm?.syncJsonEditor()
 				}
 			}}
 		/>

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -388,7 +388,7 @@
 				if (!held || !current || block?.label !== 'retry' || block['dbt_retry_job']) return
 				args = { ...current, command: { ...block, dbt_retry_job: held } }
 				if (jsonView) {
-					runForm?.setCode(JSON.stringify(args, null, '\t'))
+					runForm?.syncJsonEditor()
 				}
 			})
 			.catch(() => {})
@@ -430,7 +430,7 @@
 			}
 		}
 		if (jsonView) {
-			runForm?.setCode(JSON.stringify(args, null, '\t'))
+			runForm?.syncJsonEditor()
 		}
 	}
 
@@ -934,9 +934,6 @@
 												rightTooltip: 'Fill args from JSON'
 											}}
 											lightMode
-											on:change={(e) => {
-												runForm?.setCode(JSON.stringify(args ?? {}, null, '\t'))
-											}}
 										/>
 									{/if}
 								</div>
@@ -1051,7 +1048,7 @@
 						const nargs = JSON.parse(JSON.stringify(e.detail))
 						args = nargs
 						if (jsonView) {
-							runForm?.setCode(JSON.stringify(args ?? {}, null, '\t'))
+							runForm?.syncJsonEditor()
 						}
 					}}
 				/>


### PR DESCRIPTION
## Summary

Fixes WIN-2456. Three defects in the JSON args editor, the third found while fixing the first.

**It opened empty.** Where seeding existed at all, it went through `jsonEditor?.setCode(...)` in the `Toggle`'s `on:change` — but the `bind:this` ref is `undefined` at that moment, because `<JsonInputs>` only mounts once the `{#if}` that same change flips renders it. In the script editor's test panel there was no seeding at all. Where the call did land late enough to win, it used `JSON.stringify(args)`, which drops every argument the user has not filled in yet — so the payload never showed the expected shape.

Seeding now happens through an `initialCode` prop, fed by a shared `argsToJsonPayload(schema, args)`: every schema property is spelled out in schema order, unset ones falling back to the schema default, and args the schema does not declare are kept. That removes the mount-timing race rather than patching around it, and works the same way for all four consumers.

**The placeholder was misplaced.** It was an absolutely positioned overlay pinned to the editor container's corner at a fixed `text-sm`, so it sat over the line-number gutter at the wrong font metrics. It now derives its origin from Monaco's own `getLayoutInfo().contentLeft` and `lineHeight`, resynced on `onDidLayoutChange`, and uses the `text-tertiary` theme token instead of a hardcoded `text-gray-500`.

**The editor kept a stale payload when args were replaced from outside it.** Nothing rewrote the open editor when the args or the schema underneath it were swapped, so it went on showing the previous payload — and since `updateOnBlur={false}`, the next keystroke committed that stale text over the new args. This was pre-existing but became reachable without typing once the editor is pre-filled: a multi-file script ran with `{"a": "z"}` for a `main(x: string)`. Affected the module tabs, the main/preprocessor tabs, the capture "Apply args" action, and — via `RunForm.setArgs` — the AI-fill and reject paths on the run page.

## Changes

- `schema.ts`: new `argsToJsonPayload(schema, args)` — schema order first, undeclared args appended, built on a null-prototype accumulator. Each declared property is read with an own-property check, so an arg named after an `Object.prototype` member (`constructor`, `toString`) is neither dropped by the `in` check nor read back as the inherited function; an argument that is simply absent falls back to the schema's `default`, because `args` only carries defaults once a `SchemaForm` has mounted and the JSON view alone never mounts one. An explicit `null` is preserved rather than resurrected into the default.
- `JsonInputs.svelte`: new `initialCode` prop. The component keeps following it while the buffer is untouched, so a payload nobody has typed into tracks the schema instead of going stale when a signature changes (this also covers `Dev.replaceScript`'s live reload, without touching `Dev.svelte`); the first edit hands the buffer to the user and later changes stop overwriting it. Ownership is latched from Monaco's own change event, not inferred from the bound `code` value — that trails the buffer by `SimpleEditor`'s 200 ms debounce, and a reseed arriving inside that window would land on top of text already typed. Reseeding never dispatches `select` — `SimpleEditor.setCode` cancels the change burst its own `setValue` opens — so the payload still reaches `args` only when the user edits it. `setCode` remains the authoritative overwrite, and re-establishes the content to follow.
- `SimpleEditor.svelte`: placeholder positioned from Monaco's content origin and line height, resynced on layout changes. New `input` event, dispatched undebounced on every user-originated model change, for consumers that must know the moment the buffer stops being the one they wrote; an `applyingCode` guard keeps `setCode`'s own `setValue` from reading as a user edit. No existing consumer listens for it.
- `ScriptEditor.svelte`, `RunForm.svelte`, `FlowPreviewContent.svelte`, `Dev.svelte`: seed via `initialCode`.
- `RunForm.setCode(code)` becomes `syncJsonEditor()` — parameterless and schema-aware — called from the four route sites that replace args from outside the editor (saved input, history pick, dbt retry) and from `RunForm.setArgs` itself, which the AI-fill callback and its reject action use. `{#key reloadArgs}` only keys the form branch, so the editor needs the explicit resync. The two redundant toggle handlers are deleted.
- `ScriptEditor.svelte`: the JSON view now shares the `{#key argsRender}` the form view already had, and `argsRender` is bumped by every writer that replaces the args under test — `setArgs`, `switchToModule`, `switchToMain` and the main/preprocessor toggle, on top of the existing `updateArgs`. `switchToModule` and `switchToMain` return early on a same-tab click: re-running their body would reset that module's test state whenever inference is pending or has failed, wiping the filled-in args as well as the arg views. Two of those writers swap the schema asynchronously (a module tab's first visit, and the preprocessor tab); both bump at the transition and leave the schema to reach the editor through `initialCode` when inference resolves, rather than remounting a second time on arrival and discarding anything typed in the meantime. The `diagram` tab runs against main's schema, so it collapses into `main` for this purpose.
- `FlowPreviewContent.selectInput` overwrote the editor when an input was selected but not when it was deselected, leaving the abandoned input's payload on screen while `previewArgs.val` reverted. The overwrite now runs in both branches.
- `schema.test.ts`: pins `argsToJsonPayload`'s contract.

`FlowInput.svelte`'s `JsonInputs` is deliberately left unseeded — it is the "Json payload" tab used to *infer* a schema, so starting empty is correct there.

## Screenshots

Test panel opens pre-filled with the argument names instead of empty:

![editor-main-prefilled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2456-editing-args-in-json-editor-broken-in-test-panel/1787827767-editor-main-prefilled.png)

Switching to a module tab reseeds from that module's own schema (`helper.ts` takes `a`, not the main script's `x`):

![editor-module-tab-reseeded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2456-editing-args-in-json-editor-broken-in-test-panel/1787827769-editor-module-tab-reseeded.png)

Same for the preprocessor tab, which now shows `event` rather than main's arguments. The leftover main keys stay in the payload on purpose: one keystroke replaces `args` wholesale, so dropping them would erase the main tab's values:

![preprocessor-tab-reseeded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2456-editing-args-in-json-editor-broken-in-test-panel/1787834512-preprocessor-tab-reseeded.png)

Placeholder sits on line 1, clear of the gutter, at the editor's own font metrics:

![placeholder-aligned](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2456-editing-args-in-json-editor-broken-in-test-panel/1787827770-placeholder-aligned.png)

## Test plan

All of the below were exercised by hand against a local instance.

- [x] On a deployed script, flip the JSON toggle on `/scripts/get` — the editor opens with every argument name, not empty. Picking a saved input or a run from history rewrites it. Opening the JSON view and hitting Run without touching the editor sends exactly what the form had, with no stray `null`s.
- [x] In the script editor's test panel, flip to JSON on the main file, then switch module tabs on a multi-file (WAC) script — each tab shows its own arguments, and editing after a switch does not write the previous tab's payload. Verified end to end: the queued job's args read `{"x": "q"}` where they previously read `{"a": "z"}` for a script whose only parameter is `x`.
- [x] Same script in form view: fill a value on each module tab and switch back and forth — values survive the round trip (this path remounts the `SchemaForm`, which it did not before).
- [x] **Defaults, with `moduleTestState` genuinely empty.** Give a module `main(a = "hi", b = 42, c: string)`, then *reload the page* — authoring the module requires visiting its tab, which caches form-computed defaults and masks the bug. With JSON on and on the main file, click that module's tab for the first time: the payload reads `{"a": "hi", "b": 42, "c": null}`, not nulls.
- [x] Type into the JSON editor, then click the tab you are already on (module or Main) — the text survives; only a real tab change reseeds.
- [x] **Schema drift while untouched.** With the JSON view open and never typed into, rename a parameter in the code — the payload follows the new name. Add a parameter, then Run without touching the editor: the submitted args contain neither the new key nor a stray `null`, so a reseed stays display-only.
- [x] **Schema drift after typing.** Type into the payload, then rename a parameter again — your text is left alone.
- [x] On a script with a preprocessor, flip to JSON and toggle Main ↔ Preprocessor — each tab shows its own schema.
- [x] Apply a payload from the Trigger captures tab with the JSON view open — the editor rewrites to the captured args.
- [x] **Typing while inference is in flight.** Type into the JSON payload and change the signature within the debounce window — the typed text survives. Checked at 0, 50, 150 and 400 ms; against the previous value-equality check, 50 ms and 150 ms destroyed it.
- [x] **A reseed does not latch the buffer as the user's.** Rename a parameter twice against an untouched payload — it follows both times, which would not happen if the first reseed's own `setValue` had counted as an edit.
- [x] Switch a tab (module or Main ↔ Preprocessor) and start typing immediately, before inference resolves — the text survives, and each switch remounts the arg views exactly once (counted by Monaco model URI).
- [x] Flow preview drawer: flip to JSON, load a run from history and a saved input, and press Escape to clear the selection. Also **edit** the payload of a selected run before clearing it — deselecting overwrites the edited text rather than leaving it stranded over reverted args.
- [x] Empty the JSON editor and confirm the placeholder sits on line 1 to the right of the gutter, at the editor's font size, and stays put when the pane is resized. Also checked the other `codearea` consumers under `/#superadmin-settings`, which have no gutter.

Not exercised: `functionExports.setPreviewArgs` and the AI-fill / reject paths through `RunForm.setArgs`. Both need an AI provider configured on the instance, so they are verified by reading the call graph rather than by running them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

