### PR TITLE
fix: scope app deployment history to the workspace and its app

### DIFF
--- a/backend/.sqlx/query-a462d8661fee58129ec52952ee08a33fcc2e22b47d352030d55e1375c885cd36.json
+++ b/backend/.sqlx/query-a462d8661fee58129ec52952ee08a33fcc2e22b47d352030d55e1375c885cd36.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT path FROM app WHERE id = $1",
+  "query": "SELECT a.path FROM app a JOIN app_version av ON av.app_id = a.id\n        WHERE a.id = $1 AND a.workspace_id = $2 AND av.id = $3",
   "describe": {
     "columns": [
       {
@@ -11,6 +11,8 @@
     ],
     "parameters": {
       "Left": [
+        "Int8",
+        "Text",
         "Int8"
       ]
     },
@@ -18,5 +20,5 @@
       false
     ]
   },
-  "hash": "abb56dec024600d0d7a63212f63c3296196898003707f2cb3a890690173a51a5"
+  "hash": "a462d8661fee58129ec52952ee08a33fcc2e22b47d352030d55e1375c885cd36"
 }

--- a/backend/.sqlx/query-b29cf43a194f4a61a67ce95a5485dc287df1b1d79bf5040216ee48583405cd8b.json
+++ b/backend/.sqlx/query-b29cf43a194f4a61a67ce95a5485dc287df1b1d79bf5040216ee48583405cd8b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT a.id as app_id, av.id as version_id, dm.deployment_msg as deployment_msg\n        FROM app a LEFT JOIN app_version av ON a.id = av.app_id LEFT JOIN deployment_metadata dm ON av.id = dm.app_version\n        WHERE a.workspace_id = $1 AND a.path = $2\n        ORDER BY created_at DESC",
+  "query": "SELECT a.id as app_id, av.id as version_id, dm.deployment_msg as deployment_msg\n        FROM app a LEFT JOIN app_version av ON a.id = av.app_id LEFT JOIN deployment_metadata dm ON av.id = dm.app_version AND dm.workspace_id = a.workspace_id\n        WHERE a.workspace_id = $1 AND a.path = $2\n        ORDER BY created_at DESC",
   "describe": {
     "columns": [
       {
@@ -31,5 +31,5 @@
       true
     ]
   },
-  "hash": "d02c1cfefc7d5f87ca4555a092f5fbc777a91271b80d0e488a8cae79afd56d8f"
+  "hash": "b29cf43a194f4a61a67ce95a5485dc287df1b1d79bf5040216ee48583405cd8b"
 }

--- a/backend/windmill-api-integration-tests/tests/app_history_cross_workspace.rs
+++ b/backend/windmill-api-integration-tests/tests/app_history_cross_workspace.rs
@@ -63,14 +63,18 @@ async fn update_history(
     Ok((status, resp.text().await?))
 }
 
