### PR TITLE
feat: make the home Build with AI composer dismissible, quiet the rest of the home page

### DIFF
--- a/frontend/src/lib/components/common/CloseButton.svelte
+++ b/frontend/src/lib/components/common/CloseButton.svelte
@@ -10,10 +10,12 @@
 		Icon?: any | undefined
 		class?: string
 		id?: string | undefined
+		/** Names the button: it has no text, so without this it reads as "button" to a screen reader. */
+		title?: string | undefined
 		onClick?: () => void | undefined | any
 	}
 
-	let { noBg = false, small = false, Icon, class: className, id, onClick }: Props = $props()
+	let { noBg = false, small = false, Icon, class: className, id, title, onClick }: Props = $props()
 
 	const dispatch = createEventDispatcher()
 </script>
@@ -22,6 +24,7 @@
 	on:click={() => (dispatch('close'), onClick?.())}
 	on:pointerdown={(e) => e.stopPropagation()}
 	{id}
+	{title}
 	startIcon={{ icon: Icon ?? X }}
 	iconOnly
 	unifiedSize="sm"

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -20,23 +20,45 @@
 
 <script lang="ts">
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
-	import { ArrowUp, ExternalLink, Globe2, KeyRound, PlugZap, Settings } from 'lucide-svelte'
+	import {
+		ArrowUp,
+		ExternalLink,
+		Globe2,
+		KeyRound,
+		PlugZap,
+		Settings,
+		WandSparkles
+	} from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
 	import { Badge } from '../common'
+	import CloseButton from '../common/CloseButton.svelte'
 	import { startSessionWithPrompt } from '../sessions/sessionSwitch.svelte'
 	import { copilotInfo, copilotWorkspace } from '$lib/aiStore'
 	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
 	import { aiUserDisabled, hubBaseUrlStore, userStore, workspaceStore } from '$lib/stores'
 	import { HOME_SHOW_HUB } from '$lib/consts'
 	import { base } from '$lib/base'
+	import { getLocalSetting, storeLocalSetting } from '$lib/utils'
+	import { isRuleActive } from '$lib/workspaceProtectionRules.svelte'
+	import { BROWSER } from 'esm-env'
 	import AIChatModelSettings from '../copilot/chat/AIChatModelSettings.svelte'
 	import HomeConnectDrawer from './HomeConnectDrawer.svelte'
 	import { USER_SETTINGS_HASH } from '../sidebar/settings'
 	import { prefersSessionHandoff } from '../copilot/chat/global/gate'
 
+	const COLLAPSED_SETTING = 'home-ai-composer-collapsed'
+
 	let value = $state('')
 	let placeholder = $state('')
 	let homeConnectDrawer: HomeConnectDrawer | undefined = $state(undefined)
+
+	// How much of the home page this reader wants the composer to take, so it lives per browser
+	// rather than per workspace or account.
+	let collapsed = $state(BROWSER && getLocalSetting(COLLAPSED_SETTING) === 'true')
+	function setCollapsed(next: boolean) {
+		collapsed = next
+		storeLocalSetting(COLLAPSED_SETTING, next ? 'true' : undefined)
+	}
 
 	// In global-AI mode the layout's chat panel is disabled and never loads the copilot
 	// config, so the home chat loads it for the current workspace itself.
@@ -48,10 +70,9 @@
 
 	// Whether the copilot config has actually loaded for the current workspace.
 	let configLoaded = $derived($copilotWorkspace === $workspaceStore)
-	// No usable model (no provider configured, or AI disabled): the composer is blurred and an
-	// overlay explains why and links to the fix. Static, not hover-gated, so keyboard and touch
-	// users see it too. Gate on `configLoaded` so the initial (unloaded) state doesn't flash the
-	// overlay while a provider is in fact configured.
+	// No usable model (no provider configured, or AI disabled): the input is blurred and an overlay
+	// explains why and links to the fix. Gate on `configLoaded` so the initial (unloaded) state
+	// doesn't flash the overlay while a provider is in fact configured.
 	let disabled = $derived(configLoaded && !$copilotInfo.enabled)
 	// Submission is stricter than the overlay: block it until the config is loaded AND
 	// enabled. Submitting during the unknown-config window hands the prompt to a session
@@ -59,17 +80,27 @@
 	// workspace that never happens and the prompt is silently lost.
 	let canSend = $derived(configLoaded && $copilotInfo.enabled)
 
