### PR TITLE
feat: reuse an existing workspace resource in the project import wizard

### DIFF
--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -24,6 +24,7 @@
 	import { applyOneMigration } from '$lib/components/workspaceSettings/projectInstall'
 	import { probeMigrationsApplied } from '$lib/importWizard/probe'
 	import {
+		projectReferencesResource,
 		retargetProjectExport,
 		type ProjectExport,
 		type ProjectMigration
@@ -99,6 +100,13 @@
 	let rows = $state<Row[]>([])
 	let blanks = $state<Blank[]>([])
 	let projectResources: { path: string; resource_type: string }[] = []
+	/**
+	 * The subset of `projectResources` the checklist asks about: the ones something in the
+	 * project actually points at. The rest are created and left alone — see
+	 * `projectReferencesResource`. Kept apart from `projectResources` because the full list
+	 * is still what a stub may not be replaced by.
+	 */
+	let askableResources: { path: string; resource_type: string }[] = []
 	let working = $state(false)
 	let resourceEditor: ResourceEditorDrawer | undefined = $state(undefined)
 
@@ -288,7 +296,10 @@
 					.filter((a: any) => a.app_type === 'raw' && typeof a.value?.raw === 'string')
 					.map((a: any) => {
 						try {
-							return [String(a.path), (JSON.parse(a.value.raw)?.files ?? {}) as Record<string, string>]
+							return [
+								String(a.path),
+								(JSON.parse(a.value.raw)?.files ?? {}) as Record<string, string>
+							]
 						} catch {
 							// Unparseable raw bundle: leave it out, and `planRetarget` refuses the app
 							// rather than uploading a bundle it could not read.
@@ -299,6 +310,9 @@
 			projectResources = (retargeted.resources ?? [])
 				.map((r) => ({ path: String(r.path), resource_type: String((r as any).resource_type) }))
 				.filter((r) => r.path.startsWith(`f/${target}/`))
+			askableResources = projectResources.filter((r) =>
+				projectReferencesResource(retargeted, r.path)
+			)
 			await refreshBlanks()
 		} catch (e: any) {
 			loadError = e?.body ?? e?.message ?? String(e)
@@ -390,7 +404,7 @@
 	 * it only moves a row from outstanding to done.
 	 */
 	async function refreshBlanks(): Promise<void> {
-		const fresh = await findBlankResources(projectResources)
+		const fresh = await findBlankResources(askableResources)
 		const stillBlank = new Map(fresh.map((b) => [b.path, b]))
 		if (blanks.length === 0) {
 			blanks = fresh

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -288,25 +288,24 @@
 			// every new-workspace import.
 			const target = targetFolder
 			const retargeted = retargetProjectExport(exportData, exportData.project?.slug ?? slug, target)
+			const rawFiles: [string, Record<string, string>][] = []
+			for (const a of (retargeted.apps ?? []) as any[]) {
+				if (a.app_type !== 'raw' || typeof a.value?.raw !== 'string') continue
+				let files: any
+				try {
+					files = JSON.parse(a.value.raw)?.files
+				} catch {
+					files = undefined
+				}
+				// A bundle that cannot be read yields no entry rather than an empty one, so
+				// `planRetarget` refuses the app instead of uploading a bundle it does not have.
+				if (!files || typeof files !== 'object') continue
+				rawFiles.push([String(a.path), files as Record<string, string>])
+			}
+			exportedAppFiles = Object.fromEntries(rawFiles)
 			// Contained for the same reason the import contains: a crafted export can name a
 			// path outside the folder, and offering that for editing would reach a resource
 			// this import was never allowed to create.
-			exportedAppFiles = Object.fromEntries(
-				(retargeted.apps ?? [])
-					.filter((a: any) => a.app_type === 'raw' && typeof a.value?.raw === 'string')
-					.map((a: any) => {
-						try {
-							return [
-								String(a.path),
-								(JSON.parse(a.value.raw)?.files ?? {}) as Record<string, string>
-							]
-						} catch {
-							// Unparseable raw bundle: leave it out, and `planRetarget` refuses the app
-							// rather than uploading a bundle it could not read.
-							return [String(a.path), {}]
-						}
-					})
-			)
 			projectResources = (retargeted.resources ?? [])
 				.map((r) => ({ path: String(r.path), resource_type: String((r as any).resource_type) }))
 				.filter((r) => r.path.startsWith(`f/${target}/`))
@@ -898,6 +897,11 @@
 									<span class="whitespace-nowrap text-2xs text-hint">
 										{b.occupiedBy ? 'Resolve in the workspace' : 'Check the workspace'}
 									</span>
+								{:else if b.reusedFrom}
+									<!-- No action either: the project reads the resource the detail line
+									     names and this row's own path is gone, so every way of filling it in
+									     leads to a resource nothing references. -->
+									<span class="whitespace-nowrap text-2xs text-hint">Reused</span>
 								{:else}
 									<Button
 										variant={b.done ? 'subtle' : 'accent'}
@@ -905,13 +909,7 @@
 										disabled={working}
 										onClick={() => startFilling(b)}
 									>
-										{b.done
-											? b.reusedFrom
-												? 'Reused'
-												: 'Saved'
-											: canConnect
-												? 'Connect'
-												: 'Fill in'}
+										{b.done ? 'Saved' : canConnect ? 'Connect' : 'Fill in'}
 									</Button>
 								{/if}
 							{/snippet}

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -414,10 +414,11 @@
 			return
 		}
 		blanks = blanks.map((b) => {
-			// A row pointed at another resource is settled whatever is at its own path. The
-			// project's items read the chosen resource now, and the stub — kept when the scan
-			// could not account for everything — is no longer what the project depends on.
-			if (b.reusedFrom) return b
+			// A row pointed at another resource is settled once its own stub is gone: the
+			// project's items read the chosen resource and nothing is left at this path. A row
+			// whose stub was kept is not settled, and re-reading it is how filling that stub in
+			// finally closes the row.
+			if (b.reusedFrom && !b.stubKept) return b
 			const f = stillBlank.get(b.path)
 			// Every field the fresh read decides is taken from it, not merged selectively: these
 			// describe what is at the path *now*. Keeping a stale `unreadable` leaves a resource
@@ -587,8 +588,11 @@
 			if (row) {
 				row.reusedFrom = target
 				row.stubKept = !outcome.stubDeleted
-				row.done = true
-				row.justSaved = true
+				// Settled only when the stub is gone. A kept stub is empty and is still what
+				// every item the scan could not move reads, so the row stays outstanding and
+				// keeps its action: filling it in is the thing left to do.
+				row.done = outcome.stubDeleted
+				row.justSaved = outcome.stubDeleted
 			}
 			await refreshBlanks()
 			sendUserToast(
@@ -915,10 +919,11 @@
 										now uses <span class="font-mono">{b.reusedFrom}</span>
 									</span>
 									{#if b.stubKept}
-										<!-- The placeholder is still at this row's path and still empty, which
-										     otherwise reads as the retarget having half-worked. -->
+										<!-- Not a footnote: some items were not moved and still read this path,
+										     so the empty resource on it is a credential someone has to fill in. -->
 										<span class="truncate text-hint">
-											the empty placeholder was kept, because some items could not be checked
+											some items still read <span class="font-mono">{b.path}</span> — fill it in
+											too
 										</span>
 									{/if}
 								{:else if b.occupiedBy}
@@ -948,7 +953,7 @@
 									<span class="whitespace-nowrap text-2xs text-hint">
 										{b.occupiedBy ? 'Resolve in the workspace' : 'Check the workspace'}
 									</span>
-								{:else if b.reusedFrom}
+								{:else if b.reusedFrom && !b.stubKept}
 									<!-- No action either: the project reads the resource the detail line
 									     names and this row's own path is gone, so every way of filling it in
 									     leads to a resource nothing references. -->

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -434,12 +434,15 @@
 					justSaved: false
 				}
 			}
-			// Gone from the blank list entirely: it was read, and it is filled.
+			// Gone from the blank list entirely: it was read, and it is filled. `stubKept` goes
+			// with it — the placeholder the items this run could not move read is a credential
+			// now, so there is nothing left to tell anyone to fill in.
 			return {
 				...b,
 				missing: [],
 				unreadable: undefined,
 				occupiedBy: undefined,
+				stubKept: undefined,
 				done: true,
 				justSaved: !b.done
 			}
@@ -530,7 +533,11 @@
 	 * there is no choice to make, so it goes straight where it always went.
 	 */
 	function startFilling(b: Blank): void {
-		if (b.done || (candidates[b.resourceType] ?? []).length === 0) {
+		// A kept-stub row has already been pointed at a resource; what is left is the empty
+		// placeholder the items this run could not move still read. Reusing a second resource
+		// would move nothing — every rewritable referrer is off the stub — and would relabel
+		// the row after a retarget that did nothing.
+		if (b.done || b.stubKept || (candidates[b.resourceType] ?? []).length === 0) {
 			fillDirectly(b)
 			return
 		}

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -28,6 +28,7 @@
 		type ProjectExport,
 		type ProjectMigration
 	} from '$lib/components/workspaceSettings/projectBundle'
+	import { userStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { escapeHtml } from '$lib/utils'
 
@@ -578,7 +579,10 @@
 				workspace,
 				folder: targetFolder,
 				from: b.path,
-				to: target
+				to: target,
+				// Only an admin's listings are the whole workspace; anyone else's are filtered by
+				// row-level security, and the scan cannot tell a filtered row from an absent one.
+				seesWholeWorkspace: !!($userStore?.is_admin || $userStore?.is_super_admin)
 			})
 			const moved = `${outcome.rewritten.length} item${outcome.rewritten.length === 1 ? '' : 's'}`
 			if (outcome.error) {
@@ -927,8 +931,7 @@
 										<!-- Not a footnote: some items were not moved and still read this path,
 										     so the empty resource on it is a credential someone has to fill in. -->
 										<span class="truncate text-hint">
-											some items still read <span class="font-mono">{b.path}</span> — fill it in
-											too
+											some items still read <span class="font-mono">{b.path}</span> — fill it in too
 										</span>
 									{/if}
 								{:else if b.occupiedBy}

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -88,11 +88,16 @@
 		 */
 		unreadable?: boolean
 		/**
-		 * The workspace resource this row was pointed at. The project's items now reference it
-		 * directly and the stub is gone, so this is what the row has to say instead of the
-		 * path it used to name.
+		 * The workspace resource this row was pointed at. The project's items reference it
+		 * directly now, so this is what the row has to say instead of the path it used to name.
 		 */
 		reusedFrom?: string
+		/**
+		 * The empty placeholder is still at this row's path, because the retarget could not
+		 * account for every item that might read it. Worth saying: the workspace has a resource
+		 * on it that looks unfinished and is not.
+		 */
+		stubKept?: boolean
 	}
 
 	let loading = $state(true)
@@ -298,7 +303,7 @@
 					files = undefined
 				}
 				// A bundle that cannot be read yields no entry rather than an empty one, so
-				// `planRetarget` refuses the app instead of uploading a bundle it does not have.
+				// `planRetarget` leaves the app alone instead of uploading a bundle it does not have.
 				if (!files || typeof files !== 'object') continue
 				rawFiles.push([String(a.path), files as Record<string, string>])
 			}
@@ -411,6 +416,10 @@
 			return
 		}
 		blanks = blanks.map((b) => {
+			// A row pointed at another resource is settled whatever is at its own path. The
+			// project's items read the chosen resource now, and the stub — kept when the scan
+			// could not account for everything — is no longer what the project depends on.
+			if (b.reusedFrom) return b
 			const f = stillBlank.get(b.path)
 			// Every field the fresh read decides is taken from it, not merged selectively: these
 			// describe what is at the path *now*. Keeping a stale `unreadable` leaves a resource
@@ -422,8 +431,6 @@
 					missing: f.missing,
 					unreadable: f.unreadable,
 					occupiedBy: f.occupiedBy,
-					// Blank again, so it is not standing in for anything.
-					reusedFrom: undefined,
 					done: false,
 					justSaved: false
 				}
@@ -525,9 +532,9 @@
 
 	/**
 	 * Point the project at an existing resource: every imported item that referenced the stub
-	 * is rewritten to the chosen path and the stub is deleted. Nothing is copied and nothing
-	 * is left behind referring to a resource that no longer exists — `applyRetarget` refuses
-	 * outright rather than doing half of that.
+	 * is rewritten to the chosen path. Nothing is copied. The stub is deleted only when
+	 * `applyRetarget` can account for every item that might read it, and kept otherwise — so
+	 * the toast says how many items moved, and whether the placeholder is still there.
 	 */
 	async function reuseChosen(): Promise<void> {
 		const b = choosing
@@ -544,14 +551,28 @@
 				hasEeLicense: !!$enterpriseLicense,
 				exportedAppFiles
 			})
+			const moved = `${outcome.rewritten.length} item${outcome.rewritten.length === 1 ? '' : 's'}`
 			if (outcome.error) {
-				sendUserToast(`Could not point the project at ${target}: ${outcome.error}`, true)
+				sendUserToast(
+					`Could not point the project at ${target}: ${outcome.error}. ${moved} had already been updated, and ${b.path} was kept.`,
+					true
+				)
 				return
 			}
 			choosing = undefined
-			await refreshBlanks()
 			const row = blanks.find((x) => x.path === b.path)
-			if (row) row.reusedFrom = target
+			if (row) {
+				row.reusedFrom = target
+				row.stubKept = !outcome.stubDeleted
+				row.done = true
+				row.justSaved = true
+			}
+			await refreshBlanks()
+			sendUserToast(
+				outcome.stubDeleted
+					? `The project now uses ${target} — ${moved} updated.`
+					: `The project now uses ${target} — ${moved} updated. ${b.path} was kept, because some items could not be checked.`
+			)
 		} catch (e: any) {
 			sendUserToast(
 				`Could not point the project at ${target}: ${e?.body ?? e?.message ?? String(e)}`,
@@ -866,7 +887,18 @@
 								</div>
 							{/snippet}
 							{#snippet detail()}
-								{#if b.occupiedBy}
+								{#if b.reusedFrom}
+									<span class="truncate text-secondary">
+										now uses <span class="font-mono">{b.reusedFrom}</span>
+									</span>
+									{#if b.stubKept}
+										<!-- The placeholder is still at this row's path and still empty, which
+										     otherwise reads as the retarget having half-worked. -->
+										<span class="truncate text-hint">
+											the empty placeholder was kept, because some items could not be checked
+										</span>
+									{/if}
+								{:else if b.occupiedBy}
 									<span class="truncate text-secondary">
 										a {resourceTypeDisplayName(b.occupiedBy)} resource already holds this path — the
 										project did not get this one
@@ -878,10 +910,6 @@
 								{:else if !b.done && b.missing.length > 0}
 									<span class="truncate text-secondary">
 										Missing {b.missing.join(', ')}
-									</span>
-								{:else if b.reusedFrom}
-									<span class="truncate text-secondary">
-										now uses <span class="font-mono">{b.reusedFrom}</span>
 									</span>
 								{/if}
 							{/snippet}

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -17,7 +17,6 @@
 	import Modal2 from '$lib/components/common/modal/Modal2.svelte'
 	import Select from '$lib/components/select/Select.svelte'
 	import { applyRetarget } from '$lib/importWizard/retargetDeployed'
-	import { enterpriseLicense } from '$lib/stores'
 	import { OauthService } from '$lib/gen'
 	import { registryCcCapableFor } from '$lib/components/oauthRegistry'
 	import { resourceTypeDisplayName } from '$lib/components/resourceTypeDisplay'
@@ -305,16 +304,16 @@
 			// spells out in code is not rewritten by the retarget, so only the raw export has
 			// its references and its resource paths agreeing. `resourceCount` asks the same
 			// question the same way, and the step and the stepper have to give one answer.
-			const fromSlug = exportData.project?.slug ?? slug
+			// Paired by position, not by reconstructing the retargeted path: `retargetProjectExport`
+			// maps `resources` in order, and an external path the bundle pulled in lands at
+			// `f/<folder>/<name>` with a `_2` suffix on collision, which no slicing recovers.
 			const askable = new Set(
-				(exportData.resources ?? [])
-					.map((r) => String(r.path))
-					.filter((p) => projectReferencesResource(exportData, p))
-					.map((p) => p.slice(`f/${fromSlug}/`.length))
+				(retargeted.resources ?? [])
+					.map((r, i) => [String(r.path), (exportData.resources ?? [])[i]] as const)
+					.filter(([, raw]) => raw && projectReferencesResource(exportData, String(raw.path)))
+					.map(([path]) => path)
 			)
-			askableResources = projectResources.filter((r) =>
-				askable.has(r.path.slice(`f/${target}/`.length))
-			)
+			askableResources = projectResources.filter((r) => askable.has(r.path))
 			await refreshBlanks()
 		} catch (e: any) {
 			loadError = e?.body ?? e?.message ?? String(e)
@@ -579,8 +578,7 @@
 				workspace,
 				folder: targetFolder,
 				from: b.path,
-				to: target,
-				hasEeLicense: !!$enterpriseLicense
+				to: target
 			})
 			const moved = `${outcome.rewritten.length} item${outcome.rewritten.length === 1 ? '' : 's'}`
 			if (outcome.error) {
@@ -961,9 +959,8 @@
 										{b.occupiedBy ? 'Resolve in the workspace' : 'Check the workspace'}
 									</span>
 								{:else if b.reusedFrom && !b.stubKept}
-									<!-- No action either: the project reads the resource the detail line
-									     names and this row's own path is gone, so every way of filling it in
-									     leads to a resource nothing references. -->
+									<!-- No action either: this row is done with, whether its own path was
+									     deleted with the retarget or filled in afterwards. -->
 									<span class="whitespace-nowrap text-2xs text-hint">Reused</span>
 								{:else}
 									<Button

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -301,8 +301,19 @@
 			projectResources = (retargeted.resources ?? [])
 				.map((r) => ({ path: String(r.path), resource_type: String((r as any).resource_type) }))
 				.filter((r) => r.path.startsWith(`f/${target}/`))
+			// Asked against the export as published, not the retargeted copy: a path the project
+			// spells out in code is not rewritten by the retarget, so only the raw export has
+			// its references and its resource paths agreeing. `resourceCount` asks the same
+			// question the same way, and the step and the stepper have to give one answer.
+			const fromSlug = exportData.project?.slug ?? slug
+			const askable = new Set(
+				(exportData.resources ?? [])
+					.map((r) => String(r.path))
+					.filter((p) => projectReferencesResource(exportData, p))
+					.map((p) => p.slice(`f/${fromSlug}/`.length))
+			)
 			askableResources = projectResources.filter((r) =>
-				projectReferencesResource(retargeted, r.path)
+				askable.has(r.path.slice(`f/${target}/`.length))
 			)
 			await refreshBlanks()
 		} catch (e: any) {
@@ -461,8 +472,8 @@
 		const next: Record<string, string[]> = Object.fromEntries(types.map((t) => [t, []]))
 		try {
 			// One call for every type at once — `resource_type` takes a comma-separated list —
-			// and every page of it: the endpoint defaults to 30 rows, so a single call would
-			// offer a workspace's first 30 resources and silently hide the rest.
+			// and every page of it: `perPage` is what bounds the answer, so without the loop a
+			// workspace past one page would have the rest of its resources silently hidden.
 			for (let page = 1; page <= 100; page++) {
 				const rows = await ResourceService.listResource({
 					workspace,

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -16,7 +16,7 @@
 	import AppConnectDrawer from '$lib/components/AppConnectDrawer.svelte'
 	import Modal2 from '$lib/components/common/modal/Modal2.svelte'
 	import Select from '$lib/components/select/Select.svelte'
-	import { applyRetarget } from '$lib/importWizard/retargetDeployed'
+	import { applyRetarget, seesWholeWorkspace } from '$lib/importWizard/retargetDeployed'
 	import { OauthService } from '$lib/gen'
 	import { registryCcCapableFor } from '$lib/components/oauthRegistry'
 	import { resourceTypeDisplayName } from '$lib/components/resourceTypeDisplay'
@@ -28,7 +28,7 @@
 		type ProjectExport,
 		type ProjectMigration
 	} from '$lib/components/workspaceSettings/projectBundle'
-	import { userStore } from '$lib/stores'
+	import { superadmin, userStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { escapeHtml } from '$lib/utils'
 
@@ -580,9 +580,9 @@
 				folder: targetFolder,
 				from: b.path,
 				to: target,
-				// Only an admin's listings are the whole workspace; anyone else's are filtered by
-				// row-level security, and the scan cannot tell a filtered row from an absent one.
-				seesWholeWorkspace: !!($userStore?.is_admin || $userStore?.is_super_admin)
+				// Asked of this workspace, not of whichever one the user record still describes:
+				// reloading on this step leaves `$userStore` pointing at the previous workspace.
+				seesWholeWorkspace: seesWholeWorkspace($userStore, !!$superadmin, workspace)
 			})
 			const moved = `${outcome.rewritten.length} item${outcome.rewritten.length === 1 ? '' : 's'}`
 			if (outcome.error) {

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -16,7 +16,7 @@
 	import AppConnectDrawer from '$lib/components/AppConnectDrawer.svelte'
 	import Modal2 from '$lib/components/common/modal/Modal2.svelte'
 	import Select from '$lib/components/select/Select.svelte'
-	import { applyRetarget, type ExportedAppFiles } from '$lib/importWizard/retargetDeployed'
+	import { applyRetarget } from '$lib/importWizard/retargetDeployed'
 	import { enterpriseLicense } from '$lib/stores'
 	import { OauthService } from '$lib/gen'
 	import { registryCcCapableFor } from '$lib/components/oauthRegistry'
@@ -125,11 +125,6 @@
 	 * editor, exactly as it did before.
 	 */
 	let candidates = $state<Record<string, string[]>>({})
-	/**
-	 * Raw-app sources from the export, keyed by where they landed. `applyRetarget` re-uploads
-	 * the `/bundle.js` in here rather than re-running the bundler — see `ExportedAppFiles`.
-	 */
-	let exportedAppFiles = $state<ExportedAppFiles>({})
 	/** The credential row whose choice dialog is open. */
 	let choosing = $state<Blank | undefined>(undefined)
 	let chosenPath = $state<string | undefined>(undefined)
@@ -293,21 +288,6 @@
 			// every new-workspace import.
 			const target = targetFolder
 			const retargeted = retargetProjectExport(exportData, exportData.project?.slug ?? slug, target)
-			const rawFiles: [string, Record<string, string>][] = []
-			for (const a of (retargeted.apps ?? []) as any[]) {
-				if (a.app_type !== 'raw' || typeof a.value?.raw !== 'string') continue
-				let files: any
-				try {
-					files = JSON.parse(a.value.raw)?.files
-				} catch {
-					files = undefined
-				}
-				// A bundle that cannot be read yields no entry rather than an empty one, so
-				// `planRetarget` leaves the app alone instead of uploading a bundle it does not have.
-				if (!files || typeof files !== 'object') continue
-				rawFiles.push([String(a.path), files as Record<string, string>])
-			}
-			exportedAppFiles = Object.fromEntries(rawFiles)
 			// Contained for the same reason the import contains: a crafted export can name a
 			// path outside the folder, and offering that for editing would reach a resource
 			// this import was never allowed to create.
@@ -548,8 +528,7 @@
 				folder: targetFolder,
 				from: b.path,
 				to: target,
-				hasEeLicense: !!$enterpriseLicense,
-				exportedAppFiles
+				hasEeLicense: !!$enterpriseLicense
 			})
 			const moved = `${outcome.rewritten.length} item${outcome.rewritten.length === 1 ? '' : 's'}`
 			if (outcome.error) {

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -14,6 +14,10 @@
 	import IconedResourceType from '$lib/components/IconedResourceType.svelte'
 	import ImportSetupRow from '$lib/components/ImportSetupRow.svelte'
 	import AppConnectDrawer from '$lib/components/AppConnectDrawer.svelte'
+	import Modal2 from '$lib/components/common/modal/Modal2.svelte'
+	import Select from '$lib/components/select/Select.svelte'
+	import { applyRetarget, type ExportedAppFiles } from '$lib/importWizard/retargetDeployed'
+	import { enterpriseLicense } from '$lib/stores'
 	import { OauthService } from '$lib/gen'
 	import { registryCcCapableFor } from '$lib/components/oauthRegistry'
 	import { resourceTypeDisplayName } from '$lib/components/resourceTypeDisplay'
@@ -82,6 +86,12 @@
 		 * is absent, and removing the row reports "all set" over a credential nobody filled.
 		 */
 		unreadable?: boolean
+		/**
+		 * The workspace resource this row was pointed at. The project's items now reference it
+		 * directly and the stub is gone, so this is what the row has to say instead of the
+		 * path it used to name.
+		 */
+		reusedFrom?: string
 	}
 
 	let loading = $state(true)
@@ -91,6 +101,26 @@
 	let projectResources: { path: string; resource_type: string }[] = []
 	let working = $state(false)
 	let resourceEditor: ResourceEditorDrawer | undefined = $state(undefined)
+
+	/** The folder the import wrote into, which is where every rewritable referrer lives. */
+	const targetFolder = $derived(folder?.trim() || slug)
+
+	/**
+	 * Resources the workspace already has, by resource type — what a stub can be replaced
+	 * by. Empty for a workspace this import created, which is why the choice is offered
+	 * rather than imposed: with nothing to choose from the button goes straight to the
+	 * editor, exactly as it did before.
+	 */
+	let candidates = $state<Record<string, string[]>>({})
+	/**
+	 * Raw-app sources from the export, keyed by where they landed. `applyRetarget` re-uploads
+	 * the `/bundle.js` in here rather than re-running the bundler — see `ExportedAppFiles`.
+	 */
+	let exportedAppFiles = $state<ExportedAppFiles>({})
+	/** The credential row whose choice dialog is open. */
+	let choosing = $state<Blank | undefined>(undefined)
+	let chosenPath = $state<string | undefined>(undefined)
+	let reusing = $state(false)
 
 	const pendingTables = $derived(rows.filter((r) => r.status !== 'done'))
 	// Split because the two say different things to the user: one data table was never
@@ -248,11 +278,24 @@
 			// Retargeted the same way the import was, so these are where the stubs actually
 			// landed. `retargetProjectExport` is a no-op when the folder is the slug, which is
 			// every new-workspace import.
-			const target = folder?.trim() || slug
+			const target = targetFolder
 			const retargeted = retargetProjectExport(exportData, exportData.project?.slug ?? slug, target)
 			// Contained for the same reason the import contains: a crafted export can name a
 			// path outside the folder, and offering that for editing would reach a resource
 			// this import was never allowed to create.
+			exportedAppFiles = Object.fromEntries(
+				(retargeted.apps ?? [])
+					.filter((a: any) => a.app_type === 'raw' && typeof a.value?.raw === 'string')
+					.map((a: any) => {
+						try {
+							return [String(a.path), (JSON.parse(a.value.raw)?.files ?? {}) as Record<string, string>]
+						} catch {
+							// Unparseable raw bundle: leave it out, and `planRetarget` refuses the app
+							// rather than uploading a bundle it could not read.
+							return [String(a.path), {}]
+						}
+					})
+			)
 			projectResources = (retargeted.resources ?? [])
 				.map((r) => ({ path: String(r.path), resource_type: String((r as any).resource_type) }))
 				.filter((r) => r.path.startsWith(`f/${target}/`))
@@ -351,6 +394,7 @@
 		const stillBlank = new Map(fresh.map((b) => [b.path, b]))
 		if (blanks.length === 0) {
 			blanks = fresh
+			await loadCandidates()
 			return
 		}
 		blanks = blanks.map((b) => {
@@ -365,6 +409,8 @@
 					missing: f.missing,
 					unreadable: f.unreadable,
 					occupiedBy: f.occupiedBy,
+					// Blank again, so it is not standing in for anything.
+					reusedFrom: undefined,
 					done: false,
 					justSaved: false
 				}
@@ -386,6 +432,121 @@
 				const row = blanks.find((x) => x.path === b.path)
 				if (row) row.justSaved = false
 			}, 1500)
+		}
+		await loadCandidates()
+	}
+
+	/**
+	 * Which existing resources each outstanding row could be replaced by. Re-read on every
+	 * refresh rather than once: a resource created from the editor here is a candidate for
+	 * the rows below it.
+	 *
+	 * The project's own resources are never offered — one of this project's stubs standing
+	 * in for another is a reference to something equally unfilled.
+	 */
+	async function loadCandidates(): Promise<void> {
+		const types = [...new Set(blanks.map((b) => b.resourceType))]
+		if (types.length === 0) {
+			candidates = {}
+			return
+		}
+		const own = new Set(projectResources.map((r) => r.path))
+		const next: Record<string, string[]> = Object.fromEntries(types.map((t) => [t, []]))
+		try {
+			// One call for every type at once — `resource_type` takes a comma-separated list —
+			// and every page of it: the endpoint defaults to 30 rows, so a single call would
+			// offer a workspace's first 30 resources and silently hide the rest.
+			for (let page = 1; page <= 100; page++) {
+				const rows = await ResourceService.listResource({
+					workspace,
+					resourceType: types.join(','),
+					page,
+					perPage: 100
+				})
+				for (const r of rows) {
+					if (own.has(r.path)) continue
+					next[r.resource_type ?? '']?.push(r.path)
+				}
+				if (rows.length < 100) break
+			}
+		} catch {
+			// Offer nothing rather than a partial list: every row then behaves as it did before
+			// this choice existed, which is a working way to fill a credential.
+			candidates = {}
+			return
+		}
+		candidates = next
+	}
+
+	/**
+	 * The row's one action. A workspace that already has a resource of this type gets the
+	 * choice first — reusing what is there is usually the answer, and entering the same
+	 * credentials a second time is the thing worth avoiding. With nothing to choose from
+	 * there is no choice to make, so it goes straight where it always went.
+	 */
+	function startFilling(b: Blank): void {
+		if (b.done || (candidates[b.resourceType] ?? []).length === 0) {
+			fillDirectly(b)
+			return
+		}
+		chosenPath = undefined
+		choosing = b
+	}
+
+	/** Connect where the instance can, hand-fill otherwise. */
+	function fillDirectly(b: Blank): void {
+		if (canConnectType(b.resourceType)) appConnect?.open(b.resourceType, b.path)
+		else resourceEditor?.initEdit(b.path)
+	}
+
+	/**
+	 * The chooser's way out: close it and do what the button did before there was a choice.
+	 * The row is read out of the state first — closing the dialog unmounts the block that
+	 * would otherwise be holding it.
+	 */
+	function fillNewInstead(): void {
+		const b = choosing
+		choosing = undefined
+		if (b) fillDirectly(b)
+	}
+
+	/**
+	 * Point the project at an existing resource: every imported item that referenced the stub
+	 * is rewritten to the chosen path and the stub is deleted. Nothing is copied and nothing
+	 * is left behind referring to a resource that no longer exists — `applyRetarget` refuses
+	 * outright rather than doing half of that.
+	 */
+	async function reuseChosen(): Promise<void> {
+		const b = choosing
+		const target = chosenPath
+		if (!b || !target) return
+		reusing = true
+		working = true
+		try {
+			const outcome = await applyRetarget({
+				workspace,
+				folder: targetFolder,
+				from: b.path,
+				to: target,
+				hasEeLicense: !!$enterpriseLicense,
+				exportedAppFiles
+			})
+			if (outcome.error) {
+				sendUserToast(`Could not point the project at ${target}: ${outcome.error}`, true)
+				return
+			}
+			choosing = undefined
+			await refreshBlanks()
+			const row = blanks.find((x) => x.path === b.path)
+			if (row) row.reusedFrom = target
+		} catch (e: any) {
+			sendUserToast(
+				`Could not point the project at ${target}: ${e?.body ?? e?.message ?? String(e)}`,
+				true
+			)
+		} finally {
+			reusing = false
+			working = false
 		}
 	}
 
@@ -705,6 +866,10 @@
 									<span class="truncate text-secondary">
 										Missing {b.missing.join(', ')}
 									</span>
+								{:else if b.reusedFrom}
+									<span class="truncate text-secondary">
+										now uses <span class="font-mono">{b.reusedFrom}</span>
+									</span>
 								{/if}
 							{/snippet}
 							{#snippet action()}
@@ -724,12 +889,15 @@
 										variant={b.done ? 'subtle' : 'accent'}
 										unifiedSize="sm"
 										disabled={working}
-										onClick={() =>
-											canConnect
-												? appConnect?.open(b.resourceType, b.path)
-												: resourceEditor?.initEdit(b.path)}
+										onClick={() => startFilling(b)}
 									>
-										{b.done ? 'Saved' : canConnect ? 'Connect' : 'Fill in'}
+										{b.done
+											? b.reusedFrom
+												? 'Reused'
+												: 'Saved'
+											: canConnect
+												? 'Connect'
+												: 'Fill in'}
 									</Button>
 								{/if}
 							{/snippet}
@@ -757,15 +925,17 @@
 				size="xs"
 			>
 				{#if missingTables.length > 0}
-					The tables {missingTables.length === 1 ? 'this data table holds' : 'these data tables hold'}
+					The tables {missingTables.length === 1
+						? 'this data table holds'
+						: 'these data tables hold'}
 					do not exist, and the project's apps and flows read them. Every one of those fails as soon
 					as it opens.
 				{/if}
 				{#if uncheckedTables.length > 0}
 					{#if missingTables.length > 0}<br /><br />{/if}
 					{uncheckedTables.length === 1 ? 'One data table is' : 'Some data tables are'} set up, but
-					{uncheckedTables.length === 1 ? 'its' : 'their'} schema could not be read, so whether the
-					project's tables are there is unknown. Check again once the database is reachable.
+					{uncheckedTables.length === 1 ? 'its' : 'their'} schema could not be read, so whether the project's
+					tables are there is unknown. Check again once the database is reachable.
 				{/if}
 			</Alert>
 		{:else}
@@ -859,3 +1029,56 @@
 <!-- `on:refresh` fires once the connection has been written into the stub — the same moment
      a save is — so the rows settle the same way either route was taken. -->
 <AppConnectDrawer bind:this={appConnect} {workspace} on:refresh={() => void refreshBlanks()} />
+
+<!-- What "Fill in" opens when the workspace already has a resource of the row's type.
+     Portalled to the body for the reason the confirmation above is: this step renders inside
+     the wizard page's CenteredModal, which is its own stacking context. -->
+<Modal2
+	title={choosing ? `Set up ${resourceTypeDisplayName(choosing.resourceType)}` : ''}
+	target="body"
+	fixedWidth="xs"
+	fixedHeight="adaptive"
+	formStyling
+	closeOnOutsideClick={!reusing}
+	bind:isOpen={
+		() => choosing !== undefined,
+		(v) => {
+			if (!v && !reusing) choosing = undefined
+		}
+	}
+>
+	{#if choosing}
+		{@const forRow = choosing}
+		{@const existing = candidates[forRow.resourceType] ?? []}
+		<div class="flex w-full flex-col gap-4 text-xs">
+			<p class="text-secondary">
+				This workspace already has {existing.length}
+				{resourceTypeDisplayName(forRow.resourceType)}
+				{existing.length === 1 ? 'resource' : 'resources'}. Use one and this project's apps, flows
+				and triggers are pointed at it — the empty
+				<span class="font-mono text-emphasis">{forRow.path}</span> it imported is removed.
+			</p>
+			<Select
+				bind:value={chosenPath}
+				items={existing.map((p) => ({ value: p, label: p }))}
+				placeholder="Pick a resource"
+				disabled={reusing}
+				clearable
+				class="w-full"
+			/>
+			<div class="flex items-center justify-between gap-2">
+				<Button variant="subtle" unifiedSize="sm" disabled={reusing} onClick={fillNewInstead}>
+					{canConnectType(forRow.resourceType) ? 'Connect a new one' : 'Fill in a new one'}
+				</Button>
+				<Button
+					variant="accent"
+					unifiedSize="sm"
+					disabled={!chosenPath || reusing}
+					onClick={() => void reuseChosen()}
+				>
+					{reusing ? 'Pointing the project at it…' : 'Use this resource'}
+				</Button>
+			</div>
+		</div>
+	{/if}
+</Modal2>

--- a/frontend/src/lib/components/ImportSetupStep.svelte
+++ b/frontend/src/lib/components/ImportSetupStep.svelte
@@ -125,6 +125,13 @@
 	 * editor, exactly as it did before.
 	 */
 	let candidates = $state<Record<string, string[]>>({})
+	/**
+	 * How many candidates are worth reading back to find the unfilled ones. Past this a
+	 * workspace holds too many resources of these types to be the case worth filtering —
+	 * one project's stub offered as another's credential — and they are all offered rather
+	 * than costing a request each.
+	 */
+	const CANDIDATE_READ_CAP = 40
 	/** The credential row whose choice dialog is open. */
 	let choosing = $state<Blank | undefined>(undefined)
 	let chosenPath = $state<string | undefined>(undefined)
@@ -475,7 +482,33 @@
 			candidates = {}
 			return
 		}
+		// An unfilled resource is never the answer to "which credential should this use" —
+		// another project's stub above all, which the path filter above cannot recognise.
+		const paths = Object.values(next).flat()
+		if (paths.length <= CANDIDATE_READ_CAP) {
+			const settled = await Promise.all(paths.map(async (p) => [p, await isUnfilled(p)] as const))
+			const unfilled = new Set(settled.filter(([, empty]) => empty).map(([p]) => p))
+			for (const t of Object.keys(next)) next[t] = next[t].filter((p) => !unfilled.has(p))
+		}
 		candidates = next
+	}
+
+	/**
+	 * Whether a resource holds nothing. Same test the checklist uses to call one of the
+	 * project's own resources blank, so a resource this drops is exactly one the wizard
+	 * would have asked someone to fill in.
+	 */
+	async function isUnfilled(path: string): Promise<boolean> {
+		try {
+			const found = await ResourceService.getResource({ workspace, path })
+			const value = found?.value
+			if (!value || typeof value !== 'object') return true
+			return !Object.values(value).some((v) => v !== undefined && v !== null && v !== '')
+		} catch {
+			// A read that fails says nothing about the value, and offering it is what this did
+			// before the check existed.
+			return false
+		}
 	}
 
 	/**
@@ -1074,8 +1107,7 @@
 				This workspace already has {existing.length}
 				{resourceTypeDisplayName(forRow.resourceType)}
 				{existing.length === 1 ? 'resource' : 'resources'}. Use one and this project's apps, flows
-				and triggers are pointed at it — the empty
-				<span class="font-mono text-emphasis">{forRow.path}</span> it imported is removed.
+				and triggers are pointed at it.
 			</p>
 			<Select
 				bind:value={chosenPath}

--- a/frontend/src/lib/components/triggers/workspaceTriggersList.ts
+++ b/frontend/src/lib/components/triggers/workspaceTriggersList.ts
@@ -79,6 +79,12 @@ export const TRIGGER_KINDS: Record<
 			onError?: (message: string) => void
 		) => Promise<Array<Record<string, any>>>
 		create?: (workspace: string, requestBody: any) => Promise<unknown>
+		/**
+		 * Write back an existing trigger's config. Used to point an imported trigger at a
+		 * resource the workspace already has; `schedule` has none because its own service
+		 * takes a different body shape, handled by the caller.
+		 */
+		update?: (workspace: string, path: string, requestBody: any) => Promise<unknown>
 	}
 > = {
 	http: {
@@ -101,7 +107,9 @@ export const TRIGGER_KINDS: Record<
 		resourceField: 'authentication_resource_path',
 		list: (workspace) => HttpTriggerService.listHttpTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			HttpTriggerService.createHttpTrigger({ workspace, requestBody })
+			HttpTriggerService.createHttpTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			HttpTriggerService.updateHttpTrigger({ workspace, path, requestBody })
 	},
 	websocket: {
 		configFields: [
@@ -119,7 +127,9 @@ export const TRIGGER_KINDS: Record<
 		note: 'Reconnect WebSocket auth after import if external service requires it.',
 		list: (workspace) => WebsocketTriggerService.listWebsocketTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			WebsocketTriggerService.createWebsocketTrigger({ workspace, requestBody })
+			WebsocketTriggerService.createWebsocketTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			WebsocketTriggerService.updateWebsocketTrigger({ workspace, path, requestBody })
 	},
 	schedule: {
 		configFields: [
@@ -180,7 +190,9 @@ export const TRIGGER_KINDS: Record<
 		eeOnly: true,
 		list: (workspace) => KafkaTriggerService.listKafkaTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			KafkaTriggerService.createKafkaTrigger({ workspace, requestBody })
+			KafkaTriggerService.createKafkaTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			KafkaTriggerService.updateKafkaTrigger({ workspace, path, requestBody })
 	},
 	nats: {
 		configFields: [
@@ -197,7 +209,9 @@ export const TRIGGER_KINDS: Record<
 		eeOnly: true,
 		list: (workspace) => NatsTriggerService.listNatsTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			NatsTriggerService.createNatsTrigger({ workspace, requestBody })
+			NatsTriggerService.createNatsTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			NatsTriggerService.updateNatsTrigger({ workspace, path, requestBody })
 	},
 	sqs: {
 		configFields: [
@@ -212,7 +226,9 @@ export const TRIGGER_KINDS: Record<
 		eeOnly: true,
 		list: (workspace) => SqsTriggerService.listSqsTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			SqsTriggerService.createSqsTrigger({ workspace, requestBody })
+			SqsTriggerService.createSqsTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			SqsTriggerService.updateSqsTrigger({ workspace, path, requestBody })
 	},
 	mqtt: {
 		configFields: [
@@ -228,7 +244,9 @@ export const TRIGGER_KINDS: Record<
 		resourceField: 'mqtt_resource_path',
 		list: (workspace) => MqttTriggerService.listMqttTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			MqttTriggerService.createMqttTrigger({ workspace, requestBody })
+			MqttTriggerService.createMqttTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			MqttTriggerService.updateMqttTrigger({ workspace, path, requestBody })
 	},
 	amqp: {
 		configFields: ['amqp_resource_path', 'queue_name', 'exchange', 'options'],
@@ -238,7 +256,9 @@ export const TRIGGER_KINDS: Record<
 		resourceField: 'amqp_resource_path',
 		list: (workspace) => AmqpTriggerService.listAmqpTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			AmqpTriggerService.createAmqpTrigger({ workspace, requestBody })
+			AmqpTriggerService.createAmqpTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			AmqpTriggerService.updateAmqpTrigger({ workspace, path, requestBody })
 	},
 	gcp: {
 		configFields: [
@@ -256,7 +276,9 @@ export const TRIGGER_KINDS: Record<
 		eeOnly: true,
 		list: (workspace) => GcpTriggerService.listGcpTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			GcpTriggerService.createGcpTrigger({ workspace, requestBody })
+			GcpTriggerService.createGcpTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			GcpTriggerService.updateGcpTrigger({ workspace, path, requestBody })
 	},
 	azure: {
 		configFields: [
@@ -274,7 +296,9 @@ export const TRIGGER_KINDS: Record<
 		eeOnly: true,
 		list: (workspace) => AzureTriggerService.listAzureTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			AzureTriggerService.createAzureTrigger({ workspace, requestBody })
+			AzureTriggerService.createAzureTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			AzureTriggerService.updateAzureTrigger({ workspace, path, requestBody })
 	},
 	postgres: {
 		configFields: [
@@ -288,7 +312,9 @@ export const TRIGGER_KINDS: Record<
 		resourceField: 'postgres_resource_path',
 		list: (workspace) => PostgresTriggerService.listPostgresTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			PostgresTriggerService.createPostgresTrigger({ workspace, requestBody })
+			PostgresTriggerService.createPostgresTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			PostgresTriggerService.updatePostgresTrigger({ workspace, path, requestBody })
 	},
 	email: {
 		configFields: ['local_part', 'workspaced_local_part'],
@@ -297,7 +323,9 @@ export const TRIGGER_KINDS: Record<
 		note: 'Email address regenerates on import.',
 		list: (workspace) => EmailTriggerService.listEmailTriggers({ workspace }),
 		create: (workspace, requestBody) =>
-			EmailTriggerService.createEmailTrigger({ workspace, requestBody })
+			EmailTriggerService.createEmailTrigger({ workspace, requestBody }),
+		update: (workspace, path, requestBody) =>
+			EmailTriggerService.updateEmailTrigger({ workspace, path, requestBody })
 	}
 }
 

--- a/frontend/src/lib/components/workspaceSettings/projectBundle.test.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectBundle.test.ts
@@ -16,6 +16,7 @@ import {
 	collectExportVarPaths,
 	extractTriggerConfigResourceRefs,
 	extractVarRefsFromValue,
+	projectReferencesResource,
 	type ProjectExport,
 	type FetchedItem,
 	type ItemRef
@@ -865,5 +866,33 @@ describe('flow_env and preprocessor_module', () => {
 		expect(out.preprocessor_module.value.path).toBe('f/proj/preproc')
 		expect(out.flow_env.SLACK).toBe('$res:f/proj/slack')
 		expect(out.flow_env.PLAIN).toBe('not-a-ref')
+	})
+})
+
+describe('projectReferencesResource', () => {
+	/**
+	 * A project declares one resource per `resource-<type>` input schema as well as one per
+	 * `$res:` reference, so an app pinning `f/proj/google_calendar` for a script whose schema
+	 * says `resource-gcal` ships both it and an unreferenced `f/proj/gcal`. Only the pinned
+	 * one has to hold a credential for the project to work.
+	 */
+	const bundle = {
+		project: { slug: 'proj', name: 'Proj', summary: '', readme: null },
+		scripts: [{ path: 'f/proj/send', content: 'const c = "$res:f/proj/google_calendar"' }],
+		flows: [],
+		apps: [],
+		resources: [
+			{ path: 'f/proj/gcal', resource_type: 'gcal' },
+			{ path: 'f/proj/google_calendar', resource_type: 'gcal' },
+			{ path: 'f/proj/db', resource_type: 'postgresql' }
+		],
+		triggers: [{ path: 'f/proj/ingest', config: { postgres_resource_path: 'f/proj/db' } }]
+	} as unknown as ProjectExport
+
+	it('sees a $res: token and a trigger\'s bare path, and not a stub nothing points at', () => {
+		expect(projectReferencesResource(bundle, 'f/proj/google_calendar')).toBe(true)
+		expect(projectReferencesResource(bundle, 'f/proj/db')).toBe(true)
+		// Declared only because a script's input schema names the type.
+		expect(projectReferencesResource(bundle, 'f/proj/gcal')).toBe(false)
 	})
 })

--- a/frontend/src/lib/components/workspaceSettings/projectBundle.test.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectBundle.test.ts
@@ -17,6 +17,7 @@ import {
 	extractTriggerConfigResourceRefs,
 	extractVarRefsFromValue,
 	projectReferencesResource,
+	textHoldsBarePath,
 	type ProjectExport,
 	type FetchedItem,
 	type ItemRef
@@ -894,5 +895,20 @@ describe('projectReferencesResource', () => {
 		expect(projectReferencesResource(bundle, 'f/proj/db')).toBe(true)
 		// Declared only because a script's input schema names the type.
 		expect(projectReferencesResource(bundle, 'f/proj/gcal')).toBe(false)
+	})
+})
+
+describe('textHoldsBarePath', () => {
+	// Gates three deletion decisions, and its two directions cost differently: a false yes
+	// keeps a stub nobody needed, a false no deletes one something still reads.
+	const P = 'f/proj/db'
+	it.each([
+		['a token only', `const c = "$res:${P}"`, false],
+		['a path written in code', `await getResource("${P}")`, true],
+		['both spellings', `"$res:${P}"; getResource("${P}")`, true],
+		['a longer path that starts the same', `await getResource("${P}_prod")`, false],
+		['the same path inside a longer token', `"$res:${P}_prod"`, false]
+	])('%s', (_label, text, expected) => {
+		expect(textHoldsBarePath(text, P)).toBe(expected)
 	})
 })

--- a/frontend/src/lib/components/workspaceSettings/projectBundle.test.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectBundle.test.ts
@@ -890,7 +890,7 @@ describe('projectReferencesResource', () => {
 		triggers: [{ path: 'f/proj/ingest', config: { postgres_resource_path: 'f/proj/db' } }]
 	} as unknown as ProjectExport
 
-	it('sees a $res: token and a trigger\'s bare path, and not a stub nothing points at', () => {
+	it("sees a $res: token and a trigger's bare path, and not a stub nothing points at", () => {
 		expect(projectReferencesResource(bundle, 'f/proj/google_calendar')).toBe(true)
 		expect(projectReferencesResource(bundle, 'f/proj/db')).toBe(true)
 		// Declared only because a script's input schema names the type.

--- a/frontend/src/lib/components/workspaceSettings/projectBundle.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectBundle.ts
@@ -263,6 +263,27 @@ export function referencesResourcePath(value: unknown, path: string): boolean {
 }
 
 /**
+ * Whether a `$res:`/`res://` token for this path survives anywhere in the value — the one
+ * spelling the rewriters relocate, and so the only one whose survival means a rewrite did
+ * not take. A bare path is deliberately not matched: nothing here moves one, so its presence
+ * says nothing about whether the rewrite worked.
+ */
+export function holdsResourceToken(value: unknown, path: string): boolean {
+	const walk = (v: any): boolean => {
+		if (typeof v === 'string') {
+			RES_TOKEN_RE.lastIndex = 0
+			let m: RegExpExecArray | null
+			while ((m = RES_TOKEN_RE.exec(v)) !== null) if (m[1] === path) return true
+			return false
+		}
+		if (Array.isArray(v)) return v.some(walk)
+		if (v && typeof v === 'object') return Object.values(v).some(walk)
+		return false
+	}
+	return walk(value)
+}
+
+/**
  * Whether the text names the resource somewhere no rewriter reaches — a path written on its
  * own rather than inside a `$res:` token, the way `getResource("f/proj/db")` does. The
  * tokens are stripped first so the ones a rewrite would move do not count, and the match is

--- a/frontend/src/lib/components/workspaceSettings/projectBundle.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectBundle.ts
@@ -263,6 +263,23 @@ export function referencesResourcePath(value: unknown, path: string): boolean {
 }
 
 /**
+ * Whether the text names the resource somewhere no rewriter reaches — a path written on its
+ * own rather than inside a `$res:` token, the way `getResource("f/proj/db")` does. The
+ * tokens are stripped first so the ones a rewrite would move do not count, and the match is
+ * bounded so `f/proj/db` is not found inside `f/proj/db_prod`.
+ */
+export function textHoldsBarePath(text: string, path: string): boolean {
+	const withoutTokens = text.replace(RES_TOKEN_RE, '')
+	const boundary = /[\w\-./]/
+	for (let i = withoutTokens.indexOf(path); i !== -1; i = withoutTokens.indexOf(path, i + 1)) {
+		const before = withoutTokens[i - 1] ?? ''
+		const after = withoutTokens[i + path.length] ?? ''
+		if (!boundary.test(before) && !boundary.test(after)) return true
+	}
+	return false
+}
+
+/**
  * Whether anything the project ships points at one of its own resources.
  *
  * A project declares two kinds of resource. One is referenced — an app pins `$res:` for a
@@ -276,7 +293,11 @@ export function referencesResourcePath(value: unknown, path: string): boolean {
  */
 export function projectReferencesResource(bundle: ProjectExport, path: string): boolean {
 	const { resources: _resources, ...rest } = bundle as any
-	return referencesResourcePath(rest, path)
+	if (referencesResourcePath(rest, path)) return true
+	// A script that reads the resource by name rather than through a `$res:` token still needs
+	// it filled in. Asked about is the safe side of this answer: the cost of a wrong yes is a
+	// row nobody had to act on, and of a wrong no a credential nobody was told to set up.
+	return textHoldsBarePath(JSON.stringify(rest ?? {}), path)
 }
 
 /**

--- a/frontend/src/lib/components/workspaceSettings/projectBundle.ts
+++ b/frontend/src/lib/components/workspaceSettings/projectBundle.ts
@@ -239,6 +239,47 @@ export function extractTriggerConfigResourceRefs(config: any): string[] {
 }
 
 /**
+ * Whether a value reaches a resource, in either spelling a rewrite has to handle: a
+ * `$res:`/`res://` token embedded in content, or the bare path standing alone as a string
+ * the way trigger configs hold it (`kafka_resource_path: "f/slug/db"`).
+ *
+ * Matching the parsed structure rather than its serialization is what keeps
+ * `f/slug/db` out of `$res:f/slug/db_prod`.
+ */
+export function referencesResourcePath(value: unknown, path: string): boolean {
+	const walk = (v: any): boolean => {
+		if (typeof v === 'string') {
+			if (v === path) return true
+			RES_TOKEN_RE.lastIndex = 0
+			let m: RegExpExecArray | null
+			while ((m = RES_TOKEN_RE.exec(v)) !== null) if (m[1] === path) return true
+			return false
+		}
+		if (Array.isArray(v)) return v.some(walk)
+		if (v && typeof v === 'object') return Object.values(v).some(walk)
+		return false
+	}
+	return walk(value)
+}
+
+/**
+ * Whether anything the project ships points at one of its own resources.
+ *
+ * A project declares two kinds of resource. One is referenced — an app pins `$res:` for a
+ * script argument, a trigger names it — and the project does not work until it holds a
+ * credential. The other is minted from a `resource-<type>` input schema: it names a type
+ * a script accepts, nothing points at it, and a standalone run picks a resource in the
+ * argument picker instead. Only the first kind is worth asking anyone to fill in.
+ *
+ * The `resources` list is excluded from the walk because a stub's own declaration carries
+ * its path, which would make every stub look referenced.
+ */
+export function projectReferencesResource(bundle: ProjectExport, path: string): boolean {
+	const { resources: _resources, ...rest } = bundle as any
+	return referencesResourcePath(rest, path)
+}
+
+/**
  * Trigger configs reference resources as plain path strings (e.g.
  * `kafka_resource_path: "f/slug/db"`), not `$res:` tokens, so token rewriting
  * misses them. Deep-walk the config and remap any string that exact-matches a

--- a/frontend/src/lib/importWizard/execution.svelte.ts
+++ b/frontend/src/lib/importWizard/execution.svelte.ts
@@ -8,9 +8,10 @@ import {
 	installProject,
 	type InstallResult
 } from '$lib/components/workspaceSettings/projectInstall'
-import type {
-	ProjectExport,
-	ProjectMigration
+import {
+	projectReferencesResource,
+	type ProjectExport,
+	type ProjectMigration
 } from '$lib/components/workspaceSettings/projectBundle'
 import { planWorkspaceId, type ImportPlan } from './plan'
 import { probeImportedPaths, probeWorkspace } from './probe'
@@ -110,12 +111,16 @@ export class ImportExecution {
 	}
 
 	/**
-	 * How many resources the project shipped. Every one arrives as an empty stub —
-	 * the hub never publishes resource values — so a non-zero count means the setup
-	 * step has something to offer.
+	 * How many of the project's resources the setup step will ask about. Every resource
+	 * arrives as an empty stub — the hub never publishes resource values — but only the ones
+	 * something in the project points at have to hold a credential for it to work, and those
+	 * are the ones the step lists. Counting all of them here would offer a fourth step that
+	 * then has nothing on it.
 	 */
 	get resourceCount(): number {
-		return this.#export?.resources?.length ?? 0
+		const e = this.#export
+		if (!e) return 0
+		return (e.resources ?? []).filter((r) => projectReferencesResource(e, String(r.path))).length
 	}
 
 	get extraCounts(): { triggers: number; migrations: number } | undefined {

--- a/frontend/src/lib/importWizard/execution.svelte.ts
+++ b/frontend/src/lib/importWizard/execution.svelte.ts
@@ -458,9 +458,7 @@ export class ImportExecution {
 		const problems: string[] = []
 		if (failed > 0) problems.push(`${failed} item${failed === 1 ? '' : 's'} failed to import`)
 		if (badMigrations > 0) {
-			problems.push(
-				`${badMigrations} data table migration${badMigrations === 1 ? '' : 's'} failed`
-			)
+			problems.push(`${badMigrations} data table migration${badMigrations === 1 ? '' : 's'} failed`)
 		}
 		if (problems.length) this.error = `${problems.join(', ')}.`
 	}

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -13,6 +13,7 @@ const state = vi.hoisted(() => ({
 	triggers: [] as any[],
 	scheduleListError: undefined as any,
 	failingTriggerPath: undefined as string | undefined,
+	deployedJs: 'COMPILED',
 	deletedResources: [] as string[],
 	updatedRawApps: [] as any[],
 	updatedTriggers: [] as any[]
@@ -74,7 +75,7 @@ vi.stubGlobal(
 	vi.fn(async (url: string) => ({
 		ok: true,
 		status: 200,
-		text: async () => (url.endsWith('.js') ? 'COMPILED' : 'STYLES')
+		text: async () => (url.endsWith('.js') ? state.deployedJs : 'STYLES')
 	}))
 )
 
@@ -104,6 +105,7 @@ describe('applyRetarget', () => {
 		state.apps = [rawApp]
 		state.scripts = []
 		state.triggers = []
+		state.deployedJs = 'COMPILED'
 		state.scheduleListError = undefined
 		state.failingTriggerPath = undefined
 		state.deletedResources = []
@@ -127,6 +129,30 @@ describe('applyRetarget', () => {
 		expect(Object.keys(sent.formData.app.value.files)).toEqual(['/App.tsx'])
 	})
 
+	// The bundle is compiled from the sources, so a `$res:` a source spells out is baked into
+	// it. `retargetProjectExport` rewrites that copy on import, while /bundle.js is still one
+	// of `files` — sending the deployed bundle back untouched would undo exactly that.
+	it("rewrites the deployed bundle's own tokens before sending it back", async () => {
+		state.deployedJs = `const cfg = "$res:${FROM}"; export default cfg`
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.stubDeleted).toBe(true)
+		const sent = state.updatedRawApps[0]
+		expect(sent.formData.js).toContain(`$res:${TO}`)
+		expect(sent.formData.js).not.toContain(`$res:${FROM}`)
+	})
+
+	// A path the bundle names any other way is one nothing here can move, so the app is left
+	// alone and the stub it still reads has to survive.
+	it('keeps the stub when the bundle names the resource outside a $res: token', async () => {
+		state.deployedJs = `const cfg = await getResource("${FROM}")`
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.stubDeleted).toBe(false)
+		expect(state.deletedResources).toEqual([])
+		expect(state.updatedRawApps).toEqual([])
+	})
+
 	// A trigger holds its resource as a bare path in its own column, not as a `$res:` token.
 	// Matching only the token spelling left the trigger on a stub that was then deleted.
 	it('finds a trigger that holds the resource as a bare path', async () => {
@@ -136,6 +162,7 @@ describe('applyRetarget', () => {
 				path: 'f/proj/ingest',
 				script_path: 'f/proj/run',
 				postgres_resource_path: FROM,
+				permissioned_as: 'u/service_account',
 				enabled: true
 			}
 		]
@@ -147,6 +174,10 @@ describe('applyRetarget', () => {
 		// Pointing a trigger at a credential must not also start it: `enabled` is left out so
 		// the backend keeps whatever the trigger is set to.
 		expect(state.updatedTriggers[0].body).not.toHaveProperty('enabled')
+		// Nor run it as whoever picked the credential: a trigger states its identity as
+		// `permissioned_as`, which the backend keeps only when told to preserve it.
+		expect(state.updatedTriggers[0].body.permissioned_as).toBe('u/service_account')
+		expect(state.updatedTriggers[0].body.preserve_permissioned_as).toBe(true)
 		expect(state.deletedResources).toEqual([FROM])
 	})
 

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -98,7 +98,8 @@ async function run() {
 		workspace: 'w',
 		folder: 'proj',
 		from: FROM,
-		to: TO
+		to: TO,
+		seesWholeWorkspace: true
 	})
 }
 
@@ -306,6 +307,23 @@ describe('applyRetarget', () => {
 		const sent = state.updatedFlows[0]
 		expect(sent.requestBody.value.modules[0].summary).toBe(`reads $res:${TO}`)
 		expect(sent.requestBody.value.modules[0].value.path).toBe(FROM)
+	})
+
+	// The listings run as the caller and row-level security filters them inside the query, so
+	// an item a member cannot read is invisible rather than counted. The stub has to outlive
+	// a scan that cannot see the whole workspace.
+	it('keeps the stub when the caller is not shown the whole workspace', async () => {
+		const outcome = await applyRetarget({
+			workspace: 'w',
+			folder: 'proj',
+			from: FROM,
+			to: TO,
+			seesWholeWorkspace: false
+		})
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.stubDeleted).toBe(false)
+		expect(state.deletedResources).toEqual([])
+		expect(outcome.gaps.map((g) => g.path)).toContain('This workspace')
 	})
 
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -8,8 +8,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => ({
 	apps: [] as any[],
+	triggers: [] as any[],
 	deletedResources: [] as string[],
-	updatedRawApps: [] as any[]
+	updatedRawApps: [] as any[],
+	updatedTriggers: [] as any[]
 }))
 
 vi.mock('$lib/gen', () => ({
@@ -36,8 +38,17 @@ vi.mock('$lib/gen', () => ({
 }))
 
 vi.mock('$lib/components/triggers/workspaceTriggersList', () => ({
-	TRIGGER_KINDS: { schedule: { badge: 'Schedule', list: vi.fn(async () => []) } },
-	WORKSPACE_TRIGGER_KINDS: ['schedule'],
+	TRIGGER_KINDS: {
+		schedule: { badge: 'Schedule', list: vi.fn(async () => []) },
+		postgres: {
+			badge: 'Postgres',
+			list: vi.fn(async () => state.triggers),
+			update: vi.fn(async (_w: string, path: string, body: any) =>
+				state.updatedTriggers.push({ path, body })
+			)
+		}
+	},
+	WORKSPACE_TRIGGER_KINDS: ['schedule', 'postgres'],
 	createWorkspaceTriggerDisabled: vi.fn(),
 	triggerHandlerRefs: () => []
 }))
@@ -76,8 +87,10 @@ async function run(exported?: typeof exportedFiles) {
 describe('applyRetarget', () => {
 	beforeEach(() => {
 		state.apps = [rawApp({ '/App.tsx': 'v1' })]
+		state.triggers = []
 		state.deletedResources = []
 		state.updatedRawApps = []
+		state.updatedTriggers = []
 	})
 
 	it("re-uploads the export's bundle rather than rebuilding it, then drops the stub", async () => {
@@ -108,5 +121,20 @@ describe('applyRetarget', () => {
 		const outcome = await run({})
 		expect(outcome.error).toContain('does not describe')
 		expect(state.deletedResources).toEqual([])
+	})
+
+	// A trigger holds its resource as a bare path in its own column, not as a `$res:` token.
+	// Matching only the token spelling left the trigger on a stub that was then deleted.
+	it('finds a trigger that holds the resource as a bare path', async () => {
+		state.apps = []
+		state.triggers = [
+			{ path: 'f/proj/ingest', script_path: 'f/proj/run', postgres_resource_path: FROM }
+		]
+		const outcome = await run(exportedFiles)
+		expect(outcome.error).toBeUndefined()
+		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
+		// The trigger keeps its own path even though it was the string being remapped.
+		expect(state.updatedTriggers[0].path).toBe('f/proj/ingest')
+		expect(state.deletedResources).toEqual([FROM])
 	})
 })

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -153,6 +153,25 @@ describe('applyRetarget', () => {
 		expect(state.updatedRawApps).toEqual([])
 	})
 
+	// The path written inside a source file is a reference too, and no rewriter reaches it.
+	// Seeing only whole-string matches left this app un-gapped and the stub was deleted.
+	it('keeps the stub when a source file names the resource in code', async () => {
+		state.apps = [
+			{
+				path: 'f/proj/dash',
+				value: {
+					files: { '/App.tsx': `const c = await getResource("${FROM}")` },
+					runnables: {}
+				}
+			}
+		]
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.stubDeleted).toBe(false)
+		expect(state.deletedResources).toEqual([])
+		expect(state.updatedRawApps).toEqual([])
+	})
+
 	// A trigger holds its resource as a bare path in its own column, not as a `$res:` token.
 	// Matching only the token spelling left the trigger on a stub that was then deleted.
 	it('finds a trigger that holds the resource as a bare path', async () => {

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
 	scripts: [] as any[],
 	triggers: [] as any[],
 	scheduleListError: undefined as any,
+	failingTriggerPath: undefined as string | undefined,
 	deletedResources: [] as string[],
 	updatedRawApps: [] as any[],
 	updatedTriggers: [] as any[]
@@ -53,9 +54,10 @@ vi.mock('$lib/components/triggers/workspaceTriggersList', () => ({
 		postgres: {
 			badge: 'Postgres',
 			list: vi.fn(async () => state.triggers),
-			update: vi.fn(async (_w: string, path: string, body: any) =>
+			update: vi.fn(async (_w: string, path: string, body: any) => {
+				if (path === state.failingTriggerPath) throw new Error('the update was rejected')
 				state.updatedTriggers.push({ path, body })
-			)
+			})
 		}
 	},
 	WORKSPACE_TRIGGER_KINDS: ['schedule', 'postgres'],
@@ -103,6 +105,7 @@ describe('applyRetarget', () => {
 		state.scripts = []
 		state.triggers = []
 		state.scheduleListError = undefined
+		state.failingTriggerPath = undefined
 		state.deletedResources = []
 		state.updatedRawApps = []
 		state.updatedTriggers = []
@@ -129,14 +132,38 @@ describe('applyRetarget', () => {
 	it('finds a trigger that holds the resource as a bare path', async () => {
 		state.apps = []
 		state.triggers = [
-			{ path: 'f/proj/ingest', script_path: 'f/proj/run', postgres_resource_path: FROM }
+			{
+				path: 'f/proj/ingest',
+				script_path: 'f/proj/run',
+				postgres_resource_path: FROM,
+				enabled: true
+			}
 		]
 		const outcome = await run()
 		expect(outcome.error).toBeUndefined()
 		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
 		// The trigger keeps its own path even though it was the string being remapped.
 		expect(state.updatedTriggers[0].path).toBe('f/proj/ingest')
+		// Pointing a trigger at a credential must not also start it: `enabled` is left out so
+		// the backend keeps whatever the trigger is set to.
+		expect(state.updatedTriggers[0].body).not.toHaveProperty('enabled')
 		expect(state.deletedResources).toEqual([FROM])
+	})
+
+	// The stub is what a reference this run did not move still resolves through, so a write
+	// that fails partway must not take it: the moved items and the rest both keep working.
+	it('keeps the stub when a write fails, and reports what had already moved', async () => {
+		state.apps = []
+		state.triggers = [
+			{ path: 'f/proj/first', postgres_resource_path: FROM },
+			{ path: 'f/proj/second', postgres_resource_path: FROM }
+		]
+		state.failingTriggerPath = 'f/proj/second'
+		const outcome = await run()
+		expect(outcome.error).toContain('the update was rejected')
+		expect(outcome.rewritten.map((r) => r.path)).toEqual(['f/proj/first'])
+		expect(outcome.stubDeleted).toBe(false)
+		expect(state.deletedResources).toEqual([])
 	})
 
 	// Most trigger kinds are cargo features an instance may not compile in, and their routes

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -90,6 +90,7 @@ const TO = 'f/shared/company_smtp'
 /** A deployed raw app: sources plus runnables, with the bundle stored out of the value. */
 const rawApp = {
 	path: 'f/proj/dash',
+	raw_app: true,
 	value: { files: { '/App.tsx': 'v1' }, runnables: { send: { fields: { smtp: `$res:${FROM}` } } } }
 }
 
@@ -160,11 +161,12 @@ describe('applyRetarget', () => {
 	})
 
 	// The path written inside a source file is a reference too, and no rewriter reaches it.
-	// Seeing only whole-string matches left this app un-gapped and the stub was deleted.
+	//
 	it('keeps the stub when a source file names the resource in code', async () => {
 		state.apps = [
 			{
 				path: 'f/proj/dash',
+				raw_app: true,
 				value: {
 					files: { '/App.tsx': `const c = await getResource("${FROM}")` },
 					runnables: {}
@@ -179,7 +181,6 @@ describe('applyRetarget', () => {
 	})
 
 	// A trigger holds its resource as a bare path in its own column, not as a `$res:` token.
-	// Matching only the token spelling left the trigger on a stub that was then deleted.
 	it('finds a trigger that holds the resource as a bare path', async () => {
 		state.apps = []
 		state.triggers = [
@@ -257,6 +258,7 @@ describe('applyRetarget', () => {
 		state.apps = [
 			{
 				path: 'f/proj/dash',
+				raw_app: true,
 				value: {
 					files: { '/App.tsx': `// the credential lives at ${FROM}` },
 					runnables: { send: { fields: { smtp: `$res:${FROM}` } } }
@@ -291,8 +293,7 @@ describe('applyRetarget', () => {
 		expect(sent.requestBody.value.grid[0].data.path).toBe(FROM)
 	})
 
-	// `rewriteFlowValue` reached module content, static inputs and flow_env only. Rewriting the
-	// serialized value moves a token wherever it sits, and still leaves a step's own path.
+	// A token moves wherever it sits in the value, and a step's own path is left alone.
 	it('moves a flow token outside the fields the import rewriter reached', async () => {
 		state.flows = [
 			{
@@ -326,6 +327,25 @@ describe('applyRetarget', () => {
 		expect(outcome.stubDeleted).toBe(false)
 		expect(state.deletedResources).toEqual([])
 		expect(outcome.gaps.map((g) => g.path)).toContain('This workspace')
+	})
+
+	// A handler field names a runnable, and the map holds a resource path. A script sharing
+	// that path is not the reference being moved.
+	it("moves a trigger's resource field without repointing its error handler", async () => {
+		state.apps = []
+		state.triggers = [
+			{
+				path: 'f/proj/ingest',
+				script_path: 'f/proj/run',
+				postgres_resource_path: FROM,
+				on_failure: `script/${FROM}`,
+				permissioned_as: 'u/service_account'
+			}
+		]
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
+		expect(state.updatedTriggers[0].body.on_failure).toBe(`script/${FROM}`)
 	})
 
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The safety property: a retarget that cannot rewrite every referrer writes nothing at all.
+ * Deleting the stub while an item still points at it is what breaks the imported project,
+ * and that item is exactly the one nobody looks at afterwards.
+ */
+
+const state = vi.hoisted(() => ({
+	apps: [] as any[],
+	deletedResources: [] as string[],
+	updatedRawApps: [] as any[]
+}))
+
+vi.mock('$lib/gen', () => ({
+	ScriptService: {
+		listSearchScript: vi.fn(async () => []),
+		getScriptByPath: vi.fn(),
+		createScript: vi.fn()
+	},
+	FlowService: {
+		listSearchFlow: vi.fn(async () => []),
+		getFlowByPath: vi.fn(),
+		updateFlow: vi.fn()
+	},
+	AppService: {
+		listSearchApp: vi.fn(async () => state.apps),
+		getAppByPath: vi.fn(async ({ path }: any) => state.apps.find((a) => a.path === path)),
+		updateApp: vi.fn(),
+		updateAppRaw: vi.fn(async (p: any) => state.updatedRawApps.push(p))
+	},
+	ScheduleService: { updateSchedule: vi.fn() },
+	ResourceService: {
+		deleteResource: vi.fn(async ({ path }: any) => state.deletedResources.push(path))
+	}
+}))
+
+vi.mock('$lib/components/triggers/workspaceTriggersList', () => ({
+	TRIGGER_KINDS: { schedule: { badge: 'Schedule', list: vi.fn(async () => []) } },
+	WORKSPACE_TRIGGER_KINDS: ['schedule'],
+	createWorkspaceTriggerDisabled: vi.fn(),
+	triggerHandlerRefs: () => []
+}))
+
+vi.mock('$lib/components/apps/editor/appPolicy', () => ({ updatePolicy: vi.fn(async () => ({})) }))
+vi.mock('$lib/sharedUtils', () => ({ updateRawAppPolicy: vi.fn(async () => ({})) }))
+
+import { applyRetarget } from './retargetDeployed'
+
+const FROM = 'f/proj/smtp'
+const TO = 'f/shared/company_smtp'
+
+/** A deployed raw app: sources plus runnables, with the bundle already stripped out. */
+function rawApp(sources: Record<string, string>) {
+	return {
+		path: 'f/proj/dash',
+		value: { files: sources, runnables: { send: { fields: { smtp: `$res:${FROM}` } } } }
+	}
+}
+
+const exportedFiles = {
+	'f/proj/dash': { '/App.tsx': 'v1', '/bundle.js': 'COMPILED', '/bundle.css': 'STYLES' }
+}
+
+async function run(exported?: typeof exportedFiles) {
+	return applyRetarget({
+		workspace: 'w',
+		folder: 'proj',
+		from: FROM,
+		to: TO,
+		hasEeLicense: true,
+		exportedAppFiles: exported
+	})
+}
+
+describe('applyRetarget', () => {
+	beforeEach(() => {
+		state.apps = [rawApp({ '/App.tsx': 'v1' })]
+		state.deletedResources = []
+		state.updatedRawApps = []
+	})
+
+	it("re-uploads the export's bundle rather than rebuilding it, then drops the stub", async () => {
+		const outcome = await run(exportedFiles)
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.stubDeleted).toBe(true)
+		expect(state.deletedResources).toEqual([FROM])
+		const sent = state.updatedRawApps[0]
+		expect(sent.formData.js).toBe('COMPILED')
+		expect(sent.formData.css).toBe('STYLES')
+		// Rewritten, and the bundle entries stay out of the value the way the import leaves them.
+		expect(JSON.stringify(sent.formData.app.value)).toContain(`$res:${TO}`)
+		expect(Object.keys(sent.formData.app.value.files)).toEqual(['/App.tsx'])
+	})
+
+	// The bundle in the export was built from the export's sources. Once the deployed sources
+	// have moved on, re-uploading it would revert whatever was changed since the import.
+	it('refuses when the app has been edited since the import, and writes nothing', async () => {
+		state.apps = [rawApp({ '/App.tsx': 'edited since' })]
+		const outcome = await run(exportedFiles)
+		expect(outcome.error).toContain('edited since the import')
+		expect(outcome.stubDeleted).toBe(false)
+		expect(state.updatedRawApps).toEqual([])
+		expect(state.deletedResources).toEqual([])
+	})
+
+	it('refuses when the export does not describe a raw app it has to rewrite', async () => {
+		const outcome = await run({})
+		expect(outcome.error).toContain('does not describe')
+		expect(state.deletedResources).toEqual([])
+	})
+})

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const state = vi.hoisted(() => ({
 	apps: [] as any[],
 	triggers: [] as any[],
+	scheduleListError: undefined as any,
 	deletedResources: [] as string[],
 	updatedRawApps: [] as any[],
 	updatedTriggers: [] as any[]
@@ -39,7 +40,13 @@ vi.mock('$lib/gen', () => ({
 
 vi.mock('$lib/components/triggers/workspaceTriggersList', () => ({
 	TRIGGER_KINDS: {
-		schedule: { badge: 'Schedule', list: vi.fn(async () => []) },
+		schedule: {
+			badge: 'Schedule',
+			list: vi.fn(async () => {
+				if (state.scheduleListError) throw state.scheduleListError
+				return []
+			})
+		},
 		postgres: {
 			badge: 'Postgres',
 			list: vi.fn(async () => state.triggers),
@@ -88,6 +95,7 @@ describe('applyRetarget', () => {
 	beforeEach(() => {
 		state.apps = [rawApp({ '/App.tsx': 'v1' })]
 		state.triggers = []
+		state.scheduleListError = undefined
 		state.deletedResources = []
 		state.updatedRawApps = []
 		state.updatedTriggers = []
@@ -136,5 +144,42 @@ describe('applyRetarget', () => {
 		// The trigger keeps its own path even though it was the string being remapped.
 		expect(state.updatedTriggers[0].path).toBe('f/proj/ingest')
 		expect(state.deletedResources).toEqual([FROM])
+	})
+
+	// Most trigger kinds are cargo features an instance may not compile in, and their routes
+	// then 404. Reading that as a failed listing refuses every retarget on a stock build.
+	it('runs when a trigger kind is not compiled in, and refuses when one truly fails', async () => {
+		state.scheduleListError = { status: 404 }
+		expect((await run(exportedFiles)).error).toBeUndefined()
+		expect(state.deletedResources).toEqual([FROM])
+
+		state.deletedResources = []
+		state.scheduleListError = { status: 500 }
+		expect((await run(exportedFiles)).error).toContain('Schedule triggers could not be listed')
+		expect(state.deletedResources).toEqual([])
+	})
+
+	// The referrer scan matches a bare path anywhere in an app's value, while the rewriter only
+	// relocates `$res:` tokens and runnable paths. Counting such an app as rewritable orphans it
+	// on a stub that is then deleted.
+	it('refuses an app that holds the resource path as a bare string', async () => {
+		state.apps = [
+			{
+				path: 'f/proj/page',
+				value: { grid: [{ data: { input: { type: 'static', value: FROM } } }] }
+			}
+		]
+		const outcome = await run(exportedFiles)
+		expect(outcome.error).toContain('f/proj/page')
+		expect(state.deletedResources).toEqual([])
+	})
+
+	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page
+	// may not hold the project's own app — and the stub would go anyway.
+	it('refuses when the app listing comes back at its server-side cap', async () => {
+		state.apps = Array.from({ length: 1000 }, (_, i) => ({ path: `f/other/a${i}`, value: {} }))
+		const outcome = await run(exportedFiles)
+		expect(outcome.error).toContain('Apps could not all be listed')
+		expect(state.deletedResources).toEqual([])
 	})
 })

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -31,6 +31,7 @@ vi.mock('$lib/gen', () => ({
 	AppService: {
 		listSearchApp: vi.fn(async () => state.apps),
 		getAppByPath: vi.fn(async ({ path }: any) => state.apps.find((a) => a.path === path)),
+		getPublicSecretOfLatestVersionOfApp: vi.fn(async () => 'secret'),
 		updateApp: vi.fn(),
 		updateAppRaw: vi.fn(async (p: any) => state.updatedRawApps.push(p))
 	},
@@ -65,37 +66,40 @@ vi.mock('$lib/components/triggers/workspaceTriggersList', () => ({
 vi.mock('$lib/components/apps/editor/appPolicy', () => ({ updatePolicy: vi.fn(async () => ({})) }))
 vi.mock('$lib/sharedUtils', () => ({ updateRawAppPolicy: vi.fn(async () => ({})) }))
 
+// The deployed bundle is served by secret, not through the generated client.
+vi.stubGlobal(
+	'fetch',
+	vi.fn(async (url: string) => ({
+		ok: true,
+		status: 200,
+		text: async () => (url.endsWith('.js') ? 'COMPILED' : 'STYLES')
+	}))
+)
+
 import { applyRetarget } from './retargetDeployed'
 
 const FROM = 'f/proj/smtp'
 const TO = 'f/shared/company_smtp'
 
-/** A deployed raw app: sources plus runnables, with the bundle already stripped out. */
-function rawApp(sources: Record<string, string>) {
-	return {
-		path: 'f/proj/dash',
-		value: { files: sources, runnables: { send: { fields: { smtp: `$res:${FROM}` } } } }
-	}
+/** A deployed raw app: sources plus runnables, with the bundle stored out of the value. */
+const rawApp = {
+	path: 'f/proj/dash',
+	value: { files: { '/App.tsx': 'v1' }, runnables: { send: { fields: { smtp: `$res:${FROM}` } } } }
 }
 
-const exportedFiles = {
-	'f/proj/dash': { '/App.tsx': 'v1', '/bundle.js': 'COMPILED', '/bundle.css': 'STYLES' }
-}
-
-async function run(exported?: typeof exportedFiles) {
+async function run() {
 	return applyRetarget({
 		workspace: 'w',
 		folder: 'proj',
 		from: FROM,
 		to: TO,
-		hasEeLicense: true,
-		exportedAppFiles: exported
+		hasEeLicense: true
 	})
 }
 
 describe('applyRetarget', () => {
 	beforeEach(() => {
-		state.apps = [rawApp({ '/App.tsx': 'v1' })]
+		state.apps = [rawApp]
 		state.scripts = []
 		state.triggers = []
 		state.scheduleListError = undefined
@@ -104,8 +108,10 @@ describe('applyRetarget', () => {
 		state.updatedTriggers = []
 	})
 
-	it("re-uploads the export's bundle rather than rebuilding it, then drops the stub", async () => {
-		const outcome = await run(exportedFiles)
+	// `updateAppRaw` refuses without a bundle, and the browser cannot rebuild one. The bundle
+	// that goes back is the deployed one, read back by secret.
+	it('sends the deployed bundle back with the rewritten value, then drops the stub', async () => {
+		const outcome = await run()
 		expect(outcome.error).toBeUndefined()
 		expect(outcome.gaps).toEqual([])
 		expect(outcome.stubDeleted).toBe(true)
@@ -118,24 +124,6 @@ describe('applyRetarget', () => {
 		expect(Object.keys(sent.formData.app.value.files)).toEqual(['/App.tsx'])
 	})
 
-	// The bundle in the export was built from the export's sources. Once the deployed sources
-	// have moved on, re-uploading it would revert whatever was changed since the import.
-	it('leaves a raw app edited since the import alone, and keeps the stub', async () => {
-		state.apps = [rawApp({ '/App.tsx': 'edited since' })]
-		const outcome = await run(exportedFiles)
-		expect(outcome.error).toBeUndefined()
-		expect(outcome.gaps.map((g) => g.reason)).toContain('has been edited since the import')
-		expect(outcome.stubDeleted).toBe(false)
-		expect(state.updatedRawApps).toEqual([])
-		expect(state.deletedResources).toEqual([])
-	})
-
-	it('keeps the stub when the export does not describe a raw app it found', async () => {
-		const outcome = await run({})
-		expect(outcome.gaps.map((g) => g.reason)).toContain('is a raw app the export does not describe')
-		expect(state.deletedResources).toEqual([])
-	})
-
 	// A trigger holds its resource as a bare path in its own column, not as a `$res:` token.
 	// Matching only the token spelling left the trigger on a stub that was then deleted.
 	it('finds a trigger that holds the resource as a bare path', async () => {
@@ -143,7 +131,7 @@ describe('applyRetarget', () => {
 		state.triggers = [
 			{ path: 'f/proj/ingest', script_path: 'f/proj/run', postgres_resource_path: FROM }
 		]
-		const outcome = await run(exportedFiles)
+		const outcome = await run()
 		expect(outcome.error).toBeUndefined()
 		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
 		// The trigger keeps its own path even though it was the string being remapped.
@@ -155,12 +143,12 @@ describe('applyRetarget', () => {
 	// then 404. Reading that as a failed listing keeps the stub on every stock build.
 	it('drops the stub when a trigger kind is not compiled in, keeps it when one truly fails', async () => {
 		state.scheduleListError = { status: 404 }
-		expect((await run(exportedFiles)).gaps).toEqual([])
+		expect((await run()).gaps).toEqual([])
 		expect(state.deletedResources).toEqual([FROM])
 
 		state.deletedResources = []
 		state.scheduleListError = { status: 500 }
-		expect((await run(exportedFiles)).gaps.map((g) => g.path)).toContain('Schedule triggers')
+		expect((await run()).gaps.map((g) => g.path)).toContain('Schedule triggers')
 		expect(state.deletedResources).toEqual([])
 	})
 
@@ -174,7 +162,7 @@ describe('applyRetarget', () => {
 				value: { grid: [{ data: { input: { type: 'static', value: FROM } } }] }
 			}
 		]
-		const outcome = await run(exportedFiles)
+		const outcome = await run()
 		expect(outcome.rewritten).toEqual([])
 		expect(outcome.gaps.map((g) => g.path)).toEqual(['f/proj/page'])
 		expect(state.deletedResources).toEqual([])
@@ -184,7 +172,7 @@ describe('applyRetarget', () => {
 	// may not hold the project's own app — and the stub would go anyway.
 	it('keeps the stub when the app listing comes back at its server-side cap', async () => {
 		state.apps = Array.from({ length: 1000 }, (_, i) => ({ path: `f/other/a${i}`, value: {} }))
-		const outcome = await run(exportedFiles)
+		const outcome = await run()
 		expect(outcome.gaps.map((g) => g.path)).toContain('Apps')
 		expect(state.deletedResources).toEqual([])
 	})
@@ -197,7 +185,7 @@ describe('applyRetarget', () => {
 		state.triggers = [
 			{ path: 'f/proj/ingest', script_path: 'f/proj/run', postgres_resource_path: FROM }
 		]
-		const outcome = await run(exportedFiles)
+		const outcome = await run()
 		expect(outcome.error).toBeUndefined()
 		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
 		expect(outcome.gaps.map((g) => g.path)).toEqual(['u/alice/report'])

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -17,6 +17,8 @@ const state = vi.hoisted(() => ({
 	deletedResources: [] as string[],
 	updatedRawApps: [] as any[],
 	updatedApps: [] as any[],
+	updatedFlows: [] as any[],
+	flows: [] as any[],
 	updatedTriggers: [] as any[]
 }))
 
@@ -27,9 +29,9 @@ vi.mock('$lib/gen', () => ({
 		createScript: vi.fn()
 	},
 	FlowService: {
-		listSearchFlow: vi.fn(async () => []),
-		getFlowByPath: vi.fn(),
-		updateFlow: vi.fn()
+		listSearchFlow: vi.fn(async () => state.flows),
+		getFlowByPath: vi.fn(async ({ path }: any) => state.flows.find((f: any) => f.path === path)),
+		updateFlow: vi.fn(async (p: any) => state.updatedFlows.push(p))
 	},
 	AppService: {
 		listSearchApp: vi.fn(async () => state.apps),
@@ -96,8 +98,7 @@ async function run() {
 		workspace: 'w',
 		folder: 'proj',
 		from: FROM,
-		to: TO,
-		hasEeLicense: true
+		to: TO
 	})
 }
 
@@ -112,6 +113,8 @@ describe('applyRetarget', () => {
 		state.deletedResources = []
 		state.updatedRawApps = []
 		state.updatedApps = []
+		state.flows = []
+		state.updatedFlows = []
 		state.updatedTriggers = []
 	})
 
@@ -285,6 +288,24 @@ describe('applyRetarget', () => {
 		const sent = state.updatedApps[0]
 		expect(sent.requestBody.value.inline).toBe(`$res:${TO}`)
 		expect(sent.requestBody.value.grid[0].data.path).toBe(FROM)
+	})
+
+	// `rewriteFlowValue` reached module content, static inputs and flow_env only. Rewriting the
+	// serialized value moves a token wherever it sits, and still leaves a step's own path.
+	it('moves a flow token outside the fields the import rewriter reached', async () => {
+		state.flows = [
+			{
+				path: 'f/proj/pipeline',
+				value: {
+					modules: [{ id: 'a', summary: `reads $res:${FROM}`, value: { type: 'script', path: FROM } }]
+				}
+			}
+		]
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		const sent = state.updatedFlows[0]
+		expect(sent.requestBody.value.modules[0].summary).toBe(`reads $res:${TO}`)
+		expect(sent.requestBody.value.modules[0].value.path).toBe(FROM)
 	})
 
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -274,7 +274,7 @@ describe('applyRetarget', () => {
 	// Scripts, flows and resources share a path namespace, and the map holds a resource path.
 	// The import's rewriters remap a runnable's own `path` on an exact match, which here would
 	// repoint the step at the credential.
-	it('moves an app\'s tokens without repointing a runnable that shares the path', async () => {
+	it("moves an app's tokens without repointing a runnable that shares the path", async () => {
 		state.apps = [
 			{
 				path: 'f/proj/page',
@@ -298,7 +298,9 @@ describe('applyRetarget', () => {
 			{
 				path: 'f/proj/pipeline',
 				value: {
-					modules: [{ id: 'a', summary: `reads $res:${FROM}`, value: { type: 'script', path: FROM } }]
+					modules: [
+						{ id: 'a', summary: `reads $res:${FROM}`, value: { type: 'script', path: FROM } }
+					]
 				}
 			}
 		]

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -339,6 +339,7 @@ describe('applyRetarget', () => {
 				script_path: 'f/proj/run',
 				postgres_resource_path: FROM,
 				on_failure: `script/${FROM}`,
+				error_handler_path: FROM,
 				permissioned_as: 'u/service_account'
 			}
 		]
@@ -346,6 +347,8 @@ describe('applyRetarget', () => {
 		expect(outcome.error).toBeUndefined()
 		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
 		expect(state.updatedTriggers[0].body.on_failure).toBe(`script/${FROM}`)
+		// The bare spelling too: a handler path is a path and never a `$res:` token.
+		expect(state.updatedTriggers[0].body.error_handler_path).toBe(FROM)
 	})
 
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -82,7 +82,7 @@ vi.stubGlobal(
 	}))
 )
 
-import { applyRetarget } from './retargetDeployed'
+import { applyRetarget, seesWholeWorkspace } from './retargetDeployed'
 
 const FROM = 'f/proj/smtp'
 const TO = 'f/shared/company_smtp'
@@ -349,5 +349,20 @@ describe('applyRetarget', () => {
 		expect(outcome.gaps.map((g) => g.path)).toEqual(['u/alice/report'])
 		expect(outcome.stubDeleted).toBe(false)
 		expect(state.deletedResources).toEqual([])
+	})
+})
+
+describe('seesWholeWorkspace', () => {
+	// The user record is per-workspace and survives a workspace change, so reading `is_admin`
+	// without checking which workspace it describes answers for the wrong one — and a wrong
+	// yes here is what lets an RLS-filtered scan clear the stub for deletion.
+	it.each([
+		['admin of this workspace', { workspace_id: 'w', is_admin: true }, false, true],
+		['admin of another workspace', { workspace_id: 'other', is_admin: true }, false, false],
+		['member of this workspace', { workspace_id: 'w', is_admin: false }, false, false],
+		['superadmin, record stale', { workspace_id: 'other', is_admin: false }, true, true],
+		['no user record', undefined, false, false]
+	])('%s', (_label, user, isSuperadmin, expected) => {
+		expect(seesWholeWorkspace(user as any, isSuperadmin, 'w')).toBe(expected)
 	})
 })

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -16,6 +16,7 @@ const state = vi.hoisted(() => ({
 	deployedJs: 'COMPILED',
 	deletedResources: [] as string[],
 	updatedRawApps: [] as any[],
+	updatedApps: [] as any[],
 	updatedTriggers: [] as any[]
 }))
 
@@ -34,7 +35,7 @@ vi.mock('$lib/gen', () => ({
 		listSearchApp: vi.fn(async () => state.apps),
 		getAppByPath: vi.fn(async ({ path }: any) => state.apps.find((a) => a.path === path)),
 		getPublicSecretOfLatestVersionOfApp: vi.fn(async () => 'secret'),
-		updateApp: vi.fn(),
+		updateApp: vi.fn(async (p: any) => state.updatedApps.push(p)),
 		updateAppRaw: vi.fn(async (p: any) => state.updatedRawApps.push(p))
 	},
 	ScheduleService: { updateSchedule: vi.fn() },
@@ -110,6 +111,7 @@ describe('applyRetarget', () => {
 		state.failingTriggerPath = undefined
 		state.deletedResources = []
 		state.updatedRawApps = []
+		state.updatedApps = []
 		state.updatedTriggers = []
 	})
 
@@ -263,6 +265,26 @@ describe('applyRetarget', () => {
 		expect(outcome.gaps.map((g) => g.path)).toEqual(['f/proj/dash'])
 		expect(outcome.stubDeleted).toBe(false)
 		expect(JSON.stringify(state.updatedRawApps[0].formData.app.value)).toContain(`$res:${TO}`)
+	})
+
+	// Scripts, flows and resources share a path namespace, and the map holds a resource path.
+	// The import's rewriters remap a runnable's own `path` on an exact match, which here would
+	// repoint the step at the credential.
+	it('moves an app\'s tokens without repointing a runnable that shares the path', async () => {
+		state.apps = [
+			{
+				path: 'f/proj/page',
+				value: {
+					grid: [{ data: { type: 'runnableByPath', runType: 'script', path: FROM } }],
+					inline: `$res:${FROM}`
+				}
+			}
+		]
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		const sent = state.updatedApps[0]
+		expect(sent.requestBody.value.inline).toBe(`$res:${TO}`)
+		expect(sent.requestBody.value.grid[0].data.path).toBe(FROM)
 	})
 
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
- * The safety property: a retarget that cannot rewrite every referrer writes nothing at all.
- * Deleting the stub while an item still points at it is what breaks the imported project,
- * and that item is exactly the one nobody looks at afterwards.
+ * The safety property: the stub survives anything the scan cannot account for. Rewriting an
+ * item onto the chosen resource is safe on its own, so it always happens; deleting the stub
+ * while an item still reads it is what breaks the imported project, and that item is exactly
+ * the one nobody looks at afterwards.
  */
 
 const state = vi.hoisted(() => ({
 	apps: [] as any[],
+	scripts: [] as any[],
 	triggers: [] as any[],
 	scheduleListError: undefined as any,
 	deletedResources: [] as string[],
@@ -17,7 +19,7 @@ const state = vi.hoisted(() => ({
 
 vi.mock('$lib/gen', () => ({
 	ScriptService: {
-		listSearchScript: vi.fn(async () => []),
+		listSearchScript: vi.fn(async () => state.scripts),
 		getScriptByPath: vi.fn(),
 		createScript: vi.fn()
 	},
@@ -94,6 +96,7 @@ async function run(exported?: typeof exportedFiles) {
 describe('applyRetarget', () => {
 	beforeEach(() => {
 		state.apps = [rawApp({ '/App.tsx': 'v1' })]
+		state.scripts = []
 		state.triggers = []
 		state.scheduleListError = undefined
 		state.deletedResources = []
@@ -104,6 +107,7 @@ describe('applyRetarget', () => {
 	it("re-uploads the export's bundle rather than rebuilding it, then drops the stub", async () => {
 		const outcome = await run(exportedFiles)
 		expect(outcome.error).toBeUndefined()
+		expect(outcome.gaps).toEqual([])
 		expect(outcome.stubDeleted).toBe(true)
 		expect(state.deletedResources).toEqual([FROM])
 		const sent = state.updatedRawApps[0]
@@ -116,18 +120,19 @@ describe('applyRetarget', () => {
 
 	// The bundle in the export was built from the export's sources. Once the deployed sources
 	// have moved on, re-uploading it would revert whatever was changed since the import.
-	it('refuses when the app has been edited since the import, and writes nothing', async () => {
+	it('leaves a raw app edited since the import alone, and keeps the stub', async () => {
 		state.apps = [rawApp({ '/App.tsx': 'edited since' })]
 		const outcome = await run(exportedFiles)
-		expect(outcome.error).toContain('edited since the import')
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.gaps.map((g) => g.reason)).toContain('has been edited since the import')
 		expect(outcome.stubDeleted).toBe(false)
 		expect(state.updatedRawApps).toEqual([])
 		expect(state.deletedResources).toEqual([])
 	})
 
-	it('refuses when the export does not describe a raw app it has to rewrite', async () => {
+	it('keeps the stub when the export does not describe a raw app it found', async () => {
 		const outcome = await run({})
-		expect(outcome.error).toContain('does not describe')
+		expect(outcome.gaps.map((g) => g.reason)).toContain('is a raw app the export does not describe')
 		expect(state.deletedResources).toEqual([])
 	})
 
@@ -147,22 +152,22 @@ describe('applyRetarget', () => {
 	})
 
 	// Most trigger kinds are cargo features an instance may not compile in, and their routes
-	// then 404. Reading that as a failed listing refuses every retarget on a stock build.
-	it('runs when a trigger kind is not compiled in, and refuses when one truly fails', async () => {
+	// then 404. Reading that as a failed listing keeps the stub on every stock build.
+	it('drops the stub when a trigger kind is not compiled in, keeps it when one truly fails', async () => {
 		state.scheduleListError = { status: 404 }
-		expect((await run(exportedFiles)).error).toBeUndefined()
+		expect((await run(exportedFiles)).gaps).toEqual([])
 		expect(state.deletedResources).toEqual([FROM])
 
 		state.deletedResources = []
 		state.scheduleListError = { status: 500 }
-		expect((await run(exportedFiles)).error).toContain('Schedule triggers could not be listed')
+		expect((await run(exportedFiles)).gaps.map((g) => g.path)).toContain('Schedule triggers')
 		expect(state.deletedResources).toEqual([])
 	})
 
 	// The referrer scan matches a bare path anywhere in an app's value, while the rewriter only
-	// relocates `$res:` tokens and runnable paths. Counting such an app as rewritable orphans it
-	// on a stub that is then deleted.
-	it('refuses an app that holds the resource path as a bare string', async () => {
+	// relocates `$res:` tokens and runnable paths. Rewriting such an app would claim a move that
+	// did not happen, and the stub it still reads would go.
+	it('leaves an app holding the resource path as a bare string alone, and keeps the stub', async () => {
 		state.apps = [
 			{
 				path: 'f/proj/page',
@@ -170,16 +175,33 @@ describe('applyRetarget', () => {
 			}
 		]
 		const outcome = await run(exportedFiles)
-		expect(outcome.error).toContain('f/proj/page')
+		expect(outcome.rewritten).toEqual([])
+		expect(outcome.gaps.map((g) => g.path)).toEqual(['f/proj/page'])
 		expect(state.deletedResources).toEqual([])
 	})
 
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page
 	// may not hold the project's own app — and the stub would go anyway.
-	it('refuses when the app listing comes back at its server-side cap', async () => {
+	it('keeps the stub when the app listing comes back at its server-side cap', async () => {
 		state.apps = Array.from({ length: 1000 }, (_, i) => ({ path: `f/other/a${i}`, value: {} }))
 		const outcome = await run(exportedFiles)
-		expect(outcome.error).toContain('Apps could not all be listed')
+		expect(outcome.gaps.map((g) => g.path)).toContain('Apps')
+		expect(state.deletedResources).toEqual([])
+	})
+
+	// The listings are workspace-wide. An item outside the project's folder is the user's own,
+	// so it is not rewritten — and it is exactly why the stub it reads has to stay.
+	it('rewrites what it owns and keeps the stub for a reference outside the project', async () => {
+		state.apps = []
+		state.scripts = [{ path: 'u/alice/report', content: `$res:${FROM}` }]
+		state.triggers = [
+			{ path: 'f/proj/ingest', script_path: 'f/proj/run', postgres_resource_path: FROM }
+		]
+		const outcome = await run(exportedFiles)
+		expect(outcome.error).toBeUndefined()
+		expect(state.updatedTriggers[0].body.postgres_resource_path).toBe(TO)
+		expect(outcome.gaps.map((g) => g.path)).toEqual(['u/alice/report'])
+		expect(outcome.stubDeleted).toBe(false)
 		expect(state.deletedResources).toEqual([])
 	})
 })

--- a/frontend/src/lib/importWizard/retargetDeployed.test.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.test.ts
@@ -245,6 +245,26 @@ describe('applyRetarget', () => {
 		expect(state.deletedResources).toEqual([])
 	})
 
+	// Both spellings at once. The token is moved so the item stops depending on the stub for
+	// what it could, and the mention it spells out still keeps the stub alive.
+	it('rewrites the token of an app that also names the resource in code, and keeps the stub', async () => {
+		state.apps = [
+			{
+				path: 'f/proj/dash',
+				value: {
+					files: { '/App.tsx': `// the credential lives at ${FROM}` },
+					runnables: { send: { fields: { smtp: `$res:${FROM}` } } }
+				}
+			}
+		]
+		const outcome = await run()
+		expect(outcome.error).toBeUndefined()
+		expect(outcome.rewritten.map((r) => r.path)).toEqual(['f/proj/dash'])
+		expect(outcome.gaps.map((g) => g.path)).toEqual(['f/proj/dash'])
+		expect(outcome.stubDeleted).toBe(false)
+		expect(JSON.stringify(state.updatedRawApps[0].formData.app.value)).toContain(`$res:${TO}`)
+	})
+
 	// `listSearchApp` caps at 1000 rows server-side, unordered and unpaginated, so a full page
 	// may not hold the project's own app — and the stub would go anyway.
 	it('keeps the stub when the app listing comes back at its server-side cap', async () => {

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -24,10 +24,7 @@
 
 import { AppService, FlowService, ResourceService, ScheduleService, ScriptService } from '$lib/gen'
 import {
-	rewriteAppValue,
 	rewriteContent,
-	rewriteFlowValue,
-	rewriteRawAppContent,
 	rewriteTriggerConfig,
 	referencesResourcePath,
 	holdsResourceToken,
@@ -309,6 +306,20 @@ export async function applyRetarget(args: {
 	return { rewritten, gaps, stubDeleted: true }
 }
 
+/**
+ * The rewrite this module needs: `$res:` tokens and nothing else.
+ *
+ * `rewriteFlowValue` and `rewriteAppValue` also remap a runnable's own `path` on an exact
+ * match. That is right for the folder-wide map the import hands them, where every path is
+ * moving. Here the map holds one entry, a resource path — and scripts, flows and resources
+ * share a namespace, so a project shipping both a script and a resource named `smtp` would
+ * have the step calling `f/<folder>/smtp` repointed at the credential. Rewriting the
+ * serialized value moves the tokens and leaves every path alone.
+ */
+function rewriteTokens<T>(value: T, map: Map<string, string>): T {
+	return JSON.parse(rewriteContent(JSON.stringify(value ?? null), map))
+}
+
 /** Why a rewriter left an item where it was, or `true` when it moved it. */
 const CHANGED_UNDER_US = 'changed while it was being retargeted'
 
@@ -376,10 +387,10 @@ async function rewriteFlow(
 	map: Map<string, string>
 ): Promise<true | string> {
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
-	const value = rewriteFlowValue(f.value, map)
+	const value = rewriteTokens(f.value ?? {}, map)
 	if (!relocated(value, map)) return CHANGED_UNDER_US
-	// Nothing moved: the item was listed for a reference no rewriter reaches, already gapped.
-	if (JSON.stringify(value) === JSON.stringify(f.value)) return true
+	// The tokens the plan saw are gone from the deployed item, so there is nothing to write.
+	if (JSON.stringify(value) === JSON.stringify(f.value ?? {})) return true
 	await FlowService.updateFlow({
 		workspace,
 		path,
@@ -405,9 +416,9 @@ async function rewriteApp(
 	map: Map<string, string>
 ): Promise<true | string> {
 	const a: any = await AppService.getAppByPath({ workspace, path })
-	const next = rewriteAppValue(a.value ?? {}, map)
+	const next = rewriteTokens(a.value ?? {}, map)
 	if (!relocated(next, map)) return CHANGED_UNDER_US
-	// Nothing moved: the item was listed for a reference no rewriter reaches, already gapped.
+	// The tokens the plan saw are gone from the deployed item, so there is nothing to write.
 	if (JSON.stringify(next) === JSON.stringify(a.value ?? {})) return true
 	const policy = (await updatePolicy(next as App, a.policy)) as any
 	await AppService.updateApp({
@@ -461,7 +472,7 @@ async function rewriteRawApp(
 	const value: any = a.value ?? {}
 	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
 	// the sources too, and both are plain text inside this JSON.
-	const next = JSON.parse(rewriteRawAppContent(JSON.stringify(value), map))
+	const next = rewriteTokens(value, map)
 	if (!relocated(next, map)) return CHANGED_UNDER_US
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
@@ -476,8 +487,8 @@ async function rewriteRawApp(
 	// is one nothing here can move, and uploading it would leave the app reading a resource
 	// about to be deleted.
 	for (const stub of map.keys()) if (textHoldsBarePath(js, stub)) return UNREACHABLE_REFERENCE
-	// Nothing moved: the app was listed for a reference no rewriter reaches, already gapped.
-	// Uploading an unchanged app would cut it a version that differs from the last in nothing.
+	// The tokens the plan saw are gone from both the value and the bundle, so there is nothing
+	// to write, and uploading would cut a version differing from the last in nothing.
 	if (js === deployedJs && css === deployedCss && JSON.stringify(next) === JSON.stringify(value))
 		return true
 	const files = { ...(next.files ?? {}) }

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -41,21 +41,6 @@ import { updateRawAppPolicy } from '$lib/sharedUtils'
 import type { App } from '$lib/components/apps/types'
 import { apiErrorMessage as errorMessage } from '$lib/utils'
 
-/**
- * The source files a raw app was imported from, keyed by the path it landed at.
- *
- * A raw app is deployed as a value plus a compiled bundle, and the bundle is stored where
- * the browser cannot read it back (`/apps/get_data/v/{id}` decrypts an embed secret). The
- * export already carries that bundle prebuilt as `/bundle.js` and `/bundle.css` — it is what
- * `installProject` uploaded in the first place — so a rewrite re-uploads it rather than
- * re-running the bundler.
- *
- * An app whose sources the export does not yield carries no entry at all. An empty one reads
- * as "the app ships no sources", which `planRetarget` would let through to an upload that
- * wipes the deployed bundle.
- */
-export type ExportedAppFiles = Record<string, Record<string, string>>
-
 export type ReferrerKind = 'script' | 'flow' | 'app' | 'raw app' | 'trigger'
 
 export interface Referrer {
@@ -96,25 +81,6 @@ export interface RetargetOutcome {
 /** Everything under the project's folder, which is all this rewrites. */
 function inFolder(path: unknown, folder: string): boolean {
 	return typeof path === 'string' && path.startsWith(`f/${folder}/`)
-}
-
-/**
- * Whether the deployed sources differ from the ones the export shipped. The two bundle
- * entries are excluded: `installProject` strips them out of `files` before it deploys, so
- * they are never part of the deployed set.
- */
-function rawSourcesDiverged(
-	deployed: Record<string, string>,
-	exported: Record<string, string>
-): boolean {
-	const strip = (f: Record<string, string>) =>
-		Object.fromEntries(
-			Object.entries(f ?? {}).filter(([k]) => k !== '/bundle.js' && k !== '/bundle.css')
-		)
-	const a = strip(deployed)
-	const b = strip(exported)
-	const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort()
-	return keys.some((k) => a[k] !== b[k])
 }
 
 /**
@@ -164,7 +130,7 @@ export async function planRetarget(
 	workspace: string,
 	folder: string,
 	from: string,
-	opts: { hasEeLicense: boolean; exportedAppFiles?: ExportedAppFiles }
+	opts: { hasEeLicense: boolean }
 ): Promise<RetargetPlan> {
 	const referrers: Referrer[] = []
 	const gaps: Gap[] = []
@@ -220,23 +186,7 @@ export async function planRetarget(
 		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
 		// low-code one keeps its components under `grid`.
 		const isRaw = !!value.files && !!value.runnables
-		if (!isRaw) {
-			referrers.push({ kind: 'app', path: a.path! })
-			continue
-		}
-		const exported = opts.exportedAppFiles?.[a.path!]
-		if (!exported) {
-			gaps.push({ path: a.path!, reason: 'is a raw app the export does not describe' })
-			continue
-		}
-		// The bundle about to be re-uploaded was built from the export's sources. If the
-		// deployed sources have moved on, it is behind them, and uploading it would revert
-		// whatever was changed since the import.
-		if (rawSourcesDiverged(value.files ?? {}, exported)) {
-			gaps.push({ path: a.path!, reason: 'has been edited since the import' })
-			continue
-		}
-		referrers.push({ kind: 'raw app', path: a.path! })
+		referrers.push({ kind: isRaw ? 'raw app' : 'app', path: a.path! })
 	}
 
 	for (const kind of WORKSPACE_TRIGGER_KINDS) {
@@ -292,14 +242,12 @@ export async function applyRetarget(args: {
 	from: string
 	to: string
 	hasEeLicense: boolean
-	/** Raw-app sources from the export, retargeted to the folder. See `ExportedAppFiles`. */
-	exportedAppFiles?: ExportedAppFiles
 }): Promise<RetargetOutcome> {
-	const { workspace, folder, from, to, hasEeLicense, exportedAppFiles } = args
+	const { workspace, folder, from, to, hasEeLicense } = args
 	const map = new Map([[from, to]])
 	const rewritten: Referrer[] = []
 
-	const plan = await planRetarget(workspace, folder, from, { hasEeLicense, exportedAppFiles })
+	const plan = await planRetarget(workspace, folder, from, { hasEeLicense })
 	const gaps = [...plan.gaps]
 
 	for (const r of plan.referrers) {
@@ -308,8 +256,7 @@ export async function applyRetarget(args: {
 			if (r.kind === 'script') moved = await rewriteScript(workspace, r.path, map)
 			else if (r.kind === 'flow') moved = await rewriteFlow(workspace, r.path, map)
 			else if (r.kind === 'app') moved = await rewriteApp(workspace, r.path, map)
-			else if (r.kind === 'raw app')
-				moved = await rewriteRawApp(workspace, r.path, map, exportedAppFiles?.[r.path] ?? {})
+			else if (r.kind === 'raw app') moved = await rewriteRawApp(workspace, r.path, map)
 			else moved = await rewriteTrigger(workspace, r, map)
 		} catch (e: any) {
 			return { rewritten, gaps, stubDeleted: false, error: errorMessage(e) }
@@ -342,6 +289,23 @@ function relocated(next: unknown, map: Map<string, string>): boolean {
 }
 
 /**
+ * Every write here is an in-place edit of a deployed item, not a redeployment by whoever
+ * opened the wizard, so each one has to say so.
+ *
+ * `preserve_on_behalf_of` is the flag that says it. Without it the backend replaces the
+ * item's stored run identity with the caller's — `resolve_on_behalf_of` for scripts and
+ * flows, the `should_preserve` branch of `update_app` for apps — and an imported item that
+ * ran as a service account would silently start running as the person who picked a
+ * credential. The backend still gates it on `wm_deployers` membership, so a caller who
+ * cannot preserve gets what they would have got anyway.
+ *
+ * For apps the policy is the other half: it carries the run identity, the execution mode and
+ * the sandbox rules, so it is read from the deployed app and handed back to the recompute
+ * rather than rebuilt from nothing.
+ */
+const PRESERVE_DEPLOYED_IDENTITY = { preserve_on_behalf_of: true }
+
+/**
  * A new script version, the way the editor saves one. Spread rather than field-by-field:
  * `Script` and `NewScript` share their names, and listing them here would silently drop
  * whichever field someone adds next.
@@ -357,7 +321,13 @@ async function rewriteScript(
 	if (content === s.content) return true
 	await ScriptService.createScript({
 		workspace,
-		requestBody: { ...s, content, parent_hash: s.hash, deployment_message: undefined }
+		requestBody: {
+			...s,
+			...PRESERVE_DEPLOYED_IDENTITY,
+			content,
+			parent_hash: s.hash,
+			deployment_message: undefined
+		}
 	})
 	return true
 }
@@ -370,15 +340,24 @@ async function rewriteFlow(
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
 	const value = rewriteFlowValue(f.value, map)
 	if (!relocated(value, map)) return false
-	await FlowService.updateFlow({ workspace, path, requestBody: { ...f, path, value } })
+	await FlowService.updateFlow({
+		workspace,
+		path,
+		requestBody: { ...f, ...PRESERVE_DEPLOYED_IDENTITY, path, value }
+	})
 	return true
 }
 
 /**
- * The policy is recomputed rather than carried over: `triggerables_v2` is keyed by
- * `<component>:rawscript/<sha256(inline content)>`, and rewriting an inline runnable's
- * content changes that key — a copied policy would leave it "forbidden by policy".
- * Mirrors what `installProject` does on import.
+ * The deployed policy is recomputed, not rebuilt. Recomputing is required: `triggerables_v2`
+ * is keyed by `<component>:rawscript/<sha256(inline content)>`, and rewriting an inline
+ * runnable's content changes that key, so a policy copied verbatim would leave the component
+ * "forbidden by policy". Handing the deployed policy to the recompute is what keeps the run
+ * identity, the sandbox rules and everything else it does not touch.
+ *
+ * No execution mode is defaulted. The backend keeps the deployed mode when the submitted
+ * policy states none, and stating one here would put a `viewer` app on the publisher's
+ * identity.
  */
 async function rewriteApp(
 	workspace: string,
@@ -388,23 +367,47 @@ async function rewriteApp(
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const next = rewriteAppValue(a.value ?? {}, map)
 	if (!relocated(next, map)) return false
-	const policy = (await updatePolicy(next as App, undefined)) as any
-	if (!policy.execution_mode) policy.execution_mode = 'publisher'
-	await AppService.updateApp({ workspace, path, requestBody: { path, value: next, policy } })
+	const policy = (await updatePolicy(next as App, a.policy)) as any
+	await AppService.updateApp({
+		workspace,
+		path,
+		requestBody: { ...PRESERVE_DEPLOYED_IDENTITY, path, value: next, policy }
+	})
 	return true
 }
 
 /**
+ * One half of a deployed raw app's compiled bundle, read back the way the Hub publish reads
+ * it: `/apps/get_data/v/{secret}.{ext}` serves it to anyone holding the secret, and the
+ * secret is minted for the caller against a plain `apps:read:<path>` check.
+ *
+ * A missing `.css` is an app that ships no styles. A missing `.js` is a broken deployment,
+ * and uploading an empty one in its place would break it further.
+ */
+async function fetchBundlePart(
+	workspace: string,
+	secret: string,
+	ext: 'js' | 'css'
+): Promise<string> {
+	const res = await fetch(
+		`/api/w/${encodeURIComponent(workspace)}/apps/get_data/v/${secret}.${ext}`,
+		{ credentials: 'include' }
+	)
+	if (res.ok) return await res.text()
+	if (ext === 'css' && res.status === 404) return ''
+	throw new Error(`the compiled bundle could not be read (${res.status})`)
+}
+
+/**
  * A raw app: its deployed value carries the sources and the runnables, and `updateAppRaw`
- * refuses without a bundle. The bundle comes from the export rather than the bundler — it is
- * the one the import uploaded, and `planRetarget` has already left the app out if the
- * deployed sources have moved on from it.
+ * refuses without a bundle. The bundle is the deployed one, read back and sent again
+ * unchanged — the sources are not being edited here, so rebuilding it is neither possible
+ * from the browser nor needed.
  */
 async function rewriteRawApp(
 	workspace: string,
 	path: string,
-	map: Map<string, string>,
-	exportedFiles: Record<string, string>
+	map: Map<string, string>
 ): Promise<boolean> {
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const value: any = a.value ?? {}
@@ -414,7 +417,11 @@ async function rewriteRawApp(
 	if (!relocated(next, map)) return false
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
-	if (!policy.execution_mode) policy.execution_mode = 'publisher'
+	const secret = await AppService.getPublicSecretOfLatestVersionOfApp({ workspace, path })
+	const [js, css] = await Promise.all([
+		fetchBundlePart(workspace, secret, 'js'),
+		fetchBundlePart(workspace, secret, 'css')
+	])
 	const files = { ...(next.files ?? {}) }
 	delete files['/bundle.js']
 	delete files['/bundle.css']
@@ -423,6 +430,7 @@ async function rewriteRawApp(
 		path,
 		formData: {
 			app: {
+				...PRESERVE_DEPLOYED_IDENTITY,
 				path,
 				summary: a.summary ?? '',
 				value: {
@@ -433,8 +441,8 @@ async function rewriteRawApp(
 				},
 				policy
 			},
-			js: exportedFiles['/bundle.js'] ?? '',
-			css: exportedFiles['/bundle.css'] ?? ''
+			js,
+			css
 		}
 	})
 	return true

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -91,6 +91,25 @@ export interface RetargetOutcome {
 	error?: string
 }
 
+/**
+ * Whether this caller's listings are the whole workspace, and so whether a clean scan proves
+ * anything. Row-level security filters the listings inside the query for everyone else.
+ *
+ * `UserExt` is per-workspace and outlives a workspace change, so the role is only this
+ * workspace's role when the record says it is. On the setup step's reload path nothing
+ * re-fetches it, and it still describes the workspace the user came from — reading
+ * `is_admin` alone there answers for the wrong workspace. An instance superadmin bypasses
+ * the policies everywhere, which is why it is asked separately.
+ */
+export function seesWholeWorkspace(
+	user: { workspace_id?: string; is_admin?: boolean } | undefined,
+	isSuperadmin: boolean,
+	workspace: string
+): boolean {
+	if (isSuperadmin) return true
+	return !!user?.is_admin && user.workspace_id === workspace
+}
+
 /** Everything under the project's folder, which is all this rewrites. */
 function inFolder(path: unknown, folder: string): boolean {
 	return typeof path === 'string' && path.startsWith(`f/${folder}/`)

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -2,9 +2,10 @@
  * Point an already-imported project at a resource the workspace already has.
  *
  * The import writes `$res:f/<folder>/<name>` into every item that uses the project's
- * resource. This rewrites those references to an existing resource and deletes the stub,
- * so the project reads the workspace's own credential — the same end state the import
- * would have produced, reached after the fact.
+ * resource — except a trigger, which holds the bare path in its own `*_resource_path`
+ * field. This rewrites those references to an existing resource and deletes the stub, so
+ * the project reads the workspace's own credential — the same end state the import would
+ * have produced, reached after the fact.
  *
  * Two rules make that safe to run over deployed items:
  *
@@ -21,7 +22,8 @@ import {
 	rewriteContent,
 	rewriteFlowValue,
 	rewriteRawAppContent,
-	rewriteTriggerConfig
+	rewriteTriggerConfig,
+	referencesResourcePath
 } from '$lib/components/workspaceSettings/projectBundle'
 import {
 	TRIGGER_KINDS,
@@ -93,11 +95,6 @@ function rawSourcesDiverged(
 	return keys.some((k) => a[k] !== b[k])
 }
 
-/** Whether a serialized item mentions the resource, in either reference spelling. */
-function mentions(blob: string, resourcePath: string): boolean {
-	return blob.includes(`$res:${resourcePath}`) || blob.includes(`res://${resourcePath}`)
-}
-
 /**
  * Which deployed items reference the stub, and whether each can be rewritten.
  *
@@ -121,17 +118,17 @@ export async function planRetarget(
 
 	for (const s of scripts ?? []) {
 		if (!inFolder(s.path, folder)) continue
-		if (mentions(String(s.content ?? ''), from)) referrers.push({ kind: 'script', path: s.path! })
+		if (referencesResourcePath(s.content ?? '', from))
+			referrers.push({ kind: 'script', path: s.path! })
 	}
 	for (const f of flows ?? []) {
 		if (!inFolder(f.path, folder)) continue
-		if (mentions(JSON.stringify(f.value ?? {}), from))
-			referrers.push({ kind: 'flow', path: f.path! })
+		if (referencesResourcePath(f.value ?? {}, from)) referrers.push({ kind: 'flow', path: f.path! })
 	}
 	for (const a of apps ?? []) {
 		if (!inFolder(a.path, folder)) continue
 		const value: any = a.value ?? {}
-		if (!mentions(JSON.stringify(value), from)) continue
+		if (!referencesResourcePath(value, from)) continue
 		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
 		// low-code one keeps its components under `grid`.
 		const isRaw = !!value.files && !!value.runnables
@@ -168,7 +165,7 @@ export async function planRetarget(
 		}
 		for (const t of rows) {
 			if (!inFolder(t.path, folder)) continue
-			if (!mentions(JSON.stringify(t), from)) continue
+			if (!referencesResourcePath(t, from)) continue
 			// `schedule` has no `update` in the table because its service takes a different body
 			// shape; `rewriteTrigger` handles it directly, the way the import's create does.
 			if (kind !== 'schedule' && !def.update) {
@@ -325,13 +322,20 @@ async function rewriteRawApp(
  * The trigger's own row, rewritten and written back. `enabled` is deliberately not sent:
  * imported triggers are created disabled and re-enabling one is the user's decision, not a
  * side effect of pointing it at a credential.
+ *
+ * `path` is put back from the row afterwards. The rewrite remaps any string equal to the
+ * stub's path, and a trigger sitting at the path the resource used to hold would otherwise
+ * be renamed along with the reference.
  */
 async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, string>) {
 	const def = TRIGGER_KINDS[r.triggerKind!]
 	const rows = await def.list(workspace)
 	const row: any = rows.find((t) => t.path === r.path)
 	if (!row) throw new Error(`trigger ${r.path} is no longer there`)
-	const { enabled: _enabled, ...rest } = rewriteTriggerConfig(row, map) as any
+	const { enabled: _enabled, ...rest } = {
+		...(rewriteTriggerConfig(row, map) as any),
+		path: r.path
+	}
 	if (r.triggerKind === 'schedule') {
 		// `EditSchedule` needs these three; everything else on the row carries over by name.
 		await ScheduleService.updateSchedule({

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -12,8 +12,10 @@
  *  - Only items inside the project's folder are rewritten. The import wrote nothing outside
  *    it, so a reference from elsewhere is the user's own and not ours to move.
  *  - The stub is deleted only when the scan can prove it saw every reference to it.
- *    Listings come back capped, a trigger kind can fail to list, and a reference can sit
- *    where no rewriter reaches — each of those is a gap, and any gap keeps the stub.
+ *    Listings come back capped, a trigger kind can fail to list, a reference can sit where no
+ *    rewriter reaches, and the listings themselves are row-level-security filtered so a
+ *    caller who is not a workspace admin is not shown every item — each of those is a gap,
+ *    and any gap keeps the stub.
  *
  * Rewriting is separable from deleting, and only the delete is destructive. An item moved
  * onto the chosen resource resolves whether or not the stub survives; an item the scan never
@@ -133,6 +135,7 @@ const TRIGGER_LIST_LIMIT = 1000
 
 /** A reference this run will not move, recorded so the stub outlives it. */
 const OUTSIDE_PROJECT = 'reads this resource from outside the project'
+const UNSEEN_BY_CALLER = 'holds items this account is not shown'
 const UNREACHABLE_REFERENCE = 'names the resource path outside a $res: reference'
 
 /**
@@ -145,10 +148,17 @@ const UNREACHABLE_REFERENCE = 'names the resource path outside a $res: reference
 export async function planRetarget(
 	workspace: string,
 	folder: string,
-	from: string
+	from: string,
+	opts: { seesWholeWorkspace: boolean }
 ): Promise<RetargetPlan> {
 	const referrers: Referrer[] = []
 	const gaps: Gap[] = []
+
+	// The listings run as the caller. Row-level security filters the rows out inside the
+	// query, so an item this account cannot read is not merely absent from the answer — it
+	// does not count towards the full-page test either, and nothing downstream can notice it.
+	// A colleague's private script reading this stub is exactly that shape.
+	if (!opts.seesWholeWorkspace) gaps.push({ path: 'This workspace', reason: UNSEEN_BY_CALLER })
 
 	const [scripts, flows, apps] = await Promise.all([
 		ScriptService.listSearchScript({ workspace }),
@@ -283,12 +293,14 @@ export async function applyRetarget(args: {
 	folder: string
 	from: string
 	to: string
+	/** Whether the listings the scan reads are the whole workspace. See `planRetarget`. */
+	seesWholeWorkspace: boolean
 }): Promise<RetargetOutcome> {
-	const { workspace, folder, from, to } = args
+	const { workspace, folder, from, to, seesWholeWorkspace } = args
 	const map = new Map([[from, to]])
 	const rewritten: Referrer[] = []
 
-	const plan = await planRetarget(workspace, folder, from)
+	const plan = await planRetarget(workspace, folder, from, { seesWholeWorkspace })
 	const gaps = [...plan.gaps]
 
 	for (const r of plan.referrers) {

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -152,9 +152,43 @@ const SEARCH_LIMITS = { script: 10000, flow: 1000, app: 1000 }
  */
 const TRIGGER_LIST_LIMIT = 1000
 
-/** Trigger fields naming a runnable, and the two spellings `rewriteTriggerConfig` remaps. */
-const RUNNABLE_REF_FIELDS = ['on_failure', 'on_recovery', 'on_success', 'url']
-const RUNNABLE_REF_RE = /^(?:\$(?:script|flow):|(?:script|flow)\/)/
+/**
+ * Where a trigger names a runnable, taken from what `triggerHandlerRefs` reads.
+ *
+ * `rewriteTriggerConfig` remaps a runnable reference on an exact path match, which is right
+ * for the folder-wide map the import hands it and wrong for a map holding one resource path:
+ * a script sharing that path is not the reference being moved, and remapping it makes the
+ * trigger run a resource. So these are put back from the row after the rewrite.
+ *
+ * Split by spelling, because only one of the two can also hold a `$res:` token. A prefixed
+ * field is restored only when it holds the runnable spelling, so a token in it still moves;
+ * a bare field is a path and nothing else, so it is always restored.
+ */
+const PREFIXED_RUNNABLE_FIELDS = ['on_failure', 'on_recovery', 'on_success', 'url']
+const PREFIXED_RUNNABLE_RE = /^(?:\$(?:script|flow):|(?:script|flow)\/)/
+const BARE_RUNNABLE_FIELDS = ['dynamic_skip', 'error_handler_path', 'script_path']
+
+/** The rewritten config with every runnable reference put back as the row holds it. */
+function restoreRunnableRefs(rewritten: any, row: any): any {
+	const out = { ...rewritten }
+	for (const k of PREFIXED_RUNNABLE_FIELDS) {
+		if (typeof row?.[k] === 'string' && PREFIXED_RUNNABLE_RE.test(row[k])) out[k] = row[k]
+	}
+	for (const k of BARE_RUNNABLE_FIELDS) {
+		if (typeof row?.[k] === 'string') out[k] = row[k]
+	}
+	// A websocket's initial messages can each carry a runnable result, whose `path` is bare.
+	// Only that field is put back; the rest of the message is rewritten like any other value.
+	if (Array.isArray(out.initial_messages)) {
+		out.initial_messages = out.initial_messages.map((m: any, i: number) => {
+			const was = row?.initial_messages?.[i]?.runnable_result?.path
+			return m?.runnable_result && typeof was === 'string'
+				? { ...m, runnable_result: { ...m.runnable_result, path: was } }
+				: m
+		})
+	}
+	return out
+}
 
 /** A reference this run will not move, recorded so the stub outlives it. */
 const OUTSIDE_PROJECT = 'reads this resource from outside the project'
@@ -570,10 +604,10 @@ async function rewriteRawApp(
  * imported triggers are created disabled and re-enabling one is the user's decision, not a
  * side effect of pointing it at a credential.
  *
- * `path` and `script_path` are put back from the row afterwards. The rewrite remaps any
- * string equal to the stub's path, so a trigger sitting at the path the resource used to
- * hold — or running a script that does — would otherwise be renamed, or repointed at the
- * reused resource, along with the reference.
+ * `path` is put back from the row afterwards, and so is every runnable reference — see
+ * `restoreRunnableRefs`. The rewrite remaps any string equal to the stub's path, so a trigger
+ * sitting at the path the resource used to hold would otherwise be renamed along with the
+ * reference.
  *
  * A trigger states its run identity as `permissioned_as`, not the `on_behalf_of` the other
  * kinds use, and `resolve_permissioned_as` keeps the row's value only when
@@ -588,19 +622,8 @@ async function rewriteTrigger(
 	const def = TRIGGER_KINDS[r.triggerKind!]
 	const row: any = r.row ?? {}
 	const { enabled: _enabled, ...rest } = {
-		...(rewriteTriggerConfig(row, map) as any),
+		...restoreRunnableRefs(rewriteTriggerConfig(row, map), row),
 		path: r.path,
-		...(typeof row.script_path === 'string' ? { script_path: row.script_path } : {}),
-		// The handler and url fields name a runnable, and `rewriteTriggerConfig` remaps one on
-		// an exact match — right for the folder-wide map the import hands it, wrong for a map
-		// holding one resource path. A schedule whose `on_failure` runs a script sharing that
-		// path would have its error handler pointed at the credential. Only the two prefixed
-		// shapes it remaps are restored, so a field holding a `$res:` token still moves.
-		...Object.fromEntries(
-			RUNNABLE_REF_FIELDS.filter(
-				(k) => typeof row[k] === 'string' && RUNNABLE_REF_RE.test(row[k])
-			).map((k) => [k, row[k]])
-		),
 		...(typeof row.permissioned_as === 'string'
 			? { permissioned_as: row.permissioned_as, preserve_permissioned_as: true }
 			: {})

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -1,0 +1,350 @@
+/**
+ * Point an already-imported project at a resource the workspace already has.
+ *
+ * The import writes `$res:f/<folder>/<name>` into every item that uses the project's
+ * resource. This rewrites those references to an existing resource and deletes the stub,
+ * so the project reads the workspace's own credential — the same end state the import
+ * would have produced, reached after the fact.
+ *
+ * Two rules make that safe to run over deployed items:
+ *
+ *  - Nothing is written unless every referrer can be rewritten. A run that gets halfway
+ *    leaves some items on the stub and some on the chosen resource, and deleting the stub
+ *    then breaks the ones left behind. `planRetarget` answers first, `applyRetarget` acts.
+ *  - Only items inside the project's folder are touched. The import wrote nothing outside
+ *    it, so a reference from elsewhere is the user's own and not ours to rewrite.
+ */
+
+import { AppService, FlowService, ResourceService, ScheduleService, ScriptService } from '$lib/gen'
+import {
+	rewriteAppValue,
+	rewriteContent,
+	rewriteFlowValue,
+	rewriteRawAppContent,
+	rewriteTriggerConfig
+} from '$lib/components/workspaceSettings/projectBundle'
+import {
+	TRIGGER_KINDS,
+	WORKSPACE_TRIGGER_KINDS,
+	type WorkspaceTriggerKind
+} from '$lib/components/triggers/workspaceTriggersList'
+import { updatePolicy } from '$lib/components/apps/editor/appPolicy'
+import { updateRawAppPolicy } from '$lib/sharedUtils'
+import type { App } from '$lib/components/apps/types'
+import { apiErrorMessage as errorMessage } from '$lib/utils'
+
+/**
+ * The source files a raw app was imported from, keyed by the path it landed at.
+ *
+ * A raw app is deployed as a value plus a compiled bundle, and the bundle is stored where
+ * the browser cannot read it back (`/apps/get_data/v/{id}` decrypts an embed secret). The
+ * export already carries that bundle prebuilt as `/bundle.js` and `/bundle.css` — it is what
+ * `installProject` uploaded in the first place — so a rewrite re-uploads it rather than
+ * re-running the bundler.
+ */
+export type ExportedAppFiles = Record<string, Record<string, string>>
+
+export type ReferrerKind = 'script' | 'flow' | 'app' | 'raw app' | 'trigger'
+
+export interface Referrer {
+	kind: ReferrerKind
+	path: string
+	/** Present for triggers: which kind's table it lives in. */
+	triggerKind?: WorkspaceTriggerKind
+}
+
+export interface RetargetPlan {
+	referrers: Referrer[]
+	/**
+	 * Referrers that cannot be rewritten, with the reason. Non-empty means the whole
+	 * retarget is refused: see the all-or-nothing rule above.
+	 */
+	blocked: { path: string; reason: string }[]
+}
+
+export interface RetargetOutcome {
+	rewritten: Referrer[]
+	/** Set when a write failed. The stub is then left in place, so nothing is broken. */
+	error?: string
+	stubDeleted: boolean
+}
+
+/** Everything under the project's folder, so nothing outside it is ever rewritten. */
+function inFolder(path: unknown, folder: string): boolean {
+	return typeof path === 'string' && path.startsWith(`f/${folder}/`)
+}
+
+/**
+ * Whether the deployed sources differ from the ones the export shipped. The two bundle
+ * entries are excluded: `installProject` strips them out of `files` before it deploys, so
+ * they are never part of the deployed set.
+ */
+function rawSourcesDiverged(
+	deployed: Record<string, string>,
+	exported: Record<string, string>
+): boolean {
+	const strip = (f: Record<string, string>) =>
+		Object.fromEntries(
+			Object.entries(f ?? {}).filter(([k]) => k !== '/bundle.js' && k !== '/bundle.css')
+		)
+	const a = strip(deployed)
+	const b = strip(exported)
+	const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort()
+	return keys.some((k) => a[k] !== b[k])
+}
+
+/** Whether a serialized item mentions the resource, in either reference spelling. */
+function mentions(blob: string, resourcePath: string): boolean {
+	return blob.includes(`$res:${resourcePath}`) || blob.includes(`res://${resourcePath}`)
+}
+
+/**
+ * Which deployed items reference the stub, and whether each can be rewritten.
+ *
+ * The `listSearch*` endpoints return each item's content in one call per kind, so this is
+ * four calls plus one per trigger kind rather than one per item.
+ */
+export async function planRetarget(
+	workspace: string,
+	folder: string,
+	from: string,
+	opts: { hasEeLicense: boolean; exportedAppFiles?: ExportedAppFiles }
+): Promise<RetargetPlan> {
+	const referrers: Referrer[] = []
+	const blocked: { path: string; reason: string }[] = []
+
+	const [scripts, flows, apps] = await Promise.all([
+		ScriptService.listSearchScript({ workspace }),
+		FlowService.listSearchFlow({ workspace }),
+		AppService.listSearchApp({ workspace })
+	])
+
+	for (const s of scripts ?? []) {
+		if (!inFolder(s.path, folder)) continue
+		if (mentions(String(s.content ?? ''), from)) referrers.push({ kind: 'script', path: s.path! })
+	}
+	for (const f of flows ?? []) {
+		if (!inFolder(f.path, folder)) continue
+		if (mentions(JSON.stringify(f.value ?? {}), from))
+			referrers.push({ kind: 'flow', path: f.path! })
+	}
+	for (const a of apps ?? []) {
+		if (!inFolder(a.path, folder)) continue
+		const value: any = a.value ?? {}
+		if (!mentions(JSON.stringify(value), from)) continue
+		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
+		// low-code one keeps its components under `grid`.
+		const isRaw = !!value.files && !!value.runnables
+		if (!isRaw) {
+			referrers.push({ kind: 'app', path: a.path! })
+			continue
+		}
+		const exported = opts.exportedAppFiles?.[a.path!]
+		if (!exported) {
+			blocked.push({ path: a.path!, reason: 'is a raw app the export does not describe' })
+			continue
+		}
+		// The bundle about to be re-uploaded was built from the export's sources. If the
+		// deployed sources have moved on, it is behind them, and uploading it would revert
+		// whatever was changed since the import.
+		if (rawSourcesDiverged(value.files ?? {}, exported)) {
+			blocked.push({ path: a.path!, reason: 'has been edited since the import' })
+			continue
+		}
+		referrers.push({ kind: 'raw app', path: a.path! })
+	}
+
+	for (const kind of WORKSPACE_TRIGGER_KINDS) {
+		const def = TRIGGER_KINDS[kind]
+		if (def.eeOnly && !opts.hasEeLicense) continue
+		let rows: Array<Record<string, any>> = []
+		try {
+			rows = await def.list(workspace)
+		} catch {
+			// A kind that cannot be listed cannot be cleared either: refusing is the
+			// all-or-nothing rule, since a trigger left on the stub breaks when it is deleted.
+			blocked.push({ path: `${def.badge} triggers`, reason: 'could not be listed' })
+			continue
+		}
+		for (const t of rows) {
+			if (!inFolder(t.path, folder)) continue
+			if (!mentions(JSON.stringify(t), from)) continue
+			// `schedule` has no `update` in the table because its service takes a different body
+			// shape; `rewriteTrigger` handles it directly, the way the import's create does.
+			if (kind !== 'schedule' && !def.update) {
+				blocked.push({
+					path: String(t.path),
+					reason: `${def.badge} triggers cannot be updated from here`
+				})
+				continue
+			}
+			referrers.push({ kind: 'trigger', path: String(t.path), triggerKind: kind })
+		}
+	}
+
+	return { referrers, blocked }
+}
+
+/**
+ * Rewrite every referrer and delete the stub.
+ *
+ * Refuses outright when `planRetarget` reports anything blocked. The first write failure
+ * stops the run and leaves the stub in place: the items already rewritten point at the
+ * chosen resource, the rest still point at the stub, and both resolve.
+ */
+export async function applyRetarget(args: {
+	workspace: string
+	folder: string
+	from: string
+	to: string
+	hasEeLicense: boolean
+	/** Raw-app sources from the export, retargeted to the folder. See `ExportedAppFiles`. */
+	exportedAppFiles?: ExportedAppFiles
+}): Promise<RetargetOutcome> {
+	const { workspace, folder, from, to, hasEeLicense, exportedAppFiles } = args
+	const map = new Map([[from, to]])
+	const rewritten: Referrer[] = []
+
+	const plan = await planRetarget(workspace, folder, from, { hasEeLicense, exportedAppFiles })
+	if (plan.blocked.length > 0) {
+		const first = plan.blocked[0]
+		return {
+			rewritten,
+			stubDeleted: false,
+			error: `${first.path} ${first.reason} — nothing was changed`
+		}
+	}
+
+	try {
+		for (const r of plan.referrers) {
+			if (r.kind === 'script') await rewriteScript(workspace, r.path, map)
+			else if (r.kind === 'flow') await rewriteFlow(workspace, r.path, map)
+			else if (r.kind === 'app') await rewriteApp(workspace, r.path, map)
+			else if (r.kind === 'raw app')
+				await rewriteRawApp(workspace, r.path, map, exportedAppFiles?.[r.path] ?? {})
+			else await rewriteTrigger(workspace, r, map)
+			rewritten.push(r)
+		}
+	} catch (e: any) {
+		return { rewritten, stubDeleted: false, error: errorMessage(e) }
+	}
+
+	// Last, and only once every referrer is off it: the stub is what keeps a reference this
+	// missed resolving, so it is the one thing that must not go early.
+	try {
+		await ResourceService.deleteResource({ workspace, path: from })
+	} catch (e: any) {
+		return { rewritten, stubDeleted: false, error: errorMessage(e) }
+	}
+	return { rewritten, stubDeleted: true }
+}
+
+/**
+ * A new script version, the way the editor saves one. Spread rather than field-by-field:
+ * `Script` and `NewScript` share their names, and listing them here would silently drop
+ * whichever field someone adds next.
+ */
+async function rewriteScript(workspace: string, path: string, map: Map<string, string>) {
+	const s: any = await ScriptService.getScriptByPath({ workspace, path })
+	const content = rewriteContent(s.content ?? '', map)
+	if (content === s.content) return
+	await ScriptService.createScript({
+		workspace,
+		requestBody: { ...s, content, parent_hash: s.hash, deployment_message: undefined }
+	})
+}
+
+async function rewriteFlow(workspace: string, path: string, map: Map<string, string>) {
+	const f: any = await FlowService.getFlowByPath({ workspace, path })
+	await FlowService.updateFlow({
+		workspace,
+		path,
+		requestBody: { ...f, path, value: rewriteFlowValue(f.value, map) }
+	})
+}
+
+/**
+ * The policy is recomputed rather than carried over: `triggerables_v2` is keyed by
+ * `<component>:rawscript/<sha256(inline content)>`, and rewriting an inline runnable's
+ * content changes that key — a copied policy would leave it "forbidden by policy".
+ * Mirrors what `installProject` does on import.
+ */
+async function rewriteApp(workspace: string, path: string, map: Map<string, string>) {
+	const a: any = await AppService.getAppByPath({ workspace, path })
+	const next = rewriteAppValue(a.value ?? {}, map)
+	const policy = (await updatePolicy(next as App, undefined)) as any
+	if (!policy.execution_mode) policy.execution_mode = 'publisher'
+	await AppService.updateApp({ workspace, path, requestBody: { path, value: next, policy } })
+}
+
+/**
+ * A raw app: its deployed value carries the sources and the runnables, and `updateAppRaw`
+ * refuses without a bundle. The bundle comes from the export rather than the bundler — it is
+ * the one the import uploaded, and `planRetarget` has already refused if the deployed
+ * sources have moved on from it.
+ */
+async function rewriteRawApp(
+	workspace: string,
+	path: string,
+	map: Map<string, string>,
+	exportedFiles: Record<string, string>
+) {
+	const a: any = await AppService.getAppByPath({ workspace, path })
+	const value: any = a.value ?? {}
+	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
+	// the sources too, and both are plain text inside this JSON.
+	const next = JSON.parse(rewriteRawAppContent(JSON.stringify(value), map))
+	const runnables = next.runnables ?? {}
+	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
+	if (!policy.execution_mode) policy.execution_mode = 'publisher'
+	const files = { ...(next.files ?? {}) }
+	delete files['/bundle.js']
+	delete files['/bundle.css']
+	await AppService.updateAppRaw({
+		workspace,
+		path,
+		formData: {
+			app: {
+				path,
+				summary: a.summary ?? '',
+				value: {
+					files,
+					runnables,
+					...(next.data !== undefined ? { data: next.data } : {}),
+					...(next.datatables !== undefined ? { datatables: next.datatables } : {})
+				},
+				policy
+			},
+			js: exportedFiles['/bundle.js'] ?? '',
+			css: exportedFiles['/bundle.css'] ?? ''
+		}
+	})
+}
+
+/**
+ * The trigger's own row, rewritten and written back. `enabled` is deliberately not sent:
+ * imported triggers are created disabled and re-enabling one is the user's decision, not a
+ * side effect of pointing it at a credential.
+ */
+async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, string>) {
+	const def = TRIGGER_KINDS[r.triggerKind!]
+	const rows = await def.list(workspace)
+	const row: any = rows.find((t) => t.path === r.path)
+	if (!row) throw new Error(`trigger ${r.path} is no longer there`)
+	const { enabled: _enabled, ...rest } = rewriteTriggerConfig(row, map) as any
+	if (r.triggerKind === 'schedule') {
+		// `EditSchedule` needs these three; everything else on the row carries over by name.
+		await ScheduleService.updateSchedule({
+			workspace,
+			path: r.path,
+			requestBody: {
+				...rest,
+				schedule: rest.schedule ?? '0 0 * * * *',
+				timezone: rest.timezone ?? 'UTC',
+				args: rest.args ?? {}
+			}
+		})
+		return
+	}
+	await def.update!(workspace, r.path, rest)
+}

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -3,17 +3,23 @@
  *
  * The import writes `$res:f/<folder>/<name>` into every item that uses the project's
  * resource — except a trigger, which holds the bare path in its own `*_resource_path`
- * field. This rewrites those references to an existing resource and deletes the stub, so
- * the project reads the workspace's own credential — the same end state the import would
- * have produced, reached after the fact.
+ * field. This rewrites those references to an existing resource, so the project reads the
+ * workspace's own credential — the same end state the import would have produced, reached
+ * after the fact.
  *
  * Two rules make that safe to run over deployed items:
  *
- *  - Nothing is written unless every referrer can be rewritten. A run that gets halfway
- *    leaves some items on the stub and some on the chosen resource, and deleting the stub
- *    then breaks the ones left behind. `planRetarget` answers first, `applyRetarget` acts.
- *  - Only items inside the project's folder are touched. The import wrote nothing outside
- *    it, so a reference from elsewhere is the user's own and not ours to rewrite.
+ *  - Only items inside the project's folder are rewritten. The import wrote nothing outside
+ *    it, so a reference from elsewhere is the user's own and not ours to move.
+ *  - The stub is deleted only when the scan can prove it saw every reference to it.
+ *    Listings come back capped, a trigger kind can fail to list, and a reference can sit
+ *    where no rewriter reaches — each of those is a gap, and any gap keeps the stub.
+ *
+ * Rewriting is separable from deleting, and only the delete is destructive. An item moved
+ * onto the chosen resource resolves whether or not the stub survives; an item the scan never
+ * saw resolves only while the stub is there. So an incomplete scan downgrades the run to
+ * "rewritten, stub kept" rather than refusing it — the outcome names the gaps so the caller
+ * can say the placeholder is still around.
  */
 
 import { AppService, FlowService, ResourceService, ScheduleService, ScriptService } from '$lib/gen'
@@ -59,23 +65,35 @@ export interface Referrer {
 	triggerKind?: WorkspaceTriggerKind
 }
 
+/** Something the scan could not account for. `path` names an item, or a listing standing in
+ *  for every item it failed to return. */
+export interface Gap {
+	path: string
+	reason: string
+}
+
 export interface RetargetPlan {
+	/** Items whose reference this run will move. */
 	referrers: Referrer[]
 	/**
-	 * Referrers that cannot be rewritten, with the reason. Non-empty means the whole
-	 * retarget is refused: see the all-or-nothing rule above.
+	 * Why the scan cannot claim it saw every reference to the stub. Empty is the only state
+	 * in which deleting the stub is provably safe.
 	 */
-	blocked: { path: string; reason: string }[]
+	gaps: Gap[]
 }
 
 export interface RetargetOutcome {
+	/** Items now reading the chosen resource. */
 	rewritten: Referrer[]
-	/** Set when a write failed. The stub is then left in place, so nothing is broken. */
-	error?: string
+	/** Why the stub was kept, when it was. */
+	gaps: Gap[]
 	stubDeleted: boolean
+	/** Set when a write failed. The run stopped there and the stub stays, so what was
+	 *  rewritten before it and what was not both resolve. */
+	error?: string
 }
 
-/** Everything under the project's folder, so nothing outside it is ever rewritten. */
+/** Everything under the project's folder, which is all this rewrites. */
 function inFolder(path: unknown, folder: string): boolean {
 	return typeof path === 'string' && path.startsWith(`f/${folder}/`)
 }
@@ -105,9 +123,9 @@ function rawSourcesDiverged(
  * A script, flow or app spells a resource reference as a `$res:` token and nothing else, so a
  * bare match is either a reference no rewriter relocates — a static string value in a
  * component, an argument the code assembles itself — or something that is not the resource at
- * all, such as a step running a script that happens to share the path. Both make the retarget
- * unsafe: the first is orphaned when the stub goes, the second is repointed at the reused
- * resource. Triggers are the exception and hold the bare path by design.
+ * all, such as a step running a script that happens to share the path. Neither is rewritable:
+ * moving the first is beyond the rewriters, and moving the second would repoint a runnable at
+ * a credential. Triggers are the exception and hold the bare path by design.
  */
 function holdsBarePath(value: unknown, path: string): boolean {
 	const walk = (v: any): boolean => {
@@ -122,15 +140,25 @@ function holdsBarePath(value: unknown, path: string): boolean {
 /**
  * What each `listSearch*` endpoint caps its answer at, server-side. The queries carry no
  * `ORDER BY` and the routes take no pagination, so a full page is an arbitrary subset with no
- * page two to ask for — the only safe reading is that the scan may have missed an item.
+ * page two to ask for.
+ *
+ * A full page is a sound truncation test only for an unscoped caller, which a wizard session
+ * is. The server applies its scope-path predicate to the rows the `LIMIT` already returned,
+ * so a scoped token can be handed a short page cut from a truncated query — reuse this scan
+ * under one and the cap goes undetected.
  */
 const SEARCH_LIMITS = { script: 10000, flow: 1000, app: 1000 }
 
+/** A reference this run will not move, recorded so the stub outlives it. */
+const OUTSIDE_PROJECT = 'reads this resource from outside the project'
+const UNREACHABLE_REFERENCE = 'names the resource path outside a $res: reference'
+
 /**
- * Which deployed items reference the stub, and whether each can be rewritten.
+ * Which deployed items reference the stub, which of them this run can move, and what it
+ * could not account for.
  *
  * The `listSearch*` endpoints return each item's content in one call per kind, so this is
- * four calls plus one per trigger kind rather than one per item.
+ * three calls plus one per trigger kind rather than one per item.
  */
 export async function planRetarget(
 	workspace: string,
@@ -139,7 +167,7 @@ export async function planRetarget(
 	opts: { hasEeLicense: boolean; exportedAppFiles?: ExportedAppFiles }
 ): Promise<RetargetPlan> {
 	const referrers: Referrer[] = []
-	const blocked: { path: string; reason: string }[] = []
+	const gaps: Gap[] = []
 
 	const [scripts, flows, apps] = await Promise.all([
 		ScriptService.listSearchScript({ workspace }),
@@ -147,38 +175,46 @@ export async function planRetarget(
 		AppService.listSearchApp({ workspace })
 	])
 
-	// A truncated scan cannot answer which items reference the stub, and deleting it under an
-	// item the scan never saw is the failure this module exists to prevent.
 	for (const [label, rows, limit] of [
 		['Scripts', scripts, SEARCH_LIMITS.script],
 		['Flows', flows, SEARCH_LIMITS.flow],
 		['Apps', apps, SEARCH_LIMITS.app]
 	] as const) {
-		if ((rows?.length ?? 0) >= limit)
-			blocked.push({ path: label, reason: 'could not all be listed' })
+		if ((rows?.length ?? 0) >= limit) gaps.push({ path: label, reason: 'could not all be listed' })
 	}
 
+	// The listings are workspace-wide, so an item outside the folder is seen for free. It is
+	// the user's own and stays on the stub, which is the whole reason the stub stays too.
 	for (const s of scripts ?? []) {
-		if (!inFolder(s.path, folder)) continue
-		if (referencesResourcePath(s.content ?? '', from))
-			referrers.push({ kind: 'script', path: s.path! })
+		if (!referencesResourcePath(s.content ?? '', from)) continue
+		if (!inFolder(s.path, folder)) {
+			gaps.push({ path: s.path!, reason: OUTSIDE_PROJECT })
+			continue
+		}
+		referrers.push({ kind: 'script', path: s.path! })
 	}
 	for (const f of flows ?? []) {
-		if (!inFolder(f.path, folder)) continue
 		const value: any = f.value ?? {}
 		if (!referencesResourcePath(value, from)) continue
+		if (!inFolder(f.path, folder)) {
+			gaps.push({ path: f.path!, reason: OUTSIDE_PROJECT })
+			continue
+		}
 		if (holdsBarePath(value, from)) {
-			blocked.push({ path: f.path!, reason: 'names the resource path outside a $res: reference' })
+			gaps.push({ path: f.path!, reason: UNREACHABLE_REFERENCE })
 			continue
 		}
 		referrers.push({ kind: 'flow', path: f.path! })
 	}
 	for (const a of apps ?? []) {
-		if (!inFolder(a.path, folder)) continue
 		const value: any = a.value ?? {}
 		if (!referencesResourcePath(value, from)) continue
+		if (!inFolder(a.path, folder)) {
+			gaps.push({ path: a.path!, reason: OUTSIDE_PROJECT })
+			continue
+		}
 		if (holdsBarePath(value, from)) {
-			blocked.push({ path: a.path!, reason: 'names the resource path outside a $res: reference' })
+			gaps.push({ path: a.path!, reason: UNREACHABLE_REFERENCE })
 			continue
 		}
 		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
@@ -190,14 +226,14 @@ export async function planRetarget(
 		}
 		const exported = opts.exportedAppFiles?.[a.path!]
 		if (!exported) {
-			blocked.push({ path: a.path!, reason: 'is a raw app the export does not describe' })
+			gaps.push({ path: a.path!, reason: 'is a raw app the export does not describe' })
 			continue
 		}
 		// The bundle about to be re-uploaded was built from the export's sources. If the
 		// deployed sources have moved on, it is behind them, and uploading it would revert
 		// whatever was changed since the import.
 		if (rawSourcesDiverged(value.files ?? {}, exported)) {
-			blocked.push({ path: a.path!, reason: 'has been edited since the import' })
+			gaps.push({ path: a.path!, reason: 'has been edited since the import' })
 			continue
 		}
 		referrers.push({ kind: 'raw app', path: a.path! })
@@ -207,10 +243,9 @@ export async function planRetarget(
 		const def = TRIGGER_KINDS[kind]
 		if (def.eeOnly && !opts.hasEeLicense) continue
 		let rows: Array<Record<string, any>> = []
-		// A kind whose listing is incomplete cannot be cleared either: refusing is the
-		// all-or-nothing rule, since a trigger left on the stub breaks when it is deleted.
-		// A 404 is not incompleteness — the instance has that trigger feature compiled out,
-		// so there is no trigger of the kind to leave behind.
+		// A 404 is not an incomplete listing — the instance has that trigger feature compiled
+		// out, so there is no trigger of the kind to have missed. Anything else means triggers
+		// of this kind may reference the stub without this ever seeing them.
 		let incomplete = false
 		try {
 			rows = await def.list(workspace, () => (incomplete = true))
@@ -219,16 +254,19 @@ export async function planRetarget(
 			incomplete = true
 		}
 		if (incomplete) {
-			blocked.push({ path: `${def.badge} triggers`, reason: 'could not be listed' })
+			gaps.push({ path: `${def.badge} triggers`, reason: 'could not be listed' })
 			continue
 		}
 		for (const t of rows) {
-			if (!inFolder(t.path, folder)) continue
 			if (!referencesResourcePath(t, from)) continue
+			if (!inFolder(t.path, folder)) {
+				gaps.push({ path: String(t.path), reason: OUTSIDE_PROJECT })
+				continue
+			}
 			// `schedule` has no `update` in the table because its service takes a different body
 			// shape; `rewriteTrigger` handles it directly, the way the import's create does.
 			if (kind !== 'schedule' && !def.update) {
-				blocked.push({
+				gaps.push({
 					path: String(t.path),
 					reason: `${def.badge} triggers cannot be updated from here`
 				})
@@ -238,15 +276,15 @@ export async function planRetarget(
 		}
 	}
 
-	return { referrers, blocked }
+	return { referrers, gaps }
 }
 
 /**
- * Rewrite every referrer and delete the stub.
+ * Rewrite every referrer the plan found, then delete the stub if the plan came back clean.
  *
- * Refuses outright when `planRetarget` reports anything blocked. The first write failure
- * stops the run and leaves the stub in place: the items already rewritten point at the
- * chosen resource, the rest still point at the stub, and both resolve.
+ * A gap never stops the rewriting — moving an item onto the chosen resource is safe on its
+ * own. It stops only the delete, which is the one step that can strand a reference nobody
+ * looked at.
  */
 export async function applyRetarget(args: {
 	workspace: string
@@ -262,37 +300,45 @@ export async function applyRetarget(args: {
 	const rewritten: Referrer[] = []
 
 	const plan = await planRetarget(workspace, folder, from, { hasEeLicense, exportedAppFiles })
-	if (plan.blocked.length > 0) {
-		const first = plan.blocked[0]
-		return {
-			rewritten,
-			stubDeleted: false,
-			error: `${first.path} ${first.reason} — nothing was changed`
-		}
-	}
+	const gaps = [...plan.gaps]
 
-	try {
-		for (const r of plan.referrers) {
-			if (r.kind === 'script') await rewriteScript(workspace, r.path, map)
-			else if (r.kind === 'flow') await rewriteFlow(workspace, r.path, map)
-			else if (r.kind === 'app') await rewriteApp(workspace, r.path, map)
+	for (const r of plan.referrers) {
+		let moved: boolean
+		try {
+			if (r.kind === 'script') moved = await rewriteScript(workspace, r.path, map)
+			else if (r.kind === 'flow') moved = await rewriteFlow(workspace, r.path, map)
+			else if (r.kind === 'app') moved = await rewriteApp(workspace, r.path, map)
 			else if (r.kind === 'raw app')
-				await rewriteRawApp(workspace, r.path, map, exportedAppFiles?.[r.path] ?? {})
-			else await rewriteTrigger(workspace, r, map)
-			rewritten.push(r)
+				moved = await rewriteRawApp(workspace, r.path, map, exportedAppFiles?.[r.path] ?? {})
+			else moved = await rewriteTrigger(workspace, r, map)
+		} catch (e: any) {
+			return { rewritten, gaps, stubDeleted: false, error: errorMessage(e) }
 		}
-	} catch (e: any) {
-		return { rewritten, stubDeleted: false, error: errorMessage(e) }
+		if (moved) rewritten.push(r)
+		else gaps.push({ path: r.path, reason: 'changed while it was being retargeted' })
 	}
 
-	// Last, and only once every referrer is off it: the stub is what keeps a reference this
-	// missed resolving, so it is the one thing that must not go early.
+	if (gaps.length > 0) return { rewritten, gaps, stubDeleted: false }
+
 	try {
 		await ResourceService.deleteResource({ workspace, path: from })
 	} catch (e: any) {
-		return { rewritten, stubDeleted: false, error: errorMessage(e) }
+		return { rewritten, gaps, stubDeleted: false, error: errorMessage(e) }
 	}
-	return { rewritten, stubDeleted: true }
+	return { rewritten, gaps, stubDeleted: true }
+}
+
+/**
+ * Whether the rewritten value has left every path being moved.
+ *
+ * `planRetarget` skips the items it can see a rewriter would not reach, so a `false` here
+ * means the item changed between the plan and the write. Each rewriter answers with this
+ * rather than writing: an item written while it still reads the stub is one the caller would
+ * count as moved.
+ */
+function relocated(next: unknown, map: Map<string, string>): boolean {
+	for (const from of map.keys()) if (referencesResourcePath(next, from)) return false
+	return true
 }
 
 /**
@@ -300,35 +346,32 @@ export async function applyRetarget(args: {
  * `Script` and `NewScript` share their names, and listing them here would silently drop
  * whichever field someone adds next.
  */
-async function rewriteScript(workspace: string, path: string, map: Map<string, string>) {
+async function rewriteScript(
+	workspace: string,
+	path: string,
+	map: Map<string, string>
+): Promise<boolean> {
 	const s: any = await ScriptService.getScriptByPath({ workspace, path })
 	const content = rewriteContent(s.content ?? '', map)
-	if (content === s.content) return
+	if (!relocated(content, map)) return false
+	if (content === s.content) return true
 	await ScriptService.createScript({
 		workspace,
 		requestBody: { ...s, content, parent_hash: s.hash, deployment_message: undefined }
 	})
+	return true
 }
 
-/**
- * The value about to be written still reaches a path being moved. `planRetarget` refuses
- * every item where that is possible, so getting here means the item changed between the plan
- * and the write. Throwing stops the run with the stub still in place, which is the state
- * where both the rewritten items and the untouched ones resolve.
- */
-function assertRelocated(next: unknown, path: string, map: Map<string, string>) {
-	for (const from of map.keys()) {
-		if (referencesResourcePath(next, from)) {
-			throw new Error(`${path} still references ${from} after the rewrite`)
-		}
-	}
-}
-
-async function rewriteFlow(workspace: string, path: string, map: Map<string, string>) {
+async function rewriteFlow(
+	workspace: string,
+	path: string,
+	map: Map<string, string>
+): Promise<boolean> {
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
 	const value = rewriteFlowValue(f.value, map)
-	assertRelocated(value, path, map)
+	if (!relocated(value, map)) return false
 	await FlowService.updateFlow({ workspace, path, requestBody: { ...f, path, value } })
+	return true
 }
 
 /**
@@ -337,33 +380,38 @@ async function rewriteFlow(workspace: string, path: string, map: Map<string, str
  * content changes that key — a copied policy would leave it "forbidden by policy".
  * Mirrors what `installProject` does on import.
  */
-async function rewriteApp(workspace: string, path: string, map: Map<string, string>) {
+async function rewriteApp(
+	workspace: string,
+	path: string,
+	map: Map<string, string>
+): Promise<boolean> {
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const next = rewriteAppValue(a.value ?? {}, map)
-	assertRelocated(next, path, map)
+	if (!relocated(next, map)) return false
 	const policy = (await updatePolicy(next as App, undefined)) as any
 	if (!policy.execution_mode) policy.execution_mode = 'publisher'
 	await AppService.updateApp({ workspace, path, requestBody: { path, value: next, policy } })
+	return true
 }
 
 /**
  * A raw app: its deployed value carries the sources and the runnables, and `updateAppRaw`
  * refuses without a bundle. The bundle comes from the export rather than the bundler — it is
- * the one the import uploaded, and `planRetarget` has already refused if the deployed
- * sources have moved on from it.
+ * the one the import uploaded, and `planRetarget` has already left the app out if the
+ * deployed sources have moved on from it.
  */
 async function rewriteRawApp(
 	workspace: string,
 	path: string,
 	map: Map<string, string>,
 	exportedFiles: Record<string, string>
-) {
+): Promise<boolean> {
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const value: any = a.value ?? {}
 	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
 	// the sources too, and both are plain text inside this JSON.
 	const next = JSON.parse(rewriteRawAppContent(JSON.stringify(value), map))
-	assertRelocated(next, path, map)
+	if (!relocated(next, map)) return false
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
 	if (!policy.execution_mode) policy.execution_mode = 'publisher'
@@ -389,6 +437,7 @@ async function rewriteRawApp(
 			css: exportedFiles['/bundle.css'] ?? ''
 		}
 	})
+	return true
 }
 
 /**
@@ -401,7 +450,11 @@ async function rewriteRawApp(
  * hold — or running a script that does — would otherwise be renamed, or repointed at the
  * reused resource, along with the reference.
  */
-async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, string>) {
+async function rewriteTrigger(
+	workspace: string,
+	r: Referrer,
+	map: Map<string, string>
+): Promise<boolean> {
 	const def = TRIGGER_KINDS[r.triggerKind!]
 	const rows = await def.list(workspace)
 	const row: any = rows.find((t) => t.path === r.path)
@@ -411,6 +464,9 @@ async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, s
 		path: r.path,
 		...(typeof row.script_path === 'string' ? { script_path: row.script_path } : {})
 	}
+	// No `relocated` check: `rewriteTriggerConfig` remaps every bare match at every depth, so
+	// the resource field always moves. What can still read `from` afterwards is a restored
+	// identity field, which is not a reference to the resource at all.
 	if (r.triggerKind === 'schedule') {
 		// `EditSchedule` needs these three; everything else on the row carries over by name.
 		await ScheduleService.updateSchedule({
@@ -423,7 +479,8 @@ async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, s
 				args: rest.args ?? {}
 			}
 		})
-		return
+		return true
 	}
 	await def.update!(workspace, r.path, rest)
+	return true
 }

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -43,6 +43,10 @@ import { apiErrorMessage as errorMessage } from '$lib/utils'
  * export already carries that bundle prebuilt as `/bundle.js` and `/bundle.css` — it is what
  * `installProject` uploaded in the first place — so a rewrite re-uploads it rather than
  * re-running the bundler.
+ *
+ * An app whose sources the export does not yield carries no entry at all. An empty one reads
+ * as "the app ships no sources", which `planRetarget` would let through to an upload that
+ * wipes the deployed bundle.
  */
 export type ExportedAppFiles = Record<string, Record<string, string>>
 
@@ -96,6 +100,33 @@ function rawSourcesDiverged(
 }
 
 /**
+ * A bare string exactly equal to the resource path, anywhere in the structure.
+ *
+ * A script, flow or app spells a resource reference as a `$res:` token and nothing else, so a
+ * bare match is either a reference no rewriter relocates — a static string value in a
+ * component, an argument the code assembles itself — or something that is not the resource at
+ * all, such as a step running a script that happens to share the path. Both make the retarget
+ * unsafe: the first is orphaned when the stub goes, the second is repointed at the reused
+ * resource. Triggers are the exception and hold the bare path by design.
+ */
+function holdsBarePath(value: unknown, path: string): boolean {
+	const walk = (v: any): boolean => {
+		if (typeof v === 'string') return v === path
+		if (Array.isArray(v)) return v.some(walk)
+		if (v && typeof v === 'object') return Object.values(v).some(walk)
+		return false
+	}
+	return walk(value)
+}
+
+/**
+ * What each `listSearch*` endpoint caps its answer at, server-side. The queries carry no
+ * `ORDER BY` and the routes take no pagination, so a full page is an arbitrary subset with no
+ * page two to ask for — the only safe reading is that the scan may have missed an item.
+ */
+const SEARCH_LIMITS = { script: 10000, flow: 1000, app: 1000 }
+
+/**
  * Which deployed items reference the stub, and whether each can be rewritten.
  *
  * The `listSearch*` endpoints return each item's content in one call per kind, so this is
@@ -116,6 +147,17 @@ export async function planRetarget(
 		AppService.listSearchApp({ workspace })
 	])
 
+	// A truncated scan cannot answer which items reference the stub, and deleting it under an
+	// item the scan never saw is the failure this module exists to prevent.
+	for (const [label, rows, limit] of [
+		['Scripts', scripts, SEARCH_LIMITS.script],
+		['Flows', flows, SEARCH_LIMITS.flow],
+		['Apps', apps, SEARCH_LIMITS.app]
+	] as const) {
+		if ((rows?.length ?? 0) >= limit)
+			blocked.push({ path: label, reason: 'could not all be listed' })
+	}
+
 	for (const s of scripts ?? []) {
 		if (!inFolder(s.path, folder)) continue
 		if (referencesResourcePath(s.content ?? '', from))
@@ -123,12 +165,22 @@ export async function planRetarget(
 	}
 	for (const f of flows ?? []) {
 		if (!inFolder(f.path, folder)) continue
-		if (referencesResourcePath(f.value ?? {}, from)) referrers.push({ kind: 'flow', path: f.path! })
+		const value: any = f.value ?? {}
+		if (!referencesResourcePath(value, from)) continue
+		if (holdsBarePath(value, from)) {
+			blocked.push({ path: f.path!, reason: 'names the resource path outside a $res: reference' })
+			continue
+		}
+		referrers.push({ kind: 'flow', path: f.path! })
 	}
 	for (const a of apps ?? []) {
 		if (!inFolder(a.path, folder)) continue
 		const value: any = a.value ?? {}
 		if (!referencesResourcePath(value, from)) continue
+		if (holdsBarePath(value, from)) {
+			blocked.push({ path: a.path!, reason: 'names the resource path outside a $res: reference' })
+			continue
+		}
 		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
 		// low-code one keeps its components under `grid`.
 		const isRaw = !!value.files && !!value.runnables
@@ -155,11 +207,18 @@ export async function planRetarget(
 		const def = TRIGGER_KINDS[kind]
 		if (def.eeOnly && !opts.hasEeLicense) continue
 		let rows: Array<Record<string, any>> = []
+		// A kind whose listing is incomplete cannot be cleared either: refusing is the
+		// all-or-nothing rule, since a trigger left on the stub breaks when it is deleted.
+		// A 404 is not incompleteness — the instance has that trigger feature compiled out,
+		// so there is no trigger of the kind to leave behind.
+		let incomplete = false
 		try {
-			rows = await def.list(workspace)
-		} catch {
-			// A kind that cannot be listed cannot be cleared either: refusing is the
-			// all-or-nothing rule, since a trigger left on the stub breaks when it is deleted.
+			rows = await def.list(workspace, () => (incomplete = true))
+		} catch (e: any) {
+			if (e?.status === 404) continue
+			incomplete = true
+		}
+		if (incomplete) {
 			blocked.push({ path: `${def.badge} triggers`, reason: 'could not be listed' })
 			continue
 		}
@@ -251,13 +310,25 @@ async function rewriteScript(workspace: string, path: string, map: Map<string, s
 	})
 }
 
+/**
+ * The value about to be written still reaches a path being moved. `planRetarget` refuses
+ * every item where that is possible, so getting here means the item changed between the plan
+ * and the write. Throwing stops the run with the stub still in place, which is the state
+ * where both the rewritten items and the untouched ones resolve.
+ */
+function assertRelocated(next: unknown, path: string, map: Map<string, string>) {
+	for (const from of map.keys()) {
+		if (referencesResourcePath(next, from)) {
+			throw new Error(`${path} still references ${from} after the rewrite`)
+		}
+	}
+}
+
 async function rewriteFlow(workspace: string, path: string, map: Map<string, string>) {
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
-	await FlowService.updateFlow({
-		workspace,
-		path,
-		requestBody: { ...f, path, value: rewriteFlowValue(f.value, map) }
-	})
+	const value = rewriteFlowValue(f.value, map)
+	assertRelocated(value, path, map)
+	await FlowService.updateFlow({ workspace, path, requestBody: { ...f, path, value } })
 }
 
 /**
@@ -269,6 +340,7 @@ async function rewriteFlow(workspace: string, path: string, map: Map<string, str
 async function rewriteApp(workspace: string, path: string, map: Map<string, string>) {
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const next = rewriteAppValue(a.value ?? {}, map)
+	assertRelocated(next, path, map)
 	const policy = (await updatePolicy(next as App, undefined)) as any
 	if (!policy.execution_mode) policy.execution_mode = 'publisher'
 	await AppService.updateApp({ workspace, path, requestBody: { path, value: next, policy } })
@@ -291,6 +363,7 @@ async function rewriteRawApp(
 	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
 	// the sources too, and both are plain text inside this JSON.
 	const next = JSON.parse(rewriteRawAppContent(JSON.stringify(value), map))
+	assertRelocated(next, path, map)
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
 	if (!policy.execution_mode) policy.execution_mode = 'publisher'
@@ -323,9 +396,10 @@ async function rewriteRawApp(
  * imported triggers are created disabled and re-enabling one is the user's decision, not a
  * side effect of pointing it at a credential.
  *
- * `path` is put back from the row afterwards. The rewrite remaps any string equal to the
- * stub's path, and a trigger sitting at the path the resource used to hold would otherwise
- * be renamed along with the reference.
+ * `path` and `script_path` are put back from the row afterwards. The rewrite remaps any
+ * string equal to the stub's path, so a trigger sitting at the path the resource used to
+ * hold — or running a script that does — would otherwise be renamed, or repointed at the
+ * reused resource, along with the reference.
  */
 async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, string>) {
 	const def = TRIGGER_KINDS[r.triggerKind!]
@@ -334,7 +408,8 @@ async function rewriteTrigger(workspace: string, r: Referrer, map: Map<string, s
 	if (!row) throw new Error(`trigger ${r.path} is no longer there`)
 	const { enabled: _enabled, ...rest } = {
 		...(rewriteTriggerConfig(row, map) as any),
-		path: r.path
+		path: r.path,
+		...(typeof row.script_path === 'string' ? { script_path: row.script_path } : {})
 	}
 	if (r.triggerKind === 'schedule') {
 		// `EditSchedule` needs these three; everything else on the row carries over by name.

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -42,7 +42,7 @@ import { updateRawAppPolicy } from '$lib/sharedUtils'
 import type { App } from '$lib/components/apps/types'
 import { apiErrorMessage as errorMessage } from '$lib/utils'
 
-export type ReferrerKind = 'script' | 'flow' | 'app' | 'raw app' | 'trigger'
+export type ReferrerKind = 'script' | 'flow' | 'app' | 'trigger'
 
 export interface Referrer {
 	kind: ReferrerKind
@@ -152,6 +152,10 @@ const SEARCH_LIMITS = { script: 10000, flow: 1000, app: 1000 }
  */
 const TRIGGER_LIST_LIMIT = 1000
 
+/** Trigger fields naming a runnable, and the two spellings `rewriteTriggerConfig` remaps. */
+const RUNNABLE_REF_FIELDS = ['on_failure', 'on_recovery', 'on_success', 'url']
+const RUNNABLE_REF_RE = /^(?:\$(?:script|flow):|(?:script|flow)\/)/
+
 /** A reference this run will not move, recorded so the stub outlives it. */
 const OUTSIDE_PROJECT = 'reads this resource from outside the project'
 const UNSEEN_BY_CALLER = 'holds items this account is not shown'
@@ -246,10 +250,7 @@ export async function planRetarget(
 			if (!reads) continue
 		}
 		const gapped = bare ? ({ gapped: true } as const) : undefined
-		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
-		// low-code one keeps its components under `grid`.
-		const isRaw = !!value.files && !!value.runnables
-		referrers.push({ kind: isRaw ? 'raw app' : 'app', path: a.path!, ...gapped })
+		referrers.push({ kind: 'app', path: a.path!, ...gapped })
 	}
 
 	for (const kind of WORKSPACE_TRIGGER_KINDS) {
@@ -328,7 +329,6 @@ export async function applyRetarget(args: {
 			if (r.kind === 'script') moved = await rewriteScript(workspace, r, map)
 			else if (r.kind === 'flow') moved = await rewriteFlow(workspace, r, map)
 			else if (r.kind === 'app') moved = await rewriteApp(workspace, r, map)
-			else if (r.kind === 'raw app') moved = await rewriteRawApp(workspace, r, map)
 			else moved = await rewriteTrigger(workspace, r, map)
 		} catch (e: any) {
 			return { rewritten, gaps, stubDeleted: false, error: errorMessage(e) }
@@ -459,6 +459,10 @@ async function rewriteApp(
 ): Promise<true | string> {
 	const path = r.path
 	const a: any = await AppService.getAppByPath({ workspace, path })
+	// The deployed record says which kind this is. `list_search_apps` returns only the path and
+	// the value, so the scan could only have guessed from the value's shape — and a guess wrong
+	// in either direction is a deploy the backend refuses for changing an app's kind.
+	if (a.raw_app) return rewriteRawApp(workspace, r, map, a)
 	if (!r.gapped && readsPathUnreachably(a.value ?? {}, map)) return UNREACHABLE_REFERENCE
 	const next = rewriteTokens(a.value ?? {}, map)
 	// The tokens the plan saw are gone from the deployed item, so there is nothing to write.
@@ -509,10 +513,10 @@ async function fetchBundlePart(
 async function rewriteRawApp(
 	workspace: string,
 	r: Referrer,
-	map: Map<string, string>
+	map: Map<string, string>,
+	a: any
 ): Promise<true | string> {
 	const path = r.path
-	const a: any = await AppService.getAppByPath({ workspace, path })
 	const value: any = a.value ?? {}
 	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
 	// the sources too, and both are plain text inside this JSON.
@@ -587,6 +591,16 @@ async function rewriteTrigger(
 		...(rewriteTriggerConfig(row, map) as any),
 		path: r.path,
 		...(typeof row.script_path === 'string' ? { script_path: row.script_path } : {}),
+		// The handler and url fields name a runnable, and `rewriteTriggerConfig` remaps one on
+		// an exact match — right for the folder-wide map the import hands it, wrong for a map
+		// holding one resource path. A schedule whose `on_failure` runs a script sharing that
+		// path would have its error handler pointed at the credential. Only the two prefixed
+		// shapes it remaps are restored, so a field holding a `$res:` token still moves.
+		...Object.fromEntries(
+			RUNNABLE_REF_FIELDS.filter(
+				(k) => typeof row[k] === 'string' && RUNNABLE_REF_RE.test(row[k])
+			).map((k) => [k, row[k]])
+		),
 		...(typeof row.permissioned_as === 'string'
 			? { permissioned_as: row.permissioned_as, preserve_permissioned_as: true }
 			: {})

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -48,6 +48,12 @@ export interface Referrer {
 	path: string
 	/** Present for triggers: which kind's table it lives in. */
 	triggerKind?: WorkspaceTriggerKind
+	/**
+	 * Present for triggers: the row the scan read, which is also what the write sends back.
+	 * Re-reading it costs another listing of the whole kind per trigger — and for schedules a
+	 * listing plus a detail fetch per row, since `list` resolves each one.
+	 */
+	row?: Record<string, any>
 }
 
 /** Something the scan could not account for. `path` names an item, or a listing standing in
@@ -222,7 +228,7 @@ export async function planRetarget(
 				})
 				continue
 			}
-			referrers.push({ kind: 'trigger', path: String(t.path), triggerKind: kind })
+			referrers.push({ kind: 'trigger', path: String(t.path), triggerKind: kind, row: t })
 		}
 	}
 
@@ -464,9 +470,7 @@ async function rewriteTrigger(
 	map: Map<string, string>
 ): Promise<boolean> {
 	const def = TRIGGER_KINDS[r.triggerKind!]
-	const rows = await def.list(workspace)
-	const row: any = rows.find((t) => t.path === r.path)
-	if (!row) throw new Error(`trigger ${r.path} is no longer there`)
+	const row: any = r.row ?? {}
 	const { enabled: _enabled, ...rest } = {
 		...(rewriteTriggerConfig(row, map) as any),
 		path: r.path,

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -91,23 +91,21 @@ function inFolder(path: unknown, folder: string): boolean {
 }
 
 /**
- * A bare string exactly equal to the resource path, anywhere in the structure.
+ * Whether the item names the resource path anywhere a rewriter would not reach it.
  *
- * A script, flow or app spells a resource reference as a `$res:` token and nothing else, so a
- * bare match is either a reference no rewriter relocates — a static string value in a
- * component, an argument the code assembles itself — or something that is not the resource at
+ * A script, flow or app spells a reference the rewriters move as a `$res:` token and nothing
+ * else. The path appearing any other way is either a reference beyond them — a static string
+ * value in a component, an argument inline code assembles itself — or not the resource at
  * all, such as a step running a script that happens to share the path. Neither is rewritable:
  * moving the first is beyond the rewriters, and moving the second would repoint a runnable at
- * a credential. Triggers are the exception and hold the bare path by design.
+ * a credential. Both are reasons the stub has to outlive the run.
+ *
+ * The whole serialized item is searched, because inline code is a string inside it and a path
+ * written in code is no less a reference for being surrounded by other characters. Triggers
+ * are the exception and hold the bare path by design, so they never come here.
  */
-function holdsBarePath(value: unknown, path: string): boolean {
-	const walk = (v: any): boolean => {
-		if (typeof v === 'string') return v === path
-		if (Array.isArray(v)) return v.some(walk)
-		if (v && typeof v === 'object') return Object.values(v).some(walk)
-		return false
-	}
-	return walk(value)
+function namesPathUnreachably(value: unknown, path: string): boolean {
+	return textHoldsBarePath(JSON.stringify(value ?? null), path)
 }
 
 /**
@@ -168,9 +166,8 @@ export async function planRetarget(
 	for (const s of scripts ?? []) {
 		const content = String(s.content ?? '')
 		const reads = referencesResourcePath(content, from)
-		// A script's content is one string, so the whole-string match `holdsBarePath` makes for
-		// a flow or an app cannot see a path written inside it. `rewriteContent` moves the
-		// `$res:` tokens and nothing else, so a bare mention is a reference this leaves behind.
+		// `rewriteContent` moves the `$res:` tokens and nothing else, so a path the code spells
+		// out is a reference this run leaves behind.
 		const bare = textHoldsBarePath(content, from)
 		if (!reads && !bare) continue
 		if (!inFolder(s.path, folder)) {
@@ -185,12 +182,17 @@ export async function planRetarget(
 	}
 	for (const f of flows ?? []) {
 		const value: any = f.value ?? {}
-		if (!referencesResourcePath(value, from)) continue
+		const reads = referencesResourcePath(value, from)
+		const bare = namesPathUnreachably(value, from)
+		if (!reads && !bare) continue
 		if (!inFolder(f.path, folder)) {
 			gaps.push({ path: f.path!, reason: OUTSIDE_PROJECT })
 			continue
 		}
-		if (holdsBarePath(value, from)) {
+		// Gapped rather than rewritten even when it also holds a `$res:` token. The stub
+		// survives either way, so the token still resolves, and rewriting half an item would
+		// only make the plan and the write disagree about what moved.
+		if (bare) {
 			gaps.push({ path: f.path!, reason: UNREACHABLE_REFERENCE })
 			continue
 		}
@@ -198,12 +200,17 @@ export async function planRetarget(
 	}
 	for (const a of apps ?? []) {
 		const value: any = a.value ?? {}
-		if (!referencesResourcePath(value, from)) continue
+		const reads = referencesResourcePath(value, from)
+		const bare = namesPathUnreachably(value, from)
+		if (!reads && !bare) continue
 		if (!inFolder(a.path, folder)) {
 			gaps.push({ path: a.path!, reason: OUTSIDE_PROJECT })
 			continue
 		}
-		if (holdsBarePath(value, from)) {
+		// Gapped rather than rewritten even when it also holds a `$res:` token. The stub
+		// survives either way, so the token still resolves, and rewriting half an item would
+		// only make the plan and the write disagree about what moved.
+		if (bare) {
 			gaps.push({ path: a.path!, reason: UNREACHABLE_REFERENCE })
 			continue
 		}
@@ -279,7 +286,7 @@ export async function applyRetarget(args: {
 	const gaps = [...plan.gaps]
 
 	for (const r of plan.referrers) {
-		let moved: boolean
+		let moved: true | string
 		try {
 			if (r.kind === 'script') moved = await rewriteScript(workspace, r.path, map)
 			else if (r.kind === 'flow') moved = await rewriteFlow(workspace, r.path, map)
@@ -289,8 +296,8 @@ export async function applyRetarget(args: {
 		} catch (e: any) {
 			return { rewritten, gaps, stubDeleted: false, error: errorMessage(e) }
 		}
-		if (moved) rewritten.push(r)
-		else gaps.push({ path: r.path, reason: 'changed while it was being retargeted' })
+		if (moved === true) rewritten.push(r)
+		else gaps.push({ path: r.path, reason: moved })
 	}
 
 	if (gaps.length > 0) return { rewritten, gaps, stubDeleted: false }
@@ -302,6 +309,9 @@ export async function applyRetarget(args: {
 	}
 	return { rewritten, gaps, stubDeleted: true }
 }
+
+/** Why a rewriter left an item where it was, or `true` when it moved it. */
+const CHANGED_UNDER_US = 'changed while it was being retargeted'
 
 /**
  * Whether the rewritten value has left every path being moved.
@@ -342,10 +352,10 @@ async function rewriteScript(
 	workspace: string,
 	path: string,
 	map: Map<string, string>
-): Promise<boolean> {
+): Promise<true | string> {
 	const s: any = await ScriptService.getScriptByPath({ workspace, path })
 	const content = rewriteContent(s.content ?? '', map)
-	if (!relocated(content, map)) return false
+	if (!relocated(content, map)) return CHANGED_UNDER_US
 	if (content === s.content) return true
 	await ScriptService.createScript({
 		workspace,
@@ -364,10 +374,10 @@ async function rewriteFlow(
 	workspace: string,
 	path: string,
 	map: Map<string, string>
-): Promise<boolean> {
+): Promise<true | string> {
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
 	const value = rewriteFlowValue(f.value, map)
-	if (!relocated(value, map)) return false
+	if (!relocated(value, map)) return CHANGED_UNDER_US
 	await FlowService.updateFlow({
 		workspace,
 		path,
@@ -391,10 +401,10 @@ async function rewriteApp(
 	workspace: string,
 	path: string,
 	map: Map<string, string>
-): Promise<boolean> {
+): Promise<true | string> {
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const next = rewriteAppValue(a.value ?? {}, map)
-	if (!relocated(next, map)) return false
+	if (!relocated(next, map)) return CHANGED_UNDER_US
 	const policy = (await updatePolicy(next as App, a.policy)) as any
 	await AppService.updateApp({
 		workspace,
@@ -442,13 +452,13 @@ async function rewriteRawApp(
 	workspace: string,
 	path: string,
 	map: Map<string, string>
-): Promise<boolean> {
+): Promise<true | string> {
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const value: any = a.value ?? {}
 	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
 	// the sources too, and both are plain text inside this JSON.
 	const next = JSON.parse(rewriteRawAppContent(JSON.stringify(value), map))
-	if (!relocated(next, map)) return false
+	if (!relocated(next, map)) return CHANGED_UNDER_US
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
 	const secret = await AppService.getPublicSecretOfLatestVersionOfApp({ workspace, path })
@@ -461,7 +471,7 @@ async function rewriteRawApp(
 	// `rewriteContent` moves the `$res:` tokens. A path the bundle spells out any other way
 	// is one nothing here can move, and uploading it would leave the app reading a resource
 	// about to be deleted.
-	for (const stub of map.keys()) if (textHoldsBarePath(js, stub)) return false
+	for (const stub of map.keys()) if (textHoldsBarePath(js, stub)) return UNREACHABLE_REFERENCE
 	const files = { ...(next.files ?? {}) }
 	delete files['/bundle.js']
 	delete files['/bundle.css']
@@ -507,7 +517,7 @@ async function rewriteTrigger(
 	workspace: string,
 	r: Referrer,
 	map: Map<string, string>
-): Promise<boolean> {
+): Promise<true | string> {
 	const def = TRIGGER_KINDS[r.triggerKind!]
 	const row: any = r.row ?? {}
 	const { enabled: _enabled, ...rest } = {

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -48,6 +48,12 @@ export interface Referrer {
 	/** Present for triggers: which kind's table it lives in. */
 	triggerKind?: WorkspaceTriggerKind
 	/**
+	 * The plan already recorded this item as naming the path somewhere no rewrite reaches, so
+	 * the stub survives whatever the write does. Its tokens are still worth moving, and the
+	 * write's own staleness check has nothing left to add.
+	 */
+	gapped?: true
+	/**
 	 * Present for triggers: the row the scan read, which is also what the write sends back.
 	 * Re-reading it costs another listing of the whole kind per trigger — and for schedules a
 	 * listing plus a detail fetch per row, since `list` resolves each one.
@@ -139,8 +145,7 @@ const UNREACHABLE_REFERENCE = 'names the resource path outside a $res: reference
 export async function planRetarget(
 	workspace: string,
 	folder: string,
-	from: string,
-	opts: { hasEeLicense: boolean }
+	from: string
 ): Promise<RetargetPlan> {
 	const referrers: Referrer[] = []
 	const gaps: Gap[] = []
@@ -176,7 +181,7 @@ export async function planRetarget(
 			gaps.push({ path: s.path!, reason: UNREACHABLE_REFERENCE })
 			if (!reads) continue
 		}
-		referrers.push({ kind: 'script', path: s.path! })
+		referrers.push({ kind: 'script', path: s.path!, ...(bare ? { gapped: true as const } : {}) })
 	}
 	for (const f of flows ?? []) {
 		const value: any = f.value ?? {}
@@ -193,7 +198,8 @@ export async function planRetarget(
 			gaps.push({ path: f.path!, reason: UNREACHABLE_REFERENCE })
 			if (!reads) continue
 		}
-		referrers.push({ kind: 'flow', path: f.path! })
+		const gapped = bare ? ({ gapped: true } as const) : undefined
+		referrers.push({ kind: 'flow', path: f.path!, ...gapped })
 	}
 	for (const a of apps ?? []) {
 		const value: any = a.value ?? {}
@@ -210,15 +216,20 @@ export async function planRetarget(
 			gaps.push({ path: a.path!, reason: UNREACHABLE_REFERENCE })
 			if (!reads) continue
 		}
+		const gapped = bare ? ({ gapped: true } as const) : undefined
 		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
 		// low-code one keeps its components under `grid`.
 		const isRaw = !!value.files && !!value.runnables
-		referrers.push({ kind: isRaw ? 'raw app' : 'app', path: a.path! })
+		referrers.push({ kind: isRaw ? 'raw app' : 'app', path: a.path!, ...gapped })
 	}
 
 	for (const kind of WORKSPACE_TRIGGER_KINDS) {
 		const def = TRIGGER_KINDS[kind]
-		if (def.eeOnly && !opts.hasEeLicense) continue
+		// No `eeOnly` skip. That reads a client-side store, which is empty on an EE instance
+		// whose licence is unset or whose fetch failed — while the rows are still in the
+		// database and the routes still answer. A kind skipped that way leaves no gap, so the
+		// stub would go while an EE trigger still points at it. On CE the routes are not
+		// registered and the 404 below says so, from the server.
 		let rows: Array<Record<string, any>> = []
 		// A 404 is not an incomplete listing — the instance has that trigger feature compiled
 		// out, so there is no trigger of the kind to have missed. Anything else means triggers
@@ -272,22 +283,21 @@ export async function applyRetarget(args: {
 	folder: string
 	from: string
 	to: string
-	hasEeLicense: boolean
 }): Promise<RetargetOutcome> {
-	const { workspace, folder, from, to, hasEeLicense } = args
+	const { workspace, folder, from, to } = args
 	const map = new Map([[from, to]])
 	const rewritten: Referrer[] = []
 
-	const plan = await planRetarget(workspace, folder, from, { hasEeLicense })
+	const plan = await planRetarget(workspace, folder, from)
 	const gaps = [...plan.gaps]
 
 	for (const r of plan.referrers) {
 		let moved: true | string
 		try {
-			if (r.kind === 'script') moved = await rewriteScript(workspace, r.path, map)
-			else if (r.kind === 'flow') moved = await rewriteFlow(workspace, r.path, map)
-			else if (r.kind === 'app') moved = await rewriteApp(workspace, r.path, map)
-			else if (r.kind === 'raw app') moved = await rewriteRawApp(workspace, r.path, map)
+			if (r.kind === 'script') moved = await rewriteScript(workspace, r, map)
+			else if (r.kind === 'flow') moved = await rewriteFlow(workspace, r, map)
+			else if (r.kind === 'app') moved = await rewriteApp(workspace, r, map)
+			else if (r.kind === 'raw app') moved = await rewriteRawApp(workspace, r, map)
 			else moved = await rewriteTrigger(workspace, r, map)
 		} catch (e: any) {
 			return { rewritten, gaps, stubDeleted: false, error: errorMessage(e) }
@@ -320,21 +330,19 @@ function rewriteTokens<T>(value: T, map: Map<string, string>): T {
 	return JSON.parse(rewriteContent(JSON.stringify(value ?? null), map))
 }
 
-/** Why a rewriter left an item where it was, or `true` when it moved it. */
-const CHANGED_UNDER_US = 'changed while it was being retargeted'
 
 /**
- * Whether the rewrite moved every `$res:` token it was there to move.
+ * Whether the item as just read names a path where no rewrite reaches it.
  *
- * Only tokens: a path the item also spells out unreachably is recorded as a gap by the plan,
- * and re-reading it here would report the same item twice — once as unmovable and once as
- * having changed underfoot. So a `false` here means what it says, that the item's tokens are
- * not where the rewrite should have put them, which is a change between the plan and the
- * write. Each rewriter answers with this rather than writing.
+ * The plan classifies items from the `listSearch*` rows; every rewriter then re-reads its
+ * item by path. A value that has gained an unreachable mention in between is one the plan
+ * cleared and the write must not: rewriting its tokens is fine, but the stub it still names
+ * has to survive. Checking the read the write is about to send is the only place that can be
+ * seen.
  */
-function relocated(next: unknown, map: Map<string, string>): boolean {
-	for (const from of map.keys()) if (holdsResourceToken(next, from)) return false
-	return true
+function readsPathUnreachably(value: unknown, map: Map<string, string>): boolean {
+	for (const from of map.keys()) if (namesPathUnreachably(value, from)) return true
+	return false
 }
 
 /**
@@ -361,12 +369,15 @@ const PRESERVE_DEPLOYED_IDENTITY = { preserve_on_behalf_of: true }
  */
 async function rewriteScript(
 	workspace: string,
-	path: string,
+	r: Referrer,
 	map: Map<string, string>
 ): Promise<true | string> {
+	const path = r.path
 	const s: any = await ScriptService.getScriptByPath({ workspace, path })
+	if (!r.gapped)
+		for (const stub of map.keys())
+			if (textHoldsBarePath(String(s.content ?? ''), stub)) return UNREACHABLE_REFERENCE
 	const content = rewriteContent(s.content ?? '', map)
-	if (!relocated(content, map)) return CHANGED_UNDER_US
 	if (content === s.content) return true
 	await ScriptService.createScript({
 		workspace,
@@ -383,12 +394,13 @@ async function rewriteScript(
 
 async function rewriteFlow(
 	workspace: string,
-	path: string,
+	r: Referrer,
 	map: Map<string, string>
 ): Promise<true | string> {
+	const path = r.path
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
+	if (!r.gapped && readsPathUnreachably(f.value ?? {}, map)) return UNREACHABLE_REFERENCE
 	const value = rewriteTokens(f.value ?? {}, map)
-	if (!relocated(value, map)) return CHANGED_UNDER_US
 	// The tokens the plan saw are gone from the deployed item, so there is nothing to write.
 	if (JSON.stringify(value) === JSON.stringify(f.value ?? {})) return true
 	await FlowService.updateFlow({
@@ -412,12 +424,13 @@ async function rewriteFlow(
  */
 async function rewriteApp(
 	workspace: string,
-	path: string,
+	r: Referrer,
 	map: Map<string, string>
 ): Promise<true | string> {
+	const path = r.path
 	const a: any = await AppService.getAppByPath({ workspace, path })
+	if (!r.gapped && readsPathUnreachably(a.value ?? {}, map)) return UNREACHABLE_REFERENCE
 	const next = rewriteTokens(a.value ?? {}, map)
-	if (!relocated(next, map)) return CHANGED_UNDER_US
 	// The tokens the plan saw are gone from the deployed item, so there is nothing to write.
 	if (JSON.stringify(next) === JSON.stringify(a.value ?? {})) return true
 	const policy = (await updatePolicy(next as App, a.policy)) as any
@@ -465,15 +478,16 @@ async function fetchBundlePart(
  */
 async function rewriteRawApp(
 	workspace: string,
-	path: string,
+	r: Referrer,
 	map: Map<string, string>
 ): Promise<true | string> {
+	const path = r.path
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const value: any = a.value ?? {}
 	// One walk over the whole value: `$res:` tokens live in the runnables and can appear in
 	// the sources too, and both are plain text inside this JSON.
+	if (!r.gapped && readsPathUnreachably(value, map)) return UNREACHABLE_REFERENCE
 	const next = rewriteTokens(value, map)
-	if (!relocated(next, map)) return CHANGED_UNDER_US
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
 	const secret = await AppService.getPublicSecretOfLatestVersionOfApp({ workspace, path })
@@ -547,9 +561,9 @@ async function rewriteTrigger(
 			? { permissioned_as: row.permissioned_as, preserve_permissioned_as: true }
 			: {})
 	}
-	// No `relocated` check: `rewriteTriggerConfig` remaps every bare match at every depth, so
-	// the resource field always moves. What can still read `from` afterwards is a restored
-	// identity field, which is not a reference to the resource at all.
+	// No unreachable-mention check: a trigger holds the bare path by design, in its own
+	// resource field, and `rewriteTriggerConfig` remaps every bare match at every depth. What
+	// can still read `from` afterwards is a restored identity field, not a reference.
 	if (r.triggerKind === 'schedule') {
 		// `EditSchedule` needs these three; everything else on the row carries over by name.
 		await ScheduleService.updateSchedule({

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -30,6 +30,7 @@ import {
 	rewriteRawAppContent,
 	rewriteTriggerConfig,
 	referencesResourcePath,
+	holdsResourceToken,
 	textHoldsBarePath
 } from '$lib/components/workspaceSettings/projectBundle'
 import {
@@ -182,37 +183,35 @@ export async function planRetarget(
 	}
 	for (const f of flows ?? []) {
 		const value: any = f.value ?? {}
-		const reads = referencesResourcePath(value, from)
+		// A token is the only spelling a rewriter moves. `referencesResourcePath` would also
+		// count a whole string equal to the path, which is the unreachable case `bare` covers.
+		const reads = holdsResourceToken(value, from)
 		const bare = namesPathUnreachably(value, from)
 		if (!reads && !bare) continue
 		if (!inFolder(f.path, folder)) {
 			gaps.push({ path: f.path!, reason: OUTSIDE_PROJECT })
 			continue
 		}
-		// Gapped rather than rewritten even when it also holds a `$res:` token. The stub
-		// survives either way, so the token still resolves, and rewriting half an item would
-		// only make the plan and the write disagree about what moved.
 		if (bare) {
 			gaps.push({ path: f.path!, reason: UNREACHABLE_REFERENCE })
-			continue
+			if (!reads) continue
 		}
 		referrers.push({ kind: 'flow', path: f.path! })
 	}
 	for (const a of apps ?? []) {
 		const value: any = a.value ?? {}
-		const reads = referencesResourcePath(value, from)
+		// A token is the only spelling a rewriter moves. `referencesResourcePath` would also
+		// count a whole string equal to the path, which is the unreachable case `bare` covers.
+		const reads = holdsResourceToken(value, from)
 		const bare = namesPathUnreachably(value, from)
 		if (!reads && !bare) continue
 		if (!inFolder(a.path, folder)) {
 			gaps.push({ path: a.path!, reason: OUTSIDE_PROJECT })
 			continue
 		}
-		// Gapped rather than rewritten even when it also holds a `$res:` token. The stub
-		// survives either way, so the token still resolves, and rewriting half an item would
-		// only make the plan and the write disagree about what moved.
 		if (bare) {
 			gaps.push({ path: a.path!, reason: UNREACHABLE_REFERENCE })
-			continue
+			if (!reads) continue
 		}
 		// `files` + `runnables` and no `grid` is the deployed shape of a raw app; the
 		// low-code one keeps its components under `grid`.
@@ -314,15 +313,16 @@ export async function applyRetarget(args: {
 const CHANGED_UNDER_US = 'changed while it was being retargeted'
 
 /**
- * Whether the rewritten value has left every path being moved.
+ * Whether the rewrite moved every `$res:` token it was there to move.
  *
- * `planRetarget` skips the items it can see a rewriter would not reach, so a `false` here
- * means the item changed between the plan and the write. Each rewriter answers with this
- * rather than writing: an item written while it still reads the stub is one the caller would
- * count as moved.
+ * Only tokens: a path the item also spells out unreachably is recorded as a gap by the plan,
+ * and re-reading it here would report the same item twice — once as unmovable and once as
+ * having changed underfoot. So a `false` here means what it says, that the item's tokens are
+ * not where the rewrite should have put them, which is a change between the plan and the
+ * write. Each rewriter answers with this rather than writing.
  */
 function relocated(next: unknown, map: Map<string, string>): boolean {
-	for (const from of map.keys()) if (referencesResourcePath(next, from)) return false
+	for (const from of map.keys()) if (holdsResourceToken(next, from)) return false
 	return true
 }
 
@@ -378,6 +378,8 @@ async function rewriteFlow(
 	const f: any = await FlowService.getFlowByPath({ workspace, path })
 	const value = rewriteFlowValue(f.value, map)
 	if (!relocated(value, map)) return CHANGED_UNDER_US
+	// Nothing moved: the item was listed for a reference no rewriter reaches, already gapped.
+	if (JSON.stringify(value) === JSON.stringify(f.value)) return true
 	await FlowService.updateFlow({
 		workspace,
 		path,
@@ -405,6 +407,8 @@ async function rewriteApp(
 	const a: any = await AppService.getAppByPath({ workspace, path })
 	const next = rewriteAppValue(a.value ?? {}, map)
 	if (!relocated(next, map)) return CHANGED_UNDER_US
+	// Nothing moved: the item was listed for a reference no rewriter reaches, already gapped.
+	if (JSON.stringify(next) === JSON.stringify(a.value ?? {})) return true
 	const policy = (await updatePolicy(next as App, a.policy)) as any
 	await AppService.updateApp({
 		workspace,
@@ -472,6 +476,10 @@ async function rewriteRawApp(
 	// is one nothing here can move, and uploading it would leave the app reading a resource
 	// about to be deleted.
 	for (const stub of map.keys()) if (textHoldsBarePath(js, stub)) return UNREACHABLE_REFERENCE
+	// Nothing moved: the app was listed for a reference no rewriter reaches, already gapped.
+	// Uploading an unchanged app would cut it a version that differs from the last in nothing.
+	if (js === deployedJs && css === deployedCss && JSON.stringify(next) === JSON.stringify(value))
+		return true
 	const files = { ...(next.files ?? {}) }
 	delete files['/bundle.js']
 	delete files['/bundle.css']

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -361,7 +361,6 @@ function rewriteTokens<T>(value: T, map: Map<string, string>): T {
 	return JSON.parse(rewriteContent(JSON.stringify(value ?? null), map))
 }
 
-
 /**
  * Whether the item as just read names a path where no rewrite reaches it.
  *

--- a/frontend/src/lib/importWizard/retargetDeployed.ts
+++ b/frontend/src/lib/importWizard/retargetDeployed.ts
@@ -29,7 +29,8 @@ import {
 	rewriteFlowValue,
 	rewriteRawAppContent,
 	rewriteTriggerConfig,
-	referencesResourcePath
+	referencesResourcePath,
+	textHoldsBarePath
 } from '$lib/components/workspaceSettings/projectBundle'
 import {
 	TRIGGER_KINDS,
@@ -121,6 +122,13 @@ function holdsBarePath(value: unknown, path: string): boolean {
  */
 const SEARCH_LIMITS = { script: 10000, flow: 1000, app: 1000 }
 
+/**
+ * What a trigger listing caps at. The kinds' list routes take pagination this table does not
+ * pass, so each answers with the server's `DEFAULT_PER_PAGE`. A full page is read the same
+ * way as a full `listSearch*` page: as a listing that cannot account for the rest.
+ */
+const TRIGGER_LIST_LIMIT = 1000
+
 /** A reference this run will not move, recorded so the stub outlives it. */
 const OUTSIDE_PROJECT = 'reads this resource from outside the project'
 const UNREACHABLE_REFERENCE = 'names the resource path outside a $res: reference'
@@ -158,10 +166,20 @@ export async function planRetarget(
 	// The listings are workspace-wide, so an item outside the folder is seen for free. It is
 	// the user's own and stays on the stub, which is the whole reason the stub stays too.
 	for (const s of scripts ?? []) {
-		if (!referencesResourcePath(s.content ?? '', from)) continue
+		const content = String(s.content ?? '')
+		const reads = referencesResourcePath(content, from)
+		// A script's content is one string, so the whole-string match `holdsBarePath` makes for
+		// a flow or an app cannot see a path written inside it. `rewriteContent` moves the
+		// `$res:` tokens and nothing else, so a bare mention is a reference this leaves behind.
+		const bare = textHoldsBarePath(content, from)
+		if (!reads && !bare) continue
 		if (!inFolder(s.path, folder)) {
 			gaps.push({ path: s.path!, reason: OUTSIDE_PROJECT })
 			continue
+		}
+		if (bare) {
+			gaps.push({ path: s.path!, reason: UNREACHABLE_REFERENCE })
+			if (!reads) continue
 		}
 		referrers.push({ kind: 'script', path: s.path! })
 	}
@@ -211,6 +229,10 @@ export async function planRetarget(
 		}
 		if (incomplete) {
 			gaps.push({ path: `${def.badge} triggers`, reason: 'could not be listed' })
+			continue
+		}
+		if (rows.length >= TRIGGER_LIST_LIMIT) {
+			gaps.push({ path: `${def.badge} triggers`, reason: 'could not all be listed' })
 			continue
 		}
 		for (const t of rows) {
@@ -406,9 +428,15 @@ async function fetchBundlePart(
 
 /**
  * A raw app: its deployed value carries the sources and the runnables, and `updateAppRaw`
- * refuses without a bundle. The bundle is the deployed one, read back and sent again
- * unchanged — the sources are not being edited here, so rebuilding it is neither possible
- * from the browser nor needed.
+ * refuses without a bundle. The bundle is the deployed one, read back, rewritten and sent
+ * again — rebuilding it is not possible from the browser and is not needed, but re-uploading
+ * it untouched is not an option either.
+ *
+ * The bundle is compiled from the sources, so a `$res:` a source file spells out is baked
+ * into it. The import rewrites that copy — `retargetProjectExport` runs while `/bundle.js`
+ * is still one of `files`, and only `installProject` splits it out afterwards. Sending the
+ * deployed bundle back unrewritten would undo on reuse what the import got right, and the
+ * app would keep reading a resource this run is about to delete.
  */
 async function rewriteRawApp(
 	workspace: string,
@@ -424,10 +452,16 @@ async function rewriteRawApp(
 	const runnables = next.runnables ?? {}
 	const policy = (await updateRawAppPolicy(runnables, a.policy)) as any
 	const secret = await AppService.getPublicSecretOfLatestVersionOfApp({ workspace, path })
-	const [js, css] = await Promise.all([
+	const [deployedJs, deployedCss] = await Promise.all([
 		fetchBundlePart(workspace, secret, 'js'),
 		fetchBundlePart(workspace, secret, 'css')
 	])
+	const js = rewriteContent(deployedJs, map)
+	const css = rewriteContent(deployedCss, map)
+	// `rewriteContent` moves the `$res:` tokens. A path the bundle spells out any other way
+	// is one nothing here can move, and uploading it would leave the app reading a resource
+	// about to be deleted.
+	for (const stub of map.keys()) if (textHoldsBarePath(js, stub)) return false
 	const files = { ...(next.files ?? {}) }
 	delete files['/bundle.js']
 	delete files['/bundle.css']
@@ -463,6 +497,11 @@ async function rewriteRawApp(
  * string equal to the stub's path, so a trigger sitting at the path the resource used to
  * hold — or running a script that does — would otherwise be renamed, or repointed at the
  * reused resource, along with the reference.
+ *
+ * A trigger states its run identity as `permissioned_as`, not the `on_behalf_of` the other
+ * kinds use, and `resolve_permissioned_as` keeps the row's value only when
+ * `preserve_permissioned_as` says so. Without the pair a trigger created under a folder's
+ * `default_permissioned_as` would start running as whoever picked the credential.
  */
 async function rewriteTrigger(
 	workspace: string,
@@ -474,7 +513,10 @@ async function rewriteTrigger(
 	const { enabled: _enabled, ...rest } = {
 		...(rewriteTriggerConfig(row, map) as any),
 		path: r.path,
-		...(typeof row.script_path === 'string' ? { script_path: row.script_path } : {})
+		...(typeof row.script_path === 'string' ? { script_path: row.script_path } : {}),
+		...(typeof row.permissioned_as === 'string'
+			? { permissioned_as: row.permissioned_as, preserve_permissioned_as: true }
+			: {})
 	}
 	// No `relocated` check: `rewriteTriggerConfig` remaps every bare match at every depth, so
 	// the resource field always moves. What can still read `from` afterwards is a restored

--- a/frontend/src/routes/(root)/(logged)/projects/import/+page@(root).svelte
+++ b/frontend/src/routes/(root)/(logged)/projects/import/+page@(root).svelte
@@ -261,9 +261,10 @@
 			setupUndecided = false
 			return
 		}
-		// Every resource the project ships arrives as an empty stub, so any project with
-		// resources has something to fill in. The step itself re-checks and shows only
-		// what is genuinely outstanding, which is what makes a re-import quiet.
+		// `resourceCount` is the referenced subset — the resources something in the project
+		// points at — and each one arrives as an empty stub, so any project that has them has
+		// something to fill in. The step itself re-checks and shows only what is genuinely
+		// outstanding, which is what makes a re-import quiet.
 		if (execution.resourceCount > 0) {
 			setupNeeded = true
 			setupUndecided = false


### PR DESCRIPTION
Two changes to step 4 of the hub project import wizard: fewer rows on the checklist, and a way to answer one without re-entering a credential the workspace already holds.

## 1. Only ask about resources the project points at

A project declares one resource per `resource-<type>` input schema as well as one per `$res:` reference. An app that pins `f/calendly/google_calendar` for a script whose schema says `resource-gcal` ships an unreferenced `f/calendly/gcal` alongside it, and the wizard asked you to fill in both.

Only the referenced ones have to hold a credential. The rest are still created — a standalone run picks from them in the argument picker — but they no longer reach the checklist, and `resourceCount` counts the same set so the wizard doesn't offer a fourth step with nothing on it.

Across the twelve published hub projects, **9 of 19 rows drop off**: calendly 3 → 2, typeform 3 → 0 (`form_input`, `question_input` and `record` are data shapes, not credentials), github-release-digest 2 → 0, odoo / uptimerobot / github-release-dashboard 1 → 0.

Worth a reviewer's opinion: four projects go from asking for one credential to asking for nothing. Filling those stubs changes no runtime behaviour, but the wizard no longer nudges you to prepare the credential. Same trade accepted in #10905, applied to already-published projects.

## 2. Reuse an existing workspace resource

The row's button offers a choice when the workspace already has a **filled** resource of that type. Picking one rewrites the deployed items to reference it — no alias, no copy — reaching the end state the import would have produced had the project named that resource from the start.

| Kind | Written back with | Note |
| --- | --- | --- |
| Script | `createScript` | New version with `parent_hash`, so history survives |
| Flow | `updateFlow` | |
| App | `updateApp` | Deployed policy passed through, `preserve_on_behalf_of` set |
| Raw app | `updateAppRaw` | Bundle read live from the deployed app, rewritten, sent back |
| Trigger | per-kind `update` | `enabled` omitted; `permissioned_as` + `preserve_permissioned_as` sent |

## The contract, and how it got here

The first implementation promised all-or-nothing: prove every referrer can be rewritten, then delete the stub. Ten review rounds followed. Six of the first ten findings were the same bug wearing different clothes — the scan kept turning out to be incomplete — so the module was **redesigned rather than patched again**:

- **Always rewrite** every referrer the scan found. Incompleteness never refuses the operation.
- **Delete the stub only when the scan can account for everything.** Otherwise keep it, and say so.

A missed referrer then points at an empty stub you can fill, rather than a resource that no longer exists. Everything that used to refuse is now a *gap*, and any gap keeps the stub: a listing returned at its server-side cap, a trigger kind that failed to list, a reference spelled where no rewriter reaches it, a referrer outside `f/<folder>/` (detected free from the workspace-wide listings, never rewritten — it is the user's own item), and **a caller whose listings are not the whole workspace**.

That last one is the subtlest and was found late. `listSearch*` runs under `user_db.begin(&authed)`, so row-level security filters rows *inside the query*: for anyone but a workspace admin, a colleague's private script referencing the stub is not a short page the truncation guard catches — it is invisible. The completeness proof cannot hold for such a caller, so it now records a gap. The check asks whether the user record describes *this* workspace, because `UserExt` is per-workspace and step 4 is reachable by reload, where it still describes the workspace you came from.

Two other things the rounds turned up, both since fixed:

- The module claimed a browser cannot read a deployed raw app's bundle back. It can (`deployToHubSession.svelte.ts:754` does exactly that), so the whole exported-bundle apparatus was deleted. "Edited since the import" is not replaced — it is unreachable.
- The import's `rewriteFlowValue` / `rewriteAppValue` also remap a runnable's own `path` on an exact match, which is right for the folder-wide map the import hands them and wrong for a one-entry resource map: a project shipping both a script and a resource named `smtp` had the step calling that script repointed at the credential. The rewrite here is token-only.

## Verified end to end on a running instance

- Step 3 previewed "2 resources" for a project shipping 3; step 4 listed only the two referenced.
- Clean scan: row settled to "now uses …" with a plain `Reused` label, stub deleted, the app's latest version carrying the chosen path.
- Live bundle: both raw apps came back with intact bundles on their new versions (199,975 and 194,973 bytes of JS) — `updateAppRaw` cannot produce that without one.
- Kept stub: a planted out-of-folder referrer produced *"some items still read f/… — fill it in too"*, the rewrite went through, the stub survived, and the outside script still resolved.
- Triggers: lemlist's schedule carries `$res:` in its args; reuse rewrote it through `updateSchedule` and the schedule stayed disabled.
- Chooser filter: a fresh import offers 1 SMTP and 1 Google Calendar candidate instead of 2 and 4, every leftover stub from an earlier import excluded.

## Tests

`npm run test:unit -- --run src/lib/importWizard src/lib/components/workspaceSettings/projectBundle.test.ts` — 116 passing. Each case guards a distinct way the safety contract can break, and several were written after confirming they fail against the code that shipped the bug.

`npm run check:fast` reports 3 errors, all in `projects/import/+page@(root).svelte` and `hubProject.ts` — untouched here, pre-existing on `main`.

## Not verified

The restrictive side of the new completeness check has no browser run behind it: signing in as a non-admin member (or as an admin who switched workspaces and reloaded onto step 4) and confirming the placeholder is kept. Every browser run so far was as a workspace admin. Likewise `preserve_on_behalf_of` / `preserve_permissioned_as` for a caller outside `wm_deployers` — the backend fails closed to the caller's identity, but that was read, not exercised.

The bare-path trigger rewrite (a `*_resource_path` column) cannot be reached from any published hub project: the only trigger kinds the twelve ship are http, email and schedule, none of which has a resource column. It is covered by unit test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fuzkt6NqsqzvSYSVKpR3pj
