### PR TITLE
fix: keep windmill-indexer out of builds without tantivy

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -101,7 +101,6 @@ jobs:
 
       - name: Install OpenSSL via vcpkg
         run: |
-          vcpkg.exe install openssl-windows:x64-windows
           vcpkg.exe install openssl:x64-windows-static
           vcpkg.exe integrate install
 

--- a/.github/workflows/build_windows_worker_.yml
+++ b/.github/workflows/build_windows_worker_.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Cargo build binary windows
         timeout-minutes: 180
         run: |
-          vcpkg.exe install openssl-windows:x64-windows
           vcpkg.exe install openssl:x64-windows-static
           vcpkg.exe integrate install
           $env:VCPKGRS_DYNAMIC=1

--- a/.github/workflows/publish_windows_worker.yml
+++ b/.github/workflows/publish_windows_worker.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Cargo build windows
         timeout-minutes: 180
         run: |
-          vcpkg.exe install openssl-windows:x64-windows
           vcpkg.exe install openssl:x64-windows-static
           vcpkg.exe integrate install
           $env:VCPKGRS_DYNAMIC=1

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -115,7 +115,7 @@ strip = "none"
 
 [features]
 default = []
-private = ["windmill-api/private", "windmill-api-agent-workers?/private", "windmill-autoscaling/private", "windmill-common/private", "windmill-dep-map/private", "windmill-object-store/private", "windmill-git-sync/private", "windmill-indexer/private", "windmill-operator?/private", "windmill-queue/private", "windmill-worker/private", "windmill-test-utils/private"]
+private = ["windmill-api/private", "windmill-api-agent-workers?/private", "windmill-autoscaling/private", "windmill-common/private", "windmill-dep-map/private", "windmill-object-store/private", "windmill-git-sync/private", "windmill-indexer?/private", "windmill-operator?/private", "windmill-queue/private", "windmill-worker/private", "windmill-test-utils/private"]
 agent_worker_server = ["windmill-api/agent_worker_server", "dep:windmill-api-agent-workers", "windmill-test-utils/agent_worker_server"]
 enterprise = ["windmill-worker/enterprise", "windmill-queue/enterprise", "windmill-api/enterprise", "windmill-api-agent-workers?/enterprise", "dep:windmill-autoscaling", "windmill-autoscaling/enterprise", "windmill-git-sync/enterprise", "windmill-common/prometheus", "windmill-common/enterprise", "windmill-object-store/enterprise", "license"]
 local_reports = ["windmill-common/local_reports"]
@@ -131,6 +131,10 @@ quickjs = ["windmill-worker/quickjs", "windmill-api/quickjs"]
 openidconnect = ["windmill-api/openidconnect", "windmill-common/openidconnect", "windmill-object-store/openidconnect"]
 cloud = ["windmill-queue/cloud", "windmill-worker/cloud", "windmill-common/cloud", "windmill-api/cloud"]
 jemalloc = ["windmill-common/jemalloc", "dep:tikv-jemallocator", "dep:tikv-jemalloc-sys", "dep:tikv-jemalloc-ctl"]
+# `tantivy` must stay the only feature that enables windmill-indexer: it is the only one that
+# also gives it `enterprise` + `parquet`, and its EE sources gate nearly everything on that
+# pair, so a bare windmill-indexer is a crate of dead code that `-D warnings` rejects. Any
+# other feature wanting one of its features has to use the optional `windmill-indexer?/` form.
 tantivy = ["dep:windmill-indexer", "windmill-api/tantivy", "windmill-indexer/enterprise", "windmill-indexer/parquet", "windmill-common/tantivy", "enterprise", "parquet"]
 sqlx = ["windmill-worker/sqlx"]
 deno_core = ["windmill-worker/deno_core", "dep:windmill-runtime-nativets", "windmill-test-utils/deno_core"]


### PR DESCRIPTION
## Summary

The Windows worker release build has been failing since `v1.799.0`. On `v1.800.0` it died with 12 warnings-as-errors, all dead code in `windmill-indexer`:

```
error: constant `LOG_STORE_MODES` is never used
  --> windmill-indexer\src\service_logs_ee.rs:65:7
...
error: could not compile `windmill-indexer` (lib) due to 12 previous errors
```

