### PR TITLE
feat: restore owner and label filter chips on the homepage

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -40,6 +40,7 @@
 		type FilterSchemaRec
 	} from '$lib/components/FilterSearchbar.svelte'
 	import NoItemFound from './NoItemFound.svelte'
+	import ListFilters from './ListFilters.svelte'
 	import ToggleButtonGroup from '../common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '../common/toggleButton-v2/ToggleButton.svelte'
 	import FlowIcon from './FlowIcon.svelte'
@@ -76,8 +77,8 @@
 
 	// FilterSearchbar schema — `_default_` is the free-text search; the rest mirror the
 	// boolean/kind list filters. Owner and label scoping are offered as searchbar presets
-	// (searchPresets); label is also a row of on-page chips (labelChips) writing the same
-	// key. `content` is a distinct mode: it swaps the list for the client-side
+	// (searchPresets) and as rows of on-page chips (ListFilters / labelChips) writing the
+	// same keys. `content` is a distinct mode: it swaps the list for the client-side
 	// content-match view below (usable on any instance, not EE-gated).
 	let searchFilterSchema = $derived({
 		_default_: { type: 'string' as const, hidden: true },
@@ -718,11 +719,15 @@
 		return true // should not happen
 	}
 
-	// Owner/label scope now live on the URL-synced searchbar filters (set via the presets),
-	// not standalone chip state — the whole data layer below still reads these two, so keep
-	// them as the single derived source. Empty string reads as "no filter".
+	// Owner/label scope lives on the URL-synced searchbar filters, written by the presets and
+	// by the on-page chip rows; the whole data layer below reads these two, so keep them as
+	// the single derived source. Empty string reads as "no filter".
 	let ownerFilter = $derived((filterValues.val.owner || undefined) as string | undefined)
 	let labelFilter = $derived((filterValues.val.label || undefined) as string | undefined)
+	function setOwnerFilter(o: string | undefined) {
+		if (o == undefined) delete filterValues.val.owner
+		else filterValues.val.owner = o
+	}
 
 	const cmp = new Intl.Collator('en').compare
 
@@ -1751,6 +1756,19 @@
 			{/if}
 		</div>
 	</div>
+	{#if !contentActive}
+		<!-- Owner chips. The function binding routes the chip's selection into the searchbar's
+		     `owner` key, and `queryName` points ListFilters' own mount-time URL read at the same
+		     `?owner=` param the filter instance syncs, so both writers agree from the first paint.
+		     No `syncQuery`: the filter instance owns the URL. -->
+		<ListFilters
+			bind:selectedFilter={() => ownerFilter, setOwnerFilter}
+			filters={owners}
+			queryName="owner"
+			maxDisplayed={20}
+			bottomMargin={false}
+		/>
+	{/if}
 	{#if !contentActive && labelChips.length > 0}
 		<!-- A chip writes the searchbar's `label` key, so chip, searchbar tag and URL are one
 		     state; clicking the selected chip clears it (delete, so no `label: null` tag). -->

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1166,12 +1166,14 @@
 	function itemLabels(x: { labels?: string[]; inherited_labels?: string[] }): string[] {
 		return [...(x.labels ?? []), ...(x.inherited_labels ?? [])]
 	}
-	// Labels ranked by how many loaded rows carry them (ties alphabetical), the same
-	// most-populated-first order the owner chips use.
+	// Labels ranked by how many loaded rows carry them (ties alphabetical). Unlike the owner
+	// chips there is no workspace-wide count endpoint, so the order is window-local and can
+	// shift as later pages load. A row carrying a label both directly and by inheritance
+	// counts once.
 	let allLabels = $derived.by(() => {
 		const counts = new Map<string, number>()
 		for (const x of combinedItems ?? [])
-			for (const l of itemLabels(x)) counts.set(l, (counts.get(l) ?? 0) + 1)
+			for (const l of new Set(itemLabels(x))) counts.set(l, (counts.get(l) ?? 0) + 1)
 		return [...counts.keys()].sort(
 			(a, b) => (counts.get(b) ?? 0) - (counts.get(a) ?? 0) || cmp(a, b)
 		)
@@ -1771,8 +1773,7 @@
 		<!-- Owner and label chips on one line. Each function binding routes the chip's
 		     selection into the searchbar key of the same name, and `queryName` points
 		     ListFilters' own mount-time URL read at the param the filter instance syncs, so
-		     both writers agree from the first paint. No `syncQuery`: the filter instance owns
-		     the URL. -->
+		     the two writers agree. No `syncQuery`: the filter instance owns the URL. -->
 		<div class="gap-2 w-full flex flex-wrap mt-3">
 			<ListFilters
 				inline

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1166,8 +1166,21 @@
 	function itemLabels(x: { labels?: string[]; inherited_labels?: string[] }): string[] {
 		return [...(x.labels ?? []), ...(x.inherited_labels ?? [])]
 	}
-	let allLabels = $derived(
-		Array.from(new Set(combinedItems?.flatMap((x) => itemLabels(x)) ?? [])).sort()
+	// Labels ranked by how many loaded rows carry them (ties alphabetical), the same
+	// most-populated-first order the owner chips use.
+	let allLabels = $derived.by(() => {
+		const counts = new Map<string, number>()
+		for (const x of combinedItems ?? [])
+			for (const l of itemLabels(x)) counts.set(l, (counts.get(l) ?? 0) + 1)
+		return [...counts.keys()].sort(
+			(a, b) => (counts.get(b) ?? 0) - (counts.get(a) ?? 0) || cmp(a, b)
+		)
+	})
+	let hasChips = $derived(
+		owners.length > 0 ||
+			allLabels.length > 0 ||
+			ownerFilter != undefined ||
+			labelFilter != undefined
 	)
 	// FilterSearchbar presets: the owner prefixes and labels the list actually holds, so
 	// scoping to one is a click in the searchbar dropdown.
@@ -1754,27 +1767,30 @@
 			{/if}
 		</div>
 	</div>
-	{#if !contentActive}
-		<!-- Owner and label chip rows. Each function binding routes the chip's selection into
-		     the searchbar key of the same name, and `queryName` points ListFilters' own
-		     mount-time URL read at the param the filter instance syncs, so both writers agree
-		     from the first paint. No `syncQuery`: the filter instance owns the URL. -->
-		<ListFilters
-			bind:selectedFilter={() => ownerFilter, setOwnerFilter}
-			filters={owners}
-			queryName="owner"
-			maxDisplayed={20}
-			bottomMargin={false}
-		/>
-		<ListFilters
-			bind:selectedFilter={() => labelFilter, setLabelFilter}
-			filters={allLabels}
-			queryName="label"
-			maxDisplayed={20}
-			bottomMargin={false}
-			color="blue"
-			icon={Tag}
-		/>
+	{#if !contentActive && hasChips}
+		<!-- Owner and label chips on one line. Each function binding routes the chip's
+		     selection into the searchbar key of the same name, and `queryName` points
+		     ListFilters' own mount-time URL read at the param the filter instance syncs, so
+		     both writers agree from the first paint. No `syncQuery`: the filter instance owns
+		     the URL. -->
+		<div class="gap-2 w-full flex flex-wrap mt-3">
+			<ListFilters
+				inline
+				bind:selectedFilter={() => ownerFilter, setOwnerFilter}
+				filters={owners}
+				queryName="owner"
+				maxDisplayed={10}
+			/>
+			<ListFilters
+				inline
+				bind:selectedFilter={() => labelFilter, setLabelFilter}
+				filters={allLabels}
+				queryName="label"
+				maxDisplayed={10}
+				color="blue"
+				icon={Tag}
+			/>
+		</div>
 	{/if}
 	{#if filteredItems?.length == 0}
 		<div class="mt-10"></div>

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import CenteredPage from '$lib/components/CenteredPage.svelte'
 	import { PIPELINE_DRAFT_KIND, pipelineFolderFromBundlePath } from '$lib/pipelinePaths'
-	import { Badge, Button, Skeleton } from '$lib/components/common'
+	import { Button, Skeleton } from '$lib/components/common'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import {
 		AssetService,
@@ -724,9 +724,15 @@
 	// the single derived source. Empty string reads as "no filter".
 	let ownerFilter = $derived((filterValues.val.owner || undefined) as string | undefined)
 	let labelFilter = $derived((filterValues.val.label || undefined) as string | undefined)
+	// Chip-row setters. Clearing deletes the key rather than writing null, which the
+	// searchbar would otherwise render as a `key: null` tag.
 	function setOwnerFilter(o: string | undefined) {
 		if (o == undefined) delete filterValues.val.owner
 		else filterValues.val.owner = o
+	}
+	function setLabelFilter(l: string | undefined) {
+		if (l == undefined) delete filterValues.val.label
+		else filterValues.val.label = l
 	}
 
 	const cmp = new Intl.Collator('en').compare
@@ -1163,13 +1169,6 @@
 	}
 	let allLabels = $derived(
 		Array.from(new Set(combinedItems?.flatMap((x) => itemLabels(x)) ?? [])).sort()
-	)
-	// Label chips under the header: every label the loaded rows carry, plus the active one
-	// when it arrived by URL and no loaded row carries it, so there is still a chip to clear it.
-	let labelChips = $derived(
-		labelFilter != undefined && !allLabels.includes(labelFilter)
-			? [labelFilter, ...allLabels]
-			: allLabels
 	)
 	// FilterSearchbar presets: the owner prefixes and labels the list actually holds, so
 	// scoping to one is a click in the searchbar dropdown.
@@ -1757,10 +1756,10 @@
 		</div>
 	</div>
 	{#if !contentActive}
-		<!-- Owner chips. The function binding routes the chip's selection into the searchbar's
-		     `owner` key, and `queryName` points ListFilters' own mount-time URL read at the same
-		     `?owner=` param the filter instance syncs, so both writers agree from the first paint.
-		     No `syncQuery`: the filter instance owns the URL. -->
+		<!-- Owner and label chip rows. Each function binding routes the chip's selection into
+		     the searchbar key of the same name, and `queryName` points ListFilters' own
+		     mount-time URL read at the param the filter instance syncs, so both writers agree
+		     from the first paint. No `syncQuery`: the filter instance owns the URL. -->
 		<ListFilters
 			bind:selectedFilter={() => ownerFilter, setOwnerFilter}
 			filters={owners}
@@ -1768,31 +1767,16 @@
 			maxDisplayed={20}
 			bottomMargin={false}
 		/>
-	{/if}
-	{#if !contentActive && labelChips.length > 0}
-		<!-- A chip writes the searchbar's `label` key, so chip, searchbar tag and URL are one
-		     state; clicking the selected chip clears it (delete, so no `label: null` tag). -->
-		<div class="gap-1.5 w-full flex flex-wrap mt-2">
-			{#each labelChips as label (label)}
-				<Badge
-					color="blue"
-					small
-					clickable
-					selected={label === labelFilter}
-					title="Label: {label}"
-					onclick={() => {
-						if (labelFilter === label) {
-							delete filterValues.val.label
-						} else {
-							filterValues.val.label = label
-						}
-					}}
-				>
-					<Tag size={10} class="inline -mt-px" />{label}
-					{#if label === labelFilter}&cross;{/if}
-				</Badge>
-			{/each}
-		</div>
+		<ListFilters
+			bind:selectedFilter={() => labelFilter, setLabelFilter}
+			filters={allLabels}
+			queryName="label"
+			maxDisplayed={20}
+			bottomMargin={false}
+			color="blue"
+			small
+			icon={Tag}
+		/>
 	{/if}
 	{#if filteredItems?.length == 0}
 		<div class="mt-10"></div>

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -76,10 +76,10 @@
 	)
 
 	// FilterSearchbar schema — `_default_` is the free-text search; the rest mirror the
-	// boolean/kind list filters. Owner and label scoping are offered as searchbar presets
-	// (searchPresets) and as rows of on-page chips (ListFilters / labelChips) writing the
-	// same keys. `content` is a distinct mode: it swaps the list for the client-side
-	// content-match view below (usable on any instance, not EE-gated).
+	// boolean/kind list filters. Owner and label are also reachable as searchbar presets
+	// (searchPresets) and as on-page chip rows (the ListFilters markup below). `content` is
+	// a distinct mode: it swaps the list for the client-side content-match view below
+	// (usable on any instance, not EE-gated).
 	let searchFilterSchema = $derived({
 		_default_: { type: 'string' as const, hidden: true },
 		content: {
@@ -719,9 +719,8 @@
 		return true // should not happen
 	}
 
-	// Owner/label scope lives on the URL-synced searchbar filters, written by the presets and
-	// by the on-page chip rows; the whole data layer below reads these two, so keep them as
-	// the single derived source. Empty string reads as "no filter".
+	// The whole data layer below reads these two derived views of the searchbar filters, so
+	// keep them the single source. Empty string reads as "no filter".
 	let ownerFilter = $derived((filterValues.val.owner || undefined) as string | undefined)
 	let labelFilter = $derived((filterValues.val.label || undefined) as string | undefined)
 	// Chip-row setters. Clearing deletes the key rather than writing null, which the
@@ -1774,7 +1773,6 @@
 			maxDisplayed={20}
 			bottomMargin={false}
 			color="blue"
-			small
 			icon={Tag}
 		/>
 	{/if}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import CenteredPage from '$lib/components/CenteredPage.svelte'
 	import { PIPELINE_DRAFT_KIND, pipelineFolderFromBundlePath } from '$lib/pipelinePaths'
-	import { Button, Skeleton } from '$lib/components/common'
+	import { Badge, Button, Skeleton } from '$lib/components/common'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import {
 		AssetService,
@@ -24,7 +24,8 @@
 		ChevronsDownUp,
 		ChevronsUpDown,
 		Code2,
-		LayoutDashboard
+		LayoutDashboard,
+		Tag
 	} from 'lucide-svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import CreateActionsMenu from './CreateActionsMenu.svelte'
@@ -75,8 +76,8 @@
 
 	// FilterSearchbar schema — `_default_` is the free-text search; the rest mirror the
 	// boolean/kind list filters. Owner and label scoping are offered as searchbar presets
-	// (searchPresets) and resolve server-side (path_start / label) rather than filtering
-	// client-side. `content` is a distinct mode: it swaps the list for the client-side
+	// (searchPresets); label is also a row of on-page chips (labelChips) writing the same
+	// key. `content` is a distinct mode: it swaps the list for the client-side
 	// content-match view below (usable on any instance, not EE-gated).
 	let searchFilterSchema = $derived({
 		_default_: { type: 'string' as const, hidden: true },
@@ -86,8 +87,8 @@
 			description: 'Search across item contents'
 		},
 		// Owner (u/<user> or f/<folder>) and label are offered as presets built from what the
-		// list actually holds (see searchPresets); they drive the same server path-scope / label
-		// filter the old on-page chips did.
+		// list actually holds (see searchPresets); owner is a server path-scope, label a
+		// client-side filter over the loaded rows.
 		owner: { type: 'string' as const, label: 'Owner' },
 		label: { type: 'string' as const, label: 'Label' },
 		kind: {
@@ -1158,8 +1159,15 @@
 	let allLabels = $derived(
 		Array.from(new Set(combinedItems?.flatMap((x) => itemLabels(x)) ?? [])).sort()
 	)
+	// Label chips under the header: every label the loaded rows carry, plus the active one
+	// when it arrived by URL and no loaded row carries it, so there is still a chip to clear it.
+	let labelChips = $derived(
+		labelFilter != undefined && !allLabels.includes(labelFilter)
+			? [labelFilter, ...allLabels]
+			: allLabels
+	)
 	// FilterSearchbar presets: the owner prefixes and labels the list actually holds, so
-	// scoping to one is a click in the searchbar dropdown instead of a wall of on-page chips.
+	// scoping to one is a click in the searchbar dropdown.
 	// Owner sets the `owner` filter (server path-scope), label sets `label` (client filter).
 	// The `:\ ` separator and escaped spaces match the canonical `key:\ value` form parseToText
 	// emits, so the "already applied" check finds them after a reparse and won't re-offer a
@@ -1743,6 +1751,31 @@
 			{/if}
 		</div>
 	</div>
+	{#if !contentActive && labelChips.length > 0}
+		<!-- A chip writes the searchbar's `label` key, so chip, searchbar tag and URL are one
+		     state; clicking the selected chip clears it (delete, so no `label: null` tag). -->
+		<div class="gap-1.5 w-full flex flex-wrap mt-2">
+			{#each labelChips as label (label)}
+				<Badge
+					color="blue"
+					small
+					clickable
+					selected={label === labelFilter}
+					title="Label: {label}"
+					onclick={() => {
+						if (labelFilter === label) {
+							delete filterValues.val.label
+						} else {
+							filterValues.val.label = label
+						}
+					}}
+				>
+					<Tag size={10} class="inline -mt-px" />{label}
+					{#if label === labelFilter}&cross;{/if}
+				</Badge>
+			{/each}
+		</div>
+	{/if}
 	{#if filteredItems?.length == 0}
 		<div class="mt-10"></div>
 	{/if}

--- a/frontend/src/lib/components/home/ListFilters.svelte
+++ b/frontend/src/lib/components/home/ListFilters.svelte
@@ -20,7 +20,8 @@
 		color?: BadgeColor
 		icon?: BadgeIconProps['icon']
 		// Emit the chips as flex items of the parent instead of a row of their own, so several
-		// ListFilters can share one line.
+		// ListFilters can share one line. The parent owns layout and spacing, so
+		// `bottomMargin` does not apply.
 		inline?: boolean
 	}
 

--- a/frontend/src/lib/components/home/ListFilters.svelte
+++ b/frontend/src/lib/components/home/ListFilters.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Folder, User } from 'lucide-svelte'
 	import { Badge } from '../common'
+	import type { BadgeColor, BadgeIconProps } from '../common/badge/model'
 	import { appIconComponent } from '../icons'
 	import { onDestroy, onMount } from 'svelte'
 
@@ -14,6 +15,11 @@
 		// Keep only the first N filters visible, the rest behind a "…" toggle. Unset
 		// shows every one.
 		maxDisplayed?: number
+		// Chip look. `icon` is drawn before every chip; unset, the icon follows the value
+		// (user/folder prefix, or the app icon under `resourceType`).
+		color?: BadgeColor
+		small?: boolean
+		icon?: BadgeIconProps['icon']
 	}
 
 	let {
@@ -23,7 +29,10 @@
 		queryName = 'filter',
 		syncQuery = false,
 		bottomMargin = true,
-		maxDisplayed
+		maxDisplayed,
+		color = 'transparent',
+		small = false,
+		icon
 	}: Props = $props()
 
 	const queryChange: (value: URL) => void = (url: URL) => {
@@ -100,12 +109,16 @@
 							setQuery(new URL(window.location.href), queryName, undefined)
 						}
 					}}
-					color={'transparent'}
+					{color}
+					{small}
 					clickable
 					selected={filter === selectedFilter}
 				>
 					<span style="height: 12px" class="-mt-0.5">
-						{#if resourceType}
+						{#if icon}
+							{@const Icon = icon}
+							<Icon class="mr-0.5" size={12} />
+						{:else if resourceType}
 							{@const SvelteComponent = appIconComponent(filter)}
 							<SvelteComponent height="14px" width="14px" />
 						{:else if filter.startsWith('u/')}
@@ -123,7 +136,8 @@
 			<div>
 				<Badge
 					class="inline-flex items-center gap-1 align-middle"
-					color={'transparent'}
+					{color}
+					{small}
 					clickable
 					title={expanded ? 'Show fewer' : `Show ${hiddenCount} more`}
 					onclick={() => (expanded = !expanded)}

--- a/frontend/src/lib/components/home/ListFilters.svelte
+++ b/frontend/src/lib/components/home/ListFilters.svelte
@@ -19,6 +19,9 @@
 		// (user/folder prefix, or the app icon under `resourceType`).
 		color?: BadgeColor
 		icon?: BadgeIconProps['icon']
+		// Emit the chips as flex items of the parent instead of a row of their own, so several
+		// ListFilters can share one line.
+		inline?: boolean
 	}
 
 	let {
@@ -30,7 +33,8 @@
 		bottomMargin = true,
 		maxDisplayed,
 		color = 'transparent',
-		icon
+		icon,
+		inline = false
 	}: Props = $props()
 
 	const queryChange: (value: URL) => void = (url: URL) => {
@@ -94,7 +98,9 @@
 </script>
 
 {#if Array.isArray(filtersAndSelected) && filtersAndSelected.length > 0}
-	<div class={`gap-2 w-full flex flex-wrap ${bottomMargin ? 'my-4' : 'mt-4'}`}>
+	<div
+		class={inline ? 'contents' : `gap-2 w-full flex flex-wrap ${bottomMargin ? 'my-4' : 'mt-4'}`}
+	>
 		{#each displayedFilters as filter (filter)}
 			<div>
 				<Badge

--- a/frontend/src/lib/components/home/ListFilters.svelte
+++ b/frontend/src/lib/components/home/ListFilters.svelte
@@ -18,7 +18,6 @@
 		// Chip look. `icon` is drawn before every chip; unset, the icon follows the value
 		// (user/folder prefix, or the app icon under `resourceType`).
 		color?: BadgeColor
-		small?: boolean
 		icon?: BadgeIconProps['icon']
 	}
 
@@ -31,7 +30,6 @@
 		bottomMargin = true,
 		maxDisplayed,
 		color = 'transparent',
-		small = false,
 		icon
 	}: Props = $props()
 
@@ -110,7 +108,6 @@
 						}
 					}}
 					{color}
-					{small}
 					clickable
 					selected={filter === selectedFilter}
 				>
@@ -137,7 +134,6 @@
 				<Badge
 					class="inline-flex items-center gap-1 align-middle"
 					{color}
-					{small}
 					clickable
 					title={expanded ? 'Show fewer' : `Show ${hiddenCount} more`}
 					onclick={() => (expanded = !expanded)}


### PR DESCRIPTION
## Summary
The home search/filter revamp (#10020, shipped in v1.800.0) moved the homepage's owner chips (`u/<user>` / `f/<folder>`) and label chips into the FilterSearchbar's preset dropdown, so scoping the list went from one visible click to opening the searchbar and picking a preset. This brings the on-page chips back as a single row under the header, wired to the same URL-synced `owner` / `label` filter keys the searchbar uses, so a chip click, the searchbar tag and the query parameter are one state.

## Changes
- `ItemsList.svelte`: render owner and label chips on one line with two `ListFilters` instances in `inline` mode inside a shared flex-wrap row. Each is bound to its searchbar key through a Svelte 5 function binding (`bind:selectedFilter={() => ownerFilter, setOwnerFilter}` and the label equivalent). `queryName` points ListFilters' mount-time URL read at the same `?owner=` / `?label=` param the filter instance syncs; no `syncQuery`, the filter instance owns the URL.
- Each group caps at 10 chips with the existing "…" overflow toggle, the selected chip always visible. Owners keep their existing order (your own space first, then most populated). Labels are now ranked by how many loaded rows carry them, ties alphabetical, instead of plain alphabetical.
- Clearing a chip deletes the key rather than writing `null`, so no `owner: null` / `label: null` tag lingers in the searchbar. A URL-supplied value no loaded row carries still gets a chip (ListFilters' selected-prepend), so it can be cleared from the page.
- `ListFilters.svelte`: optional `color`, `icon` and `inline` props. `inline` renders the chips as `display: contents` so several instances can share one row; the defaults leave the 15 other call sites unchanged. The label group passes `color="blue" icon={Tag}` for the pre-revamp look.
- The row hides in content-search mode. The searchbar owner/label presets stay, so both entry points keep working.

## Test plan
- [x] `npm run check:fast` and prettier pass for both files; Svelte autofixer reports no issues.
- [x] With 12 folders and skewed labels (billing on 5 scripts, ops on 3, one tag each): one row shows `u/admin`, nine folders and "…", then `billing`, `ops`, `tag01`…`tag08` and "…". Expanding shows every chip, collapsing returns to 10.
- [x] Clicking `billing` narrows to the five billing scripts, the URL gains `label=billing`, the searchbar shows `label: billing`; clicking again clears it.
- [x] Clicking a folder chip narrows the list to that folder, the URL gains `owner=f%2F…`, the searchbar shows the matching tag; clicking the selected chip again restores all rows and drops the param.
- [x] Loading `?owner=u%2Fadmin&label=ops` directly selects both chips on mount and shows only the matching rows; browser Back restores URL, chips and searchbar tags together.
- [x] Loading `?label=zzz` (no such label) shows a `zzz ✗` chip alongside the real ones, with an empty list.
- [ ] Reviewer: on a workspace with labeled runnables in a few folders, toggle chips and clear from the searchbar side; confirm chips and tags stay in sync both ways.

## Screenshots
Default state: owners then labels on one wrapped row, each group capped at 10 with its overflow toggle:

![home-chips-oneline](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/restore-homepage-tag-label-filtering/1788360722-home-chips-oneline.png)

`billing` selected: list narrowed to the five billing scripts, chip shows the clear mark, searchbar carries the matching tag:

![home-chips-oneline-billing](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/restore-homepage-tag-label-filtering/1788360744-home-chips-oneline-billing.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbM6X8fYEQWKMTjUyp6aqy