### PR TITLE
feat(frontend): autosave drafts for new resources and variables

### DIFF
--- a/frontend/src/lib/components/AppConnectDrawer.svelte
+++ b/frontend/src/lib/components/AppConnectDrawer.svelte
@@ -73,9 +73,14 @@
 
 <Drawer
 	bind:this={drawer}
-	on:close={() => {
+	on:close={async () => {
+		// Flushed before the step reset (which retires the form the draft mirrors)
+		// and before `close`, whose list refetch would otherwise outrun the draft's
+		// own commit delay and the syncer's debounce, and miss the new row.
+		const flushed = appConnectInner?.flushDraft()
 		step = 1
 		handedOff = false
+		await flushed
 		dispatch('close')
 	}}
 	size="700px"

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -329,7 +329,15 @@
 	}
 
 	let pathError = $state('')
-	let pathDirty = $state(false)
+
+	async function resourcePathIsFree(p: string): Promise<boolean> {
+		try {
+			return !(await ResourceService.existsResource({ workspace: effectiveWorkspace, path: p }))
+		} catch {
+			// Fail closed: an unanswered check is not evidence the path is free.
+			return false
+		}
+	}
 
 	// Fields saved as linked secret variables never enter the draft: a resource
 	// draft is stored as-is, without the encryption those variables get.
@@ -349,8 +357,7 @@
 		workspace: () => effectiveWorkspace,
 		path: () => path,
 		pathError: () => pathError,
-		touched: () =>
-			pathDirty ||
+		contentTouched: () =>
 			description !== '' ||
 			(labels?.length ?? 0) > 0 ||
 			wsSpecific ||
@@ -367,7 +374,8 @@
 			labels,
 			wsSpecific,
 			resource_type: resourceType
-		})
+		}),
+		pathIsFree: resourcePathIsFree
 	})
 
 	export async function open(rt?: string) {
@@ -1015,10 +1023,11 @@
 
 	export async function back() {
 		if (step == 2 && manual) {
-			// Back abandons this form; the draft it mirrored goes with it.
-			await newDraftSync.finish()
+			// Back abandons this form; the draft it mirrored goes with it. Not
+			// awaited: the step change is the user's feedback and must not wait on
+			// a POST (`finish` captures what it deletes before returning).
+			void newDraftSync.finish()
 			newDraftSync.reset()
-			pathDirty = false
 		}
 		if (step == 4) {
 			step -= 2
@@ -1351,7 +1360,6 @@
 				<ResourcePathHint />
 				<Path
 					bind:error={pathError}
-					bind:dirty={pathDirty}
 					bind:path
 					initialPath=""
 					namePlaceholder={resourceType}

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -993,7 +993,9 @@
 					}
 				})
 			}
-			newDraftSync.finish()
+			// Awaited: `refresh` refetches the list, and a debounced delete would
+			// leave the just-created resource still flagged as a draft.
+			await newDraftSync.finish()
 			dispatch('refresh', path)
 			dispatch('close')
 			sendUserToast(
@@ -1005,10 +1007,16 @@
 		}
 	}
 
+	/** Settle the pending draft write before the drawer's close event, whose
+	 * list refetch would otherwise outrun the debounced POST. */
+	export async function flushDraft(): Promise<void> {
+		await newDraftSync.flush()
+	}
+
 	export async function back() {
 		if (step == 2 && manual) {
 			// Back abandons this form; the draft it mirrored goes with it.
-			newDraftSync.finish()
+			await newDraftSync.finish()
 			newDraftSync.reset()
 			pathDirty = false
 		}

--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -23,6 +23,7 @@
 	import { registryEntryFor, registryCcCapableFor, stripSandboxSuffix } from './oauthRegistry'
 	import { createEventDispatcher, onDestroy, tick, untrack } from 'svelte'
 	import Path from './Path.svelte'
+	import { useNewItemDraftSync } from './useNewItemDraftSync.svelte'
 	import { Button, RadioCard, Skeleton } from './common'
 	import ApiConnectForm from './ApiConnectForm.svelte'
 	import SearchItems from './SearchItems.svelte'
@@ -328,6 +329,46 @@
 	}
 
 	let pathError = $state('')
+	let pathDirty = $state(false)
+
+	// Fields saved as linked secret variables never enter the draft: a resource
+	// draft is stored as-is, without the encryption those variables get.
+	function draftArgs(): Record<string, any> {
+		const out: Record<string, any> = {}
+		for (const [k, v] of Object.entries($state.snapshot(args) ?? {})) {
+			out[k] = linkedSecrets.includes(k) ? '' : v
+		}
+		return out
+	}
+	// The manual step is a brand-new resource: mirror the form to a draft keyed
+	// by the typed path, so a closed drawer can be picked up from the resources
+	// list (draft-only row → editor). Filling an existing path is not a draft.
+	const newDraftSync = useNewItemDraftSync({
+		itemKind: 'resource',
+		enabled: () => step == 2 && manual && !fillPath,
+		workspace: () => effectiveWorkspace,
+		path: () => path,
+		pathError: () => pathError,
+		touched: () =>
+			pathDirty ||
+			description !== '' ||
+			(labels?.length ?? 0) > 0 ||
+			wsSpecific ||
+			Object.entries(draftArgs()).some(
+				([k, v]) =>
+					v !== '' &&
+					v !== undefined &&
+					v !== (resourceTypeInfo?.schema as any)?.properties?.[k]?.default
+			),
+		value: () => ({
+			path,
+			description,
+			args: draftArgs(),
+			labels,
+			wsSpecific,
+			resource_type: resourceType
+		})
+	})
 
 	export async function open(rt?: string) {
 		if (!rt) {
@@ -952,6 +993,7 @@
 					}
 				})
 			}
+			newDraftSync.finish()
 			dispatch('refresh', path)
 			dispatch('close')
 			sendUserToast(
@@ -964,6 +1006,12 @@
 	}
 
 	export async function back() {
+		if (step == 2 && manual) {
+			// Back abandons this form; the draft it mirrored goes with it.
+			newDraftSync.finish()
+			newDraftSync.reset()
+			pathDirty = false
+		}
 		if (step == 4) {
 			step -= 2
 		} else if (step > 1) {
@@ -1295,6 +1343,7 @@
 				<ResourcePathHint />
 				<Path
 					bind:error={pathError}
+					bind:dirty={pathDirty}
 					bind:path
 					initialPath=""
 					namePlaceholder={resourceType}

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -205,10 +205,6 @@
 	)
 
 	let pathError = $state('')
-	// Set before `save` awaits anything: the drawer closes without awaiting the
-	// write, and the close-time draft move would otherwise leave a draft on the
-	// resource being created.
-	let saving = $state(false)
 
 	async function resourcePathIsFree(ws: string, p: string): Promise<boolean> {
 		try {
@@ -219,19 +215,26 @@
 		}
 	}
 
-	// A new resource's handle is keyed on the empty `initialPath`, so it is
-	// detached and never POSTs; the form is mirrored under the typed path
-	// instead. Inert in edit mode.
+	// Nothing deployed at this path: the item IS its draft. Its list row is keyed
+	// by the path inside that draft, so the key has to follow the form's path —
+	// which is what `useNewItemDraftSync` does and the `useMany` handle can't
+	// (it is pinned to the path this editor opened).
+	const draftOnly = $derived(!!selected && existedInitially[selected] === false)
+	// What the form was opened with: the empty seed for a new resource, the
+	// draft itself for a draft-only one. Divergence from it is the user's edit.
+	let openedWith: Record<string, ResourceState> = $state({})
+
 	const newDraftSync = useNewItemDraftSync<ResourceState>({
 		itemKind: 'resource',
-		enabled: () => !initialPath,
+		enabled: () => draftOnly,
 		workspace: () => selected,
 		path: () => current?.path ?? '',
 		pathError: () => pathError,
 		contentTouched: () =>
 			!!current &&
 			!!selected &&
-			!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' }),
+			!!openedWith[selected] &&
+			!draftValuesEqual({ ...current, path: '' }, { ...openedWith[selected], path: '' }),
 		value: () => (current ? ($state.snapshot(current) as ResourceState) : undefined),
 		pathIsFree: (p) => (selected ? resourcePathIsFree(selected, p) : Promise.resolve(false))
 	})
@@ -253,6 +256,7 @@
 			}
 			ensureHandle(selected, s)
 			initialStates[selected] = structuredClone(s)
+			openedWith[selected] = structuredClone(s)
 			existedInitially[selected] = false
 		})
 	})
@@ -302,7 +306,15 @@
 				const s: ResourceState = savedDraftState ?? deployedState
 				ensureHandle(ws, s)
 				initialStates[ws] = structuredClone(deployedState)
+				openedWith[ws] = structuredClone(s)
 				existedInitially[ws] = !noDeployed
+				if (noDeployed) {
+					// The helper owns this draft's key from here (see `draftOnly`);
+					// leaving the handle syncing too would write the same content back
+					// under the path this editor opened, stranding the row on a rename.
+					UserDraft.stopSync('resource', initialPath, { workspace: ws })
+					newDraftSync.adopt(ws, initialPath, structuredClone(s))
+				}
 				perWsUser[ws] = user
 				// Keep resource_type in sync for the base workspace (controls the schema)
 				if (ws === effectiveWorkspace) {
@@ -343,36 +355,10 @@
 	export function localDraftCurrent(): ResourceState | undefined {
 		return current
 	}
-	/** A draft-only item's list row is keyed by the path INSIDE the draft, while
-	 * the autosave handle stays keyed on the path the editor opened. Renaming
-	 * one would leave the row pointing at a key that holds no draft — it would
-	 * 404 on reopen and its delete would miss — so move the draft to the path
-	 * the form now carries. Reads its state synchronously: the caller runs this
-	 * as the drawer closes, and awaiting first would race the editor's teardown. */
-	async function moveRenamedDraftOnly(): Promise<void> {
-		const ws = selected
-		if (!ws || !initialPath || existedInitially[ws] !== false || saving) return
-		const s = states[ws]?.draft
-		if (!s || !s.path || s.path === initialPath || pathError !== '') return
-		const value = $state.snapshot(s) as ResourceState
-		const target = s.path
-		// The path may have been typed too recently for `Path`'s debounced check
-		// to have run: moving onto an occupied path would hand this draft to the
-		// item living there.
-		if (!(await resourcePathIsFree(ws, target))) return
-		UserDraft.save('resource', target, value, { workspace: ws })
-		UserDraft.remove('resource', initialPath, { workspace: ws })
-		await Promise.all([
-			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: target }),
-			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: initialPath })
-		])
-	}
-
 	/** Settle every pending draft write. The drawer awaits this before its
 	 * `onClose`, whose list refetch would otherwise outrun the debounced POST. */
 	export async function flushDraft(): Promise<void> {
-		// Both started before the first await so they read live editor state.
-		await Promise.all([newDraftSync.flush(), moveRenamedDraftOnly()])
+		await newDraftSync.flush()
 	}
 
 	/** Returns true when the item was draft-only: discarding deleted it
@@ -385,10 +371,11 @@
 			})
 			return false
 		}
-		// Draft-only: no baseline to fall back to. Blank the cell so the form
-		// unmounts — mounted on the empty state it re-fills the path from
-		// `initialPath`, and that autosave would displace the delete. Flushed so
-		// the list refetch on drawer close no longer finds the row.
+		// Draft-only: the item is the draft, so discarding deletes it. `finish`
+		// drops it wherever the helper keyed it and settles that before the
+		// caller's list refetch; `remove` then blanks the cell so the form
+		// unmounts, and clears the key this editor opened if the two differ.
+		await newDraftSync.finish()
 		UserDraft.remove('resource', initialPath ?? '', { workspace: selected })
 		await UserDraftDbSyncer.flush({
 			workspace: selected,
@@ -426,14 +413,12 @@
 
 	export async function save(): Promise<void> {
 		const dirty = dirtyWorkspaces
-		// Synchronous, before the first await: the drawer closes right after
-		// calling this, and the close-time draft move must see it.
-		saving = true
 		try {
 			for (const ws of dirty) {
 				const s = states[ws].draft!
 				const ini = initialStates[ws]
-				if (existedInitially[ws]) {
+				const wasDeployed = existedInitially[ws]
+				if (wasDeployed) {
 					await ResourceService.updateResource({
 						workspace: ws,
 						path: ini.path,
@@ -463,19 +448,19 @@
 					})
 				}
 				initialStates[ws] = $state.snapshot(s) as ResourceState
+				openedWith[ws] = $state.snapshot(s) as ResourceState
 				existedInitially[ws] = true
-				if (initialPath) {
+				// Both awaited: the caller refetches the list right after, and a
+				// debounced delete would bring the just-deployed item back as a draft.
+				if (wasDeployed) {
 					// Reset the handle to the new deployed baseline via `discard`, not
 					// `remove`. See VariableEditor for the full rationale.
 					UserDraft.discard('resource', initialPath, s, { workspace: ws })
-					// Flushed: the caller refetches the list right after, and the
-					// discard's delete rides the same debounce — the just-deployed item
-					// would still come back rendered as a draft.
 					await UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: initialPath })
 				} else {
-					// Awaited: the caller refetches the list right after, and a debounced
-					// delete would leave the just-created item still flagged as a draft.
+					// The helper held this draft (new or draft-only), wherever it keyed it.
 					await newDraftSync.finish()
+					if (initialPath) UserDraft.restartSync('resource', initialPath, { workspace: ws })
 				}
 				// Path now exists server-side — drop the autocomplete cache so
 				// it shows up immediately instead of after the 60s TTL.

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -331,6 +331,32 @@
 	export function localDraftCurrent(): ResourceState | undefined {
 		return current
 	}
+	/** A draft-only item's list row is keyed by the path INSIDE the draft, while
+	 * the autosave handle stays keyed on the path the editor opened. Renaming
+	 * one would leave the row pointing at a key that holds no draft — it would
+	 * 404 on reopen and its delete would miss — so move the draft to the path
+	 * the form now carries. Reads its state synchronously: the caller runs this
+	 * as the drawer closes, and awaiting first would race the editor's teardown. */
+	function moveRenamedDraftOnly(): Promise<unknown> {
+		const ws = selected
+		if (!ws || !initialPath || existedInitially[ws] !== false) return Promise.resolve()
+		const s = states[ws]?.draft
+		if (!s || !s.path || s.path === initialPath) return Promise.resolve()
+		UserDraft.save('resource', s.path, $state.snapshot(s) as ResourceState, { workspace: ws })
+		UserDraft.remove('resource', initialPath, { workspace: ws })
+		return Promise.all([
+			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: s.path }),
+			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: initialPath })
+		])
+	}
+
+	/** Settle every pending draft write. The drawer awaits this before its
+	 * `onClose`, whose list refetch would otherwise outrun the debounced POST. */
+	export async function flushDraft(): Promise<void> {
+		// Both started before the first await so they read live editor state.
+		await Promise.all([newDraftSync.flush(), moveRenamedDraftOnly()])
+	}
+
 	/** Returns true when the item was draft-only: discarding deleted it
 	 * outright, so there is nothing left for the editor to show. */
 	export async function discardLocalDraft(): Promise<boolean> {
@@ -422,7 +448,9 @@
 					// `remove`. See VariableEditor for the full rationale.
 					UserDraft.discard('resource', initialPath, s, { workspace: ws })
 				} else {
-					newDraftSync.finish()
+					// Awaited: the caller refetches the list right after, and a debounced
+					// delete would leave the just-created item still flagged as a draft.
+					await newDraftSync.finish()
 				}
 				// Path now exists server-side — drop the autocomplete cache so
 				// it shows up immediately instead of after the 60s TTL.

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -236,7 +236,12 @@
 			!!openedWith[selected] &&
 			!draftValuesEqual({ ...current, path: '' }, { ...openedWith[selected], path: '' }),
 		value: () => (current ? ($state.snapshot(current) as ResourceState) : undefined),
