### PR TITLE
fix: let a draft-only schedule, trigger or resource be deleted

### DIFF
--- a/backend/windmill-api-integration-tests/tests/protection_rules.rs
+++ b/backend/windmill-api-integration-tests/tests/protection_rules.rs
@@ -124,6 +124,72 @@ async fn test_protection_rules(db: Pool<Postgres>) -> anyhow::Result<()> {
     assert!(!resp.status().is_success(), "Non-admin should be blocked from flows: {}", resp.status());
 
     // ========================================
+    // 4b. ...but a draft-only resource stays deletable: nothing is deployed at
+    // its path, so its DELETE is a draft discard rather than a deployment.
+    // ========================================
+
+    let draft_only_path = "u/test-user-2/draft_only_resource";
+    let resp = authed(
+        client().post(format!("{base}/drafts/update/resource/{draft_only_path}")),
+        "SECRET_TOKEN_2",
+    )
+    .json(&json!({ "value": {
+        "path": draft_only_path,
+        "value": { "a": 1 },
+        "resource_type": "c_test",
+        "description": ""
+    }}))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "Non-admin should save a draft: {}",
+        resp.text().await?
+    );
+
+    let resp = authed(
+        client().delete(format!("{base}/resources/delete/{draft_only_path}")),
+        "SECRET_TOKEN_2",
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "Draft-only delete should not be gated by the deploy rules: {}",
+        resp.text().await?
+    );
+
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM draft WHERE workspace_id = 'test-workspace' AND path = $1 \
+         AND typ = 'resource'::DRAFT_KIND",
+    )
+    .bind(draft_only_path)
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(remaining, 0, "the draft should be gone");
+
+    // The gate itself is still there for a DEPLOYED resource at the same path.
+    let resp = authed(
+        client().post(format!("{base}/resources/create")),
+        "SECRET_TOKEN_2",
+    )
+    .json(&json!({
+        "path": draft_only_path,
+        "value": { "a": 1 },
+        "resource_type": "c_test",
+        "description": ""
+    }))
+    .send()
+    .await?;
+    assert!(
+        !resp.status().is_success(),
+        "Non-admin should still be blocked from creating a resource: {}",
+        resp.status()
+    );
+
+    // ========================================
     // 5. Admin bypasses protection rule
     // ========================================
 

--- a/backend/windmill-api-integration-tests/tests/schedules.rs
+++ b/backend/windmill-api-integration-tests/tests/schedules.rs
@@ -234,3 +234,67 @@ async fn test_schedule_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// A schedule that exists only as a draft is listed (synthesized from the
+/// `draft` table) but has no `schedule` row, so its DELETE used to 404 and
+/// leave the row unremovable. It must drop the draft instead, and still 404
+/// once nothing is left at the path.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_delete_draft_only_schedule(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let path = "u/test-user/draft_only_schedule";
+
+    let resp = authed(client().post(format!(
+        "http://localhost:{port}/api/w/test-workspace/drafts/update/trigger_schedule/{path}"
+    )))
+    .json(&json!({ "value": {
+        "path": path,
+        "schedule": "0 0 */6 * * *",
+        "timezone": "UTC",
+        "script_path": "u/test-user/never_deployed",
+        "is_flow": false,
+    }}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), 200, "save draft: {}", resp.text().await?);
+
+    let resp = authed(client().get(format!(
+        "http://localhost:{port}/api/w/test-workspace/schedules/list?include_draft_only=true"
+    )))
+    .send()
+    .await
+    .unwrap();
+    let listed: Vec<serde_json::Value> = resp.json().await?;
+    assert!(
+        listed
+            .iter()
+            .any(|s| s["path"] == path && s["draft_only"] == json!(true)),
+        "draft-only schedule should be listed: {listed:?}"
+    );
+
+    let resp = authed(client().delete(schedule_url(port, "delete", path)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "delete: {}", resp.text().await?);
+
+    let remaining: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM draft WHERE workspace_id = 'test-workspace' AND path = $1 \
+         AND typ = 'trigger_schedule'::DRAFT_KIND",
+    )
+    .bind(path)
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(remaining, 0, "the draft should be gone");
+
+    let resp = authed(client().delete(schedule_url(port, "delete", path)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404, "nothing left at the path");
+
+    Ok(())
+}

