### PR TITLE
chore: bump tantivy to 0.27 and pin argon2 to 0.5

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -8777,7 +8777,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -12719,7 +12719,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.27.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -12772,7 +12772,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "bitpacking",
 ]
@@ -12780,7 +12780,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -12795,7 +12795,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12818,7 +12818,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "fnv",
  "nom",
@@ -12830,7 +12830,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -12843,7 +12843,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -12852,7 +12852,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
+source = "git+https://github.com/windmill-labs/tantivy?rev=ea3b818c7b93db0c2b5db4f5e7ffef38f339060a#ea3b818c7b93db0c2b5db4f5e7ffef38f339060a"
 dependencies = [
  "serde",
 ]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "generic-array",
 ]
 
@@ -261,13 +261,13 @@ dependencies = [
 
 [[package]]
 name = "argon2"
-version = "0.6.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
- "blake2 0.11.0",
- "cpufeatures 0.3.1",
+ "blake2",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -1825,15 +1825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
-dependencies = [
- "digest 0.11.3",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,15 +1854,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -2408,7 +2390,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
 
@@ -2471,12 +2453,6 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cms"
@@ -2843,15 +2819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,15 +2846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
 ]
 
 [[package]]
@@ -3455,7 +3413,7 @@ dependencies = [
  "arrow",
  "arrow-buffer",
  "base64 0.22.1",
- "blake2 0.10.6",
+ "blake2",
  "blake3",
  "chrono",
  "datafusion-common",
@@ -3731,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "datasketches"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+checksum = "46c4cf71a36b46dcfc00e5014c0c20ccad2b1b6a008304d7d57d2749b2d41b3d"
 
 [[package]]
 name = "debug-helper"
@@ -4497,19 +4455,8 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
- "ctutils",
 ]
 
 [[package]]
@@ -5174,6 +5121,12 @@ dependencies = [
  "swc_macros_common",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "frostem"
+version = "1.20260821.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ed6437a2ed7fc408115e25cdb41e15ba4b17742a4c8d3d1b5276fe9b687209"
 
 [[package]]
 name = "fs3"
@@ -6185,15 +6138,6 @@ name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -7381,15 +7325,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
@@ -7423,9 +7358,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 
 [[package]]
 name = "lzma-sys"
@@ -7849,9 +7784,9 @@ dependencies = [
 
 [[package]]
 name = "murmurhash32"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+checksum = "a8afc6df942f4c022d70c5725e18df1a705773870e5b7f96fde94ca0334ce77a"
 
 [[package]]
 name = "mysql-common-derive"
@@ -8842,7 +8777,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -8989,12 +8924,13 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.6.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
- "getrandom 0.4.3",
- "phc",
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -9136,17 +9072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c7bc82ccbe2c7ef7ceed38dcac90d7ff46681e061e9d7310cbcd409113e303"
 dependencies = [
  "phf 0.11.3",
-]
-
-[[package]]
-name = "phc"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
-dependencies = [
- "base64ct",
- "ctutils",
- "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -10658,16 +10583,6 @@ checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
-]
-
-[[package]]
-name = "rust-stemmers"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
-dependencies = [
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -12803,12 +12718,12 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tantivy"
-version = "0.26.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.27.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "aho-corasick",
  "arc-swap",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bitpacking",
  "bon",
  "byteorder",
@@ -12819,20 +12734,20 @@ dependencies = [
  "downcast-rs",
  "fastdivide",
  "fnv",
+ "frostem",
  "fs4",
  "htmlescape",
  "itertools 0.14.0",
  "levenshtein_automata",
  "log",
- "lru 0.16.4",
- "lz4_flex 0.13.1",
+ "lru 0.18.3",
+ "lz4_flex 0.14.0",
  "measure_time",
  "memmap2",
  "once_cell",
  "oneshot",
  "rayon",
  "regex",
- "rust-stemmers",
  "rustc-hash 2.1.3",
  "serde",
  "serde_json",
@@ -12849,22 +12764,23 @@ dependencies = [
  "thiserror 2.0.20",
  "time",
  "typetag",
+ "unwrap-infallible",
  "uuid",
  "winapi",
 ]
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.9.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.10.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "bitpacking",
 ]
 
 [[package]]
 name = "tantivy-columnar"
-version = "0.6.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.7.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -12878,8 +12794,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-common"
-version = "0.10.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.11.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12901,8 +12817,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.25.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.26.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "fnv",
  "nom",
@@ -12913,8 +12829,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-sstable"
-version = "0.6.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.7.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -12926,8 +12842,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-stacker"
-version = "0.6.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.7.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "murmurhash32",
  "tantivy-common",
@@ -12935,8 +12851,8 @@ dependencies = [
 
 [[package]]
 name = "tantivy-tokenizer-api"
-version = "0.6.0"
-source = "git+https://github.com/windmill-labs/tantivy?rev=6ae7c70bc603b8e69e27f3240e08bd00a93fb12c#6ae7c70bc603b8e69e27f3240e08bd00a93fb12c"
+version = "0.7.0"
+source = "git+https://github.com/windmill-labs/tantivy?rev=33fafac9d0b69627e589fa4fbb3de252dd466dd7#33fafac9d0b69627e589fa4fbb3de252dd466dd7"
 dependencies = [
  "serde",
 ]
@@ -14229,7 +14145,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "subtle",
 ]
 
@@ -14256,6 +14172,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unwrap-infallible"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e497bb1f828cc9fb236722c2eaa100dcf201563f38f4da6252357a59037adf31"
 
 [[package]]
 name = "ureq"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -700,7 +700,7 @@ tikv-jemalloc-ctl = { version = "^0.5" }
 triomphe = "^0"
 pin-project-lite = "^0"
 
-tantivy = { git="https://github.com/windmill-labs/tantivy", rev="33fafac9d0b69627e589fa4fbb3de252dd466dd7" }
+tantivy = { git="https://github.com/windmill-labs/tantivy", rev="ea3b818c7b93db0c2b5db4f5e7ffef38f339060a" }
 
 backon = "1.3.0"
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -477,7 +477,10 @@ rust-embed = { version = "^6", features = ["interpolate-folder-path"] }
 mime_guess = "^2"
 hex = "^0"
 sql-builder = "^3"
-argon2 = "^0"
+# Pinned: `^0` floats to 0.6, which moved `password_hash::SaltString`, put
+# `rand_core` behind a feature and changed `hash_password`'s signature —
+# users_ee.rs is written against 0.5 and does not compile otherwise.
+argon2 = "0.5"
 quick_cache = "^0"
 rand = "=0.9.0"
 rand_core = { version = "^0", features = ["std"] }
@@ -697,7 +700,7 @@ tikv-jemalloc-ctl = { version = "^0.5" }
 triomphe = "^0"
 pin-project-lite = "^0"
 
-tantivy = { git="https://github.com/windmill-labs/tantivy", rev="6ae7c70bc603b8e69e27f3240e08bd00a93fb12c" }
+tantivy = { git="https://github.com/windmill-labs/tantivy", rev="33fafac9d0b69627e589fa4fbb3de252dd466dd7" }
 
 backon = "1.3.0"
 


### PR DESCRIPTION
## Summary

Moves the pinned tantivy fork from a 0.26.0-era base to current upstream (0.27.0-dev), and pins `argon2` to `0.5` to unbreak a feature combination that does not currently compile on main.

We were **1 commit ahead / 216 behind** `quickwit-oss/tantivy`. The one commit ahead is windmill's own patch; the 216 behind land disproportionately on the one thing we still ask tantivy to do.

## Why now

After #10886 moved service log retrieval to a Parquet store, tantivy serves exactly one query: a terms aggregation over `host_key` intersected with a `RangeQuery` on `timestamp`. Reviewing the 216 missed commits against that surface:

**Correctness, on our path**
- `fix term aggregation u32::MAX overflow issue` — widens a per-bucket `doc_count` to `u64`. Needs >4.29 B docs in one bucket, so not reachable for us today, but it is a real ceiling.
- `Fix numeric term key normalization across segments (#3051)` — inconsistent term-key normalization *across segments*, the class of bug that silently splits or merges buckets. Our aggregation groups across every segment.
- `fix(sstable): report the real term ordinal when an automaton prunes blocks` and `fix/streamer-term-ord-skipped-blocks` — term-ordinal bugs underpinning term lookup.

**Performance, on our path**
- `Speed up range-query intersections via seek_danger on RangeDocSet (up to ~50x faster)` — our count query is literally a range-query intersection.
- `Optimize low-cardinality term aggregation counters` — `host_key` cardinality is the host count.
- `select-nth instead of full sort in segment-level agg top-k` — our aggregation is `size: 100` top-k.
- The 0.26.1 aggregation perf fix, which we never picked up.

Areas we no longer use are nearly untouched by the delta: doc store 0 commits, snippets 0, scoring 1, positions 4 — so the upgrade surface is small.

## Changes

- `backend/Cargo.toml`: tantivy rev `6ae7c70` → `33fafac`, rebasing windmill's patch onto upstream main. **No API changes were required** — 0.26.0 → 0.27.0 compiled clean.
- The fork patch is cleaned up in passing: it carried a stray `println!` alongside the `error!`, writing raw text straight to stdout and bypassing tracing entirely. Dropped, and the commit now explains the constraint (propagating with `?` returns from the worker closure, killing the indexing thread for the life of the writer, so one malformed document would stop all subsequent indexing).
- `backend/Cargo.toml`: `argon2 = "^0"` → `"0.5"`. The caret floated to 0.6, which moved `password_hash::SaltString`, put `rand_core` behind a feature and changed `hash_password`'s signature; `windmill-api/src/users_ee.rs` is written against 0.5 and does not compile otherwise. This break is **pre-existing on main**, unrelated to tantivy, and blocks `--features quickjs,tantivy,private` today.

## Test plan

- [x] `cargo check --features quickjs,tantivy,private` — clean (was failing on main before the argon2 pin)
- [x] `cargo check -p windmill-indexer --features private,parquet,enterprise` — clean, no API changes
- [x] `cargo test -p windmill-indexer --features private,parquet,enterprise --lib` — 11/11, including `test_job_indexing_pipeline` and `test_delete_old_jobs_from_index`
- [x] Ran a real instance (`MODE=standalone+search`, filesystem object store), drove jobs, waited for a full ingest pass: index built with no indexing errors, per-host count returned 18 hits, Parquet retrieval returned the same 18 — the two agree exactly
- [ ] CI on the full feature matrix

## Follow-up

Windmill's patch is worth upstreaming — "don't kill the indexing worker because one document failed" is a reasonable ask, and landing it would let us drop the fork and depend on crates.io directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the `tantivy` fork from its 0.26-era base to upstream 0.27.0 and pins `argon2` to 0.5, fixing a pre-existing compile break on `--features quickjs,tantivy,private`.

- The 216-commit gap lands almost entirely on the one query we still run — a terms aggregation on `host_key` over a `RangeQuery` on `timestamp` — and brings per-bucket `doc_count` overflow fixes, cross-segment term-key normalization, term-ordinal lookup fixes, up to ~50x faster range-query intersections, and a faster low-cardinality aggregation path.
- No API changes were required; 0.26 → 0.27 compiled clean.
- The pin now points at the fork's merged main head, which folds in the patch that drops a stray `println!` writing raw text to stdout, bypassing tracing.
- `argon2` `^0` floated to 0.6, which moved `password_hash::SaltString` and changed `hash_password`'s signature; `windmill-api/src/users_ee.rs` is written against 0.5 and doesn't compile otherwise.
- Verified with `cargo check --features quickjs,tantivy,private`, `cargo test`, and a live run where index hits matched Parquet retrieval exactly.

<sup>Written for commit 565ffc96ceea6ed563b394c47333f00ae150def5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