-		pathIsFree: (p) => (selected ? resourcePathIsFree(selected, p) : Promise.resolve(false))
+		pathIsFree: (p) => (selected ? resourcePathIsFree(selected, p) : Promise.resolve(false)),
+		onAbandonKey: (ws, p) => {
+			// The handle is pinned to the path this editor opened; once the draft
+			// has moved off it, its next write would recreate the row it left.
+			if (p === initialPath) UserDraft.stopSync('resource', p, { workspace: ws })
+		}
 	})
 
 	// New-resource bootstrap: seed empty state per workspace (edit mode
@@ -308,13 +313,10 @@
 				initialStates[ws] = structuredClone(deployedState)
 				openedWith[ws] = structuredClone(s)
 				existedInitially[ws] = !noDeployed
-				if (noDeployed) {
-					// The helper owns this draft's key from here (see `draftOnly`);
-					// leaving the handle syncing too would write the same content back
-					// under the path this editor opened, stranding the row on a rename.
-					UserDraft.stopSync('resource', initialPath, { workspace: ws })
-					newDraftSync.adopt(ws, initialPath, structuredClone(s))
-				}
+				// The helper owns this draft's key from here (see `draftOnly`): the
+				// handle keeps autosaving it while the path is unchanged, and hands
+				// the key over the moment a rename moves it.
+				if (noDeployed) newDraftSync.adopt(ws, initialPath, structuredClone(s))
 				perWsUser[ws] = user
 				// Keep resource_type in sync for the base workspace (controls the schema)
 				if (ws === effectiveWorkspace) {

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -237,10 +237,14 @@
 			!draftValuesEqual({ ...current, path: '' }, { ...openedWith[selected], path: '' }),
 		value: () => (current ? ($state.snapshot(current) as ResourceState) : undefined),
 		pathIsFree: (p) => (selected ? resourcePathIsFree(selected, p) : Promise.resolve(false)),
+		keyed: (v, p) => ({ ...v, path: p }),
 		onAbandonKey: (ws, p) => {
 			// The handle is pinned to the path this editor opened; once the draft
 			// has moved off it, its next write would recreate the row it left.
 			if (p === initialPath) UserDraft.stopSync('resource', p, { workspace: ws })
+		},
+		onResumeKey: (ws, p) => {
+			if (p === initialPath) UserDraft.restartSync('resource', p, { workspace: ws })
 		}
 	})
 

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -205,7 +205,19 @@
 	)
 
 	let pathError = $state('')
-	let pathDirty = $state(false)
+	// Set before `save` awaits anything: the drawer closes without awaiting the
+	// write, and the close-time draft move would otherwise leave a draft on the
+	// resource being created.
+	let saving = $state(false)
+
+	async function resourcePathIsFree(ws: string, p: string): Promise<boolean> {
+		try {
+			return !(await ResourceService.existsResource({ workspace: ws, path: p }))
+		} catch {
+			// Fail closed: an unanswered check is not evidence the path is free.
+			return false
+		}
+	}
 
 	// A new resource's handle is keyed on the empty `initialPath`, so it is
 	// detached and never POSTs; the form is mirrored under the typed path
@@ -216,12 +228,12 @@
 		workspace: () => selected,
 		path: () => current?.path ?? '',
 		pathError: () => pathError,
-		touched: () =>
-			pathDirty ||
-			(!!current &&
-				!!selected &&
-				!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' })),
-		value: () => (current ? ($state.snapshot(current) as ResourceState) : undefined)
+		contentTouched: () =>
+			!!current &&
+			!!selected &&
+			!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' }),
+		value: () => (current ? ($state.snapshot(current) as ResourceState) : undefined),
+		pathIsFree: (p) => (selected ? resourcePathIsFree(selected, p) : Promise.resolve(false))
 	})
 
 	// New-resource bootstrap: seed empty state per workspace (edit mode
@@ -337,15 +349,21 @@
 	 * 404 on reopen and its delete would miss — so move the draft to the path
 	 * the form now carries. Reads its state synchronously: the caller runs this
 	 * as the drawer closes, and awaiting first would race the editor's teardown. */
-	function moveRenamedDraftOnly(): Promise<unknown> {
+	async function moveRenamedDraftOnly(): Promise<void> {
 		const ws = selected
-		if (!ws || !initialPath || existedInitially[ws] !== false) return Promise.resolve()
+		if (!ws || !initialPath || existedInitially[ws] !== false || saving) return
 		const s = states[ws]?.draft
-		if (!s || !s.path || s.path === initialPath) return Promise.resolve()
-		UserDraft.save('resource', s.path, $state.snapshot(s) as ResourceState, { workspace: ws })
+		if (!s || !s.path || s.path === initialPath || pathError !== '') return
+		const value = $state.snapshot(s) as ResourceState
+		const target = s.path
+		// The path may have been typed too recently for `Path`'s debounced check
+		// to have run: moving onto an occupied path would hand this draft to the
+		// item living there.
+		if (!(await resourcePathIsFree(ws, target))) return
+		UserDraft.save('resource', target, value, { workspace: ws })
 		UserDraft.remove('resource', initialPath, { workspace: ws })
-		return Promise.all([
-			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: s.path }),
+		await Promise.all([
+			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: target }),
 			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: initialPath })
 		])
 	}
@@ -408,6 +426,9 @@
 
 	export async function save(): Promise<void> {
 		const dirty = dirtyWorkspaces
+		// Synchronous, before the first await: the drawer closes right after
+		// calling this, and the close-time draft move must see it.
+		saving = true
 		try {
 			for (const ws of dirty) {
 				const s = states[ws].draft!
@@ -447,6 +468,10 @@
 					// Reset the handle to the new deployed baseline via `discard`, not
 					// `remove`. See VariableEditor for the full rationale.
 					UserDraft.discard('resource', initialPath, s, { workspace: ws })
+					// Flushed: the caller refetches the list right after, and the
+					// discard's delete rides the same debounce — the just-deployed item
+					// would still come back rendered as a draft.
+					await UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'resource', path: initialPath })
 				} else {
 					// Awaited: the caller refetches the list right after, and a debounced
 					// delete would leave the just-created item still flagged as a draft.
@@ -479,7 +504,6 @@
 				<ResourceForm
 					bind:path={() => current!.path, setPath}
 					bind:pathError
-					bind:pathDirty
 					bind:labels={current.labels}
 					bind:description={current.description}
 					bind:args={current.args}

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -14,6 +14,8 @@
 	import type { UserExt } from '$lib/stores'
 	import { UserDraft, draftValuesEqual, type UserDraftHandle } from '$lib/userDraft.svelte'
 	import { setLocalDraftHint } from '$lib/localDraftHints.svelte'
+	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
+	import { useNewItemDraftSync } from './useNewItemDraftSync.svelte'
 
 	interface Props {
 		canSave?: boolean
@@ -47,12 +49,16 @@
 		onCanWriteChange
 	}: Props = $props()
 
+	// Persisted as the draft value: the list pages' draft-only rows and the
+	// global AI chat read this exact shape, `resource_type` included, since a
+	// draft with no deployed row has nowhere else to carry its type.
 	type ResourceState = {
 		path: string
 		description: string
 		args: Record<string, any>
 		labels: string[] | undefined
 		wsSpecific: boolean
+		resource_type?: string
 	}
 
 	const dispatch = createEventDispatcher()
@@ -198,6 +204,26 @@
 		})
 	)
 
