### PR TITLE
feat: enable Anthropic prompt caching on Vertex AI agent steps

### DIFF
--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -24,6 +24,14 @@ lazy_static::lazy_static! {
         .ok()
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
+    /// A Google Cloud project can have explicit prompt caching turned off (by request to
+    /// Cloud support), and Vertex then rejects any request carrying cache breakpoints.
+    /// Such a project needs this to run Anthropic agent steps at all.
+    pub static ref DISABLE_ANTHROPIC_PROMPT_CACHING: bool =
+        std::env::var("DISABLE_ANTHROPIC_PROMPT_CACHING")
+            .ok()
+            .map(|v| v == "true" || v == "1")
+            .unwrap_or(false);
 }
 
 pub const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";

--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -24,9 +24,11 @@ lazy_static::lazy_static! {
         .ok()
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
-    /// A Google Cloud project can have explicit prompt caching turned off (by request to
-    /// Cloud support), and Vertex then rejects any request carrying cache breakpoints.
-    /// Such a project needs this to run Anthropic agent steps at all.
+    /// Drops the cache breakpoints from agent-step requests on every Anthropic platform,
+    /// not just the one that motivates it: a Google Cloud project can have explicit prompt
+    /// caching turned off (by request to Cloud support), and Vertex then rejects any request
+    /// carrying breakpoints. An instance that sets this to unblock such a project also gives
+    /// up caching on its direct-Anthropic and Foundry resources.
     pub static ref DISABLE_ANTHROPIC_PROMPT_CACHING: bool =
         std::env::var("DISABLE_ANTHROPIC_PROMPT_CACHING")
             .ok()

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -636,11 +636,7 @@ impl AnthropicQueryBuilder {
             vec![AnthropicSystemContent {
                 r#type: "text".to_string(),
                 text,
-                cache_control: if self.is_vertex() {
-                    None
-                } else {
-                    Some(CacheControl::ephemeral())
-                },
+                cache_control: Some(CacheControl::ephemeral()),
             }]
         });
 
