### PR TITLE
fix(cli): stop the migration guard misreading its own git history

### DIFF
--- a/cli/src/utils/git.ts
+++ b/cli/src/utils/git.ts
@@ -170,20 +170,12 @@ export function gitRecordedDatatableMigrationPaths(): RecordedMigrationPaths {
     };
   }
 
-  // `core.quotePath` (on by default) C-quotes any path with a non-ASCII byte, which
-  // matches nothing the caller holds and reads as "never tracked".
+  // `-z`, not `core.quotePath=false`: that setting only stops git C-quoting non-ASCII
+  // bytes, leaving a path holding `"`, `\` or a control character quoted and matching
+  // nothing the caller holds. `-z` emits every path raw, NUL-separated.
   const r = spawnSync(
     "git",
-    [
-      "-c",
-      "core.quotePath=false",
-      "log",
-      "HEAD",
-      "--format=",
-      "--name-only",
-      "--",
-      "migrations/datatable",
-    ],
+    ["log", "HEAD", "--format=", "--name-only", "-z", "--", "migrations/datatable"],
     { encoding: "utf8", stdio: "pipe", maxBuffer: 64 * 1024 * 1024 },
   );
   if ((r.status ?? 1) !== 0) {
@@ -195,7 +187,7 @@ export function gitRecordedDatatableMigrationPaths(): RecordedMigrationPaths {
     };
   }
   const paths = new Set<string>();
