### PR TITLE
fix: name the reason a fork can't be created instead of hiding the option

### DIFF
--- a/frontend/src/lib/components/sessions/SessionChangesBar.svelte
+++ b/frontend/src/lib/components/sessions/SessionChangesBar.svelte
@@ -11,9 +11,14 @@
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 	import SessionStatusPopover from './SessionStatusPopover.svelte'
 	import WorkspaceFamilyPicker from './WorkspaceFamilyPicker.svelte'
-	import { maybePremium, userStore, userWorkspaces, workspaceStore } from '$lib/stores'
-	import { canCreateFork } from '$lib/utils/editInFork'
-	import { isCloudHosted } from '$lib/cloud'
+	import {
+		maybePremium,
+		premiumFetchFailed,
+		userStore,
+		userWorkspaces,
+		workspaceStore
+	} from '$lib/stores'
+	import { forkBlockedReason } from '$lib/utils/editInFork'
 	import { sessionState, type Session } from './sessionState.svelte'
 	import { getRuntime } from './sessionRuntime.svelte'
 	import SessionDiffDrawer from './SessionDiffDrawer.svelte'
@@ -60,10 +65,13 @@
 	)
 	const isFork = $derived(!!parentWorkspaceId)
 
-	// Same gate as the sidebar WorkspaceMenu / SessionWorkspaceBar. On cloud,
-	// forking is a premium-only feature (backend caps it per paid seat).
+	// Same blockers the fork dropdowns explain, minus their dev-workspace relaxation: this gates
+	// whether the bar renders at all, so it needs the answer for the active workspace itself.
 	const forksAllowed = $derived(
-		(!isCloudHosted() || $maybePremium) && canCreateFork($userStore) && $workspaceStore !== 'admins'
+		!forkBlockedReason($userStore, $workspaceStore, {
+			premium: $maybePremium,
+			premiumUnknown: $premiumFetchFailed
+		})
 	)
 
 	const runtime = $derived(getRuntime(session.id))

--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -3,6 +3,7 @@
 	import {
 		enterpriseLicense,
 		maybePremium,
+		premiumFetchFailed,
 		superadmin,
 		userStore,
 		userWorkspaces,
@@ -175,6 +176,7 @@
 	const forkGateReason = $derived(
 		forkBlockedReason($userStore, $workspaceStore, {
 			premium: $maybePremium,
+			premiumUnknown: $premiumFetchFailed,
 			hasDevWorkspace: !!devOfRoot
 		})
 	)
@@ -202,7 +204,7 @@
 			(ceWorkspaceCapReached && !onRequestCreateFork
 				? {
 						note: 'Workspace limit reached',
-						title: `Community edition is limited to ${CE_MAX_NON_ADMIN_WORKSPACES + 1} workspaces. Archive a workspace or upgrade to an enterprise license to create more forks.`
+						detail: `Community edition is limited to ${CE_MAX_NON_ADMIN_WORKSPACES + 1} workspaces. Archive a workspace or upgrade to an enterprise license to create more forks.`
 					}
 				: undefined)
 	)
@@ -566,13 +568,15 @@
 			{:else if forkAffordanceOpen && createForkBlocked}
 				<div class="my-1 border-t border-border-light shrink-0"></div>
 				<div
-					class={`${rowBase} opacity-60 cursor-not-allowed`}
+					class="px-3 py-1.5 flex flex-col gap-0.5 opacity-60 cursor-not-allowed"
 					aria-disabled="true"
-					title={createForkBlocked.title}
 				>
-					<Plus size={14} class="shrink-0 text-tertiary" />
-					<span>{createForkLabel}</span>
-					<span class="ml-auto shrink-0 text-2xs text-tertiary">{createForkBlocked.note}</span>
+					<div class="flex flex-row gap-2 items-center text-xs font-normal text-primary">
+						<Plus size={14} class="shrink-0 text-tertiary" />
+						<span>{createForkLabel}</span>
+						<span class="ml-auto shrink-0 text-2xs text-tertiary">{createForkBlocked.note}</span>
+					</div>
+					<span class="text-2xs text-tertiary pl-6">{createForkBlocked.detail}</span>
 				</div>
 			{/if}
 			{#if settingsHref}

--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -17,7 +17,7 @@
 		buildWorkspaceHierarchy
 	} from '$lib/utils/workspaceHierarchy'
 	import { useForkableWorkspaces } from '$lib/utils/useForkableWorkspaces.svelte'
