### PR TITLE
feat: add 180 and 365 day token expiration options

### DIFF
--- a/frontend/src/lib/components/settings/CreateToken.svelte
+++ b/frontend/src/lib/components/settings/CreateToken.svelte
@@ -287,7 +287,9 @@
 							{ label: '1 day', value: 1 * 24 * 60 * 60 },
 							{ label: '7 days', value: 7 * 24 * 60 * 60 },
 							{ label: '30 days', value: 30 * 24 * 60 * 60 },
-							{ label: '90 days', value: 90 * 24 * 60 * 60 }
+							{ label: '90 days', value: 90 * 24 * 60 * 60 },
+							{ label: '180 days', value: 180 * 24 * 60 * 60 },
+							{ label: '365 days', value: 365 * 24 * 60 * 60 }
 						]}
 					/>
 				</div>


### PR DESCRIPTION
## Summary

The token creation "Expires In" dropdown only offered durations up to 90 days, while the backend
accepts any expiration `DateTime`. Service accounts and CI integrations commonly need longer-lived
tokens, so this adds 6-month and 1-year options.

Fixes WIN-2465

## Changes

- Add `180 days` and `365 days` entries to the "Expires In" options in `CreateToken.svelte`, after the existing `90 days` option.

No backend change: `create_token_internal` stores the requested expiration verbatim and enforces no
upper bound on token lifetime.

## Screenshots

![expires-in-options](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben-win-2465/1788262626-expires-in-options.png)

## Test plan

- [x] Drove the running dev frontend with Playwright: opened User settings → Tokens → "Expires In" and confirmed the dropdown now lists `180 days` and `365 days` after `90 days`.
- [x] Selected `365 days` and clicked "New token"; the created row in the `token` table had `expiration - created_at` of ~365 days (created 2026-09-01, expires 2027-09-01).
- [x] `npm run check:fast` clean for the changed file (the 4 remaining repo-wide errors are pre-existing and unrelated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `180 days` and `365 days` options to the token "Expires In" dropdown so service accounts and CI integrations can create longer-lived tokens than the previous 90-day maximum. No backend change is needed since `create_token_internal` already stores any expiration date without an upper bound. Fixes WIN-2465.

<sup>Written for commit 386c8130d74255e2af9a16ff4a989e89efe22a16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