+	let pathError = $state('')
+	let pathDirty = $state(false)
+
+	// A new resource's handle is keyed on the empty `initialPath`, so it is
+	// detached and never POSTs; the form is mirrored under the typed path
+	// instead. Inert in edit mode.
+	const newDraftSync = useNewItemDraftSync<ResourceState>({
+		itemKind: 'resource',
+		enabled: () => !initialPath,
+		workspace: () => selected,
+		path: () => current?.path ?? '',
+		pathError: () => pathError,
+		touched: () =>
+			pathDirty ||
+			(!!current &&
+				!!selected &&
+				!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' })),
+		value: () => (current ? ($state.snapshot(current) as ResourceState) : undefined)
+	})
+
 	// New-resource bootstrap: seed empty state per workspace (edit mode
 	// is seeded by the lazy-fetch effect below).
 	$effect(() => {
@@ -210,7 +236,8 @@
 				description: '',
 				args: (defaultValues && Object.keys(defaultValues).length > 0 ? defaultValues : {}) as any,
 				labels: undefined,
-				wsSpecific: false
+				wsSpecific: false,
+				resource_type
 			}
 			ensureHandle(selected, s)
 			initialStates[selected] = structuredClone(s)
@@ -231,22 +258,39 @@
 				// `.draft` already holds the editor's `ResourceState` shape.
 				const savedDraftState = (r as any).draft as ResourceState | undefined
 				fetchedResources[ws] = r
+				// Draft-only paths (`no_deployed`) have no row — saving must
+				// CREATE, not update (update 404s).
+				const noDeployed = !!(r as any).no_deployed
 				// Deployed baseline as the dirty-check reference, so the banner
 				// compares draft-vs-deployed and fires immediately when a draft exists.
-				const deployedState: ResourceState = {
-					path: r.path,
-					description: r.description ?? '',
-					args: (r.value ?? {}) as any,
-					labels: r.labels ?? undefined,
-					wsSpecific: r.ws_specific ?? false
+				// A draft-only item has no deployed side: everything in it is unsaved.
+				const deployedState: ResourceState = noDeployed
+					? {
+							path: '',
+							description: '',
+							args: {},
+							labels: undefined,
+							wsSpecific: false,
+							resource_type: r.resource_type
+						}
+					: {
+							path: r.path,
+							description: r.description ?? '',
+							args: (r.value ?? {}) as any,
+							labels: r.labels ?? undefined,
+							wsSpecific: r.ws_specific ?? false,
+							resource_type: r.resource_type
+						}
+				// A draft saved without `resource_type` compares against a baseline
+				// that has it; fill it in so the field alone can't read as a change.
+				if (savedDraftState && savedDraftState.resource_type === undefined) {
+					savedDraftState.resource_type = r.resource_type
 				}
 				// Open with the saved draft if present, else the deployed.
 				const s: ResourceState = savedDraftState ?? deployedState
 				ensureHandle(ws, s)
 				initialStates[ws] = structuredClone(deployedState)
-				// Draft-only paths (`no_deployed`) have no row — saving must
-				// CREATE, not update (update 404s).
-				existedInitially[ws] = !(r as any).no_deployed
+				existedInitially[ws] = !noDeployed
 				perWsUser[ws] = user
 				// Keep resource_type in sync for the base workspace (controls the schema)
 				if (ws === effectiveWorkspace) {
@@ -268,7 +312,7 @@
 	})
 
 	$effect(() => {
-		canSave = anyDirty && dirtyValid && dirtyCanWrite
+		canSave = anyDirty && dirtyValid && dirtyCanWrite && pathError === ''
 	})
 
 	// Drive the parent drawer's "unsaved changes" banner. The drawer chrome
@@ -287,11 +331,27 @@
 	export function localDraftCurrent(): ResourceState | undefined {
 		return current
 	}
-	export function discardLocalDraft(): void {
-		if (!selected) return
-		UserDraft.discard('resource', initialPath ?? '', initialStates[selected], {
-			workspace: selected
+	/** Returns true when the item was draft-only: discarding deleted it
+	 * outright, so there is nothing left for the editor to show. */
+	export async function discardLocalDraft(): Promise<boolean> {
+		if (!selected) return false
+		if (existedInitially[selected]) {
+			UserDraft.discard('resource', initialPath ?? '', initialStates[selected], {
+				workspace: selected
+			})
+			return false
+		}
+		// Draft-only: no baseline to fall back to. Blank the cell so the form
+		// unmounts — mounted on the empty state it re-fills the path from
+		// `initialPath`, and that autosave would displace the delete. Flushed so
+		// the list refetch on drawer close no longer finds the row.
+		UserDraft.remove('resource', initialPath ?? '', { workspace: selected })
+		await UserDraftDbSyncer.flush({
+			workspace: selected,
+			itemKind: 'resource',
+			path: initialPath ?? ''
 		})
+		return true
 	}
 
 	$effect(() => {
@@ -355,11 +415,15 @@
 						}
 					})
 				}
-				// Reset the handle to the new deployed baseline via `discard`, not
-				// `remove`. See VariableEditor for the full rationale.
 				initialStates[ws] = $state.snapshot(s) as ResourceState
 				existedInitially[ws] = true
-				UserDraft.discard('resource', initialPath ?? '', s, { workspace: ws })
+				if (initialPath) {
+					// Reset the handle to the new deployed baseline via `discard`, not
+					// `remove`. See VariableEditor for the full rationale.
+					UserDraft.discard('resource', initialPath, s, { workspace: ws })
+				} else {
+					newDraftSync.finish()
+				}
 				// Path now exists server-side — drop the autocomplete cache so
 				// it shows up immediately instead of after the 60s TTL.
 				invalidateWorkspacePaths(ws)
@@ -386,6 +450,8 @@
 			{#key current}
 				<ResourceForm
 					bind:path={() => current!.path, setPath}
+					bind:pathError
+					bind:pathDirty
 					bind:labels={current.labels}
 					bind:description={current.description}
 					bind:args={current.args}

--- a/frontend/src/lib/components/ResourceEditorDrawer.svelte
+++ b/frontend/src/lib/components/ResourceEditorDrawer.svelte
@@ -23,7 +23,8 @@
 		workspace = undefined,
 		disableChatOffset = false,
 		onRestored = undefined,
-		onSaved = undefined
+		onSaved = undefined,
+		onClose = undefined
 	}: {
 		workspace?: string
 		disableChatOffset?: boolean
@@ -31,6 +32,9 @@
 		/** Fires after Save has written, for a caller showing state derived from the
 		 * resource — `onRestored` only covers restoring an old version. */
 		onSaved?: () => void
+		/** Fires whenever the drawer closes, saved or not: a new resource left
+		 * unsaved persists as a draft-only row, which a list only sees on refetch. */
+		onClose?: () => void
 	} = $props()
 
 	let drawer: Drawer | undefined = $state()
@@ -44,7 +48,7 @@
 				save: () => void
 				localDraftDeployed: () => unknown
 				localDraftCurrent: () => unknown
-				discardLocalDraft: () => void
+				discardLocalDraft: () => Promise<boolean>
 		  }
 		| undefined = $state(undefined)
 	let hasLocalDraft = $state(false)
@@ -97,7 +101,10 @@
 	bind:this={drawer}
 	size="50rem"
 	{disableChatOffset}
-	on:close={() => clearPageDrawerAnchor(RESOURCES_PATH)}
+	on:close={() => {
+		clearPageDrawerAnchor(RESOURCES_PATH)
+		onClose?.()
+	}}
 >
 	<DrawerContent
 		title={mode == 'edit' ? 'Edit ' + path : addResourceTitle(resource_type)}
@@ -131,7 +138,10 @@
 				reserveSpace={mode == 'edit'}
 				getDeployed={() => resourceEditor?.localDraftDeployed()}
 				getCurrent={() => resourceEditor?.localDraftCurrent()}
-				onDiscard={() => resourceEditor?.discardLocalDraft()}
+				onDiscard={async () => {
+					// A draft-only resource is gone once discarded; nothing is left to edit.
+					if (await resourceEditor?.discardLocalDraft()) drawer?.closeDrawer()
+				}}
 				disabled={!canWriteSelected}
 			/>
 		{/snippet}

--- a/frontend/src/lib/components/ResourceEditorDrawer.svelte
+++ b/frontend/src/lib/components/ResourceEditorDrawer.svelte
@@ -49,6 +49,7 @@
 				localDraftDeployed: () => unknown
 				localDraftCurrent: () => unknown
 				discardLocalDraft: () => Promise<boolean>
+				flushDraft: () => Promise<void>
 		  }
 		| undefined = $state(undefined)
 	let hasLocalDraft = $state(false)
@@ -101,8 +102,11 @@
 	bind:this={drawer}
 	size="50rem"
 	{disableChatOffset}
-	on:close={() => {
+	on:close={async () => {
 		clearPageDrawerAnchor(RESOURCES_PATH)
+		// Before `onClose`: its list refetch would otherwise outrun the draft's
+		// own commit delay and the syncer's debounce, and miss the new row.
+		await resourceEditor?.flushDraft()
 		onClose?.()
 	}}
 >

--- a/frontend/src/lib/components/ResourceForm.svelte
+++ b/frontend/src/lib/components/ResourceForm.svelte
@@ -29,6 +29,10 @@
 		path: string
 		initialPath: string
 		hidePath?: boolean
+		/** `Path`'s validation error (`''` when valid). */
+		pathError?: string
+		/** Whether the user edited the path (as opposed to `Path`'s auto-filled name). */
+		pathDirty?: boolean
 		labels: string[] | undefined
 		description: string
 		args: Record<string, any>
@@ -53,6 +57,8 @@
 		path = $bindable(),
 		initialPath,
 		hidePath = false,
+		pathError = $bindable(''),
+		pathDirty = $bindable(false),
 		labels = $bindable(),
 		description = $bindable(),
 		args = $bindable(),
@@ -160,6 +166,8 @@
 			<Path
 				disabled={initialPath != '' && !isOwner(initialPath, $userStore, ws)}
 				bind:path
+				bind:error={pathError}
+				bind:dirty={pathDirty}
 				{initialPath}
 				namePlaceholder="resource"
 				kind="resource"

--- a/frontend/src/lib/components/ResourceForm.svelte
+++ b/frontend/src/lib/components/ResourceForm.svelte
@@ -30,9 +30,9 @@
 		initialPath: string
 		hidePath?: boolean
 		/** `Path`'s validation error (`''` when valid). */
-		pathError?: string
+		pathError: string
 		/** Whether the user edited the path (as opposed to `Path`'s auto-filled name). */
-		pathDirty?: boolean
+		pathDirty: boolean
 		labels: string[] | undefined
 		description: string
 		args: Record<string, any>
@@ -57,8 +57,8 @@
 		path = $bindable(),
 		initialPath,
 		hidePath = false,
-		pathError = $bindable(''),
-		pathDirty = $bindable(false),
+		pathError = $bindable(),
+		pathDirty = $bindable(),
 		labels = $bindable(),
 		description = $bindable(),
 		args = $bindable(),

--- a/frontend/src/lib/components/ResourceForm.svelte
+++ b/frontend/src/lib/components/ResourceForm.svelte
@@ -31,8 +31,6 @@
 		hidePath?: boolean
 		/** `Path`'s validation error (`''` when valid). */
 		pathError: string
-		/** Whether the user edited the path (as opposed to `Path`'s auto-filled name). */
-		pathDirty: boolean
 		labels: string[] | undefined
 		description: string
 		args: Record<string, any>
@@ -58,7 +56,6 @@
 		initialPath,
 		hidePath = false,
 		pathError = $bindable(),
-		pathDirty = $bindable(),
 		labels = $bindable(),
 		description = $bindable(),
 		args = $bindable(),
@@ -167,7 +164,6 @@
 				disabled={initialPath != '' && !isOwner(initialPath, $userStore, ws)}
 				bind:path
 				bind:error={pathError}
-				bind:dirty={pathDirty}
 				{initialPath}
 				namePlaceholder="resource"
 				kind="resource"

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -26,6 +26,8 @@
 	import LocalDraftBanner from './LocalDraftBanner.svelte'
 	import { isEncryptedDraftValue } from '$lib/encryptedDraft'
 	import { setLocalDraftHint } from '$lib/localDraftHints.svelte'
+	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
+	import { useNewItemDraftSync } from './useNewItemDraftSync.svelte'
 
 	const dispatch = createEventDispatcher()
 
@@ -56,6 +58,7 @@
 	let perWsUser: Record<string, UserExt | undefined> = $state({})
 	let selected: string | undefined = $state(undefined)
 	let pathError = $state('')
+	let pathDirty = $state(false)
 
 	const handlesArray = UserDraft.useMany<VariableState>(() =>
 		workspaceSpecs.map((s) => ({
@@ -115,6 +118,23 @@
 	const dirtyWorkspaces = $derived(
 		Object.keys(states).filter((ws) => !draftValuesEqual(states[ws].draft, initialStates[ws]))
 	)
+
+	// A new variable's handle is keyed on the empty `editPath`, so it is
+	// detached and never POSTs; the form is mirrored under the typed path
+	// instead. Inert in edit mode.
+	const newDraftSync = useNewItemDraftSync<VariableState>({
+		itemKind: 'variable',
+		enabled: () => !edit,
+		workspace: () => selected,
+		path: () => current?.path ?? '',
+		pathError: () => pathError,
+		touched: () =>
+			pathDirty ||
+			(!!current &&
+				!!selected &&
+				!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' })),
+		value: () => (current ? ($state.snapshot(current) as VariableState) : undefined)
+	})
 
 	// The list-page `*` hint is owned by UserDraftDbSyncer (set on save, cleared
 	// on delete). The editor only CLEARS it — a workspace at the deployed
@@ -176,25 +196,34 @@
 			]).then(([v, user]) => {
 				// `.draft` already holds the editor's `VariableState` shape.
 				const savedDraftState = (v as any).draft as VariableState | undefined
+				// Draft-only paths (`no_deployed`) have no row — saving must
+				// CREATE, not update (update 404s).
+				const noDeployed = !!(v as any).no_deployed
 				// Deployed baseline as the dirty-check reference, so the banner
 				// compares draft-vs-deployed and fires immediately when a draft exists.
-				const deployedState: VariableState = {
-					path: v.path,
-					variable: {
-						value: v.value ?? '',
-						is_secret: v.is_secret,
-						description: v.description ?? ''
-					},
-					labels: v.labels ?? undefined,
-					wsSpecific: v.ws_specific ?? false
-				}
+				// A draft-only item has no deployed side: everything in it is unsaved.
+				const deployedState: VariableState = noDeployed
+					? {
+							path: '',
+							variable: { value: '', is_secret: true, description: '' },
+							labels: undefined,
+							wsSpecific: false
+						}
+					: {
+							path: v.path,
+							variable: {
+								value: v.value ?? '',
+								is_secret: v.is_secret,
+								description: v.description ?? ''
+							},
+							labels: v.labels ?? undefined,
+							wsSpecific: v.ws_specific ?? false
+						}
 				// Open with the saved draft if present, else the deployed.
 				const s: VariableState = savedDraftState ?? deployedState
 				ensureHandle(ws, s)
 				initialStates[ws] = structuredClone(deployedState)
-				// Draft-only paths (`no_deployed`) have no row — saving must
-				// CREATE, not update (update 404s).
-				existedInitially[ws] = !(v as any).no_deployed
+				existedInitially[ws] = !noDeployed
 				extraPerms[ws] = v.extra_perms ?? {}
 				perWsUser[ws] = user
 			})
@@ -210,6 +239,8 @@
 		extraPerms = {}
 		perWsUser = {}
 		pathError = ''
+		pathDirty = false
+		newDraftSync.reset()
 	}
 
 	export function initNew(): void {
@@ -238,7 +269,8 @@
 	}
 
 	async function loadSecret(): Promise<void> {
-		if (!editPath || !selected) return
+		// A draft-only variable has no deployed secret to load.
+		if (!editPath || !selected || !existedInitially[selected]) return
 		const getV = await VariableService.getVariable({
 			workspace: selected,
 			path: editPath,
@@ -293,7 +325,11 @@
 				// the server draft row so `is_draft` clears on refetch.
 				initialStates[ws] = $state.snapshot(s) as VariableState
 				existedInitially[ws] = true
-				UserDraft.discard('variable', editPath ?? '', s, { workspace: ws })
+				if (editPath) {
+					UserDraft.discard('variable', editPath, s, { workspace: ws })
+				} else {
+					newDraftSync.finish()
+				}
 				// Path now exists server-side — drop the autocomplete cache so
 				// it shows up immediately instead of after the 60s TTL.
 				invalidateWorkspacePaths(ws)
@@ -307,7 +343,16 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} size="50rem" on:close={() => clearPageDrawerAnchor(VARIABLES_PATH)}>
+<Drawer
+	bind:this={drawer}
+	size="50rem"
+	on:close={() => {
+		clearPageDrawerAnchor(VARIABLES_PATH)
+		// A new variable left unsaved persists as a draft-only row, which a
+		// list only sees on refetch.
+		dispatch('close')
+	}}
+>
 	<DrawerContent
 		title={edit ? `Update variable at ${initialPath}` : 'Add a variable'}
 		bannerReserved={edit}
@@ -319,11 +364,25 @@
 				reserveSpace={edit}
 				getDeployed={() => (selected ? initialStates[selected] : undefined)}
 				getCurrent={() => current}
-				onDiscard={() => {
+				onDiscard={async () => {
 					if (!selected) return
-					UserDraft.discard('variable', editPath ?? '', initialStates[selected], {
-						workspace: selected
+					if (existedInitially[selected]) {
+						UserDraft.discard('variable', editPath ?? '', initialStates[selected], {
+							workspace: selected
+						})
+						return
+					}
+					// Draft-only: no baseline to fall back to. Blank the cell so the form
+					// unmounts — mounted on the empty state it re-fills the path from
+					// `initialPath`, and that autosave would displace the delete. Flushed
+					// so the list refetch on drawer close no longer finds the row.
+					UserDraft.remove('variable', editPath ?? '', { workspace: selected })
+					await UserDraftDbSyncer.flush({
+						workspace: selected,
+						itemKind: 'variable',
+						path: editPath ?? ''
 					})
+					drawer?.closeDrawer()
 				}}
 				disabled={!can_write}
 			/>
@@ -347,6 +406,7 @@
 						bind:this={form}
 						bind:path={current.path}
 						bind:pathError
+						bind:pathDirty
 						bind:variable={current.variable}
 						bind:labels={current.labels}
 						bind:wsSpecific={current.wsSpecific}

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -149,10 +149,14 @@
 			!draftValuesEqual({ ...current, path: '' }, { ...openedWith[selected], path: '' }),
 		value: () => (current ? ($state.snapshot(current) as VariableState) : undefined),
 		pathIsFree: (p) => (selected ? variablePathIsFree(selected, p) : Promise.resolve(false)),
+		keyed: (v, p) => ({ ...v, path: p }),
 		onAbandonKey: (ws, p) => {
 			// The handle is pinned to the path this editor opened; once the draft
 			// has moved off it, its next write would recreate the row it left.
 			if (p === editPath) UserDraft.stopSync('variable', p, { workspace: ws })
+		},
+		onResumeKey: (ws, p) => {
+			if (p === editPath) UserDraft.restartSync('variable', p, { workspace: ws })
 		}
 	})
 

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -58,7 +58,18 @@
 	let perWsUser: Record<string, UserExt | undefined> = $state({})
 	let selected: string | undefined = $state(undefined)
 	let pathError = $state('')
-	let pathDirty = $state(false)
+	// Set before `save` awaits anything, so a close-time draft move can't leave
+	// a draft on the variable being created.
+	let saving = $state(false)
+
+	async function variablePathIsFree(ws: string, p: string): Promise<boolean> {
+		try {
+			return !(await VariableService.existsVariable({ workspace: ws, path: p }))
+		} catch {
+			// Fail closed: an unanswered check is not evidence the path is free.
+			return false
+		}
+	}
 
 	const handlesArray = UserDraft.useMany<VariableState>(() =>
 		workspaceSpecs.map((s) => ({
@@ -128,12 +139,12 @@
 		workspace: () => selected,
 		path: () => current?.path ?? '',
 		pathError: () => pathError,
-		touched: () =>
-			pathDirty ||
-			(!!current &&
-				!!selected &&
-				!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' })),
-		value: () => (current ? ($state.snapshot(current) as VariableState) : undefined)
+		contentTouched: () =>
+			!!current &&
+			!!selected &&
+			!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' }),
+		value: () => (current ? ($state.snapshot(current) as VariableState) : undefined),
+		pathIsFree: (p) => (selected ? variablePathIsFree(selected, p) : Promise.resolve(false))
 	})
 
 	// The list-page `*` hint is owned by UserDraftDbSyncer (set on save, cleared
@@ -236,16 +247,22 @@
 	 * 404 on reopen and its delete would miss — so move the draft to the path
 	 * the form now carries. Reads its state synchronously: the caller runs this
 	 * as the drawer closes, and awaiting first would race the form's teardown. */
-	function moveRenamedDraftOnly(): Promise<unknown> {
+	async function moveRenamedDraftOnly(): Promise<void> {
 		const ws = selected
-		if (!ws || !editPath || existedInitially[ws] !== false) return Promise.resolve()
+		if (!ws || !editPath || existedInitially[ws] !== false || saving) return
 		const s = states[ws]?.draft
-		if (!s || !s.path || s.path === editPath) return Promise.resolve()
+		if (!s || !s.path || s.path === editPath || pathError !== '') return
+		const value = $state.snapshot(s) as VariableState
+		const target = s.path
 		const from = editPath
-		UserDraft.save('variable', s.path, $state.snapshot(s) as VariableState, { workspace: ws })
+		// The path may have been typed too recently for `Path`'s debounced check
+		// to have run: moving onto an occupied path would hand this draft to the
+		// item living there.
+		if (!(await variablePathIsFree(ws, target))) return
+		UserDraft.save('variable', target, value, { workspace: ws })
 		UserDraft.remove('variable', from, { workspace: ws })
-		return Promise.all([
-			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: s.path }),
+		await Promise.all([
+			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: target }),
 			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: from })
 		])
 	}
@@ -266,7 +283,7 @@
 		extraPerms = {}
 		perWsUser = {}
 		pathError = ''
-		pathDirty = false
+		saving = false
 		newDraftSync.reset()
 	}
 
@@ -312,6 +329,8 @@
 
 	async function save(): Promise<void> {
 		const dirty = dirtyWorkspaces
+		// Synchronous, before the first await, so the close-time draft move sees it.
+		saving = true
 		try {
 			for (const ws of dirty) {
 				const s = states[ws].draft!
@@ -354,6 +373,10 @@
 				existedInitially[ws] = true
 				if (editPath) {
 					UserDraft.discard('variable', editPath, s, { workspace: ws })
+					// Flushed: the caller refetches the list right after, and the
+					// discard's delete rides the same debounce — the just-deployed item
+					// would still come back rendered as a draft.
+					await UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: editPath })
 				} else {
 					// Awaited: the caller refetches the list right after, and a debounced
 					// delete would leave the just-created item still flagged as a draft.
@@ -436,7 +459,6 @@
 						bind:this={form}
 						bind:path={current.path}
 						bind:pathError
-						bind:pathDirty
 						bind:variable={current.variable}
 						bind:labels={current.labels}
 						bind:wsSpecific={current.wsSpecific}

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -230,6 +230,33 @@
 		})
 	})
 
+	/** A draft-only item's list row is keyed by the path INSIDE the draft, while
+	 * the autosave handle stays keyed on the path the editor opened. Renaming
+	 * one would leave the row pointing at a key that holds no draft — it would
+	 * 404 on reopen and its delete would miss — so move the draft to the path
+	 * the form now carries. Reads its state synchronously: the caller runs this
+	 * as the drawer closes, and awaiting first would race the form's teardown. */
+	function moveRenamedDraftOnly(): Promise<unknown> {
+		const ws = selected
+		if (!ws || !editPath || existedInitially[ws] !== false) return Promise.resolve()
+		const s = states[ws]?.draft
+		if (!s || !s.path || s.path === editPath) return Promise.resolve()
+		const from = editPath
+		UserDraft.save('variable', s.path, $state.snapshot(s) as VariableState, { workspace: ws })
+		UserDraft.remove('variable', from, { workspace: ws })
+		return Promise.all([
+			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: s.path }),
+			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: from })
+		])
+	}
+
+	/** Settle every pending draft write before the drawer's close event, whose
+	 * list refetch would otherwise outrun the debounced POST. */
+	async function flushDraft(): Promise<void> {
+		// Both started before the first await so they read live form state.
+		await Promise.all([newDraftSync.flush(), moveRenamedDraftOnly()])
+	}
+
 	function reset() {
 		// Clearing workspaceSpecs triggers useMany's reconcile to release
 		// every acquired entry. The $derived `states` then collapses to {}.
@@ -328,7 +355,9 @@
 				if (editPath) {
 					UserDraft.discard('variable', editPath, s, { workspace: ws })
 				} else {
-					newDraftSync.finish()
+					// Awaited: the caller refetches the list right after, and a debounced
+					// delete would leave the just-created item still flagged as a draft.
+					await newDraftSync.finish()
 				}
 				// Path now exists server-side — drop the autocomplete cache so
 				// it shows up immediately instead of after the 60s TTL.
@@ -346,10 +375,11 @@
 <Drawer
 	bind:this={drawer}
 	size="50rem"
-	on:close={() => {
+	on:close={async () => {
 		clearPageDrawerAnchor(VARIABLES_PATH)
-		// A new variable left unsaved persists as a draft-only row, which a
-		// list only sees on refetch.
+		// A new variable left unsaved persists as a draft-only row, which a list
+		// only sees on refetch — settle the write before asking for that refetch.
+		await flushDraft()
 		dispatch('close')
 	}}
 >

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -58,9 +58,9 @@
 	let perWsUser: Record<string, UserExt | undefined> = $state({})
 	let selected: string | undefined = $state(undefined)
 	let pathError = $state('')
-	// Set before `save` awaits anything, so a close-time draft move can't leave
-	// a draft on the variable being created.
-	let saving = $state(false)
+	// What the form was opened with: the empty seed for a new variable, the
+	// draft itself for a draft-only one. Divergence from it is the user's edit.
+	let openedWith: Record<string, VariableState> = $state({})
 
 	async function variablePathIsFree(ws: string, p: string): Promise<boolean> {
 		try {
@@ -130,19 +130,23 @@
 		Object.keys(states).filter((ws) => !draftValuesEqual(states[ws].draft, initialStates[ws]))
 	)
 
-	// A new variable's handle is keyed on the empty `editPath`, so it is
-	// detached and never POSTs; the form is mirrored under the typed path
-	// instead. Inert in edit mode.
+	// Nothing deployed at this path: the item IS its draft. Its list row is keyed
+	// by the path inside that draft, so the key has to follow the form's path —
+	// which is what `useNewItemDraftSync` does and the `useMany` handle can't
+	// (it is pinned to the path this editor opened).
+	const draftOnly = $derived(!!selected && existedInitially[selected] === false)
+
 	const newDraftSync = useNewItemDraftSync<VariableState>({
 		itemKind: 'variable',
-		enabled: () => !edit,
+		enabled: () => draftOnly,
 		workspace: () => selected,
 		path: () => current?.path ?? '',
 		pathError: () => pathError,
 		contentTouched: () =>
 			!!current &&
 			!!selected &&
-			!draftValuesEqual({ ...current, path: '' }, { ...initialStates[selected], path: '' }),
+			!!openedWith[selected] &&
+			!draftValuesEqual({ ...current, path: '' }, { ...openedWith[selected], path: '' }),
 		value: () => (current ? ($state.snapshot(current) as VariableState) : undefined),
 		pathIsFree: (p) => (selected ? variablePathIsFree(selected, p) : Promise.resolve(false))
 	})
@@ -234,44 +238,25 @@
 				const s: VariableState = savedDraftState ?? deployedState
 				ensureHandle(ws, s)
 				initialStates[ws] = structuredClone(deployedState)
+				openedWith[ws] = structuredClone(s)
 				existedInitially[ws] = !noDeployed
+				if (noDeployed) {
+					// The helper owns this draft's key from here (see `draftOnly`);
+					// leaving the handle syncing too would write the same content back
+					// under the path this editor opened, stranding the row on a rename.
+					UserDraft.stopSync('variable', p, { workspace: ws })
+					newDraftSync.adopt(ws, p, structuredClone(s))
+				}
 				extraPerms[ws] = v.extra_perms ?? {}
 				perWsUser[ws] = user
 			})
 		})
 	})
 