@@ -665,27 +661,23 @@ impl AnthropicQueryBuilder {
         let max_tokens = Some(args.max_tokens.unwrap_or(64000));
 
         // Apply cache_control on the last custom tool
-        if !self.is_vertex() {
-            if let Some(ref mut tools_vec) = tools_option {
-                if let Some(AnthropicTool::Custom(ref mut custom)) = tools_vec.last_mut() {
-                    custom.cache_control = Some(CacheControl::ephemeral());
-                }
+        if let Some(ref mut tools_vec) = tools_option {
+            if let Some(AnthropicTool::Custom(ref mut custom)) = tools_vec.last_mut() {
+                custom.cache_control = Some(CacheControl::ephemeral());
             }
         }
 
         // Apply cache_control on the last content block of the last message
-        if !self.is_vertex() {
-            if let Some(last_msg) = anthropic_messages.last_mut() {
-                if let Some(last_block) = last_msg.content.last_mut() {
-                    match last_block {
-                        AnthropicRequestContent::Text { cache_control, .. } => {
-                            *cache_control = Some(CacheControl::ephemeral());
-                        }
-                        AnthropicRequestContent::ToolResult { cache_control, .. } => {
-                            *cache_control = Some(CacheControl::ephemeral());
-                        }
-                        _ => {}
+        if let Some(last_msg) = anthropic_messages.last_mut() {
+            if let Some(last_block) = last_msg.content.last_mut() {
+                match last_block {
+                    AnthropicRequestContent::Text { cache_control, .. } => {
+                        *cache_control = Some(CacheControl::ephemeral());
                     }
+                    AnthropicRequestContent::ToolResult { cache_control, .. } => {
+                        *cache_control = Some(CacheControl::ephemeral());
+                    }
+                    _ => {}
                 }
             }
         }
@@ -882,10 +874,15 @@ mod tests {
         }
     }
 
-    async fn build_text_body(messages: &[OpenAIMessage], system_prompt: Option<&str>) -> String {
+    async fn build_text_body_on(
+        platform: AIPlatform,
+        messages: &[OpenAIMessage],
+        system_prompt: Option<&str>,
+        tools: Option<&[ToolDef]>,
+    ) -> String {
         let args = BuildRequestArgs {
             messages,
-            tools: None,
+            tools,
             model: "claude-sonnet-4",
             temperature: None,
             reasoning_effort: None,
@@ -899,10 +896,14 @@ mod tests {
             prompt_cache_key: None,
         };
 
-        AnthropicQueryBuilder::new(AIProvider::Anthropic, AIPlatform::Standard)
+        AnthropicQueryBuilder::new(AIProvider::Anthropic, platform)
             .build_request(&args, &authed_client(), "test-workspace")
             .await
             .unwrap()
+    }
+
+    async fn build_text_body(messages: &[OpenAIMessage], system_prompt: Option<&str>) -> String {
+        build_text_body_on(AIPlatform::Standard, messages, system_prompt, None).await
     }
 
     /// The worker prepends the system prompt as a system message *and* passes it as
@@ -944,6 +945,35 @@ mod tests {
         let request: serde_json::Value = serde_json::from_str(&body).unwrap();
 
         assert!(request.get("system").is_none());
+    }
+
+    /// Vertex serves the same Messages API and honours `cache_control` breakpoints, so
+    /// its requests must carry the same three the standard platform gets.
+    #[tokio::test]
+    async fn sets_cache_breakpoints_on_every_platform() {
+        let messages = vec![message("system", SYSTEM_PROMPT), message("user", "hi")];
+        let tools = vec![ToolDef {
+            r#type: "function".to_string(),
+            function: ToolDefFunction {
+                name: "get_weather".to_string(),
+                description: None,
+                parameters: RawValue::from_string("{}".to_string()).unwrap(),
+            },
+        }];
+        let ephemeral = serde_json::json!({ "type": "ephemeral" });
+
+        for platform in [AIPlatform::Standard, AIPlatform::GoogleVertexAi] {
+            let body =
+                build_text_body_on(platform, &messages, Some(SYSTEM_PROMPT), Some(&tools)).await;
+            let request: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+            assert_eq!(request["system"][0]["cache_control"], ephemeral);
+            let tools = request["tools"].as_array().unwrap();
+            assert_eq!(tools.last().unwrap()["cache_control"], ephemeral);
+            let sent = request["messages"].as_array().unwrap();
+            let content = sent.last().unwrap()["content"].as_array().unwrap();
+            assert_eq!(content.last().unwrap()["cache_control"], ephemeral);
+        }
     }
 
     fn has_header(headers: &[(String, String)], name: &str, value: &str) -> bool {

--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -1,7 +1,7 @@
 use super::{anthropic_model_rejects_sampling_params, REASONING_OFF_SENTINEL};
 use crate::{
     ai_google::parse_data_url,
-    ai_providers::{AIPlatform, AIProvider},
+    ai_providers::{AIPlatform, AIProvider, DISABLE_ANTHROPIC_PROMPT_CACHING},
     image_handler::prepare_messages_for_api,
     proxy::{
         add_user_to_body, common_outbound_headers, credential_header, ProxyBuildArgs, ProxyRequest,
@@ -632,11 +632,13 @@ impl AnthropicQueryBuilder {
             }
         }
 
+        let caching = !*DISABLE_ANTHROPIC_PROMPT_CACHING;
+
         let system = collect_system_prompt(&prepared_messages, args.system_prompt).map(|text| {
             vec![AnthropicSystemContent {
                 r#type: "text".to_string(),
                 text,
-                cache_control: Some(CacheControl::ephemeral()),
+                cache_control: caching.then(CacheControl::ephemeral),
             }]
         });
 
@@ -661,23 +663,27 @@ impl AnthropicQueryBuilder {
         let max_tokens = Some(args.max_tokens.unwrap_or(64000));
 
         // Apply cache_control on the last custom tool
-        if let Some(ref mut tools_vec) = tools_option {
-            if let Some(AnthropicTool::Custom(ref mut custom)) = tools_vec.last_mut() {
-                custom.cache_control = Some(CacheControl::ephemeral());
+        if caching {
+            if let Some(ref mut tools_vec) = tools_option {
+                if let Some(AnthropicTool::Custom(ref mut custom)) = tools_vec.last_mut() {
+                    custom.cache_control = Some(CacheControl::ephemeral());
+                }
             }
         }
 
         // Apply cache_control on the last content block of the last message
-        if let Some(last_msg) = anthropic_messages.last_mut() {
-            if let Some(last_block) = last_msg.content.last_mut() {
-                match last_block {
-                    AnthropicRequestContent::Text { cache_control, .. } => {
-                        *cache_control = Some(CacheControl::ephemeral());
+        if caching {
+            if let Some(last_msg) = anthropic_messages.last_mut() {
+                if let Some(last_block) = last_msg.content.last_mut() {
+                    match last_block {
+                        AnthropicRequestContent::Text { cache_control, .. } => {
+                            *cache_control = Some(CacheControl::ephemeral());
+                        }
+                        AnthropicRequestContent::ToolResult { cache_control, .. } => {
+                            *cache_control = Some(CacheControl::ephemeral());
+                        }
+                        _ => {}
                     }
-                    AnthropicRequestContent::ToolResult { cache_control, .. } => {
-                        *cache_control = Some(CacheControl::ephemeral());
-                    }
-                    _ => {}
                 }
             }
         }
@@ -968,8 +974,8 @@ mod tests {
             let request: serde_json::Value = serde_json::from_str(&body).unwrap();
 
             assert_eq!(request["system"][0]["cache_control"], ephemeral);
-            let tools = request["tools"].as_array().unwrap();
-            assert_eq!(tools.last().unwrap()["cache_control"], ephemeral);
+            let sent_tools = request["tools"].as_array().unwrap();
+            assert_eq!(sent_tools.last().unwrap()["cache_control"], ephemeral);
             let sent = request["messages"].as_array().unwrap();
             let content = sent.last().unwrap()["content"].as_array().unwrap();
             assert_eq!(content.last().unwrap()["cache_control"], ephemeral);


### PR DESCRIPTION
## Summary

The Anthropic query builder skipped `cache_control: {"type": "ephemeral"}` whenever the platform was Google Vertex AI, so AI agent steps running Claude models through Vertex never got prompt caching. Vertex serves the same Messages API (`vertex-2023-10-16`) and supports explicit cache breakpoints, and the frontend copilot path already applies `cache_control` for every Anthropic platform, so the backend exclusion was unintended.

The three `is_vertex()` guards are removed, and Vertex agent steps now emit the same cache breakpoints the standard Anthropic platform already gets.

Fixes WIN-2464

## Changes

- `backend/windmill-ai/src/providers/anthropic.rs`: drop the `is_vertex()` guards around `cache_control` on the system prompt, the last custom tool definition, and the last content block of the last message.
- Add `sets_cache_breakpoints_on_every_platform`, which asserts all three breakpoints for both `AIPlatform::Standard` and `AIPlatform::GoogleVertexAi`.
- Add a `DISABLE_ANTHROPIC_PROMPT_CACHING` env flag that suppresses all three breakpoints, for Vertex projects that have prompt caching disabled (see below).

The change is scoped to Anthropic-on-Vertex: `AIPlatform::GoogleVertexAi` only reaches `AnthropicQueryBuilder` through `AIProvider::Anthropic`. Azure Foundry is constructed with `AIPlatform::Standard` and Bedrock routes to `OtherQueryBuilder`, so neither took the guarded branch before or after. The request still carries at most 3 breakpoints, under Anthropic's limit of 4.

## Test plan

- [x] `cargo test -p windmill-ai --lib` — 112 tests pass, including the new one. The new test was confirmed to fail when a guard is restored, so it is a real regression guard.
- [x] End-to-end against the running backend: ran an AI agent step (`preview_flow`, `kind: anthropic`, `platform: google_vertex_ai`) pointed at a local stub standing in for the Vertex endpoint, and inspected the request the backend actually sent to `…/models/claude-sonnet-4-5:streamRawPredict`. The body carried `anthropic_version: vertex-2023-10-16` plus `cache_control: {"type":"ephemeral"}` on `system[0]`, on the last entry of `tools`, and on the last content block of the last message. Both the tool-less and the with-tool variants completed successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Anthropic prompt caching on Vertex AI agent steps so Claude models on Vertex get the same cache breakpoints as the standard Anthropic platform. Previously the backend skipped `cache_control` on Vertex even though Vertex supports explicit breakpoints and the frontend already applies them. Fixes WIN-2464.

- Removes the `is_vertex()` guards that suppressed `cache_control` on the system prompt, the last custom tool, and the last message content block.
- Adds a regression test asserting all three breakpoints on both `Standard` and `GoogleVertexAi` platforms.
- Adds a `DISABLE_ANTHROPIC_PROMPT_CACHING` escape hatch, which suppresses breakpoints on every Anthropic platform — not just Vertex — for Google projects that have explicit prompt caching disabled.

<sup>Written for commit d05be770a355865acce58a5db8390fce4b760915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Vertex projects with prompt caching disabled

A Google Cloud project can have explicit prompt caching turned off by request to Cloud support, after which Vertex rejects any request carrying cache breakpoints. `DISABLE_ANTHROPIC_PROMPT_CACHING=true` turns the breakpoints off instance-wide so such a project can still run Anthropic agent steps. It follows the existing `ALLOW_PRIVATE_AI_BASE_URLS` pattern in `ai_providers.rs` and defaults to off, so nothing changes for the ordinary case.

An instance-level flag was chosen over a per-resource field because the constraint is a property of the GCP project, and a resource-level toggle would mean changing the AI provider resource type, which lives in a separate repo.

## Verification limits

The request body the backend emits for Vertex is verified end-to-end against a local stub, with and without the flag. Real Vertex API responses (and therefore actual `cache_read_input_tokens` accrual across tool round-trips) are unexercised, since that needs a GCP project with Vertex Claude access that the dev environment does not have.

The flag itself has no unit test: it is a `lazy_static` read from the process environment, so a test cannot vary it within one test binary. It is covered by the runtime check above instead.
