### PR TITLE
fix(dev): insert clipboardPaste from the VS Code preview

### DIFF
--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -28,6 +28,7 @@
 	} from '$lib/utils'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import { onDestroy, onMount, setContext, untrack } from 'svelte'
+	import { insertClipboardText } from './insertClipboardText'
 	import DarkModeToggle from '$lib/components/sidebar/DarkModeToggle.svelte'
 	import { page } from '$app/state'
 	import { getUserExt } from '$lib/user'
@@ -324,6 +325,8 @@
 			}, 500)
 		} else if (event.data.type == 'error') {
 			sendUserToast(event.data.error.message, true)
+		} else if (event.data.type == 'clipboardPaste' && typeof event.data.text == 'string') {
+			insertClipboardText(event.data.text)
 		}
 	}
 
@@ -583,9 +586,6 @@
 			document.execCommand('copy')
 		} else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyX') {
 			document.execCommand('cut')
-		} else if ((event.ctrlKey || event.metaKey) && event.code === 'KeyV') {
-			event.preventDefault()
-			document.execCommand('paste')
 		}
 	}
 

--- a/frontend/src/lib/components/insertClipboardText.test.ts
+++ b/frontend/src/lib/components/insertClipboardText.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { insertClipboardText } from './insertClipboardText'
+
+describe('insertClipboardText', () => {
+	it('replaces the selection in a focused input', () => {
+		const input = document.createElement('input')
+		document.body.appendChild(input)
+		input.value = 'abxxef'
+		input.focus()
+		input.setSelectionRange(2, 4)
+		expect(insertClipboardText('cd')).toBe(true)
+		expect(input.value).toBe('abcdef')
+		input.remove()
+	})
+
+	it('appends into a textarea with no selection', () => {
+		const area = document.createElement('textarea')
+		document.body.appendChild(area)
+		area.value = 'id-'
+		area.focus()
+		area.setSelectionRange(3, 3)
+		expect(insertClipboardText('99')).toBe(true)
+		expect(area.value).toBe('id-99')
+		area.remove()
+	})
+
+	it('returns false when nothing is focused', () => {
+		;(document.activeElement as HTMLElement | null)?.blur?.()
+		expect(insertClipboardText('nope')).toBe(false)
+	})
+})

--- a/frontend/src/lib/components/insertClipboardText.ts
+++ b/frontend/src/lib/components/insertClipboardText.ts
@@ -1,0 +1,27 @@
+/**
+ * Insert clipboard text into the focused form control.
+ * Used when the VS Code preview hosts /dev in a nested iframe: Cmd+V never
+ * reaches the frame, so the extension posts { type: 'clipboardPaste', text }.
+ */
+export function insertClipboardText(text: string, doc: Document = document): boolean {
+	const el = doc.activeElement
+	if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+		const start = el.selectionStart ?? el.value.length
+		const end = el.selectionEnd ?? el.value.length
+		const next = el.value.slice(0, start) + text + el.value.slice(end)
+		const proto = Object.getOwnPropertyDescriptor(
+			el instanceof HTMLTextAreaElement
+				? HTMLTextAreaElement.prototype
+				: HTMLInputElement.prototype,
+			'value'
+		)
+		proto?.set?.call(el, next)
+		el.setSelectionRange(start + text.length, start + text.length)
+		el.dispatchEvent(new Event('input', { bubbles: true }))
+		return true
+	}
+	if (el instanceof HTMLElement && el.isContentEditable) {
+		return doc.execCommand('insertText', false, text)
+	}
+	return false
+}


### PR DESCRIPTION
The VS Code extension hosts this /dev page in a nested iframe. Cmd+V never reaches the iframe, so preview form fields cannot paste (windmill-labs/windmill-vscode#30).

Accept { type: clipboardPaste, text } from the parent webview and insert into the focused input or textarea. Companion: windmill-labs/windmill-vscode#44.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes paste in the VS Code preview's `/dev` page by handling `clipboardPaste` messages from the parent webview instead of relying on `document.execCommand('paste')`, which never fired in the nested iframe.

- Adds an `insertClipboardText` helper that replaces the selection or appends text in the focused input, textarea, or contenteditable element.
- Removes the intercepted Cmd+V keydown handler, since the extension now forwards paste text.
- Adds unit tests covering selection replacement, textarea append, and the no-focus case.

<sup>Written for commit 624a5e7ee7dfbbfe93d011019529f216af12e2b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