-	// Applied to the AI-specific parts only (title, input, example tags) when disabled. The
-	// CLI/MCP and Hub buttons are unrelated to AI and stay sharp and clickable.
+	// The input alone: what the overlay covers and the one part a missing provider makes unusable.
 	let blurClass = $derived(disabled ? 'blur-sm pointer-events-none select-none' : '')
 
 	// Disabled because the user spent their free Windmill AI grant, not because AI was never
 	// set up — the two look identical otherwise, and the "configure AI" copy would be a lie.
 	let freeTierExhausted = $derived($copilotInfo.freeTier?.exhausted === true)
 
+	// A workspace locked against direct deployment is run, not authored in, so its home page drops
+	// the composer and the button to reopen it. This is about the workspace, not the caller:
+	// `createSession` would steer a prompt into the paired dev workspace and an admin bypasses the
+	// lock outright, yet neither makes prod the place to start one. Unresolved rules read as
+	// unlocked, so the far commoner unlocked workspace never pops the composer in mid-load.
+	let runOnlyWorkspace = $derived(isRuleActive('DisableDirectDeployment'))
+
 	// The composer hands off to /sessions, which refuses operators — so hide it from them (the
 	// prompt would be silently dropped) while the AI-independent CLI/MCP row below stays.
-	let showComposer = $derived(prefersSessionHandoff($userStore?.operator))
+	let showComposer = $derived(prefersSessionHandoff($userStore?.operator) && !runOnlyWorkspace)
+
+	// The hero's margins are for the full block; around the lone button row left by a collapsed,
+	// operator or run-only view they would just be empty page.
+	let outerSpacing = $derived(showComposer && !collapsed ? 'mt-20 mb-16' : 'mt-8 mb-2')
 
 	let starting = $state(false)
 	async function start() {
@@ -100,7 +131,7 @@
 	// Typewriter effect: type a prompt out, hold, delete, then advance to the next. Only while the
 	// composer is shown — otherwise (operators) it would loop forever driving an unrendered input.
 	$effect(() => {
-		if (!showComposer) return
+		if (!showComposer || collapsed) return
 		let promptIndex = 0
 		let charIndex = 0
 		let deleting = false
@@ -135,17 +166,26 @@
 	})
 </script>
 
-<div class="w-full flex justify-center">
+<div class="w-full flex justify-center {outerSpacing}">
 	<div class="max-w-[40rem] grow relative group">
-		{#if showComposer}
-			<div class={blurClass} inert={disabled}>
-				<div class="flex items-center justify-center gap-2 mb-4">
-					<p class="text-center font-regular text-3xl">Build with AI</p>
-					<Badge color="blue" small>Beta</Badge>
+		{#if showComposer && !collapsed}
+			{#if !disabled}
+				<!-- The one dismiss control while the composer is usable; the overlay below carries its
+				     own once it takes over, so the two never show at the same time. -->
+				<div class="absolute right-0 top-0 z-20">
+					<CloseButton small noBg title="Hide Build with AI" onClick={() => setCollapsed(true)} />
 				</div>
-				<!-- anchors the send button / model settings to the input, not to the whole
-				     block — the row below would otherwise push them down -->
-				<div class="relative">
+			{/if}
+			<div class="flex items-center justify-center gap-2 mb-4">
+				<p class="text-center font-regular text-3xl">Build with AI</p>
+				<Badge color="blue" small>Beta</Badge>
+			</div>
+			<!-- Anchors the send button / model settings to the input, not to the whole block — the row
+			     below would otherwise push them down. The inner wrapper stays `relative` in both
+			     states: `blur-sm` is a filter, which makes an element the containing block for its
+			     absolutely positioned children, so those two would shift when the blur turns on. -->
+			<div class="relative">
+				<div class="relative {blurClass}" inert={disabled}>
 					<TextInput
 						bind:value
 						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent"
@@ -165,12 +205,56 @@
 						<AIChatModelSettings />
 					</div>
 				</div>
+				{#if disabled}
+					<!-- Covers the input alone: the title, the example prompts and the CLI/MCP row are all
+					     still legible and usable without a provider. Static, not hover-gated, so keyboard
+					     and touch users see it too. -->
+					<div
+						class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-md bg-surface/70"
+					>
+						<p class="text-sm text-secondary">
+							{#if $aiUserDisabled}
+								Windmill AI is disabled in your account settings
+							{:else if freeTierExhausted}
+								You have used all of your free Windmill AI tokens
+							{:else}
+								No AI provider is configured
+							{/if}
+						</p>
+						<div class="flex items-center gap-2">
+							{#if $aiUserDisabled}
+								<!-- The fix lives in account settings (a hash-opened drawer, not a route), so link
+								     the hash the sidebar's Account menu uses rather than the workspace AI settings. -->
+								<Button
+									unifiedSize="sm"
+									variant="accent"
+									startIcon={{ icon: Settings }}
+									href={USER_SETTINGS_HASH}
+								>
+									Open account settings
+								</Button>
+							{:else}
+								<Button
+									unifiedSize="sm"
+									variant="accent"
+									startIcon={{ icon: freeTierExhausted ? KeyRound : Settings }}
+									href="{base}/workspace_settings?tab=ai"
+								>
+									{freeTierExhausted ? 'Add your own API key' : 'Configure AI'}
+								</Button>
+							{/if}
+							<Button unifiedSize="sm" variant="default" onClick={() => setCollapsed(true)}>
+								Hide
+							</Button>
+						</div>
+					</div>
+				{/if}
 			</div>
 		{/if}
 
 		<div class="flex items-center justify-between gap-2">
-			{#if showComposer}
-				<div class="flex flex-row flex-wrap items-center gap-1.5 {blurClass}" inert={disabled}>
+			{#if showComposer && !collapsed}
+				<div class="flex flex-row flex-wrap items-center gap-1.5">
 					{#each homeAIExamples as example (example.label)}
 						<Button
 							variant="default"
@@ -182,13 +266,24 @@
 						</Button>
 					{/each}
 				</div>
+			{:else if showComposer}
+				<!-- All that is left of the composer once dismissed: sits with the CLI/MCP row so the
+				     collapsed home page is one quiet line. -->
+				<Button
+					variant="subtle"
+					unifiedSize="xs"
+					btnClasses="!text-2xs !text-hint"
+					startIcon={{ icon: WandSparkles }}
+					onClick={() => setCollapsed(false)}
+				>
+					Build with AI
+				</Button>
 			{:else}
 				<div></div>
 			{/if}
 
-			<!-- Not AI-related, so shown even to operators / when the composer is hidden: kept out of
-			     the blurred subtree and above the disabled overlay so it stays sharp and clickable. -->
-			<div class="relative z-20 flex flex-row items-center gap-1">
+			<!-- Not AI-related, so shown even to operators / when the composer is hidden. -->
+			<div class="flex flex-row items-center gap-1">
 				<Button
 					variant="subtle"
 					unifiedSize="xs"
@@ -213,42 +308,6 @@
 				{/if}
 			</div>
 		</div>
-		{#if showComposer && disabled}
-			<div
-				class="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-md bg-surface/70"
-			>
-				<p class="text-sm text-secondary">
-					{#if $aiUserDisabled}
-						Windmill AI is disabled in your account settings
-					{:else if freeTierExhausted}
-						You have used all of your free Windmill AI tokens
-					{:else}
-						No AI provider is configured
-					{/if}
-				</p>
-				{#if $aiUserDisabled}
-					<!-- The fix lives in account settings (a hash-opened drawer, not a route), so link
-					     the hash the sidebar's Account menu uses rather than the workspace AI settings. -->
-					<Button
-						unifiedSize="sm"
-						variant="accent"
-						startIcon={{ icon: Settings }}
-						href={USER_SETTINGS_HASH}
-					>
-						Open account settings
-					</Button>
-				{:else}
-					<Button
-						unifiedSize="sm"
-						variant="accent"
-						startIcon={{ icon: freeTierExhausted ? KeyRound : Settings }}
-						href="{base}/workspace_settings?tab=ai"
-					>
-						{freeTierExhausted ? 'Add your own API key' : 'Configure AI'}
-					</Button>
-				{/if}
-			</div>
-		{/if}
 	</div>
 </div>
 

--- a/frontend/src/lib/components/home/NoItemFound.svelte
+++ b/frontend/src/lib/components/home/NoItemFound.svelte
@@ -30,7 +30,7 @@
 {:else}
 	<div class="flex justify-center items-center h-48">
 		<div class="text-primary text-center">
-			<div class="text-xs font-normal text-hint">
+			<div class="text-lg font-normal text-hint">
 				Get started by creating your first script, flow, or app
 			</div>
 		</div>

--- a/frontend/src/lib/components/home/TutorialBanner.svelte
+++ b/frontend/src/lib/components/home/TutorialBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/common'
-	import { GraduationCap, X } from 'lucide-svelte'
+	import CloseButton from '$lib/components/common/CloseButton.svelte'
+	import { GraduationCap } from 'lucide-svelte'
 	import { base } from '$lib/base'
 	import { goto } from '$app/navigation'
 	import { sendUserToast, type ToastAction } from '$lib/toast'
@@ -153,44 +154,25 @@
 </script>
 
 {#if !isDismissed}
-	<div
-		class="flex items-center justify-between gap-4 px-4 py-3 rounded-lg border border-light bg-surface-tertiary mb-4"
-	>
-		<div class="flex items-center gap-3 flex-1 min-w-0">
-			<GraduationCap size={20} class="text-accent-primary flex-shrink-0" />
-			<div class="flex-1 min-w-0">
-				<div class="text-emphasis flex-wrap text-left text-xs font-semibold">
-					{#if hasCompletedAny}
-						New tutorial available!
-					{:else}
-						Learn with interactive tutorials
-					{/if}
-				</div>
-				<div class="text-hint text-3xs truncate text-left font-normal">
-					{#if hasCompletedAny}
-						Continue your learning journey and master new Windmill skills.
-					{:else}
-						Get started quickly with step-by-step guides on building flows, scripts, and more.
-					{/if}
-				</div>
-			</div>
-		</div>
-		<div class="flex items-center gap-2 flex-shrink-0">
-			<Button
-				size="xs"
-				variant="accent"
-				onclick={goToTutorials}
-				startIcon={{ icon: GraduationCap }}
-			>
-				View tutorials
-			</Button>
-			<button
-				onclick={dismissBanner}
-				class="p-1.5 rounded hover:bg-surface-hover text-secondary hover:text-primary transition-colors"
-				aria-label="Dismiss tutorial banner"
-			>
-				<X size={16} />
-			</button>
-		</div>
+	<!-- A standing invitation, not an announcement: it sits inline at the start of the row rather
+	     than filling the page, so it reads as one more control and not as a card the user has to
+	     dispatch before getting to their work. -->
+	<div class="flex items-center gap-2 mt-4 mb-4">
+		<span class="text-hint text-xs truncate min-w-0">
+			{#if hasCompletedAny}
+				New tutorial available!
+			{:else}
+				First time?
+			{/if}
+		</span>
+		<Button
+			unifiedSize="sm"
+			variant="default"
+			onclick={goToTutorials}
+			startIcon={{ icon: GraduationCap }}
+		>
+			Tutorials
+		</Button>
+		<CloseButton small noBg title="Dismiss tutorial banner" onClick={dismissBanner} />
 	</div>
 {/if}

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -263,6 +263,8 @@
 	<ForkWorkspaceBanner />
 	<WorkspaceDraftsBanner />
 	<div class="max-w-7xl px-4 sm:px-8 md:px-8 h-fit w-full mb-6">
+		<TutorialBanner />
+
 		<!-- HomeAIChat carries both the AI composer and the AI-independent CLI/MCP connect row,
 		     so it shows whenever the sessions beta is on; the composer itself is gated on operator
 		     status and on the workspace inside the component, which owns its own vertical spacing
@@ -278,8 +280,6 @@
 			</Alert>
 			<div class="my-4"></div>
 		{/if}
-
-		<TutorialBanner />
 
 		<NoDirectDeployAlert onUpdateCanEditStatus={(v) => (showCreateButtons = v)} />
 

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -265,11 +265,10 @@
 	<div class="max-w-7xl px-4 sm:px-8 md:px-8 h-fit w-full mb-6">
 		<!-- HomeAIChat carries both the AI composer and the AI-independent CLI/MCP connect row,
 		     so it shows whenever the sessions beta is on; the composer itself is gated on operator
-		     status inside the component (operators are refused by /sessions). -->
+		     status and on the workspace inside the component, which owns its own vertical spacing
+		     because the hero and the bare connect row want different amounts of it. -->
 		{#if isGlobalAiEnabled()}
-			<div class="w-full mb-16 mt-20">
-				<HomeAIChat />
-			</div>
+			<HomeAIChat />
 		{/if}
 
 		{#if $workspaceStore == 'admins'}


### PR DESCRIPTION
## Summary

The home page led with three things competing for attention: a full-bleed AI composer, a card-styled tutorial banner, and two Accent buttons. This makes the composer dismissible, shrinks the tutorial banner to an inline row, and enlarges the empty state.

The composer is also hidden entirely in workspaces that are meant to be run rather than authored in: those where the `DisableDirectDeployment` protection rule is active. That covers both a prod paired with a dev workspace (the pairing creates the `dev_workspace_lock` ruleset) and any workspace an admin has locked down. The gate is deliberately a property of the workspace, not of the caller: a session started from a locked prod would be steered into the paired dev workspace, and an admin bypasses the lock outright, but neither makes prod the place to start authoring.

Three commits: the composer feature, the tutorial banner restyle, and the empty state.

## Changes

**AI composer (`HomeAIChat.svelte`, `CloseButton.svelte`)**

- A close button at the top-right of the composer dismisses the whole block (title, textarea, model picker, example prompts). Collapsed, the only thing left is a subtle `Build with AI` button in the left slot of the row that already carries CLI / MCP and Hub, so the home page reduces to one quiet line.
- The state persists per browser under the `home-ai-composer-collapsed` local setting, via the existing `getLocalSetting` / `storeLocalSetting` helpers.
- The composer and its reopen button are both hidden when `DisableDirectDeployment` is active. Unresolved rules read as unlocked, so the far commoner unlocked workspace never pops the composer in mid-load.
- The "no AI provider" blur and overlay now cover the input alone instead of the whole block. The title, the example prompts and the connect row stay legible and usable without a provider, and the overlay carries its own secondary `Hide` next to `Configure AI` so there is exactly one dismiss control per state.
- The blurred wrapper is `relative` in both states: `blur-sm` is a filter, which makes an element the containing block for its absolute children, so the send button and model picker would otherwise shift when the blur turns on.
- The typewriter placeholder effect stops while collapsed instead of driving an unrendered input.
- `CloseButton` gains an optional `title` prop forwarded to `Button`, so an icon-only close button can carry an accessible name.

**Tutorial banner (`TutorialBanner.svelte`)**

- From a full-width bordered card to a single inline row: no fill, no border, no subtitle, no duplicated graduation-cap icon.
- `View tutorials` becomes `Tutorials` and drops from Accent to the design system's secondary tier. The home page had two Accent buttons where the guidelines allow one; `accent-secondary` is marketing-only.
- The prompt shortens to `First time?`. The `New tutorial available!` state is unchanged.
- Left-aligned, on the same gutter as the tab group and item list below it, and moved above the composer.
- The hand-rolled `<button>` dismiss becomes `CloseButton`, per frontend/AGENTS.md on raw HTML elements. The CTA moves off the deprecated `size` prop to `unifiedSize`.

**Layout (`+page.svelte`, `NoItemFound.svelte`)**

- The `mt-20 mb-16` wrapper around the composer moved into `HomeAIChat`, which now picks its own vertical spacing. Hero margins around a bare connect row were just empty page, so the collapsed, operator and run-only views get `mt-8 mb-2`, which puts about the same gap under that row as above it.
- The empty-workspace line goes from `text-xs` to `text-lg`, keeping its `text-hint` weight and colour.

## Screenshots

Expanded, with the tutorial row above it and the larger empty state below:

![expanded](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-header-collapsable/1788303323-expanded.png)

Collapsed, persisted across reloads:

![collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-header-collapsable/1788303323-collapsed-after.png)

No AI provider configured: blur and overlay on the input only, `Hide` alongside `Configure AI`:

![disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-header-collapsable/1788303323-disabled-expanded.png)

Workspace with `DisableDirectDeployment` active, composer and reopen button both gone:

![prod-hidden](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-header-collapsable/1788303323-prod-hidden.png)

Dark mode:

![banner-dark](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-header-collapsable/1788303323-banner-dark.png)

## Test plan

- [x] Click the close button: composer, example prompts and title all go, one row remains
- [x] Reload: still collapsed, no textarea rendered
- [x] Click `Build with AI`: composer, typewriter placeholder and example tags return, setting cleared
- [x] Add a `DisableDirectDeployment` protection ruleset to the workspace: composer and reopen button both gone, `Edits restricted` badge shows
- [x] Unset the workspace AI config: title and example prompts stay sharp, only the input is blurred, and the overlay's `Hide` collapses the composer
- [x] Tutorial banner renders as one inline row above the composer, `Tutorials` navigates, the X dismisses and toasts
- [x] Dark mode and a 900px viewport, both composer states
- [x] `npm run check:fast` clean for the changed files

No test is included: the change is a boolean plus a localStorage key and some Tailwind classes, with no pure-logic utility a future change could break silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjJhxHHqRqyEX7HsbPjetn