### PR TITLE
fix(ai-chat): consume an @ mention with the message that carried it

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
@@ -688,6 +688,15 @@
 		selectedContext = [...selectedContext, contextToAdd]
 	}
 
+	/** Consume inside the submit gesture, never after it: the manager's preflight
+	 * awaits attachment upkeep and a session fork that can take seconds, and
+	 * consuming past them would hand this message a mention the user picked for
+	 * the next one. */
+	function consumeMentionsIfGlobal() {
+		if (aiChatManager.mode !== AIMode.GLOBAL) return
+		aiChatManager.contextManager?.consumeMentionContext()
+	}
+
 	function sendRequest() {
 		// The send button is disabled while decoding, but Enter reaches here directly.
 		// Sending now would drop the in-flight attachments onto the following message.
@@ -705,6 +714,10 @@
 			])
 		) {
 			draft.take()
+			// The answer carries only its choice strings, so a mention here rides
+			// nothing — but clearForSend below keeps the selection, which would hand
+			// it to the next turn.
+			consumeMentionsIfGlobal()
 			contextTextareaComponent?.clearForSend()
 			return
 		}
@@ -728,6 +741,8 @@
 					[...selectedContext],
 					sent.files
 				)
+				// Consumed at enqueue, not at flush: the entry above pinned them.
+				consumeMentionsIfGlobal()
 				contextTextareaComponent?.clearForSend()
 			}
 			return
@@ -748,17 +763,24 @@
 			onEditEnd()
 		} else {
 			const sent = draft.take()
+			// Pin before consuming: the manager falls back to the live selection only
+			// when given no override, and the consume below empties it.
+			const carried = aiChatManager.mode === AIMode.GLOBAL ? [...selectedContext] : undefined
+			consumeMentionsIfGlobal()
 			aiChatManager.sendRequest({
 				instructions: sent.text,
 				pastes: sent.pastes,
 				images: sent.images,
-				files: sent.files
+				files: sent.files,
+				contextOverride: carried,
+				contextOverrideOrigin: carried ? 'pinned' : undefined
 			})
-			// clearForSend() pre-zaps the textarea's mention-sync so the wipe
-			// doesn't drop `selectedContext` before `AIChatManager.beforeSend`
-			// snapshots it. Only mounted in SCRIPT/FLOW/GLOBAL — APP and the
-			// fallback textarea still rely on the draft reset alone (no
-			// `@`-mention state to coordinate).
+			// clearForSend() pre-zaps the textarea's mention-sync so the wipe doesn't
+			// drop `selectedContext` before the send has settled its context: the pin
+			// above in GLOBAL, the manager's own read of the live selection in
+			// SCRIPT/FLOW. Only mounted in SCRIPT/FLOW/GLOBAL — APP and the fallback
+			// textarea still rely on the draft reset alone (no `@`-mention state to
+			// coordinate).
 			contextTextareaComponent?.clearForSend()
 		}
 	}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -95,6 +95,7 @@ import {
 	createAppBackendRunnableContextElement,
 	createAppFrontendFileContextElement,
 	flattenDatatablesToAppContextElements,
+	isMentionContext,
 	isSameContextElement,
 	type ContextElement,
 	type AppDatatableElement
@@ -1853,6 +1854,25 @@ export class AIChatManager {
 		}
 	}
 
