### PR TITLE
fix: point the app viewer's edit button at the editor for the app's kind

### DIFF
--- a/frontend/src/lib/components/apps/editor/InWorkspaceAppViewer.svelte
+++ b/frontend/src/lib/components/apps/editor/InWorkspaceAppViewer.svelte
@@ -22,19 +22,22 @@
 
 	let {
 		workspace,
-		path,
-		editHref
+		path
 	}: {
 		workspace: string
 		path: string
-		/** Where the Edit button points (low-code vs raw editor). */
-		editHref: string
 	} = $props()
 
 	let app: any = $state(undefined)
 	let notExists = $state(false)
 	let noPermission = $state(false)
 	let canWriteApp = $state(false)
+	/** Raw vs low-code, read from the app itself rather than from the route:
+	 * both kinds render here and either route serves either kind (links to a raw
+	 * app point at /apps/get all over the app), so only the app can say which
+	 * editor the Edit button must open. */
+	let isRawApp = $state(false)
+	let editHref = $derived(`${base}/${isRawApp ? 'apps_raw' : 'apps'}/edit/${path}?nodraft=true`)
 	let refresh: (() => void) | undefined
 
 	// The opaque iframe loads the dedicated cookieless, chrome-less viewer route.
@@ -103,11 +106,14 @@
 		}
 	}
 
