### PR TITLE
fix(cli): make a sync push into a fork converge on schedules and inline names

### DIFF
--- a/cli/src/commands/schedule/schedule.ts
+++ b/cli/src/commands/schedule/schedule.ts
@@ -106,7 +106,8 @@ export async function pushSchedule(
   path: string,
   schedule: Schedule | ScheduleFile | undefined,
   localSchedule: ScheduleFile,
-  permissionedAsContext?: PermissionedAsContext
+  permissionedAsContext?: PermissionedAsContext,
+  enabledOwnedByParent?: boolean
 ): Promise<void> {
   path = removeType(path, "schedule").replaceAll(SEP, "/");
   log.debug(`Processing local schedule ${path}`);
@@ -122,6 +123,14 @@ export async function pushSchedule(
 
   // Strip CLI-only boolean marker before sending to API
   delete (localSchedule as any).has_permissioned_as;
+
+  // In a fork, the file's `enabled` is the parent's for a path the parent
+  // also has (see sync push's `parentOwnedScheduleEnabled`): the fork's own
+  // flag stays as it is. A schedule the fork does not have yet is created as
+  // the file says, there being no fork state to keep.
+  if (enabledOwnedByParent && schedule) {
+    delete localSchedule.enabled;
+  }
 
   const preserveFields: { permissioned_as?: string; preserve_permissioned_as?: boolean } = {};
   if (permissionedAsContext?.userIsAdminOrDeployer) {
@@ -153,13 +162,9 @@ export async function pushSchedule(
           ...preserveFields,
         },
       });
-      // Tarball export from a fork strips `enabled` from schedule YAMLs so
-      // the fork→parent git-sync round-trip can't flip the parent's state.
-      // Skip the secondary setScheduleEnabled call when the local YAML
-      // doesn't carry `enabled` — sending `{ enabled: undefined }` would
-      // serialize to `{}` and the backend (`SetEnabled.enabled` is required)
-      // would reject the request. Preserving the target's existing flag is
-      // exactly the round-trip-safe behavior.
+      // No `enabled` in the file (absent from the YAML, or set aside above)
+      // leaves the remote flag alone: `SetEnabled.enabled` is required, so
+      // `{ enabled: undefined }` would be rejected rather than ignored.
       if (
         localSchedule.enabled !== undefined &&
         localSchedule.enabled !== schedule.enabled

--- a/cli/src/commands/schedule/schedule.ts
+++ b/cli/src/commands/schedule/schedule.ts
@@ -129,6 +129,14 @@ export async function pushSchedule(
   // flag stays as it is. A schedule the fork does not have yet is created as
   // the file says, there being no fork state to keep.
   if (enabledOwnedByParent && schedule) {
+    if (
+      localSchedule.enabled !== undefined &&
+      localSchedule.enabled !== schedule.enabled
+    ) {
+      log.warnAlways(
+        `Schedule ${path} stays ${schedule.enabled ? "enabled" : "disabled"}: the file says ${localSchedule.enabled ? "enabled" : "disabled"}, but in a fork that flag is the parent workspace's`
+      );
+    }
     delete localSchedule.enabled;
   }
 
@@ -189,7 +197,7 @@ export async function pushSchedule(
           if (!conflict) {
             throw e;
           }
-          log.warn(
+          log.warnAlways(
             `Schedule ${path} left ${schedule.enabled ? "enabled" : "disabled"}: the parent workspace '${conflict.parentWorkspaceId}' has the same schedule, so its flag is the parent's to set`
           );
         }

--- a/cli/src/commands/schedule/schedule.ts
+++ b/cli/src/commands/schedule/schedule.ts
@@ -126,8 +126,7 @@ export async function pushSchedule(
 
   // In a fork, the file's `enabled` is the parent's for a path the parent
   // also has (see sync push's `parentOwnedScheduleEnabled`): the fork's own
-  // flag stays as it is. A schedule the fork does not have yet is created as
-  // the file says, there being no fork state to keep.
+  // flag stays as it is.
   if (enabledOwnedByParent && schedule) {
     if (
       localSchedule.enabled !== undefined &&
@@ -180,27 +179,12 @@ export async function pushSchedule(
         log.info(colors.bold.yellow(
           `Schedule ${path} is ${localSchedule.enabled ? "enabled" : "disabled"} locally but not on remote, updating remote`
         ));
-        try {
-          await wmill.setScheduleEnabled({
-            workspace: workspace,
-            path,
-            requestBody: {
-              enabled: localSchedule.enabled,
-            },
-          });
-        } catch (e) {
-          // The parent listing behind `enabledOwnedByParent` sees what the
-          // pusher may read; the backend's check does not. A path it turns
-          // out the parent has is the parent's after all: keep the fork's
-          // flag rather than fail the whole push.
-          const conflict = parseForkConflict(e);
-          if (!conflict) {
-            throw e;
-          }
-          log.warnAlways(
-            `Schedule ${path} left ${schedule.enabled ? "enabled" : "disabled"}: the parent workspace '${conflict.parentWorkspaceId}' has the same schedule, so its flag is the parent's to set`
-          );
-        }
+        await setEnabledUnlessParentOwned(
+          workspace,
+          path,
+          localSchedule.enabled,
+          schedule.enabled
+        );
       }
     } catch (e) {
       console.error((e as any).body);
@@ -221,6 +205,44 @@ export async function pushSchedule(
       console.error((e as any).body);
       throw e;
     }
+    // A create in a fork lands disabled whatever the request says. A fork-only
+    // path the file wants enabled is enabled here, so one push converges; a
+    // parent-owned one stays disabled.
+    if (enabledOwnedByParent !== undefined && localSchedule.enabled === true) {
+      if (enabledOwnedByParent) {
+        log.warnAlways(
+          `Schedule ${path} created disabled: the file says enabled, but in a fork that flag is the parent workspace's`
+        );
+      } else {
+        await setEnabledUnlessParentOwned(workspace, path, true, false);
+      }
+    }
+  }
+}
+
+// The parent listing behind `enabledOwnedByParent` sees only what the pusher
+// may read; the backend's `fork-conflict` refusal is the last word, so a path
+// it says the parent has keeps the fork's flag rather than failing the push.
+async function setEnabledUnlessParentOwned(
+  workspace: string,
+  path: string,
+  enabled: boolean,
+  remoteEnabled: boolean
+): Promise<void> {
+  try {
+    await wmill.setScheduleEnabled({
+      workspace,
+      path,
+      requestBody: { enabled },
+    });
+  } catch (e) {
+    const conflict = parseForkConflict(e);
+    if (!conflict) {
+      throw e;
+    }
+    log.warnAlways(
+      `Schedule ${path} left ${remoteEnabled ? "enabled" : "disabled"}: the parent workspace '${conflict.parentWorkspaceId}' has the same schedule, so its flag is the parent's to set`
+    );
   }
 }
 

--- a/cli/src/commands/schedule/schedule.ts
+++ b/cli/src/commands/schedule/schedule.ts
@@ -172,13 +172,27 @@ export async function pushSchedule(
         log.info(colors.bold.yellow(
           `Schedule ${path} is ${localSchedule.enabled ? "enabled" : "disabled"} locally but not on remote, updating remote`
         ));
-        await wmill.setScheduleEnabled({
-          workspace: workspace,
-          path,
-          requestBody: {
-            enabled: localSchedule.enabled,
-          },
-        });
+        try {
+          await wmill.setScheduleEnabled({
+            workspace: workspace,
+            path,
+            requestBody: {
+              enabled: localSchedule.enabled,
+            },
+          });
+        } catch (e) {
+          // The parent listing behind `enabledOwnedByParent` sees what the
+          // pusher may read; the backend's check does not. A path it turns
+          // out the parent has is the parent's after all: keep the fork's
+          // flag rather than fail the whole push.
+          const conflict = parseForkConflict(e);
+          if (!conflict) {
+            throw e;
+          }
+          log.warn(
+            `Schedule ${path} left ${schedule.enabled ? "enabled" : "disabled"}: the parent workspace '${conflict.parentWorkspaceId}' has the same schedule, so its flag is the parent's to set`
+          );
+        }
       }
     } catch (e) {
       console.error((e as any).body);

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -25,7 +25,7 @@ import {
 } from "yaml";
 import JSZip from "jszip";
 import { minimatch } from "minimatch";
-import { yamlParseContent } from "../../utils/yaml.ts";
+import { yamlParseContent, yamlParseFile } from "../../utils/yaml.ts";
 import * as wmill from "../../../gen/services.gen.ts";
 
 import {
@@ -1138,7 +1138,7 @@ export function rawAppPathWithinFolder(
   return resolved;
 }
 
-function ZipFSElement(
+export function ZipFSElement(
   zip: JSZip,
   useYaml: boolean,
   defaultTs: "bun" | "deno",
@@ -1146,6 +1146,14 @@ function ZipFSElement(
   resourceTypeToIsFileset: Record<string, boolean>,
   ignoreCodebaseChanges: boolean,
   stripOnBehalfOf: boolean,
+  // Names a flow's rendered inline-script files after the checkout's own
+  // `!inline` references (module id -> file). The export carries script
+  // source, never a reference, so without a checkout to defer to every file
+  // is named from the step summary, and a file the checkout names otherwise
+  // reads as a delete + add on every push while the resolved flows are equal.
+  localFlowInlineMapping?: (
+    flowDir: string,
+  ) => Promise<Record<string, string>>,
 ): DynFSElement {
   // Pre-scan: find zip base paths of scripts that have modules.
   // These scripts use the folder layout: {basePath}__mod/script.{ext}
@@ -1254,13 +1262,9 @@ function ZipFSElement(
               const assigner = newPathAssigner(defaultTs, {
                 skipInlineScriptSuffix: getNonDottedPaths(),
               });
-              // Preserve original !inline filenames from the flow to avoid phantom renames
-              const inlineMapping = extractCurrentMapping(
-                flow.value.modules as any,
-                {},
-                flow.value.failure_module,
-                flow.value.preprocessor_module,
-              );
+              const inlineMapping = localFlowInlineMapping
+                ? await localFlowInlineMapping(finalPath)
+                : {};
               inlineScripts = extractInlineScriptsForFlows(
                 flow.value.modules as any,
                 inlineMapping,
@@ -2581,7 +2585,7 @@ export function preservePendingScriptLocks(
   }
 }
 
-async function compareDynFSElement(
+export async function compareDynFSElement(
   els1: DynFSElement,
   els2: DynFSElement | undefined,
   ignore: (path: string, isDirectory: boolean) => boolean,
@@ -2594,6 +2598,9 @@ async function compareDynFSElement(
   branchOverride?: string,
   isEls1Remote?: boolean,
   caseInsensitiveFs?: boolean,
+  // Which schedule files carry an `enabled` that is not the target's to set
+  // (see push's `parentOwnedScheduleEnabled`): those compare without it.
+  parentOwnsScheduleEnabled?: (scheduleFilePath: string) => boolean,
 ): Promise<{ changes: Change[]; localMap: Record<string, string> }> {
   let [m1, m2] = els2
     ? await Promise.all([
@@ -2785,12 +2792,28 @@ async function compareDynFSElement(
           );
           throw error;
         }
+        if (
+          parentOwnsScheduleEnabled &&
+          getTypeStrFromPath(k) === "schedule" &&
+          parentOwnsScheduleEnabled(k)
+        ) {
+          delete parsedV?.enabled;
+          delete parsedM2?.enabled;
+        }
         if (deepEqual(parsedV, parsedM2)) {
           continue;
         }
       } else if (k.endsWith(".yaml")) {
         const before = parseYaml(k, m2[k]);
         const after = parseYaml(k, v);
+        if (
+          parentOwnsScheduleEnabled &&
+          getTypeStrFromPath(k) === "schedule" &&
+          parentOwnsScheduleEnabled(k)
+        ) {
+          delete before?.enabled;
+          delete after?.enabled;
+        }
         if (deepEqual(before, after)) {
           continue;
         }
@@ -4543,6 +4566,58 @@ async function checkServerLockJobs(
   }
 }
 
+// A fork clones every schedule disabled and the backend refuses to enable one
+// whose path the parent also has (`fork-conflict:schedule`), while for those
+// paths a fork's export writes the *parent's* `enabled` into the file. So on a
+// push into a fork such a file's `enabled` describes the parent, not the
+// target: the push leaves the fork's flag alone rather than aborting on the
+// refusal, or reporting the file as edited on every run when the two differ.
+// A schedule only the fork has keeps toggling from the file. When the parent
+// cannot be listed from here (a job token is scoped to the fork), every
+// schedule may be the parent's, and none is toggled.
+//
+// Returns undefined when the target is not a fork; otherwise whether a
+// schedule file's `enabled` belongs to the parent.
+async function parentOwnedScheduleEnabled(
+  workspaceId: string,
+): Promise<((scheduleFilePath: string) => boolean) | undefined> {
+  let parentWorkspaceId: string | null | undefined;
+  try {
+    const { workspaces } = await wmill.listUserWorkspaces();
+    parentWorkspaceId = workspaces?.find(
+      (w) => w.id === workspaceId,
+    )?.parent_workspace_id;
+  } catch {
+    // The id prefix still identifies a throwaway fork.
+  }
+  if (!isForkWorkspace(workspaceId, parentWorkspaceId)) {
+    return undefined;
+  }
+  let parentPaths: Set<string> | undefined;
+  if (parentWorkspaceId) {
+    try {
+      parentPaths = new Set();
+      const perPage = 100;
+      for (let page = 1; ; page++) {
+        const batch = await wmill.listSchedules({
+          workspace: parentWorkspaceId,
+          page,
+          perPage,
+        });
+        batch.forEach((s) => parentPaths!.add(s.path));
+        if (batch.length < perPage) break;
+      }
+    } catch {
+      parentPaths = undefined;
+    }
+  }
+  return (scheduleFilePath) =>
+    parentPaths === undefined ||
+    parentPaths.has(
+      removeType(scheduleFilePath, "schedule").replaceAll(SEP, "/"),
+    );
+}
+
 export async function push(
   opts: GlobalOptions &
     SyncOptions & {
@@ -4596,6 +4671,9 @@ export async function push(
 
   const workspace = await resolveWorkspace(opts, wsNameForConfig);
   await requireLogin(opts);
+  const parentOwnsScheduleEnabled = await parentOwnedScheduleEnabled(
+    workspace.workspaceId,
+  );
 
   // If wsNameForConfig wasn't set from flags, infer from the resolved profile
   if (!wsNameForConfig) {
@@ -4696,6 +4774,24 @@ export async function push(
     // ignore
   }
 
+  // See ZipFSElement's `localFlowInlineMapping`.
+  const localFlowInlineMapping = async (
+    flowDir: string,
+  ): Promise<Record<string, string>> => {
+    let flow: any;
+    try {
+      flow = await yamlParseFile(path.join(process.cwd(), flowDir, "flow.yaml"));
+    } catch {
+      return {};
+    }
+    return extractCurrentMapping(
+      flow?.value?.modules,
+      {},
+      flow?.value?.failure_module,
+      flow?.value?.preprocessor_module,
+    );
+  };
+
   const remote = ZipFSElement(
     (await downloadZip(
       workspace,
@@ -4721,6 +4817,7 @@ export async function push(
     resourceTypeToIsFileset,
     false,
     parseSyncBehavior(opts.syncBehavior) >= 1,
+    localFlowInlineMapping,
   );
 
   const local = await FSFSElement(
@@ -4741,6 +4838,7 @@ export async function push(
     wsNameForFiles,
     false, // els1 (local) is not the remote source
     await isCaseInsensitiveFilesystem(process.cwd()),
+    parentOwnsScheduleEnabled,
   );
 
   // Detect resources/variables that the local config flags as ws_specific
@@ -5807,6 +5905,9 @@ export async function push(
                   originalLocalPath: originalWorkspaceSpecificPath,
                   permissionedAsContext,
                   wsSpecific: isWsSpecific ? true : undefined,
+                  enabledOwnedByParent: parentOwnsScheduleEnabled?.(
+                    change.path,
+                  ),
                   keyPushOpts: {
                     noninteractive:
                       (opts.yes ?? false) || !process.stdin.isTTY,
@@ -5942,6 +6043,9 @@ export async function push(
                   originalLocalPath: localFilePath,
                   permissionedAsContext,
                   wsSpecific: isAddedWsSpecific ? true : undefined,
+                  enabledOwnedByParent: parentOwnsScheduleEnabled?.(
+                    change.path,
+                  ),
                   keyPushOpts: {
                     noninteractive:
                       (opts.yes ?? false) || !process.stdin.isTTY,

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4582,6 +4582,34 @@ async function checkServerLockJobs(
   }
 }
 
+// The checkout's `!inline` references of one flow (module id -> file), as
+// `ZipFSElement`'s `localFlowInlineMapping` names the remote render. Empty
+// when the flow has no local flow.yaml.
+export async function checkoutInlineNames(
+  flowYamlPath: string,
+): Promise<Record<string, string>> {
+  let flow: any;
+  try {
+    flow = await yamlParseFile(flowYamlPath);
+  } catch {
+    return {};
+  }
+  const mapping = extractCurrentMapping(
+    flow?.value?.modules,
+    {},
+    flow?.value?.failure_module,
+    flow?.value?.preprocessor_module,
+  );
+  // A reference that leaves the flow folder would render the remote step
+  // onto another item's path; such a step keeps its summary-derived name.
+  for (const [id, ref] of Object.entries(mapping)) {
+    if (path.isAbsolute(ref) || ref.split(/[\\/]/).includes("..")) {
+      delete mapping[id];
+    }
+  }
+  return mapping;
+}
+
 // A fork clones every schedule disabled and the backend refuses to enable one
 // whose path the parent also has (`fork-conflict:schedule`), while for those
 // paths a fork's export writes the *parent's* `enabled` into the file. So on a
@@ -4791,22 +4819,8 @@ export async function push(
   }
 
   // See ZipFSElement's `localFlowInlineMapping`.
-  const localFlowInlineMapping = async (
-    flowDir: string,
-  ): Promise<Record<string, string>> => {
-    let flow: any;
-    try {
-      flow = await yamlParseFile(path.join(process.cwd(), flowDir, "flow.yaml"));
-    } catch {
-      return {};
-    }
-    return extractCurrentMapping(
-      flow?.value?.modules,
-      {},
-      flow?.value?.failure_module,
-      flow?.value?.preprocessor_module,
-    );
-  };
+  const localFlowInlineMapping = (flowDir: string) =>
+    checkoutInlineNames(path.join(process.cwd(), flowDir, "flow.yaml"));
 
   const remote = ZipFSElement(
     (await downloadZip(

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4610,30 +4610,30 @@ export async function checkoutInlineNames(
   return mapping;
 }
 
-// A fork clones every schedule disabled and the backend refuses to enable one
-// whose path the parent also has (`fork-conflict:schedule`), while for those
-// paths a fork's export writes the *parent's* `enabled` into the file. So on a
-// push into a fork such a file's `enabled` describes the parent, not the
-// target: the push leaves the fork's flag alone rather than aborting on the
-// refusal, or reporting the file as edited on every run when the two differ.
-// A schedule only the fork has keeps toggling from the file. When the parent
-// cannot be listed from here (a job token is scoped to the fork), every
-// schedule may be the parent's, and none is toggled.
-//
-// Returns undefined when the target is not a fork; otherwise whether a
-// schedule file's `enabled` belongs to the parent.
+// For a path the parent also has, a fork's export writes the parent's
+// `enabled` and the backend refuses to enable the fork's copy: the file's flag
+// is the parent's. A parent that cannot be listed (a fork-scoped job token)
+// may own every path. Undefined when the target is not a fork.
 async function parentOwnedScheduleEnabled(
   workspaceId: string,
 ): Promise<((scheduleFilePath: string) => boolean) | undefined> {
   let parentWorkspaceId: string | null | undefined;
+  let known = false;
   try {
     const { workspaces } = await wmill.listUserWorkspaces();
-    parentWorkspaceId = workspaces?.find(
-      (w) => w.id === workspaceId,
-    )?.parent_workspace_id;
+    const entry = workspaces?.find((w) => w.id === workspaceId);
+    known = entry !== undefined;
+    parentWorkspaceId = entry?.parent_workspace_id;
   } catch {
-    // The id prefix still identifies a throwaway fork.
+    // A fork-scoped token cannot list workspaces.
   }
+  // No parent on record (a fork whose parent was deleted keeps its
+  // `wm-fork-` id): nothing defers to a parent any more.
+  if (known && !parentWorkspaceId) {
+    return undefined;
+  }
+  // Without the listing only the `wm-fork-` prefix says fork: a dev
+  // workspace (custom id) reached with a fork-scoped token counts as none.
   if (!isForkWorkspace(workspaceId, parentWorkspaceId)) {
     return undefined;
   }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -1257,55 +1257,71 @@ export function ZipFSElement(
               log.error(`Failed to parse flow.yaml at path: ${p}`);
               throw error;
             }
-            let inlineScripts;
+            let inlineScripts: InlineScript[];
             try {
-              const assigner = newPathAssigner(defaultTs, {
-                skipInlineScriptSuffix: getNonDottedPaths(),
-              });
+              // Extraction rewrites the modules' content into `!inline` refs,
+              // so each attempt works on its own copy of the flow.
+              const render = (
+                source: OpenFlow,
+                inlineMapping: Record<string, string>,
+              ): [OpenFlow, InlineScript[]] => {
+                const f: OpenFlow = structuredClone(source);
+                const assigner = newPathAssigner(defaultTs, {
+                  skipInlineScriptSuffix: getNonDottedPaths(),
+                });
+                const options = {
+                  skipInlineScriptSuffix: getNonDottedPaths(),
+                  failOnInlineDirective: true,
+                };
+                const scripts = extractInlineScriptsForFlows(
+                  f.value.modules as any,
+                  inlineMapping,
+                  SEP,
+                  defaultTs,
+                  assigner,
+                  options,
+                );
+                if (f.value.failure_module) {
+                  scripts.push(
+                    ...extractInlineScriptsForFlows(
+                      [f.value.failure_module],
+                      inlineMapping,
+                      SEP,
+                      defaultTs,
+                      assigner,
+                      options,
+                    ),
+                  );
+                }
+                if (f.value.preprocessor_module) {
+                  scripts.push(
+                    ...extractInlineScriptsForFlows(
+                      [f.value.preprocessor_module],
+                      inlineMapping,
+                      SEP,
+                      defaultTs,
+                      assigner,
+                      options,
+                    ),
+                  );
+                }
+                return [f, scripts];
+              };
               const inlineMapping = localFlowInlineMapping
                 ? await localFlowInlineMapping(finalPath)
                 : {};
-              inlineScripts = extractInlineScriptsForFlows(
-                flow.value.modules as any,
-                inlineMapping,
-                SEP,
-                defaultTs,
-                assigner,
-                {
-                  skipInlineScriptSuffix: getNonDottedPaths(),
-                  failOnInlineDirective: true,
-                },
-              );
-              if (flow.value.failure_module) {
-                inlineScripts.push(
-                  ...extractInlineScriptsForFlows(
-                    [flow.value.failure_module],
-                    inlineMapping,
-                    SEP,
-                    defaultTs,
-                    assigner,
-                    {
-                      skipInlineScriptSuffix: getNonDottedPaths(),
-                      failOnInlineDirective: true,
-                    },
-                  ),
-                );
+              let rendered = render(flow, inlineMapping);
+              // The assigner keeps the names it hands out unique, not the
+              // checkout's: one of those equal to another step's
+              // summary-derived name would leave two files at one path, so
+              // such a flow renders the export's way.
+              if (
+                new Set(rendered[1].map((s) => s.path)).size !==
+                rendered[1].length
+              ) {
+                rendered = render(flow, {});
               }
-              if (flow.value.preprocessor_module) {
-                inlineScripts.push(
-                  ...extractInlineScriptsForFlows(
-                    [flow.value.preprocessor_module],
-                    inlineMapping,
-                    SEP,
-                    defaultTs,
-                    assigner,
-                    {
-                      skipInlineScriptSuffix: getNonDottedPaths(),
-                      failOnInlineDirective: true,
-                    },
-                  ),
-                );
-              }
+              [flow, inlineScripts] = rendered;
             } catch (error) {
               log.error(
                 `Failed to extract inline scripts for flow at path: ${p}`,
@@ -4671,9 +4687,6 @@ export async function push(
 
   const workspace = await resolveWorkspace(opts, wsNameForConfig);
   await requireLogin(opts);
-  const parentOwnsScheduleEnabled = await parentOwnedScheduleEnabled(
-    workspace.workspaceId,
-  );
 
   // If wsNameForConfig wasn't set from flags, infer from the resolved profile
   if (!wsNameForConfig) {
@@ -4711,6 +4724,9 @@ export async function push(
 
   // Merge CLI flags with resolved settings (CLI flags take precedence only for explicit overrides)
   opts = mergeCliWithEffectiveOptions(originalCliOpts, effectiveOpts);
+  const parentOwnsScheduleEnabled = opts.includeSchedules
+    ? await parentOwnedScheduleEnabled(workspace.workspaceId)
+    : undefined;
 
   if (opts.lint) {
     log.info("Running lint validation before push...");

--- a/cli/src/core/log.ts
+++ b/cli/src/core/log.ts
@@ -41,6 +41,12 @@ export function warnStderr(msg: unknown) {
   console.error(`\x1b[33m${String(msg)}\x1b[39m`);
 }
 
+// A notice that must reach a log even in silent (`--json-output`) mode:
+// stderr keeps stdout parseable, and a job that runs the CLI records both.
+export function warnAlways(msg: unknown) {
+  console.error(`\x1b[33m${String(msg)}\x1b[39m`);
+}
+
 export function error(msg: unknown) {
   console.error(`\x1b[31m${String(msg)}\x1b[39m`);
 }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -189,6 +189,8 @@ export interface PushObjOptions {
   keyPushOpts?: PushWorkspaceKeyOptions;
   /** TypeScript runtime a bare `.ts` denotes, for raw-app runnables */
   defaultTs?: "bun" | "deno";
+  /** schedule push into a fork: the file's `enabled` is the parent's */
+  enabledOwnedByParent?: boolean;
 }
 
 /**
@@ -217,6 +219,7 @@ export async function pushObj(
     wsSpecific,
     keyPushOpts,
     defaultTs,
+    enabledOwnedByParent,
   } = opts;
   const typeEnding = getTypeStrFromPath(p);
 
@@ -250,7 +253,7 @@ export async function pushObj(
   } else if (typeEnding === "resource-type") {
     await pushResourceType(workspace, p, befObj, newObj);
   } else if (typeEnding === "schedule") {
-    await pushSchedule(workspace, p, befObj, newObj, permissionedAsContext);
+    await pushSchedule(workspace, p, befObj, newObj, permissionedAsContext, enabledOwnedByParent);
   } else if (typeEnding === "http_trigger") {
     await pushTrigger("http", workspace, p, befObj, newObj, permissionedAsContext);
   } else if (typeEnding === "websocket_trigger") {

--- a/cli/test/push_diff_convergence_unit.test.ts
+++ b/cli/test/push_diff_convergence_unit.test.ts
@@ -229,3 +229,50 @@ test("push: an inline script the checkout names differently from the step summar
     ),
   ).toEqual(["edited f/mail/flow_v2.flow/process_mail.inline_script.py"]);
 });
+
+test("push: a checkout name that collides with another step's summary-derived name keeps two files", async () => {
+  const zip = new JSZip();
+  zip.file(
+    "f/mail/flow_v2.flow.json",
+    JSON.stringify({
+      summary: "Flow V2",
+      description: "",
+      value: {
+        modules: [
+          {
+            id: "a",
+            summary: SUMMARY,
+            value: {
+              type: "rawscript",
+              content: "a",
+              input_transforms: {},
+              language: "python3",
+            },
+          },
+          {
+            id: "b",
+            summary: "process_mail",
+            value: {
+              type: "rawscript",
+              content: "b",
+              input_transforms: {},
+              language: "python3",
+            },
+          },
+        ],
+      },
+      schema: { type: "object", properties: {} },
+    }),
+    { createFolders: false },
+  );
+  // Nothing local: every rendered file is a "deleted" row, one per path.
+  const rows = await diff(
+    local({}),
+    ZipFSElement(zip, true, "bun", {}, {}, false, true, checkoutNames) as any,
+    { includeSchedules: false },
+  );
+  expect(rows.filter((r) => r.endsWith(".py")).sort()).toEqual([
+    "deleted f/mail/flow_v2.flow/process_mail.inline_script.py",
+    "deleted f/mail/flow_v2.flow/process_one_mail_end-to-end_(spam_check,_classify).inline_script.py",
+  ]);
+});

--- a/cli/test/push_diff_convergence_unit.test.ts
+++ b/cli/test/push_diff_convergence_unit.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, expect, test } from "bun:test";
 import JSZip from "jszip";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import {
   compareDynFSElement,
   ZipFSElement,
@@ -29,6 +29,11 @@ type Mock = {
   getChildren(): AsyncIterable<Mock>;
 };
 
+// Both sides of the differ use the OS separator; fixtures are written with
+// "/" and rows are read back the same way.
+const osPath = (p: string) => p.split("/").join(sep);
+const slashPath = (p: string) => p.split(sep).join("/");
+
 function local(files: Record<string, string>): Mock {
   return {
     isDirectory: true,
@@ -40,7 +45,7 @@ function local(files: Record<string, string>): Mock {
       for (const [path, content] of Object.entries(files)) {
         yield {
           isDirectory: false,
-          path,
+          path: osPath(path),
           async getContentText() {
             return content;
           },
@@ -74,7 +79,7 @@ async function diff(
     false,
     parentOwnsScheduleEnabled,
   );
-  return changes.map((c) => `${c.name} ${c.path}`);
+  return changes.map((c) => `${c.name} ${slashPath(c.path)}`);
 }
 
 const SCHEDULE = (enabled: string) =>
@@ -85,7 +90,7 @@ test("push into a fork: a schedule the parent also has compares without `enabled
   const skips = { includeSchedules: true };
   // The parent has `f/mail/nightly`; any other schedule is the fork's own.
   const parentHas = (filePath: string) =>
-    filePath === "f/mail/nightly.schedule.yaml";
+    slashPath(filePath) === "f/mail/nightly.schedule.yaml";
 
   // Not a fork: `enabled` is compared like any other field.
   expect(
@@ -182,7 +187,7 @@ function localFlow(content: string) {
 
 // The checkout's `!inline` references, as `push` reads them from its flow.yaml.
 const checkoutNames = async (flowDir: string) =>
-  flowDir === "f/mail/flow_v2.flow"
+  slashPath(flowDir) === "f/mail/flow_v2.flow"
     ? { a: "process_mail.inline_script.py" }
     : {};
 

--- a/cli/test/push_diff_convergence_unit.test.ts
+++ b/cli/test/push_diff_convergence_unit.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import JSZip from "jszip";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import {
+  checkoutInlineNames,
   compareDynFSElement,
   ZipFSElement,
 } from "../src/commands/sync/sync.ts";
@@ -280,4 +281,18 @@ test("push: a checkout name that collides with another step's summary-derived na
     "deleted f/mail/flow_v2.flow/process_mail.inline_script.py",
     "deleted f/mail/flow_v2.flow/process_one_mail_end-to-end_(spam_check,_classify).inline_script.py",
   ]);
+});
+
+test("push: checkout inline names stay inside the flow folder", async () => {
+  const flowYaml = join(process.cwd(), "flow.yaml");
+  writeFileSync(
+    flowYaml,
+    `summary: x\nvalue:\n  modules:\n    - id: a\n      value:\n        type: rawscript\n        content: '!inline a.inline_script.py'\n        language: python3\n    - id: b\n      value:\n        type: rawscript\n        content: '!inline ../shared/b.py'\n        language: python3\n    - id: c\n      value:\n        type: rawscript\n        content: '!inline /tmp/c.py'\n        language: python3\n`,
+  );
+  expect(await checkoutInlineNames(flowYaml)).toEqual({
+    a: "a.inline_script.py",
+  });
+  expect(
+    await checkoutInlineNames(join(process.cwd(), "missing.yaml")),
+  ).toEqual({});
 });

--- a/cli/test/push_diff_convergence_unit.test.ts
+++ b/cli/test/push_diff_convergence_unit.test.ts
@@ -1,0 +1,231 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import JSZip from "jszip";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  compareDynFSElement,
+  ZipFSElement,
+} from "../src/commands/sync/sync.ts";
+
+// The differ also reads the working tree (shared lockfiles, dependency files);
+// an empty one keeps that out of the picture.
+const originalCwd = process.cwd();
+beforeAll(() => {
+  process.chdir(mkdtempSync(join(tmpdir(), "wmill-push-diff-")));
+});
+afterAll(() => {
+  process.chdir(originalCwd);
+});
+
+// A push is only useful when a second run of it finds nothing left to do.
+// These pin the two shapes that used to be listed on every run of a push into
+// a fork while the push itself either applied nothing or aborted.
+
+type Mock = {
+  isDirectory: boolean;
+  path: string;
+  getContentText(): Promise<string>;
+  getChildren(): AsyncIterable<Mock>;
+};
+
+function local(files: Record<string, string>): Mock {
+  return {
+    isDirectory: true,
+    path: "",
+    async getContentText() {
+      return "";
+    },
+    async *getChildren() {
+      for (const [path, content] of Object.entries(files)) {
+        yield {
+          isDirectory: false,
+          path,
+          async getContentText() {
+            return content;
+          },
+          async *getChildren() {},
+        };
+      }
+    },
+  };
+}
+
+const noIgnore = () => false;
+
+async function diff(
+  localEl: Mock,
+  remoteEl: Mock,
+  skips: Record<string, unknown>,
+  parentOwnsScheduleEnabled?: (scheduleFilePath: string) => boolean,
+) {
+  const { changes } = await compareDynFSElement(
+    localEl as any,
+    remoteEl as any,
+    noIgnore,
+    false,
+    skips as any,
+    true,
+    [],
+    false,
+    undefined,
+    undefined,
+    false,
+    false,
+    parentOwnsScheduleEnabled,
+  );
+  return changes.map((c) => `${c.name} ${c.path}`);
+}
+
+const SCHEDULE = (enabled: string) =>
+  `summary: nightly\nargs: {}\nenabled: ${enabled}\nis_flow: true\nschedule: 0 0 0 * * *\nscript_path: f/mail/flow\ntimezone: UTC\n`;
+
+test("push into a fork: a schedule the parent also has compares without `enabled`", async () => {
+  const remote = local({ "f/mail/nightly.schedule.yaml": SCHEDULE("true") });
+  const skips = { includeSchedules: true };
+  // The parent has `f/mail/nightly`; any other schedule is the fork's own.
+  const parentHas = (filePath: string) =>
+    filePath === "f/mail/nightly.schedule.yaml";
+
+  // Not a fork: `enabled` is compared like any other field.
+  expect(
+    await diff(
+      local({ "f/mail/nightly.schedule.yaml": SCHEDULE("false") }),
+      remote,
+      skips,
+    ),
+  ).toEqual(["edited f/mail/nightly.schedule.yaml"]);
+  expect(
+    await diff(
+      local({ "f/mail/nightly.schedule.yaml": SCHEDULE("false") }),
+      remote,
+      skips,
+      parentHas,
+    ),
+  ).toEqual([]);
+  // The key being absent is the same case as it differing.
+  expect(
+    await diff(
+      local({
+        "f/mail/nightly.schedule.yaml": SCHEDULE("false").replace(
+          "enabled: false\n",
+          "",
+        ),
+      }),
+      remote,
+      skips,
+      parentHas,
+    ),
+  ).toEqual([]);
+  // Only `enabled` is set aside.
+  expect(
+    await diff(
+      local({
+        "f/mail/nightly.schedule.yaml": SCHEDULE("false").replace(
+          "0 0 0 * * *",
+          "0 0 1 * * *",
+        ),
+      }),
+      remote,
+      skips,
+      parentHas,
+    ),
+  ).toEqual(["edited f/mail/nightly.schedule.yaml"]);
+  // A schedule only the fork has keeps toggling from the file.
+  expect(
+    await diff(
+      local({ "f/mail/fork_only.schedule.yaml": SCHEDULE("true") }),
+      local({ "f/mail/fork_only.schedule.yaml": SCHEDULE("false") }),
+      skips,
+      parentHas,
+    ),
+  ).toEqual(["edited f/mail/fork_only.schedule.yaml"]);
+});
+
+const SUMMARY = "process one mail end-to-end (spam check, classify)";
+
+function remoteFlow(content: string) {
+  const zip = new JSZip();
+  zip.file(
+    "f/mail/flow_v2.flow.json",
+    JSON.stringify({
+      summary: "Flow V2",
+      description: "",
+      value: {
+        modules: [
+          {
+            id: "a",
+            summary: SUMMARY,
+            value: {
+              type: "rawscript",
+              content,
+              input_transforms: {},
+              language: "python3",
+            },
+          },
+        ],
+      },
+      schema: { type: "object", properties: {} },
+    }),
+    // The backend's archive carries no directory entries.
+    { createFolders: false },
+  );
+  return zip;
+}
+
+function localFlow(content: string) {
+  return local({
+    "f/mail/flow_v2.flow/flow.yaml": `summary: Flow V2\ndescription: ''\nvalue:\n  modules:\n    - id: a\n      summary: ${SUMMARY}\n      value:\n        type: rawscript\n        content: '!inline process_mail.inline_script.py'\n        input_transforms: {}\n        language: python3\nschema:\n  type: object\n  properties: {}\n`,
+    "f/mail/flow_v2.flow/process_mail.inline_script.py": content,
+  });
+}
+
+// The checkout's `!inline` references, as `push` reads them from its flow.yaml.
+const checkoutNames = async (flowDir: string) =>
+  flowDir === "f/mail/flow_v2.flow"
+    ? { a: "process_mail.inline_script.py" }
+    : {};
+
+test("push: an inline script the checkout names differently from the step summary is not a rename", async () => {
+  const skips = { includeSchedules: false };
+  const render = (content: string, withCheckout: boolean) =>
+    ZipFSElement(
+      remoteFlow(content),
+      true,
+      "bun",
+      {},
+      {},
+      false,
+      true,
+      withCheckout ? checkoutNames : undefined,
+    ) as any;
+
+  // Same content, file named by hand: three rows before, none after.
+  expect(
+    await diff(
+      localFlow("def main():\n    return 1\n"),
+      render("def main():\n    return 1\n", false),
+      skips,
+    ),
+  ).toEqual([
+    "deleted f/mail/flow_v2.flow/process_one_mail_end-to-end_(spam_check,_classify).inline_script.py",
+    "edited f/mail/flow_v2.flow/flow.yaml",
+    "added f/mail/flow_v2.flow/process_mail.inline_script.py",
+  ]);
+  expect(
+    await diff(
+      localFlow("def main():\n    return 1\n"),
+      render("def main():\n    return 1\n", true),
+      skips,
+    ),
+  ).toEqual([]);
+
+  // A real edit is still one.
+  expect(
+    await diff(
+      localFlow("def main():\n    return 2\n"),
+      render("def main():\n    return 1\n", true),
+      skips,
+    ),
+  ).toEqual(["edited f/mail/flow_v2.flow/process_mail.inline_script.py"]);
+});


### PR DESCRIPTION
## Summary

A git-sync **Pull from repo** into a fork workspace (the pull job runs `wmill sync push` from the fork branch into the fork) reported `All 19 changes pushed`, and the next pull listed the same 19 rows. Nothing was dropped this time (unlike #10473): the content did land, but each row was a difference the push can never make go away, so the list is permanent and reads like a silent no-op. Two of the four shapes are the CLI's to fix:

1. **Schedules in a fork.** A fork clones every schedule disabled, the backend refuses to enable one whose path the parent also has (`fork-conflict:schedule:<parent>`), and for those paths the fork's tarball export writes the *parent's* `enabled` into the file (#9476). Between #8976 and #9476 the fork export omitted `enabled` entirely, so a fork branch can carry schedule files with no `enabled` or a stale one. On a push into the fork the differ then reports every such file as edited forever (`isSuperset` considers the push up to date), and when the file says `enabled: true` against a disabled fork copy the push calls `setScheduleEnabled`, hits the refusal, and aborts the whole pull job.
2. **Inline-script names.** `ZipFSElement` names a flow's rendered inline-script files from the step summary. A checkout that names the file differently (the flow.yaml `!inline` reference still resolves) shows a delete + `flow.yaml` edit + add on every push while the resolved flows compare equal, so `pushFlow` reports "up to date" and the three rows never clear. The existing "preserve original `!inline` filenames" `extractCurrentMapping(...)` call ran on the *remote* modules, whose content is script source and never an `!inline` reference, so it was always empty.

The other two shapes are on the checkout side and unchanged: a flow step lock file missing from git (the server relocks the flow after every push, so the `.lock` "deleted" row returns) and a stray file inside a `.flow/` folder.

## Changes

- `cli/src/commands/sync/sync.ts`: `push()` resolves `parentOwnedScheduleEnabled(workspaceId)`: `undefined` unless the target is a fork (`listUserWorkspaces` parent id, or the `wm-fork-` id prefix); otherwise a predicate saying whether a schedule file's `enabled` belongs to the parent, built from `listSchedules` on the parent. When the parent cannot be listed (a job token is scoped to the fork), every schedule is treated as the parent's, so nothing is toggled and nothing aborts. A fork-only schedule keeps toggling from the file.
- `cli/src/commands/sync/sync.ts`: `compareDynFSElement` takes that predicate and compares matching schedule files without `enabled` (YAML and JSON).
- `cli/src/commands/sync/sync.ts`: `ZipFSElement` takes an optional `localFlowInlineMapping(flowDir)`; `push()` feeds it the checkout's `flow.yaml` `!inline` references (module id → file, via `extractCurrentMapping`), so the remote render uses the same file names as git. `pull()` is untouched: a rename on pull converges after one pull. The dead remote-side `extractCurrentMapping` call is removed. Both functions are now exported for the unit test.
- `cli/src/commands/schedule/schedule.ts`, `cli/src/types.ts`: `pushSchedule(..., enabledOwnedByParent)` (threaded through `PushObjOptions`) drops `enabled` from the update when the fork already has the row, which also skips the `setScheduleEnabled` call. Creating a schedule the fork does not have keeps the file's value. The stale comment saying the fork export "strips" `enabled` is replaced by the one constraint that guard now serves.
- `cli/test/push_diff_convergence_unit.test.ts`: a schedule the parent has compares without `enabled` (differing or absent), still reports other field changes, and a fork-only schedule still reports an `enabled` change; a remote flow rendered with the checkout's names produces no rows for identical content and a single `edited` for a real content change.

- Review follow-ups (368cad5bad): the parent lookup runs only when `includeSchedules` is on, after the options merge; a `fork-conflict:schedule` answer to `setScheduleEnabled` is logged and skipped instead of failing the push (the parent listing is RLS-scoped, the backend's check is not); a checkout `!inline` name equal to another step's summary-derived name makes that flow render the export's way, so two steps never share one path.

- Hardening (f092836443): when a fork schedule's flag is set aside while the file disagrees, or the backend refuses an enable with `fork-conflict`, the CLI says so on stderr through a new `log.warnAlways` that survives `--json-output` (the git-sync job runs with that flag, and `log.warn` is silenced after startup there). `checkoutInlineNames` ignores a reference that leaves the flow folder (`..` segments or an absolute path), so a remote step can never be rendered onto another item's path.
- b4dcf0490c: a create into a fork lands disabled on the backend whatever the request says, so a fork-only schedule the file wants enabled is enabled right after creation (one push converges) while a parent-owned one is created disabled with a notice. A `wm-fork-*` workspace whose parent was deleted keeps its prefix but nothing defers to a parent any more: when the listing says it has no parent it is handled as a normal workspace, so its schedules toggle from git again.
- Known limit, unchanged behavior: a fork-scoped job token cannot call `listUserWorkspaces` or the parent's `listSchedules` (both 401), so in the git-sync job a throwaway fork is detected by its `wm-fork-` prefix and every schedule is treated as the parent's (fork-only schedules are not toggled from git there, with a notice). A dev workspace (custom id with a parent) is not detected on that path and keeps today's behavior; closing that needs the parent id on a workspace-scoped endpoint, a backend follow-up.

## Test plan

- [x] `UNIT_ONLY=1 bun test test/push_diff_convergence_unit.test.ts` passes; full `bun run test:unit`: 1102 pass, 0 fail
- [x] `bun run check`: the same 18 pre-existing errors as `main`, none in the touched files beyond the pre-existing `JSZip | TarAsZip` ones at the two `ZipFSElement` call sites
- [x] Manual, against a local CE backend with a parent workspace, a fork created via `create_fork`, and a checkout pulled from the parent (dotted layout, `includeSchedules`): with the fork's step renamed and the checkout keeping the old file name, `wmill sync push --workspace <fork>` lists one `edited` content row instead of the delete/edit/add triple, applies the content, and a second run lists nothing for that flow
- [x] Manual: parent schedule disabled while the checkout says `enabled: true` (previously aborted the push with `fork-conflict:schedule`), and a checkout schedule file with no `enabled` key against an enabled parent (previously "edited" on every run): the push succeeds, the fork's copies stay disabled, and the second dry run lists neither
- [x] Manual: a schedule that exists only in the fork, `enabled: true` in the checkout, is enabled by the push
- [x] Manual: a push into a non-fork workspace still applies `enabled` from the file; `sync pull` unchanged
- [ ] Shipping needs the usual chain: publish `windmill-cli`, republish hub script 13952 (git-sync init) with the new pin, bump `GIT_SYNC_PULL_SCRIPT_PATH` and `gitInitRepo` (auto-pull runs the same pinned script)

No frontend changes, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcofduXAs9FT948Aj78V8m

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2478: previously, `wmill sync push` into a fork could repeatedly report schedule and inline-script filename changes or abort on a schedule conflict. It now preserves parent-owned schedule flags, enables fork-only schedules on create, and renders inline scripts with safe checkout filenames so repeated pushes converge.

- Parent schedule ownership comes from workspace and schedule listings when available; fork-scoped jobs fall back to `wm-fork-` detection, while forks without a parent treat schedules as local.
- `fork-conflict:schedule` responses no longer fail the push, and warnings remain visible with `--json-output`.
- Inline references outside the flow folder are ignored, and colliding checkout names fall back to unique export-derived names.
- Non-fork pushes and `sync pull` keep their existing behavior; unit tests cover schedule changes, inline matching, collisions, path traversal, and OS-specific paths.

**Release**

- Publish `windmill-cli`, republish hub script 13952 with the new pin, and bump `GIT_SYNC_PULL_SCRIPT_PATH` and `gitInitRepo`.

<sup>Written for commit b4dcf0490c817f0a64e2ec0892db184aaa463972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Fixes WIN-2478

