### PR TITLE
test: keep the mcp preprocessor header test off the dependency job

### DIFF
--- a/backend/windmill-api-integration-tests/tests/mcp_preprocessor_headers.rs
+++ b/backend/windmill-api-integration-tests/tests/mcp_preprocessor_headers.rs
@@ -15,6 +15,12 @@ use windmill_test_utils::*;
 
 const SCRIPT_PATH: &str = "u/test-user/mcp_hdr_probe";
 
+/// A bun lock the executor accepts without installing anything: no dependencies
+/// in the `package.json` half, `<empty>` for the `bun.lock` half. The empty
+/// string is not a substitute: a lock carrying no `//bun.lock` separator is
+/// rejected at run time.
+const EMPTY_BUN_LOCK: &str = "{}\n//bun.lock\n<empty>";
+
 /// Echoes the two halves of the event separately, so the assertions can tell
 /// which one a value arrived in.
 const PREPROCESSOR_SCRIPT: &str = r#"
@@ -84,7 +90,7 @@ async fn test_mcp_preprocessor_receives_the_callers_headers(
             "description": "",
             "content": PREPROCESSOR_SCRIPT,
             "language": "bun",
-            "lock": "",
+            "lock": EMPTY_BUN_LOCK,
             "schema": {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
@@ -101,13 +107,14 @@ async fn test_mcp_preprocessor_receives_the_callers_headers(
         resp.text().await.unwrap_or_default()
     );
 
-    // A script counts as deployed once it has a lock, which normally arrives from
-    // a dependency job. Planting an empty one keeps the test to the path under
-    // test instead of a bun resolution whose timing it does not control.
-    sqlx::query("UPDATE script SET lock = '' WHERE path = $1 AND workspace_id = 'test-workspace'")
-        .bind(SCRIPT_PATH)
-        .execute(&db)
-        .await?;
+    // A supplied lock queues no dependency job, so the version is deployed (hence
+    // listable and runnable) as soon as the create returns.
+    let queued: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM v2_job_queue WHERE workspace_id = 'test-workspace'",
+    )
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(queued, 0, "the supplied lock must queue no dependency job");
 
     let tools = mcp_post(
         port,


### PR DESCRIPTION
## Summary

`test_mcp_preprocessor_receives_the_callers_headers` fails intermittently on main ([run 33952526800](https://github.com/windmill-labs/windmill/actions/runs/33952526800/job/101269855284)) with:

```
Invalid requirements, expected to find //bun.lock split pattern in reqs. Found: ||
```

The test created its bun script with `"lock": ""` and then planted `lock = ''` on the row, with a comment claiming that kept it off "a bun resolution whose timing it does not control". An empty lock is not a valid bun lock: `split_lockfile` (`backend/windmill-worker/src/bun_executor.rs:355`) rejects any lock with no `//bun.lock` separator, and the job dies with the error above.

The test passed only by accident. A `lock: ""` in the create payload is normalized to `None` (`backend/windmill-api-scripts/src/scripts.rs:1451`), so `needs_lock_gen` was true and `scripts/create` queued a dependency job. That job rewrote the lock with a real one before the worker pulled the MCP job. Whenever it is slow, fails, or loses the race, the planted `''` is what the executor sees. Confirmed by deleting the queued dependency job right after the create, which reproduces the CI panic verbatim.

The fix supplies a valid install-free lock at create time, so no dependency job is queued at all and the executor skips `bun install`: the test now touches neither bun resolution nor the network.

## Changes

- Create the probe script with `lock: "{}\n//bun.lock\n<empty>"` (the existing idiom from `backend/tests/fixtures/dedicated_flows.sql`) instead of `""`. A non-empty supplied lock sets `needs_lock_gen = false`, and the `<empty>` half makes `split_lockfile` report empty dependencies so the executor skips both `write_lock` and `install_bun_lockfile`.
- Drop the `UPDATE script SET lock = ''` hack, which is what made the test depend on the dependency job in the first place.
- Assert `v2_job_queue` is empty after the create, so a regression that re-queues a dependency job fails loudly here instead of coming back as a timing-dependent flake.

No production code changes; the test's assertions on `event.headers` vs `event.body` are untouched.

## Test plan

- [x] Reproduced the CI failure locally: deleting the queued dependency job right after the create yields the exact panic from the failing run.
- [x] `cargo test -p windmill-api-integration-tests --features mcp --test mcp_preprocessor_headers`, 15 consecutive runs with the FS script cache cleared before each, all pass in ~1.2s.
- [x] The new `v2_job_queue` assertion holds, confirming no dependency job is queued and no `bun install` runs.
- [x] `rustfmt --check` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESK92Dtojyu4XMg19GHfp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky MCP preprocessor header test by supplying a valid empty bun lock at script creation, so no dependency job is queued and the test no longer races bun resolution. Also asserts `v2_job_queue` is empty after create to catch regressions.

<sup>Written for commit 6674b0958d5f2142a3a1862b67be8ebf23958f9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