-  for (const line of (r.stdout ?? "").split("\n")) {
+  for (const line of (r.stdout ?? "").split("\0")) {
     const p = line.trim();
     if (p.length === 0) continue;
     if (prefix.length > 0) {

--- a/cli/src/utils/git.ts
+++ b/cli/src/utils/git.ts
@@ -156,9 +156,34 @@ export function gitRecordedDatatableMigrationPaths(): RecordedMigrationPaths {
   }
   const prefix = (prefixOut.stdout ?? "").trim();
 
+  // `git log HEAD` fails on a repository with no commits, which is not the same as
+  // git being broken and must not be reported as such.
+  const head = spawnSync("git", ["rev-parse", "--verify", "--quiet", "HEAD"], {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  if ((head.status ?? 1) !== 0) {
+    return {
+      kind: "unknown",
+      reason: "this repository has no commits yet",
+      remedy: "Commit the migrations you sync",
+    };
+  }
+
+  // `core.quotePath` (on by default) C-quotes any path with a non-ASCII byte, which
+  // matches nothing the caller holds and reads as "never tracked".
   const r = spawnSync(
     "git",
-    ["log", "HEAD", "--format=", "--name-only", "--", "migrations/datatable"],
+    [
+      "-c",
+      "core.quotePath=false",
+      "log",
+      "HEAD",
+      "--format=",
+      "--name-only",
+      "--",
+      "migrations/datatable",
+    ],
     { encoding: "utf8", stdio: "pipe", maxBuffer: 64 * 1024 * 1024 },
   );
   if ((r.status ?? 1) !== 0) {

--- a/cli/test/git_recorded_migrations_unit.test.ts
+++ b/cli/test/git_recorded_migrations_unit.test.ts
@@ -55,15 +55,23 @@ describe("gitRecordedDatatableMigrationPaths", () => {
     }
   });
 
-  test("records a path with a non-ASCII byte unquoted", () => {
-    // core.quotePath would return "migrations/datatable/dt/1_caf\303\251.up.sql",
-    // which matches no path the caller holds and reads as never recorded.
-    const rel = commitMigration("20260101000000_café.up.sql");
+  test("records paths git would otherwise C-quote", () => {
+    // Non-ASCII is what `core.quotePath=false` covers; `"` and `\` stay quoted under
+    // it and need `-z`. All three read as never recorded when quoted.
+    const rels = [
+      commitMigration("20260101000000_café.up.sql"),
+      commitMigration('20260101000001_a"b.up.sql'),
+      commitMigration("20260101000002_a\\b.up.sql"),
+    ];
     const r = gitRecordedDatatableMigrationPaths();
     expect(r.kind).toBe("known");
-    if (r.kind === "known") expect(r.paths.has(rel)).toBe(true);
+    if (r.kind === "known") {
+      for (const rel of rels) expect(r.paths.has(rel)).toBe(true);
+    }
   });
 
+  // Guards the `-z` parser, not the pre-existing behaviour: the split moved from
+  // newline to NUL, and a deletion still has to leave the path listed.
   test("a committed migration stays recorded after its deletion is committed", () => {
     const rel = commitMigration("20260101000000_a.up.sql");
     fs.rmSync(path.join(dir, rel));

--- a/cli/test/git_recorded_migrations_unit.test.ts
+++ b/cli/test/git_recorded_migrations_unit.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `gitRecordedDatatableMigrationPaths` is what a push consults before deleting a data
+ * table migration the working tree no longer has: a path in history is a real deletion,
+ * a path never recorded is one this clone may simply never have synced. Both failures
+ * pinned here made it answer "never recorded" or "git is broken" about a repository
+ * that was neither, so a migration the user committed would have been kept and the
+ * remedy offered would have been the wrong one.
+ *
+ * Runs real git in a temp repo — the answer is a property of git's output, not of any
+ * logic that could be tested without it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gitRecordedDatatableMigrationPaths } from "../src/utils/git.ts";
+
+let dir: string;
+let cwd: string;
+
+const git = (...args: string[]) =>
+  execFileSync("git", args, { cwd: dir, encoding: "utf8", stdio: "pipe" });
+
+const commitMigration = (name: string) => {
+  const rel = `migrations/datatable/dt/${name}`;
+  fs.mkdirSync(path.join(dir, path.dirname(rel)), { recursive: true });
+  fs.writeFileSync(path.join(dir, rel), "select 1;\n");
+  git("add", "-A");
+  git("commit", "-m", `add ${name}`);
+  return rel;
+};
+
+beforeEach(() => {
+  cwd = process.cwd();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "wmill-git-"));
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@t.dev");
+  git("config", "user.name", "t");
+  process.chdir(dir);
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("gitRecordedDatatableMigrationPaths", () => {
+  test("a repository with no commits is not a broken one", () => {
+    const r = gitRecordedDatatableMigrationPaths();
+    expect(r.kind).toBe("unknown");
+    if (r.kind === "unknown") {
+      expect(r.reason).toBe("this repository has no commits yet");
+    }
+  });
+
+  test("records a path with a non-ASCII byte unquoted", () => {
+    // core.quotePath would return "migrations/datatable/dt/1_caf\303\251.up.sql",
+    // which matches no path the caller holds and reads as never recorded.
+    const rel = commitMigration("20260101000000_café.up.sql");
+    const r = gitRecordedDatatableMigrationPaths();
+    expect(r.kind).toBe("known");
+    if (r.kind === "known") expect(r.paths.has(rel)).toBe(true);
+  });
+
+  test("a committed migration stays recorded after its deletion is committed", () => {
+    const rel = commitMigration("20260101000000_a.up.sql");
+    fs.rmSync(path.join(dir, rel));
+    git("add", "-A");
+    git("commit", "-m", "delete it");
+    const r = gitRecordedDatatableMigrationPaths();
+    expect(r.kind).toBe("known");
+    if (r.kind === "known") expect(r.paths.has(rel)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`gitRecordedDatatableMigrationPaths` answers "has this branch ever tracked this data table migration?" — a push keeps a migration on the remote when the answer is no, on the grounds that this clone may simply never have synced it. Two ways it answered wrongly:

- **`core.quotePath` is on by default**, so a path holding a non-ASCII byte comes back C-quoted — `"migrations/datatable/dt/1_caf\303\251.up.sql"` — matching nothing the caller holds, and reading as never recorded. A migration the user committed and deleted would be kept instead of deployed.
- **`git log HEAD` fails on a repository with no commits**, which fell into the generic `its history could not be read` / `Check that git runs correctly in this directory`. Git runs fine; nothing is committed yet, and that is now what it says (with `Commit the migrations you sync` as the remedy).

Both are one-line-ish fixes inside the existing function. No new callers, no behaviour change beyond the two wrong answers.

## Where this came from

Found while building windmill-labs/windmill#10851 on top of this function. That PR no longer touches it, so these are split out rather than shipped as unrelated scope.

## Test plan

- [x] New `cli/test/git_recorded_migrations_unit.test.ts` runs real git in a temp repo — the answer is a property of git's output, not of logic testable without it.
- [x] Both new cases **fail against `main`** and pass with the fix; the third (a committed migration stays recorded after its deletion is committed) guards the pre-existing behaviour they must not break.
- [x] `bunx tsc --noEmit` clean for `utils/git.ts`, `UNIT_ONLY=1 bun test test/*_unit*` 1098 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `gitRecordedDatatableMigrationPaths` misreading its own git history so it no longer treats migration paths git would C-quote (non-ASCII, `"`, `\`, control characters) as untracked and no longer reports a repo with no commits as broken git. Previously paths were parsed from newline-separated output under the default `core.quotePath`, and `git log HEAD` failed on empty repos; now paths are read raw NUL-separated via `-z` and an empty repo returns "no commits yet" with the remedy to commit. Adds temp-repo unit tests covering both cases and the existing behavior.

<sup>Written for commit 16a13d510ec95f60de0e21718962b457fa467180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

