### PR TITLE
fix: resolve chat path links against the session's operating workspace

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -688,8 +688,8 @@ export class AIChatManager {
 	workspaceResolver: (() => string | undefined) | undefined = undefined
 
 	// The workspace every workspace-scoped chat action targets — skills, tool
-	// loop, logging, user-message context, and commit. Session-resolved when a
-	// resolver is set, else the globally-active workspace.
+	// loop, logging, user-message context, message rendering, and commit.
+	// Session-resolved when a resolver is set, else the globally-active workspace.
 	get operatingWorkspace(): string | undefined {
 		return this.workspaceResolver?.() ?? get(workspaceStore)
 	}

--- a/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
@@ -13,8 +13,20 @@
 	import { messageDraft, segments } from './chatDraft'
 	import { lineCountLabel } from './pasteTokens'
 	import ExpandableImage from '$lib/components/common/image/ExpandableImage.svelte'
+	import { workspaceStore } from '$lib/stores'
 
 	const aiChatManager = getAiChatManager()
+
+	// Paths in a message name items the chat's tools reach, so they resolve against the
+	// operating workspace, never `workspaceStore`: a fork session leaves the store on the
+	// navigated workspace, where a fork-only item resolves to nothing and the rest resolve
+	// to a different copy.
+	const messageWorkspace = $derived.by(() => {
+		// Registers the dependency that `operatingWorkspace`'s own untracked
+		// `get(workspaceStore)` cannot.
+		void $workspaceStore
+		return aiChatManager.operatingWorkspace
+	})
 
 	// Per-message expand/collapse state for paste chips shown in the bubble.
 	let expandedPastes = $state<Set<number>>(new Set())
@@ -119,7 +131,7 @@
 		{:else}
 			<div class={twMerge('text-sm py-1 px-2', message.role === 'tool' && 'text-primary py-0')}>
 				{#if message.role === 'assistant'}
-					<div class="px-[1px]"><AssistantMessage {message} /></div>
+					<div class="px-[1px]"><AssistantMessage {message} workspace={messageWorkspace} /></div>
 				{:else if message.role === 'tool'}
 					<div class="px-[1px]"
 						><ToolExecutionDisplay message={message as ToolDisplayMessage} /></div

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -6,7 +6,6 @@
 	import { thinkingPreferences } from './thinkingPreferences.svelte'
 	import CodeDisplay from './script/CodeDisplay.svelte'
 	import LinkRenderer from './LinkRenderer.svelte'
-	import { workspaceStore } from '$lib/stores'
 	import {
 		extractCandidatePaths,
 		remarkWindmillPaths,
@@ -16,9 +15,12 @@
 
 	interface Props {
 		message: DisplayMessage
+		// Workspace the message's paths are resolved against: the one the chat
+		// operates on, which is not always the one being navigated.
+		workspace: string | undefined
 	}
 
-	let { message }: Props = $props()
+	let { message, workspace }: Props = $props()
 
 	const reasoning = $derived(
 		message.role === 'assistant' ? message.reasoning?.trim() || undefined : undefined
@@ -69,12 +71,11 @@
 	// Only populate the registry for messages that contain path-shaped tokens. The
 	// registry still dedups concurrent calls across messages and workspaces.
 	$effect(() => {
-		const ws = $workspaceStore
-		if (ws && candidatePaths.length > 0) workspaceItemRegistry.ensureLoaded(ws)
+		if (workspace && candidatePaths.length > 0) workspaceItemRegistry.ensureLoaded(workspace)
 	})
 
 	const plugins = $derived.by(() => {
-		const ws = $workspaceStore ?? ''
+		const ws = workspace ?? ''
 		if (!ws || candidatePaths.length === 0) {
 			return [gfmPlugin(), rendererPlugin]
 		}

--- a/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
+++ b/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
@@ -3,7 +3,10 @@
 	import { ExternalLink, PanelRight } from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
 	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
-	import { runToolDisplayAction } from './createdResourceActions.svelte'
+	import {
+		hasToolDisplayActionHandler,
+		runToolDisplayAction
+	} from './createdResourceActions.svelte'
 	import {
 		workspaceItemAction,
 		type WindmillItemKind,
@@ -27,7 +30,12 @@
 		title
 	}: Props = $props()
 
-	const drawerAction = $derived(workspaceItemAction(wmKind, wmPath, wmTargetKind))
+	// The drawers ride with the docked chat, so a surface can render this pill with nothing
+	// able to open one.
+	const drawerAction = $derived.by(() => {
+		const action = workspaceItemAction(wmKind, wmPath, wmTargetKind)
+		return action && hasToolDisplayActionHandler(action.type) ? action : undefined
+	})
 
 	async function openDrawer(event?: Event) {
 		event?.preventDefault()

--- a/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
@@ -28,7 +28,10 @@
 	import MqttIcon from '$lib/components/icons/MqttIcon.svelte'
 	import AmqpIcon from '$lib/components/icons/AmqpIcon.svelte'
 	import NatsIcon from '$lib/components/icons/NatsIcon.svelte'
-	import { runToolDisplayAction } from './createdResourceActions.svelte'
+	import {
+		hasToolDisplayActionHandler,
+		runToolDisplayAction
+	} from './createdResourceActions.svelte'
 	import type { CreatedResourceTriggerKind, ToolDisplayAction } from './shared'
 
 	interface Props {
@@ -122,17 +125,21 @@
 					<div class="truncate text-xs font-semibold text-primary">{card.title}</div>
 					<div class="truncate text-2xs text-secondary">{card.subtitle}</div>
 				</div>
-				<Button
-					size="xs"
-					variant="default"
-					title={action.label}
-					loading={runningActionId === action.id}
-					disabled={runningActionId !== undefined && runningActionId !== action.id}
-					startIcon={{ icon: card.buttonIcon }}
-					onClick={() => handleAction(action)}
-				>
-					Open
-				</Button>
+				<!-- open_created_resource is serviced solely by the docked chat's drawers, so
+				     elsewhere the card stands alone as a record of what the tool created. -->
+				{#if hasToolDisplayActionHandler(action.type)}
+					<Button
+						unifiedSize="sm"
+						variant="default"
+						title={action.label}
+						loading={runningActionId === action.id}
+						disabled={runningActionId !== undefined && runningActionId !== action.id}
+						startIcon={{ icon: card.buttonIcon }}
+						onClick={() => handleAction(action)}
+					>
+						Open
+					</Button>
+				{/if}
 			</div>
 		{/each}
 	</div>

--- a/frontend/src/lib/components/copilot/chat/createdResourceActions.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/createdResourceActions.svelte.ts
@@ -28,7 +28,7 @@ export function registerToolDisplayActionHandler(
 /**
  * Reactive: reads the `$state` registry, so a component re-renders when a page mounts or
  * unmounts its handler. Offering an action without checking this yields an affordance whose
- * only outcome is the "not available" toast below.
+ * only outcome is the unavailable-action toast.
  */
 export function hasToolDisplayActionHandler(type: ToolDisplayAction['type']): boolean {
 	return toolDisplayActionHandlers[type] !== undefined

--- a/frontend/src/lib/components/copilot/chat/createdResourceActions.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/createdResourceActions.svelte.ts
@@ -25,6 +25,15 @@ export function registerToolDisplayActionHandler(
 	}
 }
 
+/**
+ * Reactive: reads the `$state` registry, so a component re-renders when a page mounts or
+ * unmounts its handler. Offering an action without checking this yields an affordance whose
+ * only outcome is the "not available" toast below.
+ */
+export function hasToolDisplayActionHandler(type: ToolDisplayAction['type']): boolean {
+	return toolDisplayActionHandlers[type] !== undefined
+}
+
 export async function runToolDisplayAction(action: ToolDisplayAction): Promise<void> {
 	const handler = toolDisplayActionHandlers[action.type]
 	if (!handler) {

--- a/frontend/src/routes/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/+page.svelte
@@ -9,6 +9,7 @@
 	import type { DisplayMessage } from '$lib/components/copilot/chat/shared'
 	import DraggableTabs, { type TabItem } from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import { Globe } from 'lucide-svelte'
+	import { workspaceStore } from '$lib/stores'
 
 	let tab = $state('button')
 
@@ -195,7 +196,7 @@ That's the full round-trip.`
 				<code>CodeDisplay</code> → <code>HighlightCode</code>), constrained to the chat panel width.
 			</div>
 			<div class="border border-border-light rounded-lg p-3 bg-surface" style="max-width: 420px;">
-				<AssistantMessage message={chatMessage} />
+				<AssistantMessage message={chatMessage} workspace={$workspaceStore} />
 			</div>
 		</TabContent>
 		<TabContent value="scrollbar" class="p-4">


### PR DESCRIPTION
## Summary

An AI session has two workspaces: the **navigation** workspace the URL and switcher show (`workspaceStore`), and the **operating** workspace the session acts on, which may be a fork. A session on a fork deliberately leaves `workspaceStore` on the navigation workspace.

Every tool call already targets the operating workspace (`AIChatManager.operatingWorkspace`), but the path pills in assistant messages resolved against the navigation workspace. Two consequences:

1. An item that exists only in the fork could not be resolved, so it rendered as **plain text instead of a link**.
2. An item present in both workspaces linkified with `?workspace=<parent>` while the session was working on the fork's copy. A fork clones its parent's items at creation and they drift independently, so this silently pointed at the wrong copy.

Path pills now resolve and link against the operating workspace. `workspaceItemRegistry` is already keyed by workspace and needed no change — only the caller did.

The chat also offers two ways to open an item in a drawer: a small button on the path pill, and an "Open" button on the action card a tool posts after creating something. Both dispatch through a shared handler registry, and the drawer handler in it (`open_created_resource`) is registered only by the docked chat's drawer host — unlike `navigate`, which the root layout registers everywhere. So on the sessions page each of these two controls could only ever raise a "This action is not available right now" toast. Both are now offered only where a handler is registered. The link and the card itself stay — only the control that cannot work is withheld.

Behaviour on the global side-panel chat is unchanged: with no session resolver `operatingWorkspace` falls back to `workspaceStore`, and both drawer affordances keep working.

## Changes

- `AIChatMessage.svelte`: derives the message workspace from `aiChatManager.operatingWorkspace` and passes it to `AssistantMessage`. `$workspaceStore` is read unconditionally rather than behind `??` — `operatingWorkspace` reaches the store through an untracked `get()`, so short-circuiting would leave the derived with no dependency and freeze it on its first value.
- `AssistantMessage.svelte`: takes `workspace` as a required prop and uses it at all four sites (registry load, loaded-check, path resolution, and the `?workspace=` stamped onto the href).
- `createdResourceActions.svelte.ts`: adds `hasToolDisplayActionHandler`, a reactive read of the handler registry so a component re-renders when a page mounts or unmounts a handler.
- `LinkRenderer.svelte`: offers the pill's drawer button only when a handler is registered for the action.
- `ToolMessageActions.svelte`: same guard on the action card's "Open" button, and the button moves off the deprecated `size` prop onto `unifiedSize="sm"` (closest match to the legacy `xs` it replaces: 28px vs ~30px).
- `kitchen_sink/+page.svelte`: the second call site of `AssistantMessage`, passing `$workspaceStore`.
- `AIChatManager.svelte.ts`: comment only — `operatingWorkspace`'s list of what it governs now names message rendering.

## Screenshots

A real session turn: the assistant was asked to create a script, called its tools against the fork, test-ran it, and reported back. The sidebar stays on the parent workspace `Test` while the session acts on `Links fork`, and the path in the model's own answer resolves to the fork.

![wm-chat-links-real-turn](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-links-operating-workspace/1788277313-wm-chat-links-real-turn.png)

The pill's href is `/scripts/get/u/admin/retry_helper?workspace=wm-fork-links`. That script exists only in the fork (`select count(*) from script where path='u/admin/retry_helper' and workspace_id='test'` returns 0), so before this change it rendered as plain text.

### Pill drawer button

Scripts never carry one, so the shot above does not show that half of the change. Below, the same sentence naming two *variables*, hovered, on each surface.

On the sessions page (session acting on the fork) — both paths resolve to the fork, and no drawer button is offered, because that surface mounts no drawer host:

![wm-sessions-no-drawer-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-links-operating-workspace/1788277795250996349-wm-sessions-no-drawer-button.png)

In the docked chat (navigated workspace `test`) — unchanged: `u/admin/fork_var` does not exist there so it stays plain text, and `u/admin/shared_var` keeps its drawer button:

![wm-docked-drawer-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-links-operating-workspace/1788277796300986930-wm-docked-drawer-button.png)

### Tool action card

Both from real turns. On the sessions page, the card the deploy tool posts keeps its icon, type and path and drops the "Open" button that had nothing behind it:

![wm-sessions-card-no-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-links-operating-workspace/1788280054-wm-sessions-card-no-button.png)

In the script editor's docked chat, where the drawer host is mounted, the same card keeps its button — and it opens the schedule editor rather than toasting:

![wm-docked-card-with-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-links-operating-workspace/1788280920-wm-docked-card-with-button.png)

## Test plan

Exercised on a local instance with a parent workspace `test` and a fork `wm-fork-links`.

- [x] Real assistant turn in a fork session: the model created `u/admin/retry_helper` through its tools, ran it, and named the path in its answer. Confirmed in the DB that the item landed in the fork and does not exist in the parent.
- [x] That path renders as a link carrying `?workspace=<fork>` — including inside `**\`…\`**`, i.e. an inline-code span nested in a bold node.
- [x] Reverted the change on the same setup to confirm it fails: a fork-only path renders as plain text and a path present in both links to `?workspace=<parent>`.
- [x] Reactivity without a reload — the reason `$workspaceStore` is read unconditionally: in the docked chat, a message naming `u/admin/shared_var` (present in both workspaces) re-resolved from `?workspace=test` to `?workspace=wm-fork-links` and back as the sidebar workspace switcher changed, with the message still on screen. A `window` property set before the switch survived it, proving the page never reloaded and the derived genuinely re-ran.
- [x] Global side-panel chat: unchanged — path links to the navigated workspace, drawer button still present and still opens the drawer on that workspace's copy.
- [x] Sessions page: variable pills render with no drawer button (verified in the DOM: 0 button siblings on all five pills of a real turn); before this change the button rendered and toasted.
- [x] Action card, both directions from real turns: a session deploy of `u/admin/card_demo` posts a card with 0 buttons; the script editor's docked chat creating `u/admin/card_demo_sched` posts the same card with its "Open" button, and clicking it opens the schedule drawer. Same component, so the guard is shown both hiding and not hiding.
- [x] `npx svelte-check` reports 0 errors across the project; `npm run check:fast` shows only the 4 errors already on `main`.

## Follow-up, not addressed here

- **Drafts do not linkify.** The registry lists deployed items, so a path the assistant has just created as a draft stays plain text until it is deployed. Observed directly in the run above: the same path was plain `<code>` while a draft, and resolved once it was deployed and the page reloaded. The reload is not incidental — `ensureLoaded` caches per workspace and never refreshes, so nothing re-resolves within a page's life. Worth deciding separately whether a draft should resolve, since "the thing the assistant just made" is the most likely path to be mentioned.
- The drawer editors resolve their workspace from `$workspaceStore`. That is unreachable today — the sessions page mounts no drawer host at all — but becomes live the moment that page gains a route to variables, resources, schedules or triggers, so the workspace has to be threaded at the same time.