-	// Edit button: determine write access on this real-origin page (cookie).
+	// Edit button: determine write access and which editor to open on this
+	// real-origin page (cookie). The sandboxed low-code app never loads on this
+	// page (it loads inside the opaque iframe), so `app` can't be the source.
 	async function loadPerms() {
 		try {
 			const lite: any = await AppService.getAppLiteByPath({ workspace, path })
 			canWriteApp = canWrite(lite?.path, lite?.extra_perms ?? {}, $userStore)
+			isRawApp = !!lite?.raw_app
 		} catch (_) {
 			canWriteApp = false
 		}

--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -427,7 +427,7 @@
 				path = `/apps/get/${e.path}`
 				break
 			case 'raw_app':
-				path = `/raw_apps/get/${e.path}`
+				path = `/apps_raw/get/${e.path}`
 				break
 			default:
 				path = '/'

--- a/frontend/src/routes/(root)/(logged)/apps/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/get/[...path]/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	/*
-	 * WIN-2006: in-workspace low-code app viewer. Thin wrapper over the shared
+	 * WIN-2006: in-workspace app viewer. Thin wrapper over the shared
 	 * InWorkspaceAppViewer, which renders the app sandboxed (opaque iframe / scoped
-	 * token) through the same machinery as the public viewer. Raw apps use the
-	 * sibling /apps_raw/get route, which wraps the same component.
+	 * token) through the same machinery as the public viewer. Raw apps also render
+	 * here — links to an app point at this route whatever its kind; the sibling
+	 * /apps_raw/get route wraps the same component.
 	 */
-	import { base } from '$lib/base'
 	import InWorkspaceAppViewer from '$lib/components/apps/editor/InWorkspaceAppViewer.svelte'
 	import { Skeleton } from '$lib/components/common'
 	import { workspaceStore } from '$lib/stores'
@@ -24,7 +24,7 @@
 	     must fully remount — otherwise the previous app (and in sandbox mode its
 	     path-scoped token) sticks around. -->
 	{#key `${workspace}/${path}`}
-		<InWorkspaceAppViewer {workspace} {path} editHref="{base}/apps/edit/{path}?nodraft=true" />
+		<InWorkspaceAppViewer {workspace} {path} />
 	{/key}
 {:else}
 	<Skeleton layout={[10]} />

--- a/frontend/src/routes/(root)/(logged)/apps_raw/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/get/[...path]/+page.svelte
@@ -5,7 +5,6 @@
 	 * apps get the identical sandbox behavior. PublicAppFrame renders raw apps
 	 * inline with the bundle isolated in RawAppPreview's own opaque iframe.
 	 */
-	import { base } from '$lib/base'
 	import InWorkspaceAppViewer from '$lib/components/apps/editor/InWorkspaceAppViewer.svelte'
 	import { Skeleton } from '$lib/components/common'
 	import { workspaceStore } from '$lib/stores'
@@ -19,7 +18,7 @@
 	<!-- Key by target: SvelteKit reuses this page component on in-route
 	     navigation, so the viewer must fully remount (see /apps/get). -->
 	{#key `${workspace}/${path}`}
-		<InWorkspaceAppViewer {workspace} {path} editHref="{base}/apps_raw/edit/{path}?nodraft=true" />
+		<InWorkspaceAppViewer {workspace} {path} />
 	{/key}
 {:else}
 	<Skeleton layout={[10]} />


### PR DESCRIPTION
## Summary

A raw app opened at `/apps/get/<path>` showed an Edit button pointing at `/apps/edit/<path>` — the low-code editor — instead of the raw editor, so editing it landed on an empty low-code canvas.

`InWorkspaceAppViewer` took the edit destination as a prop and each route wrapper hardcoded its own (`/apps/get` → `/apps/edit`, `/apps_raw/get` → `/apps_raw/edit`). But both routes render both app kinds, and links to an app point at `/apps/get` whatever its kind — global search, content search, copilot workspace items, audit logs, `AppNavbarItem` — so the route can't decide which editor to open. Only the app can.

## Changes

- `InWorkspaceAppViewer`: drop the `editHref` prop and derive the target from `raw_app` on the `getAppLiteByPath` response the component already fetches to decide write access. That call is the right source: for a sandboxed low-code app the app itself only loads inside the opaque iframe, so the component's own `app` state can be empty. No extra request, and the button only renders once that response has landed.
- `/apps/get` and `/apps_raw/get` route wrappers: stop passing `editHref`.
- `GlobalSearchModal`: `raw_app` results navigated to `/raw_apps/get/`, which 404s — the route is `/apps_raw/get/`. Latent fix: `fetchCombinedItems` tags every app `type: 'app'`, so that switch branch is currently unreachable.

## Test plan

Exercised on a local instance with a deployed raw app and a low-code app, driving the UI with Playwright:

- [x] Raw app at `/apps/get/<path>` → Edit points at `/apps_raw/edit/<path>` and lands in the raw editor with its files
- [x] Low-code app at `/apps/get/<path>` → Edit still points at `/apps/edit/<path>`
- [x] Raw app at `/apps_raw/get/<path>` → `/apps_raw/edit/<path>`
- [x] Low-code app at `/apps_raw/get/<path>` → `/apps/edit/<path>` (button follows the app, not the route)
- [x] `npm run check:fast` reports the same 4 pre-existing errors as the clean tree

## Screenshots

**Before** — the raw app's Edit button led here, the low-code editor on an empty canvas:

![before-lowcode-editor-for-raw-app](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-edit-button-routing-fix/1788793478-before-lowcode-editor-for-raw-app.png)

**After** — the same raw app at `/apps/get/f/test/raw_edit_btn`:

![raw-app-viewer-apps-get](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-edit-button-routing-fix/1788793480-raw-app-viewer-apps-get.png)

Clicking Edit now lands in the raw editor (`/apps_raw/edit/f/test/raw_edit_btn`):

![raw-app-editor-after-edit-click](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-edit-button-routing-fix/1788793483-raw-app-editor-after-edit-click.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDiZaPzhC4R9G4hLPgy1B2


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the app viewer's Edit button so raw apps open the raw editor instead of the empty low-code canvas when viewed at `/apps/get/<path>`.

- The viewer derives the editor destination from the app's `raw_app` flag on the `getAppLiteByPath` response instead of a hardcoded `editHref` prop.
- The `/apps/get` and `/apps_raw/get` route wrappers no longer pass `editHref`.
- Global search sends raw-app results to `/apps_raw/get/` instead of the 404ing `/raw_apps/get/`.

<sup>Written for commit 8a97391b5ac8bf586eea92cdde979e6667fe4953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

