### PR TITLE
feat: offer known Google scopes as checkboxes in the oauth connect dialog

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -86,11 +86,9 @@
   "gforms": {
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
-    "scopes": [
-      "https://www.googleapis.com/auth/forms.body",
-      "https://www.googleapis.com/auth/forms.responses.readonly"
-    ],
+    "scopes": ["https://www.googleapis.com/auth/forms"],
     "scope_options": [
+      "https://www.googleapis.com/auth/forms",
       "https://www.googleapis.com/auth/forms.body",
       "https://www.googleapis.com/auth/forms.body.readonly",
       "https://www.googleapis.com/auth/forms.responses.readonly"

--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -29,6 +29,10 @@
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/spreadsheets"],
+    "scope_options": [
+      "https://www.googleapis.com/auth/spreadsheets",
+      "https://www.googleapis.com/auth/spreadsheets.readonly"
+    ],
     "extra_params": {
       "access_type": "offline",
       "prompt": "consent"
@@ -38,6 +42,11 @@
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/drive"],
+    "scope_options": [
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/drive"
+    ],
     "extra_params": {
       "access_type": "offline",
       "prompt": "consent"
@@ -47,6 +56,13 @@
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/gmail.send"],
+    "scope_options": [
+      "https://www.googleapis.com/auth/gmail.send",
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.compose",
+      "https://www.googleapis.com/auth/gmail.modify",
+      "https://www.googleapis.com/auth/gmail.labels"
+    ],
     "extra_params": {
       "access_type": "offline",
       "prompt": "consent"
@@ -56,6 +72,12 @@
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/calendar.events"],
+    "scope_options": [
+      "https://www.googleapis.com/auth/calendar.events",
+      "https://www.googleapis.com/auth/calendar.events.readonly",
+      "https://www.googleapis.com/auth/calendar.readonly",
+      "https://www.googleapis.com/auth/calendar"
+    ],
     "extra_params": {
       "access_type": "offline",
       "prompt": "consent"
@@ -64,7 +86,15 @@
   "gforms": {
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
-    "scopes": ["https://www.googleapis.com/auth/forms"],
+    "scopes": [
+      "https://www.googleapis.com/auth/forms.body",
+      "https://www.googleapis.com/auth/forms.responses.readonly"
+    ],
+    "scope_options": [
+      "https://www.googleapis.com/auth/forms.body",
+      "https://www.googleapis.com/auth/forms.body.readonly",
+      "https://www.googleapis.com/auth/forms.responses.readonly"
+    ],
     "extra_params": {
       "access_type": "offline",
       "prompt": "consent"
@@ -74,6 +104,10 @@
     "auth_url": "https://accounts.google.com/o/oauth2/v2/auth",
     "token_url": "https://oauth2.googleapis.com/token",
     "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
+    "scope_options": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/cloud-platform.read-only"
+    ],
     "extra_params": {
       "access_type": "offline",
       "prompt": "consent"
@@ -87,6 +121,15 @@
       "https://www.googleapis.com/auth/admin.directory.user",
       "https://www.googleapis.com/auth/admin.directory.user.security",
       "https://www.googleapis.com/auth/admin.directory.orgunit"
+    ],
+    "scope_options": [
+      "https://www.googleapis.com/auth/admin.directory.user",
+      "https://www.googleapis.com/auth/admin.directory.user.readonly",
+      "https://www.googleapis.com/auth/admin.directory.group",
+      "https://www.googleapis.com/auth/admin.directory.group.readonly",
+      "https://www.googleapis.com/auth/admin.directory.orgunit",
+      "https://www.googleapis.com/auth/admin.directory.orgunit.readonly",
+      "https://www.googleapis.com/auth/admin.directory.user.security"
     ],
     "extra_params": {
       "access_type": "offline",

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -88,6 +88,8 @@ pub struct OAuthConfig {
     #[serde(default = "empty_string")]
     pub token_url: String,
     pub userinfo_url: Option<String>,
+    /// The registry JSON may also carry `scope_options`, a frontend-only pick
+    /// list for the connect dialog; it is deliberately not modelled here.
     pub scopes: Option<Vec<String>>,
     /// Default scopes for the client-credentials (2-legged) flow. These differ
     /// from the authorization-code `scopes` for most providers (member/consent
@@ -96,12 +98,6 @@ pub struct OAuthConfig {
     /// provider-specific scopes themselves.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cc_scopes: Option<Vec<String>>,
-    /// Scopes the provider is known to accept beyond the `scopes` default, offered
-    /// as pick-list entries in the connect dialog so users don't have to type
-    /// scope URLs. Purely advisory: the request still carries whatever the user
-    /// selected or typed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scope_options: Option<Vec<String>>,
     pub extra_params: Option<HashMap<String, String>>,
     pub extra_params_callback: Option<HashMap<String, String>>,
     pub req_body_auth: Option<bool>,

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -96,6 +96,12 @@ pub struct OAuthConfig {
     /// provider-specific scopes themselves.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cc_scopes: Option<Vec<String>>,
+    /// Scopes the provider is known to accept beyond the `scopes` default, offered
+    /// as pick-list entries in the connect dialog so users don't have to type
+    /// scope URLs. Purely advisory: the request still carries whatever the user
+    /// selected or typed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_options: Option<Vec<String>>,
     pub extra_params: Option<HashMap<String, String>>,
     pub extra_params_callback: Option<HashMap<String, String>>,
     pub req_body_auth: Option<bool>,

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -1532,7 +1532,7 @@
 					>
 
 					{#if editScopes}
-						<OauthScopes bind:scopes />
+						<OauthScopes bind:scopes options={registryEntry()?.scope_options} />
 					{:else}
 						<div class="flex flex-col gap-1">
 							{#each scopes as scope}

--- a/frontend/src/lib/components/OauthScopes.svelte
+++ b/frontend/src/lib/components/OauthScopes.svelte
@@ -106,7 +106,9 @@
 	>
 		Add item
 	</Button>
-	<span class="ml-2 text-xs text-primary font-normal">
-		({custom.length} item{custom.length > 1 ? 's' : ''})
-	</span>
+	{#if custom.length > 0}
+		<span class="ml-2 text-xs text-primary font-normal">
+			({custom.length} item{custom.length > 1 ? 's' : ''})
+		</span>
+	{/if}
 </div>

--- a/frontend/src/lib/components/OauthScopes.svelte
+++ b/frontend/src/lib/components/OauthScopes.svelte
@@ -42,9 +42,10 @@
 		lastWritten = JSON.stringify([scopes, options])
 	}
 
+	// Ticking an option absorbs a free-text row holding the same value.
 	function toggle(option: string, on: boolean) {
 		const rest = checkedOptions().filter((o) => o != option)
-		write(on ? [...rest, option] : rest, custom)
+		write(on ? [...rest, option] : rest, on ? custom.filter((r) => r != option) : custom)
 	}
 
 	function setRow(i: number, value: string) {
@@ -59,7 +60,7 @@
 		{#each options as option (option)}
 			<label class="flex items-center gap-2 text-xs">
 				<Checkbox
-					checked={scopes?.includes(option) ?? false}
+					checked={checkedOptions().includes(option)}
 					onChange={(e) => toggle(option, e.currentTarget.checked)}
 				/>
 				<span class="font-mono break-all">{option}</span>

--- a/frontend/src/lib/components/OauthScopes.svelte
+++ b/frontend/src/lib/components/OauthScopes.svelte
@@ -1,35 +1,65 @@
 <script lang="ts">
 	import { Button } from './common'
+	import Checkbox from './common/checkbox/Checkbox.svelte'
 	import { Minus, Plus } from 'lucide-svelte'
 
 	interface Props {
 		scopes?: string[]
+		/** Scopes the provider is known to accept, offered as checkboxes. Anything
+		 * not in this list stays editable as free text below them. */
+		options?: string[]
 	}
 
-	let { scopes = $bindable() }: Props = $props()
+	let { scopes = $bindable(), options = [] }: Props = $props()
 
 	$effect.pre(() => {
 		if (!scopes) {
 			scopes = []
 		}
 	})
+
+	function toggle(option: string, on: boolean) {
+		const current = scopes ?? []
+		scopes = on
+			? current.includes(option)
+				? current
+				: [...current, option]
+			: current.filter((s) => s != option)
+	}
 </script>
 
+{#if options.length > 0}
+	<div class="flex flex-col gap-1 mb-2">
+		{#each options as option (option)}
+			<label class="flex items-center gap-2 text-xs">
+				<Checkbox
+					checked={scopes?.includes(option) ?? false}
+					onChange={(e) => toggle(option, e.currentTarget.checked)}
+				/>
+				<span class="font-mono break-all">{option}</span>
+			</label>
+		{/each}
+	</div>
+	<span class="text-xs text-secondary">Custom scopes</span>
+{/if}
+
 {#if scopes && Array.isArray(scopes)}
-	{#each scopes as v, i}
-		<div class="flex flex-row max-w-md mb-2">
-			<input type="text" bind:value={scopes[i]} />
-			<Button
-				variant="default"
-				size="xs"
-				btnClasses="mx-6"
-				on:click={() => {
-					scopes = scopes?.filter((el) => el != v)
-				}}
-				startIcon={{ icon: Minus }}
-				iconOnly
-			/>
-		</div>
+	{#each scopes as v, i (i)}
+		{#if !options.includes(v)}
+			<div class="flex flex-row max-w-md mb-2">
+				<input type="text" bind:value={scopes[i]} />
+				<Button
+					variant="default"
+					size="xs"
+					btnClasses="mx-6"
+					on:click={() => {
+						scopes = scopes?.filter((el) => el != v)
+					}}
+					startIcon={{ icon: Minus }}
+					iconOnly
+				/>
+			</div>
+		{/if}
 	{/each}
 {/if}
 

--- a/frontend/src/lib/components/OauthScopes.svelte
+++ b/frontend/src/lib/components/OauthScopes.svelte
@@ -41,7 +41,10 @@
 		lastWritten = JSON.stringify([scopes, options])
 	}
 
-	// Ticking an option absorbs a free-text row holding the same value.
+	// Ticking an option absorbs a free-text row holding the same value. The
+	// target state comes from `ticked`, not the DOM: `Checkbox` re-asserts its
+	// `checked` prop on every click, so the input already reads the old value
+	// again by the time `change` fires.
 	function toggle(option: string, on: boolean) {
 		const rest = ticked.filter((o) => o != option)
 		write(on ? [...rest, option] : rest, on ? custom.filter((r) => r != option) : custom)
@@ -60,7 +63,7 @@
 			<label class="flex items-center gap-2 text-xs">
 				<Checkbox
 					checked={ticked.includes(option)}
-					onChange={(e) => toggle(option, e.currentTarget.checked)}
+					onChange={() => toggle(option, !ticked.includes(option))}
 				/>
 				<span class="font-mono break-all">{option}</span>
 			</label>

--- a/frontend/src/lib/components/OauthScopes.svelte
+++ b/frontend/src/lib/components/OauthScopes.svelte
@@ -13,10 +13,12 @@
 
 	let { scopes = $bindable(), options = [] }: Props = $props()
 
-	// Free-text rows are kept apart from `scopes` (the only value the parent
-	// binds) so a row survives while its text transiently equals an option, e.g.
-	// typing `…/calendar` on the way to `…/calendar.acls`. `lastWritten` tells a
-	// parent-side reset apart from the echo of our own write.
+	// Ticked options and free-text rows are kept apart from `scopes` (the only
+	// value the parent binds) so a row can pass through an option's exact value
+	// while typing (`…/calendar` on the way to `…/calendar.acls`) without ticking
+	// or unticking anything. `lastWritten` tells a parent-side reset apart from
+	// the echo of our own write.
+	let ticked: string[] = $state([])
 	let custom: string[] = $state([])
 	let lastWritten: string | undefined = undefined
 
@@ -27,31 +29,28 @@
 		const json = JSON.stringify([scopes, options])
 		if (json != lastWritten) {
 			lastWritten = json
+			ticked = scopes.filter((v) => options.includes(v))
 			custom = scopes.filter((v) => !options.includes(v))
 		}
 	})
 
-	// Options ticked by checkbox, excluding values a free-text row currently holds.
-	function checkedOptions(): string[] {
-		return (scopes ?? []).filter((v) => options.includes(v) && !custom.includes(v))
-	}
-
-	function write(checked: string[], rows: string[]) {
+	function write(nextTicked: string[], rows: string[]) {
+		ticked = nextTicked
 		custom = rows
-		scopes = [...checked.filter((o) => !rows.includes(o)), ...rows]
+		scopes = [...nextTicked.filter((o) => !rows.includes(o)), ...rows]
 		lastWritten = JSON.stringify([scopes, options])
 	}
 
 	// Ticking an option absorbs a free-text row holding the same value.
 	function toggle(option: string, on: boolean) {
-		const rest = checkedOptions().filter((o) => o != option)
+		const rest = ticked.filter((o) => o != option)
 		write(on ? [...rest, option] : rest, on ? custom.filter((r) => r != option) : custom)
 	}
 
 	function setRow(i: number, value: string) {
 		const rows = [...custom]
 		rows[i] = value
-		write(checkedOptions(), rows)
+		write(ticked, rows)
 	}
 </script>
 
@@ -60,7 +59,7 @@
 		{#each options as option (option)}
 			<label class="flex items-center gap-2 text-xs">
 				<Checkbox
-					checked={checkedOptions().includes(option)}
+					checked={ticked.includes(option)}
 					onChange={(e) => toggle(option, e.currentTarget.checked)}
 				/>
 				<span class="font-mono break-all">{option}</span>
@@ -83,7 +82,7 @@
 			btnClasses="mx-6"
 			onclick={() => {
 				write(
-					checkedOptions(),
+					ticked,
 					custom.filter((_, j) => j != i)
 				)
 			}}
@@ -99,7 +98,7 @@
 		unifiedSize="sm"
 		startIcon={{ icon: Plus }}
 		onclick={() => {
-			write(checkedOptions(), [...custom, ''])
+			write(ticked, [...custom, ''])
 		}}
 	>
 		Add item

--- a/frontend/src/lib/components/OauthScopes.svelte
+++ b/frontend/src/lib/components/OauthScopes.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from './common'
+	import TextInput from './text_input/TextInput.svelte'
 	import Checkbox from './common/checkbox/Checkbox.svelte'
 	import { Minus, Plus } from 'lucide-svelte'
 
@@ -12,19 +13,44 @@
 
 	let { scopes = $bindable(), options = [] }: Props = $props()
 
+	// Free-text rows are kept apart from `scopes` (the only value the parent
+	// binds) so a row survives while its text transiently equals an option, e.g.
+	// typing `…/calendar` on the way to `…/calendar.acls`. `lastWritten` tells a
+	// parent-side reset apart from the echo of our own write.
+	let custom: string[] = $state([])
+	let lastWritten: string | undefined = undefined
+
 	$effect.pre(() => {
 		if (!scopes) {
 			scopes = []
 		}
+		const json = JSON.stringify([scopes, options])
+		if (json != lastWritten) {
+			lastWritten = json
+			custom = scopes.filter((v) => !options.includes(v))
+		}
 	})
 
+	// Options ticked by checkbox, excluding values a free-text row currently holds.
+	function checkedOptions(): string[] {
+		return (scopes ?? []).filter((v) => options.includes(v) && !custom.includes(v))
+	}
+
+	function write(checked: string[], rows: string[]) {
+		custom = rows
+		scopes = [...checked.filter((o) => !rows.includes(o)), ...rows]
+		lastWritten = JSON.stringify([scopes, options])
+	}
+
 	function toggle(option: string, on: boolean) {
-		const current = scopes ?? []
-		scopes = on
-			? current.includes(option)
-				? current
-				: [...current, option]
-			: current.filter((s) => s != option)
+		const rest = checkedOptions().filter((o) => o != option)
+		write(on ? [...rest, option] : rest, custom)
+	}
+
+	function setRow(i: number, value: string) {
+		const rows = [...custom]
+		rows[i] = value
+		write(checkedOptions(), rows)
 	}
 </script>
 
@@ -43,39 +69,41 @@
 	<span class="text-xs text-secondary">Custom scopes</span>
 {/if}
 
-{#if scopes && Array.isArray(scopes)}
-	{#each scopes as v, i (i)}
-		{#if !options.includes(v)}
-			<div class="flex flex-row max-w-md mb-2">
-				<input type="text" bind:value={scopes[i]} />
-				<Button
-					variant="default"
-					size="xs"
-					btnClasses="mx-6"
-					on:click={() => {
-						scopes = scopes?.filter((el) => el != v)
-					}}
-					startIcon={{ icon: Minus }}
-					iconOnly
-				/>
-			</div>
-		{/if}
-	{/each}
-{/if}
+{#each custom as v, i (i)}
+	<div class="flex flex-row max-w-md mb-2">
+		<TextInput
+			value={v}
+			size="sm"
+			inputProps={{ oninput: (e) => setRow(i, e.currentTarget.value) }}
+		/>
+		<Button
+			variant="default"
+			unifiedSize="sm"
+			btnClasses="mx-6"
+			onclick={() => {
+				write(
+					checkedOptions(),
+					custom.filter((_, j) => j != i)
+				)
+			}}
+			startIcon={{ icon: Minus }}
+			iconOnly
+		/>
+	</div>
+{/each}
 
 <div class="flex items-center mt-1">
 	<Button
 		variant="default"
-		hover="yo"
-		size="xs"
+		unifiedSize="sm"
 		startIcon={{ icon: Plus }}
-		on:click={() => {
-			scopes = (scopes ?? []).concat('')
+		onclick={() => {
+			write(checkedOptions(), [...custom, ''])
 		}}
 	>
 		Add item
 	</Button>
 	<span class="ml-2 text-xs text-primary font-normal">
-		({(scopes ?? []).length} item{(scopes ?? []).length > 1 ? 's' : ''})
+		({custom.length} item{custom.length > 1 ? 's' : ''})
 	</span>
 </div>


### PR DESCRIPTION
## Summary
Users connecting a Google integration on a shared instance type extra scopes as free text (for example `gmail.modify`) and then hit Google's "This app is blocked" page when the instance's OAuth client is not verified for that scope. This adds an advisory `scope_options` list to the seven Google registry entries and renders it as checkboxes in the connect dialog, so users pick from the scopes the instance's client is meant to carry instead of guessing scope URLs. Free-text entry stays for self-hosters with custom clients.

The `gforms` entry keeps its legacy `https://www.googleapis.com/auth/forms` default: accounts connected before scopes were stored per account refresh with the registry default, so changing it could make Google reject their refresh. The Forms API v1 scopes (`forms.body`, `forms.body.readonly`, `forms.responses.readonly`) are offered as options instead, alongside the legacy one, so new connections can pick the correct set.

## Changes
- `backend/oauth_connect.json`: `scope_options` on gsheets, gdrive, gmail, gcal, gforms, gcloud, gworkspace (defaults plus least-privilege/read-only and, for Gmail, readonly/compose/modify/labels). Defaults are unchanged.
- `backend/windmill-oauth/src/lib.rs`: a comment on `OAuthConfig::scopes` noting the JSON-only `scope_options` key. The key is deliberately not modelled in Rust: the backend never reads it, serde ignores it, and modelling it would touch every exhaustive `OAuthConfig` literal including the EE Slack client.
- `frontend/src/lib/components/OauthScopes.svelte`: optional `options` prop rendered as `Checkbox` rows above the free-text list. Ticked options and free-text rows are tracked as their own state, so a row can be typed through an option's exact value without ticking or unticking anything, ticking an option absorbs a row holding the same value, and the counter counts free-text rows only (hidden when there are none). The toggle takes its target from that state rather than the input's `checked`, because `Checkbox` re-asserts its `checked` prop on every click and the input already reads the old value again by the time `change` fires.
- `frontend/src/lib/components/AppConnectInner.svelte`: passes `registryEntry()?.scope_options`.

Companion: windmill-labs/windmill-integrations#182 adds the key to the registry validator type.

## Test plan
- [x] `svelte-check`: 0 errors; registry validator (`validate-oauth-connect.ts`) passes for gmail/gforms/gdrive
- [x] Exercised on a local instance (`cargo run --features private,oauth2` + vite dev, Gmail tile configured) with Playwright: defaults pre-ticked (`gmail.send`), ticking `gmail.modify` and unticking/re-ticking `gmail.send` work, a custom row typed through the exact `gmail.labels` value leaves that box unticked and the row survives, and the read-only list after closing the editor shows the ticked options plus the custom row. The first browser run caught the `Checkbox` re-assert issue described above; the jsdom harness had not.
- [ ] Complete a real Google connection with a ticked scope and confirm the authorize URL carries it (needs a client verified for that scope; pending the verification this PR supports)

## Screenshots
Connect dialog for Gmail with the option checkboxes (defaults pre-ticked):

![connect-gmail-2-checkboxes](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/google-oauth-scope-options/1788383240-connect-gmail-2-checkboxes.png)

`gmail.modify` ticked, plus a custom row:

![connect-gmail-3-modify-ticked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/google-oauth-scope-options/1788383243-connect-gmail-3-modify-ticked.png)

Read-only view after closing the editor:

![connect-gmail-4-readonly-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/google-oauth-scope-options/1788383245-connect-gmail-4-readonly-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kv72vdCDggCZEjJSmNCwnX