-	import { canCreateFork } from '$lib/utils/editInFork'
+	import { forkBlockedReason, type ForkBlockedReason } from '$lib/utils/editInFork'
 	import { forkAccentStyle } from '$lib/utils/forkColor'
 	import { getUserExt } from '$lib/user'
 	import { WorkspaceService } from '$lib/gen'
@@ -27,7 +27,6 @@
 		canUserBypassRuleKindInRulesets
 	} from '$lib/workspaceProtectionRules.svelte'
 	import { resource } from 'runed'
-	import { isCloudHosted } from '$lib/cloud'
 	import { random_adj } from '$lib/components/random_positive_adjetive'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import InputError from '$lib/components/InputError.svelte'
@@ -169,19 +168,20 @@
 		rootRulesetsResource.loading || rootUserInfoResource.loading || !canDeployRoot
 	)
 
-	// Structural gate: hidden in the admins workspace, or when the user can't fork; on cloud, forking
-	// is premium-only (backend caps it per paid seat). DisableWorkspaceForking on the active workspace
-	// (a locked prod) doesn't apply when there's a dev to fork from instead — the dev isn't locked, and
-	// devOfRoot only resolves when the user is a member of it.
-	const forksGateOpen = $derived(
-		(!isCloudHosted() || $maybePremium) &&
-			$workspaceStore !== 'admins' &&
-			(canCreateFork($userStore) || !!devOfRoot)
+	// Why forking is unavailable here (admins workspace, non-premium cloud, or a protection rule), or
+	// undefined when it is available. DisableWorkspaceForking on the active workspace (a locked prod)
+	// doesn't apply when there's a dev to fork from instead — the dev isn't locked, and devOfRoot only
+	// resolves when the user is a member of it.
+	const forkGateReason = $derived(
+		forkBlockedReason($userStore, $workspaceStore, {
+			premium: $maybePremium,
+			hasDevWorkspace: !!devOfRoot
+		})
 	)
 	// A fork is a new workspace, so it's subject to the community-edition cap on
 	// the number of non-'admins' workspaces (backend _check_nb_of_workspaces,
 	// run only on community builds). An enterprise license lifts the cap. We
-	// mirror the backend count with the client-side workspace list to hide the
+	// mirror the backend count with the client-side workspace list to disable the
 	// affordance once the cap is reached; the server still enforces the real
 	// (instance-wide) check on commit, so this is purely UX.
 	const CE_MAX_NON_ADMIN_WORKSPACES = 2
@@ -189,20 +189,24 @@
 	const ceWorkspaceCapReached = $derived(
 		!$enterpriseLicense && nonAdminWorkspaceCount >= CE_MAX_NON_ADMIN_WORKSPACES
 	)
-	// The interactive create-fork row is shown unless the cap is reached;
-	// otherwise (structural gate open but cap hit) we surface a disabled row
-	// explaining the limit — never stage a fork the backend would reject.
+	// Structural: the consumer wired up a create path at all, and there's a family to fork from. The
+	// row is absent only in that case — every other blocker keeps it visible and names itself.
 	const forkAffordanceOpen = $derived(
-		allowCreateFork && forksGateOpen && (!!onCreateFork || !!onRequestCreateFork) && !!root
+		allowCreateFork && (!!onCreateFork || !!onRequestCreateFork) && !!root
 	)
-	// The upsell (CE workspace cap) only applies to in-place inline creation;
-	// onRequestCreateFork delegates to a flow that enforces its own limits.
-	const showCreateFork = $derived(
-		forkAffordanceOpen && (!ceWorkspaceCapReached || !!onRequestCreateFork)
+	// Blocker for the create-fork row: the gate above, else the CE workspace cap. The cap only applies
+	// to in-place inline creation; onRequestCreateFork delegates to a flow that enforces its own
+	// limits. Never stage a fork the backend would reject.
+	const createForkBlocked = $derived<ForkBlockedReason | undefined>(
+		forkGateReason ??
+			(ceWorkspaceCapReached && !onRequestCreateFork
+				? {
+						note: 'Workspace limit reached',
+						title: `Community edition is limited to ${CE_MAX_NON_ADMIN_WORKSPACES + 1} workspaces. Archive a workspace or upgrade to an enterprise license to create more forks.`
+					}
+				: undefined)
 	)
-	const showForkUpsell = $derived(
-		forkAffordanceOpen && ceWorkspaceCapReached && !onRequestCreateFork
-	)
+	const showCreateFork = $derived(forkAffordanceOpen && !createForkBlocked)
 
 	let dropdownOpen = $state(false)
 	let creatingFork = $state(false)
@@ -559,17 +563,16 @@
 						<span>{createForkLabel}</span>
 					</button>
 				{/if}
-			{:else if showForkUpsell}
+			{:else if forkAffordanceOpen && createForkBlocked}
 				<div class="my-1 border-t border-border-light shrink-0"></div>
 				<div
 					class={`${rowBase} opacity-60 cursor-not-allowed`}
 					aria-disabled="true"
-					title="Community edition is limited to {CE_MAX_NON_ADMIN_WORKSPACES +
-						1} workspaces. Archive a workspace or upgrade to an enterprise license to create more forks."
+					title={createForkBlocked.title}
 				>
 					<Plus size={14} class="shrink-0 text-tertiary" />
 					<span>{createForkLabel}</span>
-					<span class="ml-auto shrink-0 text-2xs text-tertiary"> Workspace limit reached </span>
+					<span class="ml-auto shrink-0 text-2xs text-tertiary">{createForkBlocked.note}</span>
 				</div>
 			{/if}
 			{#if settingsHref}

--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -3,6 +3,7 @@
 	import {
 		isPremiumStore,
 		maybePremium,
+		premiumFetchFailed,
 		superadmin,
 		userStore,
 		userWorkspaces,
@@ -33,6 +34,7 @@
 	import type { MenubarBuilders } from '@melt-ui/svelte'
 	import {
 		buildWorkspaceHierarchy,
+		findCanonicalDevWorkspace,
 		findWorkspaceAncestors,
 		findWorkspaceRoot,
 		isForkOwner
@@ -112,11 +114,17 @@
 		}
 		return withForks
 	})
-	// Gate for the "Workspace fork" entry pinned below the list (the global fork
-	// modal carries its own base-workspace picker). When forking is unavailable the
-	// entry stays, disabled and carrying the reason, rather than disappearing.
+	// Gate for the "Workspace fork" entry pinned below the list. When forking is unavailable the
+	// entry stays, disabled and carrying the reason, rather than disappearing. The global fork modal
+	// carries its own base-workspace picker, so a canonical dev workspace is a fork base like it is
+	// in the scope header's picker — judging it without one would disable the entry here while that
+	// picker offers the same fork one panel away.
 	const forkBlocked = $derived(
-		forkBlockedReason($userStore, $workspaceStore, { premium: $maybePremium })
+		forkBlockedReason($userStore, $workspaceStore, {
+			premium: $maybePremium,
+			premiumUnknown: $premiumFetchFailed,
+			hasDevWorkspace: !!findCanonicalDevWorkspace($workspaceStore, $userWorkspaces)
+		})
 	)
 	const familyWorkspaces = $derived.by(() => {
 		if (strictWorkspaceSelect) return hierarchy
@@ -385,18 +393,21 @@
 					{/if}
 					{#if forkBlocked}
 						<!-- Kept visible so the reason forking is unavailable is readable here, rather than
-						     leaving the entry to silently vanish. -->
-						<div
-							class="text-primary font-normal w-full flex flex-row gap-2 items-center px-4 py-2 text-xs opacity-60 cursor-not-allowed"
-							role="menuitem"
-							tabindex="-1"
-							aria-disabled="true"
-							title={forkBlocked.title}
+						     leaving the entry to silently vanish. Styled disabled rather than natively
+						     disabled, like the user-disabled workspace rows above, so the row still reads
+						     as menu content. -->
+						<MenuItem
+							class={twMerge(itemClass, 'flex-col gap-0.5 opacity-60 cursor-not-allowed')}
+							onClick={(e) => e.preventDefault()}
+							{item}
 						>
-							<Plus size={16} />
-							Workspace fork
-							<span class="ml-auto shrink-0 text-2xs text-tertiary">{forkBlocked.note}</span>
-						</div>
+							<div class="flex flex-row gap-2 items-center w-full">
+								<Plus size={16} />
+								Workspace fork
+								<span class="ml-auto shrink-0 text-2xs text-tertiary">{forkBlocked.note}</span>
+							</div>
+							<span class="text-2xs text-tertiary text-left w-full pl-6">{forkBlocked.detail}</span>
+						</MenuItem>
 					{:else}
 						<MenuItem
 							class={itemClass}

--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -37,7 +37,7 @@
 		findWorkspaceRoot,
 		isForkOwner
 	} from '$lib/utils/workspaceHierarchy'
-	import { canCreateFork } from '$lib/utils/editInFork'
+	import { forkBlockedReason } from '$lib/utils/editInFork'
 	import { getContrastTextColor } from '$lib/utils'
 	import { workspaceRootId } from '$lib/components/sessions/sessionScope.svelte'
 	import { devBadgeText } from '$lib/utils/devWorkspaceLabel'
@@ -113,10 +113,10 @@
 		return withForks
 	})
 	// Gate for the "Workspace fork" entry pinned below the list (the global fork
-	// modal carries its own base-workspace picker). Hidden on non-premium cloud,
-	// in the admins workspace, or when forking is disabled.
-	const canForkHere = $derived(
-		(!isCloudHosted() || $maybePremium) && $workspaceStore !== 'admins' && canCreateFork($userStore)
+	// modal carries its own base-workspace picker). When forking is unavailable the
+	// entry stays, disabled and carrying the reason, rather than disappearing.
+	const forkBlocked = $derived(
+		forkBlockedReason($userStore, $workspaceStore, { premium: $maybePremium })
 	)
 	const familyWorkspaces = $derived.by(() => {
 		if (strictWorkspaceSelect) return hierarchy
@@ -375,7 +375,7 @@
 					</div>
 				{/each}
 			</div>
-			{#if (isCloudHosted() || $superadmin || canForkHere) && !strictWorkspaceSelect}
+			{#if !strictWorkspaceSelect}
 				<div class="py-1" role="none">
 					{#if isCloudHosted() || $superadmin}
 						<MenuItem href="{base}/user/create_workspace" class={itemClass} {item}>
@@ -383,7 +383,21 @@
 							Workspace
 						</MenuItem>
 					{/if}
-					{#if canForkHere}
+					{#if forkBlocked}
+						<!-- Kept visible so the reason forking is unavailable is readable here, rather than
+						     leaving the entry to silently vanish. -->
+						<div
+							class="text-primary font-normal w-full flex flex-row gap-2 items-center px-4 py-2 text-xs opacity-60 cursor-not-allowed"
+							role="menuitem"
+							tabindex="-1"
+							aria-disabled="true"
+							title={forkBlocked.title}
+						>
+							<Plus size={16} />
+							Workspace fork
+							<span class="ml-auto shrink-0 text-2xs text-tertiary">{forkBlocked.note}</span>
+						</div>
+					{:else}
 						<MenuItem
 							class={itemClass}
 							onClick={() => (globalForkModal.val = { opened: true })}

--- a/frontend/src/lib/utils/editInFork.ts
+++ b/frontend/src/lib/utils/editInFork.ts
@@ -56,36 +56,51 @@ export function canCreateFork(user: UserExt | undefined): boolean {
 	)
 }
 
-/** Why a create-fork entry is disabled: a short right-hand note, and the tooltip that explains it. */
-export type ForkBlockedReason = { note: string; title: string }
+/**
+ * Why a create-fork entry is disabled: a short right-hand note and the sentence explaining it. Both
+ * render as visible text — a disabled row can't take focus and a native `title` never opens on
+ * touch, so a tooltip would keep the reason from the users most likely to be stuck on it.
+ */
+export type ForkBlockedReason = { note: string; detail: string }
 
 /**
  * The blocker on creating a fork of the given workspace, or undefined when there is none. Callers
  * render the create-fork entry disabled and carrying this reason rather than dropping it, so a user
  * who can't fork reads why instead of hunting for a missing entry. `premium` comes from
- * `maybePremium` (forking is metered per paid seat on cloud); `hasDevWorkspace` relaxes the forking
- * rule, since a locked prod's dev workspace is itself forkable.
+ * `maybePremium` (forking is metered per paid seat on cloud) and `premiumUnknown` from
+ * `premiumFetchFailed`, which is the half of `maybePremium` that must not be reported as "you don't
+ * pay for this"; `hasDevWorkspace` relaxes the forking rule, since a locked prod's dev workspace is
+ * itself forkable.
  */
 export function forkBlockedReason(
 	user: UserExt | undefined,
 	workspaceId: string | undefined,
-	{ premium, hasDevWorkspace = false }: { premium: boolean; hasDevWorkspace?: boolean }
+	{
+		premium,
+		premiumUnknown = false,
+		hasDevWorkspace = false
+	}: { premium: boolean; premiumUnknown?: boolean; hasDevWorkspace?: boolean }
 ): ForkBlockedReason | undefined {
 	if (workspaceId === 'admins')
 		return {
 			note: 'Not forkable',
-			title: 'The admins workspace cannot be forked. Switch to another workspace to create a fork.'
+			detail: 'The admins workspace cannot be forked. Switch to another workspace first.'
 		}
 	if (isCloudHosted() && !premium)
-		return {
-			note: 'Paid plans only',
-			title:
-				'Forking a workspace is available on paid plans. Upgrade this workspace to create forks.'
-		}
+		return premiumUnknown
+			? {
+					note: 'Plan unknown',
+					detail:
+						"This workspace's plan could not be checked, and forking needs a paid plan. Reload to try again."
+				}
+			: {
+					note: 'Paid plans only',
+					detail: 'Forking a workspace needs a paid plan. Upgrade this workspace to create forks.'
+				}
 	if (!canCreateFork(user) && !hasDevWorkspace)
 		return {
 			note: 'Disabled',
-			title:
+			detail:
 				'A protection rule disables forking of this workspace. A workspace admin can change it in the workspace settings.'
 		}
 	return undefined

--- a/frontend/src/lib/utils/editInFork.ts
+++ b/frontend/src/lib/utils/editInFork.ts
@@ -13,6 +13,7 @@ import { goto } from '$lib/navigation'
 import { sendUserToast } from '$lib/toast'
 import { checkItemExists } from '$lib/utils_workspace_deploy'
 import { updateDevWorkspaceModal } from '$lib/utils/editInForkModal.svelte'
+import { isCloudHosted } from '$lib/cloud'
 
 export type ItemType = 'script' | 'flow' | 'app' | 'raw_app'
 
@@ -53,6 +54,41 @@ export function canCreateFork(user: UserExt | undefined): boolean {
 		!isRuleActive('DisableWorkspaceForking') ||
 		canUserBypassRuleKind('DisableWorkspaceForking', user)
 	)
+}
+
+/** Why a create-fork entry is disabled: a short right-hand note, and the tooltip that explains it. */
+export type ForkBlockedReason = { note: string; title: string }
+
+/**
+ * The blocker on creating a fork of the given workspace, or undefined when there is none. Callers
+ * render the create-fork entry disabled and carrying this reason rather than dropping it, so a user
+ * who can't fork reads why instead of hunting for a missing entry. `premium` comes from
+ * `maybePremium` (forking is metered per paid seat on cloud); `hasDevWorkspace` relaxes the forking
+ * rule, since a locked prod's dev workspace is itself forkable.
+ */
+export function forkBlockedReason(
+	user: UserExt | undefined,
+	workspaceId: string | undefined,
+	{ premium, hasDevWorkspace = false }: { premium: boolean; hasDevWorkspace?: boolean }
+): ForkBlockedReason | undefined {
+	if (workspaceId === 'admins')
+		return {
+			note: 'Not forkable',
+			title: 'The admins workspace cannot be forked. Switch to another workspace to create a fork.'
+		}
+	if (isCloudHosted() && !premium)
+		return {
+			note: 'Paid plans only',
+			title:
+				'Forking a workspace is available on paid plans. Upgrade this workspace to create forks.'
+		}
+	if (!canCreateFork(user) && !hasDevWorkspace)
+		return {
+			note: 'Disabled',
+			title:
+				'A protection rule disables forking of this workspace. A workspace admin can change it in the workspace settings.'
+		}
+	return undefined
 }
 
 function editPathFor(itemType: ItemType, itemPath: string): string {


### PR DESCRIPTION
## Summary

The create-fork entry disappeared from both fork dropdowns whenever forking was unavailable, so a user who could not fork had no way to find out why — the option simply wasn't there. Both dropdowns now keep the entry, disabled, with the blocker named in the row.

A shared `forkBlockedReason(user, workspaceId, { premium, premiumUnknown, hasDevWorkspace })` in `editInFork.ts` returns `{ note, detail }` or `undefined`, replacing the three copies of the gate that had drifted apart.

## Changes

- `lib/utils/editInFork.ts`: new `forkBlockedReason` covering the three blockers in order — the `admins` workspace, a cloud workspace without a paid plan, and a `DisableWorkspaceForking` protection rule the user can't bypass. `hasDevWorkspace` preserves the existing exception (a locked prod is still forkable through its dev workspace), and `premiumUnknown` (from `premiumFetchFailed`) keeps a failed tier fetch from telling a paying workspace it isn't paying.
- `WorkspaceFamilyPicker.svelte`: the "Create new fork…" row is now hidden only for structural reasons (no create callback wired, or no family root). Every other blocker renders the disabled row that already existed for the community-edition workspace cap, which folds into the same `{ note, detail }` shape.
- `sidebar/WorkspaceMenu.svelte`: same treatment for its "Workspace fork" entry, judged with the same dev-workspace exception as the picker so the two panels can't contradict each other.
- `sessions/SessionChangesBar.svelte`: the third inline copy of the gate now calls the shared helper.

Both rows print the reason as visible text rather than a `title` tooltip: a disabled row can't take focus and a native tooltip never opens on touch, so the explanation would have been unreachable for exactly the users stuck on it.

## Screenshots

Protection rule active, non-admin user (previously: no entry at all):

![v2-rule-scope](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fork-warning/1788372518-v2-rule-scope.png)

![v2-rule-wsmenu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fork-warning/1788372520-v2-rule-wsmenu.png)

`admins` workspace:

![v2-admins-scope](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fork-warning/1788372522-v2-admins-scope.png)

![v2-admins-wsmenu](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fork-warning/1788372524-v2-admins-wsmenu.png)

Admin in the same rule-protected workspace — bypass applies, entry stays actionable:

![v2-admin-bypass](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fork-warning/1788372525-v2-admin-bypass.png)

## Test plan

- [x] `admins` workspace: both dropdowns show the entry disabled with "Not forkable" and the sentence
- [x] Non-admin in a workspace carrying `DisableWorkspaceForking`: both show "Disabled" with the protection-rule sentence
- [x] Workspace admin in that same workspace: entry enabled, unchanged from before
- [ ] Cloud, non-premium workspace: "Paid plans only" (not exercised — verified against self-hosted EE, where `isCloudHosted()` is false)
- [ ] Community edition at the workspace cap: picker still shows "Workspace limit reached" with its detail line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cq84eSViYocWFKfqvzdpR