### PR TITLE
fix: render the MCP OAuth consent page without a workspace

### DIFF
--- a/frontend/src/routes/(root)/(logged)/oauth/mcp_authorize/+page@(root).svelte
+++ b/frontend/src/routes/(root)/(logged)/oauth/mcp_authorize/+page@(root).svelte
@@ -1,3 +1,7 @@
+<!-- `@(root)` skips the (logged) layout on purpose: that layout renders nothing but
+     "Loading user..." until `$userStore` is set, and `$userStore` is only ever filled in
+     for a chosen workspace. An MCP client sends the browser straight here after login, so
+     in gateway mode there is no workspace yet — picking one is what this page is for. -->
 <script lang="ts">
 	import { page } from '$app/state'
 	import CenteredModal from '$lib/components/CenteredModal.svelte'
@@ -138,9 +142,13 @@
 </script>
 
 {#if !redirectUriValid}
-	<p class="text-center text-sm text-primary mb-6"> Error: invalid or unsafe redirect_uri </p>
+	<CenteredModal title="Authorization Request">
+		<p class="text-center text-sm text-primary"> Error: invalid or unsafe redirect_uri </p>
+	</CenteredModal>
 {:else if !isGateway && !workspaceId}
-	<p class="text-center text-sm text-primary mb-6">Error: missing workspace_id</p>
+	<CenteredModal title="Authorization Request">
+		<p class="text-center text-sm text-primary">Error: missing workspace_id</p>
+	</CenteredModal>
 {:else}
 	<CenteredModal title={success ? 'Authorization Approved' : 'Authorization Request'}>
 		{#if success}

--- a/frontend/src/routes/(root)/(logged)/oauth/mcp_authorize/layoutReset.test.ts
+++ b/frontend/src/routes/(root)/(logged)/oauth/mcp_authorize/layoutReset.test.ts
@@ -1,0 +1,14 @@
+import { readdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Renaming the page back drops it into the (logged) layout, where it hangs on
+// "Loading user..." with no type error and no other failing test — see the page header.
+const routeDir = dirname(fileURLToPath(import.meta.url))
+
+describe('mcp oauth consent route', () => {
+	it('escapes the (logged) layout', () => {
+		expect(readdirSync(routeDir)).toContain('+page@(root).svelte')
+	})
+})

--- a/frontend/src/routes/(root)/+layout.svelte
+++ b/frontend/src/routes/(root)/+layout.svelte
@@ -147,7 +147,10 @@
 			} else {
 				if (
 					(!page.url.pathname.startsWith('/user/') || page.url.pathname.startsWith('/user/cli')) &&
-					!page.url.pathname.startsWith('/oauth/mcp_authorize') &&
+					// The MCP consent page carries its own workspace picker, so it is left to
+					// run without one. Nothing sets `$userStore` on this branch, which is why
+					// that page must stay outside the (logged) layout — see its `@(root)` name.
+					!page.url.pathname.startsWith(`${base}/oauth/mcp_authorize`) &&
 					// The hub import wizard asks for the destination itself, and may end in a
 					// workspace that does not exist yet — bouncing it to the picker would
 					// force the very choice it exists to make.


### PR DESCRIPTION
## Summary

Starting the MCP gateway OAuth flow from a fresh browser left the consent page stuck on
**"Loading user..."** — the workspace picker and consent screen never rendered (GIT-995).

`/oauth/mcp_authorize` lived under the `(logged)` layout, which renders nothing but a
"Loading user..." modal until `$userStore` is set. `$userStore` is only ever set for a
chosen workspace (`updateUserStore` in `(root)/(logged)/+layout.svelte`), and
`(root)/+layout.svelte` deliberately exempts this path from the bounce to
`/user/workspaces` — gateway mode picks the workspace on the consent page itself. So on a
session with no persisted workspace, nothing filled `$userStore` in and the page hung
forever. A SAML ACS redirect lands the browser straight on the deep link
(`safe_relay_state_redirect`), which is exactly that state; going through the workspace
picker first is what made the flow appear to work.

The page needs a session, not a workspace, so it now escapes the `(logged)` layout via
SvelteKit's `@(root)` layout reset — the same shape as
`(root)/(logged)/projects/import/+page@(root).svelte` and `user/(user)/+layout@(root).svelte`.
Auth is unchanged: `(root)/+layout.svelte` still calls `globalWhoami()` and still bounces a
logged-out visitor to `/user/login?rd=<deep link>`.

## Changes

- Rename `oauth/mcp_authorize/+page.svelte` to `+page@(root).svelte` so the consent page
  renders under `(root)` instead of `(logged)`.
- Prefix the existing `/oauth/mcp_authorize` exemption in `(root)/+layout.svelte` with
  `${base}`. Without it a deployment served under a base path (`VITE_BASE_URL`) never
  matched the exemption and bounced to `/user/workspaces` instead of the consent page —
  verified both ways against a `VITE_BASE_URL=/windmill` dev server.
- Wrap the page's two error branches (invalid `redirect_uri`, missing `workspace_id`) in
  `CenteredModal`. They used to be a bare `<p>` inside the app chrome; standalone they
  would have been loose text on an empty page.
- Add a route-shape regression test: renaming the file back reintroduces the hang with no
  type error and nothing else failing.

Both consent modes now render standalone rather than inside the sidebar chrome. That was
already the intent — `CenteredModal` is `h-screen` with its own background, so it was
never meant to sit inside the app content area.

## Screenshots

Before — gateway consent page on a session with no workspace:

![before-loading-user](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-995-bugmcp-gateway-oauth-gets-stuck-on-loading-user-after-sso/1788594886-before-loading-user.png)

After — workspace picker and scope selector on the same URL:

![after-consent](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/git-995-bugmcp-gateway-oauth-gets-stuck-on-loading-user-after-sso/1788594888-after-consent.png)

## Test plan

Exercised on the running instance (backend rebuilt with `--features quickjs,mcp`, a client
registered through `/api/mcp/oauth/server/register`, two workspaces, driven with Playwright):

- [x] Gateway mode, session with no persisted workspace: `/api/mcp/gateway/oauth/server/authorize`
      redirects to the consent page, which renders the picker (previously "Loading user...").
      Pick a workspace → scope selector appears → Approve → redirect carries `code` + `state`.
- [x] Code exchanged at `/api/mcp/gateway/oauth/server/token` with the PKCE verifier, and the
      resulting bearer token drives a real `initialize` call against `/api/mcp/gateway`.
- [x] Workspace mode (`/api/w/<ws>/mcp/oauth/server/authorize`): consent page and scope
      selector render, Approve returns a code.
- [x] Logged out: the consent URL still bounces to `/user/login?rd=<deep link>`; logging in
      and picking a workspace lands back on the consent page.
- [x] Base path (`VITE_BASE_URL=/windmill`): consent page renders; reverting the `${base}`
      prefix reproduces the bounce to `/user/workspaces`.
- [x] Error branch: a malformed `redirect_uri` renders "Error: invalid or unsafe redirect_uri"
      inside the modal.
- [x] `npm run check` (svelte-check): 0 errors. `npx vitest run --project server` on the new
      test passes; the 8 failing test files and the 4 `check:fast` errors in the tree are
      pre-existing on main (copilot/chat, dbtable, `projects/import`, `hubProject.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EeEWKSqcnCEcPKe9uUuHC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP OAuth consent page hanging on "Loading user..." when the gateway flow starts from a fresh browser session without a persisted workspace. The page lived under the `(logged)` layout, which renders nothing until `$userStore` is set, and `$userStore` is only set once a workspace is chosen — which is exactly what the consent page is supposed to do. It now escapes that layout via SvelteKit's `@(root)` reset and renders standalone with its workspace picker and scope selector; logged-out visitors still get bounced to login and back to the deep link.

The `(root)` layout's exemption for this route now includes the `${base}` prefix, so deployments under `VITE_BASE_URL` no longer bounce to the workspace picker. The page's error branches (invalid `redirect_uri`, missing `workspace_id`) are wrapped in `CenteredModal` since the page no longer renders inside the app chrome — both consent modes now render standalone, which is what that component's full-screen design was built for. A regression test asserts the route file keeps the `@(root)` suffix; renaming it back reintroduces the hang with no type error and no other failing test.

<sup>Written for commit 0f4cd50add03725996e86d3409e3e427210078c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

