### PR TITLE
feat: add --keep-deleted flag to wmill sync pull and push

### DIFF
--- a/cli/src/commands/shared_ui.ts
+++ b/cli/src/commands/shared_ui.ts
@@ -44,29 +44,15 @@ export type SharedUiChange =
   | { type: "deleted"; path: string };
 
 /**
- * Diff the local <cwd>/ui/ folder against the workspace's shared UI store in
- * the push direction (local -> remote), returning entries whose `path` is
- * prefixed with `ui/`. This is the same comparison pushSharedUi applies, so the
- * dry-run preview and the real push never diverge.
- *
- * Mirrors pushSharedUi's no-op: with no local ui/ folder there is nothing to
- * push, so the apply is a no-op and the preview must be empty (even when the
- * remote store is non-empty) to avoid phantom diffs the apply won't perform.
+ * The push-direction diff (local -> remote) of two already-read file maps.
+ * Split out so the preview and the push itself compare identically off one
+ * read of each side.
  */
-export async function diffSharedUi(
-  workspace: string,
+function sharedUiChanges(
+  files: Record<string, string>,
+  remote: Record<string, string>,
   keepDeleted?: boolean,
-): Promise<SharedUiChange[]> {
-  const localDir = path.join(process.cwd(), SHARED_UI_DIR);
-  if (!fs.existsSync(localDir)) {
-    return [];
-  }
-  const files = await readDirRecursive(localDir);
-
-  // If endpoint missing or unauthorized, treat remote as empty (the push
-  // would attempt the PUT anyway).
-  const remote = (await fetchSharedUi(workspace)) ?? {};
-
+): SharedUiChange[] {
   // Use Object.hasOwn, not `in`: a file named after an Object.prototype member
   // (e.g. ui/toString) would otherwise register as always-present and be
   // misdiffed.
@@ -90,6 +76,35 @@ export async function diffSharedUi(
 }
 
 /**
+ * Diff the local <cwd>/ui/ folder against the workspace's shared UI store in
+ * the push direction (local -> remote), returning entries whose `path` is
+ * prefixed with `ui/`. This is the same comparison pushSharedUi applies, so the
+ * dry-run preview and the real push never diverge.
+ *
+ * Mirrors pushSharedUi's no-ops: with no local ui/ folder, or under
+ * `keepDeleted` with an unreadable store, the apply does nothing, so the
+ * preview must be empty (even when the remote store is non-empty) to avoid
+ * phantom diffs the apply won't perform.
+ */
+export async function diffSharedUi(
+  workspace: string,
+  keepDeleted?: boolean,
+): Promise<SharedUiChange[]> {
+  const localDir = path.join(process.cwd(), SHARED_UI_DIR);
+  if (!fs.existsSync(localDir)) {
+    return [];
+  }
+  const files = await readDirRecursive(localDir);
+  const remote = await fetchSharedUi(workspace);
+  if (remote === undefined && keepDeleted) {
+    return [];
+  }
+  // If endpoint missing or unauthorized, treat remote as empty (the push
+  // would attempt the PUT anyway).
+  return sharedUiChanges(files, remote ?? {}, keepDeleted);
+}
+
+/**
  * Push the local <cwd>/ui/ folder to the workspace's shared UI store.
  * Returns true if a push was performed, false if the folder is missing or
  * already matches the remote store. Note an empty-but-existing folder still
@@ -105,29 +120,40 @@ export async function pushSharedUi(
     return false;
   }
 
-  // Skip if no change — reuse diffSharedUi so preview and push never diverge.
-  const diff = await diffSharedUi(workspace, keepDeleted);
-  if (diff.length === 0) {
+  const files = await readDirRecursive(localDir);
+  const remote = await fetchSharedUi(workspace);
+  // The store is written whole, so a remote-only file is pruned by omission
+  // alone. An unreadable store leaves no way to carry those files over, so
+  // the shared UI is left untouched rather than cleared.
+  if (remote === undefined && keepDeleted) {
+    log.warn(
+      colors.yellow(
+        "Could not read the shared UI folder from the remote; skipping its push so --keep-deleted does not clear it.",
+      ),
+    );
+    return false;
+  }
+
+  // Same comparison as diffSharedUi, off the same two maps, so preview and
+  // push never diverge.
+  if (sharedUiChanges(files, remote ?? {}, keepDeleted).length === 0) {
     log.info(colors.gray("Shared UI folder up to date"));
     return false;
   }
 
-  const files = await readDirRecursive(localDir);
   if (keepDeleted) {
-    // The store is written whole, so a remote-only file is pruned by omission
-    // alone: carry it back into the map. An unreadable store leaves no way to
-    // do that without pruning it, so the shared UI is left untouched instead.
-    const remote = await fetchSharedUi(workspace);
-    if (remote === undefined) {
-      log.warn(
-        colors.yellow(
-          "Could not read the shared UI folder from the remote; skipping its push so --keep-deleted does not clear it.",
-        ),
-      );
-      return false;
-    }
-    for (const [rel, content] of Object.entries(remote)) {
-      if (!Object.hasOwn(files, rel)) files[rel] = content;
+    for (const [rel, content] of Object.entries(remote!)) {
+      // defineProperty, not assignment: `files.__proto__ = "..."` runs the
+      // inherited setter and creates no own property, so a remote `ui/__proto__`
+      // would be dropped from the whole-map PUT — i.e. deleted despite the flag.
+      if (!Object.hasOwn(files, rel)) {
+        Object.defineProperty(files, rel, {
+          value: content,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      }
     }
   }
   await wmill.updateSharedUi({

--- a/cli/src/commands/shared_ui.ts
+++ b/cli/src/commands/shared_ui.ts
@@ -26,6 +26,18 @@ async function readDirRecursive(
   return out;
 }
 
+/** The workspace's shared UI store, or undefined when it cannot be read. */
+async function fetchSharedUi(
+  workspace: string,
+): Promise<Record<string, string> | undefined> {
+  try {
+    const got = await wmill.getSharedUi({ workspace });
+    return got.files ?? {};
+  } catch {
+    return undefined;
+  }
+}
+
 export type SharedUiChange =
   | { type: "added"; path: string }
   | { type: "edited"; path: string; before: string; after: string }
@@ -41,21 +53,19 @@ export type SharedUiChange =
  * push, so the apply is a no-op and the preview must be empty (even when the
  * remote store is non-empty) to avoid phantom diffs the apply won't perform.
  */
-export async function diffSharedUi(workspace: string): Promise<SharedUiChange[]> {
+export async function diffSharedUi(
+  workspace: string,
+  keepDeleted?: boolean,
+): Promise<SharedUiChange[]> {
   const localDir = path.join(process.cwd(), SHARED_UI_DIR);
   if (!fs.existsSync(localDir)) {
     return [];
   }
   const files = await readDirRecursive(localDir);
 
-  let remote: Record<string, string> = {};
-  try {
-    const got = await wmill.getSharedUi({ workspace });
-    remote = got.files ?? {};
-  } catch {
-    // If endpoint missing or unauthorized, treat remote as empty (the push
-    // would attempt the PUT anyway).
-  }
+  // If endpoint missing or unauthorized, treat remote as empty (the push
+  // would attempt the PUT anyway).
+  const remote = (await fetchSharedUi(workspace)) ?? {};
 
   // Use Object.hasOwn, not `in`: a file named after an Object.prototype member
   // (e.g. ui/toString) would otherwise register as always-present and be
@@ -69,9 +79,11 @@ export async function diffSharedUi(workspace: string): Promise<SharedUiChange[]>
       changes.push({ type: "edited", path: p, before: remote[rel], after: content });
     }
   }
-  for (const rel of Object.keys(remote)) {
-    if (!Object.hasOwn(files, rel)) {
-      changes.push({ type: "deleted", path: `${SHARED_UI_DIR}/${rel}` });
+  if (!keepDeleted) {
+    for (const rel of Object.keys(remote)) {
+      if (!Object.hasOwn(files, rel)) {
+        changes.push({ type: "deleted", path: `${SHARED_UI_DIR}/${rel}` });
+      }
     }
   }
   return changes;
@@ -81,22 +93,43 @@ export async function diffSharedUi(workspace: string): Promise<SharedUiChange[]>
  * Push the local <cwd>/ui/ folder to the workspace's shared UI store.
  * Returns true if a push was performed, false if the folder is missing or
  * already matches the remote store. Note an empty-but-existing folder still
- * pushes an empty map (clearing the remote store) if the remote is non-empty.
+ * pushes an empty map (clearing the remote store) if the remote is non-empty —
+ * unless `keepDeleted`, which folds remote-only files back into the map.
  */
-export async function pushSharedUi(workspace: string): Promise<boolean> {
+export async function pushSharedUi(
+  workspace: string,
+  keepDeleted?: boolean,
+): Promise<boolean> {
   const localDir = path.join(process.cwd(), SHARED_UI_DIR);
   if (!fs.existsSync(localDir)) {
     return false;
   }
 
   // Skip if no change — reuse diffSharedUi so preview and push never diverge.
-  const diff = await diffSharedUi(workspace);
+  const diff = await diffSharedUi(workspace, keepDeleted);
   if (diff.length === 0) {
     log.info(colors.gray("Shared UI folder up to date"));
     return false;
   }
 
   const files = await readDirRecursive(localDir);
+  if (keepDeleted) {
+    // The store is written whole, so a remote-only file is pruned by omission
+    // alone: carry it back into the map. An unreadable store leaves no way to
+    // do that without pruning it, so the shared UI is left untouched instead.
+    const remote = await fetchSharedUi(workspace);
+    if (remote === undefined) {
+      log.warn(
+        colors.yellow(
+          "Could not read the shared UI folder from the remote; skipping its push so --keep-deleted does not clear it.",
+        ),
+      );
+      return false;
+    }
+    for (const [rel, content] of Object.entries(remote)) {
+      if (!Object.hasOwn(files, rel)) files[rel] = content;
+    }
+  }
   await wmill.updateSharedUi({
     workspace,
     requestBody: { files },
@@ -111,9 +144,12 @@ export async function pushSharedUi(workspace: string): Promise<boolean> {
 
 /**
  * Pull the workspace's shared UI store into <cwd>/ui/.
- * Files removed remotely are also removed locally.
+ * Files removed remotely are also removed locally, unless `keepDeleted`.
  */
-export async function pullSharedUi(workspace: string): Promise<boolean> {
+export async function pullSharedUi(
+  workspace: string,
+  keepDeleted?: boolean,
+): Promise<boolean> {
   const localDir = path.join(process.cwd(), SHARED_UI_DIR);
   let got;
   try {
@@ -145,15 +181,17 @@ export async function pullSharedUi(workspace: string): Promise<boolean> {
   }
 
   // Delete locally-orphaned files
-  const known = new Set(Object.keys(files));
-  const local = await readDirRecursive(localDir);
-  for (const rel of Object.keys(local)) {
-    if (!known.has(rel)) {
-      const full = path.join(localDir, rel);
-      try {
-        fs.unlinkSync(full);
-      } catch {
-        // ignore
+  if (!keepDeleted) {
+    const known = new Set(Object.keys(files));
+    const local = await readDirRecursive(localDir);
+    for (const rel of Object.keys(local)) {
+      if (!known.has(rel)) {
+        const full = path.join(localDir, rel);
+        try {
+          fs.unlinkSync(full);
+        } catch {
+          // ignore
+        }
       }
     }
   }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3174,6 +3174,28 @@ export function untrackedDatatableMigrationDeletions<
   );
 }
 
+/**
+ * `--keep-deleted`: strip every deletion from the changeset, in place, so the
+ * sync only adds and updates. A path missing on one side is not on its own
+ * evidence that it should go from the other — a partial clone, a scoped
+ * checkout or an item authored in the UI all read as deletions here.
+ */
+function dropDeletions(changes: Change[], keptOn: "local" | "remote"): void {
+  const deletions = changes.filter((c) => c.name === "deleted");
+  if (deletions.length === 0) return;
+  const kept = changes.filter((c) => c.name !== "deleted");
+  changes.length = 0;
+  changes.push(...kept);
+  log.info(
+    colors.yellow(
+      `--keep-deleted: keeping ${deletions.length} item(s) that exist only ` +
+        (keptOn === "local"
+          ? `on disk instead of deleting them locally`
+          : `on the remote instead of deleting them from the workspace`),
+    ),
+  );
+}
+
 interface ChangeTracker {
   scripts: string[];
   flows: string[];
@@ -3433,6 +3455,7 @@ export async function pull(
       repository?: string;
       promotion?: string;
       branch?: string;
+      keepDeleted?: boolean;
       useIndividualBranch?: boolean;
       groupByFolder?: boolean;
       gitDeployItems?: string;
@@ -3683,6 +3706,10 @@ export async function pull(
     true, // els1 (remote) is the remote source
     await isCaseInsensitiveFilesystem(process.cwd()),
   );
+
+  if (opts.keepDeleted) {
+    dropDeletions(changes, "local");
+  }
 
   log.info(
     `remote (${workspace.name}) -> local: ${changes.length} changes to apply`,
@@ -4118,7 +4145,7 @@ export async function pull(
   }
 
   try {
-    await pullSharedUi(workspace.workspaceId);
+    await pullSharedUi(workspace.workspaceId, opts.keepDeleted);
   } catch (e) {
     log.warn(`Failed to pull shared UI folder: ${e}`);
   }
@@ -4490,6 +4517,7 @@ export async function push(
     SyncOptions & {
       repository?: string;
       branch?: string;
+      keepDeleted?: boolean;
       acceptOverridingPermissionedAsWithSelf?: boolean;
     },
 ) {
@@ -4789,6 +4817,13 @@ export async function push(
         `dedupeLockfiles is on but this checkout still holds one lockfile per script. Run 'wmill generate-metadata' (or pull) to convert it — until then every script reads as changed.`,
       ),
     );
+  }
+
+  // After the shared-lock pass, which reads a shared lockfile's deletion as the
+  // signal that this checkout is not deduplicated — an advisory about the local
+  // tree that holds whether or not remote items are being kept.
+  if (opts.keepDeleted) {
+    dropDeletions(changes, "remote");
   }
 
   const autoRegenerate = !!(opts as any).autoMetadata;
@@ -5103,7 +5138,10 @@ export async function push(
   // unchanged (pushSharedUi still runs) and the summary count includes ui/.
   if (opts.dryRun) {
     try {
-      for (const c of await diffSharedUi(workspace.workspaceId)) {
+      for (const c of await diffSharedUi(
+        workspace.workspaceId,
+        opts.keepDeleted,
+      )) {
         if (c.type === "added") {
           changes.push({ name: "added", path: c.path, content: "" });
         } else if (c.type === "deleted") {
@@ -6313,7 +6351,7 @@ export async function push(
       }
     }
     try {
-      await pushSharedUi(workspace.workspaceId);
+      await pushSharedUi(workspace.workspaceId, opts.keepDeleted);
     } catch (e) {
       log.warn(`Failed to push shared UI folder: ${e}`);
     }
@@ -6415,7 +6453,10 @@ export async function push(
     let sharedUiPushed = false;
     if (!opts.dryRun) {
       try {
-        sharedUiPushed = await pushSharedUi(workspace.workspaceId);
+        sharedUiPushed = await pushSharedUi(
+          workspace.workspaceId,
+          opts.keepDeleted,
+        );
       } catch (e) {
         log.warn(`Failed to push shared UI folder: ${e}`);
       }
@@ -6480,6 +6521,10 @@ const command = new Command()
   .option("--include-groups", "Include syncing groups")
   .option("--include-settings", "Include syncing workspace settings")
   .option("--include-key", "Include workspace encryption key")
+  .option(
+    "--keep-deleted",
+    "Do not delete local files for items that no longer exist on the remote workspace. Only adds and updates.",
+  )
   .option("--skip-branch-validation", "Skip git branch validation and prompts")
   .option("--json-output", "Output results in JSON format")
   .option(
@@ -6542,6 +6587,10 @@ const command = new Command()
   .option(
     "--skip-reencrypt-on-key-change",
     "When the pushed encryption key differs from the remote, do NOT re-encrypt existing remote secrets. Only safe if they are already encrypted with the new key (e.g. workspace/instance migration). Default is to re-encrypt.",
+  )
+  .option(
+    "--keep-deleted",
+    "Do not delete remote items that no longer exist locally. Only adds and updates.",
   )
   .option("--skip-branch-validation", "Skip git branch validation and prompts")
   .option("--json-output", "Output results in JSON format")

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4144,10 +4144,14 @@ export async function pull(
     }
   }
 
-  try {
-    await pullSharedUi(workspace.workspaceId, opts.keepDeleted);
-  } catch (e) {
-    log.warn(`Failed to pull shared UI folder: ${e}`);
+  // Skipped under --dry-run since pullSharedUi writes to the local ui/ folder.
+  // An empty changeset falls through the return above and reaches here.
+  if (!opts.dryRun) {
+    try {
+      await pullSharedUi(workspace.workspaceId, opts.keepDeleted);
+    } catch (e) {
+      log.warn(`Failed to pull shared UI folder: ${e}`);
+    }
   }
 
   // Datatable migrations are part of the workspace export now, so they flow
@@ -4452,12 +4456,19 @@ function removeSuffix(str: string, suffix: string) {
 }
 
 // Shown after a `wmill sync push --dry-run` preview that has changes. `sync push`
-// deploys to the remote workspace and is destructive (it overwrites and prunes
-// remote items that differ from or are absent locally), so the preview reminds
-// the caller — especially an AI agent that ran the dry-run to inspect changes —
-// to get explicit user confirmation before applying it for real.
-const SYNC_PUSH_DESTRUCTIVE_WARNING =
-  "`wmill sync push` is destructive: applying it deploys these changes to the remote workspace and overwrites or deletes remote items that differ from or are absent locally — this is not automatically reversible. If you are an AI agent, do NOT run `wmill sync push` (without --dry-run) until the user has explicitly confirmed this deploy, unless your custom instructions explicitly allow bypassing that confirmation.";
+// deploys to the remote workspace and is destructive (it overwrites remote items
+// that differ from local, and prunes those absent locally unless --keep-deleted),
+// so the preview reminds the caller — especially an AI agent that ran the dry-run
+// to inspect changes — to get explicit user confirmation before applying it for real.
+function syncPushDestructiveWarning(keepDeleted?: boolean): string {
+  return (
+    "`wmill sync push` is destructive: applying it deploys these changes to the remote workspace and overwrites " +
+    (keepDeleted
+      ? "remote items that differ from local"
+      : "or deletes remote items that differ from or are absent locally") +
+    " — this is not automatically reversible. If you are an AI agent, do NOT run `wmill sync push` (without --dry-run) until the user has explicitly confirmed this deploy, unless your custom instructions explicitly allow bypassing that confirmation."
+  );
+}
 
 // A script pushed without a local lock queues a server-side dependency job; if
 // that job fails the script deploys broken (no lock/assets) with no CLI signal.
@@ -5313,7 +5324,9 @@ export async function push(
           : {}),
       })),
       total: changes.length,
-      ...(changes.length > 0 ? { warning: SYNC_PUSH_DESTRUCTIVE_WARNING } : {}),
+      ...(changes.length > 0
+        ? { warning: syncPushDestructiveWarning(opts.keepDeleted) }
+        : {}),
     };
     console.log(JSON.stringify(result, null, 2));
     return;
@@ -5377,7 +5390,9 @@ export async function push(
 
     if (opts.dryRun) {
       log.info(colors.gray(`Dry run complete.`));
-      log.warn(colors.yellow(`\n⚠ ${SYNC_PUSH_DESTRUCTIVE_WARNING}`));
+      log.warn(
+        colors.yellow(`\n⚠ ${syncPushDestructiveWarning(opts.keepDeleted)}`),
+      );
       return;
     }
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -7519,6 +7519,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - \`--include-groups\` - Include syncing groups
   - \`--include-settings\` - Include syncing workspace settings
   - \`--include-key\` - Include workspace encryption key
+  - \`--keep-deleted\` - Do not delete local files for items that no longer exist on the remote workspace. Only adds and updates.
   - \`--skip-branch-validation\` - Skip git branch validation and prompts
   - \`--json-output\` - Output results in JSON format
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string). Overrides wmill.yaml includes
@@ -7550,6 +7551,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - \`--include-settings\` - Include syncing workspace settings
   - \`--include-key\` - Include workspace encryption key
   - \`--skip-reencrypt-on-key-change\` - When the pushed encryption key differs from the remote, do NOT re-encrypt existing remote secrets. Only safe if they are already encrypted with the new key (e.g. workspace/instance migration). Default is to re-encrypt.
+  - \`--keep-deleted\` - Do not delete remote items that no longer exist locally. Only adds and updates.
   - \`--skip-branch-validation\` - Skip git branch validation and prompts
   - \`--json-output\` - Output results in JSON format
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string)

--- a/cli/test/shared_ui_diff_unit.test.ts
+++ b/cli/test/shared_ui_diff_unit.test.ts
@@ -11,12 +11,25 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 let remoteFiles: Record<string, string> = {};
+let remoteUnreadable = false;
+let pushedFiles: Record<string, string> | undefined;
 
 mock.module("../gen/services.gen.ts", () => ({
-  getSharedUi: async (_args: { workspace: string }) => ({ files: remoteFiles }),
+  getSharedUi: async (_args: { workspace: string }) => {
+    if (remoteUnreadable) throw new Error("shared UI store unreadable");
+    return { files: remoteFiles };
+  },
+  updateSharedUi: async (args: {
+    workspace: string;
+    requestBody: { files: Record<string, string> };
+  }) => {
+    pushedFiles = args.requestBody.files;
+  },
 }));
 
-const { diffSharedUi } = await import("../src/commands/shared_ui.ts");
+const { diffSharedUi, pushSharedUi } = await import(
+  "../src/commands/shared_ui.ts"
+);
 
 describe("diffSharedUi", () => {
   const ws = "test-workspace";
@@ -25,6 +38,8 @@ describe("diffSharedUi", () => {
 
   beforeEach(() => {
     remoteFiles = {};
+    remoteUnreadable = false;
+    pushedFiles = undefined;
     prevCwd = process.cwd();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-shared-ui-"));
     process.chdir(tmpDir);
@@ -88,5 +103,47 @@ describe("diffSharedUi", () => {
     remoteFiles = { "theme.json": "{}" };
     const changes = await diffSharedUi(ws);
     expect(changes).toEqual([]);
+  });
+
+  test("emits nothing under keepDeleted when the remote store is unreadable", async () => {
+    // pushSharedUi skips the push rather than clearing a store it can't read,
+    // so the preview must show that same nothing.
+    remoteUnreadable = true;
+    writeUi("theme.json", "{}");
+    expect(await diffSharedUi(ws, true)).toEqual([]);
+  });
+});
+
+describe("pushSharedUi with keepDeleted", () => {
+  const ws = "test-workspace";
+  let tmpDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    remoteFiles = {};
+    remoteUnreadable = false;
+    pushedFiles = undefined;
+    prevCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "wm-shared-ui-push-"));
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("carries remote-only files, including ui/__proto__, into the pushed map", async () => {
+    // JSON.parse, not a literal: `{__proto__: …}` sets the prototype instead of
+    // creating the own property the API response really has.
+    remoteFiles = JSON.parse('{"__proto__":"keep me","extra.json":"1"}');
+    fs.mkdirSync(path.join(tmpDir, "ui"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "ui", "theme.json"), "{}", "utf-8");
+
+    expect(await pushSharedUi(ws, true)).toBe(true);
+    // The store is written whole, so anything missing here is deleted.
+    expect(pushedFiles!["extra.json"]).toEqual("1");
+    expect(Object.getOwnPropertyDescriptor(pushedFiles!, "__proto__")?.value)
+      .toEqual("keep me");
   });
 });

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -2850,6 +2850,26 @@ describe("keep deleted", () => {
       expect(afterPull).toContain(localOnly);
       // Adds still apply: the script deleted above is written back.
       expect(afterPull).toContain(contentFile);
+
+      // An empty changeset falls past the dry-run return, on to the shared-UI
+      // step — which writes to disk, so a dry run must skip it.
+      // Including the metadata and lock the pull's auto-fill generated for it.
+      for (const ext of [".ts", ".script.yaml", ".script.lock"]) {
+        await rm(join(tempDir, `f/test/local_only_${uniqueId}${ext}`), {
+          force: true,
+        });
+      }
+      await mkdir(join(tempDir, "ui"), { recursive: true });
+      await writeFile(join(tempDir, "ui", "custom.css"), "body{}", "utf-8");
+      const dryRun = await backend.runCLICommand(
+        ["sync", "pull", "--dry-run"],
+        tempDir
+      );
+      expect(dryRun.code).toEqual(0);
+      // Guards against a vacuous pass: a non-empty changeset would return at
+      // the dry-run check above and never reach the shared-UI step.
+      expect(dryRun.stdout + dryRun.stderr).toContain("0 changes to apply");
+      expect(await listFilesRecursive(tempDir)).toContain("ui/custom.css");
     });
   });
 });

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -2774,3 +2774,82 @@ kind: script
     });
   });
 });
+
+describe("keep deleted", () => {
+  test("Integration: --keep-deleted keeps items absent from the other side", async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      const uniqueId = Date.now();
+      const scriptPath = `f/test/keep_deleted_${uniqueId}`;
+
+      const resp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/scripts/create`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            path: scriptPath,
+            content: 'export async function main() { return "keep me"; }',
+            language: "bun",
+            summary: "Kept by --keep-deleted",
+            schema: {
+              $schema: "https://json-schema.org/draft/2020-12/schema",
+              type: "object",
+              properties: {},
+              required: [],
+            },
+          }),
+        }
+      );
+      expect(resp.status).toBeLessThan(300);
+      await resp.text();
+
+      await writeWmillYaml(tempDir);
+      expect(
+        (await backend.runCLICommand(["sync", "pull", "--yes"], tempDir)).code
+      ).toEqual(0);
+
+      const contentFile = `${scriptPath}.ts`;
+      const metadataFile = `${scriptPath}.script.yaml`;
+      expect(await listFilesRecursive(tempDir)).toContain(contentFile);
+
+      // Push direction: the remote script survives losing its local files.
+      await rm(join(tempDir, contentFile));
+      await rm(join(tempDir, metadataFile));
+      expect(
+        (
+          await backend.runCLICommand(
+            ["sync", "push", "--yes", "--keep-deleted"],
+            tempDir
+          )
+        ).code
+      ).toEqual(0);
+      // A push deletion archives the script rather than removing the row, so
+      // `archived` — not the status code — is what says it survived.
+      const remote = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/scripts/get/p/${scriptPath}`
+      );
+      expect(remote.status).toEqual(200);
+      expect((await remote.json()).archived).not.toEqual(true);
+
+      // Pull direction: a file with no remote counterpart survives the pull.
+      const localOnly = `f/test/local_only_${uniqueId}.ts`;
+      await writeFile(
+        join(tempDir, localOnly),
+        'export async function main() { return "local only"; }',
+        "utf-8"
+      );
+      expect(
+        (
+          await backend.runCLICommand(
+            ["sync", "pull", "--yes", "--keep-deleted"],
+            tempDir
+          )
+        ).code
+      ).toEqual(0);
+      const afterPull = await listFilesRecursive(tempDir);
+      expect(afterPull).toContain(localOnly);
+      // Adds still apply: the script deleted above is written back.
+      expect(afterPull).toContain(contentFile);
+    });
+  });
+});

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -605,6 +605,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - `--include-groups` - Include syncing groups
   - `--include-settings` - Include syncing workspace settings
   - `--include-key` - Include workspace encryption key
+  - `--keep-deleted` - Do not delete local files for items that no longer exist on the remote workspace. Only adds and updates.
   - `--skip-branch-validation` - Skip git branch validation and prompts
   - `--json-output` - Output results in JSON format
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string). Overrides wmill.yaml includes
@@ -636,6 +637,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - `--include-settings` - Include syncing workspace settings
   - `--include-key` - Include workspace encryption key
   - `--skip-reencrypt-on-key-change` - When the pushed encryption key differs from the remote, do NOT re-encrypt existing remote secrets. Only safe if they are already encrypted with the new key (e.g. workspace/instance migration). Default is to re-encrypt.
+  - `--keep-deleted` - Do not delete remote items that no longer exist locally. Only adds and updates.
   - `--skip-branch-validation` - Skip git branch validation and prompts
   - `--json-output` - Output results in JSON format
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string)

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3671,6 +3671,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - \`--include-groups\` - Include syncing groups
   - \`--include-settings\` - Include syncing workspace settings
   - \`--include-key\` - Include workspace encryption key
+  - \`--keep-deleted\` - Do not delete local files for items that no longer exist on the remote workspace. Only adds and updates.
   - \`--skip-branch-validation\` - Skip git branch validation and prompts
   - \`--json-output\` - Output results in JSON format
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string). Overrides wmill.yaml includes
@@ -3702,6 +3703,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - \`--include-settings\` - Include syncing workspace settings
   - \`--include-key\` - Include workspace encryption key
   - \`--skip-reencrypt-on-key-change\` - When the pushed encryption key differs from the remote, do NOT re-encrypt existing remote secrets. Only safe if they are already encrypted with the new key (e.g. workspace/instance migration). Default is to re-encrypt.
+  - \`--keep-deleted\` - Do not delete remote items that no longer exist locally. Only adds and updates.
   - \`--skip-branch-validation\` - Skip git branch validation and prompts
   - \`--json-output\` - Output results in JSON format
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string)

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -610,6 +610,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - `--include-groups` - Include syncing groups
   - `--include-settings` - Include syncing workspace settings
   - `--include-key` - Include workspace encryption key
+  - `--keep-deleted` - Do not delete local files for items that no longer exist on the remote workspace. Only adds and updates.
   - `--skip-branch-validation` - Skip git branch validation and prompts
   - `--json-output` - Output results in JSON format
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string). Overrides wmill.yaml includes
@@ -641,6 +642,7 @@ sync local with a remote workspaces or the opposite (push or pull)
   - `--include-settings` - Include syncing workspace settings
   - `--include-key` - Include workspace encryption key
   - `--skip-reencrypt-on-key-change` - When the pushed encryption key differs from the remote, do NOT re-encrypt existing remote secrets. Only safe if they are already encrypted with the new key (e.g. workspace/instance migration). Default is to re-encrypt.
+  - `--keep-deleted` - Do not delete remote items that no longer exist locally. Only adds and updates.
   - `--skip-branch-validation` - Skip git branch validation and prompts
   - `--json-output` - Output results in JSON format
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which file to take into account (among files that are compatible with windmill). Patterns can include * (any string until '/') and ** (any string)


### PR DESCRIPTION
## Summary

`wmill sync pull` and `wmill sync push` are symmetric mirrors: any path present on one side and
absent on the other is emitted as a deletion and applied — `pull` `rm`s the local file, `push`
archives/deletes the remote item. There was no way to opt out.

A missing path is not on its own evidence that the item should go: a partial clone, a scoped
checkout, or an item authored straight in the UI all read as deletions to the diff.
`--keep-deleted` strips every deletion from the changeset so a sync only ever adds and updates.

## Changes

- `dropDeletions()` in `cli/src/commands/sync/sync.ts` — removes every `deleted` change in place
  and logs how many items were kept, so the change count, the `--dry-run` preview, the
  confirmation prompt and the apply loop all agree.
- `pull`: applied right after `compareDynFSElement`.
- `push`: applied right after the shared-lock pass, so that pass still gets to raise its
  "this checkout is not deduplicated" advisory — an observation about the local tree that stands
  whether or not remote items are being kept.
- `--keep-deleted` option declared on both subcommands (CLI flag only; no `wmill.yaml` key).
- `cli/src/commands/shared_ui.ts`: the `ui/` folder syncs out-of-band as a whole-map PUT, so the
  flag has to reach it too — `diffSharedUi` stops emitting deletions, `pullSharedUi` skips the
  orphan-unlink pass, and `pushSharedUi` folds remote-only files back into the map before the PUT.
  If the remote store cannot be read there, the shared-UI push is skipped with a warning rather
  than silently pruning it.
- Regenerated `system_prompts/auto-generated/` and `cli/src/guidance/skills.gen.ts`.

## Test plan

- [x] `cli/test/sync_pull_push.test.ts` — one integration test covering both directions: a remote
      script survives losing its local files under `push --keep-deleted` (asserted on `archived`,
      since a push deletion archives rather than dropping the row), and a local-only file survives
      `pull --keep-deleted` while remote adds still apply.
- [x] `bun run test:unit` — 1095 pass, 0 fail.
- [x] Exercised by hand against a local backend (workspace with two scripts):

  | | without flag | with `--keep-deleted` |
  |---|---|---|
  | `push --dry-run`, local files deleted | `- script f/demo/second.ts` → 2 changes | `keeping 2 item(s) … from the workspace` → 0 changes |
  | `pull --dry-run`, local-only file | `- script f/demo/localonly.ts` → 1 change | `keeping 1 item(s) … locally` → 0 changes |

  A real `push --keep-deleted` left the remote script at `"archived": false`.

## Notes

- The push confirmation prompt and `SYNC_PUSH_DESTRUCTIVE_WARNING` are unchanged; the warning
  still states unconditionally that push deletes remote items absent locally. Happy to soften the
  wording if reviewers would rather it mention the flag.