### PR TITLE
chore: stop denying reads of secret files in claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,22 +55,18 @@
       "mcp__claude_ai_Gmail__list_drafts"
     ],
     "deny": [
-      "Read(.env)",
-      "Read(.env.*)",
-      "Read(**/.env)",
-      "Read(**/.env.*)",
-      "Read(**/secrets/**)",
-      "Read(**/*.pem)",
-      "Read(**/*.key)",
-      "Read(**/credentials.json)",
-      "Read(**/.secret*)",
-      "Read(**/.secrets*)",
-      "Read(**/*.secret)",
-      "Read(**/*.secrets)",
       "Edit(.env)",
       "Edit(.env.*)",
       "Edit(**/.env)",
-      "Edit(**/.env.*)"
+      "Edit(**/.env.*)",
+      "Edit(**/secrets/**)",
+      "Edit(**/*.pem)",
+      "Edit(**/*.key)",
+      "Edit(**/credentials.json)",
+      "Edit(**/.secret*)",
+      "Edit(**/.secrets*)",
+      "Edit(**/*.secret)",
+      "Edit(**/*.secrets)"
     ],
     "ask": [
       "Bash(rmdir:*)",


### PR DESCRIPTION
## Summary

The `Read()` deny rules in `.claude/settings.json` cost a permission prompt on ordinary
read commands, including under `bypassPermissions`. Any `Read()` deny rule makes Claude
Code resolve the file operands of every Bash command that reads files, and a path it
cannot resolve escalates to the user rather than being allowed.

Two everyday cases hit it:

- a command that reads a relative path after a `cd` into a directory the analyzer does
  not track, which is normal when working across git worktrees
- a plain recursive grep anywhere in the repo, because the walk could reach `.env`

Anchoring the patterns does not help. A deny list holding only paths the command could
not possibly touch still escalates, because the analyzer cannot prove a path is safe
when the working directory is unknown. `additionalDirectories` does not help either.
Permission patterns have no negation syntax, so the protection cannot be narrowed to
paths outside the repo.

This trades read protection on secret files for prompt-free reads. Write protection is
unchanged and now covers more files than before.

## Changes

- Remove the twelve `Read()` deny rules covering `.env*`, `secrets/`, `*.pem`, `*.key`,
  `credentials.json`, and the `.secret*` / `*.secret*` families
- Add eight matching `Edit()` deny rules so those same files stay write-protected, next
  to the four `.env` write rules that were already there
- No change to the allow list, the ask list, the hooks, or the plugin config

## Test plan

- [ ] `python3 -c "import json; json.load(open('.claude/settings.json'))"` parses
- [ ] A recursive grep at the repo root runs without a permission prompt
- [ ] A command that reads a relative path after `cd` into another worktree runs without a prompt
- [ ] Editing a `.env` file through Edit or Write is still refused
- [ ] The three `PreToolUse` Bash hooks still load and fire

## Notes for review

This file is tracked and applies to everyone working in the repo, so the security
tradeoff is a team decision rather than a personal preference. Two alternatives were
considered and rejected. A `PreToolUse` hook cannot rescue the current rules, because a
hook decision cannot allow past a deny rule. The sandbox can enforce read denial at the
OS level without prompting, via `sandbox.filesystem.denyRead` and
`autoAllowBashIfSandboxed`, but it also confines network egress and would need an
allowlist covering cargo, npm, and local services before it is usable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNCupPk2yewQT1JMNjkV8M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes Read deny rules for secret files in `.claude/settings.json` so ordinary read commands like recursive grep or reading after a `cd` no longer trigger permission prompts. Adds matching Edit deny rules so those files remain write-protected.

<sup>Written for commit 05f59db68ee29510afab37601253cabede94c3f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

