### PR TITLE
fix: keep the runs page path filter and persisted toggles through url sync

### DIFF
--- a/frontend/src/lib/components/FilterSearchbar.svelte
+++ b/frontend/src/lib/components/FilterSearchbar.svelte
@@ -112,16 +112,36 @@
 	}
 
 	/**
-	 * Creates a URL-synced filter instance that automatically syncs with URL search parameters
+	 * Creates a URL-synced filter instance that automatically syncs with URL search parameters.
+	 *
+	 * `initial` supplies defaults for keys the URL doesn't carry (a route segment, a persisted
+	 * toggle); the returned `seed` re-applies them after a navigation has rewritten the query.
 	 */
 	export function useUrlSyncedFilterInstance<T extends FilterSchemaRec>(
-		schemaRec: T
-	): { val: Partial<FilterInstanceRec<T>> } {
+		schemaRec: T,
+		initial?: Partial<FilterInstanceRec<T>>
+	): {
+		val: Partial<FilterInstanceRec<T>>
+		seed: (values: Partial<FilterInstanceRec<T>>) => void
+	} {
 		// Build the Zod schema from the filter schema
 		const zodSchema = filterSchemaRecToZodSchema(schemaRec)
 
 		// Create URL-synced search params
 		const urlFilter = useSearchParams(zodSchema) as Record<string, unknown>
+
+		// A default has to arrive as a URL param: the URL→instance effect below drops whatever the
+		// URL lacks, so a value written to the instance is undone on the next sync. Going through
+		// urlFilter rather than straight to history keeps the search-param cells in step, so it
+		// does not matter whether a popstate follows.
+		function seed(values: Partial<FilterInstanceRec<T>>) {
+			const sp = new URLSearchParams(window.location.search)
+			for (const [key, value] of Object.entries(values) as [string, unknown][]) {
+				if (value === undefined || value === null || sp.has(key)) continue
+				urlFilter[key] = value instanceof Date ? value.toISOString() : value
+			}
+		}
+		if (initial) seed(initial)
 
 		// Create the filter instance object
 		const filterInstance: { val: Partial<FilterInstanceRec<T>> } = $state({ val: {} })
@@ -173,7 +193,15 @@
 			})
 		}
 
-		return filterInstance
+		return {
+			get val() {
+				return filterInstance.val
+			},
+			set val(v: Partial<FilterInstanceRec<T>>) {
+				filterInstance.val = v
+			},
+			seed
+		}
 	}
 
 	function filterToText<F extends FilterSchema>(filter: FilterInstance<F>, schema: F): string {

--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -84,6 +84,8 @@
 		initialPath?: string
 	}
 
+	let { initialPath }: Props = $props()
+
 	let paths: string[] = $state([])
 	let usernames: string[] = $state([])
 	let folders: string[] = $state([])
@@ -100,24 +102,29 @@
 	let perPage = useLocalStorageValue('runs_per_page', 1000, 'number')
 	let showSchedulesStorage = useLocalStorageValue('runs_show_schedules', true, 'boolean')
 	let showFutureJobsStorage = useLocalStorageValue('runs_show_future_jobs', true, 'boolean')
-	let filters = useUrlSyncedFilterInstance(untrack(() => runsFilterSearchbarSchema))
+	function filterSeeds() {
+		return {
+			path: initialPath || undefined,
+			job_trigger_kind: showSchedulesStorage.val === false ? ('!schedule' as const) : undefined,
+			show_future_jobs: showFutureJobsStorage.val === false ? false : undefined
+		}
+	}
 
-	let { initialPath }: Props = $props()
+	let filters = useUrlSyncedFilterInstance(
+		untrack(() => runsFilterSearchbarSchema),
+		untrack(filterSeeds)
+	)
+
+	// `runs/[...path]` is a single route, so a navigation between its URLs — the sidebar's own
+	// "Runs" entry, `/runs/<path>` → `/runs`, Back — rewrites the query without remounting, and
+	// what was seeded at mount is gone. Re-apply it. Editing a filter writes with `replaceState`,
+	// which never reaches `page.url`, so a filter the user clears stays cleared.
+	$effect(() => {
+		page.url.href
+		untrack(() => filters.seed(filterSeeds()))
+	})
 
 	let batchRerunOptionsIsOpen = $state(false)
