### PR TITLE
fix: only warn about manual action when the username actually changes

### DIFF
--- a/frontend/src/lib/components/ChangeInstanceUsernameInner.svelte
+++ b/frontend/src/lib/components/ChangeInstanceUsernameInner.svelte
@@ -6,30 +6,34 @@
 	import { createEventDispatcher } from 'svelte'
 
 	interface Props {
-		email: string;
-		username: string;
-		isConflict?: boolean;
-		noPadding?: boolean;
+		email: string
+		username: string
+		isConflict?: boolean
+		noPadding?: boolean
 	}
 
-	let {
-		email,
-		username = $bindable(),
-		isConflict = false,
-		noPadding = false
-	}: Props = $props();
+	let { email, username = $bindable(), isConflict = false, noPadding = false }: Props = $props()
 
 	let loading = $state(false)
 
-	let usernameInfo:
-		| {
-				username: string
-				workspace_usernames: {
-					workspace_id: string
-					username: string
-				}[]
-		  }
-		| undefined = $state(undefined)
+	type UsernameInfo = {
+		username: string
+		workspace_usernames: {
+			workspace_id: string
+			username: string
+		}[]
+	}
+
+	let usernameInfo: UsernameInfo | undefined = $state(undefined)
+
+	let affectedWorkspaces = $derived.by(
+		() => usernameInfo?.workspace_usernames.filter((w) => w.username !== username) ?? []
+	)
+	let isRenaming = $derived.by(
+		() =>
+			usernameInfo !== undefined &&
+			(username !== usernameInfo.username || affectedWorkspaces.length > 0)
+	)
 
 	function handleKeyUp(event: KeyboardEvent) {
 		const key = event.key
@@ -102,31 +106,30 @@
 			Users are required to have an instance-wide username that is shared across all workspaces.
 			However, this user has different usernames in different workspaces.
 
-			{#if usernameInfo?.workspace_usernames && usernameInfo.workspace_usernames.filter((w) => w.username !== username).length > 0}
+			{#if affectedWorkspaces.length > 0}
 				<br />
 				<br />
-				Workspaces requiring username modification: {usernameInfo.workspace_usernames
-					.filter((w) => w.username !== username)
+				Workspaces requiring username modification: {affectedWorkspaces
 					.map((wu) => `${wu.workspace_id} (${wu.username})`)
 					.join(', ')}
 			{/if}
 		</Alert>
 	{/if}
 
-	{#if !isConflict && usernameInfo?.workspace_usernames && usernameInfo.workspace_usernames.filter((w) => w.username !== username).length > 0}
+	{#if !isConflict && affectedWorkspaces.length > 0}
 		<Alert title="Concerned workspaces" class="mb-4">
-			{usernameInfo.workspace_usernames
-				.filter((w) => w.username !== username)
-				.map((wu) => `${wu.workspace_id}`)
-				.join(', ')}
+			{affectedWorkspaces.map((wu) => `${wu.workspace_id}`).join(', ')}
 		</Alert>
 	{/if}
 
-	<Alert type="warning" title="Manual action required" class="mb-4">
-		This operation does not handle references in scripts, workflows and applications to scripts in
-		the workspace, and references in resources to variables. You will have to handle those manually.
-		<br />
-	</Alert>
+	{#if isRenaming}
+		<Alert type="warning" title="Manual action required" class="mb-4">
+			This operation does not handle references in scripts, workflows and applications to scripts in
+			the workspace, and references in resources to variables. You will have to handle those
+			manually.
+			<br />
+		</Alert>
+	{/if}
 
 	<Button
 		variant="default"

--- a/frontend/src/lib/components/ChangeInstanceUsernameInner.svelte
+++ b/frontend/src/lib/components/ChangeInstanceUsernameInner.svelte
@@ -57,6 +57,11 @@
 	const dispatch = createEventDispatcher()
 
 	async function renameUser() {
+		// Renaming before the current usernames are known would apply a change whose scope
+		// the "Manual action required" warning could not have been shown for.
+		if (!usernameInfo) {
+			return
+		}
 		loading = true
 		try {
 			const automateUsernameCreation =
@@ -139,7 +144,7 @@
 				dispatch('close')
 			})
 		}}
-		disabled={email === undefined || !username}
+		disabled={email === undefined || !username || !usernameInfo}
 		{loading}
 	>
 		Confirm username change


### PR DESCRIPTION
## Summary

The instance user editor's username section always rendered the "Manual action required" warning — even on first open, when the field still holds the user's current username and confirming would change nothing. The warning now renders only when a rename would actually take effect.

## Changes

- `ChangeInstanceUsernameInner.svelte`: gate the "Manual action required" alert on `isRenaming` — the typed username differs from the instance username, or at least one workspace username differs from it (the conflict path, where the field is disabled and pre-filled, still warns because its workspaces differ by definition).
- Hoist the `workspace_usernames` filter that was inlined three times in the markup into a single `affectedWorkspaces` derived.
- Block the rename (button disabled, `renameUser` early-returns) until `username_info` has loaded, so a pending or failed fetch can't apply a rename whose scope the warning could not have been shown for.

## Screenshots

Field holds the current username — no warning:

![no-change](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-username-change-manual-action-alert/1757066700-no-change.png)

A different username typed — "Concerned workspaces" and "Manual action required" both appear:

_(second screenshot upload was blocked locally; the state is described above and reproducible with the test plan)_

## Test plan

- [x] Superadmin settings → user row → Edit: the popover opens with the current username pre-filled and no "Manual action required" alert
- [x] Typing a different username makes both "Concerned workspaces" and "Manual action required" appear immediately
- [x] Confirming the change still renames the user across `password` and every `usr` row
- [ ] Conflict path ("Fix username conflict"): the disabled, auto-filled field still shows both the "Username conflict" and "Manual action required" alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QT712GyPPXD24rgTdLd9a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The instance user editor no longer shows the "Manual action required" warning when the username field still holds the current username and confirming would change nothing. The warning now renders only when a rename would actually take effect.

- Hoists the three inline workspace username filters into a single `affectedWorkspaces` derived.
- Blocks the rename until `username_info` has loaded, so a pending or failed fetch can't apply a change whose scope the warning never covered.

<sup>Written for commit 0ee7f6046af55f62861677fef01e2fbf4468abcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