+	/** Give back the mentions a send carried when its text returns to the composer,
+	 * so its `@` tokens still have entries to bind to. Additive, unlike the DOM
+	 * restore above: dropping the entries this send did not carry would strand the
+	 * tokens naming them in a draft whose text now shares the same composer.
+	 *
+	 * `originMode` is the mode the send was submitted in, and is required: the
+	 * composer only consumes in GLOBAL, so reading the mode at restore time would
+	 * strand a send whose mode changed mid-turn and resurrect chips for one that
+	 * never consumed. Every caller states which mode it means. */
+	#restoreMentionContext(context: ContextElement[] | undefined, originMode: AIMode) {
+		if (originMode !== AIMode.GLOBAL) return
+		const mentions = (context ?? []).filter(isMentionContext)
+		if (mentions.length === 0) return
+		const selection = this.contextManager?.getSelectedContext() ?? []
+		const missing = mentions.filter((m) => !selection.some((s) => isSameContextElement(s, m)))
+		if (missing.length === 0) return
+		this.contextManager?.setSelectedContext([...selection, ...missing])
+	}
+
 	/** Send `text` as a turn, or queue it when one is already streaming. Callers
 	 * that send programmatically (an editor button, an arriving hand-off) must go
 	 * through this rather than `sendRequest`: a second concurrent loop shares this
@@ -1885,6 +1905,10 @@ export class AIChatManager {
 		// is selected now. If its text was prepended onto an existing draft, that
 		// draft's chips are kept too — both instructions now share one composer.
 		this.#restoreDomContext(queued.context, mergedIntoDraft)
+		// The queue aggregates several enqueues into one entry and records no
+		// originating mode, so the mode now is the closest signal available. A
+		// recall after a mid-turn mode switch can therefore miss a restore.
+		this.#restoreMentionContext(queued.context, this.mode)
 	}
 
 	/** Put what the user typed back where they can see it: into the input
@@ -2813,8 +2837,8 @@ export class AIChatManager {
 			lang?: ScriptLang | 'bunnative'
 			isPreprocessor?: boolean
 			// Use this selected-context snapshot for the turn instead of the live
-			// contextManager. Set when flushing a queued message that captured its
-			// context at submit time; the live selection is left untouched.
+			// contextManager. Set whenever a send settles its context ahead of the
+			// turn: a composer submit at the click, a queued message at enqueue.
 			contextOverride?: ContextElement[]
 			/** Where `contextOverride` came from. 'pinned' (default): the chips were
 			 * selected for THIS message, so they are consumed from the live selection
@@ -2964,12 +2988,18 @@ export class AIChatManager {
 			// re-reserves them, so release this send's outgoing-files reservation.
 			this.#releaseOutgoingReservation(reservationKey)
 			if (!options.queued) {
-				this.aiChatInput?.restoreInstructions(
-					this.instructions,
-					pastes,
-					options.images ?? [],
-					options.files ?? []
-				)
+				// Reached only once the mode has already moved off GLOBAL, so the
+				// restore is keyed to requestedMode: a GLOBAL submit whose mode
+				// flipped during the upkeep awaits above still gets its mentions
+				// back, while a send that started outside GLOBAL consumed none.
+				const taken =
+					this.aiChatInput?.restoreInstructions(
+						this.instructions,
+						pastes,
+						options.images ?? [],
+						options.files ?? []
+					) === true
+				if (taken) this.#restoreMentionContext(options.contextOverride, requestedMode)
 			}
 			return false
 		}
@@ -2990,6 +3020,11 @@ export class AIChatManager {
 			// put them back in the composer instead of silently discarding them
 			// (the input already cleared itself optimistically on send). Queued
 			// drafts are the caller's to restore (it re-queues on false).
+			//
+			// No mention restore: an entry exists only while its `@` token is in the
+			// text (the picker adds both, the textarea's sync drops the entry when
+			// the token goes), and this branch requires empty text. A mention source
+			// that does not write a token would break that and need one here.
 			if (!this.instructions.trim() && files.length === 0) {
 				sendUserToast(`${sendModel.model} can't read images. Switch to a vision model first.`, true)
 				if (!options.queued) this.restoreToInput('', requestedImages)
@@ -3046,7 +3081,13 @@ export class AIChatManager {
 				console.error('AIChatManager beforeSend hook failed', e)
 				rollbackOptimisticSend()
 				if (!options.queued) {
-					this.aiChatInput?.restoreInstructions(this.instructions, pastes, images, files)
+					// Mentions were consumed at submit, so they come back with the text or
+					// not at all. Only when the composer took it: it declines when the
+					// user has started a new draft, and restoring then would put these
+					// mentions on that draft and every turn after it.
+					const taken =
+						this.aiChatInput?.restoreInstructions(this.instructions, pastes, images, files) === true
+					if (taken) this.#restoreMentionContext(options.contextOverride, requestedMode)
 				}
 				sendUserToast(
 					`Could not prepare the session before sending: ${
@@ -3086,7 +3127,11 @@ export class AIChatManager {
 				})
 				if (accepted === false) this.#restoreQueue(next)
 			} else {
-				this.aiChatInput?.restoreInstructions(this.instructions, pastes, images, files)
+				// Same pairing as the beforeSend catch above: mentions ride back with the
+				// text, only if the composer took it.
+				const taken =
+					this.aiChatInput?.restoreInstructions(this.instructions, pastes, images, files) === true
+				if (taken) this.#restoreMentionContext(options.contextOverride, requestedMode)
 			}
 			return true
 		}
@@ -3181,9 +3226,10 @@ export class AIChatManager {
 			hideTarget?.removeEventListener('visibilitychange', checkpointOnHide)
 		}
 		try {
-			// A queued message carries its own context snapshot (contextOverride); use
-			// it verbatim and leave the live selection alone (it belongs to whatever the
-			// user has selected since). Otherwise read the current selection.
+			// A pinned snapshot (a queued message, or a composer submit settling its
+			// context at the click) is used verbatim, leaving the live selection alone —
+			// it belongs to whatever the user has selected since. Otherwise read the
+			// current selection.
 			const oldSelectedContext =
 				options.contextOverride ?? this.contextManager?.getSelectedContext() ?? []
 			// DOM selector chips are one-shot: they ride with this message (captured in
@@ -3194,9 +3240,9 @@ export class AIChatManager {
 				// context, consumed on its original send. The live selection belongs to
 				// the composer's own draft — touching it here would strip it.
 			} else if (options.contextOverride) {
-				// Queued message: only the chips it carried are consumed. Drop just
-				// those from the live selection (still there if the user didn't
-				// re-select); a newer selection made since is left intact.
+				// A pinned submit consumes only the chips it carried. Drop just those
+				// from the live selection (still there if the user didn't re-select); a
+				// newer selection made since is left intact.
 				for (const c of options.contextOverride) {
 					if (c.type === 'app_dom_selector') {
 						// Match appPath too: another app's live chip can share this
@@ -3615,6 +3661,7 @@ export class AIChatManager {
 				// retarget whatever draft is sitting there.
 				if (textRestored) {
 					this.#restoreDomContext(oldSelectedContext)
+					this.#restoreMentionContext(oldSelectedContext, requestedMode)
 				}
 				if (this.displayMessages.length === 0) {
 					// saveChat no-ops on an empty transcript; the chat persisted earlier

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -2164,6 +2164,98 @@ describe('AIChatManager queued messages', () => {
 		expect(chips.map((c) => c.selector)).toEqual(['div.card'])
 	})
 
+	// The composer consumes an `@` mention on send, so a send that never became a
+	// turn has to give it back — otherwise the restored text keeps its `@` token
+	// with nothing behind it.
+	it('restores a cancelled GLOBAL send’s @ mentions', async () => {
+		const manager = createManager(createInputMock())
+		manager.mode = AIMode.GLOBAL
+		const cm = manager.contextManager
+		const mention = {
+			type: 'workspace_script' as const,
+			path: 'f/etl/sync',
+			title: 'f/etl/sync'
+		}
+		// What the composer does at submit: pin what it carries, then consume.
+		const carried = [mention]
+		cm.setSelectedContext([])
+		mocks.runChatLoop.mockImplementationOnce(async ({ abortController }: any) => {
+			abortController.abort('user_cancelled')
+			throw new Error('aborted')
+		})
+
+		await manager.sendRequest({
+			instructions: 'why does this retry',
+			contextOverride: carried,
+			contextOverrideOrigin: 'pinned'
+		})
+
+		expect(cm.getSelectedContext()).toEqual([mention])
+	})
+
+	// The mode switcher stays live while a turn streams, so the restore is keyed
+	// to the mode the send was submitted in. Reading the mode at rollback time
+	// would strand the mention behind a `@` token that resolves to nothing.
+	it('restores a GLOBAL send’s @ mentions after a mid-turn switch to SCRIPT', async () => {
+		const manager = createManager(createInputMock())
+		manager.mode = AIMode.GLOBAL
+		const cm = manager.contextManager
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		cm.setSelectedContext([])
+		mocks.runChatLoop.mockImplementationOnce(async ({ abortController }: any) => {
+			// The user navigates to a script editor while the turn is streaming.
+			manager.mode = AIMode.SCRIPT
+			abortController.abort('user_cancelled')
+			throw new Error('aborted')
+		})
+
+		await manager.sendRequest({
+			instructions: 'why does this retry',
+			contextOverride: [mention],
+			contextOverrideOrigin: 'pinned'
+		})
+
+		expect(cm.getSelectedContext()).toEqual([mention])
+	})
+
+	// Attachments are refused outside GLOBAL, and the refusal sits past the
+	// preflight awaits — so it is reached exactly when a GLOBAL submit's mode
+	// changed underneath it, and owes that send its mentions back.
+	it('restores mentions when a GLOBAL send is refused for switching modes with attachments', async () => {
+		const manager = createManager(createInputMock())
+		manager.mode = AIMode.GLOBAL
+		const cm = manager.contextManager
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		cm.setSelectedContext([])
+
+		const pending = manager.sendRequest({
+			instructions: 'describe this image',
+			images: [{ id: 'img-1', dataUrl: 'data:image/png;base64,AAAA' } as any],
+			contextOverride: [mention],
+			contextOverrideOrigin: 'pinned'
+		})
+		manager.mode = AIMode.SCRIPT
+		await pending
+
+		expect(cm.getSelectedContext()).toEqual([mention])
+	})
+
+	// The editor modes show mentions as chips the user deletes by hand, so the
+	// restore must never re-add one they removed.
+	it('leaves an editor mode’s context alone when a queued draft comes back', () => {
+		const manager = createManager(createInputMock())
+		manager.mode = AIMode.SCRIPT
+		const cm = manager.contextManager
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		manager.queueMessage('fix this', [], [mention])
+		// The user deletes the chip while the turn streams.
+		cm.setSelectedContext([])
+
+		manager.dequeueMessage()
+
+		expect(cm.getSelectedContext()).toEqual([])
+	})
+
 	it('restores a dequeued inline prompt’s pinned DOM context, replacing the live selection', () => {
 		const manager = createManager(createInputMock())
 		const cm = manager.contextManager
@@ -2279,6 +2371,90 @@ describe('AIChatManager queued messages', () => {
 		expect(input.restoreInstructions).toHaveBeenCalledWith('look', [], [img('a')], [])
 		// the optimistic bubble is rolled back
 		expect(manager.displayMessages).toHaveLength(0)
+	})
+
+	// The composer consumes mentions before calling in, so a send that never left
+	// the preflight has to give them back with the text. GLOBAL renders no chip for
+	// them, so a mention lost here is invisible: the restored `@` token silently
+	// resolves to nothing, and a mention-only draft comes back empty.
+	it('restores consumed mentions when beforeSend rejects a GLOBAL send', async () => {
+		const input = createInputMock()
+		const manager = createManager(input)
+		manager.mode = AIMode.GLOBAL
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		manager.contextManager.setSelectedContext([])
+		manager.beforeSend = vi.fn().mockRejectedValue(new Error('workspace fork failed'))
+
+		const accepted = await manager.sendRequest({
+			instructions: '@f/etl/sync fix this',
+			contextOverride: [mention],
+			contextOverrideOrigin: 'pinned'
+		})
+
+		expect(accepted).toBe(false)
+		expect(manager.contextManager.getSelectedContext()).toEqual([mention])
+	})
+
+	it('restores consumed mentions when a GLOBAL send is cancelled during the preflight', async () => {
+		const input = createInputMock()
+		const manager = createManager(input)
+		manager.mode = AIMode.GLOBAL
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		manager.contextManager.setSelectedContext([])
+		// Stop/Escape while "Creating workspace fork..." is showing.
+		manager.beforeSend = vi.fn().mockImplementation(async () => {
+			manager.cancel('user_cancelled')
+		})
+
+		await manager.sendRequest({
+			instructions: '@f/etl/sync fix this',
+			contextOverride: [mention],
+			contextOverrideOrigin: 'pinned'
+		})
+
+		expect(mocks.runChatLoop).not.toHaveBeenCalled()
+		expect(manager.contextManager.getSelectedContext()).toEqual([mention])
+	})
+
+	// The gate, and the reason the restore is not unconditional: an occupied
+	// composer declines the dead draft's text, and its mentions would then ride the
+	// draft the user is writing now and every turn after it.
+	it('does not restore mentions into a draft the composer kept', async () => {
+		const input = createInputMock()
+		input.restoreInstructions.mockReturnValue(false)
+		const manager = createManager(input)
+		manager.mode = AIMode.GLOBAL
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		manager.contextManager.setSelectedContext([])
+		manager.beforeSend = vi.fn().mockRejectedValue(new Error('workspace fork failed'))
+
+		await manager.sendRequest({
+			instructions: '@f/etl/sync fix this',
+			contextOverride: [mention],
+			contextOverrideOrigin: 'pinned'
+		})
+
+		expect(manager.contextManager.getSelectedContext()).toEqual([])
+	})
+
+	// The bit-identity tripwire: an editor mode reaches these same bailouts with a
+	// contextOverride (a replay, a queued flush) and must come out of them with the
+	// selection main would have left.
+	it('leaves an editor mode’s selection untouched through the same bailout', async () => {
+		const input = createInputMock()
+		const manager = createManager(input)
+		manager.mode = AIMode.SCRIPT
+		const mention = { type: 'workspace_script' as const, path: 'f/etl/sync', title: 'f/etl/sync' }
+		manager.contextManager.setSelectedContext([])
+		manager.beforeSend = vi.fn().mockRejectedValue(new Error('workspace fork failed'))
+
+		await manager.sendRequest({
+			instructions: 'fix this',
+			contextOverride: [mention],
+			contextOverrideOrigin: 'pinned'
+		})
+
+		expect(manager.contextManager.getSelectedContext()).toEqual([])
 	})
 
 	it('drops the queued message when switching conversations (no cross-chat leak)', async () => {

--- a/frontend/src/lib/components/copilot/chat/ContextManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/ContextManager.svelte.ts
@@ -2,7 +2,12 @@ import { ResourceService, type Flow, type ListResourceResponse, type ScriptLang 
 import { scriptLangToEditorLang } from '$lib/scripts'
 import { SQLSchemaLanguages, type DBSchemas } from '$lib/stores'
 import { diffLines } from 'diff'
-import { createAppDomSelectorElement, type ContextElement, type FlowModuleElement } from './context'
+import {
+	createAppDomSelectorElement,
+	isMentionContext,
+	type ContextElement,
+	type FlowModuleElement
+} from './context'
 import type { FlowModule } from '$lib/gen'
 
 import type { DisplayMessage } from './shared'
@@ -328,6 +333,13 @@ export default class ContextManager {
 
 	setSelectedContext(newSelectedContext: ContextElement[]) {
 		this.selectedContext = newSelectedContext
+	}
+
+	/** Callers must gate on mode: only a GLOBAL send owns its mentions. Outside
+	 * GLOBAL these are chips the user removes by hand, and dropping them here
+	 * would delete a selection they still expect to see. */
+	consumeMentionContext() {
+		this.selectedContext = this.selectedContext.filter((c) => !isMentionContext(c))
 	}
 
 	getAvailableContext() {

--- a/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
@@ -736,9 +736,9 @@
 		textarea?.focus()
 	}
 
