### PR TITLE
fix: fade the home Build with AI placeholder every 10s instead of typing it

### DIFF
--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -133,7 +133,7 @@
 	const prompts = homeAIExamples.map((e) => e.prompt)
 
 	const CYCLE_MS = 7_000
-	// Must match the `placeholder:duration-*` class on the textarea: the swap happens once the
+	// Must match the `duration-*` class on the placeholder overlay: the swap happens once the
 	// fade-out has finished, and Tailwind only emits classes it finds written out in full.
 	const FADE_MS = 600
 
@@ -189,12 +189,27 @@
 				<div class="relative {blurClass}" inert={disabled}>
 					<TextInput
 						bind:value
-						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent placeholder:transition-opacity placeholder:duration-[600ms] placeholder:ease-in-out {placeholderVisible
-							? 'placeholder:opacity-100'
-							: 'placeholder:opacity-0'}"
+						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent"
 						underlyingInputEl="textarea"
-						inputProps={{ rows: 4, placeholder, onkeydown: onKeydown }}
+						inputProps={{
+							rows: 4,
+							'aria-label': 'Describe what you want to build',
+							onkeydown: onKeydown
+						}}
 					/>
+					{#if !value}
+						<!-- Drawn over the textarea instead of set as its `placeholder`: WebKit and Gecko do
+						     not run transitions on `::placeholder`, so the fade would be a hard cut there.
+						     The 1px margin is the textarea's border, so the text sits where typing starts. -->
+						<span
+							aria-hidden="true"
+							class="pointer-events-none absolute inset-x-4 top-3 m-px text-xs text-hint transition-opacity duration-[600ms] ease-in-out {placeholderVisible
+								? 'opacity-100'
+								: 'opacity-0'}"
+						>
+							{placeholder}
+						</span>
+					{/if}
 					<Button
 						endIcon={starting ? {} : { icon: ArrowUp }}
 						wrapperClasses="absolute right-2 bottom-3.5"

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
 	/** Example prompts: the short `label` is shown as a clickable tag under the chat,
-	 * the `prompt` is what gets typed out as the placeholder / dropped into the input. */
+	 * the `prompt` is what rotates through the placeholder / gets dropped into the input. */
 	export const homeAIExamples: { label: string; prompt: string }[] = [
 		{
 			label: 'Sync Salesforce',
@@ -49,7 +49,8 @@
 	const COLLAPSED_SETTING = 'home-ai-composer-collapsed'
 
 	let value = $state('')
-	let placeholder = $state('')
+	let placeholder = $state(homeAIExamples[0].prompt)
+	let placeholderVisible = $state(true)
 	let homeConnectDrawer: HomeConnectDrawer | undefined = $state(undefined)
 
 	// How much of the home page this reader wants the composer to take, so it lives per browser
@@ -130,45 +131,29 @@
 
 	const prompts = homeAIExamples.map((e) => e.prompt)
 
-	const TYPE_MS = 45
-	const DELETE_MS = 25
-	const HOLD_MS = 1800
-	const PAUSE_MS = 400
+	const CYCLE_MS = 10_000
+	const FADE_MS = 200
 
-	// Typewriter effect: type a prompt out, hold, delete, then advance to the next. Only while the
-	// composer is shown — otherwise (operators) it would loop forever driving an unrendered input.
+	// Rotate the example prompt every CYCLE_MS: fade the placeholder out, swap it, fade it back in.
+	// Only while the composer is shown — otherwise (operators) it would loop forever driving an
+	// unrendered input. The index lives outside the effect so re-showing the composer resumes the
+	// rotation from the prompt currently displayed rather than restarting it.
+	let promptIndex = 0
 	$effect(() => {
 		if (!showComposer || collapsed) return
-		let promptIndex = 0
-		let charIndex = 0
-		let deleting = false
 		let timer: ReturnType<typeof setTimeout>
 
-		function tick() {
-			const current = prompts[promptIndex]
-			if (!deleting) {
-				charIndex++
-				placeholder = current.slice(0, charIndex)
-				if (charIndex >= current.length) {
-					deleting = true
-					timer = setTimeout(tick, HOLD_MS)
-					return
-				}
-				timer = setTimeout(tick, TYPE_MS)
-			} else {
-				charIndex--
-				placeholder = current.slice(0, charIndex)
-				if (charIndex <= 0) {
-					deleting = false
-					promptIndex = (promptIndex + 1) % prompts.length
-					timer = setTimeout(tick, PAUSE_MS)
-					return
-				}
-				timer = setTimeout(tick, DELETE_MS)
-			}
+		function next() {
+			placeholderVisible = false
+			timer = setTimeout(() => {
+				promptIndex = (promptIndex + 1) % prompts.length
+				placeholder = prompts[promptIndex]
+				placeholderVisible = true
+				timer = setTimeout(next, CYCLE_MS)
+			}, FADE_MS)
 		}
 
-		timer = setTimeout(tick, TYPE_MS)
+		timer = setTimeout(next, CYCLE_MS)
 		return () => clearTimeout(timer)
 	})
 </script>
@@ -195,7 +180,9 @@
 				<div class="relative {blurClass}" inert={disabled}>
 					<TextInput
 						bind:value
-						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent"
+						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent placeholder:transition-opacity placeholder:duration-200 {placeholderVisible
+							? 'placeholder:opacity-100'
+							: 'placeholder:opacity-0'}"
 						underlyingInputEl="textarea"
 						inputProps={{ rows: 4, placeholder, onkeydown: onKeydown }}
 					/>

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -40,6 +40,7 @@
 	import { base } from '$lib/base'
 	import { getLocalSetting, storeLocalSetting } from '$lib/utils'
 	import { isRuleActive } from '$lib/workspaceProtectionRules.svelte'
+	import { useReducedMotion } from '$lib/svelte5Utils.svelte'
 	import { BROWSER } from 'esm-env'
 	import AIChatModelSettings from '../copilot/chat/AIChatModelSettings.svelte'
 	import HomeConnectDrawer from './HomeConnectDrawer.svelte'
@@ -138,11 +139,13 @@
 
 	// Rotate the example prompt every CYCLE_MS: fade the placeholder out, swap it, fade it back in.
 	// Only while the composer is shown — otherwise (operators) it would loop forever driving an
-	// unrendered input. The index lives outside the effect so re-showing the composer resumes the
-	// rotation from the prompt currently displayed rather than restarting it.
+	// unrendered input — and not under reduced motion, where the first prompt simply stays put.
+	// The index lives outside the effect so re-showing the composer resumes the rotation from the
+	// prompt currently displayed rather than restarting it.
+	const reducedMotion = useReducedMotion()
 	let promptIndex = 0
 	$effect(() => {
-		if (!showComposer || collapsed) return
+		if (!showComposer || collapsed || reducedMotion.val) return
 		let timer: ReturnType<typeof setTimeout>
 
 		function next() {

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -154,7 +154,11 @@
 		}
 
 		timer = setTimeout(next, CYCLE_MS)
-		return () => clearTimeout(timer)
+		return () => {
+			clearTimeout(timer)
+			// Torn down mid-fade, the input would otherwise remount with an invisible placeholder.
+			placeholderVisible = true
+		}
 	})
 </script>
 

--- a/frontend/src/lib/components/home/HomeAIChat.svelte
+++ b/frontend/src/lib/components/home/HomeAIChat.svelte
@@ -131,8 +131,10 @@
 
 	const prompts = homeAIExamples.map((e) => e.prompt)
 
-	const CYCLE_MS = 10_000
-	const FADE_MS = 200
+	const CYCLE_MS = 7_000
+	// Must match the `placeholder:duration-*` class on the textarea: the swap happens once the
+	// fade-out has finished, and Tailwind only emits classes it finds written out in full.
+	const FADE_MS = 600
 
 	// Rotate the example prompt every CYCLE_MS: fade the placeholder out, swap it, fade it back in.
 	// Only while the composer is shown — otherwise (operators) it would loop forever driving an
@@ -184,7 +186,7 @@
 				<div class="relative {blurClass}" inert={disabled}>
 					<TextInput
 						bind:value
-						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent placeholder:transition-opacity placeholder:duration-200 {placeholderVisible
+						class="resize-none px-4 py-3 pb-9 shadow-sm border-accent placeholder:transition-opacity placeholder:duration-[600ms] placeholder:ease-in-out {placeholderVisible
 							? 'placeholder:opacity-100'
 							: 'placeholder:opacity-0'}"
 						underlyingInputEl="textarea"


### PR DESCRIPTION
## Summary
The "Build with AI" composer on the home page typed each example prompt into the textarea placeholder character by character and then deleted it, so the placeholder was in constant motion. It now holds one example prompt and, every 7 seconds, fades it out (600ms, ease-in-out), swaps to the next prompt while invisible, and fades it back in (600ms).

## Changes
- `HomeAIChat.svelte`: replace the typewriter `$effect` (type / hold / delete / pause timers) with a single 7s cycle that toggles a `placeholderVisible` flag around the prompt swap.
- The example prompt is drawn as a decorative `aria-hidden` span positioned over the textarea's content box (same font, hint color, 1px margin for the border) and removed as soon as the value is non-empty. It is not set as the textarea's `placeholder` attribute because WebKit and Gecko do not run transitions on `::placeholder`, so a fade there renders as a hard cut. The textarea gets a stable `aria-label` ("Describe what you want to build") instead of a rotating accessible name.
- The placeholder starts as the first example prompt instead of empty, so there is no typing-in on load.
- The prompt index lives outside the effect, so hiding and re-showing the composer resumes from the current prompt rather than restarting from the first.
- The effect cleanup resets `placeholderVisible` to true, so hiding the composer during the fade-out and reopening it does not remount the overlay invisible for the rest of the cycle.
- Under `prefers-reduced-motion: reduce` (via the existing `useReducedMotion()` helper) the rotation does not run and the first example prompt stays as a static placeholder.

## Test plan
- [x] Home page with an AI provider configured: the overlay shows the first example prompt at full opacity on load, and its bounding box matches the textarea's content box (border + padding) to the pixel, with the same 12px/16px font and the hint color.
- [x] Sampled the overlay's computed opacity every 16ms: transition is `opacity 0.6s cubic-bezier(0.4, 0, 0.2, 1)`; opacity holds at 1 for 7s, goes 1 to 0 in ~580ms, the text swaps at opacity 0, then goes 0 to 1 in ~600ms.
- [x] Prompts rotate in order (Salesforce -> Discord -> Slack report) and wrap around.
- [x] Typing removes the overlay; clearing the textarea brings it back.
- [x] Clicked "Hide Build with AI" while the overlay had the `opacity-0` class, then reopened via the "Build with AI" pill: the overlay remounts with `opacity-100`, computed opacity 1, same prompt as before hiding.
- [x] With `prefers-reduced-motion: reduce` emulated: 9s of sampling shows opacity pinned at 1 and no prompt swap; switching the emulation back to `no-preference` on the same page resumes the fade and rotation.
- [x] `npm run check:fast` shows no errors in the changed file; the Svelte autofixer and Prettier pass.

## Screenshots
Two captures of the same page one rotation apart, showing the placeholder moved on to the next example prompt.

![home-build-with-ai-prompt-a](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-placeholder-fade-animation/1788419037-home-build-with-ai-prompt-a.png)
![home-build-with-ai-prompt-b](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/build-ai-placeholder-fade-animation/1788419039-home-build-with-ai-prompt-b.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FYwgUVWBC2qfk5jv8ZYcn
