### PR TITLE
fix: keep the instance user editor popover inside the viewport

### DIFF
--- a/frontend/src/lib/components/InstanceNameEditor.svelte
+++ b/frontend/src/lib/components/InstanceNameEditor.svelte
@@ -53,7 +53,7 @@
 
 <Popover
 	floatingConfig={{ strategy: 'fixed', placement: 'left-end' }}
-	contentClasses="flex flex-col pt-9"
+	contentClasses="pt-9"
 	closeButton
 >
 	{#snippet trigger()}
@@ -65,7 +65,7 @@
 		<!-- The scroll sits here rather than on the popover box, which is what the close button
 		     is positioned against — box-level overflow scrolls that button out of reach. The
 		     box's `pt-9` clears the button's 34px, so the scrollbar starts below it. -->
-		<div class="flex flex-col gap-8 max-w-sm p-4 pt-0 min-h-0 max-h-[70vh] overflow-y-auto">
+		<div class="flex flex-col gap-8 max-w-sm p-4 pt-0 max-h-[70vh] overflow-y-auto">
 			<ChangeInstanceEmailInner
 				{email}
 				{username}

--- a/frontend/src/lib/components/InstanceNameEditor.svelte
+++ b/frontend/src/lib/components/InstanceNameEditor.svelte
@@ -6,7 +6,6 @@
 	import { createEventDispatcher } from 'svelte'
 	import Button from './common/button/Button.svelte'
 	import Popover from './meltComponents/Popover.svelte'
-	import { offset, flip, shift } from 'svelte-floating-ui/dom'
 	import ChangeInstanceUsernameInner from './ChangeInstanceUsernameInner.svelte'
 	import ChangeInstanceEmailInner from './ChangeInstanceEmailInner.svelte'
 	import { UserService } from '$lib/gen'
@@ -53,11 +52,8 @@
 </script>
 
 <Popover
-	floatingConfig={{
-		strategy: 'fixed',
-		placement: 'left-end',
-		middleware: [offset(8), flip(), shift()]
-	}}
+	floatingConfig={{ strategy: 'fixed', placement: 'left-end' }}
+	contentClasses="flex flex-col pt-9"
 	closeButton
 >
 	{#snippet trigger()}
@@ -66,7 +62,10 @@
 		>
 	{/snippet}
 	{#snippet content()}
-		<div class="flex flex-col gap-8 max-w-sm p-4">
+		<!-- The scroll sits here rather than on the popover box, which is what the close button
+		     is positioned against — box-level overflow scrolls that button out of reach. The
+		     box's `pt-9` clears the button's 34px, so the scrollbar starts below it. -->
+		<div class="flex flex-col gap-8 max-w-sm p-4 pt-0 min-h-0 max-h-[70vh] overflow-y-auto">
 			<ChangeInstanceEmailInner
 				{email}
 				{username}


### PR DESCRIPTION
## Summary

Opening **Edit** on a user in Instance settings → Users produced a popover taller than the
viewport: its bottom ran off the screen and the *Login type* section was unreachable.

The popover content is 842px tall. It grew past a typical laptop viewport when #10355 added the
`ChangeInstanceEmailInner` block, which contributes 121px plus its `gap-8` — about 153px, taking
the content from ~690px to 842px.

Nothing clamped it, because the call site passed floating-ui middleware objects to melt's
`floatingConfig`:

```js
floatingConfig={{ strategy: 'fixed', placement: 'left-end', middleware: [offset(8), flip(), shift()] }}
```

melt builds its own middleware array from named config keys and ignores a `middleware` key
entirely (`@melt-ui/svelte/dist/internal/actions/floating/action.js`), so those three did nothing.

## Changes

- Dropped the dead `middleware` array and its `svelte-floating-ui/dom` import; `strategy` and
  `placement` are unchanged.
- `max-h-[70vh]` + `overflow-y-auto` on the content, matching how `Menu.svelte` and
  `DropdownV2.svelte` already handle tall content.
- The scroll goes on the content wrapper rather than the popover box, because `closeButton`
  renders an absolutely-positioned `.close` against the box — box-level overflow scrolls it out
  of reach (measured: top 22 → -252). `contentClasses="flex flex-col"` lets the wrapper shrink
  under the box.
- `pt-9` on the box reserves a strip for that close button, which occupies 6–34px
  (`.close` is `top-1.5` + `h-7`), so the scrollbar starts below it instead of running underneath.
  This also stops the X overlapping the "Email" label, which it did before.

## Screenshots

**Before** — the popover runs off the bottom; *Login type* is unreachable.

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-edit-user-overflow/1788535594-before-overflow.png)

**After** — clamped inside the viewport, close button clear of the scrollbar.

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-edit-user-overflow/1788535594-x-clear-top.png)

**After, scrolled to the bottom** — *Login type* reachable, X still pinned.

![after scrolled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-edit-user-overflow/1788535594-after-scrolled-final.png)

## Test plan

- [x] At a 1200×700 viewport, open Instance settings → Users → **Edit** on a user: the box sits
      at 202–692, fully inside the viewport.
- [x] Scroll the popover to the bottom: *Login type* and **Update login type** are reachable.
- [x] The close button stays pinned while scrolled (close bottom at 200, scroll area top at 202,
      so the scrollbar never runs under it).
- [x] A shorter popover shows no odd gap where the strip is reserved.

## Notes for reviewers

Not fixed here, flagged for later: 18 other call sites pass a `middleware` array to a melt
`Popover` where it is equally ignored (`wizards/*`, the copilot popovers,
`apps/editor/inlineScriptsPanel/*`, `ChangeInstanceUsername`). Separately, `Popover.svelte`
assigns `floatingConfig ?? {…defaults…}`, so any call site passing a config replaces the
component's defaults wholesale — 57 of 61 such sites end up with no `fitViewport`, and therefore
no max-height. A structural fix (merge instead of replace, type the prop as melt's
`FloatingConfig`) would need a scroll container in `Popover.svelte` to go with it, since
`fitViewport` alone clamps the box without scrolling it. Left out of this PR to keep the blast
radius at one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5v4NFqdTaZdkR8Ua1nr13