### PR TITLE
fix(cli): keep permissioned_as on single-item push, as sync push does

### DIFF
--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -409,7 +409,8 @@ async function push(
   if (isRawAppByName || hasRawAppYaml) {
     const { pushRawApp } = await import("./raw_apps.ts");
     const merged = await mergeConfigWithConfigFile(opts);
-    // Raw apps have no policy, so no ownership to preserve.
+    // Raw-app ownership preservation is not implemented on either push
+    // path: sync push hands pushRawApp no context either.
     await pushRawApp(
       workspace.workspaceId,
       remotePath,

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -426,7 +426,7 @@ async function push(
       undefined,
       await buildPermissionedAsContext(
         workspace.workspaceId,
-        await readEffectiveSyncBehavior(),
+        await readEffectiveSyncBehavior(opts, workspace),
       ),
     );
     log.info(colors.bold.underline.green("App pushed"));

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -12,7 +12,11 @@ import * as wmill from "../../../gen/services.gen.ts";
 import { ListableApp, Policy } from "../../../gen/types.gen.ts";
 
 import { GlobalOptions, isSuperset } from "../../types.ts";
-import { getWmillYamlPath, mergeConfigWithConfigFile } from "../../core/conf.ts";
+import {
+  getWmillYamlPath,
+  mergeConfigWithConfigFile,
+  readEffectiveSyncBehavior,
+} from "../../core/conf.ts";
 import { readInlinePathSync } from "../../utils/utils.ts";
 import devCommand from "./dev.ts";
 import lintCommand from "./lint.ts";
@@ -21,6 +25,7 @@ import newCommand from "./new.ts";
 import generateAgentsCommand from "./generate_agents.ts";
 import { isVersionsGeq1585 } from "../sync/global.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
+import { buildPermissionedAsContext } from "../../core/permissioned_as.ts";
 import { applyExtraPermsDiff } from "../../core/extra_perms.ts";
 
 export interface AppFile {
@@ -404,6 +409,7 @@ async function push(
   if (isRawAppByName || hasRawAppYaml) {
     const { pushRawApp } = await import("./raw_apps.ts");
     const merged = await mergeConfigWithConfigFile(opts);
+    // Raw apps have no policy, so no ownership to preserve.
     await pushRawApp(
       workspace.workspaceId,
       remotePath,
@@ -413,7 +419,16 @@ async function push(
     );
     log.info(colors.bold.underline.green("Raw app pushed"));
   } else {
-    await pushApp(workspace.workspaceId, remotePath, absoluteFilePath);
+    await pushApp(
+      workspace.workspaceId,
+      remotePath,
+      absoluteFilePath,
+      undefined,
+      await buildPermissionedAsContext(
+        workspace.workspaceId,
+        await readEffectiveSyncBehavior(),
+      ),
+    );
     log.info(colors.bold.underline.green("App pushed"));
   }
 }

--- a/cli/src/commands/flow/flow.ts
+++ b/cli/src/commands/flow/flow.ts
@@ -335,9 +335,9 @@ async function push(opts: Options & { message?: string }, filePath: string, remo
   // Reading the config moves the cwd to the wmill.yaml root when it sits in a
   // parent directory, so pin the file against the invocation cwd first.
   filePath = pathResolve(filePath);
-  const syncBehavior = await readEffectiveSyncBehavior();
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
+  const syncBehavior = await readEffectiveSyncBehavior(opts, workspace);
 
   await pushFlow(
     workspace.workspaceId,

--- a/cli/src/commands/flow/flow.ts
+++ b/cli/src/commands/flow/flow.ts
@@ -4,7 +4,7 @@ import { Command } from "@cliffy/command";
 import { Confirm } from "@cliffy/prompt/confirm";
 import { Table } from "@cliffy/table";
 import * as log from "../../core/log.ts";
-import { dirname, sep as SEP } from "node:path";
+import { dirname, sep as SEP, resolve as pathResolve } from "node:path";
 import { stringify as yamlStringify } from "yaml";
 import { yamlParseFile } from "../../utils/yaml.ts";
 import { readTextFile, validateRequiredArgs } from "../../utils/utils.ts";
@@ -21,11 +21,16 @@ import {
 } from "../../core/context.ts";
 import { resolve, track_job, pollForJobResult } from "../script/script.ts";
 import { defaultFlowDefinition } from "../../../bootstrap/flow_bootstrap.ts";
-import { SyncOptions, mergeConfigWithConfigFile } from "../../core/conf.ts";
+import {
+  SyncOptions,
+  mergeConfigWithConfigFile,
+  readEffectiveSyncBehavior,
+} from "../../core/conf.ts";
 import { FSFSElement, elementsToMap, ignoreF } from "../sync/sync.ts";
 import { Flow } from "../../../gen/types.gen.ts";
 import { applyExtraPermsDiff } from "../../core/extra_perms.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
+import { buildPermissionedAsContext } from "../../core/permissioned_as.ts";
 import {
   collectPathScriptPaths,
   replaceInlineScripts,
@@ -327,10 +332,20 @@ async function push(opts: Options & { message?: string }, filePath: string, remo
   if (!validatePath(remotePath)) {
     return;
   }
+  // Reading the config moves the cwd to the wmill.yaml root when it sits in a
+  // parent directory, so pin the file against the invocation cwd first.
+  filePath = pathResolve(filePath);
+  const syncBehavior = await readEffectiveSyncBehavior();
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
 
-  await pushFlow(workspace.workspaceId, remotePath, filePath, opts.message);
+  await pushFlow(
+    workspace.workspaceId,
+    remotePath,
+    filePath,
+    opts.message,
+    await buildPermissionedAsContext(workspace.workspaceId, syncBehavior)
+  );
   log.info(colors.bold.underline.green("Flow pushed"));
 }
 

--- a/cli/src/commands/schedule/schedule.ts
+++ b/cli/src/commands/schedule/schedule.ts
@@ -6,13 +6,19 @@ import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
-import { sep as SEP } from "node:path";
+import { sep as SEP, resolve as pathResolve } from "node:path";
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
-import { mergeConfigWithConfigFile } from "../../core/conf.ts";
+import {
+  mergeConfigWithConfigFile,
+  readEffectiveSyncBehavior,
+} from "../../core/conf.ts";
 import * as wmill from "../../../gen/services.gen.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
-import { lookupUsernameByEmail } from "../../core/permissioned_as.ts";
+import {
+  buildPermissionedAsContext,
+  lookupUsernameByEmail,
+} from "../../core/permissioned_as.ts";
 
 import {
   GlobalOptions,
@@ -299,6 +305,10 @@ async function disable(opts: GlobalOptions, path: string) {
 }
 
 async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
+  // Reading the config moves the cwd to the wmill.yaml root when it sits in a
+  // parent directory, so pin the file against the invocation cwd first.
+  filePath = pathResolve(filePath);
+  const syncBehavior = await readEffectiveSyncBehavior();
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
 
@@ -317,7 +327,8 @@ async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
     workspace.workspaceId,
     remotePath,
     undefined,
-    parseFromFile(filePath)
+    parseFromFile(filePath),
+    await buildPermissionedAsContext(workspace.workspaceId, syncBehavior)
   );
   console.log(colors.bold.underline.green("Schedule pushed"));
 }

--- a/cli/src/commands/schedule/schedule.ts
+++ b/cli/src/commands/schedule/schedule.ts
@@ -308,9 +308,9 @@ async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
   // Reading the config moves the cwd to the wmill.yaml root when it sits in a
   // parent directory, so pin the file against the invocation cwd first.
   filePath = pathResolve(filePath);
-  const syncBehavior = await readEffectiveSyncBehavior();
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
+  const syncBehavior = await readEffectiveSyncBehavior(opts, workspace);
 
   if (!validatePath(remotePath)) {
     return;

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -7,6 +7,7 @@ import {
   validatePath,
 } from "../../core/context.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
+import { buildPermissionedAsContext } from "../../core/permissioned_as.ts";
 import { applyExtraPermsDiff } from "../../core/extra_perms.ts";
 import { writeFile, stat, mkdir } from "node:fs/promises";
 import { Buffer } from "node:buffer";
@@ -58,6 +59,7 @@ import {
   SyncOptions,
   mergeConfigWithConfigFile,
   readConfigFile,
+  readEffectiveSyncBehavior,
 } from "../../core/conf.ts";
 import { SyncCodebase, listSyncCodebases } from "../../utils/codebase.ts";
 import { pollJobWithQueueLogging } from "../../utils/job_polling.ts";
@@ -231,7 +233,11 @@ async function push(opts: PushOptions, filePath: string) {
     opts.message,
     opts,
     await getRawWorkspaceDependencies(true),
-    codebases
+    codebases,
+    await buildPermissionedAsContext(
+      workspace.workspaceId,
+      await readEffectiveSyncBehavior()
+    )
   );
   log.info(colors.bold.underline.green(`Script ${filePath} pushed`));
 }

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -236,7 +236,7 @@ async function push(opts: PushOptions, filePath: string) {
     codebases,
     await buildPermissionedAsContext(
       workspace.workspaceId,
-      await readEffectiveSyncBehavior()
+      await readEffectiveSyncBehavior(opts, workspace)
     )
   );
   log.info(colors.bold.underline.green(`Script ${filePath} pushed`));

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -77,6 +77,7 @@ import {
 import {
   getEffectiveSettings,
   getWorkspaceNames,
+  inferWsNameFromProfile,
   mergeConfigWithConfigFile,
   parseSyncBehavior,
   SyncOptions,
@@ -512,31 +513,6 @@ function resolveWsNameForFiles(_opts: SyncOptions, wsName: string): string {
 
 // After resolveWorkspace, infer the workspace config name from the resolved profile
 // by matching baseUrl + workspaceId against the workspaces config entries.
-function inferWsNameFromProfile(
-  opts: SyncOptions,
-  profile: { remote: string; workspaceId: string },
-): string | undefined {
-  if (!opts.workspaces) return undefined;
-  const wsNames = Object.keys(opts.workspaces).filter(
-    (k) => k !== "commonSpecificItems",
-  );
-  for (const name of wsNames) {
-    const entry = (opts.workspaces as any)[name] as WorkspaceEntryConfig;
-    if (!entry?.baseUrl) continue;
-    try {
-      const entryUrl = new URL(entry.baseUrl).toString();
-      const profileUrl = new URL(profile.remote).toString();
-      const entryWsId = entry.workspaceId ?? name;
-      if (entryUrl === profileUrl && entryWsId === profile.workspaceId) {
-        return name;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return undefined;
-}
-
 // Merge CLI options with effective settings, preserving CLI flags as overrides
 function mergeCliWithEffectiveOptions<
   T extends GlobalOptions & SyncOptions & { repository?: string },

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -85,7 +85,10 @@ import {
   WorkspaceEntryConfig,
 } from "../../core/conf.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
-import { preCheckPermissionedAs } from "../../core/permissioned_as.ts";
+import {
+  buildPermissionedAsContext,
+  preCheckPermissionedAs,
+} from "../../core/permissioned_as.ts";
 import {
   fromWorkspaceSpecificPath,
   toWorkspaceSpecificPath,
@@ -5544,27 +5547,19 @@ export async function push(
       return;
     }
 
-    let permissionedAsContext: PermissionedAsContext | undefined = undefined;
-    if (parseSyncBehavior(opts.syncBehavior) >= 1) {
-      const user = await wmill.whoami({ workspace: workspace.workspaceId });
-      const userIsAdminOrDeployer =
-        user.is_admin || (user.groups ?? []).includes("wm_deployers");
-      log.debug(
-        `permissioned_as: user=${user.email}, is_admin=${user.is_admin}, groups=${JSON.stringify(user.groups)}, isAdminOrDeployer=${userIsAdminOrDeployer}`,
+    const permissionedAsContext: PermissionedAsContext | undefined =
+      await buildPermissionedAsContext(
+        workspace.workspaceId,
+        opts.syncBehavior,
       );
-      permissionedAsContext = {
-        userCache: new Map(),
-        userIsAdminOrDeployer,
-        userEmail: user.email,
-      };
-
+    if (permissionedAsContext) {
       // ws_specific_flag changes have no content payload, so they don't
       // affect permissioned_as resolution — filter them out before the
       // pre-check (which expects only added/edited/deleted).
       await preCheckPermissionedAs(
         changes.filter((c) => c.name !== "ws_specific_flag"),
-        user.email,
-        userIsAdminOrDeployer,
+        permissionedAsContext.userEmail,
+        permissionedAsContext.userIsAdminOrDeployer,
         opts.acceptOverridingPermissionedAsWithSelf ?? false,
         !!process.stdin.isTTY,
       );

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -76,8 +76,8 @@ import {
 } from "../../utils/utils.ts";
 import {
   getEffectiveSettings,
-  getWorkspaceNames,
   inferWsNameFromProfile,
+  resolveWsNameForConfigFromFlags,
   mergeConfigWithConfigFile,
   parseSyncBehavior,
   SyncOptions,
@@ -433,37 +433,6 @@ export function computeWsSpecificFlagOnlyPushes(
   return out;
 }
 
-// Resolve workspace name from a --branch override (git branch → workspace name).
-// Falls back to using the branch value as-is (backward compat: old key = branch name).
-function resolveWsNameFromBranch(
-  opts: SyncOptions,
-  branchName: string,
-): string {
-  const match = findWorkspaceByGitBranch(opts.workspaces, branchName);
-  return match ? match[0] : branchName;
-}
-
-// Resolve wsNameForConfig from CLI flags. Prefers --branch → matching config key,
-// then --workspace → matching config key (incl. when --base-url is set). Returns
-// undefined when no flag-based resolution applies; callers then fall back to
-// inferWsNameFromProfile on the resolved workspace profile.
-export function resolveWsNameForConfigFromFlags(
-  opts: SyncOptions & { branch?: string; workspace?: string },
-): string | undefined {
-  if (opts.branch) {
-    return resolveWsNameFromBranch(opts, opts.branch);
-  }
-  if (opts.workspace) {
-    // Use getWorkspaceNames so reserved keys (e.g. commonSpecificItems) are filtered out,
-    // matching the behavior of findWorkspaceByGitBranch / inferWsNameFromProfile.
-    const validKeys = getWorkspaceNames(opts.workspaces);
-    if (validKeys.includes(opts.workspace)) {
-      return opts.workspace;
-    }
-  }
-  return undefined;
-}
-
 // Warn if --workspace overrides auto-detected branch or if workspace not in config.
 function warnWorkspaceOverride(
   opts: SyncOptions,
@@ -511,8 +480,6 @@ function resolveWsNameForFiles(_opts: SyncOptions, wsName: string): string {
   return wsName;
 }
 
-// After resolveWorkspace, infer the workspace config name from the resolved profile
-// by matching baseUrl + workspaceId against the workspaces config entries.
 // Merge CLI options with effective settings, preserving CLI flags as overrides
 function mergeCliWithEffectiveOptions<
   T extends GlobalOptions & SyncOptions & { repository?: string },

--- a/cli/src/commands/trigger/trigger.ts
+++ b/cli/src/commands/trigger/trigger.ts
@@ -23,7 +23,7 @@ import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
-import { sep as SEP } from "node:path";
+import { sep as SEP, resolve as pathResolve } from "node:path";
 import {
   GlobalOptions,
   isSuperset,
@@ -41,6 +41,8 @@ import { getCurrentGitBranch } from "../../utils/git.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { validatePath, resolveWorkspace } from "../../core/context.ts";
 import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
+import { buildPermissionedAsContext } from "../../core/permissioned_as.ts";
+import { readEffectiveSyncBehavior } from "../../core/conf.ts";
 
 type Trigger = {
   http: HttpTrigger;
@@ -620,6 +622,10 @@ async function extractTriggerKindFromPath(filePath: string): Promise<string | un
 }
 
 async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
+  // Reading the config moves the cwd to the wmill.yaml root when it sits in a
+  // parent directory, so pin the file against the invocation cwd first.
+  filePath = pathResolve(filePath);
+  const syncBehavior = await readEffectiveSyncBehavior();
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
 
@@ -643,7 +649,8 @@ async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
     workspace.workspaceId,
     remotePath,
     undefined,
-    parseFromFile(filePath)
+    parseFromFile(filePath),
+    await buildPermissionedAsContext(workspace.workspaceId, syncBehavior)
   );
   console.log(colors.bold.underline.green("Trigger pushed"));
 }

--- a/cli/src/commands/trigger/trigger.ts
+++ b/cli/src/commands/trigger/trigger.ts
@@ -625,9 +625,9 @@ async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
   // Reading the config moves the cwd to the wmill.yaml root when it sits in a
   // parent directory, so pin the file against the invocation cwd first.
   filePath = pathResolve(filePath);
-  const syncBehavior = await readEffectiveSyncBehavior();
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
+  const syncBehavior = await readEffectiveSyncBehavior(opts, workspace);
 
   if (!validatePath(remotePath)) {
     return;

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -631,19 +631,53 @@ export async function getEffectiveSettings(
 }
 
 /**
- * `syncBehavior` as the current branch's workspace sees it. The top level alone
- * misses a `workspaces.<name>.overrides.syncBehavior`, which is where a repo
- * that varies settings per workspace puts it. Resolves the workspace from the
- * git branch only: the single-item commands have no `--workspace-name` flag to
- * override it with, so a repo that maps workspaces some other way still reads
- * the top-level value.
+ * Match a workspace config entry to a resolved workspace profile by remote +
+ * workspace id. The fallback for when no flag names the entry outright.
  */
-export async function readEffectiveSyncBehavior(): Promise<string | undefined> {
+export function inferWsNameFromProfile(
+  opts: SyncOptions,
+  profile: { remote: string; workspaceId: string }
+): string | undefined {
+  if (!opts.workspaces) return undefined;
+  for (const name of getWorkspaceNames(opts.workspaces)) {
+    const entry = (opts.workspaces as any)[name] as WorkspaceEntryConfig;
+    if (!entry?.baseUrl) continue;
+    try {
+      const entryUrl = new URL(entry.baseUrl).toString();
+      const profileUrl = new URL(profile.remote).toString();
+      const entryWsId = entry.workspaceId ?? name;
+      if (entryUrl === profileUrl && entryWsId === profile.workspaceId) {
+        return name;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * `syncBehavior` as the workspace being pushed to sees it. The top level alone
+ * misses a `workspaces.<name>.overrides.syncBehavior`, which is where a repo
+ * that varies settings per workspace puts it, and the entry to read is the one
+ * `--workspace` names — falling back to the profile, then to the git branch —
+ * the same order `sync push` resolves it in.
+ */
+export async function readEffectiveSyncBehavior(
+  opts: { workspace?: string },
+  profile?: { remote: string; workspaceId: string }
+): Promise<string | undefined> {
+  const config = await readConfigFile();
+  const named =
+    opts.workspace && getWorkspaceNames(config.workspaces).includes(opts.workspace)
+      ? opts.workspace
+      : undefined;
   const effective = await getEffectiveSettings(
-    await readConfigFile(),
+    config,
     undefined,
     false,
-    true
+    true,
+    named ?? (profile ? inferWsNameFromProfile(config, profile) : undefined)
   );
   return effective.syncBehavior;
 }

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -630,6 +630,24 @@ export async function getEffectiveSettings(
   return effective;
 }
 
+/**
+ * `syncBehavior` as the current branch's workspace sees it. The top level alone
+ * misses a `workspaces.<name>.overrides.syncBehavior`, which is where a repo
+ * that varies settings per workspace puts it. Resolves the workspace from the
+ * git branch only: the single-item commands have no `--workspace-name` flag to
+ * override it with, so a repo that maps workspaces some other way still reads
+ * the top-level value.
+ */
+export async function readEffectiveSyncBehavior(): Promise<string | undefined> {
+  const effective = await getEffectiveSettings(
+    await readConfigFile(),
+    undefined,
+    false,
+    true
+  );
+  return effective.syncBehavior;
+}
+
 const RESERVED_WORKSPACE_KEYS = new Set(["commonSpecificItems"]);
 
 /**

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -630,6 +630,34 @@ export async function getEffectiveSettings(
   return effective;
 }
 
+// Resolve workspace name from a --branch override (git branch → workspace name).
+// Falls back to using the branch value as-is (backward compat: old key = branch name).
+function resolveWsNameFromBranch(opts: SyncOptions, branchName: string): string {
+  const match = findWorkspaceByGitBranch(opts.workspaces, branchName);
+  return match ? match[0] : branchName;
+}
+
+// Resolve wsNameForConfig from CLI flags. Prefers --branch → matching config key,
+// then --workspace → matching config key (incl. when --base-url is set). Returns
+// undefined when no flag-based resolution applies; callers then fall back to
+// inferWsNameFromProfile on the resolved workspace profile.
+export function resolveWsNameForConfigFromFlags(
+  opts: SyncOptions & { branch?: string; workspace?: string }
+): string | undefined {
+  if (opts.branch) {
+    return resolveWsNameFromBranch(opts, opts.branch);
+  }
+  if (opts.workspace) {
+    // Use getWorkspaceNames so reserved keys (e.g. commonSpecificItems) are filtered out,
+    // matching the behavior of findWorkspaceByGitBranch / inferWsNameFromProfile.
+    const validKeys = getWorkspaceNames(opts.workspaces);
+    if (validKeys.includes(opts.workspace)) {
+      return opts.workspace;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Match a workspace config entry to a resolved workspace profile by remote +
  * workspace id. The fallback for when no flag names the entry outright.
@@ -667,11 +695,8 @@ export async function readEffectiveSyncBehavior(
   opts: { workspace?: string },
   profile?: { remote: string; workspaceId: string }
 ): Promise<string | undefined> {
-  const config = await readConfigFile();
-  const named =
-    opts.workspace && getWorkspaceNames(config.workspaces).includes(opts.workspace)
-      ? opts.workspace
-      : undefined;
+  const config = await readConfigFile({ warnIfMissing: false });
+  const named = resolveWsNameForConfigFromFlags({ ...config, ...opts });
   const effective = await getEffectiveSettings(
     config,
     undefined,

--- a/cli/src/core/permissioned_as.ts
+++ b/cli/src/core/permissioned_as.ts
@@ -3,11 +3,41 @@ import * as log from "./log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import { Confirm } from "@cliffy/prompt/confirm";
 import { getTypeStrFromPath } from "../types.ts";
+import { parseSyncBehavior } from "./conf.ts";
 
 export interface PermissionedAsContext {
   userCache: Map<string, { username: string; email: string }>;
   userIsAdminOrDeployer: boolean;
   userEmail: string;
+}
+
+/**
+ * The whole-tree `sync push` and the single-item `push` commands must resolve
+ * ownership the same way, so both build the context here: a push that leaves it
+ * undefined reassigns `permissioned_as` / `on_behalf_of` to whoever ran it.
+ * Undefined below syncBehavior v1, where that reassignment is the contract, and
+ * for a caller who is neither admin nor in `wm_deployers` the backend enforces
+ * it anyway — the flag on the context is what keeps the CLI from claiming
+ * otherwise.
+ */
+export async function buildPermissionedAsContext(
+  workspace: string,
+  syncBehavior: string | number | undefined
+): Promise<PermissionedAsContext | undefined> {
+  if (parseSyncBehavior(syncBehavior) < 1) {
+    return undefined;
+  }
+  const user = await wmill.whoami({ workspace });
+  const userIsAdminOrDeployer =
+    user.is_admin || (user.groups ?? []).includes("wm_deployers");
+  log.debug(
+    `permissioned_as: user=${user.email}, is_admin=${user.is_admin}, groups=${JSON.stringify(user.groups)}, isAdminOrDeployer=${userIsAdminOrDeployer}`
+  );
+  return {
+    userCache: new Map(),
+    userIsAdminOrDeployer,
+    userEmail: user.email,
+  };
 }
 
 async function ensureUserCache(

--- a/cli/test/schedule_push_permissioned_as_unit.test.ts
+++ b/cli/test/schedule_push_permissioned_as_unit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression guard: the standalone `wmill schedule push` must resolve ownership
+ * the same way `wmill sync push` does. It only preserves the remote's
+ * `permissioned_as` when the command hands `pushSchedule` a context, so a push
+ * that builds none silently reassigns the schedule to whoever ran it.
+ */
+
+import { expect, test, describe, beforeEach, mock } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let updateScheduleCalls: any[] = [];
+let remotePermissionedAs: string | undefined = "u/svc";
+
+const REMOTE_SCHEDULE = () => ({
+  path: "u/admin/sched",
+  schedule: "0 0 */6 * * *",
+  timezone: "Etc/UTC",
+  script_path: "u/admin/script",
+  is_flow: false,
+  args: {},
+  enabled: false,
+  summary: "before",
+  permissioned_as: remotePermissionedAs,
+});
+
+mock.module("../gen/services.gen.ts", () => ({
+  getSchedule: async () => REMOTE_SCHEDULE(),
+  updateSchedule: async (a: unknown) => {
+    updateScheduleCalls.push(a);
+  },
+  whoami: async () => ({
+    email: "deployer@windmill.dev",
+    username: "deployer",
+    is_admin: true,
+    groups: [],
+  }),
+}));
+
+const realContext = await import("../src/core/context.ts");
+mock.module("../src/core/context.ts", () => ({
+  ...realContext,
+  resolveWorkspace: async () => ({
+    workspaceId: "w",
+    name: "w",
+    remote: "http://localhost/",
+    token: "t",
+  }),
+}));
+
+const realAuth = await import("../src/core/auth.ts");
+mock.module("../src/core/auth.ts", () => ({
+  ...realAuth,
+  requireLogin: async () => ({}),
+}));
+
+const scheduleCommand = (await import("../src/commands/schedule/schedule.ts"))
+  .default;
+
+async function pushIn(syncBehavior: string | undefined): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "windmill_sched_push_"));
+  await writeFile(
+    join(dir, "wmill.yaml"),
+    `defaultTs: bun\nincludeSchedules: true\n${syncBehavior ? `syncBehavior: ${syncBehavior}\n` : ""}`,
+    "utf-8"
+  );
+  await writeFile(
+    join(dir, "sched.schedule.yaml"),
+    `schedule: "0 0 */6 * * *"\ntimezone: Etc/UTC\nscript_path: u/admin/script\nis_flow: false\nargs: {}\nenabled: false\nsummary: after\n`,
+    "utf-8"
+  );
+
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    await scheduleCommand.parse([
+      "push",
+      "sched.schedule.yaml",
+      "u/admin/sched",
+    ]);
+  } finally {
+    process.chdir(cwd);
+  }
+}
+
+describe("wmill schedule push ownership", () => {
+  beforeEach(() => {
+    updateScheduleCalls = [];
+    remotePermissionedAs = "u/svc";
+  });
+
+  test("keeps the remote's permissioned_as under syncBehavior v1", async () => {
+    await pushIn("v1");
+
+    expect(updateScheduleCalls).toHaveLength(1);
+    const body = updateScheduleCalls[0].requestBody;
+    expect(body.summary).toBe("after");
+    expect(body.permissioned_as).toBe("u/svc");
+    expect(body.preserve_permissioned_as).toBe(true);
+  });
+
+  test("leaves ownership to the backend below syncBehavior v1", async () => {
+    await pushIn(undefined);
+
+    expect(updateScheduleCalls).toHaveLength(1);
+    const body = updateScheduleCalls[0].requestBody;
+    expect(body.permissioned_as).toBeUndefined();
+    expect(body.preserve_permissioned_as).toBeUndefined();
+  });
+});

--- a/cli/test/schedule_push_permissioned_as_unit.test.ts
+++ b/cli/test/schedule_push_permissioned_as_unit.test.ts
@@ -58,11 +58,11 @@ mock.module("../src/core/auth.ts", () => ({
 const scheduleCommand = (await import("../src/commands/schedule/schedule.ts"))
   .default;
 
-async function pushIn(syncBehavior: string | undefined): Promise<void> {
+async function pushIn(wmillYamlTail: string): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), "windmill_sched_push_"));
   await writeFile(
     join(dir, "wmill.yaml"),
-    `defaultTs: bun\nincludeSchedules: true\n${syncBehavior ? `syncBehavior: ${syncBehavior}\n` : ""}`,
+    `defaultTs: bun\nincludeSchedules: true\n${wmillYamlTail}`,
     "utf-8"
   );
   await writeFile(
@@ -91,7 +91,7 @@ describe("wmill schedule push ownership", () => {
   });
 
   test("keeps the remote's permissioned_as under syncBehavior v1", async () => {
-    await pushIn("v1");
+    await pushIn("syncBehavior: v1\n");
 
     expect(updateScheduleCalls).toHaveLength(1);
     const body = updateScheduleCalls[0].requestBody;
@@ -100,8 +100,22 @@ describe("wmill schedule push ownership", () => {
     expect(body.preserve_permissioned_as).toBe(true);
   });
 
+  // The entry to read is the one matching the workspace being pushed to, not
+  // the top level: a repo that varies settings per workspace puts syncBehavior
+  // under `overrides` and nowhere else.
+  test("reads syncBehavior from the target workspace's overrides", async () => {
+    await pushIn(
+      `workspaces:\n  other:\n    baseUrl: http://localhost/\n    workspaceId: w\n    overrides:\n      syncBehavior: v1\n`
+    );
+
+    expect(updateScheduleCalls).toHaveLength(1);
+    const body = updateScheduleCalls[0].requestBody;
+    expect(body.permissioned_as).toBe("u/svc");
+    expect(body.preserve_permissioned_as).toBe(true);
+  });
+
   test("leaves ownership to the backend below syncBehavior v1", async () => {
-    await pushIn(undefined);
+    await pushIn("");
 
     expect(updateScheduleCalls).toHaveLength(1);
     const body = updateScheduleCalls[0].requestBody;

--- a/cli/test/workspace_key_filename_integration.test.ts
+++ b/cli/test/workspace_key_filename_integration.test.ts
@@ -7,8 +7,10 @@ import { stringify as yamlStringify } from "yaml";
 
 import { resolveWsNameForGitBranch } from "../src/core/specific_items.ts";
 import { findResourceFile } from "../src/commands/script/script.ts";
-import { resolveWsNameForConfigFromFlags } from "../src/commands/sync/sync.ts";
-import type { SyncOptions } from "../src/core/conf.ts";
+import {
+  resolveWsNameForConfigFromFlags,
+  type SyncOptions,
+} from "../src/core/conf.ts";
 
 // Integration tests covering the bug where workspace-specific filenames used
 // the raw git branch name instead of the wmill.yaml workspace config key.


### PR DESCRIPTION
> **Left in draft on purpose:** this changes which identity deployed items run as, across five commands and every repo on `syncBehavior: v1`. Reviews are clean (Codex + Claude both "Good to merge" @ `135aa13`), but a run-as identity change wants a human look before it goes ready rather than an agent's judgement call.

## Summary

`wmill schedule push <file> <remote_path>` reset a schedule's `permissioned_as` to whoever ran the push, every time, with no way to opt out (GIT-996). A schedule that must keep running as a specific service identity needed a `wmill schedule set-permissioned-as` follow-up after every single push.

The preserve-on-update logic in `pushSchedule` was already correct, but it is gated on a `permissionedAsContext` that only `wmill sync push` ever built — the standalone command passed `undefined`, so the branch never fired. The same omission was present in the standalone `app push`, `flow push`, `script push` and `trigger push`, so all five are fixed together.

## Changes

- `buildPermissionedAsContext` in `cli/src/core/permissioned_as.ts`: the whoami lookup that `sync push` did inline, now shared. Returns `undefined` below `syncBehavior: v1`, which is where the old inline gate sat, so both push paths resolve ownership identically. `sync push` now calls it instead of building the context itself.
- All five standalone `push` commands build and pass the context.
- `readEffectiveSyncBehavior` in `cli/src/core/conf.ts`: resolves `syncBehavior` through the current branch's `workspaces.<name>.overrides` the way `sync push` does, rather than reading only the top level of `wmill.yaml`.
- Each push pins its file argument with `path.resolve` before reading the config: `readConfigFile` moves the cwd to the `wmill.yaml` root when the file sits in a parent directory, which would otherwise break a relative path passed from a subdirectory.
- Regression test driving the real `schedule push` command over a temp `wmill.yaml`, asserting both sides of the gate.

## Decisions

- **Gated on `syncBehavior: v1`, matching `sync push`.** That is the flag that already versions this behaviour (`wmill init` writes it for new repos), and it is what makes the pull/push pair coherent: a v1 pull strips `permissioned_as` from the file, so the value can only come back from the remote at push time. Below v1, both push paths keep reassigning ownership, unchanged. A v0 repo can still pin an owner by putting `permissioned_as` and `preserve_permissioned_as: true` in the YAML itself.
- **Raw apps are not covered.** `pushRawApp` always sends a freshly generated policy and takes no context, on this path or `sync push`'s, so `wmill app push` on a `.raw_app` folder still reassigns `on_behalf_of`. Left as-is so the two paths stay in parity; the code comment says so.
- **Non-admin pushers are out of scope.** Preservation stays gated on admin / `wm_deployers` in every pusher, and the backend enforces the same rule regardless of what the CLI sends, so a non-admin `schedule push` still reassigns ownership exactly as it did before this PR. `sync push` warns first via `preCheckPermissionedAs`; wiring an equivalent pre-check into the single-item commands would mean synthesizing `Change` entries and is a separate change.

## Test plan

- [x] `cd cli && bun test test/*_unit*.test.ts` — 1106 pass, including the new guard; the new test fails on the pre-fix code with `permissioned_as: undefined`
- [x] `bunx tsc --noEmit` — no new errors (38 pre-existing, unchanged)
- [x] Reproduced the bug on the unpatched code: schedule owned by `u/svc`, push as `admin`, owner reset to `u/admin`
- [x] Exercised against a running instance with `syncBehavior: v1` — `schedule`, `flow`, `app`, `script` and `trigger` push each keep the remote's `u/svc` / `svc@windmill.dev` owner while applying the local edit
- [x] Below v1 and with no `wmill.yaml` at all: unchanged behaviour, no crash
- [x] `syncBehavior: v1` set only under `workspaces.<branch>.overrides`: now honoured
- [x] Relative file path from a subdirectory below the `wmill.yaml` root, with explicit `--base-url/--workspace/--token`: pushes and preserves
- [x] `sync push` unaffected: still preserves, and still refuses a non-admin push with the `preCheckPermissionedAs` message

---

Follow-up from review: `syncBehavior` is now resolved from the workspace being pushed to — the entry `--workspace` names, else the one matching the resolved profile's remote + workspace id, else the git branch — the same order `sync push` uses. `resolveWsNameForConfigFromFlags` and `inferWsNameFromProfile` moved from `sync.ts` to `conf.ts` so both paths resolve it through one implementation rather than two that must stay in step. `readEffectiveSyncBehavior` reads the config with `warnIfMissing: false`, so a push in a checkout with no `wmill.yaml` doesn't gain a new warning.