-async fn history(port: u16, workspace: &str, path: &str) -> anyhow::Result<serde_json::Value> {
-    Ok(authed(client().get(format!(
+/// Deserializes into a `Vec` rather than a bare `Value` so the negative assertions
+/// cannot pass on an error body: indexing a JSON object with `[0]` yields `Null`.
+async fn history(port: u16, workspace: &str, path: &str) -> anyhow::Result<Vec<serde_json::Value>> {
+    let resp = authed(client().get(format!(
         "http://localhost:{port}/api/w/{workspace}/apps/history/p/{path}"
     )))
     .send()
-    .await?
-    .json()
-    .await?)
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(status, 200, "history of {path} in {workspace}: {body}");
+    Ok(serde_json::from_str(&body)?)
 }
 
 #[sqlx::test(
@@ -136,8 +140,14 @@ async fn test_app_history_is_workspace_scoped(db: Pool<Postgres>) -> anyhow::Res
     .execute(&db)
     .await?;
 
+    let victim_history = history(port, "test-workspace", victim_path).await?;
     assert_eq!(
-        history(port, "test-workspace", victim_path).await?[0]["deployment_msg"],
+        victim_history.len(),
+        1,
+        "the injected row must not add a history entry: {victim_history:?}"
+    );
+    assert_eq!(
+        victim_history[0]["deployment_msg"],
         serde_json::Value::Null,
         "another workspace's deployment metadata must not surface"
     );

--- a/backend/windmill-api-integration-tests/tests/app_history_cross_workspace.rs
+++ b/backend/windmill-api-integration-tests/tests/app_history_cross_workspace.rs
@@ -1,0 +1,146 @@
+//! `app_version.id` is a global sequence, so an app-history deployment message
+//! addressed by `(app_id, app_version)` alone crosses workspaces. This pins both
+//! halves: the write refuses a version that is not the workspace's app's, and the
+//! read only joins deployment metadata owned by the workspace.
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    builder.header("Authorization", "Bearer SECRET_TOKEN")
+}
+
+fn new_app(path: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": "Test app",
+        "value": { "type": "rawapp", "inline_script": null },
+        "policy": { "execution_mode": "anonymous", "triggerables": {} }
+    })
+}
+
+/// Creates the app and returns its `(app_id, version_id)`.
+async fn create_app(port: u16, workspace: &str, path: &str) -> anyhow::Result<(i64, i64)> {
+    let base = format!("http://localhost:{port}/api/w/{workspace}/apps");
+    let resp = authed(client().post(format!("{base}/create")))
+        .json(&new_app(path))
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(status, 201, "create {path} in {workspace}: {body}");
+
+    let latest = authed(client().get(format!("{base}/get_latest_version/{path}")))
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+    Ok((
+        latest["app_id"].as_i64().unwrap(),
+        latest["version"].as_i64().unwrap(),
+    ))
+}
+
+async fn update_history(
+    port: u16,
+    workspace: &str,
+    app_id: i64,
+    version: i64,
+    msg: &str,
+) -> anyhow::Result<(u16, String)> {
+    let resp = authed(client().post(format!(
+        "http://localhost:{port}/api/w/{workspace}/apps/history_update/a/{app_id}/v/{version}"
+    )))
+    .json(&json!({ "deployment_msg": msg }))
+    .send()
+    .await?;
+    let status = resp.status().as_u16();
+    Ok((status, resp.text().await?))
+}
+
+async fn history(port: u16, workspace: &str, path: &str) -> anyhow::Result<serde_json::Value> {
+    Ok(authed(client().get(format!(
+        "http://localhost:{port}/api/w/{workspace}/apps/history/p/{path}"
+    )))
+    .send()
+    .await?
+    .json()
+    .await?)
+}
+
+#[sqlx::test(
+    migrations = "../migrations",
+    fixtures("base", "app_history_second_workspace")
+)]
+async fn test_app_history_is_workspace_scoped(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let victim_path = "u/test-user/victim_app";
+    let attacker_path = "u/test-user/attacker_app";
+    let (victim_app, victim_version) = create_app(port, "test-workspace", victim_path).await?;
+    let (attacker_app, attacker_version) =
+        create_app(port, "test-workspace-2", attacker_path).await?;
+
+    // Own app, another workspace's version: the version must belong to the app.
+    let (status, body) = update_history(
+        port,
+        "test-workspace-2",
+        attacker_app,
+        victim_version,
+        "injected",
+    )
+    .await?;
+    assert_eq!(status, 404, "foreign version must be rejected: {body}");
+
+    // Another workspace's app entirely: the app must belong to the workspace.
+    let (status, body) = update_history(
+        port,
+        "test-workspace-2",
+        victim_app,
+        victim_version,
+        "injected",
+    )
+    .await?;
+    assert_eq!(status, 404, "foreign app must be rejected: {body}");
+
+    // The legitimate update still lands, and only in its own workspace.
+    let (status, body) = update_history(
+        port,
+        "test-workspace-2",
+        attacker_app,
+        attacker_version,
+        "deployed by owner",
+    )
+    .await?;
+    assert_eq!(status, 200, "own app and version must be accepted: {body}");
+    assert_eq!(
+        history(port, "test-workspace-2", attacker_path).await?[0]["deployment_msg"],
+        "deployed by owner"
+    );
+
+    // A deployment_metadata row owned by another workspace but pointing at this
+    // app's version must not surface — the read joins on workspace too.
+    sqlx::query(
+        "INSERT INTO deployment_metadata (workspace_id, path, app_version, deployment_msg)
+         VALUES ('test-workspace-2', $1, $2, 'injected')",
+    )
+    .bind(victim_path)
+    .bind(victim_version)
+    .execute(&db)
+    .await?;
+
+    assert_eq!(
+        history(port, "test-workspace", victim_path).await?[0]["deployment_msg"],
+        serde_json::Value::Null,
+        "another workspace's deployment metadata must not surface"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-integration-tests/tests/fixtures/app_history_second_workspace.sql
+++ b/backend/windmill-api-integration-tests/tests/fixtures/app_history_second_workspace.sql
@@ -1,0 +1,17 @@
+-- Additive fixture: a second workspace sharing the `base` fixture's admin user,
+-- so the same caller can hold an app in each workspace.
+
+INSERT INTO workspace (id, name, owner) VALUES
+	('test-workspace-2', 'test-workspace-2', 'test-user');
+
+INSERT INTO usr(workspace_id, email, username, is_admin, role) VALUES
+	('test-workspace-2', 'test@windmill.dev', 'test-user', true, 'Admin');
+
+INSERT INTO workspace_key(workspace_id, kind, key) VALUES
+	('test-workspace-2', 'cloud', 'test-key-2');
+
+INSERT INTO workspace_settings (workspace_id) VALUES
+	('test-workspace-2');
+
+INSERT INTO group_ (workspace_id, name, summary, extra_perms) VALUES
+	('test-workspace-2', 'all', 'All users', '{}');

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -546,7 +546,7 @@ async fn list_apps(
     if lq.with_deployment_msg.unwrap_or(false) {
         sqlb.join("deployment_metadata dm")
             .left()
-            .on("dm.app_version = app.versions[array_upper(app.versions, 1)]")
+            .on("dm.app_version = app.versions[array_upper(app.versions, 1)] AND dm.workspace_id = app.workspace_id")
             .fields(&["dm.deployment_msg"]);
     }
 
@@ -1055,7 +1055,7 @@ async fn get_app_history(
     let mut tx = user_db.begin(&authed).await?;
     let query_result = sqlx::query!(
         "SELECT a.id as app_id, av.id as version_id, dm.deployment_msg as deployment_msg
-        FROM app a LEFT JOIN app_version av ON a.id = av.app_id LEFT JOIN deployment_metadata dm ON av.id = dm.app_version
+        FROM app a LEFT JOIN app_version av ON a.id = av.app_id LEFT JOIN deployment_metadata dm ON av.id = dm.app_version AND dm.workspace_id = a.workspace_id
         WHERE a.workspace_id = $1 AND a.path = $2
         ORDER BY created_at DESC",
         w_id,
@@ -1084,7 +1084,7 @@ async fn get_latest_version(
     let mut tx = user_db.begin(&authed).await?;
     let row = sqlx::query!(
         "SELECT a.id as app_id, av.id as version_id, dm.deployment_msg as deployment_msg
-        FROM app a LEFT JOIN app_version av ON a.id = av.app_id LEFT JOIN deployment_metadata dm ON av.id = dm.app_version
+        FROM app a LEFT JOIN app_version av ON a.id = av.app_id LEFT JOIN deployment_metadata dm ON av.id = dm.app_version AND dm.workspace_id = a.workspace_id
         WHERE a.workspace_id = $1 AND a.path = $2
         ORDER BY created_at DESC",
         w_id,
@@ -1112,15 +1112,24 @@ async fn update_app_history(
     Json(app_history_update): Json<AppHistoryUpdate>,
 ) -> Result<()> {
     let mut tx = user_db.begin(&authed).await?;
-    let app_path = sqlx::query_scalar!("SELECT path FROM app WHERE id = $1", app_id)
-        .fetch_optional(&mut *tx)
-        .await?;
+    // `app_version.id` is a global sequence, so the version has to be tied back to the app and
+    // the app to the workspace: without both, the row this writes lands on another workspace's
+    // deployment history.
+    let app_path = sqlx::query_scalar!(
+        "SELECT a.path FROM app a JOIN app_version av ON av.app_id = a.id
+        WHERE a.id = $1 AND a.workspace_id = $2 AND av.id = $3",
+        app_id,
+        w_id,
+        app_version,
+    )
+    .fetch_optional(&mut *tx)
+    .await?;
 
     let Some(app_path) = app_path else {
         tx.commit().await?;
-        return Err(Error::NotFound(
-            format!("App with ID {app_id} not found").to_string(),
-        ));
+        return Err(Error::NotFound(format!(
+            "App with ID {app_id} and version {app_version} not found"
+        )));
     };
 
     check_scopes(&authed, || format!("apps:write:{}", &app_path))?;


### PR DESCRIPTION
## Summary

Fixes WIN-2443.

`POST /api/w/{workspace}/apps/history_update/a/{app_id}/v/{version}` addressed a
deployment message by `(app_id, app_version)` without tying either to the calling
workspace:

- the app lookup was `SELECT path FROM app WHERE id = $1`, so any app id from any
  workspace resolved;
- `app_version.id` is a global sequence and the supplied version was never checked
  against the resolved app, so any version id in the instance could be referenced;
- `get_app_history`, `get_latest_version` and `list_apps?with_deployment_msg=true`
  joined `deployment_metadata` on `av.id = dm.app_version` alone, so a row written
  under another workspace surfaced in the victim's deployment history.

Together, any authenticated user could write an arbitrary deployment message into
another workspace's app history by calling the endpoint with their own app id and the
victim's version id.

## Changes

- `update_app_history` resolves the app path with a single query that joins
  `app_version` and filters on `a.workspace_id`, so both the app and the version must
  belong to the caller's workspace; otherwise it 404s (message now names the version
  too).
- `get_app_history` and `get_latest_version` scope the `deployment_metadata` join with
  `AND dm.workspace_id = a.workspace_id`.
- `list_apps` scopes the same join with `AND dm.workspace_id = app.workspace_id`, so a
  pre-existing injected row cannot leak through the list either.
- New integration test `app_history_cross_workspace` covering both halves, with a
  second-workspace fixture.

The only caller of the endpoint, `DeploymentHistory.svelte`, passes an app id and
version taken from the current workspace's own history, so it is unaffected.

### Not covered: same-workspace residual rows

The join is scoped by workspace, not by path. The pre-fix endpoint also allowed
planting `(own_workspace, own_app_path, coworkers_version_id)`, and such a row still
satisfies `dm.workspace_id = a.workspace_id`, so it can still surface on a co-worker's
history in that same workspace. Nothing can create one after this PR — this is residual
data only. Tightening the join with `AND dm.path = a.path` would be a regression:
nothing rewrites `deployment_metadata.path` on app rename, so it would hide the
messages of every renamed app's older versions.

## Test plan

- [x] `cargo test -p windmill-api-integration-tests --test app_history_cross_workspace`
      passes; it fails on the pre-fix code (write half: 200 instead of 404) and fails
      again with only the read-side join scoping reverted (injected message surfaces).
- [x] `cargo test -p windmill-api-integration-tests --test apps` still passes.
- [x] `SQLX_OFFLINE=true cargo check -p windmill-api --features quickjs` and
      `SQLX_OFFLINE=true cargo check -p windmill-api-integration-tests --all-targets`.
- [x] On a running instance with two workspaces: `history_update` with a foreign app id
      or a foreign version returns 404, the legitimate update returns 200 and appears in
      its own workspace's history; a `deployment_metadata` row planted under the other
      workspace for the victim's version no longer appears in the victim's
      `history/p`, `get_latest_version`, or `apps/list?with_deployment_msg=true`.
- [x] Updating the deployment message of a **non-latest** version returns 200 and
      persists, and `apps/list?with_deployment_msg=true` keeps showing each app's own
      latest-version message.
- [x] UI: the app editor's Deployment History panel lists the deployment message and
      updating it through the pencil control still writes to the correct workspace.

---

Left in draft: this changes an authorization path, so it wants a human look before
ready. The review round is clean (see the marker comment).