### PR TITLE
feat: workspace setting to hide the AI assistant, agent steps unaffected

### DIFF
--- a/backend/windmill-api-integration-tests/tests/workspaces.rs
+++ b/backend/windmill-api-integration-tests/tests/workspaces.rs
@@ -889,6 +889,53 @@ async fn test_get_copilot_info_ignores_empty_instance_ai_row(
     Ok(())
 }
 
+/// A workspace with no provider of its own is served the instance config, but the
+/// `copilot_disabled` flag must still come from the workspace's own row.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_get_copilot_info_keeps_workspace_copilot_disabled_over_instance_fallback(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace/workspaces");
+
+    sqlx::query("UPDATE workspace_settings SET ai_config = $1 WHERE workspace_id = $2")
+        .bind(json!({ "copilot_disabled": true }))
+        .bind("test-workspace")
+        .execute(&db)
+        .await?;
+    sqlx::query(
+        "INSERT INTO global_settings (name, value) VALUES ($1, $2) \
+         ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value",
+    )
+    .bind("ai_config")
+    .bind(json!({
+        "providers": {
+            "openai": {
+                "resource_path": "u/test-user/openai_instance",
+                "models": ["gpt-4o-mini"]
+            }
+        }
+    }))
+    .execute(&db)
+    .await?;
+
+    let resp = authed(client().get(format!("{base}/get_copilot_info")))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let settings = resp.json::<serde_json::Value>().await?;
+    assert_eq!(
+        settings["providers"]["openai"]["models"][0], "gpt-4o-mini",
+        "instance providers are still served"
+    );
+    assert_eq!(settings["copilot_disabled"], true);
+
+    Ok(())
+}
+
 #[sqlx::test(migrations = "../migrations", fixtures("base"))]
 async fn test_error_handler_instance_alerts_fallback(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;
@@ -941,7 +988,12 @@ async fn test_error_handler_instance_alerts_fallback(db: Pool<Postgres>) -> anyh
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200, "disable on fork: {}", resp.text().await?);
+    assert_eq!(
+        resp.status(),
+        200,
+        "disable on fork: {}",
+        resp.text().await?
+    );
     assert!(!stored().await?);
 
     Ok(())
