### PR TITLE
fix: show a loading indicator while the initial data table migration is generated

### DIFF
--- a/frontend/src/lib/components/workspaceSettings/DataTableMigrationsButton.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DataTableMigrationsButton.svelte
@@ -52,6 +52,8 @@
 	let loadError = $state<string | undefined>(undefined)
 	let loading = $state(false)
 	let busy = $state(false)
+	// pg_dump can take a while, so the snapshot gets its own flag to spin its button.
+	let generatingInitial = $state(false)
 
 	// Only workspace admins and super admins can opt a data table in or out.
 	const canManage = $derived(!!$userStore?.is_admin || !!$superadmin)
@@ -280,6 +282,7 @@
 		})
 		if (!confirmed) return
 		busy = true
+		generatingInitial = true
 		try {
 			await WorkspaceService.generateInitialDatatableMigration({
 				workspace,
@@ -291,6 +294,7 @@
 			sendUserToast(`Failed to generate initial migration: ${e?.body ?? e?.message ?? e}`, true)
 		} finally {
 			busy = false
+			generatingInitial = false
 		}
 	}
 
@@ -493,12 +497,13 @@
 			<div class="flex flex-col grow min-h-0 overflow-auto border rounded-md divide-y">
 				{#if migrations.length === 0}
 					<div class="flex flex-col items-center gap-3 p-6 text-sm text-tertiary">
-						<span>No migrations yet</span>
+						<span>{generatingInitial ? 'Snapshotting current schema…' : 'No migrations yet'}</span>
 						<Button
 							variant="subtle"
 							size="xs"
 							startIcon={{ icon: Camera }}
 							disabled={busy}
+							loading={generatingInitial}
 							on:click={generateInitial}
 						>
 							Generate initial migration


### PR DESCRIPTION
## Summary

Generating the initial data table migration snapshots the schema with `pg_dump`, which takes long enough to notice, but the modal gave no feedback: the button was only disabled (`busy`), which reads as an unresponsive UI rather than work in progress. The same gap is on the enable-migrations path, which chains straight into generation.

## Changes

- Track the snapshot separately from the generic `busy` flag with a `generatingInitial` state, set around the `generateInitialDatatableMigration` call and cleared in `finally` — after the list reload, so the indicator stays up until the list is current, and clears on both the success and the error path.
- Pass `loading={generatingInitial}` to the "Generate initial migration" button: the camera icon becomes a spinner and the button stays locked.
- Swap the empty-state line to "Snapshotting current schema…" while it runs, instead of a stale "No migrations yet".

## Screenshots

Before / while generating / after:

![01-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/initial-migration-loading-indicator/1788153317-01-before.png)

![02-generating](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/initial-migration-loading-indicator/1788153319-02-generating.png)

![03-done](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/initial-migration-loading-indicator/1788153322-03-done.png)

## Test plan

- [x] Workspace settings → Data tables → Migrations on a data table with no migrations: "Generate initial migration" spins and the empty state reads "Snapshotting current schema…" while `pg_dump` runs.
- [x] On success the list shows the `initial` migration as applied and the indicator clears.
- [x] On failure (exercised with a real `pg_dump` server-version mismatch) the state returns to "No migrations yet" with the camera icon and an error toast.