-	/** A draft-only item's list row is keyed by the path INSIDE the draft, while
-	 * the autosave handle stays keyed on the path the editor opened. Renaming
-	 * one would leave the row pointing at a key that holds no draft — it would
-	 * 404 on reopen and its delete would miss — so move the draft to the path
-	 * the form now carries. Reads its state synchronously: the caller runs this
-	 * as the drawer closes, and awaiting first would race the form's teardown. */
-	async function moveRenamedDraftOnly(): Promise<void> {
-		const ws = selected
-		if (!ws || !editPath || existedInitially[ws] !== false || saving) return
-		const s = states[ws]?.draft
-		if (!s || !s.path || s.path === editPath || pathError !== '') return
-		const value = $state.snapshot(s) as VariableState
-		const target = s.path
-		const from = editPath
-		// The path may have been typed too recently for `Path`'s debounced check
-		// to have run: moving onto an occupied path would hand this draft to the
-		// item living there.
-		if (!(await variablePathIsFree(ws, target))) return
-		UserDraft.save('variable', target, value, { workspace: ws })
-		UserDraft.remove('variable', from, { workspace: ws })
-		await Promise.all([
-			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: target }),
-			UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: from })
-		])
-	}
-
 	/** Settle every pending draft write before the drawer's close event, whose
 	 * list refetch would otherwise outrun the debounced POST. */
 	async function flushDraft(): Promise<void> {
-		// Both started before the first await so they read live form state.
-		await Promise.all([newDraftSync.flush(), moveRenamedDraftOnly()])
+		await newDraftSync.flush()
 	}
 
 	function reset() {
@@ -283,7 +268,7 @@
 		extraPerms = {}
 		perWsUser = {}
 		pathError = ''
-		saving = false
+		openedWith = {}
 		newDraftSync.reset()
 	}
 
@@ -299,6 +284,7 @@
 		}
 		ensureHandle(ws, s)
 		initialStates[ws] = structuredClone(s)
+		openedWith[ws] = structuredClone(s)
 		existedInitially[ws] = false
 		selected = ws
 		drawer?.openDrawer()
@@ -329,12 +315,11 @@
 
 	async function save(): Promise<void> {
 		const dirty = dirtyWorkspaces
-		// Synchronous, before the first await, so the close-time draft move sees it.
-		saving = true
 		try {
 			for (const ws of dirty) {
 				const s = states[ws].draft!
 				const ini = initialStates[ws]
+				const wasDeployed = existedInitially[ws]
 				if (existedInitially[ws]) {
 					await VariableService.updateVariable({
 						workspace: ws,
@@ -370,17 +355,17 @@
 				// `undefined` reads as dirty). The `value: null` POST also deletes
 				// the server draft row so `is_draft` clears on refetch.
 				initialStates[ws] = $state.snapshot(s) as VariableState
+				openedWith[ws] = $state.snapshot(s) as VariableState
 				existedInitially[ws] = true
-				if (editPath) {
-					UserDraft.discard('variable', editPath, s, { workspace: ws })
-					// Flushed: the caller refetches the list right after, and the
-					// discard's delete rides the same debounce — the just-deployed item
-					// would still come back rendered as a draft.
-					await UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: editPath })
+				// Both awaited: the caller refetches the list right after, and a
+				// debounced delete would bring the just-deployed item back as a draft.
+				if (wasDeployed) {
+					UserDraft.discard('variable', editPath!, s, { workspace: ws })
+					await UserDraftDbSyncer.flush({ workspace: ws, itemKind: 'variable', path: editPath! })
 				} else {
-					// Awaited: the caller refetches the list right after, and a debounced
-					// delete would leave the just-created item still flagged as a draft.
+					// The helper held this draft (new or draft-only), wherever it keyed it.
 					await newDraftSync.finish()
+					if (editPath) UserDraft.restartSync('variable', editPath, { workspace: ws })
 				}
 				// Path now exists server-side — drop the autocomplete cache so
 				// it shows up immediately instead of after the 60s TTL.
@@ -425,10 +410,11 @@
 						})
 						return
 					}
-					// Draft-only: no baseline to fall back to. Blank the cell so the form
-					// unmounts — mounted on the empty state it re-fills the path from
-					// `initialPath`, and that autosave would displace the delete. Flushed
-					// so the list refetch on drawer close no longer finds the row.
+					// Draft-only: the item is the draft, so discarding deletes it. `finish`
+					// drops it wherever the helper keyed it and settles that before the
+					// caller's list refetch; `remove` then blanks the cell so the form
+					// unmounts, and clears the key this editor opened if the two differ.
+					await newDraftSync.finish()
 					UserDraft.remove('variable', editPath ?? '', { workspace: selected })
 					await UserDraftDbSyncer.flush({
 						workspace: selected,

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -148,7 +148,12 @@
 			!!openedWith[selected] &&
 			!draftValuesEqual({ ...current, path: '' }, { ...openedWith[selected], path: '' }),
 		value: () => (current ? ($state.snapshot(current) as VariableState) : undefined),
-		pathIsFree: (p) => (selected ? variablePathIsFree(selected, p) : Promise.resolve(false))
+		pathIsFree: (p) => (selected ? variablePathIsFree(selected, p) : Promise.resolve(false)),
+		onAbandonKey: (ws, p) => {
+			// The handle is pinned to the path this editor opened; once the draft
+			// has moved off it, its next write would recreate the row it left.
+			if (p === editPath) UserDraft.stopSync('variable', p, { workspace: ws })
+		}
 	})
 
 	// The list-page `*` hint is owned by UserDraftDbSyncer (set on save, cleared
@@ -240,13 +245,10 @@
 				initialStates[ws] = structuredClone(deployedState)
 				openedWith[ws] = structuredClone(s)
 				existedInitially[ws] = !noDeployed
-				if (noDeployed) {
-					// The helper owns this draft's key from here (see `draftOnly`);
-					// leaving the handle syncing too would write the same content back
-					// under the path this editor opened, stranding the row on a rename.
-					UserDraft.stopSync('variable', p, { workspace: ws })
-					newDraftSync.adopt(ws, p, structuredClone(s))
-				}
+				// The helper owns this draft's key from here (see `draftOnly`): the
+				// handle keeps autosaving it while the path is unchanged, and hands
+				// the key over the moment a rename moves it.
+				if (noDeployed) newDraftSync.adopt(ws, p, structuredClone(s))
 				extraPerms[ws] = v.extra_perms ?? {}
 				perWsUser[ws] = user
 			})

--- a/frontend/src/lib/components/VariableForm.svelte
+++ b/frontend/src/lib/components/VariableForm.svelte
@@ -26,7 +26,7 @@
 		initialPath: string
 		pathError: string
 		/** Whether the user edited the path (as opposed to `Path`'s auto-filled name). */
-		pathDirty?: boolean
+		pathDirty: boolean
 		variable: Variable
 		labels: string[] | undefined
 		wsSpecific: boolean
@@ -42,7 +42,7 @@
 		path = $bindable(),
 		initialPath,
 		pathError = $bindable(),
-		pathDirty = $bindable(false),
+		pathDirty = $bindable(),
 		variable = $bindable(),
 		labels = $bindable(),
 		wsSpecific = $bindable(),

--- a/frontend/src/lib/components/VariableForm.svelte
+++ b/frontend/src/lib/components/VariableForm.svelte
@@ -25,8 +25,6 @@
 		path: string
 		initialPath: string
 		pathError: string
-		/** Whether the user edited the path (as opposed to `Path`'s auto-filled name). */
-		pathDirty: boolean
 		variable: Variable
 		labels: string[] | undefined
 		wsSpecific: boolean
@@ -42,7 +40,6 @@
 		path = $bindable(),
 		initialPath,
 		pathError = $bindable(),
-		pathDirty = $bindable(),
 		variable = $bindable(),
 		labels = $bindable(),
 		wsSpecific = $bindable(),