-
-	// Initialize path filter from route param if provided and not already set via query params
-	if (untrack(() => initialPath) && !filters.val.path) {
-		filters.val.path = untrack(() => initialPath)
-	}
-
-	// Apply persistent toggle values from local storage if URL doesn't specify them
-	if (!page.url.searchParams.has('job_trigger_kind') && showSchedulesStorage.val === false) {
-		filters.val.job_trigger_kind = '!schedule'
-	}
-	if (!page.url.searchParams.has('show_future_jobs') && showFutureJobsStorage.val === false) {
-		filters.val.show_future_jobs = false
-	}
 
 	// Sync toggle state back to local storage when filters change
 	$effect(() => {


### PR DESCRIPTION
## Summary

Navigating to `/runs/<path>` (the "View runs" entry on a script or flow) showed every run in the
workspace instead of that runnable's. `RunsPage` set `filters.val.path` right after
`useUrlSyncedFilterInstance` had already registered its URL to instance `$effect`, and that effect
deletes any key the URL query string does not carry — so on the first flush the path filter was
wiped before a single request went out. The route segment is not a query param, so the URL never
carried it.

The two localStorage-persisted toggles ("show schedules", "show future jobs") were set the same way
and lost the same race: their sync-back effect then wrote the cleared state to localStorage, so an
off toggle silently flipped back on at every load.

The fix gives `useUrlSyncedFilterInstance` an optional `initial` record, which it seeds as URL
search params — through the same `useSearchParams` proxy the two sync effects read, so the value and
the cell move together. The URL stays the instance's single source of truth, an explicit `?path=` in
the query still wins over the route segment, and clearing a chip still clears it for good.

Regression from #8027 (unified filters, v1.643.0), which swapped direct `useSearchParams` — whose
writes updated the URL synchronously — for the effect-based two-way sync.

## Changes

- `FilterSearchbar.svelte`: `useUrlSyncedFilterInstance` takes an optional `initial` record and
  seeds each key the URL doesn't already carry, before the sync effects are registered. The same
  `seed` is returned on the instance so a caller can re-apply its defaults later.
- `RunsPage.svelte`: pass `initialPath` and the two persisted toggle values as `initial` instead of
  assigning them to `filters.val` after creation; move the `$props()` destructuring above the
  filter-instance declaration.
- `RunsPage.svelte`: re-seed when `page.url` changes. `runs/[...path]` is one route, so the
  sidebar's own "Runs" entry (and `/runs/<path>` → `/runs`, and Back) rewrites the query without
  remounting, which otherwise dropped the seeded toggles one click after they were applied. Filter
  edits write through `replaceState` and never reach `page.url`, so a filter the user clears stays
  cleared.

Scope notes:

- The ticket proposed inlining a `history.replaceState` in `RunsPage`. Seeding inside the hook
  instead covers the two toggles, which have the same defect and sit on the adjacent lines, and —
  more importantly — writing through `urlFilter` rather than raw history keeps `useSearchParams`'
  cells in step. A raw `replaceState` only reaches the instance if a `popstate` happens to follow,
  which on the sidebar path means racing a 100 ms synthetic dispatch in `(logged)/+layout.svelte`
  and, on a real Back, desyncing the URL from the chips.
- The other five `useUrlSyncedFilterInstance` call sites (variables, resources, assets, schedules,
  home) pass no `initial`; the return type gains `seed` and `val` becomes an accessor pair, which
  `bind:value={x.val}` handles unchanged.
- Deliberate behavior change: a persisted toggle now appears in the URL (`?show_future_jobs=false`),
  so a copied link or an "open in session" link carries it. That is already what happens when the
  user flips the toggle by hand — the seed just makes the persisted default behave the same way, and
  a default that is *not* in the URL is exactly what caused this bug.

No automated test: the defect is `$effect` ordering inside a mounted component, and this repo has no
vitest project that runs rune-using tests (`vite.config.js` excludes `*.svelte.test.ts` from the
`server` project and no project includes it, so the existing `flowDiffManager.svelte.test.ts` never
runs). A unit test of the seed helper alone would not reach the ordering, so it would be ceremonial.
Verified manually instead, before and after, per the test plan.

## Screenshots

Before — `/runs/u/admin/alpha` lists both `u/admin/alpha` and `u/admin/beta` runs, no `path` chip,
no `?path=` in the URL:

![wm-2482-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben-win-2482/1788786559-wm-2482-before.png)

After — `path: u/admin/alpha` chip, 3 matching runs, URL carries `?path=u%2Fadmin%2Falpha`:

![wm-2482-after-final](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben-win-2482/1788786562-wm-2482-after-final.png)

## Test plan

Exercised on the dev instance (two scripts `u/admin/alpha` and `u/admin/beta`, 3 runs each). Each
"before" claim was reproduced on the pre-fix code first.

- [x] `/runs/u/admin/alpha` filters to that path; URL gains `?path=u%2Fadmin%2Falpha`. Before: 6
      unfiltered jobs, no chip.
- [x] "View runs" from the Home script row (client-side navigation, the reported entry point) lands
      on a filtered runs page.
- [x] An explicit `?path=` in the query wins over the route segment
      (`/runs/u/admin/alpha?path=u/admin/beta` shows beta).
- [x] Clearing the `path` chip drops the param from the URL and shows every run — no re-seeding.
- [x] Turning "show schedules" off persists across a reload (`?job_trigger_kind=!schedule`). Before:
      localStorage flipped back to `true` on load.
- [x] With both toggles off, the sidebar "Runs" entry and browser Back both keep them off; toggling
      one back on removes its param and it stays on — the re-seed does not fight the user.
- [x] The desync case: clear the `path` chip on `/runs/u/admin/alpha`, navigate to `/runs`, press
      Back. URL, chip and table agree at every step (path re-applied, as a fresh load of that URL
      would do).
- [x] `/runs/u/admin/alpha` → sidebar "Runs" correctly drops the path filter and shows every run.
- [x] Route seed and toggle seeds apply together on one load.
- [x] `/variables` and `/assets` (call sites that pass no `initial`) load and filter unchanged.
- [x] `npm run check` — 0 errors, 82 warnings (baseline); prettier clean.
