### PR TITLE
test: fit the relock no-op tests inside the 60s worker cap

### DIFF
--- a/backend/tests/relock_noop.rs
+++ b/backend/tests/relock_noop.rs
@@ -10,6 +10,11 @@ use windmill_test_utils::*;
 
 const W: &str = "test-workspace";
 
+/// Ceiling on any one wait below. Everything here settles in well under a second, so this only
+/// bounds a step that is stuck, and it has to stay clear of the 60s cap `in_test_worker` puts on
+/// the whole body: past that the harness reports a worker timeout instead of what was waited on.
+const WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(20);
+
 const A: &str = "def main():\n    return 'a'\n";
 const A_COMMENTED: &str = "# same dependencies, different content\ndef main():\n    return 'a'\n";
 const A_WITH_TINY: &str = "import tiny\n\ndef main():\n    return 'a'\n";
@@ -101,15 +106,14 @@ async fn wait_for_jobs(
     count: usize,
 ) {
     for i in 0..count {
-        tokio::time::timeout(std::time::Duration::from_secs(20), completed.next())
+        tokio::time::timeout(WAIT_BUDGET, completed.next())
             .await
             .unwrap_or_else(|_| panic!("only {i} of {count} jobs completed"));
     }
     // Then let anything else that was queued run out, so a job the assertions say must not
     // exist would have shown up here. A dependency job queues its fan-out before it completes,
-    // so an empty queue is a fixpoint rather than a lull, and waiting for one is both quicker
-    // and firmer than sitting out a fixed delay.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    // so an empty queue is a fixpoint rather than a lull.
+    let deadline = std::time::Instant::now() + WAIT_BUDGET;
     loop {
         while let Ok(Some(_)) =
             tokio::time::timeout(std::time::Duration::from_millis(20), completed.next()).await
@@ -277,7 +281,7 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
                 .unwrap();
 
             // b's relock skips generation and reaches its commit, where it waits on the lock.
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            let deadline = std::time::Instant::now() + WAIT_BUDGET;
             let mut waiting = false;
             while !waiting && std::time::Instant::now() < deadline {
                 waiting = sqlx::query_scalar(

--- a/backend/tests/relock_noop.rs
+++ b/backend/tests/relock_noop.rs
@@ -16,7 +16,8 @@ const W: &str = "test-workspace";
 /// rather than surfacing as a worker timeout.
 const WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// How often the waits below re-check, and the floor on one turn of the drain loop.
+/// How often the waits below re-check. The drain reads the queue once per completion it waits
+/// this long for, so it doubles as the floor on one turn of that loop.
 const POLL: std::time::Duration = std::time::Duration::from_millis(20);
 
 const A: &str = "def main():\n    return 'a'\n";
@@ -131,9 +132,6 @@ async fn wait_for_jobs(
             tokio::time::Instant::now() < deadline,
             "the queue never emptied"
         );
-        // The stream ends instantly once it is closed, so this is what keeps the loop from
-        // spinning on the queue read until the deadline.
-        tokio::time::sleep(POLL).await;
     }
 }
 

--- a/backend/tests/relock_noop.rs
+++ b/backend/tests/relock_noop.rs
@@ -10,10 +10,14 @@ use windmill_test_utils::*;
 
 const W: &str = "test-workspace";
 
-/// Ceiling on any one wait below. Everything here settles in well under a second, so this only
-/// bounds a step that is stuck, and it has to stay clear of the 60s cap `in_test_worker` puts on
-/// the whole body: past that the harness reports a worker timeout instead of what was waited on.
-const WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(20);
+/// Budget for one wait below, counted completions and drain together. Even against a cold cache
+/// these settle in a few seconds, so it only bounds a step that is stuck, and it stays under the
+/// 60s cap `in_test_worker` puts on the whole body so the panic names what was being waited on
+/// rather than surfacing as a worker timeout.
+const WAIT_BUDGET: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// How often the waits below re-check, and the floor on one turn of the drain loop.
+const POLL: std::time::Duration = std::time::Duration::from_millis(20);
 
 const A: &str = "def main():\n    return 'a'\n";
 const A_COMMENTED: &str = "# same dependencies, different content\ndef main():\n    return 'a'\n";
@@ -105,20 +109,17 @@ async fn wait_for_jobs(
     completed: &mut (impl futures::Stream<Item = uuid::Uuid> + Unpin),
     count: usize,
 ) {
+    let deadline = tokio::time::Instant::now() + WAIT_BUDGET;
     for i in 0..count {
-        tokio::time::timeout(WAIT_BUDGET, completed.next())
+        tokio::time::timeout_at(deadline, completed.next())
             .await
             .unwrap_or_else(|_| panic!("only {i} of {count} jobs completed"));
     }
     // Then let anything else that was queued run out, so a job the assertions say must not
     // exist would have shown up here. A dependency job queues its fan-out before it completes,
     // so an empty queue is a fixpoint rather than a lull.
-    let deadline = std::time::Instant::now() + WAIT_BUDGET;
     loop {
-        while let Ok(Some(_)) =
-            tokio::time::timeout(std::time::Duration::from_millis(20), completed.next()).await
-        {
-        }
+        while let Ok(Some(_)) = tokio::time::timeout(POLL, completed.next()).await {}
         let queued: i64 = sqlx::query_scalar("SELECT count(*) FROM v2_job_queue")
             .fetch_one(db)
             .await
@@ -127,9 +128,12 @@ async fn wait_for_jobs(
             return;
         }
         assert!(
-            std::time::Instant::now() < deadline,
+            tokio::time::Instant::now() < deadline,
             "the queue never emptied"
         );
+        // The stream ends instantly once it is closed, so this is what keeps the loop from
+        // spinning on the queue read until the deadline.
+        tokio::time::sleep(POLL).await;
     }
 }
 
@@ -293,7 +297,7 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
                 .await
                 .unwrap();
                 if !waiting {
-                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                    tokio::time::sleep(POLL).await;
                 }
             }
             assert!(waiting, "b's relock never reached the row lock");

--- a/backend/tests/relock_noop.rs
+++ b/backend/tests/relock_noop.rs
@@ -1,3 +1,7 @@
+// These pin language-independent behaviour, and Python is the cheapest runtime that still
+// generates a real lock out of relative imports, so the whole file needs that feature.
+#![cfg(feature = "python")]
+
 use sqlx::{Pool, Postgres};
 use tokio_stream::StreamExt;
 use windmill_api_client::types::NewScript;
@@ -6,21 +10,17 @@ use windmill_test_utils::*;
 
 const W: &str = "test-workspace";
 
-const A: &str = r#"export async function main() { return "a" }"#;
-const A_COMMENTED: &str = r#"// same dependencies, different content
-export async function main() { return "a" }"#;
-const A_WITH_LODASH: &str = r#"import _ from "lodash@4.17.21";
-export async function main() { return _.trim(" a ") }"#;
-const B: &str = r#"import { main as a } from "/f/rel/a.ts";
-export async function main() { return "b" + (await a()) }"#;
-const C: &str = r#"import { main as b } from "/f/rel/b.ts";
-export async function main() { return "c" + (await b()) }"#;
+const A: &str = "def main():\n    return 'a'\n";
+const A_COMMENTED: &str = "# same dependencies, different content\ndef main():\n    return 'a'\n";
+const A_WITH_TINY: &str = "import tiny\n\ndef main():\n    return 'a'\n";
+const B: &str = "from f.rel.a import main as a\n\ndef main():\n    return 'b' + a()\n";
+const C: &str = "from f.rel.b import main as b\n\ndef main():\n    return 'c' + b()\n";
 
-fn bun_script(path: &str, content: &str, parent_hash: Option<String>) -> NewScript {
+fn py_script(path: &str, content: &str, parent_hash: Option<String>) -> NewScript {
     NewScript {
         draft_only: None,
         content: content.into(),
-        language: windmill_api_client::types::ScriptLang::Bun,
+        language: windmill_api_client::types::ScriptLang::Python3,
         lock: None,
         parent_hash,
         path: path.into(),
@@ -96,17 +96,37 @@ async fn dependency_jobs_since(
 }
 
 async fn wait_for_jobs(
+    db: &Pool<Postgres>,
     completed: &mut (impl futures::Stream<Item = uuid::Uuid> + Unpin),
     count: usize,
 ) {
-    for _ in 0..count {
-        completed.next().await;
+    for i in 0..count {
+        tokio::time::timeout(std::time::Duration::from_secs(20), completed.next())
+            .await
+            .unwrap_or_else(|_| panic!("only {i} of {count} jobs completed"));
     }
     // Then let anything else that was queued run out, so a job the assertions say must not
-    // exist would have shown up here.
-    while let Ok(Some(_)) =
-        tokio::time::timeout(std::time::Duration::from_secs(2), completed.next()).await
-    {}
+    // exist would have shown up here. A dependency job queues its fan-out before it completes,
+    // so an empty queue is a fixpoint rather than a lull, and waiting for one is both quicker
+    // and firmer than sitting out a fixed delay.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    loop {
+        while let Ok(Some(_)) =
+            tokio::time::timeout(std::time::Duration::from_millis(20), completed.next()).await
+        {
+        }
+        let queued: i64 = sqlx::query_scalar("SELECT count(*) FROM v2_job_queue")
+            .fetch_one(db)
+            .await
+            .unwrap();
+        if queued == 0 {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the queue never emptied"
+        );
+    }
 }
 
 /// A redeploy of an imported script whose dependencies did not move relocks its importer,
@@ -128,10 +148,10 @@ async fn relative_import_relock_deploys_only_when_the_lock_changed(
             // importer whose edges are recorded is what a later relock of it can skip on.
             for (path, content) in [("f/rel/a", A), ("f/rel/b", B), ("f/rel/c", C)] {
                 client
-                    .create_script(W, &bun_script(path, content, None))
+                    .create_script(W, &py_script(path, content, None))
                     .await
                     .unwrap();
-                wait_for_jobs(&mut completed, 1).await;
+                wait_for_jobs(&db, &mut completed, 1).await;
             }
             let b_before = versions(&db, "f/rel/b").await;
             let c_before = versions(&db, "f/rel/c").await;
@@ -144,11 +164,11 @@ async fn relative_import_relock_deploys_only_when_the_lock_changed(
             client
                 .create_script(
                     W,
-                    &bun_script("f/rel/a", A_COMMENTED, Some(format!("{a_hash:016x}"))),
+                    &py_script("f/rel/a", A_COMMENTED, Some(format!("{a_hash:016x}"))),
                 )
                 .await
                 .unwrap();
-            wait_for_jobs(&mut completed, 2).await;
+            wait_for_jobs(&db, &mut completed, 2).await;
 
             let jobs = dependency_jobs_since(&db, since).await;
             let paths: Vec<&str> = jobs.iter().map(|(p, _, _)| p.as_str()).collect();
@@ -181,11 +201,11 @@ async fn relative_import_relock_deploys_only_when_the_lock_changed(
             client
                 .create_script(
                     W,
-                    &bun_script("f/rel/a", A_WITH_LODASH, Some(format!("{a_hash:016x}"))),
+                    &py_script("f/rel/a", A_WITH_TINY, Some(format!("{a_hash:016x}"))),
                 )
                 .await
                 .unwrap();
-            wait_for_jobs(&mut completed, 3).await;
+            wait_for_jobs(&db, &mut completed, 3).await;
 
             let jobs = dependency_jobs_since(&db, since).await;
             let paths: Vec<&str> = jobs.iter().map(|(p, _, _)| p.as_str()).collect();
@@ -203,7 +223,7 @@ async fn relative_import_relock_deploys_only_when_the_lock_changed(
                 );
                 assert!(vs[0].created_at < vs[1].created_at, "{path}: lineage order");
                 assert!(
-                    vs[1].lock.as_deref().unwrap_or("").contains("lodash"),
+                    vs[1].lock.as_deref().unwrap_or("").contains("tiny"),
                     "{path}: the new version carries the new lock: {:?}",
                     vs[1].lock
                 );
@@ -233,10 +253,10 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
         async {
             for (path, content) in [("f/rel/a", A), ("f/rel/b", B)] {
                 client
-                    .create_script(W, &bun_script(path, content, None))
+                    .create_script(W, &py_script(path, content, None))
                     .await
                     .unwrap();
-                wait_for_jobs(&mut completed, 1).await;
+                wait_for_jobs(&db, &mut completed, 1).await;
             }
 
             // A deploy of b that holds its head's row lock for as long as this transaction lives.
@@ -251,14 +271,15 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
             client
                 .create_script(
                     W,
-                    &bun_script("f/rel/a", A_COMMENTED, Some(format!("{a_hash:016x}"))),
+                    &py_script("f/rel/a", A_COMMENTED, Some(format!("{a_hash:016x}"))),
                 )
                 .await
                 .unwrap();
 
             // b's relock skips generation and reaches its commit, where it waits on the lock.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
             let mut waiting = false;
-            for _ in 0..300 {
+            while !waiting && std::time::Instant::now() < deadline {
                 waiting = sqlx::query_scalar(
                     "SELECT EXISTS (SELECT 1 FROM pg_stat_activity
                      WHERE datname = current_database() AND wait_event_type = 'Lock'
@@ -267,10 +288,9 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
                 .fetch_one(&db)
                 .await
                 .unwrap();
-                if waiting {
-                    break;
+                if !waiting {
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
             assert!(waiting, "b's relock never reached the row lock");
 
@@ -284,7 +304,7 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
             deploy.commit().await.unwrap();
 
             // a's own job, the relock that waited, and the relock it queued for the successor.
-            wait_for_jobs(&mut completed, 3).await;
+            wait_for_jobs(&db, &mut completed, 3).await;
 
             let jobs = dependency_jobs_since(&db, since).await;
             let paths: Vec<&str> = jobs.iter().map(|(p, _, _)| p.as_str()).collect();
@@ -324,7 +344,6 @@ async fn relock_waiting_on_a_deploy_requeues_for_its_successor(
 
 /// A multi-file importer: on a skipped relock each module gets its own last lock back, not the
 /// parent script's, so an import's content-only redeploy leaves the importer alone as well.
-#[cfg(feature = "python")]
 #[sqlx::test(fixtures("base"))]
 async fn multi_file_importer_relock_is_a_no_op_too(db: Pool<Postgres>) -> anyhow::Result<()> {
     std::env::set_var("DEPENDENCY_JOB_DEBOUNCE_DELAY", "0");
@@ -332,8 +351,7 @@ async fn multi_file_importer_relock_is_a_no_op_too(db: Pool<Postgres>) -> anyhow
     let mut completed = listen_for_completed_jobs(&db).await;
 
     let py = |path: &str, content: &str, parent_hash: Option<String>, with_module: bool| {
-        let mut ns = bun_script(path, content, parent_hash);
-        ns.language = windmill_api_client::types::ScriptLang::Python3;
+        let mut ns = py_script(path, content, parent_hash);
         if with_module {
             ns.modules = Some(std::collections::HashMap::from([(
                 "helper.py".to_string(),
@@ -363,7 +381,7 @@ async fn multi_file_importer_relock_is_a_no_op_too(db: Pool<Postgres>) -> anyhow
                 .create_script(W, &py("f/rel/pa", "def main():\n    return 'a'\n", None, false))
                 .await
                 .unwrap();
-            wait_for_jobs(&mut completed, 1).await;
+            wait_for_jobs(&db, &mut completed, 1).await;
             client
                 .create_script(
                     W,
@@ -376,7 +394,7 @@ async fn multi_file_importer_relock_is_a_no_op_too(db: Pool<Postgres>) -> anyhow
                 )
                 .await
                 .unwrap();
-            wait_for_jobs(&mut completed, 1).await;
+            wait_for_jobs(&db, &mut completed, 1).await;
             let lock_before = module_lock(&db).await;
             assert!(lock_before.is_some(), "the module got a lock of its own on deploy");
 
@@ -394,7 +412,7 @@ async fn multi_file_importer_relock_is_a_no_op_too(db: Pool<Postgres>) -> anyhow
                 )
                 .await
                 .unwrap();
-            wait_for_jobs(&mut completed, 2).await;
+            wait_for_jobs(&db, &mut completed, 2).await;
 
             let jobs = dependency_jobs_since(&db, since).await;
             let paths: Vec<&str> = jobs.iter().map(|(p, _, _)| p.as_str()).collect();


### PR DESCRIPTION
## Summary

`relock_noop::relative_import_relock_deploys_only_when_the_lock_changed` and
`relock_noop::relock_waiting_on_a_deploy_requeues_for_its_successor` have been failing
intermittently on every open backend PR, with `worker timed out: Elapsed(())` at
`windmill-test-utils/src/lib.rs:384`, usually preceded by `has been running for over 60 seconds`.

`in_test_worker` wraps the spawned worker in `tokio::time::timeout(60s, ..)` and `select!`s it
against the test body with `biased`. A healthy worker future never resolves, so that timeout is in
practice a hard 60-second wall-clock cap on the whole test, and when it trips the harness blames
the worker rather than the test. **That cap is not touched here** — it is long-standing (#6573)
and guards every backend test. The two tests were simply too slow, so this makes them fit.

Reproduced on a run of `main` itself, not caused by any one branch.

## Where the time went

In one CI run of the `relock_noop` binary, all three of its tests started together. The file's
Python test finished in 8.3s; the two Bun tests blew the cap on the same runner in the same
minute. Two costs, measured locally with checkpoint timestamps inside the test bodies:

- **The blind drain.** `wait_for_jobs` ended with a `timeout(2s, completed.next())` loop, so every
  call paid a flat 2 seconds of pure sleeping regardless of what happened. Test 1 calls it five
  times and test 2 three times: **10s and 6s of the (then) 11.5s and 7.4s runtimes were that
  sleep.** It is also a weak check — under load 2s may not be long enough for a spurious job to
  show up at all.
- **Bun.** Every deploy and relock spawns `bun run build.js` plus a prebundle. Locally that is
  cheap; on CI it is what separates the Bun tests from their Python sibling. Note test 2 has no npm
  dependency at all and was still the one that timed out, so this is per-job Bun cost, not the
  `lodash` fetch.

## Changes

All in `backend/tests/relock_noop.rs`.

- **Deploy Python scripts instead of Bun ones.** What these tests pin is language-independent —
  relock cascade, lock comparison, requeue-on-supersede — and Python is the cheapest runtime that
  still produces a real lockfile out of relative imports. The "dependency changed" step swaps
  `lodash@4.17.21` for the PyPI package `tiny`, which `backend/tests/python_jobs.rs` already
  resolves earlier in the same `cargo test` run. The file is now `#![cfg(feature = "python")]` —
  `backend-test.yml`, the job that runs these tests, builds with `python`, and the third test in
  the file was already gated that way. The trade is real and worth naming: a build without the
  `python` feature no longer runs these two.
- **Replace the 2s blind drain with a fixpoint.** `wait_for_jobs` now waits until `v2_job_queue`
  is empty. A dependency job queues its fan-out (`process_relative_imports`) *before* it completes,
  so an empty queue is a real fixpoint rather than a lull — quicker *and* firmer than sitting out a
  fixed delay, since a spurious job is now observed as a queued row instead of hoped-for within 2s.
- **Shrink the lock-wait poll** from 300 × 100ms (a 30-second budget on its own) to 20ms polling
  under a shared `WAIT_BUDGET` ceiling. Measured, that step takes **45–67ms**: a's content-only
  redeploy has the same requirement set as its predecessor, so `uv_pip_compile` hits
  `pip_resolution_cache` and no `uv` process runs at all. I also confirmed the poll observes the
  real thing rather than passing vacuously — at the moment it fires, `pg_stat_activity` shows
  b's relock `active`/`Lock`/`transactionid` on the `fetch_script_for_update` SELECT, while the
  test's own lock-holding transaction sits `idle in transaction`/`Client` and is correctly not
  matched.
- **Bound the counted wait.** Each `completed.next()` now has a `WAIT_BUDGET` timeout reporting
  `only {i} of {count} jobs completed`, so a missing job is named instead of hanging until the
  worker cap trips (see the mutation results below).
- **One `WAIT_BUDGET` (20s) for all three waits** instead of three separate magic numbers, with the
  constraint that matters written next to it: it has to stay clear of the 60s cap, or a stuck step
  reports as a worker timeout instead of saying what it was waiting on.

## Measurements

`before` and `after` binaries built from the same feature set (`quickjs,python`) and run
**interleaved within each rep** — before, then after, back to back — so load drift cancels rather
than favouring whichever variant happened to run in a calm minute. Load average is sampled at the
start of each variant's block and recorded per rep. This box has 24 cores and four sibling agent
sessions were running their own builds and backend test suites on it; **that ambient load is the
busy-runner condition**, so no synthetic load generator was used (adding one would only have
starved the sibling sessions). Seconds:

| round | rep | loadavg (before / after) | test 1 before → after | test 2 before → after | all 3 before → after |
|---|---|---|---|---|---|
| A (quiet) | 1 | 4.3 / 5.9 | 11.52 → **1.77** | 7.85 → **1.38** | 12.58 → **1.66** |
| A (quiet) | 2 | 5.6 / 5.1 | 11.57 → **1.49** | 7.43 → **1.33** | 11.66 → **1.64** |
| A (quiet) | 3 | 5.0 / 3.2 | 11.42 → **1.48** | 7.28 → **1.32** | 11.64 → **1.63** |
| A (quiet) | 4 | 3.0 / 2.4 | 11.55 → **1.56** | 7.68 → **1.31** | 11.65 → **1.57** |
| A (quiet) | 5 | 2.7 / 2.3 | 11.53 → **3.56** | 7.26 → **3.10** | 12.23 → **3.92** |
| A (quiet) | 6 | 8.9 / 20.8 | 14.19 → **3.42** | 10.09 → **3.09** | 14.00 → **3.61** |
| B (busy) | 1 | 31.8 / 33.9 | 18.22 → **4.25** | 9.39 → **3.68** | 16.44 → **4.18** |
| B (busy) | 2 | 33.4 / 34.5 | 14.06 → **1.98** | 10.15 → **1.76** | 14.16 → **2.95** |
| B (busy) | 3 | 31.4 / 20.3 | 14.75 → **1.62** | 7.50 → **1.57** | 11.68 → **2.06** |
| B (busy) | 4 | 19.2 / 15.6 | 13.69 → **1.61** | 7.64 → **1.51** | 12.23 → **1.77** |
| B (busy) | 5 | 14.8 / 10.0 | 12.56 → **1.49** | 7.30 → **1.36** | 11.71 → **1.69** |
| C (busy) | 1 | 33.2 / 33.9 | 21.72 → **4.56** | 9.34 → **4.15** | 14.61 → **5.43** |
| C (busy) | 2 | 33.7 / 36.1 | 14.45 → **3.43** | 9.36 → **3.39** | 18.05 → **3.86** |
| C (busy) | 3 | 34.9 / 46.6 | 16.21 → **2.32** | 21.05 → **1.48** | 14.11 → **1.79** |
| C (busy) | 4 | 43.4 / 26.1 | 14.98 → **2.78** | 7.83 → **3.73** | 19.75 → **2.15** |
| C (busy) | 5 | 24.6 / 23.4 | 11.73 → **16.59** | 8.03 → **50.05** | 16.48 → **2.09** |
| C (busy) | 6 | 35.2 / 22.5 | 12.04 → **1.49** | 10.65 → **1.36** | 12.07 → **1.68** |

### The margin is the point

Speed is only the mechanism; **headroom under the 60s cap is the actual claim that the flake is
gone rather than rarer.**

- On the five genuinely quiet reps (loadavg ≤ 6 on both blocks), **before** ran 7.3–12.6s — a
  ~5x margin — and **after** runs 1.3–3.9s, a **~15–45x margin**.
- Under ambient load, **before** ran 11.7–21.7s (~3x margin, and on CI it went past 60s outright);
  **after** stays at or under 5.4s in 16 of 17 reps.
- Repetition in the CI shape (whole binary, `--test-threads=3`): **45 consecutive runs at loadavg
  14–36, 45/45 pass, max 9.8s, median ~2.5s** — still a ~6x margin at the worst run of 45.

A ~3–5x margin is what CI load erases; ~15x is not.

**The one honest outlier**: round C rep 5, `after`, test 2 took 50.05s (it still passed) at the
peak of sibling contention on this box's shared Postgres — note its `all3` in the very same rep was
2.09s. Log analysis of the slowest run I could capture attributes the tail to Postgres, not to the
test: `SLOW_QUERY … total duration: 1.81s` on the job-queue read, while four other test suites were
concurrently creating and dropping `sqlx::test` databases in the same cluster. CI runs one Postgres
for one job, so that specific contention does not exist there — but it is one outlier in ~60 runs,
not zero, and it belongs in the record.

## Does it still pin the same behaviour?

Checked by breaking the production code from #10966 and confirming the tests fail:

| mutation in `worker_lockfiles.rs` | result |
|---|---|
| `commit_relock` never returns `Unchanged` (always deploys) | all 3 tests FAIL in 1.5s — test 1 on `the leaf's own job and one no-op relock of its importer, and nothing for c` |
| `commit_relock` re-reads the head once instead of `0..4` | test 2 FAILS on `only 2 of 3 jobs completed` |

The second one is why the bounded counted wait was added: before it, that regression reported as a
60s `worker timed out`; now it reports in 23s with the reason.

## Deliberate coverage trade

These tests no longer drive the relock path with Bun/TS. That is intentional, not incidental:
`commit_relock`, `requeue_relock` and the fan-out are language-agnostic, and Bun relative-import
lock generation itself stays covered by `backend/tests/bun_jobs.rs` and
`backend/tests/dedicated_workers.rs`.

This unblocks the backend test job for the currently open PRs.

## Test plan

- [x] `cargo test --features quickjs,python --test relock_noop` — 3/3 pass
- [x] Pre-PR review: `local-review-codex` (`gpt-5.6-sol`, xhigh) clean; `local-review` returned two
      P2 nits (a comment that argued against the deleted implementation, and a lock-wait deadline
      cut below what the happy path warranted) — both addressed above
- [x] 45 consecutive runs of the whole binary at `--test-threads=3` under load, 0 failures
- [x] Both properties re-verified by mutating the production code and watching the tests fail
- [x] Compiles and is a no-op (0 tests) without the `python` feature
- [x] `rustfmt --check` clean on the changed file
- [ ] CI backend-test green