-	// Wipe after dispatching a send: pre-zero `prevMentionedTitles` so the
-	// effect above sees no diff when `value` clears, leaving `selectedContext`
-	// untouched until `AIChatManager.beforeSend` snapshots it. A manual
+	// Wipe after dispatching a send: pre-zero `prevMentionedTitles` so the effect
+	// above sees no diff when `value` clears, leaving `selectedContext` for the
+	// send that is already carrying it to settle (see the caller). A manual
 	// textarea clear by the user keeps the old behaviour (badges drop).
 	export function clearForSend() {
 		prevMentionedTitles = new Set()

--- a/frontend/src/lib/components/copilot/chat/context.ts
+++ b/frontend/src/lib/components/copilot/chat/context.ts
@@ -331,6 +331,13 @@ export function contextElementKey(c: ContextElement): string {
 	return c.type === 'app_dom_selector' ? `dom:${c.appPath}:${c.selector}` : `${c.type}:${c.title}`
 }
 
+/** An `@`-mentioned workspace item, attached to one message the way a DOM pick
+ * is. Membership only: this does not gate on mode, so every caller must. Outside
+ * GLOBAL these stay selected as chips the user removes by hand. */
+export function isMentionContext(c: ContextElement): boolean {
+	return c.type === 'workspace_script' || c.type === 'workspace_flow' || c.type === 'workspace_app'
+}
+
 export function isSameContextElement(a: ContextElement, b: ContextElement): boolean {
 	if (a.type !== b.type) return false
 	if (a.type === 'app_dom_selector' && b.type === 'app_dom_selector') {


### PR DESCRIPTION
## Summary

An `@`-mentioned workspace item (script, flow or app) stayed in `selectedContext` after the message that mentioned it was sent, so every later turn in the session restamped it into `## SELECTED CONTEXT`. Mention a script once and it rode the rest of the conversation.

Mentions are now treated the way a DOM pick already is: attached to the one message that carried them.

The whole change is scoped to `AIMode.GLOBAL` (sessions). In SCRIPT/FLOW/APP the mentions still stay selected as chips the user removes by hand, so `isMentionContext` is a membership predicate only and every caller gates on mode itself. `sendRequest`'s existing consume block, `restartGeneration`, `fix()` and `askAi()` are untouched.

## Changes

- `context.ts` — `isMentionContext(c)`: is this one of the three `@`-mentionable workspace types. Membership only, no mode gate.
- `ContextManager.svelte.ts` — `consumeMentionContext()` drops those entries from the live selection.
- `AIChatInput.svelte` — the composer owns the consume. At the submit click it pins the live selection as `contextOverride` (`contextOverrideOrigin: 'pinned'`, both pre-existing on main) and consumes in the same synchronous gesture, so the send keeps what the user picked for it and the next draft starts clean. Consuming inside the gesture rather than in `sendRequest` matters: the preflight awaits attachment upkeep and a workspace fork that can take seconds, and a consume after those would take a mention the user picked for the *next* message. The same consume runs on the `askUserQuestion` answer branch, which returns before the ordinary send path: the answer transmits only its choice strings, but `clearForSend` deliberately keeps the selection, so a mention typed into an answer used to ride every later turn.
- `AIChatManager.svelte.ts` — `#restoreMentionContext(context, originMode)` gives the mentions back whenever a send hands its text back to the composer: the post-turn rollback, the queued-draft recall, the two preflight bailouts (`beforeSend` rejection, Stop during the fork), and the attachment-mode-mismatch refusal. Restores are additive and conditional on the composer actually taking the text — if it declines into a draft the user has since started, the mentions would otherwise ride that draft and every turn after it.
- `originMode` is required rather than defaulted, and the four sites inside `sendRequest` pass `requestedMode` (captured synchronously at the top, before any await) rather than the live `this.mode`. The mode switcher stays enabled while a turn streams, so reading the mode at restore time would strand a GLOBAL send whose mode changed underneath it, and resurrect chips for an editor-mode send that consumed nothing. A defaulted parameter would let a future call site inherit that decision silently, which is the failure this change exists to remove.
- `ContextTextarea.svelte` — comment correction only; `clearForSend`'s existing rationale was falsified by the pin above.

## Screenshots

Same three-turn session both times: `@u/admin/alpha reply with the word ONE only`, then two follow-ups that mention nothing. The `u/admin/alpha` chip above a bubble is the context that rode with that message.

**Before** (this branch with the consume disabled, everything else identical) — the mention stays selected and restamps itself onto every later turn:

![before-broken](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2460-investigate-the-variables-that-stack-on-top-of-messages/1788190000-before-broken.png)

**After** — the mention rides the message that carried it, and the next two turns are clean:

![after-fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/alexandre/win-2460-investigate-the-variables-that-stack-on-top-of-messages/1788190000-after-fixed.png)

## Test plan

`frontend/src/lib/components/copilot/chat/AIChatManager.test.ts` — 151 pass. Eight new tests, each proven to fail against the code it guards (by deleting the gate it protects, not just by passing):

- [x] an editor mode's selection is left alone through the same paths (two tripwires: dequeue and the preflight bailout)
- [x] a cancelled GLOBAL send's mentions come back
- [x] mentions come back when `beforeSend` rejects, and when the send is stopped during the preflight
- [x] mentions are *not* restored into a draft the composer kept
- [x] a GLOBAL send's mentions come back after the mode is switched to SCRIPT mid-turn
- [x] the attachment-mode-mismatch refusal restores the mentions of the GLOBAL send it refused

The consume itself has no unit test: it lives in the composer (`AIChatInput.svelte`), which this repo does not test as a component. It is covered by the browser runs below.

Driven in a browser against live Anthropic calls: a mention rides exactly one message (single and multiple mentions), verified on the sent bubble's chip and in the request payload, and the before/after above was captured by toggling only the consume.

A ten-check manual protocol covering the rest of the user-visible behaviour — editor modes, queue during a stream, recall, cancel, the two preflight bailouts, an occupied composer, raw-app DOM picks — has been walked through by hand on a dev instance with no failures.

## Notes

- No new UI surface: the chip on a sent bubble is pre-existing rendering of `message.contextElements`. In a session the composer deliberately renders no mention chip (`AIChatDisplay.svelte` passes `showContext={mode !== AIMode.GLOBAL}`), so the sent bubble is the only place the behaviour is observable.
- Deliberately out of scope: when the queue flushes a message whose `contextOverride` is `undefined`, it still reads the live selection. Pre-existing, unrelated to mentions, and touching it would put this change back into shared multi-mode code.
- Known residual, filed rather than fixed: the queue aggregates several enqueues into one entry and records no originating mode, so `dequeueMessage` restores against the mode at recall. Recalling a queued draft after a mid-turn mode switch in the legacy panel can therefore miss a restore. Making it exact needs per-entry mode on the queue — a data-model change well outside this fix. The call site says so in one comment.
- One hand-back path deliberately has no mention restore: the blind-model image-only bail. A mention entry exists only while its `@` token is in the text, and that branch requires empty text. The reasoning is recorded at the site, since it spans three files and would otherwise be re-derived by the next reader.