@@ -76,7 +73,6 @@
 	<Path
 		disabled={initialPath != '' && !isOwner(initialPath, $userStore, ws)}
 		bind:error={pathError}
-		bind:dirty={pathDirty}
 		bind:path
 		{initialPath}
 		namePlaceholder="variable"

--- a/frontend/src/lib/components/VariableForm.svelte
+++ b/frontend/src/lib/components/VariableForm.svelte
@@ -25,6 +25,8 @@
 		path: string
 		initialPath: string
 		pathError: string
+		/** Whether the user edited the path (as opposed to `Path`'s auto-filled name). */
+		pathDirty?: boolean
 		variable: Variable
 		labels: string[] | undefined
 		wsSpecific: boolean
@@ -40,6 +42,7 @@
 		path = $bindable(),
 		initialPath,
 		pathError = $bindable(),
+		pathDirty = $bindable(false),
 		variable = $bindable(),
 		labels = $bindable(),
 		wsSpecific = $bindable(),
@@ -73,6 +76,7 @@
 	<Path
 		disabled={initialPath != '' && !isOwner(initialPath, $userStore, ws)}
 		bind:error={pathError}
+		bind:dirty={pathDirty}
 		bind:path
 		{initialPath}
 		namePlaceholder="variable"

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
@@ -220,6 +220,41 @@ describe('useNewItemDraftSync', () => {
 		cleanup()
 	})
 
+	/** An editor's own autosave handle stays pinned to the path it opened, so
+	 * once the draft moves the helper has to hand that key back for suspension —
+	 * otherwise the handle's next write recreates the row just deleted. */
+	it('reports the key it abandons so a pinned handle can be suspended', async () => {
+		const form = $state({ path: 'u/me/pinned', n: 1 })
+		const abandoned: string[] = []
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				contentTouched: () => false,
+				value: () => ({ n: form.n }),
+				onAbandonKey: (_ws, p) => abandoned.push(p)
+			})
+			sync.adopt('w', 'u/me/pinned', { n: 1 })
+		})
+		flushSync()
+		// Untouched: the key is still in use, nothing handed back.
+		vi.advanceTimersByTime(2000)
+		flushSync()
+		expect(abandoned).toEqual([])
+
+		form.path = 'u/me/elsewhere'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		await sync!.flush()
+		expect(abandoned).toEqual(['u/me/pinned'])
+		cleanup()
+	})
+
 	/** An adopted draft exists whether or not the user edits it, so the
 	 * touched gate that keeps an untouched NEW item from leaving a row must not
 	 * apply — deleting here would wipe the item the editor is showing. An

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flushSync } from 'svelte'
+
+const save = vi.fn()
+const remove = vi.fn()
+vi.mock('$lib/userDraft.svelte', () => ({
+	UserDraft: {
+		save: (...a: unknown[]) => save(...a),
+		remove: (...a: unknown[]) => remove(...a)
+	}
+}))
+
+import { useNewItemDraftSync } from './useNewItemDraftSync.svelte'
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => {
+	vi.useRealTimers()
+	vi.clearAllMocks()
+})
+
+/** Drives the helper through a new-item drawer session and pins the writes
+ * it must and must not make: nothing for an untouched form (the path field
+ * auto-fills a name on mount), a move that deletes the key it left, a delete
+ * once the path fails validation, and no delete at all on teardown — a draft
+ * left behind by closing the drawer is the feature. */
+describe('useNewItemDraftSync', () => {
+	it('writes only a touched form, follows the path, and leaves the draft on teardown', () => {
+		const form = $state({ path: 'u/me/auto_name', pathError: '', touched: false, n: 1 })
+		let draftPath = ''
+		const cleanup = $effect.root(() => {
+			const sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => form.pathError,
+				touched: () => form.touched,
+				value: () => ({ n: form.n })
+			})
+			$effect(() => {
+				draftPath = sync.draftPath
+			})
+		})
+		flushSync()
+		vi.advanceTimersByTime(2000)
+		flushSync()
+		expect(save).not.toHaveBeenCalled()
+
+		form.touched = true
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(save).toHaveBeenCalledWith('resource', 'u/me/auto_name', { n: 1 }, { workspace: 'w' })
+		expect(draftPath).toBe('u/me/auto_name')
+
+		form.n = 2
+		flushSync()
+		expect(save).toHaveBeenLastCalledWith(
+			'resource',
+			'u/me/auto_name',
+			{ n: 2 },
+			{ workspace: 'w' }
+		)
+
+		form.path = 'u/me/renamed'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(remove).toHaveBeenCalledWith('resource', 'u/me/auto_name', { workspace: 'w' })
+		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/renamed', { n: 2 }, { workspace: 'w' })
+
+		form.pathError = 'path already used'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(remove).toHaveBeenLastCalledWith('resource', 'u/me/renamed', { workspace: 'w' })
+		expect(draftPath).toBe('')
+
+		form.pathError = ''
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/renamed', { n: 2 }, { workspace: 'w' })
+
+		cleanup()
+		expect(remove).toHaveBeenCalledTimes(2)
+	})
+
+	it('finish deletes the persisted key and stops mirroring until reset', () => {
+		const form = $state({ path: 'u/me/item', touched: true, n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'variable',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				touched: () => form.touched,
+				value: () => ({ n: form.n })
+			})
+		})
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(save).toHaveBeenCalledTimes(1)
+
+		sync!.finish()
+		flushSync()
+		expect(remove).toHaveBeenCalledWith('variable', 'u/me/item', { workspace: 'w' })
+
+		form.n = 2
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(save).toHaveBeenCalledTimes(1)
+
+		sync!.reset()
+		form.n = 3
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(save).toHaveBeenLastCalledWith('variable', 'u/me/item', { n: 3 }, { workspace: 'w' })
+		expect(remove).toHaveBeenCalledTimes(1)
+
+		cleanup()
+	})
+})

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
@@ -38,7 +38,7 @@ describe('useNewItemDraftSync', () => {
 				workspace: () => 'w',
 				path: () => form.path,
 				pathError: () => form.pathError,
-				touched: () => form.touched,
+				contentTouched: () => form.touched,
 				value: () => ({ n: form.n })
 			})
 			$effect(() => {
@@ -103,7 +103,7 @@ describe('useNewItemDraftSync', () => {
 				workspace: () => 'w',
 				path: () => form.path,
 				pathError: () => '',
-				touched: () => form.touched,
+				contentTouched: () => form.touched,
 				value: () => ({ n: form.n })
 			})
 		})
@@ -127,6 +127,104 @@ describe('useNewItemDraftSync', () => {
 		})
 	})
 
+	/** A close cuts the commit delay short, so `Path`'s debounced existence
+	 * check may not have run. Keying a draft on an occupied path would hand it
+	 * to the item already there, and saving from that item would overwrite it. */
+	it('refuses to commit a forced flush onto an occupied path', async () => {
+		const form = $state({ path: 'u/me/taken', touched: false, n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				// Still clear: the check that would set it has not run yet.
+				pathError: () => '',
+				contentTouched: () => form.touched,
+				value: () => ({ n: form.n }),
+				pathIsFree: async () => false
+			})
+		})
+		flushSync()
+		form.touched = true
+		flushSync()
+
+		await sync!.flush()
+		expect(save).not.toHaveBeenCalled()
+		cleanup()
+	})
+
+	/** A move deletes the key it left on the same debounce as the write, so the
+	 * close-time flush has to settle both or the list refetch renders a ghost
+	 * row at the old path. */
+	it('settles the key a move deleted, not just the one it wrote', async () => {
+		const form = $state({ path: 'u/me/first', touched: true, n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				contentTouched: () => form.touched,
+				value: () => ({ n: form.n })
+			})
+		})
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+
+		form.path = 'u/me/second'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+
+		await sync!.flush()
+		const flushed = flush.mock.calls.map((c: any[]) => c[0].path)
+		expect(flushed).toContain('u/me/first')
+		expect(flushed).toContain('u/me/second')
+		cleanup()
+	})
+
+	/** `Path` auto-fills a unique name on mount and flips its own `dirty` on any
+	 * keyup, tabbing included. Only a departure from that name counts, or an
+	 * untouched drawer would leave a phantom row behind. */
+	it('treats the auto-filled path as untouched but a typed one as an edit', () => {
+		const form = $state({ path: '', n: 1 })
+		const cleanup = $effect.root(() => {
+			useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				contentTouched: () => false,
+				value: () => ({ n: form.n })
+			})
+		})
+		flushSync()
+		// `Path` fills its generated name in after mount.
+		form.path = 'u/me/lucky_resource'
+		flushSync()
+		vi.advanceTimersByTime(2000)
+		flushSync()
+		expect(save).not.toHaveBeenCalled()
+
+		form.path = 'u/me/typed_by_hand'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		expect(save).toHaveBeenCalledWith(
+			'resource',
+			'u/me/typed_by_hand',
+			{ n: 1 },
+			{ workspace: 'w' }
+		)
+		cleanup()
+	})
+
 	it('finish deletes the persisted key and stops mirroring until reset', async () => {
 		const form = $state({ path: 'u/me/item', touched: true, n: 1 })
 		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
@@ -137,7 +235,7 @@ describe('useNewItemDraftSync', () => {
 				workspace: () => 'w',
 				path: () => form.path,
 				pathError: () => '',
-				touched: () => form.touched,
+				contentTouched: () => form.touched,
 				value: () => ({ n: form.n })
 			})
 		})

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
@@ -3,11 +3,15 @@ import { flushSync } from 'svelte'
 
 const save = vi.fn()
 const remove = vi.fn()
+const flush = vi.fn(async () => {})
 vi.mock('$lib/userDraft.svelte', () => ({
 	UserDraft: {
 		save: (...a: unknown[]) => save(...a),
 		remove: (...a: unknown[]) => remove(...a)
 	}
+}))
+vi.mock('$lib/userDraftDbSyncer.svelte', () => ({
+	UserDraftDbSyncer: { flush: (...a: unknown[]) => flush(...(a as [])) }
 }))
 
 import { useNewItemDraftSync } from './useNewItemDraftSync.svelte'
@@ -18,8 +22,8 @@ afterEach(() => {
 	vi.clearAllMocks()
 })
 
-/** Drives the helper through a new-item drawer session and pins the writes
- * it must and must not make: nothing for an untouched form (the path field
+/** Drives the helper through a new-item drawer session and pins the writes it
+ * must and must not make: nothing for an untouched form (the path field
  * auto-fills a name on mount), a move that deletes the key it left, a delete
  * once the path fails validation, and no delete at all on teardown — a draft
  * left behind by closing the drawer is the feature. */
@@ -86,7 +90,44 @@ describe('useNewItemDraftSync', () => {
 		expect(remove).toHaveBeenCalledTimes(2)
 	})
 
