### PR TITLE
fix: keep a local dbt descriptor under sync pull --keep-deleted

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3175,15 +3175,42 @@ export function untrackedDatatableMigrationDeletions<
 }
 
 /**
+ * Whether a pull change removes a local dbt descriptor. A dbt project's
+ * descriptor is optional and the remote spells "this project names none" as
+ * empty content, so its removal reaches the apply loop as an add or an edit
+ * whose content is `""` — a `deleted` change is never produced for it.
+ */
+function removesDbtDescriptor(change: Change): boolean {
+  return (
+    isDbtDescriptorPath(change.path) &&
+    ((change.name === "added" && change.content === "") ||
+      (change.name === "edited" && change.after === ""))
+  );
+}
+
+/**
  * `--keep-deleted`: strip every deletion from the changeset, in place, so the
  * sync only adds and updates. A path missing on one side is not on its own
  * evidence that it should go from the other — a partial clone, a scoped
  * checkout or an item authored in the UI all read as deletions here.
+ *
+ * A dbt descriptor the remote no longer names counts too, but only on a pull,
+ * where applying it removes a local file. A push removes nothing: the descriptor
+ * is a script's content, so an empty one updates the remote script in place.
  */
-function dropDeletions(changes: Change[], keptOn: "local" | "remote"): void {
-  const deletions = changes.filter((c) => c.name === "deleted");
+export function dropDeletions(
+  changes: Change[],
+  keptOn: "local" | "remote",
+): void {
+  const isDeletion = (c: Change) =>
+    c.name === "deleted" ||
+    // Only an edit can take a descriptor away: `added` means the map this pull
+    // compared against held none at that path, so there is no known content to
+    // keep.
+    (keptOn === "local" && c.name === "edited" && removesDbtDescriptor(c));
+  const deletions = changes.filter(isDeletion);
   if (deletions.length === 0) return;
-  const kept = changes.filter((c) => c.name !== "deleted");
+  const kept = changes.filter((c) => !isDeletion(c));
   changes.length = 0;
   changes.push(...kept);
   log.info(
@@ -3808,22 +3835,17 @@ export async function pull(
 
       const target = path.join(process.cwd(), targetPath);
       const stateTarget = path.join(process.cwd(), ".wmill", targetPath);
-      // An empty dbt descriptor is not a file: the remote spells "this project
-      // named no descriptor" as empty content, and writing that would put a
-      // Windmill file inside a project that has none. ABSENCE is the state to
-      // reach, so both copies are removed if present and their being missing —
-      // a project pulled for the first time — is the goal, not an error. The
-      // `.wmill` copy goes too, or the same change is reported on every pull.
+      // ABSENCE is the state to reach, never an empty file: writing one would
+      // put a Windmill file inside a project that has none. So both copies are
+      // removed if present, and their being missing — a project pulled for the
+      // first time — is the goal, not an error. The `.wmill` copy goes too, or
+      // the same change is reported on every pull.
       //
       // `force` covers the missing file and NOTHING else: a permission or
       // read-only-filesystem failure has to surface, or the pull reports
       // success while the old descriptor — its warehouse, its command, its
       // arguments — is still what runs locally.
-      if (
-        isDbtDescriptorPath(change.path) &&
-        ((change.name === "added" && change.content === "") ||
-          (change.name === "edited" && change.after === ""))
-      ) {
+      if (removesDbtDescriptor(change)) {
         await rm(target, { force: true });
         if (opts.stateful) {
           await rm(stateTarget, { force: true });

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3195,19 +3195,17 @@ function removesDbtDescriptor(change: Change): boolean {
  * checkout or an item authored in the UI all read as deletions here.
  *
  * A dbt descriptor the remote no longer names counts too, but only on a pull,
- * where applying it removes a local file. A push removes nothing: the descriptor
- * is a script's content, so an empty one updates the remote script in place.
+ * where applying it removes a local file — `added` as much as `edited`, since a
+ * stateful pull compares `.wmill` and absence from that map says nothing about
+ * the working tree the apply loop deletes from. A push removes nothing: the
+ * descriptor is a script's content, so an empty one updates the script in place.
  */
 export function dropDeletions(
   changes: Change[],
   keptOn: "local" | "remote",
 ): void {
   const isDeletion = (c: Change) =>
-    c.name === "deleted" ||
-    // Only an edit can take a descriptor away: `added` means the map this pull
-    // compared against held none at that path, so there is no known content to
-    // keep.
-    (keptOn === "local" && c.name === "edited" && removesDbtDescriptor(c));
+    c.name === "deleted" || (keptOn === "local" && removesDbtDescriptor(c));
   const deletions = changes.filter(isDeletion);
   if (deletions.length === 0) return;
   const kept = changes.filter((c) => !isDeletion(c));

--- a/cli/test/dbt_optional_descriptor_unit.test.ts
+++ b/cli/test/dbt_optional_descriptor_unit.test.ts
@@ -301,20 +301,35 @@ describe("a dbt project without a descriptor", () => {
 // keep — the descriptor's warehouse and run arguments with it.
 describe("--keep-deleted and a descriptor the remote no longer names", () => {
   const DESCRIPTOR = "f/analytics/analytics__dbt/wm_dbt.yaml";
-  const changeset = () =>
+  const emptied = {
+    name: "edited",
+    path: DESCRIPTOR,
+    before: "warehouse: wh\n",
+    after: "",
+  };
+  const unknownToTheMap = { name: "added", path: DESCRIPTOR, content: "" };
+  const changeset = (descriptor: unknown) =>
     [
-      { name: "edited", path: DESCRIPTOR, before: "warehouse: wh\n", after: "" },
+      descriptor,
       { name: "edited", path: "f/other/script.ts", before: "a", after: "b" },
     ] as Parameters<typeof dropDeletions>[0];
 
   test("survives a pull", () => {
-    const changes = changeset();
+    const changes = changeset(emptied);
+    dropDeletions(changes, "local");
+    expect(changes.map((c) => c.path)).toEqual(["f/other/script.ts"]);
+  });
+
+  // A stateful pull compares `.wmill`, so a descriptor missing from the compared
+  // map can still be a working-tree file holding real settings.
+  test("survives a pull that compared a map without it", () => {
+    const changes = changeset(unknownToTheMap);
     dropDeletions(changes, "local");
     expect(changes.map((c) => c.path)).toEqual(["f/other/script.ts"]);
   });
 
   test("is still pushed, deleting no remote item", () => {
-    const changes = changeset();
+    const changes = changeset(emptied);
     dropDeletions(changes, "remote");
     expect(changes.map((c) => c.path)).toEqual([
       DESCRIPTOR,

--- a/cli/test/dbt_optional_descriptor_unit.test.ts
+++ b/cli/test/dbt_optional_descriptor_unit.test.ts
@@ -7,7 +7,11 @@ import { expect, test, describe, beforeEach, afterEach } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { FSFSElement, elementsToMap } from "../src/commands/sync/sync.ts";
+import {
+  FSFSElement,
+  dropDeletions,
+  elementsToMap,
+} from "../src/commands/sync/sync.ts";
 import { listWorkspacePaths } from "../src/commands/dev/dev.ts";
 import {
   DbtPathCollisionError,
@@ -290,6 +294,32 @@ describe("a dbt project without a descriptor", () => {
     const key = "f/analytics/analytics__dbt/wm_dbt.yaml";
     expect(normalized(local)[key]).toBe("");
     expect(normalized(remoteMap)[key]).toBe("");
+  });
+});
+
+// Unguarded, `--keep-deleted` lets a pull remove the very file it promises to
+// keep — the descriptor's warehouse and run arguments with it.
+describe("--keep-deleted and a descriptor the remote no longer names", () => {
+  const DESCRIPTOR = "f/analytics/analytics__dbt/wm_dbt.yaml";
+  const changeset = () =>
+    [
+      { name: "edited", path: DESCRIPTOR, before: "warehouse: wh\n", after: "" },
+      { name: "edited", path: "f/other/script.ts", before: "a", after: "b" },
+    ] as Parameters<typeof dropDeletions>[0];
+
+  test("survives a pull", () => {
+    const changes = changeset();
+    dropDeletions(changes, "local");
+    expect(changes.map((c) => c.path)).toEqual(["f/other/script.ts"]);
+  });
+
+  test("is still pushed, deleting no remote item", () => {
+    const changes = changeset();
+    dropDeletions(changes, "remote");
+    expect(changes.map((c) => c.path)).toEqual([
+      DESCRIPTOR,
+      "f/other/script.ts",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

`wmill sync pull --keep-deleted` could delete a local dbt descriptor (`<project>__dbt/wm_dbt.yaml`), losing the warehouse, command and run arguments it held — the exact outcome the flag exists to prevent.

A dbt project's descriptor is optional, and both sides spell "this project names no descriptor" as empty content rather than as an absent file. So a descriptor the remote no longer names reaches the pull as an `added`/`edited` change with empty content, never as a `deleted` one. `dropDeletions` (added in #10878) filters on `name === "deleted"`, so it left the change in place and the apply loop's `rm` ran anyway. The dry-run preview reinforced this, listing it as `~ script f/…/wm_dbt.yaml`.

## Changes

- Extract the descriptor-removal condition out of the pull apply loop into `removesDbtDescriptor(change)`, so the apply loop and `dropDeletions` read one predicate and cannot drift — that drift is what caused this.
- `dropDeletions` now counts a descriptor removal as a deletion on pull, so `--keep-deleted` strips it.

One deliberate asymmetry: **push is untouched.** There the descriptor is a script's *content*, so an empty one updates the remote script in place rather than deleting a remote item. Making `push --keep-deleted` refuse it would change what push means.

Both change shapes count, not just `edited`. A stateful pull compares `.wmill` rather than the working tree, so a descriptor absent from that map still arrives as `added` while a real file with real settings sits on disk — and the apply loop deletes from the working tree. An earlier revision of this PR counted only `edited` (to keep the `keeping N item(s)` line from over-reporting on a first clone) and reintroduced the data loss on that path, silently. The safe rule is worth the cosmetic over-count.

## Test plan

Three unit tests in `cli/test/dbt_optional_descriptor_unit.test.ts` (the two pull ones fail without the fix; the push one pins the deliberate asymmetry). Verified end-to-end against a local backend:

- [x] Stateless: project pushed with no descriptor, then a local `wm_dbt.yaml` with warehouse/command/args — `sync pull --yes --keep-deleted` keeps it and reports it as kept
- [x] Stateful (`stateful: true`): `.wmill` not knowing the project while the working tree holds a populated descriptor — the file survives, and is now reported instead of silently removed
- [x] `sync pull --yes` without the flag still removes it — unchanged
- [x] Fresh clone of a descriptor-less project: no stray `wm_dbt.yaml`
- [x] A real remote descriptor still round-trips: push, delete locally, pull restores it
- [x] Non-dbt `--keep-deleted` both directions: remote script survives a push, local-only file survives a pull
- [x] CLI unit suite 1100/1100; `tsc --noEmit` unchanged from baseline (18 pre-existing errors, same files)