### PR TITLE
fix(flows): stop re-evaluating skip_if once a loop is in progress

### DIFF
--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -5637,6 +5637,83 @@ async fn test_whileloop_propagates_inner_iterator_eval_failure(
 
 #[cfg(all(feature = "quickjs", feature = "python"))]
 #[sqlx::test(fixtures("base"))]
+async fn test_whileloop_skip_if_evaluated_once_at_entry(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    // Regression test for #11007: `skip_if` on a while-loop module must be
+    // evaluated once, at loop entry, using the preceding step's result.
+    // Re-evaluating it on every iteration aliases `results.first` to the
+    // previous iteration's own result instead, which here lacks `.ok` and
+    // makes `skip_if` incorrectly turn true after the first iteration.
+    let port = 123;
+    let flow: FlowValue = serde_json::from_value(serde_json::json!({
+        "modules": [
+            {
+                "id": "first",
+                "value": {
+                    "type": "rawscript",
+                    "language": "python3",
+                    "content": "def main(): return {\"ok\": True}",
+                },
+            },
+            {
+                "id": "outer",
+                "value": {
+                    "type": "whileloopflow",
+                    "skip_failures": false,
+                    "modules": [
+                        {
+                            "id": "inner",
+                            "value": {
+                                "input_transforms": {
+                                    "i": {
+                                        "type": "javascript",
+                                        "expr": "flow_input.iter.index",
+                                    },
+                                },
+                                "type": "rawscript",
+                                "language": "python3",
+                                "content": "def main(i): return i",
+                            },
+                        },
+                    ],
+                },
+                "skip_if": { "expr": "!results.first.ok" },
+                "stop_after_if": {
+                    "expr": "result >= 2",
+                    "skip_if_stopped": false,
+                },
+            },
+        ],
+    }))
+    .unwrap();
+    let job = JobPayload::RawFlow { value: flow, path: None, restarted_from: None };
+
+    let cjob = RunJob::from(job).run_until_complete(&db, false, port).await;
+
+    assert!(cjob.success, "flow should succeed");
+
+    let outer_module = get_module(&cjob, "outer").expect("outer module status");
+    match outer_module {
+        windmill_common::flow_status::FlowStatusModule::Success { skipped, flow_jobs, .. } => {
+            assert!(
+                !skipped,
+                "while-loop must not be skipped: skip_if should only run once, at entry"
+            );
+            assert_eq!(
+                flow_jobs.map(|v| v.len()),
+                Some(3),
+                "while-loop should run 3 iterations before stop_after_if halts it"
+            );
+        }
+        other => panic!("expected outer module to be Success, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[cfg(all(feature = "quickjs", feature = "python"))]
+#[sqlx::test(fixtures("base"))]
 async fn test_stop_after_all_iters_if_bad_expr_parallel_branchall(
     db: Pool<Postgres>,
 ) -> anyhow::Result<()> {

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3891,7 +3891,14 @@ async fn push_next_flow_job(
 
     drop(resume_messages);
 
-    let is_skipped = if let Some(skip_if) = &module.skip_if {
+    // `skip_if` is a one-time entry gate: once `InProgress` (looping), the last
+    // completed job is an inner iteration, not `previous_id`'s module, so
+    // re-evaluating here would alias `results.<previous_id>` to the wrong result.
+    let is_skipped = if let Some(skip_if) = module
+        .skip_if
+        .as_ref()
+        .filter(|_| !matches!(status_module, FlowStatusModule::InProgress { .. }))
+    {
         let idcontext = get_transform_context(&flow_job, previous_id.as_str(), &status);
         let skip_if_res = compute_bool_from_expr(
             &skip_if.expr,

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3891,14 +3891,18 @@ async fn push_next_flow_job(
 
     drop(resume_messages);
 
-    // `skip_if` is a one-time entry gate: once `InProgress` (looping), the last
-    // completed job is an inner iteration, not `previous_id`'s module, so
-    // re-evaluating here would alias `results.<previous_id>` to the wrong result.
-    let is_skipped = if let Some(skip_if) = module
-        .skip_if
-        .as_ref()
-        .filter(|_| !matches!(status_module, FlowStatusModule::InProgress { .. }))
-    {
+    // `skip_if` is a one-time entry gate, so only first-entry statuses evaluate it.
+    // Once the module is looping, the last completed job is an inner iteration, not
+    // `previous_id`'s, and re-evaluating would alias `results.<previous_id>` to it.
+    // A restart-at-iteration also enters as `InProgress`: it resumes without re-gating.
+    let is_skipped = if let Some(skip_if) = module.skip_if.as_ref().filter(|_| {
+        matches!(
+            status_module,
+            FlowStatusModule::WaitingForPriorSteps { .. }
+                | FlowStatusModule::WaitingForEvents { .. }
+                | FlowStatusModule::WaitingForExecutor { .. }
+        )
+    }) {
         let idcontext = get_transform_context(&flow_job, previous_id.as_str(), &status);
         let skip_if_res = compute_bool_from_expr(
             &skip_if.expr,


### PR DESCRIPTION
Fixes #11007

## What

`skip_if` is meant as a one-time entry gate for a module, but the engine re-evaluates it on every iteration of an in-progress `whileloopflow`/`forloopflow` (the flow stays "at" the same step for the loop's whole lifetime).

`previous_id` is derived once from the static step index and keeps pointing at the module preceding this step for as long as we're still "at" it. Once the loop is `InProgress`, the last completed job is an inner iteration, not that preceding module — but the `results` proxy in `windmill-jseval` aliases `results.<previous_id>` to the last job's result as a shortcut. So a `skip_if` referencing the true preceding step's result silently reads the wrong value on the second and later evaluations, and can flip the loop's own module to `skipped` after a single iteration even though nothing should stop it.

## Fix

Skip the `skip_if` check once `status_module` is already `InProgress`: it only makes sense as an entry gate, and a module that's already running can't meaningfully be skipped anyway.

## Testing

- `cargo check -p windmill-worker`: clean.
- Built from source and ran the minimal repro in #11007 against both the unpatched and patched binary:
  - Without the fix: 4/4 runs stop after 1 iteration, `poll_fix_loop` marked `skipped: true`.
  - With the fix: 3/3 runs complete all 6 iterations, `poll_fix_loop` marked `skipped: false`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11007. `skip_if` was re-evaluated on every iteration of an in-progress while/for loop, reading the wrong job's result and potentially flipping the module to skipped. Now the check only runs in entry states (`WaitingForPriorSteps`, `WaitingForEvents`, `WaitingForExecutor`), preserving the one-time entry gate; a restart-at-iteration also resumes without re-gating. Adds a regression test covering the loop-entry case.

<sup>Written for commit 93a7d9c459bb173629889c011a440c37d86a0e65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

