### PR TITLE
fix(cli): say which workspace id is targeted, and when wmill.yaml is bypassed

### DIFF
--- a/cli/src/commands/sync/pull.ts
+++ b/cli/src/commands/sync/pull.ts
@@ -150,7 +150,18 @@ export async function downloadZip(
   }
 
   if (zipResponse.status === 404 || body.includes("no rows returned")) {
-    log.info(colors.red(`Workspace '${workspace.workspaceId}' not found on ${workspace.remote}. Please check your --workspace and try again.`));
+    log.info(
+      colors.red(
+        `Workspace id '${workspace.workspaceId}' not found on ${workspace.remote}` +
+          (workspace.name !== workspace.workspaceId
+            ? ` (resolved from profile '${workspace.name}')`
+            : "") +
+          `.\n` +
+          `Note this is the workspace *id* sent to the API, which is not necessarily what you passed to --workspace:\n` +
+          `  - check 'wmill workspace list' (the 'workspace id' column)\n` +
+          `  - check the 'workspaces' block of wmill.yaml ('workspaceId' overrides the workspace name)`
+      )
+    );
   } else {
     log.info(colors.red(`Failed to request tarball from API: ${zipResponse.status} ${zipResponse.statusText}`));
     if (body) log.info(colors.red(body));

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -211,7 +211,7 @@ export function getWmillYamlPath(): string | null {
  * Look up one `workspaces` entry, for diagnostics only. readConfigFile() must
  * not be used for that: it chdirs to the config's directory, exits on an
  * unsupported syncBehavior and throws on a malformed file. A diagnostic may
- * never fail, move or slow down the command it is diagnosing.
+ * never fail or relocate the command it is diagnosing.
  */
 export async function peekWorkspaceEntry(
   workspaceName: string

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -145,7 +145,9 @@ function getGitRepoRoot(): string | null {
 }
 
 export const GLOBAL_CONFIG_OPT = { noCdToRoot: false };
-function findWmillYaml(): string | null {
+
+// Pure upward search: no chdir, no logging. findWmillYaml() adds the chdir.
+function locateWmillYaml(): string | null {
   const startDir = resolve(process.cwd());
   const isInGitRepo = isGitRepository();
   const gitRoot = isInGitRepo ? getGitRepoRoot() : null;
@@ -176,6 +178,13 @@ function findWmillYaml(): string | null {
     currentDir = parentDir;
   }
 
+  return foundPath;
+}
+
+function findWmillYaml(): string | null {
+  const startDir = resolve(process.cwd());
+  const foundPath = locateWmillYaml();
+
   // If wmill.yaml was found in a parent directory, warn the user and change working directory
   if (
     !GLOBAL_CONFIG_OPT.noCdToRoot &&
@@ -196,6 +205,37 @@ function findWmillYaml(): string | null {
 
 export function getWmillYamlPath(): string | null {
   return findWmillYaml();
+}
+
+/**
+ * Look up one `workspaces` entry, for diagnostics only. readConfigFile() must
+ * not be used for that: it chdirs to the config's directory, exits on an
+ * unsupported syncBehavior and throws on a malformed file. A diagnostic may
+ * never fail, move or slow down the command it is diagnosing.
+ */
+export async function peekWorkspaceEntry(
+  workspaceName: string
+): Promise<WorkspaceEntryConfig | undefined> {
+  if (RESERVED_WORKSPACE_KEYS.has(workspaceName)) {
+    return undefined;
+  }
+  const wmillYamlPath = locateWmillYaml();
+  if (!wmillYamlPath) {
+    return undefined;
+  }
+  try {
+    const conf = (await yamlParseFile(wmillYamlPath)) as SyncOptions;
+    const workspaces =
+      conf?.workspaces ??
+      conf?.gitBranches ??
+      conf?.environments ??
+      conf?.git_branches;
+    const entry = (workspaces as any)?.[workspaceName];
+    return typeof entry === "object" && entry !== null ? entry : undefined;
+  } catch (e) {
+    log.debug(`Failed to parse ${wmillYamlPath} for workspace lookup: ${e}`);
+    return undefined;
+  }
 }
 
 let legacyConfigWarned = false;

--- a/cli/src/core/context.ts
+++ b/cli/src/core/context.ts
@@ -219,6 +219,9 @@ async function tryResolveWorkspace(
     // First try: look up workspace by name in wmill.yaml workspaces config
     const config = await readConfigFile({ warnIfMissing: false });
     const wsEntry = config.workspaces?.[opts.workspace] as WorkspaceEntryConfig | undefined;
+    // What wmill.yaml said to target, kept for the fallback below: a profile
+    // found by name can silently point somewhere else entirely.
+    let configuredTarget: { workspaceId: string; baseUrl: string } | undefined;
     if (wsEntry?.baseUrl) {
       const workspaceId = getEffectiveWorkspaceId(opts.workspace, wsEntry);
       let normalizedBaseUrl: string;
@@ -230,6 +233,8 @@ async function tryResolveWorkspace(
           error: colors.red.underline(`Invalid baseUrl in workspace '${opts.workspace}' configuration: ${wsEntry.baseUrl}`),
         };
       }
+
+      configuredTarget = { workspaceId, baseUrl: normalizedBaseUrl };
 
       // Find matching profile by baseUrl + workspaceId
       const allProfs = await allWorkspaces(opts.configDir);
@@ -283,6 +288,22 @@ async function tryResolveWorkspace(
         ),
       };
     }
+    if (
+      configuredTarget &&
+      (e.workspaceId !== configuredTarget.workspaceId ||
+        e.remote !== configuredTarget.baseUrl)
+    ) {
+      log.warnStderr(
+        colors.yellow(
+          `⚠️  Falling back to the local profile named '${opts.workspace}' (${e.workspaceId} on ${e.remote}), which does NOT match wmill.yaml:\n` +
+            `   wmill.yaml maps workspace '${opts.workspace}' to ${configuredTarget.workspaceId} on ${configuredTarget.baseUrl}, but no profile targets it.\n` +
+            `   Run: wmill workspace add <profile-name> ${configuredTarget.workspaceId} ${configuredTarget.baseUrl}`
+        )
+      );
+    }
+    log.infoStderr(
+      `Using local profile '${e.name}' → ${e.workspaceId} on ${e.remote}`
+    );
     (opts as any).__secret_workspace = e;
     return { isError: false, value: e };
   }
@@ -486,6 +507,31 @@ export async function resolveWorkspace(
         return process.exit(-1);
       }
 
+      // --base-url pins the target: `--workspace` is the remote workspace id
+      // and wmill.yaml's `workspaces` block is never consulted. Say so when it
+      // maps that name to a different id, or the request 404s on an id the
+      // user never typed. Only peek at a wmill.yaml sitting in the cwd:
+      // readConfigFile chdirs to the directory of a config found further up,
+      // and this branch must not gain that side effect.
+      if (existsSync(join(process.cwd(), "wmill.yaml"))) {
+        const config = await readConfigFile({ warnIfMissing: false });
+        const yamlEntry = config.workspaces?.[opts.workspace] as
+          | WorkspaceEntryConfig
+          | undefined;
+        const yamlWorkspaceId = yamlEntry
+          ? getEffectiveWorkspaceId(opts.workspace, yamlEntry)
+          : undefined;
+        if (yamlWorkspaceId && yamlWorkspaceId !== opts.workspace) {
+          log.warnStderr(
+            colors.yellow(
+              `⚠️  --base-url is set, so '--workspace ${opts.workspace}' is used as the workspace id directly and wmill.yaml is ignored.\n` +
+                `   wmill.yaml maps workspace '${opts.workspace}' to workspace id '${yamlWorkspaceId}'${yamlEntry!.baseUrl ? ` on ${yamlEntry!.baseUrl}` : ""}.\n` +
+                `   Use '--workspace ${yamlWorkspaceId}', or drop --base-url/--token to resolve through wmill.yaml.`
+            )
+          );
+        }
+      }
+
       // Try to find existing workspace profile by name, then by workspaceId + remote
       if (opts.workspace) {
         let existingWorkspace = await getWorkspaceByName(
@@ -523,19 +569,29 @@ export async function resolveWorkspace(
             );
             return process.exit(-1);
           }
-          return {
+          log.infoStderr(
+            `Using workspace id '${existingWorkspace.workspaceId}' on ${normalizedBaseUrl} (from --base-url, profile '${existingWorkspace.name}')`
+          );
+          const resolved = {
             ...existingWorkspace,
             token: opts.token,
           };
+          (opts as any).__secret_workspace = resolved;
+          return resolved;
         }
       }
 
-      return {
+      log.infoStderr(
+        `Using workspace id '${opts.workspace}' on ${normalizedBaseUrl} (from --base-url/--workspace)`
+      );
+      const resolved = {
         remote: normalizedBaseUrl,
         workspaceId: opts.workspace,
         name: opts.workspace,
         token: opts.token,
       };
+      (opts as any).__secret_workspace = resolved;
+      return resolved;
     } else {
       log.infoStderr(
         colors.red(

--- a/cli/src/core/context.ts
+++ b/cli/src/core/context.ts
@@ -565,10 +565,10 @@ export async function resolveWorkspace(
       // consulted and `--workspace` reaches the API as a workspace id. Name the
       // id being sent, and the mapping being skipped, before the request 404s
       // on an id the user never typed.
+      // Only an explicit `workspaceId:` is worth reporting: an entry without one
+      // maps the name to itself, leaving nothing to correct.
       const yamlEntry = await peekWorkspaceEntry(opts.workspace);
-      const yamlWorkspaceId = yamlEntry
-        ? getEffectiveWorkspaceId(opts.workspace, yamlEntry)
-        : undefined;
+      const yamlWorkspaceId = yamlEntry?.workspaceId;
       if (yamlWorkspaceId && yamlWorkspaceId !== resolved.workspaceId) {
         log.warnStderr(
           colors.yellow(

--- a/cli/src/core/context.ts
+++ b/cli/src/core/context.ts
@@ -20,6 +20,7 @@ import {
 import { getLastUsedProfile, setLastUsedProfile } from "./branch-profiles.ts";
 import {
   readConfigFile,
+  peekWorkspaceEntry,
   findWorkspaceByGitBranch,
   getEffectiveWorkspaceId,
   getWmillYamlPath,
@@ -507,30 +508,7 @@ export async function resolveWorkspace(
         return process.exit(-1);
       }
 
-      // --base-url pins the target: `--workspace` is the remote workspace id
-      // and wmill.yaml's `workspaces` block is never consulted. Say so when it
-      // maps that name to a different id, or the request 404s on an id the
-      // user never typed. Only peek at a wmill.yaml sitting in the cwd:
-      // readConfigFile chdirs to the directory of a config found further up,
-      // and this branch must not gain that side effect.
-      if (existsSync(join(process.cwd(), "wmill.yaml"))) {
-        const config = await readConfigFile({ warnIfMissing: false });
-        const yamlEntry = config.workspaces?.[opts.workspace] as
-          | WorkspaceEntryConfig
-          | undefined;
-        const yamlWorkspaceId = yamlEntry
-          ? getEffectiveWorkspaceId(opts.workspace, yamlEntry)
-          : undefined;
-        if (yamlWorkspaceId && yamlWorkspaceId !== opts.workspace) {
-          log.warnStderr(
-            colors.yellow(
-              `⚠️  --base-url is set, so '--workspace ${opts.workspace}' is used as the workspace id directly and wmill.yaml is ignored.\n` +
-                `   wmill.yaml maps workspace '${opts.workspace}' to workspace id '${yamlWorkspaceId}'${yamlEntry!.baseUrl ? ` on ${yamlEntry!.baseUrl}` : ""}.\n` +
-                `   Use '--workspace ${yamlWorkspaceId}', or drop --base-url/--token to resolve through wmill.yaml.`
-            )
-          );
-        }
-      }
+      let resolved: Workspace | undefined;
 
       // Try to find existing workspace profile by name, then by workspaceId + remote
       if (opts.workspace) {
@@ -569,27 +547,43 @@ export async function resolveWorkspace(
             );
             return process.exit(-1);
           }
-          log.infoStderr(
-            `Using workspace id '${existingWorkspace.workspaceId}' on ${normalizedBaseUrl} (from --base-url, profile '${existingWorkspace.name}')`
-          );
-          const resolved = {
+          resolved = {
             ...existingWorkspace,
             token: opts.token,
           };
-          (opts as any).__secret_workspace = resolved;
-          return resolved;
         }
       }
 
-      log.infoStderr(
-        `Using workspace id '${opts.workspace}' on ${normalizedBaseUrl} (from --base-url/--workspace)`
-      );
-      const resolved = {
+      resolved ??= {
         remote: normalizedBaseUrl,
         workspaceId: opts.workspace,
         name: opts.workspace,
         token: opts.token,
       };
+
+      // --base-url pins the target, so wmill.yaml's `workspaces` block is never
+      // consulted and `--workspace` reaches the API as a workspace id. Name the
+      // id being sent, and the mapping being skipped, before the request 404s
+      // on an id the user never typed.
+      const yamlEntry = await peekWorkspaceEntry(opts.workspace);
+      const yamlWorkspaceId = yamlEntry
+        ? getEffectiveWorkspaceId(opts.workspace, yamlEntry)
+        : undefined;
+      if (yamlWorkspaceId && yamlWorkspaceId !== resolved.workspaceId) {
+        log.warnStderr(
+          colors.yellow(
+            `⚠️  --base-url is set, so wmill.yaml is not consulted: workspace id '${resolved.workspaceId}' is sent to the API.\n` +
+              `   wmill.yaml maps workspace '${opts.workspace}' to workspace id '${yamlWorkspaceId}'${yamlEntry!.baseUrl ? ` on ${yamlEntry!.baseUrl}` : ""}.\n` +
+              `   Use '--workspace ${yamlWorkspaceId}', or drop --base-url/--token to resolve through wmill.yaml.`
+          )
+        );
+      }
+      log.infoStderr(
+        `Using workspace id '${resolved.workspaceId}' on ${normalizedBaseUrl} (--base-url given` +
+          (resolved.name !== resolved.workspaceId
+            ? `, profile '${resolved.name}')`
+            : ")")
+      );
       (opts as any).__secret_workspace = resolved;
       return resolved;
     } else {

--- a/cli/test/base_url_workspace_resolution_unit.test.ts
+++ b/cli/test/base_url_workspace_resolution_unit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveWorkspace } from "../src/core/context.ts";
+import { getWorkspaceConfigFilePath } from "../windmill-utils-internal/src/config/config.ts";
+import type { GlobalOptions } from "../src/types.ts";
+
+const BASE_URL = "http://localhost:9999/";
+
+// --base-url pins the target: --workspace reaches the API as a workspace id and
+// wmill.yaml is not consulted. The warning that says so may only peek at the
+// file — readConfigFile() exits on an unsupported syncBehavior and throws on a
+// malformed one, so resolving through it lets an unrelated config fail a
+// command that never needed it.
+async function withWmillYaml(
+  wmillYaml: string,
+  fn: (opts: GlobalOptions) => Promise<void>
+): Promise<void> {
+  const repoDir = await mkdtemp(path.join(os.tmpdir(), "wmill_baseurl_repo_"));
+  const configDir = await mkdtemp(path.join(os.tmpdir(), "wmill_baseurl_conf_"));
+  const originalCwd = process.cwd();
+  try {
+    await writeFile(path.join(repoDir, "wmill.yaml"), wmillYaml);
+    await writeFile(await getWorkspaceConfigFilePath(configDir), "");
+
+    process.chdir(repoDir);
+    await fn({
+      configDir,
+      baseUrl: BASE_URL,
+      token: "sometoken",
+      workspace: "staging",
+    } as GlobalOptions);
+  } finally {
+    process.chdir(originalCwd);
+    await rm(repoDir, { recursive: true, force: true });
+    await rm(configDir, { recursive: true, force: true });
+  }
+}
+
+describe("--base-url workspace resolution", () => {
+  const rejectedConfigs: [string, string][] = [
+    ["an unsupported syncBehavior", "syncBehavior: v2\n"],
+    ["a malformed file", 'workspaces:\n  staging:\n   baseUrl: "unterminated\n'],
+  ];
+
+  for (const [label, wmillYaml] of rejectedConfigs) {
+    test(`resolves despite ${label}`, async () => {
+      await withWmillYaml(wmillYaml, async (opts) => {
+        const workspace = await resolveWorkspace(opts);
+        expect(workspace.workspaceId).toBe("staging");
+        expect(workspace.remote).toBe(BASE_URL);
+      });
+    });
+  }
+
+  test("a workspaces mapping never overrides the explicit workspace id", async () => {
+    await withWmillYaml(
+      "workspaces:\n  staging:\n    baseUrl: http://elsewhere.example/\n    workspaceId: admins\n",
+      async (opts) => {
+        const workspace = await resolveWorkspace(opts);
+        expect(workspace.workspaceId).toBe("staging");
+        expect(workspace.remote).toBe(BASE_URL);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`wmill sync pull --base-url <url> --token <tok> --workspace staging` fails with
`Workspace 'staging' not found on <url>` even when `wmill.yaml` maps that workspace to a
different id:

```yaml
workspaces:
  staging:
    baseUrl: https://…/
    workspaceId: admins
    gitBranch: staging
```

The override is applied correctly — on the paths that read it. `--base-url` is not one of them:
it pins the target explicitly, so `--workspace` reaches the API as a workspace *id* and the
`workspaces:` block is never consulted. A second path is worse: when no local profile matches the
`(baseUrl, workspaceId)` the yaml configures, `tryResolveWorkspace` silently falls back to a
profile that merely shares the *name*, and sends that profile's own id instead.

Neither was announced anywhere, so the first sign was a 404 naming an id the user never typed,
under a message telling them to check `--workspace`. This makes every path say which workspace id
it is about to send and where it came from. No resolution behavior changes.

## Changes

- `--base-url` mode now warns when `wmill.yaml` maps the given name to a different workspace id,
  naming both the id being sent and the one being skipped, with the two ways to fix it.
- The silent same-name profile fallback now warns that the profile does not match `wmill.yaml`,
  and prints a copy-pasteable `wmill workspace add` for the profile that is missing.
- Every resolution path prints what it targets before the request, so a 404 is never the first
  hint. The `--base-url` branch was the only one that never populated the `__secret_workspace`
  cache, so it resolved (and logged) twice per invocation — cached now, like the others.
- The sync-pull 404 no longer blames `--workspace` for an id the user may never have typed; it
  names the id actually sent, the profile it came from, and where to look.
- `peekWorkspaceEntry` in `conf.ts` reads one `workspaces` entry for diagnostics without
  `readConfigFile`'s side effects, which would otherwise let an unrelated `wmill.yaml` fail a
  command that never reads it: `readConfigFile` chdirs to the config's directory, `process.exit`s
  on an unsupported `syncBehavior` and throws on a malformed file. Factored the pure upward search
  out of `findWmillYaml` rather than duplicating the walk.

## Test plan

- [x] `cli/test/base_url_workspace_resolution_unit.test.ts` — a `wmill.yaml` that the config
      reader rejects (unsupported `syncBehavior`, malformed file) must not block
      `--base-url/--token/--workspace` resolution, and a `workspaces:` mapping must never
      override the explicit id. Verified it fails on the pre-fix commit.
- [x] `UNIT_ONLY=1 bun test test/*_unit*` — 1108 pass.
- [x] Exercised end to end against a stub server that logs request paths, in a repo whose
      `wmill.yaml` maps `staging` → `admins`:
      - `--base-url … --workspace staging` → warns, then `GET /api/w/staging/…`
      - `--workspace staging` with a mismatched same-named profile → warns, then `GET /api/w/staging/…`
      - `--workspace staging` with a correct profile, and branch-based resolution → unchanged
        output, `GET /api/w/admins/…`
      - same-named profile whose id differs (`staging` → `production`) → warning and target line
        agree on `production`
      - unsupported `syncBehavior` / malformed `wmill.yaml` + `--base-url` → reaches the API
        (exits 1 before the fix)
      - `variable list --base-url … 2>/dev/null` → stdout clean (leaked a config warning before
        the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaQ3UtkbHA6pxqQStqRQQj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CLI workspace resolution say which workspace ID it sends to the API and when `wmill.yaml` is bypassed, so 404s no longer name an ID the user never typed.

- `--base-url` mode now warns when `wmill.yaml` maps the workspace name to a different explicit `workspaceId:`, naming both the ID sent and the one skipped.
- The silent same-name profile fallback now warns when a profile doesn't match `wmill.yaml` and prints a copy-pasteable `wmill workspace add` command.
- The sync-pull 404 message names the ID actually sent and the profile it came from instead of blaming `--workspace`.
- Added `peekWorkspaceEntry` in `conf.ts` for diagnostics that avoids `readConfigFile`'s side effects (chdir, `process.exit`, throws on malformed files).
- Cached the resolved workspace in `--base-url` mode so it resolves and logs once per invocation instead of twice.

<sup>Written for commit dae77f2888c8f997f7402406738528ec624f18de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