--- a/backend/windmill-api-integration-tests/tests/schedules.rs
+++ b/backend/windmill-api-integration-tests/tests/schedules.rs
@@ -113,7 +113,9 @@ async fn test_schedule_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
         "expected at least 2 schedules, got {}",
         list.len()
     );
-    assert!(list.iter().any(|s| s["path"] == "u/test-user/test_schedule"));
+    assert!(list
+        .iter()
+        .any(|s| s["path"] == "u/test-user/test_schedule"));
 
     // --- list_with_jobs ---
     let resp = authed(client().get(format!("{base}/list_with_jobs")))
@@ -125,18 +127,14 @@ async fn test_schedule_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     assert!(!list.is_empty());
 
     // --- update ---
-    let resp = authed(client().post(schedule_url(
-        port,
-        "update",
-        "u/test-user/test_schedule",
-    )))
-    .json(&json!({
-        "schedule": "0 0 */12 * * *",
-        "timezone": "Europe/Paris"
-    }))
-    .send()
-    .await
-    .unwrap();
+    let resp = authed(client().post(schedule_url(port, "update", "u/test-user/test_schedule")))
+        .json(&json!({
+            "schedule": "0 0 */12 * * *",
+            "timezone": "Europe/Paris"
+        }))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(resp.status(), 200, "update: {}", resp.text().await?);
 
     // verify update
@@ -204,14 +202,11 @@ async fn test_schedule_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     assert_eq!(resp.status(), 200);
 
     // --- delete ---
-    let resp = authed(client().delete(schedule_url(
-        port,
-        "delete",
-        "u/test-user/another_schedule",
-    )))
-    .send()
-    .await
-    .unwrap();
+    let resp =
+        authed(client().delete(schedule_url(port, "delete", "u/test-user/another_schedule")))
+            .send()
+            .await
+            .unwrap();
     assert_eq!(resp.status(), 200);
 
     let resp = authed_get(port, "exists", "u/test-user/another_schedule").await;
@@ -220,16 +215,14 @@ async fn test_schedule_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     // ===== Global endpoints =====
 
     // --- preview ---
-    let resp = authed(client().post(format!(
-        "http://localhost:{port}/api/schedules/preview"
-    )))
-    .json(&json!({
-        "schedule": "0 0 */6 * * *",
-        "timezone": "UTC"
-    }))
-    .send()
-    .await
-    .unwrap();
+    let resp = authed(client().post(format!("http://localhost:{port}/api/schedules/preview")))
+        .json(&json!({
+            "schedule": "0 0 */6 * * *",
+            "timezone": "UTC"
+        }))
+        .send()
+        .await
+        .unwrap();
     assert_eq!(resp.status(), 200, "preview: {}", resp.text().await?);
 
     Ok(())
@@ -295,6 +288,36 @@ async fn test_delete_draft_only_schedule(db: Pool<Postgres>) -> anyhow::Result<(
         .await
         .unwrap();
     assert_eq!(resp.status(), 404, "nothing left at the path");
+
+    // A legacy (email IS NULL) draft is owned by nobody and keeps the write gate
+    // on the drafts routes, so this one must not become a second door to it.
+    let legacy_path = "u/test-user/legacy_draft_only_schedule";
+    sqlx::query(
+        "INSERT INTO draft (workspace_id, email, path, typ, value) \
+         VALUES ('test-workspace', NULL, $1, 'trigger_schedule'::DRAFT_KIND, '{}'::json)",
+    )
+    .bind(legacy_path)
+    .execute(&db)
+    .await?;
+
+    let resp = authed(client().delete(schedule_url(port, "delete", legacy_path)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        404,
+        "legacy draft is not this route's to delete"
+    );
+
+    let legacy_remaining: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM draft WHERE workspace_id = 'test-workspace' AND path = $1 \
+         AND typ = 'trigger_schedule'::DRAFT_KIND",
+    )
+    .bind(legacy_path)
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(legacy_remaining, 1, "the legacy draft should survive");
 
     Ok(())
 }