`windmill-indexer` is an optional dependency that only `tantivy` is supposed to enable, and `tantivy` is what also gives it `enterprise` and `parquet`. But the root crate's `private` feature listed it as `windmill-indexer/private` without the `?`, and that form implicitly enables the optional dependency. Every build with `private` therefore compiled the crate: `ee_windows`, `ce`, `ce_rpi`, `oss`, `ee_rhel`. None of them enable `tantivy`, so the crate got neither `enterprise` nor `parquet` — and its EE sources gate nearly every item on that pair, leaving a lib of dead code. `windmill-api` already used the `?` form for the same dependency; the root crate was the outlier.

Nothing outside `#[cfg(feature = "tantivy")]` references `windmill_indexer`, so the crate was pure dead weight in all those builds, not just a warning problem.

The Windows release job is where it surfaced because `actions-rust-lang/setup-rust-toolchain` defaults `RUSTFLAGS` to `-D warnings` there. `backend-test-windows.yml` unsets it deliberately, and the Linux PR job runs `cargo test --all`, which applies the CLI feature names to every workspace member directly — so `windmill-indexer` never gets built in the warning-producing shape on PR CI.

Separately, `vcpkg.exe install openssl-windows:x64-windows` has been erroring on every Windows job (`C:\vcpkg\ports\openssl-windows: error: openssl-windows does not exist`) — including the last green release build and the passing `v1.800.0` integration-test job. The port is gone from the runner's vcpkg image. It never failed the step because GitHub's pwsh wrapper only propagates the last command's exit code, but it is a red herring in every Windows log, and `OPENSSL_DIR` points at the `x64-windows-static` install the next line provides.

## Changes

- `backend/Cargo.toml`: `windmill-indexer/private` → `windmill-indexer?/private` in the root `private` feature, so the crate is only compiled when `tantivy` enables it.
- `backend/Cargo.toml`: comment on the `tantivy` feature recording the invariant that it must stay the only enabler.
- Dropped the dead `vcpkg.exe install openssl-windows:x64-windows` line from all three Windows workflows (`publish_windows_worker`, `build_windows_worker_`, `backend-test-windows`).

## Test plan

- [x] Reproduced the exact 12 CI errors locally with `RUSTFLAGS="-D warnings" cargo check --no-default-features --features worker_windows_core,python,deno_core,rust,mysql,oracledb,duckdb,bigquery,snowflake,csharp,nu,php,java,ruby,rlang` (the `ee_windows` set minus `mssql-winauth`, which is Windows-only) on `main`.
- [x] Same command on this branch: `Finished`. `windmill-indexer` is no longer in the graph.
- [x] `RUSTFLAGS="-D warnings" cargo check --features tantivy,worker_windows_core,<languages>`: `Finished` — the tantivy path still builds the indexer.
- [x] `cargo tree -e features -i windmill-indexer` under `ee` still resolves `private` + `enterprise` + `parquet`, and under `all_sqlx_features` still `enterprise` + `parquet` — the `.sqlx` offline cache is unaffected.
- [ ] `build_windows_worker_` dispatched on this branch — the real `cargo check --features=ee_windows` under `-D warnings` on a Windows runner, which also confirms the vcpkg removal still resolves OpenSSL.

## Not done here

No PR-time CI guard is added. `build_windows_worker_.yml` already runs exactly the right check (`cargo check --features=ee_windows` with `-D warnings`) but is `workflow_dispatch`-only, so a recurrence still only surfaces at release time — and a red release build keeps `main` red until the next one. Wiring it to `pull_request` would close the loop at the cost of a Windows runner on every PR; that tradeoff is worth deciding deliberately rather than folding into this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows worker release builds failing since v1.799.0 due to warnings-as-errors from dead code in `windmill-indexer`. The crate was being enabled unconditionally by the root `private` feature; it's now optional so it only compiles when `tantivy` is enabled.

**Changes**
- Changed `windmill-indexer/private` to `windmill-indexer?/private` in `backend/Cargo.toml`.
- Added a comment noting that `tantivy` must stay the only feature enabling `windmill-indexer`.
- Removed the broken `vcpkg.exe install openssl-windows:x64-windows` step from the three Windows workflows.

<sup>Written for commit 165e2209501d773f670339d29152972af50dde63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

