### PR TITLE
fix: bump git sync hub scripts to cli 1.802.1, test the fork ui pull

### DIFF
--- a/.github/workflows/git-sync-test.yml
+++ b/.github/workflows/git-sync-test.yml
@@ -9,6 +9,7 @@ on:
       - "backend/windmill-api-integration-tests/tests/git_sync*"
       - "backend/ee-repo-ref.txt"
       - "backend/windmill-common/src/workspaces.rs"
+      - "frontend/src/lib/hubPaths.json"
       - "backend/windmill-worker/src/result_processor.rs"
       - "backend/windmill-api-workspaces/**"
       - "cli/src/commands/sync/**"
@@ -22,6 +23,7 @@ on:
       - "backend/windmill-api-integration-tests/tests/git_sync*"
       - "backend/ee-repo-ref.txt"
       - "backend/windmill-common/src/workspaces.rs"
+      - "frontend/src/lib/hubPaths.json"
       - "backend/windmill-worker/src/result_processor.rs"
       - "backend/windmill-api-workspaces/**"
       - "cli/src/commands/sync/**"
@@ -59,7 +61,7 @@ jobs:
           echo "$CHANGED_FILES"
 
           # Direct git sync file changes — always relevant.
-          if echo "$CHANGED_FILES" | grep -qE '^(backend/windmill-git-sync/|backend/windmill-worker/src/result_processor\.rs|backend/windmill-api-workspaces/|backend/windmill-api-integration-tests/tests/git_sync|backend/windmill-common/src/workspaces\.rs|cli/src/commands/sync/|cli/src/utils/git\.ts|integration_tests/test/git_sync|\.github/workflows/git-sync-test\.yml)'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(backend/windmill-git-sync/|backend/windmill-worker/src/result_processor\.rs|backend/windmill-api-workspaces/|backend/windmill-api-integration-tests/tests/git_sync|backend/windmill-common/src/workspaces\.rs|frontend/src/lib/hubPaths\.json|cli/src/commands/sync/|cli/src/utils/git\.ts|integration_tests/test/git_sync|\.github/workflows/git-sync-test\.yml)'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Relevant: direct git sync file changes"
             exit 0

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -175,7 +175,7 @@ pub enum ObjectType {
     DatatableMigration,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28911/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28931/sync-script-to-git-repo-windmill";
 
 /// Hub script that applies a repository's state back into a workspace
 /// (the repo → Windmill / "pull" direction). Same script the UI runs from
@@ -183,7 +183,7 @@ pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28911/sync-script-to-git-repo
 /// ignores the slug, so the slug is kept free of characters that would be
 /// percent-encoded into the run URL (a `:` becomes `%3A`, which some hardened
 /// reverse proxies reject as double-encoding when the client re-encodes it).
-pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28910/git-sync-init-repository-windmill";
+pub const GIT_SYNC_PULL_SCRIPT_PATH: &str = "hub/28930/git-sync-init-repository-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,6 +1,6 @@
 {
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28910/git-sync-init-repository-windmill",
+	"gitInitRepo": "hub/28930/git-sync-init-repository-windmill",
 	"slackErrorHandler": "hub/28794/workspace-or-schedule-error-handler-slack",
 	"emailErrorHandler": "hub/19795/workspace-or-error-handler-email",
 	"slackRecoveryHandler": "hub/28791/slack/schedule-recovery-handler-slack",

--- a/integration_tests/test/git_sync_test.py
+++ b/integration_tests/test/git_sync_test.py
@@ -1,9 +1,11 @@
+import json
 import os
 import shutil
 import tempfile
 import time
 import unittest
 import uuid
+from pathlib import Path
 
 import git as gitpython
 
@@ -17,6 +19,13 @@ def ts_script(body: str) -> str:
 
 def unique_name(prefix: str = "git-sync-test") -> str:
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def ui_pull_script_path() -> str:
+    """The hub script the git-sync UI runs for a pull (git → workspace)."""
+    hub_paths = Path(__file__).resolve().parents[2] / "frontend/src/lib/hubPaths.json"
+    with open(hub_paths) as f:
+        return json.load(f)["gitInitRepo"]
 
 
 class GitSyncTestBase(unittest.TestCase):
@@ -220,6 +229,84 @@ class GitSyncTestBase(unittest.TestCase):
             f"Expected '{script_path}' .ts file in repo files: {files}",
         )
         return matching[0]
+
+    def _seed_wmill_yaml(
+        self, repo_name: str, branch: str = "main", include_schedules: bool = False
+    ):
+        """Commit a minimal wmill.yaml: the pull CLI requires one in the repo.
+        Real setups get it from the init/settings-push flow; pushes alone
+        don't write it."""
+        self._gitea.create_file(
+            repo_name,
+            "wmill.yaml",
+            "defaultTs: bun\n"
+            "includes:\n"
+            '  - "**"\n'
+            "excludes: []\n"
+            "codebases: []\n"
+            "skipVariables: true\n"
+            "skipResources: true\n"
+            "skipResourceTypes: true\n"
+            "skipSecrets: true\n"
+            f"includeSchedules: {'true' if include_schedules else 'false'}\n"
+            "includeTriggers: false\n",
+            branch=branch,
+        )
+
+    def _create_fork(self, client: WindmillClient) -> tuple:
+        """Fork `client`'s workspace the way the UI does (branch job first, then
+        the workspace). Returns (fork_id, fork_branch)."""
+        fork_id = f"wm-fork-{uuid.uuid4().hex[:8]}"
+        self._fork_workspaces_to_cleanup.append(fork_id)
+        job_ids = client.create_workspace_fork_branch(fork_id, f"Fork {fork_id}")
+        if job_ids:
+            client.wait_for_jobs_by_ids(job_ids, timeout=90)
+            time.sleep(3)
+        client.create_workspace_fork(fork_id, f"Fork {fork_id}")
+        return fork_id, f"wm-fork/main/{fork_id[len('wm-fork-'):]}"
+
+    def _run_ui_pull(
+        self,
+        client: WindmillClient,
+        resource_path: str,
+        include_type: list,
+        clone_ref: str = None,
+        dry_run: bool = False,
+        timeout: int = 180,
+    ) -> dict:
+        """Run the pull the git-sync UI runs (git → `client`'s workspace) and
+        return the job's result. `dry_run` is the UI's preview."""
+        payload = {
+            "workspace_id": client._workspace,
+            "repo_url_resource_path": resource_path,
+            "dry_run": dry_run,
+            "pull": True,
+            "only_wmill_yaml": False,
+            "settings_json": json.dumps({
+                "include_path": ["**"],
+                "exclude_path": [],
+                "extra_include_path": [],
+                "include_type": include_type,
+            }),
+            "use_promotion_overrides": False,
+            **({"clone_ref": clone_ref} if clone_ref else {}),
+        }
+        response = client._client.post(
+            f"/api/w/{client._workspace}/jobs/run/p/{ui_pull_script_path()}",
+            params={"skip_preprocessor": "true"},
+            json=payload,
+        )
+        self.assertEqual(
+            response.status_code // 100, 2, f"UI pull failed to start: {response.content.decode()}"
+        )
+        job_id = response.content.decode()
+        client.wait_for_jobs_by_ids([job_id], timeout=timeout)
+        job = client._client.get(f"/api/w/{client._workspace}/jobs_u/get/{job_id}").json()
+        self.assertTrue(
+            job.get("success"),
+            f"UI pull job {job_id} failed: {job.get('result')}\n{job.get('logs')}",
+        )
+        return job.get("result") or {}
 
 
 class TestGitSync(GitSyncTestBase):
@@ -802,27 +889,6 @@ class TestGitSyncAutoPull(GitSyncTestBase):
     # Two poll cycles + job execution, with slack for a loaded CI runner.
     PULL_TIMEOUT = 240
 
-    def _seed_wmill_yaml(self, repo_name: str, branch: str = "main"):
-        """Commit a minimal wmill.yaml: the pull CLI requires one in the repo.
-        Real setups get it from the init/settings-push flow; pushes alone
-        don't write it."""
-        self._gitea.create_file(
-            repo_name,
-            "wmill.yaml",
-            "defaultTs: bun\n"
-            "includes:\n"
-            '  - "**"\n'
-            "excludes: []\n"
-            "codebases: []\n"
-            "skipVariables: true\n"
-            "skipResources: true\n"
-            "skipResourceTypes: true\n"
-            "skipSecrets: true\n"
-            "includeSchedules: false\n"
-            "includeTriggers: false\n",
-            branch=branch,
-        )
-
     def _configure_auto_pull(self, resource_path: str, sync_forks: bool = False):
         """Single sync repo with auto-pull enabled in polling mode."""
         auto_pull = {"enabled": True, "mode": "polling"}
@@ -914,16 +980,7 @@ class TestGitSyncAutoPull(GitSyncTestBase):
 
         self._configure_auto_pull(resource_path, sync_forks=True)
 
-        # Create the fork (branch first, then workspace), like the UI does.
-        fork_id = f"wm-fork-{uuid.uuid4().hex[:8]}"
-        self._fork_workspaces_to_cleanup.append(fork_id)
-        job_ids = self._client.create_workspace_fork_branch(fork_id, f"Fork {fork_id}")
-        if job_ids:
-            self._client.wait_for_jobs_by_ids(job_ids, timeout=90)
-            time.sleep(3)
-        self._client.create_workspace_fork(fork_id, f"Fork {fork_id}")
-
-        fork_branch = f"wm-fork/main/{fork_id[len('wm-fork-'):]}"
+        fork_id, fork_branch = self._create_fork(self._client)
         self._gitea.create_file(
             repo_name, script_file, ts_script("return 'fork only'"),
             branch=fork_branch,
@@ -1012,19 +1069,12 @@ class TestGitSyncAutoPull(GitSyncTestBase):
             f"attach_dev_workspace failed: {attach.content.decode()}",
         )
 
-        # Fork the dev workspace (branch first, then workspace) — its parent is
-        # the dev, so this is a fork OF a dev workspace.
-        fork_id = f"wm-fork-{uuid.uuid4().hex[:8]}"
-        self._fork_workspaces_to_cleanup.append(fork_id)
-        job_ids = dev_client.create_workspace_fork_branch(fork_id, f"Fork {fork_id}")
-        if job_ids:
-            dev_client.wait_for_jobs_by_ids(job_ids, timeout=90)
-            time.sleep(3)
-        dev_client.create_workspace_fork(fork_id, f"Fork {fork_id}")
+        # Fork the dev workspace — its parent is the dev, so this is a fork OF
+        # a dev workspace.
+        fork_id, fork_branch = self._create_fork(dev_client)
 
         # The fork branch is named after the tracked branch, not the dev label.
         fork_suffix = fork_id[len("wm-fork-"):]
-        fork_branch = f"wm-fork/main/{fork_suffix}"
         branches = self._get_branches(self._clone_repo_all_branches(repo_name))
         self.assertTrue(
             any(fork_branch in b for b in branches),
@@ -1194,4 +1244,67 @@ class TestGitSyncAutoPull(GitSyncTestBase):
             self._client.count_deployment_callback_jobs(),
             initial_count,
             "Unknown webhook delivery enqueued a job",
+        )
+
+
+class TestGitSyncUiPull(GitSyncTestBase):
+    """The pull the git-sync UI runs (hub init script, git → workspace)."""
+
+    def test_fork_pull_does_not_report_parent_owned_schedule_enabled(self):
+        """In a fork, a schedule the parent also has takes its `enabled` from
+        the parent, so a fork-branch file that disagrees on that flag can never
+        be made to agree: a pull that treated it as a change would list the
+        same row on every run. Pull into the fork, then preview: the schedule
+        must not be reported, while an ordinary fork-branch edit does land."""
+        repo_name, _ = self._create_test_repo()
+        resource_path = self._setup_git_sync_resource(repo_name)
+        include_type = ["script", "schedule"]
+        self._configure_single_repo_sync(resource_path, include_type=include_type)
+
+        script_path = self._deploy_seed_script("forkuipull")
+        schedule_path = f"u/admin/{unique_name('forkuipull_sched')}"
+        initial_count = self._client.count_deployment_callback_jobs()
+        self._client.create_schedule(schedule_path, script_path, schedule="0 0 0 1 1 *")
+        self.addCleanup(self._client.delete_schedule, schedule_path)
+        self._client.wait_for_sync_jobs(initial_count, min_new=1)
+        time.sleep(3)
+        self._seed_wmill_yaml(repo_name, include_schedules=True)
+
+        # Fork after the schedule reached git so the fork branch inherits it
+        # with the parent's `enabled: true`; the fork's own copy lands disabled.
+        fork_id, fork_branch = self._create_fork(self._client)
+
+        schedule_file = f"{schedule_path}.schedule.yaml"
+        fork_dir = self._clone_repo(repo_name, branch=fork_branch)
+        content = self._read_file_content(fork_dir, schedule_file)
+        self.assertIn(
+            "enabled: true", content, f"expected the parent's enabled schedule in git:\n{content}"
+        )
+        self._gitea.create_file(
+            repo_name,
+            schedule_file,
+            content.replace("enabled: true", "enabled: false"),
+            branch=fork_branch,
+        )
+        # A real change alongside it proves the pull ran against the fork branch.
+        script_file = self._repo_script_file(repo_name, script_path, branch=fork_branch)
+        self._gitea.create_file(
+            repo_name, script_file, ts_script("return 'fork ui pull'"), branch=fork_branch
+        )
+
+        fork_client = WindmillClient(workspace=fork_id)
+        self._run_ui_pull(fork_client, resource_path, include_type, clone_ref=fork_branch)
+        self.assertIn(
+            "fork ui pull",
+            fork_client.get_script_content(script_path),
+            "the fork-branch script edit was not applied by the pull",
+        )
+        preview = self._run_ui_pull(
+            fork_client, resource_path, include_type, clone_ref=fork_branch, dry_run=True
+        )
+        changes = preview.get("changes") or []
+        self.assertEqual(
+            [c for c in changes if c.get("path", "").endswith(schedule_file)],
+            [],
+            f"a pull into the fork keeps reporting the parent-owned schedule flag: {changes}",
         )

--- a/integration_tests/test/git_sync_test.py
+++ b/integration_tests/test/git_sync_test.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import tempfile
 import time
@@ -21,11 +22,19 @@ def unique_name(prefix: str = "git-sync-test") -> str:
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
 def ui_pull_script_path() -> str:
     """The hub script the git-sync UI runs for a pull (git → workspace)."""
-    hub_paths = Path(__file__).resolve().parents[2] / "frontend/src/lib/hubPaths.json"
-    with open(hub_paths) as f:
+    with open(REPO_ROOT / "frontend/src/lib/hubPaths.json") as f:
         return json.load(f)["gitInitRepo"]
+
+
+def backend_pull_script_path() -> str:
+    """The hub script the backend runs for an auto-pull: `GIT_SYNC_PULL_SCRIPT_PATH`."""
+    source = (REPO_ROOT / "backend/windmill-common/src/workspaces.rs").read_text()
+    return re.search(r'GIT_SYNC_PULL_SCRIPT_PATH: &str = "([^"]+)"', source).group(1)
 
 
 class GitSyncTestBase(unittest.TestCase):
@@ -1250,6 +1259,11 @@ class TestGitSyncAutoPull(GitSyncTestBase):
 class TestGitSyncUiPull(GitSyncTestBase):
     """The pull the git-sync UI runs (hub init script, git → workspace)."""
 
+    def test_ui_pull_script_is_the_backend_pull_script(self):
+        """The UI's pull and the backend's auto-pull are the same hub script,
+        so the two pins must move together."""
+        self.assertEqual(ui_pull_script_path(), backend_pull_script_path())
+
     def test_fork_pull_does_not_report_parent_owned_schedule_enabled(self):
         """In a fork, a schedule the parent also has takes its `enabled` from
         the parent, so a fork-branch file that disagrees on that flag can never
@@ -1302,7 +1316,9 @@ class TestGitSyncUiPull(GitSyncTestBase):
         preview = self._run_ui_pull(
             fork_client, resource_path, include_type, clone_ref=fork_branch, dry_run=True
         )
-        changes = preview.get("changes") or []
+        self.assertIn("changes", preview, f"preview result has no changes list: {preview}")
+        changes = preview["changes"]
+        self.assertIsInstance(changes, list, f"preview changes is not a list: {preview}")
         self.assertEqual(
             [c for c in changes if c.get("path", "").endswith(schedule_file)],
             [],


### PR DESCRIPTION
## Summary
The git-sync pull the UI runs into a fork listed the same rows on every run: in a fork, a schedule the parent also has takes its `enabled` from the parent, so a fork-branch `schedule.yaml` that disagrees on that flag can never be made to agree (and a `true` against a disabled fork copy aborts the pull with `fork-conflict:schedule`). #10951 fixed this in the CLI and `windmill-cli@1.802.1` carries it. The two git-sync hub scripts were republished pinning 1.802.1 (windmill-labs/windmill-integrations#183): ask 13952 "Git-sync: init repository" is now `hub/28930`, ask 6943 "Sync script to Git repo" is `hub/28931`. This PR points the backend and frontend at them and adds the e2e that pins the behaviour.

## Changes
- `LATEST_GIT_SYNC_SCRIPT_PATH` 28911 → 28931 and `GIT_SYNC_PULL_SCRIPT_PATH` 28910 → 28930 in `backend/windmill-common/src/workspaces.rs`; `gitInitRepo` 28910 → 28930 in `frontend/src/lib/hubPaths.json`.
- New e2e `TestGitSyncUiPull.test_fork_pull_does_not_report_parent_owned_schedule_enabled` in `integration_tests/test/git_sync_test.py`: a parent schedule (enabled, synced to git) → fork → on the fork branch flip the `schedule.yaml` to `enabled: false` and edit the seed script → run the pull the UI runs (hub init script, `pull=true`, `clone_ref=wm-fork/main/<id>`), then its preview. The script edit must have landed (positive control) and the schedule must not be listed. The hub id is read from `hubPaths.json`, the pin the UI actually runs.
- Shared helpers on the base class: `_seed_wmill_yaml(include_schedules=...)` (moved from the auto-pull class), `_create_fork`, `_run_ui_pull`; the two existing fork tests use `_create_fork`.
- `.github/workflows/git-sync-test.yml` also triggers on `frontend/src/lib/hubPaths.json`, since the e2e now depends on it.

## Test plan
- [x] Before/after against the same local EE backend (Gitea + this suite): with `gitInitRepo` at `hub/28910` the new test fails with `[{'path': 'u/admin/….schedule.yaml', 'type': 'edited'}] != []` after the apply; at `hub/28930` it passes and the pull job log shows `changes: []`.
- [x] Full `test.git_sync_test` suite locally against the bumped pins: 18/18 OK.
- [x] `hub/28930` and `hub/28931` both import `windmill-cli@1.802.1`; the published tarball contains `parentOwnedScheduleEnabled`; `sync git-deploy --help` exits 0 on 1.802.1 (the deployment callback still has its subcommand).
- [ ] CI `Git Sync Integration Tests` green on this PR.

## Screenshots
No visible UI change: the frontend diff is the hub id in `hubPaths.json`, which the pull modal runs as a job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yMLnAWdjpCEs5VyGMn9ww

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git-sync pulls in forks repeatedly reporting parent-owned schedule flag changes. The hub scripts now pin `windmill-cli@1.802.1`, which ignores the `enabled` flag on schedules the parent owns, so a pull into a fork no longer lists the same schedule row on every run.

- Bumps the git-sync init and sync hub script paths in `backend/windmill-common/src/workspaces.rs` and `frontend/src/lib/hubPaths.json` to versions carrying the fix.
- Adds an e2e test that pulls into a fork and asserts a parent-owned schedule's `enabled` flag isn't reported as a change, while a real fork-branch script edit still lands; it guards the preview response shape and matches schedule rows by file path.
- Adds a test that reads both pins from source and asserts the UI pull and backend auto-pull use the same hub script, so the pins can't drift apart.
- Refactors fork creation, UI pull, and `wmill.yaml` seeding into shared test base helpers.
- Triggers the git-sync CI workflow when `frontend/src/lib/hubPaths.json` changes, since the new tests depend on it.

<sup>Written for commit d469131030d2f96d04206b15d5e2d3197fbc263e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