@@ -1044,9 +1096,11 @@ async fn test_create_service_account_drops_orphaned_group_memberships(
     .await?;
 
     // Same username, different workspace, and very much alive — must not be touched.
-    sqlx::query("INSERT INTO workspace (id, name, owner) VALUES ('other-workspace', 'other', 'svc_acct')")
-        .execute(&db)
-        .await?;
+    sqlx::query(
+        "INSERT INTO workspace (id, name, owner) VALUES ('other-workspace', 'other', 'svc_acct')",
+    )
+    .execute(&db)
+    .await?;
     sqlx::query(
         "INSERT INTO group_ (workspace_id, name, summary) VALUES
          ('other-workspace', 'all', 'All users'),

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -27135,6 +27135,13 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/ModelPriceOverride"
+        copilot_disabled:
+          type: boolean
+          description: >-
+            Hides the Windmill AI assistant (chat, sessions, code generation, completion,
+            fixes) from the workspace UI. Read from the workspace's own settings even when
+            the providers served fall back to the instance config. AI agent steps and the
+            AI sandbox in flows are unaffected.
 
     FreeTierInfo:
       type: object

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -445,6 +445,12 @@ pub struct AIConfig {
     /// Only models whose rates differ from the built-in table are stored.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_pricing: Option<HashMap<String, ModelPriceOverride>>,
+    /// Hides the Windmill AI assistant (chat, sessions, generation, completion, fixes) from
+    /// the workspace UI. Only the workspace's own row is consulted: the flag holds even when
+    /// the providers served come from the instance config or the free tier. AI agent steps
+    /// and the AI sandbox are unaffected, so the providers stay in force.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub copilot_disabled: bool,
 }
 
 /// Negotiated rates in USD per million tokens. An unset cache rate is read as the

--- a/backend/windmill-api/src/workspaces.rs
+++ b/backend/windmill-api/src/workspaces.rs
@@ -146,6 +146,7 @@ async fn edit_copilot_config(
     .await?;
 
     let workspace_has_config = ai_config.has_providers();
+    let copilot_disabled = ai_config.copilot_disabled;
     let instance_ai_config =
         sqlx::query_scalar!("SELECT value FROM global_settings WHERE name = 'ai_config'")
             .fetch_optional(&db)
@@ -158,7 +159,7 @@ async fn edit_copilot_config(
         .as_ref()
         .and_then(|v| serde_json::from_value::<AIConfig>(v.clone()).ok())
         .filter(|c| c.has_providers());
-    let effective_ai_config = if workspace_has_config {
+    let mut effective_ai_config = if workspace_has_config {
         ai_config
     } else if let Some(instance_config) = instance_config_with_providers {
         instance_config
@@ -172,6 +173,7 @@ async fn edit_copilot_config(
     } else {
         AIConfig::default()
     };
+    effective_ai_config.copilot_disabled = copilot_disabled;
 
     Ok(Json(EditCopilotConfigResponse {
         effective_ai_config,
@@ -207,6 +209,9 @@ async fn get_copilot_info(
         ))
     })?;
 
+    let copilot_disabled = workspace_ai_config
+        .as_ref()
+        .is_some_and(|c| c.0.copilot_disabled);
     let instance_config =
         sqlx::query_scalar!("SELECT value FROM global_settings WHERE name = 'ai_config'")
             .fetch_optional(&db)
@@ -215,20 +220,23 @@ async fn get_copilot_info(
             // A provider-less instance config (e.g. `{}`) is unconfigured; don't let it shadow the
             // free-tier fallback, matching the proxy and edit_copilot_config paths.
             .filter(|c| c.has_providers());
-    if let Some(workspace_ai_config) = workspace_ai_config.filter(|c| c.0.has_providers()) {
-        Ok(Json(workspace_ai_config.0))
-    } else if let Some(instance_config) = instance_config {
-        Ok(Json(instance_config))
-    } else if let Some(free_config) =
-        crate::ai_free_tier_oss::free_tier_copilot_config(&db, &authed.email).await?
-    {
-        // Nothing configured: fall back to Windmill's free tier (EE-only). The config
-        // carries a `free_tier` marker even once the user's grant is spent — with no
-        // providers, but telling the client *why* AI is off.
-        Ok(Json(free_config))
-    } else {
-        Ok(Json(AIConfig::default()))
-    }
+    let mut effective =
+        if let Some(workspace_ai_config) = workspace_ai_config.filter(|c| c.0.has_providers()) {
+            workspace_ai_config.0
+        } else if let Some(instance_config) = instance_config {
+            instance_config
+        } else if let Some(free_config) =
+            crate::ai_free_tier_oss::free_tier_copilot_config(&db, &authed.email).await?
+        {
+            // Nothing configured: fall back to Windmill's free tier (EE-only). The config
+            // carries a `free_tier` marker even once the user's grant is spent — with no
+            // providers, but telling the client *why* AI is off.
+            free_config
+        } else {
+            AIConfig::default()
+        };
+    effective.copilot_disabled = copilot_disabled;
+    Ok(Json(effective))
 }
 
 #[cfg(feature = "enterprise")]

--- a/frontend/src/lib/aiStore.test.ts
+++ b/frontend/src/lib/aiStore.test.ts
@@ -35,6 +35,24 @@ describe('setCopilotInfo legacy /thinking migration', () => {
 		expect(info.aiModels.map((m) => m.model)).toEqual(['claude-sonnet-4-6'])
 	})
 
+	it('keeps the models but turns the assistant off when the workspace disabled it', () => {
+		setCopilotInfo({
+			providers: {
+				anthropic: {
+					resource_path: 'u/admin/anthropic',
+					models: ['claude-sonnet-4-6']
+				}
+			},
+			copilot_disabled: true
+		})
+
+		const info = get(copilotInfo)
+		expect(info.enabled).toBe(false)
+		expect(info.workspaceDisabled).toBe(true)
+		// The providers still describe what AI agent steps can run on.
+		expect(info.aiModels.map((m) => m.model)).toEqual(['claude-sonnet-4-6'])
+	})
+
 	it('defaults provider web search on unless explicitly disabled', () => {
 		setCopilotInfo({
 			providers: {

--- a/frontend/src/lib/aiStore.ts
+++ b/frontend/src/lib/aiStore.ts
@@ -41,6 +41,10 @@ export const copilotSessionModel = writable<ReasoningProviderModel | undefined>(
 
 export const copilotInfo = writable<{
 	enabled: boolean
+	// The workspace hid the assistant (`ai_config.copilot_disabled`). `enabled` is then false
+	// whatever the providers say, and the AI entry points that nudge "configure AI" when
+	// `enabled` is off render nothing at all instead.
+	workspaceDisabled: boolean
 	codeCompletionModel?: AIProviderModel
 	defaultModel?: AIProviderModel
 	metadataModel?: AIProviderModel
@@ -56,6 +60,7 @@ export const copilotInfo = writable<{
 	freeTier?: FreeTierInfo
 }>({
 	enabled: false,
+	workspaceDisabled: false,
 	codeCompletionModel: undefined,
 	defaultModel: undefined,
 	metadataModel: undefined,
@@ -71,7 +76,7 @@ export const copilotInfo = writable<{
 aiUserDisabled.subscribe((disabled) => {
 	copilotInfo.update((info) => ({
 		...info,
-		enabled: info.aiModels.length > 0 && !disabled
+		enabled: info.aiModels.length > 0 && !disabled && !info.workspaceDisabled
 	}))
 })
 
@@ -126,9 +131,11 @@ export function setCopilotInfo(aiConfig: AIConfig) {
 			return model
 		})
 
+		const workspaceDisabled = aiConfig.copilot_disabled === true
 		copilotInfo.set({
-			// Providers are configured; the per-user opt-out is the only thing that can gate it off.
-			enabled: !get(aiUserDisabled),
+			// Providers are configured; only the workspace or per-user opt-outs can gate it off.
+			enabled: !workspaceDisabled && !get(aiUserDisabled),
+			workspaceDisabled,
 			// Strip the deprecated /thinking suffix from the configured model slots too,
 			// otherwise a workspace whose default still carries it sends an invalid model id.
 			codeCompletionModel: stripModelSuffix(aiConfig.code_completion_model),
@@ -146,6 +153,7 @@ export function setCopilotInfo(aiConfig: AIConfig) {
 
 		copilotInfo.set({
 			enabled: false,
+			workspaceDisabled: aiConfig.copilot_disabled === true,
 			codeCompletionModel: undefined,
 			defaultModel: undefined,
 			metadataModel: undefined,

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineInsertMenu.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineInsertMenu.svelte
@@ -28,6 +28,7 @@
 <script lang="ts">
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
+	import { copilotInfo } from '$lib/aiStore'
 	import LanguageIcon from '$lib/components/common/languageIcons/LanguageIcon.svelte'
 	import { twMerge } from 'tailwind-merge'
 	import {
@@ -79,9 +80,11 @@
 	// focus off to the first tabbable in the next column.
 	let languageEl: HTMLElement | undefined
 	let outputEl: HTMLElement | undefined
-	// Refs into the bottom panel for the Output → Path → AI Prompt → Save chain.
+	// Refs into the bottom panel for the Output → Path → AI Prompt → Save chain. The AI
+	// prompt is absent where the workspace hid the assistant, so Path advances to Save.
 	let pathEl: HTMLElement | undefined
 	let aiPromptEl: HTMLElement | undefined
+	let saveEl: HTMLElement | undefined
 
 	let compatibleKinds = $derived.by<PipelineOutputKind[]>(() => {
 		if (!selected.language) return []
@@ -261,7 +264,7 @@
 {#snippet bottomSection(close: () => void)}
 	<Label label="Path">
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div bind:this={pathEl} class="flex" onkeydown={selectAndAdvanceTo(() => aiPromptEl)}>
+		<div bind:this={pathEl} class="flex" onkeydown={selectAndAdvanceTo(() => aiPromptEl ?? saveEl)}>
 			<div
 				class="border rounded-md rounded-r-none border-r-0 text-xs w-fit shrink-0 whitespace-nowrap flex items-center px-2 text-secondary bg-surface-input"
 			>
@@ -270,25 +273,27 @@
 			<TextInput bind:value={selected.scriptPath} class="rounded-l-none" />
 		</div>
 	</Label>
-	<Label label="AI Prompt (optional)">
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div
-			bind:this={aiPromptEl}
-			onkeydown={(e) =>
-				(e.metaKey || e.ctrlKey) && e.key === 'Enter' && (confirm(close), e.stopPropagation())}
-		>
-			<TextInput
-				class="resize-none h-12 !max-h-12"
-				underlyingInputEl="textarea"
-				inputProps={{
-					placeholder: 'Describe what the script should do — leave empty to use a template'
-				}}
-				bind:value={selected.aiPrompt}
-			/>
-		</div>
-	</Label>
+	{#if !$copilotInfo.workspaceDisabled}
+		<Label label="AI Prompt (optional)">
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				bind:this={aiPromptEl}
+				onkeydown={(e) =>
+					(e.metaKey || e.ctrlKey) && e.key === 'Enter' && (confirm(close), e.stopPropagation())}
+			>
+				<TextInput
+					class="resize-none h-12 !max-h-12"
+					underlyingInputEl="textarea"
+					inputProps={{
+						placeholder: 'Describe what the script should do — leave empty to use a template'
+					}}
+					bind:value={selected.aiPrompt}
+				/>
+			</div>
+		</Label>
+	{/if}
 	{@const hasAiPrompt = !!selected.aiPrompt?.trim()}
-	<div class="ml-auto">
+	<div class="ml-auto" bind:this={saveEl}>
 		<Button
 			variant="accent"
 			btnClasses="w-fit"

--- a/frontend/src/lib/components/copilot/AIFormAssistant.svelte
+++ b/frontend/src/lib/components/copilot/AIFormAssistant.svelte
@@ -5,6 +5,7 @@
 	import OpenInSessionButton from '$lib/components/sessions/OpenInSessionButton.svelte'
 	import { AIBtnClasses } from './chat/AIButtonStyle'
 	import { workspaceStore } from '$lib/stores'
+	import { copilotInfo } from '$lib/aiStore'
 	import { logFeatureUsage } from '$lib/utils/featureUsage'
 
 	interface Props {
@@ -49,45 +50,47 @@
 	)
 </script>
 
-<div class="my-3 p-3 bg-surface-secondary rounded-md relative flex flex-col gap-3">
-	<div class="flex flex-row gap-2 justify-between items-center">
-		<!-- Heading stays neutral because the two branches do different things: the
+{#if !$copilotInfo.workspaceDisabled}
+	<div class="my-3 p-3 bg-surface-secondary rounded-md relative flex flex-col gap-3">
+		<div class="flex flex-row gap-2 justify-between items-center">
+			<!-- Heading stays neutral because the two branches do different things: the
 		     hand-off runs the item, the legacy path fills the form. Each button
 		     names its own action. A plain Button rather than AskAiButton, whose own
 		     session branch would fire here too and open an empty session. -->
-		<h3 class="text-sm font-medium">AI can help with these inputs</h3>
-		<OpenInSessionButton
-			source={sessionSource}
-			label="Run in AI session"
-			tooltip="Open an AI session that picks inputs and runs this"
-			btnProps={{ iconOnly: false, startIcon: { icon: WandSparkles } }}
-		>
-			{#snippet fallback()}
-				<Button
-					unifiedSize="md"
-					startIcon={{ icon: WandSparkles }}
-					btnClasses={AIBtnClasses('default')}
-					on:click={fillFormWithAI}
-				>
-					Fill with AI
-				</Button>
-			{/snippet}
-		</OpenInSessionButton>
+			<h3 class="text-sm font-medium">AI can help with these inputs</h3>
+			<OpenInSessionButton
+				source={sessionSource}
+				label="Run in AI session"
+				tooltip="Open an AI session that picks inputs and runs this"
+				btnProps={{ iconOnly: false, startIcon: { icon: WandSparkles } }}
+			>
+				{#snippet fallback()}
+					<Button
+						unifiedSize="md"
+						startIcon={{ icon: WandSparkles }}
+						btnClasses={AIBtnClasses('default')}
+						on:click={fillFormWithAI}
+					>
+						Fill with AI
+					</Button>
+				{/snippet}
+			</OpenInSessionButton>
+		</div>
+		<div class="flex flex-row gap-2 items-center">
+			<p class="text-sm text-primary">
+				{instructions
+					? 'Instructions: ' + instructions
+					: 'No AI instructions provided. Click edit to add guidance for AI form filling.'}
+			</p>
+			<Button
+				color="light"
+				size="xs2"
+				startIcon={{
+					icon: Pencil
+				}}
+				iconOnly
+				on:click={onEditInstructions}
+			/>
+		</div>
 	</div>
-	<div class="flex flex-row gap-2 items-center">
-		<p class="text-sm text-primary">
-			{instructions
-				? 'Instructions: ' + instructions
-				: 'No AI instructions provided. Click edit to add guidance for AI form filling.'}
-		</p>
-		<Button
-			color="light"
-			size="xs2"
-			startIcon={{
-				icon: Pencil
-			}}
-			iconOnly
-			on:click={onEditInstructions}
-		/>
-	</div>
-</div>
+{/if}

--- a/frontend/src/lib/components/copilot/AIFormSettings.svelte
+++ b/frontend/src/lib/components/copilot/AIFormSettings.svelte
@@ -3,6 +3,7 @@
 	import Label from '../Label.svelte'
 	import Toggle from '../Toggle.svelte'
 	import Tooltip from '../Tooltip.svelte'
+	import { copilotInfo } from '$lib/aiStore'
 
 	interface Props {
 		prompt?: string | undefined
@@ -12,35 +13,37 @@
 	let { prompt = $bindable(undefined), type = 'script' }: Props = $props()
 </script>
 
-<div>
-	<Toggle
-		textClass="font-medium"
-		size="xs"
-		checked={prompt !== undefined}
-		on:change={() => {
-			if (prompt !== undefined) {
-				prompt = undefined
-			} else {
-				prompt = ''
-			}
-		}}
-		options={{ right: `Enable filling ${type} inputs with AI` }}
-	/>
-	{#if prompt !== undefined}
-		<div transition:slide={{ duration: 120 }} class="mt-6">
-			<Label label="Additional prompt for AI">
-				{#snippet header()}
-					<Tooltip>
-						AI will use script description and each field description to fill the inputs form. In
-						addition, any prompt passed here will be used by AI to guide it. You can mention
-						specific fields and interaction between fields here.
-					</Tooltip>
-				{/snippet}
-				<textarea
-					bind:value={prompt}
-					placeholder="Instructions for the AI about how to fill the form"
-				></textarea>
-			</Label>
-		</div>
-	{/if}
-</div>
+{#if !$copilotInfo.workspaceDisabled}
+	<div>
+		<Toggle
+			textClass="font-medium"
+			size="xs"
+			checked={prompt !== undefined}
+			on:change={() => {
+				if (prompt !== undefined) {
+					prompt = undefined
+				} else {
+					prompt = ''
+				}
+			}}
+			options={{ right: `Enable filling ${type} inputs with AI` }}
+		/>
+		{#if prompt !== undefined}
+			<div transition:slide={{ duration: 120 }} class="mt-6">
+				<Label label="Additional prompt for AI">
+					{#snippet header()}
+						<Tooltip>
+							AI will use script description and each field description to fill the inputs form. In
+							addition, any prompt passed here will be used by AI to guide it. You can mention
+							specific fields and interaction between fields here.
+						</Tooltip>
+					{/snippet}
+					<textarea
+						bind:value={prompt}
+						placeholder="Instructions for the AI about how to fill the form"
+					></textarea>
+				</Label>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/frontend/src/lib/components/copilot/CronGen.svelte
+++ b/frontend/src/lib/components/copilot/CronGen.svelte
@@ -79,66 +79,68 @@
 	})
 </script>
 
-<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
-	{#snippet trigger()}
-		<Button
-			color={genLoading ? 'red' : 'light'}
-			size="xs"
-			nonCaptureEvent={!genLoading}
-			startIcon={{ icon: Wand2 }}
-			iconOnly
-			title="AI Assistant"
-			btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
-			loading={genLoading}
-			clickableWhileLoading
-			on:click={genLoading ? () => abortController?.abort() : () => {}}
-		/>
-	{/snippet}
-	{#snippet content({ close })}
-		<div class="border rounded-lg shadow-lg p-4 bg-surface">
-			{#if $copilotInfo.enabled}
-				<div class="flex w-96">
-					<input
-						bind:this={instructionsField}
-						type="text"
-						placeholder="CRON schedule description"
-						bind:value={instructions}
-						onkeypress={({ key }) => {
-							if (key === 'Enter' && instructions.length > 0) {
+{#if !$copilotInfo.workspaceDisabled}
+	<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
+		{#snippet trigger()}
+			<Button
+				color={genLoading ? 'red' : 'light'}
+				size="xs"
+				nonCaptureEvent={!genLoading}
+				startIcon={{ icon: Wand2 }}
+				iconOnly
+				title="AI Assistant"
+				btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
+				loading={genLoading}
+				clickableWhileLoading
+				on:click={genLoading ? () => abortController?.abort() : () => {}}
+			/>
+		{/snippet}
+		{#snippet content({ close })}
+			<div class="border rounded-lg shadow-lg p-4 bg-surface">
+				{#if $copilotInfo.enabled}
+					<div class="flex w-96">
+						<input
+							bind:this={instructionsField}
+							type="text"
+							placeholder="CRON schedule description"
+							bind:value={instructions}
+							onkeypress={({ key }) => {
+								if (key === 'Enter' && instructions.length > 0) {
+									close()
+									generateCron()
+								}
+							}}
+						/>
+						<Button
+							size="xs"
+							color="light"
+							variant="contained"
+							buttonType="button"
+							btnClasses="!ml-2 text-ai bg-violet-100 dark:bg-gray-700"
+							title="Generate CRON schedule from prompt"
+							aria-label="Generate"
+							iconOnly
+							on:click={() => {
 								close()
 								generateCron()
-							}
-						}}
-					/>
-					<Button
-						size="xs"
-						color="light"
-						variant="contained"
-						buttonType="button"
-						btnClasses="!ml-2 text-ai bg-violet-100 dark:bg-gray-700"
-						title="Generate CRON schedule from prompt"
-						aria-label="Generate"
-						iconOnly
-						on:click={() => {
-							close()
-							generateCron()
-						}}
-						disabled={instructions.length == 0}
-						startIcon={{ icon: Wand2 }}
-					/>
-				</div>
-			{:else}
-				<div class="block text-primary">
-					<p class="text-sm"
-						>Enable Windmill AI in the <a
-							href="{base}/workspace_settings?tab=ai"
-							target="_blank"
-							class="inline-flex flex-row items-center gap-1"
-							>workspace settings <ExternalLink size={16} /></a
-						></p
-					>
-				</div>
-			{/if}
-		</div>
-	{/snippet}
-</Popover>
+							}}
+							disabled={instructions.length == 0}
+							startIcon={{ icon: Wand2 }}
+						/>
+					</div>
+				{:else}
+					<div class="block text-primary">
+						<p class="text-sm"
+							>Enable Windmill AI in the <a
+								href="{base}/workspace_settings?tab=ai"
+								target="_blank"
+								class="inline-flex flex-row items-center gap-1"
+								>workspace settings <ExternalLink size={16} /></a
+							></p
+						>
+					</div>
+				{/if}
+			</div>
+		{/snippet}
+	</Popover>
+{/if}

--- a/frontend/src/lib/components/copilot/RegexGen.svelte
+++ b/frontend/src/lib/components/copilot/RegexGen.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
+	import { run } from 'svelte/legacy'
 
 	import { base } from '$lib/base'
 	import { Button } from '../common'
@@ -55,7 +55,7 @@
 
 	run(() => {
 		input && setTimeout(() => input?.focus(), 100)
-	});
+	})
 
 	let promptHistory: string[] = $state(JSON.parse(getPromptsRegex() || '[]'))
 
@@ -93,17 +93,17 @@
 	}
 </script>
 
-<Popover
-	floatingConfig={{
-		middleware: [
-			autoPlacement({
-				allowedPlacements: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'top', 'bottom']
-			})
-		]
-	}}
->
-	{#snippet trigger()}
-	
+{#if !$copilotInfo.workspaceDisabled}
+	<Popover
+		floatingConfig={{
+			middleware: [
+				autoPlacement({
+					allowedPlacements: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'top', 'bottom']
+				})
+			]
+		}}
+	>
+		{#snippet trigger()}
 			<Button
 				title="Generate regexes from prompt"
 				btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
@@ -116,10 +116,8 @@
 				clickableWhileLoading
 				on:click={genLoading ? () => abortController?.abort() : () => {}}
 			/>
-		
-	{/snippet}
-	{#snippet content({ close })}
-	
+		{/snippet}
+		{#snippet content({ close })}
 			<div class="block text-primary p-4">
 				{#if $copilotInfo.enabled}
 					<div class="flex flex-col gap-4">
@@ -129,11 +127,11 @@
 								bind:this={input}
 								bind:value={funcDesc}
 								onkeypress={({ key }) => {
-								if (key === 'Enter' && funcDesc?.length > 0) {
-									close()
-									onGenerate()
-								}
-							}}
+									if (key === 'Enter' && funcDesc?.length > 0) {
+										close()
+										onGenerate()
+									}
+								}}
 								placeholder="Describe what the regex should do"
 							/>
 							<Button
@@ -183,6 +181,6 @@
 					</p>
 				{/if}
 			</div>
-		
-	{/snippet}
-</Popover>
+		{/snippet}
+	</Popover>
+{/if}

--- a/frontend/src/lib/components/copilot/ResourceGen.svelte
+++ b/frontend/src/lib/components/copilot/ResourceGen.svelte
@@ -119,69 +119,71 @@
 	})
 </script>
 
-<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
-	{#snippet trigger()}
-		<Button
-			color={genLoading ? 'red' : 'light'}
-			size="xs"
-			unifiedSize="md"
-			nonCaptureEvent={!genLoading}
-			startIcon={{ icon: Wand2 }}
-			iconOnly
-			title="AI Assistant"
-			btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
-			loading={genLoading}
-			clickableWhileLoading
-			on:click={genLoading ? () => abortController?.abort() : () => {}}
-		/>
-	{/snippet}
-	{#snippet content({ close })}
-		<div class="border rounded-lg shadow-lg p-4 bg-surface">
-			{#if $copilotInfo.enabled}
-				<div class="flex flex-col w-80 gap-2">
-					<textarea
-						bind:this={instructionsField}
-						placeholder="Describe the resource values to generate..."
-						bind:value={instructions}
-						rows={3}
-						class="text-xs"
-						onkeydown={(e) => {
-							if (e.key === 'Enter' && !e.shiftKey && instructions.length > 0) {
-								e.preventDefault()
+{#if !$copilotInfo.workspaceDisabled}
+	<Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
+		{#snippet trigger()}
+			<Button
+				color={genLoading ? 'red' : 'light'}
+				size="xs"
+				unifiedSize="md"
+				nonCaptureEvent={!genLoading}
+				startIcon={{ icon: Wand2 }}
+				iconOnly
+				title="AI Assistant"
+				btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
+				loading={genLoading}
+				clickableWhileLoading
+				on:click={genLoading ? () => abortController?.abort() : () => {}}
+			/>
+		{/snippet}
+		{#snippet content({ close })}
+			<div class="border rounded-lg shadow-lg p-4 bg-surface">
+				{#if $copilotInfo.enabled}
+					<div class="flex flex-col w-80 gap-2">
+						<textarea
+							bind:this={instructionsField}
+							placeholder="Describe the resource values to generate..."
+							bind:value={instructions}
+							rows={3}
+							class="text-xs"
+							onkeydown={(e) => {
+								if (e.key === 'Enter' && !e.shiftKey && instructions.length > 0) {
+									e.preventDefault()
+									close()
+									generateResource()
+								}
+							}}
+						></textarea>
+						<Button
+							size="xs"
+							color="light"
+							variant="contained"
+							buttonType="button"
+							btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
+							title="Generate resource from prompt"
+							on:click={() => {
 								close()
 								generateResource()
-							}
-						}}
-					></textarea>
-					<Button
-						size="xs"
-						color="light"
-						variant="contained"
-						buttonType="button"
-						btnClasses="text-ai bg-violet-100 dark:bg-gray-700"
-						title="Generate resource from prompt"
-						on:click={() => {
-							close()
-							generateResource()
-						}}
-						disabled={instructions.length == 0}
-						startIcon={{ icon: Wand2 }}
-					>
-						Generate
-					</Button>
-				</div>
-			{:else}
-				<div class="block text-primary">
-					<p class="text-sm"
-						>Enable Windmill AI in the <a
-							href="{base}/workspace_settings?tab=ai"
-							target="_blank"
-							class="inline-flex flex-row items-center gap-1"
-							>workspace settings <ExternalLink size={16} /></a
-						></p
-					>
-				</div>
-			{/if}
-		</div>
-	{/snippet}
-</Popover>
+							}}
+							disabled={instructions.length == 0}
+							startIcon={{ icon: Wand2 }}
+						>
+							Generate
+						</Button>
+					</div>
+				{:else}
+					<div class="block text-primary">
+						<p class="text-sm"
+							>Enable Windmill AI in the <a
+								href="{base}/workspace_settings?tab=ai"
+								target="_blank"
+								class="inline-flex flex-row items-center gap-1"
+								>workspace settings <ExternalLink size={16} /></a
+							></p
+						>
+					</div>
+				{/if}
+			</div>
+		{/snippet}
+	</Popover>
+{/if}

--- a/frontend/src/lib/components/copilot/ScriptFix.svelte
+++ b/frontend/src/lib/components/copilot/ScriptFix.svelte
@@ -77,7 +77,7 @@
 	const sessionScopedManager = getContext<AIChatManager | undefined>('aiChatManager')
 </script>
 
-{#if SUPPORTED_LANGUAGES.has(lang)}
+{#if SUPPORTED_LANGUAGES.has(lang) && !$copilotInfo.workspaceDisabled}
 	{#if sessionScopedManager}
 		<Button
 			title="Fix the failing run in this chat"

--- a/frontend/src/lib/components/copilot/ScriptGen.svelte
+++ b/frontend/src/lib/components/copilot/ScriptGen.svelte
@@ -355,7 +355,7 @@
 		</div>
 	{/if}
 {/if}
-{#if ($generatedCode.length === 0 || genLoading) && SUPPORTED_LANGUAGES.has(lang ?? '')}
+{#if ($generatedCode.length === 0 || genLoading) && SUPPORTED_LANGUAGES.has(lang ?? '') && !$copilotInfo.workspaceDisabled}
 	<Popover
 		floatingConfig={{
 			middleware: [

--- a/frontend/src/lib/components/copilot/StepGenQuick.svelte
+++ b/frontend/src/lib/components/copilot/StepGenQuick.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { workspaceStore } from '$lib/stores'
+	import { copilotInfo } from '$lib/aiStore'
 	import { ScriptService, type Script } from '$lib/gen'
 
 	import { Wand2, Loader2 } from 'lucide-svelte'
@@ -27,6 +28,7 @@
 		filteredItems = $bindable([])
 	}: Props = $props()
 	let prefilteredItems = $derived(scripts ?? [])
+	let aiHidden = $derived(disableAi || $copilotInfo.workspaceDisabled)
 
 	const dispatch = createEventDispatcher()
 
@@ -80,7 +82,7 @@
 				onkeydown: (e) => {
 					if (e.key === 'Escape') dispatch('escape')
 				},
-				placeholder: `Search ${trigger ? 'triggers' : 'scripts'} ${disableAi ? '' : 'or AI gen'}`
+				placeholder: `Search ${trigger ? 'triggers' : 'scripts'} ${aiHidden ? '' : 'or AI gen'}`
 			}}
 			size="sm"
 		/>
@@ -89,7 +91,7 @@
 		{#if loading}
 			<Loader2 size={12} class="animate-spin text-gray-400" />
 		{/if}
-		{#if funcDesc?.length === 0 && !loading && !disableAi}
+		{#if funcDesc?.length === 0 && !loading && !aiHidden}
 			<Wand2 size={12} class="fill-current opacity-70 text-ai" />
 		{/if}
 	</div>

--- a/frontend/src/lib/components/copilot/StepInputsGen.svelte
+++ b/frontend/src/lib/components/copilot/StepInputsGen.svelte
@@ -226,7 +226,7 @@ input_name2: expression2
 				Fill inputs
 			{/if}
 		</Button>
-	{:else}
+	{:else if !$copilotInfo.workspaceDisabled}
 		<Popover
 			floatingConfig={{
 				placement: 'top-end'

--- a/frontend/src/lib/components/copilot/chat/AIButton.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIButton.svelte
@@ -38,7 +38,7 @@
 		{/snippet}
 		{@render button({ onPress: () => togglePanel() })}
 	</DarkPopover>
-{:else}
+{:else if !$copilotInfo.workspaceDisabled}
 	<Popover placement="bottom" class="h-full">
 		{#snippet trigger()}
 			{@render button({ onPress: () => togglePanel() })}

--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -70,7 +70,7 @@
 					? ''
 					: !hasCopilot
 						? $copilotInfo.workspaceDisabled
-							? 'Windmill AI is disabled in this workspace'
+							? 'Windmill AI is hidden in this workspace'
 							: $aiUserDisabled
 								? 'Windmill AI is disabled in your account settings'
 								: isAdmin

--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -69,11 +69,13 @@
 				: freeTierExhausted
 					? ''
 					: !hasCopilot
-						? $aiUserDisabled
-							? 'Windmill AI is disabled in your account settings'
-							: isAdmin
-								? `Enable Windmill AI in your [workspace settings](${base}/workspace_settings?tab=ai) to use this chat`
-								: 'Ask an admin to enable Windmill AI in this workspace to use this chat'
+						? $copilotInfo.workspaceDisabled
+							? 'Windmill AI is disabled in this workspace'
+							: $aiUserDisabled
+								? 'Windmill AI is disabled in your account settings'
+								: isAdmin
+									? `Enable Windmill AI in your [workspace settings](${base}/workspace_settings?tab=ai) to use this chat`
+									: 'Ask an admin to enable Windmill AI in this workspace to use this chat'
 						: aiChatManager.mode === AIMode.SCRIPT &&
 							  aiChatManager.scriptEditorOptions?.lang &&
 							  !SUPPORTED_CHAT_SCRIPT_LANGUAGES.includes(aiChatManager.scriptEditorOptions.lang)

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -2350,6 +2350,10 @@ export class AIChatManager {
 	}
 
 	openChat = () => {
+		// Nothing may open the docked pane in a workspace that hid the assistant.
+		if (get(copilotInfo).workspaceDisabled) {
+			return
+		}
 		chatState.size = this.savedSize > 0 ? this.savedSize : DEFAULT_SIZE
 		localStorage.setItem('ai-chat-open', 'true')
 	}
@@ -2361,6 +2365,9 @@ export class AIChatManager {
 	}
 
 	toggleOpen = () => {
+		if (chatState.size === 0 && get(copilotInfo).workspaceDisabled) {
+			return
+		}
 		if (chatState.size > 0) {
 			this.savedSize = chatState.size
 		}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -2887,6 +2887,12 @@ export class AIChatManager {
 			sendUserToast('This action needs the AI chat. Start an AI session to continue.', true)
 			return
 		}
+		// The workspace hid the assistant: every entry point is gone from the UI, so a turn
+		// reaching here comes from a path that missed the gate and would stream unseen.
+		if (!this.isSessionChat && get(copilotInfo).workspaceDisabled) {
+			sendUserToast('Windmill AI is hidden in this workspace.', true)
+			return
+		}
 		// Refused before anything mutates, so there is nothing to unwind: the
 		// draft (already taken by the composer) goes back where the user can see
 		// it, and the turn never starts. Only the message's own send restores it

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -7,6 +7,7 @@
 	import { userStore, workspaceStore } from '$lib/stores'
 	import { chatState } from './sharedChatState.svelte'
 	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
+	import { copilotInfo } from '$lib/aiStore'
 	import { aiChatManager } from './AIChatManager.svelte'
 	import { onDestroy } from 'svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
@@ -63,6 +64,14 @@
 	$effect(() => {
 		if ($workspaceStore && loadAiConfig) {
 			loadCopilot($workspaceStore)
+		}
+	})
+
+	// The pane restores its last open state from localStorage before the config can say
+	// the workspace hid the assistant; close it as soon as that is known.
+	$effect(() => {
+		if ($copilotInfo.workspaceDisabled && chatState.size > 0) {
+			aiChatManager.closeChat()
 		}
 	})
 

--- a/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
@@ -245,6 +245,7 @@
 	// on indices that render nothing.
 	let showAiRows = $derived(
 		!disableAi &&
+			!$copilotInfo.workspaceDisabled &&
 			funcDesc?.length > 0 &&
 			kind != 'failure' &&
 			kind != 'preprocessor' &&

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -96,7 +96,11 @@
 
 	// The composer hands off to /sessions, which refuses operators — so hide it from them (the
 	// prompt would be silently dropped) while the AI-independent CLI/MCP row below stays.
-	let showComposer = $derived(prefersSessionHandoff($userStore?.operator) && !runOnlyWorkspace)
+	let showComposer = $derived(
+		prefersSessionHandoff($userStore?.operator) &&
+			!runOnlyWorkspace &&
+			!$copilotInfo.workspaceDisabled
+	)
 
 	// The hero's margins are for the full block; around the lone button row left by a collapsed,
 	// operator or run-only view they would just be empty page.

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -102,9 +102,12 @@
 			!$copilotInfo.workspaceDisabled
 	)
 
-	// The hero's margins are for the full block; around the lone button row left by a collapsed,
-	// operator or run-only view they would just be empty page.
-	let outerSpacing = $derived(showComposer && !collapsed ? 'mt-20 mb-16' : 'mt-8 mb-2')
+	// The hero's margins and centered column are for the full block. The lone button row left
+	// by a collapsed, operator, run-only or hidden-assistant view is a hint line and should
+	// cost the page almost nothing: no top margin, and the content column's full width so it
+	// hugs the right edge instead of floating centered in empty space.
+	let hero = $derived(showComposer && !collapsed)
+	let outerSpacing = $derived(hero ? 'mt-20 mb-16' : 'mt-0 mb-1')
 
 	let starting = $state(false)
 	async function start() {
@@ -171,7 +174,7 @@
 </script>
 
 <div class="w-full flex justify-center {outerSpacing}">
-	<div class="max-w-[40rem] grow relative group">
+	<div class="{hero ? 'max-w-[40rem]' : ''} grow relative group">
 		{#if showComposer && !collapsed}
 			{#if !disabled}
 				<!-- The one dismiss control while the composer is usable; the overlay below carries its

--- a/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppTemplatePicker.svelte
@@ -345,70 +345,73 @@
 				{/if}
 			</div>
 
-			<div class="pt-6">
-				<h2 class="text-xs font-semibold text-emphasis mb-1 flex items-center gap-2">
-					<Sparkles size={16} class="text-ai" />
-					Start with AI
-					<span class="text-xs font-normal text-tertiary">(optional)</span>
-				</h2>
+			{#if !$copilotInfo.workspaceDisabled}
+				<div class="pt-6">
+					<h2 class="text-xs font-semibold text-emphasis mb-1 flex items-center gap-2">
+						<Sparkles size={16} class="text-ai" />
+						Start with AI
+						<span class="text-xs font-normal text-tertiary">(optional)</span>
+					</h2>
 
-				{#if !aiConfigLoaded}
-					<div class="flex items-center gap-2 text-xs text-tertiary">
-						<Loader2 size={14} class="animate-spin" />
-						Loading AI settings...
-					</div>
-				{:else if !isAiEnabled}
-					<Alert type="info" title="AI is not configured.">
-						You can still create an app manually but using AI is highly recommended.
-						<br />
-						{#if $userStore?.is_admin}
-							Configure AI in
-							<a
-								href="{base}/workspace_settings?tab=ai"
-								target="_blank"
-								class="inline-flex items-center gap-1 font-semibold"
-								>workspace settings <ExternalLinkIcon size={16} />
-							</a>
-							{#if $superadmin}
-								or
+					{#if !aiConfigLoaded}
+						<div class="flex items-center gap-2 text-xs text-tertiary">
+							<Loader2 size={14} class="animate-spin" />
+							Loading AI settings...
+						</div>
+					{:else if !isAiEnabled}
+						<Alert type="info" title="AI is not configured.">
+							You can still create an app manually but using AI is highly recommended.
+							<br />
+							{#if $userStore?.is_admin}
+								Configure AI in
+								<a
+									href="{base}/workspace_settings?tab=ai"
+									target="_blank"
+									class="inline-flex items-center gap-1 font-semibold"
+									>workspace settings <ExternalLinkIcon size={16} />
+								</a>
+								{#if $superadmin}
+									or
+									<a
+										href="{base}/?workspace=admins#superadmin-settings"
+										target="_blank"
+										class="inline-flex items-center gap-1 font-semibold"
+										>instance settings <ExternalLinkIcon size={16} />
+									</a>
+								{/if} to enable this feature.
+							{:else if $superadmin}
+								Configure AI in
 								<a
 									href="{base}/?workspace=admins#superadmin-settings"
 									target="_blank"
 									class="inline-flex items-center gap-1 font-semibold"
 									>instance settings <ExternalLinkIcon size={16} />
-								</a>
-							{/if} to enable this feature.
-						{:else if $superadmin}
-							Configure AI in
-							<a
-								href="{base}/?workspace=admins#superadmin-settings"
-								target="_blank"
-								class="inline-flex items-center gap-1 font-semibold"
-								>instance settings <ExternalLinkIcon size={16} />
-							</a> to enable this feature.
-						{:else}
-							Ask your workspace admin to configure AI in workspace settings to enable this feature.
-						{/if}
-					</Alert>
-				{:else}
-					<div class="flex flex-col gap-2">
-						<TextInput
-							underlyingInputEl="textarea"
-							bind:value={initialPrompt}
-							inputProps={{
-								rows: 3,
-								placeholder:
-									"Describe what you want to build... (e.g., 'Create a todo list app with user authentication')"
-							}}
-						/>
-						<p class="text-xs text-tertiary">
-							{handsOffToSession
-								? 'Leave empty to start with a blank template, or describe your app to open an AI session that builds it.'
-								: 'Leave empty to start with a blank template, or describe your app to get AI assistance right away.'}
-						</p>
-					</div>
-				{/if}
-			</div>
+								</a> to enable this feature.
+							{:else}
+								Ask your workspace admin to configure AI in workspace settings to enable this
+								feature.
+							{/if}
+						</Alert>
+					{:else}
+						<div class="flex flex-col gap-2">
+							<TextInput
+								underlyingInputEl="textarea"
+								bind:value={initialPrompt}
+								inputProps={{
+									rows: 3,
+									placeholder:
+										"Describe what you want to build... (e.g., 'Create a todo list app with user authentication')"
+								}}
+							/>
+							<p class="text-xs text-tertiary">
+								{handsOffToSession
+									? 'Leave empty to start with a blank template, or describe your app to open an AI session that builds it.'
+									: 'Leave empty to start with a blank template, or describe your app to get AI assistance right away.'}
+							</p>
+						</div>
+					{/if}
+				</div>
+			{/if}
 
 			<div class="pt-6 flex justify-end gap-3">
 				<Button
@@ -417,7 +420,7 @@
 					on:click={() => start(false)}
 					disabled={!templates[selectedTemplateIndex] || newSchemaAlreadyExists}
 				>
-					Start without AI
+					{$copilotInfo.workspaceDisabled ? 'Start' : 'Start without AI'}
 				</Button>
 				{#if isAiEnabled}
 					<Button

--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -49,6 +49,7 @@
 	import NatsIcon from '../icons/NatsIcon.svelte'
 	import RunsSearch from './RunsSearch.svelte'
 	import AskAiButton from '../copilot/AskAiButton.svelte'
+	import { copilotInfo } from '$lib/aiStore'
 
 	let open: boolean = $state(false)
 
@@ -648,7 +649,7 @@
 							{placeholderFromPrefix(searchTerm)}
 						</label>
 					</div>
-					{#if (itemMap[tab] ?? []).length === 0 && searchTerm.length > 0}
+					{#if (itemMap[tab] ?? []).length === 0 && searchTerm.length > 0 && !$copilotInfo.workspaceDisabled}
 						<AskAiButton
 							bind:this={askAiButton}
 							label="Ask AI"
@@ -724,16 +725,18 @@
 
 						{#if (itemMap[tab] ?? []).length === 0}
 							<div class="p-2">
-								<QuickMenuItem
-									onselect={() => {
-										askAiButton?.onClick()
-									}}
-									id={'ai:no-results-ask-ai'}
-									hovered={true}
-									label={`Try asking \`${searchTerm}\` to AI`}
-									icon={WandSparkles}
-									bind:mouseMoved
-								/>
+								{#if !$copilotInfo.workspaceDisabled}
+									<QuickMenuItem
+										onselect={() => {
+											askAiButton?.onClick()
+										}}
+										id={'ai:no-results-ask-ai'}
+										hovered={true}
+										label={`Try asking \`${searchTerm}\` to AI`}
+										icon={WandSparkles}
+										bind:mouseMoved
+									/>
+								{/if}
 								<div class="flex w-full justify-center items-center">
 									<div class="text-primary text-center">
 										<div class="pt-1 text-sm">Tip: press `esc` to quickly clear the search bar</div>

--- a/frontend/src/lib/components/sessions/OpenInSessionButton.svelte
+++ b/frontend/src/lib/components/sessions/OpenInSessionButton.svelte
@@ -40,6 +40,7 @@
 	import AIButton from '$lib/components/copilot/chat/AIButton.svelte'
 	import { AIBtnClasses } from '$lib/components/copilot/chat/AIButtonStyle'
 	import { prefersSessionHandoff } from '$lib/components/copilot/chat/global/gate'
+	import { copilotInfo } from '$lib/aiStore'
 	import { userStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { openSourceInSession } from './sessionSwitch.svelte'
@@ -80,7 +81,9 @@
 	// them, so an entry point on a page they can reach (Runs, the trigger lists)
 	// would only route them into that refusal.
 	const show = $derived(
-		!inSessionPanel && !!(source?.target || source?.page) && prefersSessionHandoff($userStore?.operator)
+		!inSessionPanel &&
+			!!(source?.target || source?.page) &&
+			prefersSessionHandoff($userStore?.operator)
 	)
 
 	// Not $state: only read inside open() as a re-entrancy latch, never rendered.
@@ -102,7 +105,10 @@
 	}
 </script>
 
-{#if show}
+{#if $copilotInfo.workspaceDisabled}
+	<!-- The workspace hid the assistant: neither the hand-off nor the docked-chat
+	     fallback has anywhere to lead, so no host renders an AI button at all. -->
+{:else if show}
 	<AIButton
 		togglePanel={open}
 		btnClasses={btnClasses ?? AIBtnClasses('default')}

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -78,6 +78,7 @@
 	let modelPricing: Record<string, ModelPriceOverride> = $state({})
 	let usingOpenaiClientCredentialsOauth = $state(false)
 	let workspaceOverrideEditorOpened = $state(false)
+	let copilotDisabled = $state(false)
 
 	// --- Initial state for dirty tracking ---
 	let initialAiProviders: Exclude<AIConfig['providers'], undefined> = $state({})
@@ -88,6 +89,7 @@
 	let initialMaxTokensPerModel: Record<string, number> = $state({})
 	let initialModelPricing: Record<string, ModelPriceOverride> = $state({})
 	let initialPrompts: Record<string, string> = $state({})
+	let initialCopilotDisabled = $state(false)
 	let lastLoadedConfigKey = $state<string | undefined>(undefined)
 
 	function clone<T>(v: T): T {
@@ -115,6 +117,7 @@
 		customPrompts = clone(config?.custom_prompts ?? {})
 		maxTokensPerModel = clone(config?.max_tokens_per_model ?? {})
 		modelPricing = clone(config?.model_pricing ?? {})
+		copilotDisabled = config?.copilot_disabled === true
 		for (const mode of ['edit', 'fix', 'gen']) {
 			if (!(mode in customPrompts)) {
 				customPrompts[mode] = ''
@@ -131,6 +134,7 @@
 		initialMaxTokensPerModel = clone(maxTokensPerModel)
 		initialModelPricing = clone(modelPricing)
 		initialPrompts = clone(customPrompts)
+		initialCopilotDisabled = copilotDisabled
 	}
 
 	export function loadFromConfig(config: AIConfig | undefined) {
@@ -146,6 +150,7 @@
 		customPrompts = clone(initialCustomPrompts)
 		maxTokensPerModel = clone(initialMaxTokensPerModel)
 		modelPricing = clone(initialModelPricing)
+		copilotDisabled = initialCopilotDisabled
 	}
 
 	$effect(() => {
@@ -180,7 +185,8 @@
 			codeCompletionModel !== initialCodeCompletionModel ||
 			JSON.stringify(customPrompts) !== JSON.stringify(initialCustomPrompts) ||
 			JSON.stringify(maxTokensPerModel) !== JSON.stringify(initialMaxTokensPerModel) ||
-			JSON.stringify(modelPricing) !== JSON.stringify(initialModelPricing)
+			JSON.stringify(modelPricing) !== JSON.stringify(initialModelPricing) ||
+			copilotDisabled !== initialCopilotDisabled
 	)
 
 	$effect(() => {
@@ -285,6 +291,8 @@
 			.filter(([_, prompt]) => prompt.trim().length > 0)
 			.reduce((acc, [mode, prompt]) => ({ ...acc, [mode]: prompt }), {})
 
+		// The flag is the one thing a workspace on instance defaults still stores of its own.
+		const copilot_disabled = copilotDisabled ? true : undefined
 		return Object.keys(aiProviders ?? {}).length > 0
 			? {
 					providers: aiProviders,
@@ -294,9 +302,10 @@
 					custom_prompts: Object.keys(custom_prompts).length > 0 ? custom_prompts : undefined,
 					max_tokens_per_model:
 						Object.keys(maxTokensPerModel).length > 0 ? maxTokensPerModel : undefined,
-					model_pricing: Object.keys(modelPricing).length > 0 ? modelPricing : undefined
+					model_pricing: Object.keys(modelPricing).length > 0 ? modelPricing : undefined,
+					copilot_disabled
 				}
-			: {}
+			: { copilot_disabled }
 	}
 
 	function isSaveDisabled(): boolean {
@@ -381,6 +390,20 @@
 <SettingsPageHeader {title} {description} {link} />
 
 <div class="flex flex-col gap-6 mt-4 pb-8">
+	{#if promptScope === 'workspace'}
+		<SettingCard
+			label="Windmill AI features"
+			description="When off, the AI chat, AI sessions, code generation and completion, AI fix and every other AI button are hidden for all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured below."
+		>
+			<Toggle
+				checked={!copilotDisabled}
+				on:change={(e) => {
+					copilotDisabled = !e.detail
+				}}
+				options={{ right: 'Show AI features in this workspace' }}
+			/>
+		</SettingCard>
+	{/if}
 	{#if usesInstanceAiConfig}
 		<div
 			class="p-3 border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 rounded-md text-xs text-secondary"
@@ -633,12 +656,12 @@
 	<ModelPricing {aiProviders} bind:modelPricing />
 {/if}
 
-{#if showWorkspaceOverrideEditor}
-	<SettingsFooter
-		hasUnsavedChanges={dirty}
-		onSave={editCopilotConfig}
-		onDiscard={discard}
-		saveLabel="Save AI settings"
-		disabled={isSaveDisabled()}
-	/>
-{/if}
+<!-- Not gated on `showWorkspaceOverrideEditor`: a workspace on instance defaults still has
+     the AI features toggle above to save. -->
+<SettingsFooter
+	hasUnsavedChanges={dirty}
+	onSave={editCopilotConfig}
+	onDiscard={discard}
+	saveLabel="Save AI settings"
+	disabled={isSaveDisabled()}
+/>

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -393,7 +393,7 @@
 	{#if promptScope === 'workspace'}
 		<SettingCard
 			label="Windmill AI features"
-			description="When off, the AI chat, AI sessions, code generation and completion, AI fix and every other AI button are hidden for all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured below."
+			description="When off, the AI chat, AI sessions, code generation and completion, AI fix and every other AI button are hidden for all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured below. This hides the assistant in the UI only; it does not restrict API access to the configured providers."
 		>
 			<Toggle
 				checked={!copilotDisabled}

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -390,20 +390,6 @@
 <SettingsPageHeader {title} {description} {link} />
 
 <div class="flex flex-col gap-6 mt-4 pb-8">
-	{#if promptScope === 'workspace'}
-		<SettingCard
-			label="Windmill AI features"
-			description="When off, the AI chat, AI sessions, code generation and completion, AI fix and every other AI button are hidden for all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured below. This hides the assistant in the UI only; it does not restrict API access to the configured providers."
-		>
-			<Toggle
-				checked={!copilotDisabled}
-				on:change={(e) => {
-					copilotDisabled = !e.detail
-				}}
-				options={{ right: 'Show AI features in this workspace' }}
-			/>
-		</SettingCard>
-	{/if}
 	{#if usesInstanceAiConfig}
 		<div
 			class="p-3 border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20 rounded-md text-xs text-secondary"
@@ -656,8 +642,23 @@
 	<ModelPricing {aiProviders} bind:modelPricing />
 {/if}
 
+{#if promptScope === 'workspace'}
+	<SettingCard
+		label="Hide AI sessions"
+		description="Hides AI sessions and every other AI assistant button (chat, code generation and completion, AI fix) from all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured above. This hides the assistant in the UI only; it does not restrict API access to the configured providers."
+	>
+		<Toggle
+			checked={copilotDisabled}
+			on:change={(e) => {
+				copilotDisabled = e.detail
+			}}
+			options={{ right: 'Hide AI sessions in this workspace' }}
+		/>
+	</SettingCard>
+{/if}
+
 <!-- Not gated on `showWorkspaceOverrideEditor`: a workspace on instance defaults still has
-     the AI features toggle above to save. -->
+     the hide toggle above to save. -->
 <SettingsFooter
 	hasUnsavedChanges={dirty}
 	onSave={editCopilotConfig}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -83,6 +83,7 @@
 	import SessionPicker from '$lib/components/sessions/SessionPicker.svelte'
 	import SessionModeSwitch from '$lib/components/sessions/SessionModeSwitch.svelte'
 	import { isGlobalAiEnabled } from '$lib/components/copilot/chat/global/gate'
+	import { copilotInfo } from '$lib/aiStore'
 	import { parsePreviewItemRoute } from '$lib/components/sessions/previewPaths'
 	import { rememberNavRoute } from '$lib/components/sessions/sessionSwitch.svelte'
 	import { sessionState } from '$lib/components/sessions/sessionState.svelte'
@@ -250,6 +251,10 @@
 	// so it follows the gate; opted-out users get the legacy Ask-AI pane instead.
 	// The /sessions page has its own gate for direct navigation.
 	const globalAiEnabled = isGlobalAiEnabled()
+	// A workspace that hid the assistant (`ai_config.copilot_disabled`) loses both entry
+	// points: the Workspace ⇄ Sessions switch and the legacy Ask-AI button.
+	const sessionsSwitchShown = $derived(globalAiEnabled && !$copilotInfo.workspaceDisabled)
+	const askAiShown = $derived(!globalAiEnabled && !$copilotInfo.workspaceDisabled)
 
 	if (page.status == 404) {
 		goto('/user/login')
@@ -999,7 +1004,7 @@
 										</Menubar>
 									</div>
 
-									{#if !embedded && globalAiEnabled}
+									{#if !embedded && sessionsSwitchShown}
 										<!-- The switch: workspace navigation ⇄ sessions sidebar. -->
 										<div class="px-2 pb-1 w-52">
 											<SessionModeSwitch
@@ -1011,7 +1016,7 @@
 
 									{#if !sessionMode}
 										<!-- Workspace scope (fork picker): part of the top workspace group. -->
-										<div class="pb-1 w-52 {globalAiEnabled ? '' : '-mt-1'}">
+										<div class="pb-1 w-52 {sessionsSwitchShown ? '' : '-mt-1'}">
 											<WorkspaceScopeHeader isCollapsed={false} />
 										</div>
 									{/if}
@@ -1047,7 +1052,7 @@
 													class="!text-xs"
 													shortcut={`${getModifierKey()}k`}
 												/>
-												{#if !globalAiEnabled}
+												{#if askAiShown}
 													<!-- Legacy Ask-AI pane, shown only when the user opted out of the
 													     AI Sessions beta (otherwise SessionModeSwitch replaces it). -->
 													<MenuButton
@@ -1134,7 +1139,7 @@
 								</Menubar>
 							</div>
 
-							{#if !embedded && globalAiEnabled}
+							{#if !embedded && sessionsSwitchShown}
 								<!-- The switch: workspace navigation ⇄ sessions sidebar. -->
 								<div class="px-2 pb-1 {isCollapsed ? 'flex justify-center' : ''}">
 									<SessionModeSwitch mode={sessionMode ? 'session' : 'nav'} {isCollapsed} />
@@ -1145,7 +1150,7 @@
 								<!-- Workspace scope (fork picker): part of the top workspace group,
 								     together with the family menu and the mode switch above. Without
 								     the switch, pull it up so the group still reads as one block. -->
-								<div class="pb-1 {globalAiEnabled ? '' : '-mt-1'}">
+								<div class="pb-1 {sessionsSwitchShown ? '' : '-mt-1'}">
 									<WorkspaceScopeHeader {isCollapsed} />
 								</div>
 							{/if}
@@ -1184,7 +1189,7 @@
 											class="!text-xs"
 											shortcut={`${getModifierKey()}k`}
 										/>
-										{#if !globalAiEnabled}
+										{#if askAiShown}
 											<!-- Legacy Ask-AI pane, shown only when the user opted out of the
 											     AI Sessions beta (otherwise SessionModeSwitch replaces it). -->
 											<MenuButton
@@ -1323,19 +1328,21 @@
 									class="!text-xs"
 									shortcut={`${getModifierKey()}k`}
 								/>
-								<MenuButton
-									stopPropagationOnClick={true}
-									on:click={() => aiChatManager.toggleOpen()}
-									{isCollapsed}
-									icon={WandSparkles}
-									iconProps={{
-										forceDarkMode: true
-									}}
-									label="Ask AI"
-									class="!text-xs"
-									iconClasses="!text-ai"
-									shortcut={`${getModifierKey()}L`}
-								/>
+								{#if !$copilotInfo.workspaceDisabled}
+									<MenuButton
+										stopPropagationOnClick={true}
+										on:click={() => aiChatManager.toggleOpen()}
+										{isCollapsed}
+										icon={WandSparkles}
+										iconProps={{
+											forceDarkMode: true
+										}}
+										label="Ask AI"
+										class="!text-xs"
+										iconClasses="!text-ai"
+										shortcut={`${getModifierKey()}L`}
+									/>
+								{/if}
 							</div>
 
 							<SidebarContent

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -859,21 +859,6 @@
 		<div class="flex-1 flex items-center justify-center">
 			<Loader2 class="animate-spin" />
 		</div>
-	{:else if aiHiddenVerdict === undefined}
-		<!-- The judged workspace's verdict is still loading: mounting the session UI now
-		     could show a session the verdict then hides. -->
-		<div class="flex-1 flex items-center justify-center">
-			<Loader2 class="animate-spin" />
-		</div>
-	{:else if aiHiddenVerdict}
-		<!-- After hydration, so a session named in the URL decides which workspace is
-		     judged. The workspace hid the assistant, and the sidebar switch with it, so
-		     only a direct URL or a session acting on such a workspace lands here. -->
-		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
-			<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
-			<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
-			<Button unifiedSize="sm" onclick={() => goto('/')}>Back to workspace</Button>
-		</div>
 	{:else if !sessionName}
 		<div class="p-8 text-secondary">No session selected — pick one in the sidebar.</div>
 	{:else if !sessionByName || recovering}
@@ -883,284 +868,309 @@
 			<Loader2 class="animate-spin" />
 		</div>
 	{:else}
-		<div class="flex-1 min-h-0 flex flex-row relative" use:splitterPointerCapture>
-			<Splitpanes
-				horizontal={false}
-				class="flex-1 min-h-0 session-splitter {previewCollapsed ? 'splitter-off' : ''}"
+		<!-- The hidden-assistant verdict overlays the session stack rather than replacing
+		     it: warm sessions and mounted preview editors must survive a cross-workspace
+		     switch, and a verdict still loading would otherwise tear them down on every
+		     one. The covered stack is inert so nothing under the overlay takes focus. -->
+		<div class="flex-1 min-h-0 flex flex-col relative">
+			<div
+				class="flex-1 min-h-0 flex flex-row relative z-0"
+				use:splitterPointerCapture
+				inert={aiHiddenVerdict !== false}
 			>
-				{#if !fullscreen}
-					<!-- Chat column. Warm sessions stay mounted (stacked, visibility-toggled)
+				<Splitpanes
+					horizontal={false}
+					class="flex-1 min-h-0 session-splitter {previewCollapsed ? 'splitter-off' : ''}"
+				>
+					{#if !fullscreen}
+						<!-- Chat column. Warm sessions stay mounted (stacked, visibility-toggled)
 					     so switching between them preserves chat scroll/draft state. -->
-					<Pane bind:size={chatPaneSize} minSize={25} class="flex flex-col min-h-0">
-						<div class="relative flex-1 min-h-0">
-							{#each warmSessions as s (s.id)}
-								<div
-									class="absolute inset-0 flex flex-col {s.id === activeSession?.id
-										? 'z-10 opacity-100 pointer-events-auto'
-										: 'z-0 opacity-0 pointer-events-none'}"
-									aria-hidden={s.id !== activeSession?.id}
-								>
-									<SessionWrapper sessionId={s.id} />
-								</div>
-							{/each}
-						</div>
-					</Pane>
-				{/if}
+						<Pane bind:size={chatPaneSize} minSize={25} class="flex flex-col min-h-0">
+							<div class="relative flex-1 min-h-0">
+								{#each warmSessions as s (s.id)}
+									<div
+										class="absolute inset-0 flex flex-col {s.id === activeSession?.id
+											? 'z-10 opacity-100 pointer-events-auto'
+											: 'z-0 opacity-0 pointer-events-none'}"
+										aria-hidden={s.id !== activeSession?.id}
+									>
+										<SessionWrapper sessionId={s.id} />
+									</div>
+								{/each}
+							</div>
+						</Pane>
+					{/if}
 
-				<!-- Preview panel: the live Windmill page, framed like the editor pane.
+					<!-- Preview panel: the live Windmill page, framed like the editor pane.
 				     Always mounted (collapse resizes it to 0 — see previewPaneSize) so
 				     warm sessions' preview hosts survive a collapsed active session. -->
-				<Pane
-					bind:size={previewPaneSize}
-					minSize={previewCollapsed ? 0 : 30}
-					maxSize={previewCollapsed ? 0 : 100}
-					class="flex flex-col min-h-0"
-				>
-					<div class="flex-1 min-h-0 flex flex-col {fullscreen ? 'p-0' : 'p-2 pl-0'}">
-						<div
-							class="flex flex-col flex-1 min-h-0 overflow-hidden relative bg-surface {fullscreen
-								? ''
-								: 'rounded-md border border-light'}"
-						>
-							{#if !fullscreen}
-								<!-- Collapse the preview panel — floats over the top-left corner so
+					<Pane
+						bind:size={previewPaneSize}
+						minSize={previewCollapsed ? 0 : 30}
+						maxSize={previewCollapsed ? 0 : 100}
+						class="flex flex-col min-h-0"
+					>
+						<div class="flex-1 min-h-0 flex flex-col {fullscreen ? 'p-0' : 'p-2 pl-0'}">
+							<div
+								class="flex flex-col flex-1 min-h-0 overflow-hidden relative bg-surface {fullscreen
+									? ''
+									: 'rounded-md border border-light'}"
+							>
+								{#if !fullscreen}
+									<!-- Collapse the preview panel — floats over the top-left corner so
 									     the tab strip keeps the full width. -->
-								<button
-									type="button"
-									onclick={() => owner?.setCollapsed(true)}
-									title="Collapse preview"
-									aria-label="Collapse preview"
-									class="absolute top-1 left-1 z-30 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
-								>
-									<PanelRightClose size={14} />
-								</button>
-							{/if}
+									<button
+										type="button"
+										onclick={() => owner?.setCollapsed(true)}
+										title="Collapse preview"
+										aria-label="Collapse preview"
+										class="absolute top-1 left-1 z-30 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
+									>
+										<PanelRightClose size={14} />
+									</button>
+								{/if}
 
-							<!-- Open-in-full-page + full-screen toggle, floating over the top-right
+								<!-- Open-in-full-page + full-screen toggle, floating over the top-right
 								     corner to mirror the collapse control. -->
-							<div class="absolute top-1 right-1 z-30 flex items-center gap-0.5">
-								{#if !activeTabIsArtifact}
-									<a
-										href={withWorkspaceParam(
-											owner?.activeTab?.loc || owner?.activeTab?.url || `${base}/`,
-											previewWorkspace
-										)}
-										title="Open in workspace"
-										aria-label="Open in workspace"
+								<div class="absolute top-1 right-1 z-30 flex items-center gap-0.5">
+									{#if !activeTabIsArtifact}
+										<a
+											href={withWorkspaceParam(
+												owner?.activeTab?.loc || owner?.activeTab?.url || `${base}/`,
+												previewWorkspace
+											)}
+											title="Open in workspace"
+											aria-label="Open in workspace"
+											class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
+										>
+											<ExternalLink size={14} />
+										</a>
+									{/if}
+									<button
+										type="button"
+										onclick={() => (fullscreen = !fullscreen)}
+										title={fullscreen ? 'Exit full screen' : 'Full screen'}
+										aria-label={fullscreen ? 'Exit full screen' : 'Full screen'}
 										class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
 									>
-										<ExternalLink size={14} />
-									</a>
-								{/if}
-								<button
-									type="button"
-									onclick={() => (fullscreen = !fullscreen)}
-									title={fullscreen ? 'Exit full screen' : 'Full screen'}
-									aria-label={fullscreen ? 'Exit full screen' : 'Full screen'}
-									class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
-								>
-									{#if fullscreen}
-										<Minimize2 size={14} />
-									{:else}
-										<Maximize2 size={14} />
-									{/if}
-								</button>
-							</div>
+										{#if fullscreen}
+											<Minimize2 size={14} />
+										{:else}
+											<Maximize2 size={14} />
+										{/if}
+									</button>
+								</div>
 
-							<!-- Tab strip: open preview pages, shared with the raw-app editor
+								<!-- Tab strip: open preview pages, shared with the raw-app editor
 								     (DraggableTabs). Clicking the active tab (label or accessory chevron)
 								     toggles its breadcrumb picker; the "+" trailing opens the router picker.
 								     Left/right padding clears the floating collapse/fullscreen buttons. -->
-							<DraggableTabs
-								tabs={previewTabItems}
-								activeId={owner?.activeId ?? ''}
-								onSelect={selectTab}
-								onActiveClick={() => (activeTabPickerOpen = !activeTabPickerOpen)}
-								onClose={closeTab}
-								onReorder={reorderTabs}
-								class="session-preview-tab-strip h-8 border-b border-light bg-surface-secondary/50 {fullscreen
-									? 'pl-1.5'
-									: 'pl-9'} pr-16"
-							>
-								{#snippet tabAccessory(_tab, isActive)}
-									{#if isActive}
-										<!-- Any active-tab click toggles the picker (`onActiveClick`); the tab
+								<DraggableTabs
+									tabs={previewTabItems}
+									activeId={owner?.activeId ?? ''}
+									onSelect={selectTab}
+									onActiveClick={() => (activeTabPickerOpen = !activeTabPickerOpen)}
+									onClose={closeTab}
+									onReorder={reorderTabs}
+									class="session-preview-tab-strip h-8 border-b border-light bg-surface-secondary/50 {fullscreen
+										? 'pl-1.5'
+										: 'pl-9'} pr-16"
+								>
+									{#snippet tabAccessory(_tab, isActive)}
+										{#if isActive}
+											<!-- Any active-tab click toggles the picker (`onActiveClick`); the tab
 										     is excluded from pointerdown-outside so toggle doesn't race close.
 										     The trigger is an inert whole-tab overlay (anchor only — clickable
 										     would break dnd reorder); the chevron is purely visual. -->
-										<Popover
-											placement="bottom-start"
-											usePointerDownOutside
-											excludeSelectors=".drawer, .session-preview-tab-strip [role='tab'][aria-selected='true']"
-											disableFocusTrap
-											closeOnOtherPopoverOpen
-											enableFlyTransition
-											bind:isOpen={activeTabPickerOpen}
-											openFocus="[data-workspace-picker-search]"
-											contentClasses="flex flex-col overflow-hidden"
-											class="absolute inset-0 pointer-events-none"
-											triggerAttrs={{
-												'aria-label': 'Change preview',
-												tabindex: -1,
-												// The inert trigger only ever receives focus from melt's
-												// close-time restore; hand it straight to the tab so
-												// arrow/Delete tab shortcuts keep working.
-												onfocus: (e: FocusEvent) =>
-													(e.currentTarget as HTMLElement)
-														.closest<HTMLElement>('[role="tab"]')
-														?.focus()
-											}}
-										>
-											{#snippet content()}
-												<!-- The picker snapshots its scope at mount, but `friendlyPath` is
+											<Popover
+												placement="bottom-start"
+												usePointerDownOutside
+												excludeSelectors=".drawer, .session-preview-tab-strip [role='tab'][aria-selected='true']"
+												disableFocusTrap
+												closeOnOtherPopoverOpen
+												enableFlyTransition
+												bind:isOpen={activeTabPickerOpen}
+												openFocus="[data-workspace-picker-search]"
+												contentClasses="flex flex-col overflow-hidden"
+												class="absolute inset-0 pointer-events-none"
+												triggerAttrs={{
+													'aria-label': 'Change preview',
+													tabindex: -1,
+													// The inert trigger only ever receives focus from melt's
+													// close-time restore; hand it straight to the tab so
+													// arrow/Delete tab shortcuts keep working.
+													onfocus: (e: FocusEvent) =>
+														(e.currentTarget as HTMLElement)
+															.closest<HTMLElement>('[role="tab"]')
+															?.focus()
+												}}
+											>
+												{#snippet content()}
+													<!-- The picker snapshots its scope at mount, but `friendlyPath` is
 												     stamped async once the editor cell loads — a picker opened
 												     before the stamp is scoped to the `draft_<uuid>` storage
 												     folder while the tree groups the draft under its friendly
 												     folder. Remount on the scope dir so it re-lands on the item. -->
-												{#key activePickerScope?.dir ?? ''}
-													<PreviewRouterPicker
-														initialScope={activePickerScope}
-														initialHighlight={activePickerHighlight}
-														{currentItem}
-														workspaceId={previewWorkspace}
-														artifacts={sessionArtifacts}
-														onPick={(t) => {
-															activeTabPickerOpen = false
-															navigatePreviewTo(t)
-														}}
-													/>
-												{/key}
-											{/snippet}
-										</Popover>
-										<ChevronDown
-											size={12}
-											class="shrink-0 text-tertiary group-hover:text-primary"
-										/>
-									{/if}
-								{/snippet}
-								{#snippet afterTabs()}
-									<Popover
-										placement="bottom-start"
-										usePointerDownOutside
-										excludeSelectors=".drawer"
-										disableFocusTrap
-										closeOnOtherPopoverOpen
-										bind:isOpen={newTabOpen}
-										enableFlyTransition
-										openFocus="[data-workspace-picker-search]"
-										contentClasses="flex flex-col overflow-hidden"
-										class="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover cursor-pointer"
-									>
-										{#snippet trigger()}
-											<Plus size={14} />
-										{/snippet}
-										{#snippet content()}
-											<PreviewRouterPicker
-												workspaceId={previewWorkspace}
-												artifacts={sessionArtifacts}
-												onPick={(t) => {
-													newTabOpen = false
-													openInNewTab(t)
-												}}
+													{#key activePickerScope?.dir ?? ''}
+														<PreviewRouterPicker
+															initialScope={activePickerScope}
+															initialHighlight={activePickerHighlight}
+															{currentItem}
+															workspaceId={previewWorkspace}
+															artifacts={sessionArtifacts}
+															onPick={(t) => {
+																activeTabPickerOpen = false
+																navigatePreviewTo(t)
+															}}
+														/>
+													{/key}
+												{/snippet}
+											</Popover>
+											<ChevronDown
+												size={12}
+												class="shrink-0 text-tertiary group-hover:text-primary"
 											/>
-										{/snippet}
-									</Popover>
-								{/snippet}
-							</DraggableTabs>
-
-							<!-- One host per tab of every warm session, stacked and
-								     visibility-toggled so switching tabs or sessions never reloads
-								     a mounted tab — hosts live as long as the session's runtime,
-								     content-gated by the shared mount MRU. Each host renders a
-								     live editor (script/flow/raw_app target) or an iframe fallback. -->
-							<div class="relative flex-1 min-h-0">
-								{#each warmSessions as s (s.id)}
-									{@const rt = getRuntime(s.id)}
-									{@const tabs = rt?.previewTabs}
-									{#each tabs?.tabs ?? [] as tab (tab.id)}
-										<!-- tabHosts is an imperative ref-bag (only tabHosts[key]?.reload() in
-										     reloadTabs); it is intentionally a plain object so component
-										     instances aren't proxied. Nothing reads it reactively, so the
-										     non-reactive binding is fine. -->
-										<!-- svelte-ignore binding_property_non_reactive -->
-										<PreviewTabHost
-											bind:this={tabHosts[tabKey(s.id, tab.id)]}
-											{tab}
-											session={s}
-											runtime={rt}
-											active={s.id === activeSession?.id && tab.id === tabs?.activeId}
-											collapsed={(tabs?.collapsed ?? false) && !fullscreen}
-											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
-											label={tabLabelFor(tab, s.workspace_id ?? '')}
-											darkMode={isDarkMode.val}
-											{fullscreen}
-											onNavigate={navigateEditorTo}
-											onLoad={(frame) => tabs && onTabLoad(tabs, tab, frame)}
-										/>
-									{/each}
-								{/each}
-								{#if (owner?.tabs.length ?? 0) === 0}
-									<!-- New session with nothing to preview: an empty state with a
-										     picker to open one, instead of defaulting to the home page. -->
-									<div
-										class="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center px-6 bg-surface"
-									>
-										<MonitorPlay size={28} class="text-tertiary" />
-										<div class="flex flex-col gap-1">
-											<span class="text-sm font-medium text-secondary">No preview open</span>
-											<span class="text-xs text-tertiary max-w-xs"
-												>Open a page, flow, script or app to preview it alongside the chat.</span
-											>
-										</div>
+										{/if}
+									{/snippet}
+									{#snippet afterTabs()}
 										<Popover
-											placement="bottom"
+											placement="bottom-start"
 											usePointerDownOutside
 											excludeSelectors=".drawer"
 											disableFocusTrap
 											closeOnOtherPopoverOpen
-											bind:isOpen={emptyStateNewTabOpen}
+											bind:isOpen={newTabOpen}
 											enableFlyTransition
 											openFocus="[data-workspace-picker-search]"
 											contentClasses="flex flex-col overflow-hidden"
+											class="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover cursor-pointer"
 										>
 											{#snippet trigger()}
-												<span
-													class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs border border-light text-secondary hover:bg-surface-hover cursor-pointer"
-												>
-													<Plus size={14} /> Open a preview
-												</span>
+												<Plus size={14} />
 											{/snippet}
 											{#snippet content()}
 												<PreviewRouterPicker
 													workspaceId={previewWorkspace}
 													artifacts={sessionArtifacts}
 													onPick={(t) => {
-														emptyStateNewTabOpen = false
+														newTabOpen = false
 														openInNewTab(t)
 													}}
 												/>
 											{/snippet}
 										</Popover>
-									</div>
-								{/if}
+									{/snippet}
+								</DraggableTabs>
+
+								<!-- One host per tab of every warm session, stacked and
+								     visibility-toggled so switching tabs or sessions never reloads
+								     a mounted tab — hosts live as long as the session's runtime,
+								     content-gated by the shared mount MRU. Each host renders a
+								     live editor (script/flow/raw_app target) or an iframe fallback. -->
+								<div class="relative flex-1 min-h-0">
+									{#each warmSessions as s (s.id)}
+										{@const rt = getRuntime(s.id)}
+										{@const tabs = rt?.previewTabs}
+										{#each tabs?.tabs ?? [] as tab (tab.id)}
+											<!-- tabHosts is an imperative ref-bag (only tabHosts[key]?.reload() in
+										     reloadTabs); it is intentionally a plain object so component
+										     instances aren't proxied. Nothing reads it reactively, so the
+										     non-reactive binding is fine. -->
+											<!-- svelte-ignore binding_property_non_reactive -->
+											<PreviewTabHost
+												bind:this={tabHosts[tabKey(s.id, tab.id)]}
+												{tab}
+												session={s}
+												runtime={rt}
+												active={s.id === activeSession?.id && tab.id === tabs?.activeId}
+												collapsed={(tabs?.collapsed ?? false) && !fullscreen}
+												mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
+												label={tabLabelFor(tab, s.workspace_id ?? '')}
+												darkMode={isDarkMode.val}
+												{fullscreen}
+												onNavigate={navigateEditorTo}
+												onLoad={(frame) => tabs && onTabLoad(tabs, tab, frame)}
+											/>
+										{/each}
+									{/each}
+									{#if (owner?.tabs.length ?? 0) === 0}
+										<!-- New session with nothing to preview: an empty state with a
+										     picker to open one, instead of defaulting to the home page. -->
+										<div
+											class="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center px-6 bg-surface"
+										>
+											<MonitorPlay size={28} class="text-tertiary" />
+											<div class="flex flex-col gap-1">
+												<span class="text-sm font-medium text-secondary">No preview open</span>
+												<span class="text-xs text-tertiary max-w-xs"
+													>Open a page, flow, script or app to preview it alongside the chat.</span
+												>
+											</div>
+											<Popover
+												placement="bottom"
+												usePointerDownOutside
+												excludeSelectors=".drawer"
+												disableFocusTrap
+												closeOnOtherPopoverOpen
+												bind:isOpen={emptyStateNewTabOpen}
+												enableFlyTransition
+												openFocus="[data-workspace-picker-search]"
+												contentClasses="flex flex-col overflow-hidden"
+											>
+												{#snippet trigger()}
+													<span
+														class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs border border-light text-secondary hover:bg-surface-hover cursor-pointer"
+													>
+														<Plus size={14} /> Open a preview
+													</span>
+												{/snippet}
+												{#snippet content()}
+													<PreviewRouterPicker
+														workspaceId={previewWorkspace}
+														artifacts={sessionArtifacts}
+														onPick={(t) => {
+															emptyStateNewTabOpen = false
+															openInNewTab(t)
+														}}
+													/>
+												{/snippet}
+											</Popover>
+										</div>
+									{/if}
+								</div>
 							</div>
 						</div>
-					</div>
-				</Pane>
-			</Splitpanes>
-			{#if previewCollapsed && !fullscreen}
-				<!-- Collapsed preview: no rail — a floating launcher in the top-right to
+					</Pane>
+				</Splitpanes>
+				{#if previewCollapsed && !fullscreen}
+					<!-- Collapsed preview: no rail — a floating launcher in the top-right to
 				     reopen the side panel. -->
-				<div class="absolute top-2 right-3 z-50">
-					<Button
-						variant="subtle"
-						unifiedSize="sm"
-						startIcon={{ icon: PanelRightOpen }}
-						title="Open side panel"
-						onclick={() => owner?.setCollapsed(false)}
-					>
-						Open side panel
-					</Button>
+					<div class="absolute top-2 right-3 z-50">
+						<Button
+							variant="subtle"
+							unifiedSize="sm"
+							startIcon={{ icon: PanelRightOpen }}
+							title="Open side panel"
+							onclick={() => owner?.setCollapsed(false)}
+						>
+							Open side panel
+						</Button>
+					</div>
+				{/if}
+			</div>
+			{#if aiHiddenVerdict === undefined}
+				<div class="absolute inset-0 z-20 flex items-center justify-center bg-surface">
+					<Loader2 class="animate-spin" />
+				</div>
+			{:else if aiHiddenVerdict}
+				<!-- The workspace hid the assistant, and the sidebar switch with it, so only a
+				     direct URL or a session acting on such a workspace lands here. -->
+				<div
+					class="absolute inset-0 z-20 bg-surface p-8 flex flex-col items-start gap-3 text-secondary text-sm"
+				>
+					<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
+					<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
+					<Button unifiedSize="sm" onclick={() => goto('/')}>Back to workspace</Button>
 				</div>
 			{/if}
 		</div>

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -283,19 +283,32 @@
 	// Whether that workspace hid the AI assistant (`ai_config.copilot_disabled`). Read
 	// directly rather than from `copilotInfo`: that store holds whichever workspace loaded
 	// last, and the gate below unmounts the session wrapper that would refresh it, so a
-	// hidden verdict would stick across session and workspace switches. A failed read
-	// leaves the page usable, as an unloaded config does everywhere else.
+	// hidden verdict would stick across session and workspace switches. Tagged with its
+	// workspace and guarded against a superseded response like the protection-rules
+	// resource: runed keeps the previous `current` while a new source loads, so a switch
+	// would otherwise be judged on the previous workspace's verdict. A failed read leaves
+	// the page usable, as an unloaded config does everywhere else.
 	const workspaceAiHidden = resource(
 		() => previewWorkspace,
-		async (workspace) => {
-			if (!workspace) return false
+		async (workspace, _prev, { signal }) => {
+			if (!workspace) return { workspace, hidden: false }
+			let hidden = false
 			try {
-				return (await WorkspaceService.getCopilotInfo({ workspace })).copilot_disabled === true
-			} catch {
-				return false
+				hidden = (await WorkspaceService.getCopilotInfo({ workspace })).copilot_disabled === true
+			} catch (e) {
+				console.error(`Failed to read the AI config of workspace ${workspace}:`, e)
 			}
+			// The generated client can't take an abort signal, so drop a superseded response here.
+			if (signal.aborted) throw new DOMException('superseded', 'AbortError')
+			return { workspace, hidden }
 		}
 	)
+	// Only a verdict for the workspace currently judged counts; `undefined` means it has not
+	// landed yet.
+	const aiHiddenVerdict = $derived.by(() => {
+		const current = workspaceAiHidden.current
+		return current && current.workspace === previewWorkspace ? current.hidden : undefined
+	})
 
 	// Lazy-mount gate: a tab's content only renders once its key lands here (on
 	// first activation) — so restoring a session with N saved tabs boots just
@@ -846,7 +859,13 @@
 		<div class="flex-1 flex items-center justify-center">
 			<Loader2 class="animate-spin" />
 		</div>
-	{:else if workspaceAiHidden.current === true}
+	{:else if aiHiddenVerdict === undefined}
+		<!-- The judged workspace's verdict is still loading: mounting the session UI now
+		     could show a session the verdict then hides. -->
+		<div class="flex-1 flex items-center justify-center">
+			<Loader2 class="animate-spin" />
+		</div>
+	{:else if aiHiddenVerdict}
 		<!-- After hydration, so a session named in the URL decides which workspace is
 		     judged. The workspace hid the assistant, and the sidebar switch with it, so
 		     only a direct URL or a session acting on such a workspace lands here. -->

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -21,8 +21,8 @@
 		type Scope
 	} from '$lib/components/sessions/PreviewRouterPicker.svelte'
 	import { goto } from '$lib/navigation'
-	import { copilotInfo } from '$lib/aiStore'
-	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
+	import { resource } from 'runed'
+	import { WorkspaceService } from '$lib/gen'
 	import SessionWrapper from '$lib/components/sessions/SessionWrapper.svelte'
 	import PreviewTabHost from '$lib/components/sessions/PreviewTabHost.svelte'
 	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
@@ -136,17 +136,6 @@
 	// Resolve by name without applying the sidebar scope filter so an open
 	// chat survives within-family workspace switches.
 	const activeSession = $derived(sessionState.sessions.find((s) => s.name === sessionName))
-
-	// With no session selected nothing else loads the copilot config here: the layout skips
-	// it in session mode and SessionWrapper only mounts with a session. Load the navigation
-	// workspace's config so the hidden-workspace gate below can fire on a cold load and
-	// follows an in-page workspace switch. Once a session is active its wrapper owns the
-	// load for the acting workspace, so this must not fire over it.
-	$effect(() => {
-		if ($workspaceStore && !activeSession) {
-			loadCopilot($workspaceStore)
-		}
-	})
 
 	// Family reconcile: a workspace switch can land this page with no session
 	// selected or with another family's session in the URL (the sidebar picker's
@@ -289,6 +278,23 @@
 	// lists or opens against the navigation workspace ($workspaceStore).
 	const previewWorkspace = $derived(
 		(activeSession ? getEffectiveWorkspaceId(activeSession) : undefined) ?? $workspaceStore
+	)
+
+	// Whether that workspace hid the AI assistant (`ai_config.copilot_disabled`). Read
+	// directly rather than from `copilotInfo`: that store holds whichever workspace loaded
+	// last, and the gate below unmounts the session wrapper that would refresh it, so a
+	// hidden verdict would stick across session and workspace switches. A failed read
+	// leaves the page usable, as an unloaded config does everywhere else.
+	const workspaceAiHidden = resource(
+		() => previewWorkspace,
+		async (workspace) => {
+			if (!workspace) return false
+			try {
+				return (await WorkspaceService.getCopilotInfo({ workspace })).copilot_disabled === true
+			} catch {
+				return false
+			}
+		}
 	)
 
 	// Lazy-mount gate: a tab's content only renders once its key lands here (on
@@ -833,20 +839,21 @@
 				Activate AI Sessions
 			</Button>
 		</div>
-	{:else if $copilotInfo.workspaceDisabled}
-		<!-- The workspace hid the assistant, and the sidebar switch with it, so only a
-		     direct URL lands here. -->
-		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
-			<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
-			<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
-			<Button unifiedSize="sm" onclick={() => goto('/')}>Back to workspace</Button>
-		</div>
 	{:else if !sessionState.hydrated}
 		<!-- Sessions hydrate from IndexedDB after the user resolves; until then an
 		     empty list means "loading", so recovery below must not fire and strand
 		     the user in a new session while their own is still arriving. -->
 		<div class="flex-1 flex items-center justify-center">
 			<Loader2 class="animate-spin" />
+		</div>
+	{:else if workspaceAiHidden.current === true}
+		<!-- After hydration, so a session named in the URL decides which workspace is
+		     judged. The workspace hid the assistant, and the sidebar switch with it, so
+		     only a direct URL or a session acting on such a workspace lands here. -->
+		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
+			<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
+			<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
+			<Button unifiedSize="sm" onclick={() => goto('/')}>Back to workspace</Button>
 		</div>
 	{:else if !sessionName}
 		<div class="p-8 text-secondary">No session selected — pick one in the sidebar.</div>

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -76,15 +76,6 @@
 
 	const globalEnabled = isGlobalAiEnabled()
 
-	// Nothing else loads the copilot config here before a session is selected: the layout
-	// skips it in session mode and SessionWrapper only mounts with a session. Read the
-	// navigation workspace's config once, synchronously at init, so the hidden-workspace
-	// gate below can fire on a cold load; a session mounting later loads its own acting
-	// workspace and, being the later call, supersedes this one.
-	if ($workspaceStore) {
-		loadCopilot($workspaceStore)
-	}
-
 	// One observer shared by every tab host, which mirrors it into page iframes
 	// (see PreviewTabHost).
 	const isDarkMode = useIsDarkMode()
@@ -145,6 +136,17 @@
 	// Resolve by name without applying the sidebar scope filter so an open
 	// chat survives within-family workspace switches.
 	const activeSession = $derived(sessionState.sessions.find((s) => s.name === sessionName))
+
+	// With no session selected nothing else loads the copilot config here: the layout skips
+	// it in session mode and SessionWrapper only mounts with a session. Load the navigation
+	// workspace's config so the hidden-workspace gate below can fire on a cold load and
+	// follows an in-page workspace switch. Once a session is active its wrapper owns the
+	// load for the acting workspace, so this must not fire over it.
+	$effect(() => {
+		if ($workspaceStore && !activeSession) {
+			loadCopilot($workspaceStore)
+		}
+	})
 
 	// Family reconcile: a workspace switch can land this page with no session
 	// selected or with another family's session in the URL (the sidebar picker's
@@ -837,7 +839,7 @@
 		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
 			<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
 			<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
-			<Button size="xs" onclick={() => goto('/')}>Back to workspace</Button>
+			<Button unifiedSize="sm" onclick={() => goto('/')}>Back to workspace</Button>
 		</div>
 	{:else if !sessionState.hydrated}
 		<!-- Sessions hydrate from IndexedDB after the user resolves; until then an

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -1169,7 +1169,7 @@
 					class="absolute inset-0 z-20 bg-surface p-8 flex flex-col items-start gap-3 text-secondary text-sm"
 				>
 					<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
-					<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
+					<p>A workspace admin hid AI sessions in the workspace settings.</p>
 					<Button unifiedSize="sm" onclick={() => goto('/')}>Back to workspace</Button>
 				</div>
 			{/if}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -22,6 +22,7 @@
 	} from '$lib/components/sessions/PreviewRouterPicker.svelte'
 	import { goto } from '$lib/navigation'
 	import { copilotInfo } from '$lib/aiStore'
+	import { loadCopilot } from '$lib/components/copilot/loadCopilot'
 	import SessionWrapper from '$lib/components/sessions/SessionWrapper.svelte'
 	import PreviewTabHost from '$lib/components/sessions/PreviewTabHost.svelte'
 	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
@@ -74,6 +75,15 @@
 	import { splitterPointerCapture } from '$lib/utils/splitterPointerCapture'
 
 	const globalEnabled = isGlobalAiEnabled()
+
+	// Nothing else loads the copilot config here before a session is selected: the layout
+	// skips it in session mode and SessionWrapper only mounts with a session. Read the
+	// navigation workspace's config once, synchronously at init, so the hidden-workspace
+	// gate below can fire on a cold load; a session mounting later loads its own acting
+	// workspace and, being the later call, supersedes this one.
+	if ($workspaceStore) {
+		loadCopilot($workspaceStore)
+	}
 
 	// One observer shared by every tab host, which mirrors it into page iframes
 	// (see PreviewTabHost).
@@ -825,8 +835,8 @@
 		<!-- The workspace hid the assistant, and the sidebar switch with it, so only a
 		     direct URL lands here. -->
 		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
-			<p class="text-primary font-medium">AI Sessions are disabled in this workspace</p>
-			<p>A workspace admin turned Windmill AI off in the workspace settings.</p>
+			<p class="text-primary font-medium">AI Sessions are hidden in this workspace</p>
+			<p>A workspace admin turned Windmill AI features off in the workspace settings.</p>
 			<Button size="xs" onclick={() => goto('/')}>Back to workspace</Button>
 		</div>
 	{:else if !sessionState.hydrated}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -21,6 +21,7 @@
 		type Scope
 	} from '$lib/components/sessions/PreviewRouterPicker.svelte'
 	import { goto } from '$lib/navigation'
+	import { copilotInfo } from '$lib/aiStore'
 	import SessionWrapper from '$lib/components/sessions/SessionWrapper.svelte'
 	import PreviewTabHost from '$lib/components/sessions/PreviewTabHost.svelte'
 	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
@@ -819,6 +820,14 @@
 			<Button size="xs" onclick={() => setSessionsBetaOptOut(false, `${base}/sessions`)}>
 				Activate AI Sessions
 			</Button>
+		</div>
+	{:else if $copilotInfo.workspaceDisabled}
+		<!-- The workspace hid the assistant, and the sidebar switch with it, so only a
+		     direct URL lands here. -->
+		<div class="p-8 flex flex-col items-start gap-3 text-secondary text-sm">
+			<p class="text-primary font-medium">AI Sessions are disabled in this workspace</p>
+			<p>A workspace admin turned Windmill AI off in the workspace settings.</p>
+			<Button size="xs" onclick={() => goto('/')}>Back to workspace</Button>
 		</div>
 	{:else if !sessionState.hydrated}
 		<!-- Sessions hydrate from IndexedDB after the user resolves; until then an


### PR DESCRIPTION
## Summary
Adds a workspace-level setting that hides every Windmill AI assistant entry point (chat, AI sessions, code generation and completion, AI fix, metadata and step-input generation, cron/regex/resource generators) so they stop taking up UI space, while AI agent steps and the AI sandbox in flows keep working with the configured providers.

The flag lives inside the existing `ai_config` workspace setting as `copilot_disabled`, so there is no migration, and workspace export, forks and `wmill settings` sync carry it unchanged (a fork copies it at fork time like every other `ai_config` field). It is UI-only: the AI proxy stays reachable because the agent step catalog and the settings page's model listing depend on it, and the settings copy says so.

## Changes
- Backend: `copilot_disabled` on `AIConfig`; `get_copilot_info` and `edit_copilot_config` copy the workspace row's flag onto the effective config even when providers fall back to the instance config or free tier. OpenAPI updated, client regenerated.
- Store: `copilotInfo.workspaceDisabled`; `enabled` is forced false while `aiModels` stays populated for the agent step catalog.
- Workspace AI settings: a "Hide AI sessions" card at the bottom of the tab with a "Hide AI sessions in this workspace" toggle, part of the form's dirty tracking; the save footer no longer hides for workspaces on instance defaults.
- Hidden when off: sidebar Workspace/AI Sessions switch and Ask AI, home composer, `OpenInSessionButton` and `AIButton` (covers the script/flow/raw-app toolbars, runs, triggers, resources, variables), AI Fix, AI Gen, fill inputs, cron/regex/resource generators, AI form settings and assistant, search modal Ask AI, raw-app "Start with AI", the docked chat (closes and refuses to open). `/sessions` shows a gate with a way back, keyed on the acting workspace's own config (read directly rather than from the shared store) so it fires on a cold load and follows session and workspace switches.
- Unchanged: AI Agent and AI Sandbox entries in the flow step picker and the agent step's provider/model pickers.
- Tests: integration test that the flag survives the instance-config fallback; store unit test.
- Home page: the collapsed / hidden-assistant line (Build with AI, CLI / MCP, Hub) is now a flush full-width hint row with no top margin instead of a centered 40rem block with `mt-8 mb-2`; the hero state is unchanged.

## Test plan
- [ ] Workspace settings > Windmill AI: turn "Hide AI sessions in this workspace" on and save; the sidebar switch disappears without a reload and the `ai_config` row carries `copilot_disabled: true`
- [ ] Home, script editor, flow editor, runs page: no AI buttons; the flow step picker has no "or AI gen"; AI Agent and AI Sandbox are still listed and the agent step editor still offers provider and model
- [ ] `/sessions` opened directly shows "AI Sessions are hidden in this workspace" with a working back button
- [ ] Toggle back on: every entry point returns
- [ ] Workspace on instance defaults: the toggle saves without opening the override editor and the instance banner stays

## Screenshots
Home row with the assistant hidden, before and after, and the dismissed composer after:
![home-hidden-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788360874-home-hidden-before.png)
![home-hidden-after2](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788360875-home-hidden-after2.png)
![home-ws2-collapsed-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788360876-home-ws2-collapsed-after.png)

The new card at the bottom of the Windmill AI settings tab (hidden state):
![settings-hide-card](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788362170-settings-hide-card.png)

Home with the assistant hidden (no sessions switch, no Ask AI, no composer):
![home-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788351783-home-disabled.png)

Flow editor step picker, assistant shown vs hidden (AI Agent and AI Sandbox stay):
![flow-enabled-insert](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788351784-flow-enabled-insert.png)
![flow-disabled-insert](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788351785-flow-disabled-insert.png)

Script editor and the sessions gate with the assistant hidden:
![script-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788351786-script-disabled.png)
![sessions-disabled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/workspace-ai-disable-setting/1788351788-sessions-disabled.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eNweUugVqerex6MLxjbeL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workspace-level setting that hides every Windmill AI assistant entry point (chat, AI sessions, code generation and completion, AI fix, and cron/regex/resource generators) from the UI, while AI agent steps and the AI sandbox in flows keep working with the configured providers. Previously there was no way to hide the assistant per-workspace.

The flag is `copilot_disabled` in the existing `ai_config` workspace setting, so no migration is needed and workspace export/forks carry it unchanged. The change is UI-only: the AI proxy stays reachable for agent steps, and the flag is read from the workspace's own row even when providers fall back to instance config or free tier.

**New Features**
- Hidden when off: sidebar sessions switch and Ask AI, home composer (the remaining Build with AI / CLI / Hub line shrinks to a flush hint row), AI buttons across script/flow/raw-app toolbars and runs/triggers/resources/variables, AI Fix, AI Gen, fill inputs, generators, AI form settings, search modal Ask AI, raw-app "Start with AI", the pipeline insert menu's AI prompt, and the docked chat (closes, refuses to open, and refuses turns that miss the gate).
- A "Hide AI sessions" toggle at the bottom of the AI settings page, available even when the workspace runs on instance defaults.
- `/sessions` opened directly shows an overlay gate with a back button, keyed on the acting workspace's own config so it fires on a cold load and follows session and workspace switches.
- The gate overlays the session stack rather than replacing it, so warm sessions and mounted preview editors survive workspace switches; the covered stack is inert while the verdict loads.
- AI Agent and AI Sandbox stay in the flow step picker, and the agent step's provider/model pickers are unaffected.
- Includes an integration test for the instance-config fallback and a store unit test.

<sup>Written for commit 1c2c6ac8f0a1bb6779c5f9c153f9dc9f913f2d7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

