### PR TITLE
fix: keep braces inside string tool arguments out of JSON depth count

### DIFF
--- a/frontend/src/lib/components/copilot/lib.toolCalls.test.ts
+++ b/frontend/src/lib/components/copilot/lib.toolCalls.test.ts
@@ -134,6 +134,37 @@ describe('parseOpenAICompletion tool call arguments', () => {
 		expect(addedMessages).toEqual(messages)
 	})
 
+	it('keeps braces inside string arguments out of the object-depth count', async () => {
+		const { parseOpenAICompletion } = await import('./lib')
+		const fn = vi.fn().mockResolvedValue('tool ok')
+		const messages: ChatCompletionMessageParam[] = []
+
+		await parseOpenAICompletion(
+			streamOf([
+				toolCallChunk({
+					id: 'call_1',
+					function: { name: 'patch_app_file', arguments: '{"new_string": ' }
+				}),
+				toolCallChunk({ function: { arguments: '"hello } goodbye \\" } "}' } })
+			]),
+			createCallbacks(),
+			messages,
+			[],
+			[createTool(fn)] as any,
+			{},
+			undefined,
+			{ workspace: 'test' }
+		)
+
+		expect(fn).toHaveBeenCalledWith(
+			expect.objectContaining({ args: { new_string: 'hello } goodbye " } ' } })
+		)
+		const assistant = messages.find((m) => m.role === 'assistant') as any
+		expect(assistant.tool_calls[0].function.arguments).toBe(
+			'{"new_string": "hello } goodbye \\" } "}'
+		)
+	})
+
 	it('marks only the executing tool call as loading when one message has several', async () => {
 		const { parseOpenAICompletion } = await import('./lib')
 		const statuses: Record<string, any> = {}

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -1177,9 +1177,21 @@ export async function getCompletion(
 function extractFirstJSON(str: string) {
 	let depth = 0,
 		i = 0
+	// Braces inside string values are not depth changes, so the scan tracks
+	// quoting and escaping: otherwise an argument such as {"a": "} "} is cut short.
+	let inString = false,
+		escaped = false
 	for (; i < str.length; i++) {
-		if (str[i] === '{') depth++
-		else if (str[i] === '}' && --depth === 0) break
+		const ch = str[i]
+		if (inString) {
+			if (escaped) escaped = false
+			else if (ch === '\\') escaped = true
+			else if (ch === '"') inString = false
+			continue
+		}
+		if (ch === '"') inString = true
+		else if (ch === '{') depth++
+		else if (ch === '}' && --depth === 0) break
 	}
 	return str.slice(0, i + 1)
 }


### PR DESCRIPTION
## Summary

Fixes #10939. On the OpenAI-compatible / Chat Completions path (OpenRouter, Custom AI, Groq, Together, Mistral, DeepSeek, Google AI…), `parseOpenAICompletion` accumulates streamed function-call argument deltas and runs each accumulation through `extractFirstJSON`, which trims anything after the first complete JSON object — a guard against Gemini emitting two objects back to back.

That scanner counted `{` / `}` without tracking whether the character sat inside a JSON string, so a closing brace in a string *value* was read as the end of the outer object. `{"new_string":"hello } goodbye"}` got truncated to `{"new_string":"hello }`, the tool call then failed Zod validation, and the edit was silently never applied. The native OpenAI provider doesn't reproduce it because it goes through the Responses API instead.

The scan now tracks string and escape state, so braces inside string values no longer change the depth. Partial accumulations are still returned whole, so the incremental "append delta, re-extract" loop converges as before, and the Gemini double-object trim it was written for still works.

## Changes

- `extractFirstJSON` (`frontend/src/lib/components/copilot/lib.ts`) tracks quoting and escaping while scanning for the end of the first object.
- Regression test in `lib.toolCalls.test.ts`: streams a two-chunk tool call whose string argument carries a bare `}` and an escaped quote followed by `}`, asserting both the parsed args handed to the tool and the exact `arguments` string persisted on the assistant message. It fails against the old brace counter.

## Test plan

- [x] `npx vitest run src/lib/components/copilot/lib.toolCalls.test.ts` — 5 passed (needs `--testTimeout=30000` locally: the pre-existing first test intermittently times out on the cold `import('./lib')`, unrelated to this change).
- [x] Exercised end to end on the running dev instance against a real streaming model over the OpenAI-compatible path (a `customai` provider, which routes through `parseOpenAICompletion`): asked the AI chat to replace `const x = true` with `const x = "hello } goodbye"` in a script. Reverting just this fix and re-running the identical flow reproduces the reported failure.
- [ ] Optional: repeat through an actual OpenRouter resource.

## Screenshots

Before the fix — the tool call is truncated, every `Edit script` attempt fails Zod validation with `path` / `old_string` undefined, and the script is left at `const x = true`:

![wm-10939-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-a5d75413/1788460799-wm-10939-before.png)

After the fix — the edit applies with the brace intact:

![wm-10939-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-a5d75413/1788460801-wm-10939-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vvU4UWCpib25ovmmAD7HH