### PR TITLE
docs: correct the array-depth caveat for resource run arguments

### DIFF
--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6221,9 +6221,11 @@ through to the script unchanged:
 \`\`\`
 
 The string may sit anywhere a string can — a top-level argument, a nested object field
-(\`{ "gh_auth": { "token": "$var:g/all/gh_token" } }\`), or an array element (array elements are
-walked only while nested at most two levels deep, and only for arrays of at most 1000 items).
-The prefix must be on the string itself.
+(\`{ "gh_auth": { "token": "$var:g/all/gh_token" } }\`), or an array element. Object fields are
+always walked, however deep. An array is walked only when at most two containers (objects or
+arrays, counted together) enclose it inside the argument value, and only when it holds at most
+1000 items; past either limit its elements are passed through unresolved. The prefix must be on
+the string itself.
 
 ## Common Resource Types
 

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -645,7 +645,7 @@ const writeVariableSchema = variableRequestSchema.extend({
 		.string()
 		.optional()
 		.describe(
-			'The value of the variable. Omit it to leave the value alone — required only when creating a new variable, or when changing a secret variable into a non-secret one. Never invent or guess the value of an existing variable: you cannot read it, and a "$var:..." reference is NOT a valid value (a variable cannot reference itself). Omitting it keeps whatever the draft already holds, so a value you set earlier in this conversation stays set; discard_local_draft abandons it.'
+			'The value of the variable. Omit it to leave the value alone — required only when creating a new variable, or when changing a secret variable into a non-secret one. Never invent or guess the value of an existing variable: you cannot read it, and a "$var:..." reference is NOT a valid value (a variable\'s value is stored and returned verbatim, never interpolated). Omitting it keeps whatever the draft already holds, so a value you set earlier in this conversation stays set; discard_local_draft abandons it.'
 		),
 	is_secret: z
 		.boolean()

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -529,9 +529,11 @@ through to the script unchanged:
 \`\`\`
 
 The string may sit anywhere a string can — a top-level argument, a nested object field
-(\`{ "gh_auth": { "token": "$var:g/all/gh_token" } }\`), or an array element (array elements are
-walked only while nested at most two levels deep, and only for arrays of at most 1000 items).
-The prefix must be on the string itself.
+(\`{ "gh_auth": { "token": "$var:g/all/gh_token" } }\`), or an array element. Object fields are
+always walked, however deep. An array is walked only when at most two containers (objects or
+arrays, counted together) enclose it inside the argument value, and only when it holds at most
+1000 items; past either limit its elements are passed through unresolved. The prefix must be on
+the string itself.
 
 ## Common Resource Types
 

--- a/system_prompts/auto-generated/skills/resources/SKILL.md
+++ b/system_prompts/auto-generated/skills/resources/SKILL.md
@@ -95,9 +95,11 @@ through to the script unchanged:
 ```
 
 The string may sit anywhere a string can — a top-level argument, a nested object field
-(`{ "gh_auth": { "token": "$var:g/all/gh_token" } }`), or an array element (array elements are
-walked only while nested at most two levels deep, and only for arrays of at most 1000 items).
-The prefix must be on the string itself.
+(`{ "gh_auth": { "token": "$var:g/all/gh_token" } }`), or an array element. Object fields are
+always walked, however deep. An array is walked only when at most two containers (objects or
+arrays, counted together) enclose it inside the argument value, and only when it holds at most
+1000 items; past either limit its elements are passed through unresolved. The prefix must be on
+the string itself.
 
 ## Common Resource Types
 

--- a/system_prompts/base/resources.md
+++ b/system_prompts/base/resources.md
@@ -90,9 +90,11 @@ through to the script unchanged:
 ```
 
 The string may sit anywhere a string can — a top-level argument, a nested object field
-(`{ "gh_auth": { "token": "$var:g/all/gh_token" } }`), or an array element (array elements are
-walked only while nested at most two levels deep, and only for arrays of at most 1000 items).
-The prefix must be on the string itself.
+(`{ "gh_auth": { "token": "$var:g/all/gh_token" } }`), or an array element. Object fields are
+always walked, however deep. An array is walked only when at most two containers (objects or
+arrays, counted together) enclose it inside the argument value, and only when it holds at most
+1000 items; past either limit its elements are passed through unresolved. The prefix must be on
+the string itself.
 
 ## Common Resource Types
 


### PR DESCRIPTION
Follow-up to #10927, which merged before two review findings from a local review pass were applied.

## The bug in the guidance

#10927 added a canonical section on passing a resource as a run argument, and its caveat about arrays was wrong:

> array elements are walked only while nested at most two levels deep

That reads as array-in-array nesting. The resolver actually shares **one** depth counter across every enclosing container — the `Value::Object` arm recurses at `depth + 1` with no cap of its own (`backend/windmill-worker/src/common.rs:385`), while the array arm gates on `depth <= 2` (`:369`), entered at `depth = 0` per top-level argument (`:199`, `:226`):

| args | array sits at | result |
|---|---|---|
| `{"a":{"b":{"c":["$res:x"]}}}` | depth 2 | resolved |
| `{"a":{"b":{"c":{"d":["$res:x"]}}}}` | depth 3 | **passed through unresolved** |

An agent following the old wording would expect the second to resolve. That is exactly the silent-passthrough failure #10927 exists to prevent, so the doc was steering toward the bug it was written to stop.

New wording:

> Object fields are always walked, however deep. An array is walked only when at most two containers (objects or arrays, counted together) enclose it inside the argument value, and only when it holds at most 1000 items; past either limit its elements are passed through unresolved.

## Second fix

`write_variable`'s `value` description justified an absolute rule with a narrow reason: "(a variable cannot reference itself)" only covers `$var:<own path>`, the one case the runtime guard rejects, which could read as licensing `$var:g/all/other` as a variable's value. It isn't — a variable's value is stored and returned verbatim, never interpolated. That is now the stated reason.

## Changes

- `system_prompts/base/resources.md` — the corrected caveat.
- `frontend/src/lib/components/copilot/chat/global/core.ts` — the widened rationale.
- Regenerated: `system_prompts/auto-generated/prompts.ts`, `.../skills/resources/SKILL.md`, `cli/src/guidance/skills.gen.ts`.

Prose only; no logic changes.

## Test plan

- [x] Verified the depth behavior against `transform_json_value` (`backend/windmill-worker/src/common.rs:355-393`) — the object arm has no depth cap, the array arm gates on `depth <= 2`, and both increment the shared counter.
- [x] `system_prompts/generate.py` re-run; the new wording appears in all three derived copies and nothing else moved.
- [x] `tsc --noEmit` clean on `frontend/src/lib/components/copilot/chat/global/core.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjRARL7JA7xm772iJP4mJk