--- a/backend/windmill-api-integration-tests/tests/schedules.rs
+++ b/backend/windmill-api-integration-tests/tests/schedules.rs
@@ -228,10 +228,9 @@ async fn test_schedule_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A schedule that exists only as a draft is listed (synthesized from the
-/// `draft` table) but has no `schedule` row, so its DELETE used to 404 and
-/// leave the row unremovable. It must drop the draft instead, and still 404
-/// once nothing is left at the path.
+/// A schedule with no `schedule` row is listed from the `draft` table, so its
+/// DELETE drops that draft, then 404s once nothing is left at the path. A legacy
+/// (`email IS NULL`) draft is owned by nobody and stays put.
 #[sqlx::test(migrations = "../migrations", fixtures("base"))]
 async fn test_delete_draft_only_schedule(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;

--- a/backend/windmill-api-schedule/src/lib.rs
+++ b/backend/windmill-api-schedule/src/lib.rs
@@ -31,8 +31,8 @@ use windmill_common::{
         self, TriggerHistoryEvent, TriggerOperation, TriggerSource, SCHEDULE_TRIGGER_KIND,
     },
     user_drafts::{
-        delete_all_drafts_for_path, fetch_draft_only_list_rows, overlay_or_draft_only,
-        UserDraftItemKind, WithDraftOverlay, WithDraftQuery,
+        delete_all_drafts_for_path, delete_draft_only_for_path, fetch_draft_only_list_rows,
+        overlay_or_draft_only, UserDraftItemKind, WithDraftOverlay, WithDraftQuery,
     },
     utils::{
         escape_ilike_pattern, not_found_if_none, paginate, Pagination, ScheduleType, StripPath,
@@ -1331,6 +1331,18 @@ async fn delete_schedule(
     .flatten();
 
     if exists.is_none() {
+        drop(tx);
+        if delete_draft_only_for_path(
+            &db,
+            &w_id,
+            UserDraftItemKind::TriggerSchedule,
+            path,
+            &authed.email,
+        )
+        .await?
+        {
+            return Ok(format!("Draft-only schedule {} deleted", path));
+        }
         return Err(windmill_common::error::Error::NotFound(format!(
             "Schedule {} not found",
             path

--- a/backend/windmill-common/src/user_drafts.rs
+++ b/backend/windmill-common/src/user_drafts.rs
@@ -401,22 +401,16 @@ pub async fn fetch_draft_only_list_rows(
     Ok(rows)
 }
 
-/// Delete the caller's OWN draft behind a synthesized draft-only list row, for
-/// the DELETE route of a kind whose list calls `fetch_draft_only_list_rows`.
-/// With no deployed row at the path the entry exists only as that draft, so
-/// dropping it IS the delete — 404-ing instead strands a row the user can see
-/// but never remove. The `NOT EXISTS` keeps a deployed row's draft untouched, so
-/// a route can call this on its not-found branch without second-guessing why the
-/// row was missing. `Ok(false)` means nothing was deleted: the caller reports
-/// its own error.
+/// Delete the caller's OWN draft at a path with no deployed row, for the DELETE
+/// route of a kind whose list synthesizes such rows via
+/// `fetch_draft_only_list_rows`. The `NOT EXISTS` leaves a deployed row's draft
+/// alone, so a route may call this on its not-found branch whatever the reason
+/// for the miss. `Ok(false)` means nothing matched: the caller reports its own error.
 ///
-/// Requires no permission check, and callers must not add one: an email-scoped
-/// row belongs to the authed user, who can always discard it — the same reason
-/// `update_draft` exempts an own-discard from `require_can_write_path`. That is
-/// also why the reach stops short of the synthesis, which additionally surfaces
-/// LEGACY (`email IS NULL`) rows: those are owned by nobody and keep the write
-/// gate, so discarding one stays on the `update_draft` / migrate routes that
-/// apply it.
+/// Takes no permission check and callers must not add one: an email-scoped row
+/// belongs to the caller, who can always discard it, as `update_draft`'s
+/// own-discard does. Legacy (`email IS NULL`) rows are owned by nobody and keep
+/// their write gate, so discarding one stays on the `update_draft` route.
 pub async fn delete_draft_only_for_path(
     db: &DB,
     w_id: &str,

--- a/backend/windmill-common/src/user_drafts.rs
+++ b/backend/windmill-common/src/user_drafts.rs
@@ -401,14 +401,22 @@ pub async fn fetch_draft_only_list_rows(
     Ok(rows)
 }
 
-/// Delete the draft behind a synthesized draft-only list row, for the DELETE
-/// route of a kind whose list calls `fetch_draft_only_list_rows`. With no
-/// deployed row at the path the entry exists only as that draft, so dropping it
-/// IS the delete — 404-ing instead strands a row the user can see but never
-/// remove. Same reach as the synthesis (own draft + legacy NULL-email row), and
-/// the `NOT EXISTS` keeps a deployed row's draft untouched, so a route can call
-/// this on its not-found branch without second-guessing why the row was missing.
-/// `Ok(false)` means nothing was deleted: the caller reports its own error.
+/// Delete the caller's OWN draft behind a synthesized draft-only list row, for
+/// the DELETE route of a kind whose list calls `fetch_draft_only_list_rows`.
+/// With no deployed row at the path the entry exists only as that draft, so
+/// dropping it IS the delete — 404-ing instead strands a row the user can see
+/// but never remove. The `NOT EXISTS` keeps a deployed row's draft untouched, so
+/// a route can call this on its not-found branch without second-guessing why the
+/// row was missing. `Ok(false)` means nothing was deleted: the caller reports
+/// its own error.
+///
+/// Requires no permission check, and callers must not add one: an email-scoped
+/// row belongs to the authed user, who can always discard it — the same reason
+/// `update_draft` exempts an own-discard from `require_can_write_path`. That is
+/// also why the reach stops short of the synthesis, which additionally surfaces
+/// LEGACY (`email IS NULL`) rows: those are owned by nobody and keep the write
+/// gate, so discarding one stays on the `update_draft` / migrate routes that
+/// apply it.
 pub async fn delete_draft_only_for_path(
     db: &DB,
     w_id: &str,
@@ -423,7 +431,7 @@ pub async fn delete_draft_only_for_path(
     let sql = format!(
         "DELETE FROM draft \
          WHERE workspace_id = $1 AND typ = $2::text::DRAFT_KIND AND path = $3 \
-           AND (email = $4 OR email IS NULL) \
+           AND email = $4 \
            AND NOT EXISTS (SELECT 1 FROM {table} t \
              WHERE t.workspace_id = draft.workspace_id AND t.path = draft.path)"
     );

--- a/backend/windmill-common/src/user_drafts.rs
+++ b/backend/windmill-common/src/user_drafts.rs
@@ -401,6 +401,43 @@ pub async fn fetch_draft_only_list_rows(
     Ok(rows)
 }
 
+/// Delete the draft behind a synthesized draft-only list row, for the DELETE
+/// route of a kind whose list calls `fetch_draft_only_list_rows`. With no
+/// deployed row at the path the entry exists only as that draft, so dropping it
+/// IS the delete — 404-ing instead strands a row the user can see but never
+/// remove. Same reach as the synthesis (own draft + legacy NULL-email row), and
+/// the `NOT EXISTS` keeps a deployed row's draft untouched, so a route can call
+/// this on its not-found branch without second-guessing why the row was missing.
+/// `Ok(false)` means nothing was deleted: the caller reports its own error.
+pub async fn delete_draft_only_for_path(
+    db: &DB,
+    w_id: &str,
+    kind: UserDraftItemKind,
+    path: &str,
+    email: &str,
+) -> Result<bool> {
+    let Some(table) = kind.deployed_table() else {
+        return Ok(false);
+    };
+    // `table` is from the closed `deployed_table()` enum, never user input.
+    let sql = format!(
+        "DELETE FROM draft \
+         WHERE workspace_id = $1 AND typ = $2::text::DRAFT_KIND AND path = $3 \
+           AND (email = $4 OR email IS NULL) \
+           AND NOT EXISTS (SELECT 1 FROM {table} t \
+             WHERE t.workspace_id = draft.workspace_id AND t.path = draft.path)"
+    );
+    let deleted = sqlx::query(&sql)
+        .bind(w_id)
+        .bind(kind.as_str())
+        .bind(path)
+        .bind(email)
+        .execute(db)
+        .await?
+        .rows_affected();
+    Ok(deleted > 0)
+}
+
 /// The get-by-path draft choreography, shared by every entity's "get by path"
 /// route. Given the deployed entity as an `Option` (caller maps its own "not
 /// found" to `None`):

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -134,7 +134,10 @@ pub struct EditResourceType {
     /// `Option` conflates: an absent field leaves the extension alone, while an
     /// explicit `null` clears it. A hub pull relies on both — a type that stops
     /// being a file type has to stop being one locally too.
-    #[serde(default, deserialize_with = "windmill_common::more_serde::double_option")]
+    #[serde(
+        default,
+        deserialize_with = "windmill_common::more_serde::double_option"
+    )]
     pub format_extension: Option<Option<String>>,
 }
 
@@ -1309,6 +1312,19 @@ async fn delete_resource(
     let path = path.to_path();
 
     check_scopes(&authed, || format!("resources:write:{}", path))?;
+
+    // Ahead of the deployment rules, which gate deployments: nothing is deployed
+    // at a draft-only path, and discarding one's own draft is already ungated on
+    // the drafts routes. Gating it here would leave the row undeletable in a
+    // protected workspace. Also ahead of the transaction, unlike the other kinds,
+    // which take this case on their not-found branch: here that branch is the
+    // `not_found_if_none` below, with the linked-variable cascade already staged.
+    if delete_draft_only_for_path(&db, &w_id, UserDraftItemKind::Resource, path, &authed.email)
+        .await?
+    {
+        return Ok(format!("draft-only resource {} deleted", path));
+    }
+
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),
@@ -1319,15 +1335,6 @@ async fn delete_resource(
     .await?
     {
         return Err(Error::PermissionDenied(msg));
-    }
-
-    // The draft-only case is taken up front, unlike the other kinds, which take
-    // it on their not-found branch: here that branch is the `not_found_if_none`
-    // below, mid-transaction with the linked-variable cascade already staged.
-    if delete_draft_only_for_path(&db, &w_id, UserDraftItemKind::Resource, path, &authed.email)
-        .await?
-    {
-        return Ok(format!("draft-only resource {} deleted", path));
     }
 
     let mut tx = user_db.begin(&authed).await?;

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -1313,12 +1313,10 @@ async fn delete_resource(
 
     check_scopes(&authed, || format!("resources:write:{}", path))?;
 
-    // Ahead of the deployment rules, which gate deployments: nothing is deployed
-    // at a draft-only path, and discarding one's own draft is already ungated on
-    // the drafts routes. Gating it here would leave the row undeletable in a
-    // protected workspace. Also ahead of the transaction, unlike the other kinds,
-    // which take this case on their not-found branch: here that branch is the
-    // `not_found_if_none` below, with the linked-variable cascade already staged.
+    // Ahead of the deploy rules: nothing is deployed at a draft-only path, so
+    // gating this discard on them would strand the row in a protected workspace.
+    // Ahead of the transaction too — the not-found branch other kinds hang this
+    // off is the `not_found_if_none` below, past the linked-variable cascade.
     if delete_draft_only_for_path(&db, &w_id, UserDraftItemKind::Resource, path, &authed.email)
         .await?
     {

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -50,9 +50,9 @@ use windmill_common::{
     error::{self, Error, JsonResult, Result},
     get_database_url,
     user_drafts::{
-        delete_all_drafts_for_path, delete_own_draft_for_path, fetch_draft_only,
-        fetch_draft_only_list_rows, maybe_overlay_draft, UserDraftItemKind, WithDraftOverlay,
-        WithDraftQuery,
+        delete_all_drafts_for_path, delete_draft_only_for_path, delete_own_draft_for_path,
+        fetch_draft_only, fetch_draft_only_list_rows, maybe_overlay_draft, UserDraftItemKind,
+        WithDraftOverlay, WithDraftQuery,
     },
     utils::{not_found_if_none, paginate, require_admin, Pagination, StripPath},
     variables,
@@ -1320,6 +1320,16 @@ async fn delete_resource(
     {
         return Err(Error::PermissionDenied(msg));
     }
+
+    // The draft-only case is taken up front, unlike the other kinds, which take
+    // it on their not-found branch: here that branch is the `not_found_if_none`
+    // below, mid-transaction with the linked-variable cascade already staged.
+    if delete_draft_only_for_path(&db, &w_id, UserDraftItemKind::Resource, path, &authed.email)
+        .await?
+    {
+        return Ok(format!("draft-only resource {} deleted", path));
+    }
+
     let mut tx = user_db.begin(&authed).await?;
 
     // Capture resource data for trashbin before deleting

--- a/backend/windmill-trigger/src/handler.rs
+++ b/backend/windmill-trigger/src/handler.rs
@@ -18,8 +18,9 @@ use windmill_common::{
     error::{Error, JsonResult, Result},
     trigger_history::{self, TriggerHistoryEvent, TriggerOperation, TriggerSource},
     user_drafts::{
-        delete_all_drafts_for_path, delete_own_draft_for_path, fetch_draft_only_list_rows,
-        overlay_or_draft_only, UserDraftItemKind, WithDraftOverlay, WithDraftQuery,
+        delete_all_drafts_for_path, delete_draft_only_for_path, delete_own_draft_for_path,
+        fetch_draft_only_list_rows, overlay_or_draft_only, UserDraftItemKind, WithDraftOverlay,
+        WithDraftQuery,
     },
     utils::{paginate, Pagination, StripPath},
     worker::CLOUD_HOSTED,
@@ -990,6 +991,18 @@ async fn delete_trigger<T: TriggerCrud>(
         .await?;
 
     if !deleted {
+        drop(tx);
+        if delete_draft_only_for_path(
+            &db,
+            &workspace_id,
+            T::user_draft_item_kind(),
+            path,
+            &authed.email,
+        )
+        .await?
+        {
+            return Ok(format!("Draft-only trigger '{}' deleted", path));
+        }
         return Err(Error::NotFound(format!(
             "Trigger not found at path: {}",
             path


### PR DESCRIPTION
## Summary

A schedule that has never been deployed — it exists only as a per-user row in the `draft` table — is listed on the schedules page, because `list_schedules` synthesizes rows for such paths when `include_draft_only=true`. Its DELETE route, however, returned `NotFound` whenever the `schedule` table had no row, so the entry was visible and impossible to remove:

```
DELETE /api/w/<ws>/schedules/delete/u/me/my_draft_schedule
Not found: Schedule u/me/my_draft_schedule not found   HTTP 404
```

The gap is not schedules-only. Fourteen list pages pass `includeDraftOnly`; auditing each backend delete found the same strand in the generic trigger handler (covering all 11 trigger kinds) and in `delete_resource`. Variables were already correct — their delete tolerates a missing row and clears drafts at the path.

Nothing was needed on the frontend: the row already renders a "Draft only" badge, a disabled enable/disable toggle and a greyed-out Runs button. Only the delete was broken.

## Changes

- Add `delete_draft_only_for_path` in `windmill-common/src/user_drafts.rs`: deletes the caller's own draft at a path with no deployed row. A `NOT EXISTS` against `UserDraftItemKind::deployed_table()` means a deployed row's draft is never touched, so a route can call it on its not-found branch without having to distinguish "absent" from "hidden by RLS".
- Call it on the not-found branch of `delete_schedule` and the generic `delete_trigger`.
- Call it in `delete_resource` ahead of both the transaction and the deployment-rule check. Ahead of the transaction because that route's not-found branch (`not_found_if_none`) sits mid-transaction with the linked-variable cascade already staged; ahead of the deployment rules because discarding one's own draft is not a deployment — gating it there would leave the row undeletable in a workspace with `DisableDirectDeployment`, while the same discard is already ungated on the drafts routes.

### Authorization

The helper is scoped to `email = $4`, the caller's own row. It deliberately stops short of the list synthesis, which additionally surfaces **legacy** (`email IS NULL`, pre-per-user-drafts) rows: those are owned by nobody and keep their write gate, which `update_draft` documents and enforces via `require_can_write_path`. Discarding a legacy draft stays on the `update_draft { legacy: true }` and admin-only migrate routes that apply that gate. Requiring no permission check here is the same reasoning `update_draft` uses to exempt an own-discard: an email-scoped row belongs to the caller, who can always discard it even after losing write access to the path.

**Known residual:** a *legacy* draft-only row still appears in these lists and still 404s on Delete. That is strictly smaller than before (every draft-only row 404'd previously; now only legacy ones do) and a correctly-gated door exists for it, but the symptom is indistinguishable from "the fix didn't land". Closing it properly means making `require_can_write_path` reachable from `windmill-api-schedule` / `windmill-trigger` / `windmill-store`, which today would be a dependency cycle on `windmill-api` — deliberately out of scope here.

## Test plan

- [x] `cargo test -p windmill-api-integration-tests --test schedules --test protection_rules --test resources --test drafts` — all green
- [x] `test_delete_draft_only_schedule`: drives the real route stack (save draft → list with `include_draft_only=true` → DELETE → assert the `draft` row is gone → DELETE again → 404), plus a legacy (`email IS NULL`) row that must survive its DELETE with a 404
- [x] `test_protection_rules` §4b: with `DisableDirectDeployment` active, a non-admin can still delete their draft-only resource, while creating a deployed one at the same path stays blocked
- [x] Both new assertions falsified: reintroducing `OR email IS NULL` fails the legacy assertion; moving the fast path back below `check_deploy_rules` fails the protection-rule assertion
- [x] Exercised on a running instance — schedule and resource draft-only deletes return 200 with the draft row gone; deployed schedules and resources carrying drafts still delete normally; the generic trigger path checked against `http_triggers` after restarting the backend with `--features quickjs,http_trigger`
- [x] Driven through the UI with Playwright: the draft-only row disappears from `/schedules` on Delete and stays gone across a reload
- [x] Legacy row checked live: DELETE returns 404 and the row survives

No `.sqlx` regeneration: the new query is the untyped builder, since the table name comes from the `deployed_table()` enum rather than a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SV5kjTis3AFtTx2nW2VRi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deletion of draft-only schedules, triggers, and resources so entries visible in lists can actually be removed instead of returning 404 and leaving a stuck row.

- Adds `delete_draft_only_for_path`, which deletes the caller's own draft only when no deployed row exists at that path.
- Calls it on the not-found branch of `delete_schedule` and `delete_trigger`, and ahead of deploy-rule checks in `delete_resource`, so discarding a draft isn't gated as a deployment.
- Legacy drafts (`email IS NULL`) still 404 on delete and remain gated on the drafts routes; this is a known residual, smaller than before since every draft-only row previously 404'd.
- Tests cover the real route stack for schedules and resources, including `DisableDirectDeployment` workspaces and legacy-row survival.

<sup>Written for commit 31f1a1bb8c3c6c689c0ede7f9eeaa73ab0652b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