-	it('finish deletes the persisted key and stops mirroring until reset', () => {
+	/** The commit is delayed so the key can't land on a half-typed path, and the
+	 * editor is destroyed the moment its drawer closes. Closing right after the
+	 * first edit therefore tears down mid-delay, and the draft must survive it. */
+	it('persists a commit still pending when the editor is torn down', async () => {
+		const form = $state({ path: 'u/me/quick', touched: false, n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				touched: () => form.touched,
+				value: () => ({ n: form.n })
+			})
+		})
+		flushSync()
+		form.touched = true
+		flushSync()
+
+		// Torn down half-way through the commit delay.
+		vi.advanceTimersByTime(500)
+		cleanup()
+		vi.advanceTimersByTime(500)
+		expect(save).toHaveBeenCalledWith('resource', 'u/me/quick', { n: 1 }, { workspace: 'w' })
+
+		// The drawer's close handler awaits this, so the list refetch behind it
+		// sees the row rather than racing the syncer's debounce.
+		await sync!.flush()
+		expect(flush).toHaveBeenCalledWith({
+			workspace: 'w',
+			itemKind: 'resource',
+			path: 'u/me/quick'
+		})
+	})
+
+	it('finish deletes the persisted key and stops mirroring until reset', async () => {
 		const form = $state({ path: 'u/me/item', touched: true, n: 1 })
 		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
 		const cleanup = $effect.root(() => {
@@ -105,8 +146,7 @@ describe('useNewItemDraftSync', () => {
 		flushSync()
 		expect(save).toHaveBeenCalledTimes(1)
 
-		sync!.finish()
-		flushSync()
+		await sync!.finish()
 		expect(remove).toHaveBeenCalledWith('variable', 'u/me/item', { workspace: 'w' })
 
 		form.n = 2

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
@@ -4,12 +4,14 @@ import { flushSync } from 'svelte'
 const save = vi.fn()
 const remove = vi.fn()
 const discard = vi.fn()
+const forcePersist = vi.fn(async () => {})
 const flush = vi.fn(async () => {})
 vi.mock('$lib/userDraft.svelte', () => ({
 	UserDraft: {
 		save: (...a: unknown[]) => save(...a),
 		remove: (...a: unknown[]) => remove(...a),
-		discard: (...a: unknown[]) => discard(...a)
+		discard: (...a: unknown[]) => discard(...a),
+		forcePersist: (...a: unknown[]) => forcePersist(...a)
 	}
 }))
 vi.mock('$lib/userDraftDbSyncer.svelte', () => ({
@@ -217,6 +219,84 @@ describe('useNewItemDraftSync', () => {
 		await sync!.flush()
 		expect(discard.mock.calls.at(-1)?.slice(0, 2)).toEqual(['resource', 'u/me/adopted'])
 		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/moved', { n: 1 }, { workspace: 'w' })
+		cleanup()
+	})
+
+	/** The list synthesizes a draft-only row from the path INSIDE the draft while
+	 * get and delete address the key, so a stored draft has to describe its own
+	 * key. A rename the draft can't follow yet must not smuggle the new path
+	 * into the row it is still living in. */
+	it('stores a draft describing the key it lives under, not an unusable path', async () => {
+		const form = $state({ path: 'u/me/home', pathError: '', n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => form.pathError,
+				contentTouched: () => false,
+				value: () => ({ path: form.path, n: form.n }),
+				keyed: (v, p) => ({ ...v, path: p })
+			})
+			sync.adopt('w', 'u/me/home', { path: 'u/me/home', n: 1 })
+		})
+		flushSync()
+
+		// Renamed to a path the draft cannot move to, then edited.
+		form.path = 'u/me/taken'
+		form.pathError = 'path already used'
+		form.n = 2
+		flushSync()
+		vi.advanceTimersByTime(2000)
+		flushSync()
+		await sync!.flush()
+		expect(save).toHaveBeenLastCalledWith(
+			'resource',
+			'u/me/home',
+			{ path: 'u/me/home', n: 2 },
+			{ workspace: 'w' }
+		)
+	})
+
+	/** Renaming away suspends the handle pinned to the original key; renaming
+	 * back has to resume it, or the draft is deleted at both keys and written
+	 * to neither. */
+	it('resumes a key it returns to after abandoning it', async () => {
+		const form = $state({ path: 'u/me/there', n: 1 })
+		const events: string[] = []
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				contentTouched: () => false,
+				value: () => ({ n: form.n }),
+				onAbandonKey: (_ws, p) => events.push(`abandon:${p}`),
+				onResumeKey: (_ws, p) => events.push(`resume:${p}`)
+			})
+			sync.adopt('w', 'u/me/there', { n: 1 })
+		})
+		flushSync()
+
+		form.path = 'u/me/away'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+
+		form.path = 'u/me/there'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		await sync!.flush()
+		expect(events).toEqual(['abandon:u/me/there', 'abandon:u/me/away', 'resume:u/me/there'])
+		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/there', { n: 1 }, { workspace: 'w' })
+		// The resumed handle's own change detection can no-op this write away.
+		expect(forcePersist).toHaveBeenCalledWith('resource', 'u/me/there', { workspace: 'w' })
 		cleanup()
 	})
 

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.dom.test.ts
@@ -3,11 +3,13 @@ import { flushSync } from 'svelte'
 
 const save = vi.fn()
 const remove = vi.fn()
+const discard = vi.fn()
 const flush = vi.fn(async () => {})
 vi.mock('$lib/userDraft.svelte', () => ({
 	UserDraft: {
 		save: (...a: unknown[]) => save(...a),
-		remove: (...a: unknown[]) => remove(...a)
+		remove: (...a: unknown[]) => remove(...a),
+		discard: (...a: unknown[]) => discard(...a)
 	}
 }))
 vi.mock('$lib/userDraftDbSyncer.svelte', () => ({
@@ -70,14 +72,14 @@ describe('useNewItemDraftSync', () => {
 		flushSync()
 		vi.advanceTimersByTime(1000)
 		flushSync()
-		expect(remove).toHaveBeenCalledWith('resource', 'u/me/auto_name', { workspace: 'w' })
+		expect(discard.mock.calls[0].slice(0, 2)).toEqual(['resource', 'u/me/auto_name'])
 		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/renamed', { n: 2 }, { workspace: 'w' })
 
 		form.pathError = 'path already used'
 		flushSync()
 		vi.advanceTimersByTime(1000)
 		flushSync()
-		expect(remove).toHaveBeenLastCalledWith('resource', 'u/me/renamed', { workspace: 'w' })
+		expect(discard.mock.calls.at(-1)?.slice(0, 2)).toEqual(['resource', 'u/me/renamed'])
 		expect(draftPath).toBe('')
 
 		form.pathError = ''
@@ -87,7 +89,7 @@ describe('useNewItemDraftSync', () => {
 		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/renamed', { n: 2 }, { workspace: 'w' })
 
 		cleanup()
-		expect(remove).toHaveBeenCalledTimes(2)
+		expect(discard).toHaveBeenCalledTimes(2)
 	})
 
 	/** The commit is delayed so the key can't land on a half-typed path, and the
@@ -188,6 +190,70 @@ describe('useNewItemDraftSync', () => {
 		cleanup()
 	})
 
+	/** A draft-only item arrives with a draft already stored under the path the
+	 * editor opened. Renaming it has to MOVE that row, so the helper must be
+	 * told which key it inherited or it would leave a second one behind. */
+	it('moves an adopted key on rename instead of leaving it behind', async () => {
+		const form = $state({ path: 'u/me/adopted', n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => '',
+				contentTouched: () => false,
+				value: () => ({ n: form.n })
+			})
+			sync.adopt('w', 'u/me/adopted', { n: 1 })
+		})
+		flushSync()
+
+		form.path = 'u/me/moved'
+		flushSync()
+		vi.advanceTimersByTime(1000)
+		flushSync()
+		await sync!.flush()
+		expect(discard.mock.calls.at(-1)?.slice(0, 2)).toEqual(['resource', 'u/me/adopted'])
+		expect(save).toHaveBeenLastCalledWith('resource', 'u/me/moved', { n: 1 }, { workspace: 'w' })
+		cleanup()
+	})
+
+	/** An adopted draft exists whether or not the user edits it, so the
+	 * touched gate that keeps an untouched NEW item from leaving a row must not
+	 * apply — deleting here would wipe the item the editor is showing. An
+	 * invalid path likewise leaves it where it is rather than dropping it. */
+	it('keeps an adopted draft through an untouched open and an invalid path', async () => {
+		const form = $state({ path: 'u/me/kept', pathError: '', n: 1 })
+		let sync: ReturnType<typeof useNewItemDraftSync> | undefined
+		const cleanup = $effect.root(() => {
+			sync = useNewItemDraftSync({
+				itemKind: 'resource',
+				enabled: () => true,
+				workspace: () => 'w',
+				path: () => form.path,
+				pathError: () => form.pathError,
+				contentTouched: () => false,
+				value: () => ({ n: form.n })
+			})
+			sync.adopt('w', 'u/me/kept', { n: 1 })
+		})
+		flushSync()
+		vi.advanceTimersByTime(2000)
+		flushSync()
+		expect(discard).not.toHaveBeenCalled()
+
+		form.pathError = 'path already used'
+		flushSync()
+		vi.advanceTimersByTime(2000)
+		flushSync()
+		await sync!.flush()
+		expect(discard).not.toHaveBeenCalled()
+		expect(sync!.draftPath).toBe('u/me/kept')
+		cleanup()
+	})
+
 	/** `Path` auto-fills a unique name on mount and flips its own `dirty` on any
 	 * keyup, tabbing included. Only a departure from that name counts, or an
 	 * untouched drawer would leave a phantom row behind. */
@@ -245,7 +311,7 @@ describe('useNewItemDraftSync', () => {
 		expect(save).toHaveBeenCalledTimes(1)
 
 		await sync!.finish()
-		expect(remove).toHaveBeenCalledWith('variable', 'u/me/item', { workspace: 'w' })
+		expect(discard.mock.calls.at(-1)?.slice(0, 2)).toEqual(['variable', 'u/me/item'])
 
 		form.n = 2
 		flushSync()
@@ -259,7 +325,7 @@ describe('useNewItemDraftSync', () => {
 		vi.advanceTimersByTime(1000)
 		flushSync()
 		expect(save).toHaveBeenLastCalledWith('variable', 'u/me/item', { n: 3 }, { workspace: 'w' })
-		expect(remove).toHaveBeenCalledTimes(1)
+		expect(discard).toHaveBeenCalledTimes(1)
 
 		cleanup()
 	})

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
@@ -16,13 +16,16 @@ export interface NewItemDraftSyncOptions<V> {
 	path: () => string
 	/** Reactive `Path` validation error (`''` when valid). */
 	pathError: () => string
-	/** Reactive: the user edited the name or the content. `Path` auto-fills a
-	 * name on mount, so opening and closing an untouched drawer must not leave
-	 * a draft behind. */
-	touched: () => boolean
+	/** Reactive: the user edited the form's content. The path is not part of
+	 * this — `Path` auto-fills a name on mount, and this helper tracks a
+	 * departure from that name itself. */
+	contentTouched: () => boolean
 	/** Reactive deep read of the value to persist (`$state.snapshot` of the
 	 * form state); `undefined` while there is nothing to persist. */
 	value: () => V | undefined
+	/** Whether nothing is deployed at `path` yet. Consulted only when a close
+	 * forces a commit early, where `Path`'s own check may not have run. */
+	pathIsFree?: (path: string) => Promise<boolean>
 }
 
 export interface NewItemDraftSync {
@@ -55,6 +58,10 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 	// the row actually left behind, not wherever the form points now.
 	let written: { workspace: string; path: string } | undefined
 	let writtenValue: string | undefined
+	// Every key this session has touched and not yet settled — the deletes a
+	// move leaves behind included, since those POST on the same debounce as the
+	// write and would otherwise still be pending when the list refetches.
+	let unsettled: { workspace: string; path: string }[] = []
 	// The commit the timer will make, snapshotted at schedule time so it still
 	// lands once the editor is gone: closing a drawer a keystroke after the
 	// first edit must keep the draft, so a pending commit is never cancelled by
@@ -63,10 +70,27 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 		| { timer: ReturnType<typeof setTimeout>; key: string; value: V | undefined }
 		| undefined
 	let pendingWorkspace: string | undefined
+	// `Path` auto-fills a unique name on mount, so a non-empty path is no
+	// evidence the user did anything. Only a departure from the name it settled
+	// on counts (`Path.dirty` can't: it flips on any keyup, tabbing included).
+	let autoPath: string | undefined
+
+	function markUnsettled(workspace: string, path: string): void {
+		if (!unsettled.some((k) => k.workspace === workspace && k.path === path)) {
+			unsettled.push({ workspace, path })
+		}
+	}
+
+	function touched(): boolean {
+		const p = opts.path()
+		if (autoPath === undefined && p !== '') autoPath = p
+		return opts.contentTouched() || (p !== '' && p !== autoPath)
+	}
 
 	function write(workspace: string | undefined, path: string, value: V | undefined): void {
 		if (written && (written.path !== path || written.workspace !== workspace)) {
 			UserDraft.remove(opts.itemKind, written.path, { workspace: written.workspace })
+			markUnsettled(written.workspace, written.path)
 			written = undefined
 			writtenValue = undefined
 		}
@@ -74,6 +98,7 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 		const serialized = JSON.stringify(value)
 		if (written && serialized === writtenValue) return
 		UserDraft.save(opts.itemKind, path, value, { workspace })
+		markUnsettled(workspace, path)
 		written = { workspace, path }
 		writtenValue = serialized
 	}
@@ -95,7 +120,7 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 	$effect(() => {
 		if (!opts.enabled() || finished) return
 		const p = opts.path()
-		const key = p !== '' && opts.pathError() === '' && opts.touched() ? p : ''
+		const key = p !== '' && opts.pathError() === '' && touched() ? p : ''
 		const workspace = opts.workspace()
 		const value = opts.value()
 		if (key === untrack(() => draftPath)) {
@@ -121,12 +146,13 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 	})
 
 	async function settle(): Promise<void> {
-		if (!written) return
-		await UserDraftDbSyncer.flush({
-			workspace: written.workspace,
-			itemKind: opts.itemKind,
-			path: written.path
-		})
+		const keys = unsettled
+		unsettled = []
+		await Promise.all(
+			keys.map((k) =>
+				UserDraftDbSyncer.flush({ workspace: k.workspace, itemKind: opts.itemKind, path: k.path })
+			)
+		)
 	}
 
 	return {
@@ -134,6 +160,16 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 			return draftPath
 		},
 		async flush() {
+			const p = pending
+			if (p && p.key) {
+				// Forced by a close, so the commit delay that lets `Path`'s debounced
+				// existence check land was cut short. Re-check before keying on it:
+				// a path that already holds an item would take this draft as an edit
+				// of that item, and saving from there would overwrite its value.
+				const free =
+					opts.pathError() === '' && (opts.pathIsFree ? await opts.pathIsFree(p.key) : true)
+				if (!free && pending === p) dropPending()
+			}
 			commit()
 			await settle()
 		},
@@ -144,19 +180,19 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 			written = undefined
 			writtenValue = undefined
 			draftPath = ''
-			if (!w) return
-			UserDraft.remove(opts.itemKind, w.path, { workspace: w.workspace })
-			await UserDraftDbSyncer.flush({
-				workspace: w.workspace,
-				itemKind: opts.itemKind,
-				path: w.path
-			})
+			if (w) {
+				UserDraft.remove(opts.itemKind, w.path, { workspace: w.workspace })
+				markUnsettled(w.workspace, w.path)
+			}
+			await settle()
 		},
 		reset() {
 			finished = false
 			dropPending()
 			written = undefined
 			writtenValue = undefined
+			unsettled = []
+			autoPath = undefined
 			draftPath = ''
 		}
 	}

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
@@ -23,9 +23,13 @@ export interface NewItemDraftSyncOptions<V> {
 	/** Reactive deep read of the value to persist (`$state.snapshot` of the
 	 * form state); `undefined` while there is nothing to persist. */
 	value: () => V | undefined
-	/** Whether nothing is deployed at `path` yet. Consulted only when a close
-	 * forces a commit early, where `Path`'s own check may not have run. */
+	/** Whether nothing is deployed at `path` yet. Consulted before every commit:
+	 * `Path`'s own check is debounced and may not have answered. */
 	pathIsFree?: (path: string) => Promise<boolean>
+	/** Called for a key this helper has stopped writing to, after its row is
+	 * deleted. An editor whose own autosave handle is pinned to that key MUST
+	 * suspend it here, or the handle's next write would recreate the row. */
+	onAbandonKey?: (workspace: string, path: string) => void
 }
 
 export interface NewItemDraftSync<V> {
@@ -105,6 +109,7 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 			// and `remove` blanks that live cell — the form would lose its state
 			// mid-rename. The fallback leaves the cell holding what the form holds.
 			UserDraft.discard(opts.itemKind, written.path, value, { workspace: written.workspace })
+			opts.onAbandonKey?.(written.workspace, written.path)
 			markUnsettled(written.workspace, written.path)
 			written = undefined
 			writtenValue = undefined
@@ -217,6 +222,7 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 			if (w) {
 				// See `write`: an adopted key is a live handle key, so keep its cell.
 				UserDraft.discard(opts.itemKind, w.path, opts.value(), { workspace: w.workspace })
+				opts.onAbandonKey?.(w.workspace, w.path)
 				markUnsettled(w.workspace, w.path)
 			}
 			await settle()

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
@@ -28,9 +28,13 @@ export interface NewItemDraftSyncOptions<V> {
 	pathIsFree?: (path: string) => Promise<boolean>
 }
 
-export interface NewItemDraftSync {
+export interface NewItemDraftSync<V> {
 	/** Storage path of the persisted draft, `''` when none. */
 	readonly draftPath: string
+	/** Take ownership of a draft that already exists at `path` — a draft-only
+	 * item the editor loaded. Without this the helper believes it has written
+	 * nothing, and a rename would add a second row instead of moving this one. */
+	adopt(workspace: string, path: string, value: V): void
 	/** Commit anything still pending and settle it server-side. Callers MUST
 	 * await this before a list refetch (both the commit delay and the syncer's
 	 * own debounce outlive a closing drawer, so a refetch would miss the row). */
@@ -51,7 +55,7 @@ export interface NewItemDraftSync {
  * the list pages' draft-only rows and the get-by-path draft overlay resolve —
  * and moves it (delete the old key, write the new) as the path changes.
  */
-export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewItemDraftSync {
+export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewItemDraftSync<V> {
 	let draftPath = $state('')
 	let finished = $state(false)
 	// The key last written, workspace included: a move or a delete has to target
@@ -67,13 +71,21 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 	// first edit must keep the draft, so a pending commit is never cancelled by
 	// teardown — only superseded by a newer one, or consumed by `flush`.
 	let pending:
-		| { timer: ReturnType<typeof setTimeout>; key: string; value: V | undefined }
+		| {
+				timer: ReturnType<typeof setTimeout>
+				workspace: string | undefined
+				key: string
+				value: V | undefined
+		  }
 		| undefined
-	let pendingWorkspace: string | undefined
 	// `Path` auto-fills a unique name on mount, so a non-empty path is no
 	// evidence the user did anything. Only a departure from the name it settled
 	// on counts (`Path.dirty` can't: it flips on any keyup, tabbing included).
 	let autoPath: string | undefined
+	// An adopted draft already exists: it is kept regardless of whether the user
+	// edits anything, and an invalid path leaves it where it is rather than
+	// deleting it. Only a brand-new item's draft is gated on being touched.
+	let adopted = false
 
 	function markUnsettled(workspace: string, path: string): void {
 		if (!unsettled.some((k) => k.workspace === workspace && k.path === path)) {
@@ -89,7 +101,10 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 
 	function write(workspace: string | undefined, path: string, value: V | undefined): void {
 		if (written && (written.path !== path || written.workspace !== workspace)) {
-			UserDraft.remove(opts.itemKind, written.path, { workspace: written.workspace })
+			// `discard`, not `remove`: an adopted key is the editor's own handle key,
+			// and `remove` blanks that live cell — the form would lose its state
+			// mid-rename. The fallback leaves the cell holding what the form holds.
+			UserDraft.discard(opts.itemKind, written.path, value, { workspace: written.workspace })
 			markUnsettled(written.workspace, written.path)
 			written = undefined
 			writtenValue = undefined
@@ -109,18 +124,36 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 		pending = undefined
 	}
 
-	function commit(): void {
+	/** Validate the pending key, then take it. The timer is cleared first and
+	 * the payload kept, so the validation below can't race a second commit of
+	 * the same transition; a newer transition scheduled meanwhile wins. */
+	async function commitPending(): Promise<void> {
 		const p = pending
 		if (!p) return
-		dropPending()
+		clearTimeout(p.timer)
+		if (p.key) {
+			// `Path` debounces its own existence check and may not have answered
+			// yet, so the key is verified here rather than trusted: keying a draft
+			// on a path that already holds an item would take it as an edit of
+			// that item, and saving from there would overwrite its value.
+			const free =
+				opts.pathError() === '' && (opts.pathIsFree ? await opts.pathIsFree(p.key) : true)
+			if (pending !== p) return
+			if (!free) {
+				pending = undefined
+				return
+			}
+		}
+		pending = undefined
 		draftPath = p.key
-		write(pendingWorkspace, p.key, p.value)
+		write(p.workspace, p.key, p.value)
 	}
 
 	$effect(() => {
 		if (!opts.enabled() || finished) return
 		const p = opts.path()
-		const key = p !== '' && opts.pathError() === '' && touched() ? p : ''
+		const usable = p !== '' && opts.pathError() === ''
+		const key = usable && (adopted || touched()) ? p : adopted ? untrack(() => draftPath) : ''
 		const workspace = opts.workspace()
 		const value = opts.value()
 		if (key === untrack(() => draftPath)) {
@@ -130,8 +163,12 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 		}
 		untrack(() => {
 			dropPending()
-			pendingWorkspace = workspace
-			pending = { timer: setTimeout(commit, COMMIT_DELAY_MS), key, value }
+			pending = {
+				timer: setTimeout(() => void commitPending(), COMMIT_DELAY_MS),
+				workspace,
+				key,
+				value
+			}
 		})
 	})
 
@@ -159,18 +196,15 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 		get draftPath() {
 			return draftPath
 		},
+		adopt(workspace: string, path: string, value: V) {
+			written = { workspace, path }
+			writtenValue = JSON.stringify(value)
+			autoPath = path
+			draftPath = path
+			adopted = true
+		},
 		async flush() {
-			const p = pending
-			if (p && p.key) {
-				// Forced by a close, so the commit delay that lets `Path`'s debounced
-				// existence check land was cut short. Re-check before keying on it:
-				// a path that already holds an item would take this draft as an edit
-				// of that item, and saving from there would overwrite its value.
-				const free =
-					opts.pathError() === '' && (opts.pathIsFree ? await opts.pathIsFree(p.key) : true)
-				if (!free && pending === p) dropPending()
-			}
-			commit()
+			await commitPending()
 			await settle()
 		},
 		async finish() {
@@ -181,13 +215,15 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 			writtenValue = undefined
 			draftPath = ''
 			if (w) {
-				UserDraft.remove(opts.itemKind, w.path, { workspace: w.workspace })
+				// See `write`: an adopted key is a live handle key, so keep its cell.
+				UserDraft.discard(opts.itemKind, w.path, opts.value(), { workspace: w.workspace })
 				markUnsettled(w.workspace, w.path)
 			}
 			await settle()
 		},
 		reset() {
 			finished = false
+			adopted = false
 			dropPending()
 			written = undefined
 			writtenValue = undefined

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
@@ -1,5 +1,6 @@
 import { untrack } from 'svelte'
 import { UserDraft, type UserDraftItemKind } from '$lib/userDraft.svelte'
+import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 
 /** Longer than `Path`'s 500ms debounced existence check, so the key never
  * lands on a half-typed path and the check's verdict is in before a commit. */
@@ -27,8 +28,12 @@ export interface NewItemDraftSyncOptions<V> {
 export interface NewItemDraftSync {
 	/** Storage path of the persisted draft, `''` when none. */
 	readonly draftPath: string
+	/** Commit anything still pending and settle it server-side. Callers MUST
+	 * await this before a list refetch (both the commit delay and the syncer's
+	 * own debounce outlive a closing drawer, so a refetch would miss the row). */
+	flush(): Promise<void>
 	/** Delete the persisted draft and stop mirroring, once the item is created. */
-	finish(): void
+	finish(): Promise<void>
 	/** Re-arm for the next drawer session (an editor instance that outlives
 	 * its drawer). Forgets the previous session's key without deleting it: a
 	 * draft left behind by closing the drawer is the point. */
@@ -46,50 +51,112 @@ export interface NewItemDraftSync {
 export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewItemDraftSync {
 	let draftPath = $state('')
 	let finished = $state(false)
-	// Last key actually written: a moved or finished draft deletes exactly the
-	// row it left behind, and component teardown deletes nothing.
-	let writtenPath = ''
+	// The key last written, workspace included: a move or a delete has to target
+	// the row actually left behind, not wherever the form points now.
+	let written: { workspace: string; path: string } | undefined
+	let writtenValue: string | undefined
+	// The commit the timer will make, snapshotted at schedule time so it still
+	// lands once the editor is gone: closing a drawer a keystroke after the
+	// first edit must keep the draft, so a pending commit is never cancelled by
+	// teardown — only superseded by a newer one, or consumed by `flush`.
+	let pending:
+		| { timer: ReturnType<typeof setTimeout>; key: string; value: V | undefined }
+		| undefined
+	let pendingWorkspace: string | undefined
+
+	function write(workspace: string | undefined, path: string, value: V | undefined): void {
+		if (written && (written.path !== path || written.workspace !== workspace)) {
+			UserDraft.remove(opts.itemKind, written.path, { workspace: written.workspace })
+			written = undefined
+			writtenValue = undefined
+		}
+		if (!workspace || !path || value === undefined) return
+		const serialized = JSON.stringify(value)
+		if (written && serialized === writtenValue) return
+		UserDraft.save(opts.itemKind, path, value, { workspace })
+		written = { workspace, path }
+		writtenValue = serialized
+	}
+
+	function dropPending(): void {
+		if (!pending) return
+		clearTimeout(pending.timer)
+		pending = undefined
+	}
+
+	function commit(): void {
+		const p = pending
+		if (!p) return
+		dropPending()
+		draftPath = p.key
+		write(pendingWorkspace, p.key, p.value)
+	}
 
 	$effect(() => {
 		if (!opts.enabled() || finished) return
 		const p = opts.path()
-		const target = p !== '' && opts.pathError() === '' && opts.touched() ? p : ''
-		if (target === untrack(() => draftPath)) return
-		const t = setTimeout(() => (draftPath = target), COMMIT_DELAY_MS)
-		return () => clearTimeout(t)
+		const key = p !== '' && opts.pathError() === '' && opts.touched() ? p : ''
+		const workspace = opts.workspace()
+		const value = opts.value()
+		if (key === untrack(() => draftPath)) {
+			// Back on the committed key: a transition away from it is stale.
+			untrack(dropPending)
+			return
+		}
+		untrack(() => {
+			dropPending()
+			pendingWorkspace = workspace
+			pending = { timer: setTimeout(commit, COMMIT_DELAY_MS), key, value }
+		})
 	})
 
 	$effect(() => {
 		if (!opts.enabled() || finished) return
-		const ws = opts.workspace()
-		const p = draftPath
-		const v = opts.value()
+		const workspace = opts.workspace()
+		const key = draftPath
+		const value = opts.value()
 		untrack(() => {
-			if (!ws) return
-			if (writtenPath && writtenPath !== p) {
-				UserDraft.remove(opts.itemKind, writtenPath, { workspace: ws })
-				writtenPath = ''
-			}
-			if (!p || v === undefined) return
-			UserDraft.save(opts.itemKind, p, v, { workspace: ws })
-			writtenPath = p
+			if (key) write(workspace, key, value)
 		})
 	})
+
+	async function settle(): Promise<void> {
+		if (!written) return
+		await UserDraftDbSyncer.flush({
+			workspace: written.workspace,
+			itemKind: opts.itemKind,
+			path: written.path
+		})
+	}
 
 	return {
 		get draftPath() {
 			return draftPath
 		},
-		finish() {
+		async flush() {
+			commit()
+			await settle()
+		},
+		async finish() {
 			finished = true
-			const ws = untrack(() => opts.workspace())
-			if (writtenPath && ws) UserDraft.remove(opts.itemKind, writtenPath, { workspace: ws })
-			writtenPath = ''
+			dropPending()
+			const w = written
+			written = undefined
+			writtenValue = undefined
 			draftPath = ''
+			if (!w) return
+			UserDraft.remove(opts.itemKind, w.path, { workspace: w.workspace })
+			await UserDraftDbSyncer.flush({
+				workspace: w.workspace,
+				itemKind: opts.itemKind,
+				path: w.path
+			})
 		},
 		reset() {
 			finished = false
-			writtenPath = ''
+			dropPending()
+			written = undefined
+			writtenValue = undefined
 			draftPath = ''
 		}
 	}

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
@@ -1,0 +1,96 @@
+import { untrack } from 'svelte'
+import { UserDraft, type UserDraftItemKind } from '$lib/userDraft.svelte'
+
+/** Longer than `Path`'s 500ms debounced existence check, so the key never
+ * lands on a half-typed path and the check's verdict is in before a commit. */
+const COMMIT_DELAY_MS = 1000
+
+export interface NewItemDraftSyncOptions<V> {
+	itemKind: UserDraftItemKind
+	/** Reactive: false leaves the helper inert (edit mode — the handle syncs). */
+	enabled: () => boolean
+	/** Reactive workspace the draft is stored in. */
+	workspace: () => string | undefined
+	/** Reactive path field (`''` while none). */
+	path: () => string
+	/** Reactive `Path` validation error (`''` when valid). */
+	pathError: () => string
+	/** Reactive: the user edited the name or the content. `Path` auto-fills a
+	 * name on mount, so opening and closing an untouched drawer must not leave
+	 * a draft behind. */
+	touched: () => boolean
+	/** Reactive deep read of the value to persist (`$state.snapshot` of the
+	 * form state); `undefined` while there is nothing to persist. */
+	value: () => V | undefined
+}
+
+export interface NewItemDraftSync {
+	/** Storage path of the persisted draft, `''` when none. */
+	readonly draftPath: string
+	/** Delete the persisted draft and stop mirroring, once the item is created. */
+	finish(): void
+	/** Re-arm for the next drawer session (an editor instance that outlives
+	 * its drawer). Forgets the previous session's key without deleting it: a
+	 * draft left behind by closing the drawer is the point. */
+	reset(): void
+}
+
+/**
+ * Server-side autosave for a drawer editor's brand-new item. Those editors
+ * key their `useMany` handle on the path they were opened with, which is
+ * empty for a new item, so the handle is detached and never POSTs. This
+ * mirrors the form into a draft keyed by the typed path instead — the key
+ * the list pages' draft-only rows and the get-by-path draft overlay resolve —
+ * and moves it (delete the old key, write the new) as the path changes.
+ */
+export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewItemDraftSync {
+	let draftPath = $state('')
+	let finished = $state(false)
+	// Last key actually written: a moved or finished draft deletes exactly the
+	// row it left behind, and component teardown deletes nothing.
+	let writtenPath = ''
+
+	$effect(() => {
+		if (!opts.enabled() || finished) return
+		const p = opts.path()
+		const target = p !== '' && opts.pathError() === '' && opts.touched() ? p : ''
+		if (target === untrack(() => draftPath)) return
+		const t = setTimeout(() => (draftPath = target), COMMIT_DELAY_MS)
+		return () => clearTimeout(t)
+	})
+
+	$effect(() => {
+		if (!opts.enabled() || finished) return
+		const ws = opts.workspace()
+		const p = draftPath
+		const v = opts.value()
+		untrack(() => {
+			if (!ws) return
+			if (writtenPath && writtenPath !== p) {
+				UserDraft.remove(opts.itemKind, writtenPath, { workspace: ws })
+				writtenPath = ''
+			}
+			if (!p || v === undefined) return
+			UserDraft.save(opts.itemKind, p, v, { workspace: ws })
+			writtenPath = p
+		})
+	})
+
+	return {
+		get draftPath() {
+			return draftPath
+		},
+		finish() {
+			finished = true
+			const ws = untrack(() => opts.workspace())
+			if (writtenPath && ws) UserDraft.remove(opts.itemKind, writtenPath, { workspace: ws })
+			writtenPath = ''
+			draftPath = ''
+		},
+		reset() {
+			finished = false
+			writtenPath = ''
+			draftPath = ''
+		}
+	}
+}

--- a/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
+++ b/frontend/src/lib/components/useNewItemDraftSync.svelte.ts
@@ -30,6 +30,15 @@ export interface NewItemDraftSyncOptions<V> {
 	 * deleted. An editor whose own autosave handle is pinned to that key MUST
 	 * suspend it here, or the handle's next write would recreate the row. */
 	onAbandonKey?: (workspace: string, path: string) => void
+	/** Called before writing to a key previously passed to `onAbandonKey`, so
+	 * the editor can resume the handle it suspended there. */
+	onResumeKey?: (workspace: string, path: string) => void
+	/** Return `value` with its own path set to `path`. A stored draft has to
+	 * describe the key it lives under: the list synthesizes a draft-only row
+	 * from the path INSIDE the draft, while get and delete address the key, so
+	 * letting the two diverge makes the row unreachable. Divergence is normal
+	 * while the form holds a path the draft cannot move to yet. */
+	keyed?: (value: V, path: string) => V
 }
 
 export interface NewItemDraftSync<V> {
@@ -90,6 +99,8 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 	// edits anything, and an invalid path leaves it where it is rather than
 	// deleting it. Only a brand-new item's draft is gated on being touched.
 	let adopted = false
+	// Keys handed to `onAbandonKey`, so a return to one can resume it.
+	const abandoned = new Set<string>()
 
 	function markUnsettled(workspace: string, path: string): void {
 		if (!unsettled.some((k) => k.workspace === workspace && k.path === path)) {
@@ -110,14 +121,28 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 			// mid-rename. The fallback leaves the cell holding what the form holds.
 			UserDraft.discard(opts.itemKind, written.path, value, { workspace: written.workspace })
 			opts.onAbandonKey?.(written.workspace, written.path)
+			abandoned.add(`${written.workspace}/${written.path}`)
 			markUnsettled(written.workspace, written.path)
 			written = undefined
 			writtenValue = undefined
 		}
 		if (!workspace || !path || value === undefined) return
-		const serialized = JSON.stringify(value)
+		// Stored describing its own key: while the form holds a path the draft
+		// cannot move to yet, the row must still name where it actually lives.
+		const stored = opts.keyed ? opts.keyed(value, path) : value
+		const serialized = JSON.stringify(stored)
 		if (written && serialized === writtenValue) return
-		UserDraft.save(opts.itemKind, path, value, { workspace })
+		const resumed = abandoned.delete(`${workspace}/${path}`)
+		if (resumed) opts.onResumeKey?.(workspace, path)
+		UserDraft.save(opts.itemKind, path, stored, { workspace })
+		if (resumed) {
+			// A live handle at this key mirrors CHANGES, and its baseline advanced
+			// while it was suspended — the value we just restored can equal it, so
+			// nothing would be sent and the row we deleted on the way out would
+			// never come back. Safe here: only a never-deployed draft is keyed this
+			// way, so there is no baseline this could overwrite.
+			void UserDraft.forcePersist(opts.itemKind, path, { workspace })
+		}
 		markUnsettled(workspace, path)
 		written = { workspace, path }
 		writtenValue = serialized
@@ -230,6 +255,7 @@ export function useNewItemDraftSync<V>(opts: NewItemDraftSyncOptions<V>): NewIte
 		reset() {
 			finished = false
 			adopted = false
+			abandoned.clear()
 			dropPending()
 			written = undefined
 			writtenValue = undefined

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getLocalDraftHint } from '$lib/localDraftHints.svelte'
+	import { UserDraft } from '$lib/userDraft.svelte'
 	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 	import { page } from '$app/state'
 	import AppConnect from '$lib/components/AppConnectDrawer.svelte'
@@ -321,14 +322,15 @@
 		draftOnly?: boolean
 	): Promise<void> {
 		if (draftOnly) {
-			// The row is the user's own draft and nothing else: the resource
-			// delete would 404 on the missing deployed row.
-			await UserDraftDbSyncer.save({
+			// The row is the user's own draft and nothing else: the resource delete
+			// would 404 on the missing deployed row. `UserDraft.remove` rather than a
+			// bare POST so the in-memory cache is evicted too — the global AI chat
+			// lists drafts from it and would keep offering this one.
+			UserDraft.remove('resource', path, { workspace: $workspaceStore! })
+			await UserDraftDbSyncer.flush({
 				workspace: $workspaceStore!,
 				itemKind: 'resource',
-				path,
-				value: null,
-				immediate: true
+				path
 			})
 			reload()
 			return

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getLocalDraftHint } from '$lib/localDraftHints.svelte'
+	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 	import { page } from '$app/state'
 	import AppConnect from '$lib/components/AppConnectDrawer.svelte'
 	import CenteredPage from '$lib/components/CenteredPage.svelte'
@@ -314,7 +315,24 @@
 		loading.types = false
 	}
 
-	async function deleteResource(path: string, account?: number): Promise<void> {
+	async function deleteResource(
+		path: string,
+		account?: number,
+		draftOnly?: boolean
+	): Promise<void> {
+		if (draftOnly) {
+			// The row is the user's own draft and nothing else: the resource
+			// delete would 404 on the missing deployed row.
+			await UserDraftDbSyncer.save({
+				workspace: $workspaceStore!,
+				itemKind: 'resource',
+				path,
+				value: null,
+				immediate: true
+			})
+			reload()
+			return
+		}
 		if (account) {
 			OauthService.disconnectAccount({ workspace: $workspaceStore!, id: account })
 		}
@@ -1313,12 +1331,12 @@
 																	// TODO
 																	// @ts-ignore
 																	if (event?.shiftKey) {
-																		deleteResource(path, account)
+																		deleteResource(path, account, draft_only)
 																	} else {
 																		deleteIsLinked = is_linked ?? false
 																		deletePath = path
 																		deleteConfirmedCallback = () => {
-																			deleteResource(path, account)
+																			deleteResource(path, account, draft_only)
 																		}
 																	}
 																}
@@ -1477,13 +1495,14 @@
 {/if}
 
 <SupabaseConnect bind:this={supabaseConnect} on:refresh={loadResources} />
-<AppConnect bind:this={appConnect} on:refresh={loadResources} />
+<AppConnect bind:this={appConnect} on:refresh={loadResources} on:close={loadResources} />
 <AgentEvalModal agentPath={evalsAgentPath} bind:open={evalsOpen} />
 
 <ResourceEditorDrawer
 	bind:this={resourceEditor}
 	on:refresh={loadResources}
 	onRestored={loadResources}
+	onClose={loadResources}
 />
 
 <ShareModal

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getLocalDraftHint } from '$lib/localDraftHints.svelte'
+	import { UserDraft } from '$lib/userDraft.svelte'
 	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 	import CenteredPage from '$lib/components/CenteredPage.svelte'
 	import {
@@ -224,14 +225,15 @@
 		draftOnly?: boolean
 	): Promise<void> {
 		if (draftOnly) {
-			// The row is the user's own draft and nothing else: the variable
-			// delete would 404 on the missing deployed row.
-			await UserDraftDbSyncer.save({
+			// The row is the user's own draft and nothing else: the variable delete
+			// would 404 on the missing deployed row. `UserDraft.remove` rather than a
+			// bare POST so the in-memory cache is evicted too — the global AI chat
+			// lists drafts from it and would keep offering this one.
+			UserDraft.remove('variable', path, { workspace: $workspaceStore! })
+			await UserDraftDbSyncer.flush({
 				workspace: $workspaceStore!,
 				itemKind: 'variable',
-				path,
-				value: null,
-				immediate: true
+				path
 			})
 			loadVariables()
 			sendUserToast(`Draft ${path} was deleted`)

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getLocalDraftHint } from '$lib/localDraftHints.svelte'
+	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 	import CenteredPage from '$lib/components/CenteredPage.svelte'
 	import {
 		Alert,
@@ -217,7 +218,25 @@
 		loading.contextual = false
 	}
 
-	async function deleteVariable(path: string, account?: number): Promise<void> {
+	async function deleteVariable(
+		path: string,
+		account?: number,
+		draftOnly?: boolean
+	): Promise<void> {
+		if (draftOnly) {
+			// The row is the user's own draft and nothing else: the variable
+			// delete would 404 on the missing deployed row.
+			await UserDraftDbSyncer.save({
+				workspace: $workspaceStore!,
+				itemKind: 'variable',
+				path,
+				value: null,
+				immediate: true
+			})
+			loadVariables()
+			sendUserToast(`Draft ${path} was deleted`)
+			return
+		}
 		if (account) {
 			OauthService.disconnectAccount({ workspace: $workspaceStore!, id: account })
 		}
@@ -316,7 +335,7 @@
 		</PageHeader>
 		<NoDirectDeployAlert onUpdateCanEditStatus={(v) => (showCreateButtons = v)} />
 
-		<VariableEditor bind:this={variableEditor} on:create={loadVariables} />
+		<VariableEditor bind:this={variableEditor} on:create={loadVariables} on:close={loadVariables} />
 		<ContextualVariableEditor
 			bind:this={contextualVariableEditor}
 			on:update={loadContextualVariables}
@@ -563,11 +582,11 @@
 															type: 'delete',
 															action: (event) => {
 																if (event['shiftKey']) {
-																	deleteVariable(path, account)
+																	deleteVariable(path, account, draft_only)
 																} else {
 																	deleteIsLinked = is_linked ?? false
 																	deleteConfirmedCallback = () => {
-																		deleteVariable(path, account)
+																		deleteVariable(path, account, draft_only)
 																	}
 																}
 															},

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -240,10 +240,14 @@ const config = {
 				// replay sanitization) whose contracts can only be asserted against a
 				// real document.
 				extends: './vite.config.js',
+				// Node resolution picks svelte's server entry, where `$effect` is inert;
+				// `*.svelte.dom.test.ts` rune modules need the browser one to run effects.
+				resolve: { conditions: ['browser'] },
 				test: {
 					name: 'dom',
 					environment: 'jsdom',
-					include: ['src/**/*.dom.{test,spec}.{js,ts}']
+					include: ['src/**/*.dom.{test,spec}.{js,ts}'],
+					server: { deps: { inline: ['svelte'] } }
 				}
 			}
 		]


### PR DESCRIPTION
## Summary

Editing a resource or a variable autosaves a per-user draft; creating one did not. The drawer editors key their `useMany` draft handle on the path they were opened with, which is empty for a new item, so the handle is detached and never persists. A half-filled connection was lost as soon as the drawer closed.

The rest of the stack was already built for this. The backend serves draft-only items on get (`no_deployed`) and synthesizes list rows for them; the list pages already request and badge those rows; the editor already creates rather than updates when reopening one. The missing piece was the new-item drawer writing a draft at all, so this change is frontend-only.

New items now autosave under the path typed in the form, which is the same key the draft-only list rows and the get-by-path overlay resolve, and the convention the AI chat already uses. Scripts, flows and apps keep their own scheme of minting a `u/<user>/draft_<uuid>` path before the editor mounts.

## Changes

- New `useNewItemDraftSync` helper mirrors a new item's form into a draft keyed by the typed path. It waits for the user to actually touch the form, so the auto-filled name never becomes a row; commits the key a second after the path settles, so a half-typed or already-taken path never lands; moves the row when the path changes; and deletes it once the item is created.
- Wired into all three new-item surfaces: the resource wizard's manual step (`AppConnectInner`, which is what "Add resource" opens), the resource editor drawer's new mode, and the variable drawer.
- A pending write is settled before the drawer's close event, so the list refetch behind it sees the row instead of racing the commit delay and the syncer's debounce. A commit still pending when the editor is torn down survives, so closing right after the first keystroke keeps the draft.
- Draft-only items get a correct empty baseline, so the unsaved-changes banner is accurate. Discarding one deletes it and closes the drawer, and renaming one moves its storage key so the row stays reachable and deletable.
- The list pages' Delete on a draft-only row deletes the draft through `UserDraft.remove`, which also evicts the in-memory cache the AI chat lists from. Previously it called the item delete endpoint, which 404s with no deployed row.
- Resource drafts carry `resource_type`, which the list-row synthesizer and the reopened editor both need. Fields saved as linked secret variables are kept out of the resource draft, since only variable drafts are encrypted at rest.
- `vite.config.js`: the `dom` vitest project resolves Svelte's browser build, without which `$effect` is inert and rune tests cannot run.

## Screenshots

![resources-draft-only-row](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/new-resource-draft-gap/1788472246-resources-draft-only-row.png)

![resource-draft-reopened](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/new-resource-draft-gap/1788472246-resource-draft-reopened.png)

![variables-draft-only-row](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/new-resource-draft-gap/1788472246-variables-draft-only-row.png)

## Test plan

- [ ] Resources, "Add resource", pick a type, edit a field, then close the drawer immediately. The draft-only row appears in the list without a manual refresh.
- [ ] Open that row. The editor shows the type's schema, the values, and the unsaved-changes banner. Save creates the resource and the draft badge goes away.
- [ ] Open "Add resource" again and close it without touching anything. No draft row is left behind.
- [ ] Rename the path while filling a new resource. The draft follows the new path and leaves no row at the old one.
- [ ] Reopen a draft-only row, rename its path, close. The row is still reachable and its Delete removes it.
- [ ] Delete a draft-only row from the list menu. It disappears and no draft row remains.
- [ ] Variables, "New variable", type a value, close. The row appears, the stored draft value is encrypted, and reopening then saving yields the original secret.
- [ ] Discard from the banner on a draft-only item deletes it and closes the drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wy24UHSVRZdDaPWiBay9MG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creating a resource or variable now autosaves drafts like editing does, so closing the drawer no longer loses a half-filled form. New-item forms mirror into a draft keyed by the typed path, which shows up as a draft-only row in the list and can be reopened, renamed, discarded, or deleted.

**Behavior notes**
- A new item's draft only starts after the user touches the form, so an auto-filled name alone never leaves a row.
- Draft-only rows are keyed by their typed path and owned by the same helper as new items, so a reopened one keeps autosaving, renaming one moves the row (the stored draft always names the key it lives under, so a pending rename leaves the row reachable), and deleting one removes the draft directly, since the item delete endpoint 404s without a deployed row.
- Draft writes settle before the drawer closes and before the post-save refetch, so the list always sees the final state; a commit pending at teardown survives, but one forced onto an occupied or invalid path is dropped.
- Resource drafts carry `resource_type`; linked secret variables are kept out because only variable drafts are encrypted.

<sup>Written for commit 1b95662f49174a0c75cd4592e4f9116d004edefc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

## Left in draft: the draft-only rename seam needs a design decision

Five review rounds. The first found real bugs in the new-item autosave, all fixed. Every round
since has landed on one seam, and the fixes for it keep generating the next finding:

**A draft-only item has two names for itself.** Its row is addressed by its storage key, but the
list synthesizes that row from the path stored *inside* the draft. Two writers share the editor's
one form cell: the `useMany` handle pinned to the path the drawer opened, and the path-following
helper this PR adds. Whenever the two names disagree — a rename to an occupied or malformed path,
a rename in flight, a rename away and back — the row becomes unreachable, undeletable, or lost.
Each fix (move the key, suspend the handle, resume it, normalize the stored path) closed one case
and opened another; the latest one also made a valid rename silently revert if the user edits any
field within the commit delay.

The new-item half of this PR is settled and verified. The draft-only half wants a shape change,
not another patch. Two options:

1. **Make a draft-only item's path read-only in the editor** (frontend only). Divergence becomes
   unrepresentable: the key is the identity until the item is deployed, and renaming is done after
   the first save, which already works. This deletes the adopt / abandon / resume / re-key
   machinery added in rounds 2-5 — a net removal of code. Cost: you cannot rename a draft before
   deploying it.
2. **Key draft-only list rows by their storage key** rather than the path inside the draft
   (backend). Preserves renaming and fixes the same class of bug for AI-created drafts, which have
   it today. Touches the draft-only synthesis for resources, variables, schedules and triggers, so
   it is its own change with its own review.

Recommendation: option 1 here, and option 2 separately if renaming a draft is worth keeping.
