### PR TITLE
feat: draw a dbt column trace, across projects and the pipeline boundary

### DIFF
--- a/backend/.sqlx/query-06c1a79bfc24b17acbd79411295c718161d95f7ad65a26525c5f43241267608d.json
+++ b/backend/.sqlx/query-06c1a79bfc24b17acbd79411295c718161d95f7ad65a26525c5f43241267608d.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,\n                               resource_type, name, asset_path, tags)\n         VALUES ($1, $2, $3, $4, 'model.p.stock', 'model', 'stock',\n                 'u/a/wh/analytics/stock', '{}'),\n                ($1, $2, $3, $4, 'model.p.stock_daily', 'model', 'stock_daily',\n                 'u/a/wh/analytics/stock_daily', '{}')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "06c1a79bfc24b17acbd79411295c718161d95f7ad65a26525c5f43241267608d"
+}

--- a/backend/.sqlx/query-1008ed150f30b56baf17b3c6e6bfc8ee144b14d564a3e589a60678b3e68effbf.json
+++ b/backend/.sqlx/query-1008ed150f30b56baf17b3c6e6bfc8ee144b14d564a3e589a60678b3e68effbf.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,\n                                      parent_unique_id, parent_column, child_unique_id,\n                                      child_column, lineage_kind)\n         VALUES ($1, $2, $3, $4, 'model.p.stock', 'sku', 'model.p.stock_daily', 'sku', 'copy')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1008ed150f30b56baf17b3c6e6bfc8ee144b14d564a3e589a60678b3e68effbf"
+}

--- a/backend/.sqlx/query-210441eb7bee09afd27a927e0e44ff3bc1143dab285e51a9b54b2c2f240b9a8c.json
+++ b/backend/.sqlx/query-210441eb7bee09afd27a927e0e44ff3bc1143dab285e51a9b54b2c2f240b9a8c.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,\n                                      parent_unique_id, parent_column, child_unique_id,\n                                      child_column, lineage_kind)\n         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000',\n                 'model.p.raw_orders', 'id', 'model.p.orders', 'order_id', 'copy'),\n                ($1, $2, $3, '00000000-0000-0000-0000-000000000000',\n                 'model.p.raw_orders', 'status', 'model.p.orders', 'order_id', 'scan')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "210441eb7bee09afd27a927e0e44ff3bc1143dab285e51a9b54b2c2f240b9a8c"
+}

--- a/backend/.sqlx/query-23151591ed03ea6d2b017e66f54115b2241215d660d25df7615c8b12d704e92c.json
+++ b/backend/.sqlx/query-23151591ed03ea6d2b017e66f54115b2241215d660d25df7615c8b12d704e92c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,\n                               resource_type, name, asset_path, tags)\n         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'source.q.' || $4,\n                 'source', $4, $5, '{}'),\n                ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'model.q.' || $6,\n                 'model', $6, $7, '{}')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "23151591ed03ea6d2b017e66f54115b2241215d660d25df7615c8b12d704e92c"
+}

--- a/backend/.sqlx/query-55af8c19888ddc222a0ef2db04fac8ee7e664e64a51972327875b1138f80db5d.json
+++ b/backend/.sqlx/query-55af8c19888ddc222a0ef2db04fac8ee7e664e64a51972327875b1138f80db5d.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT p.asset_path AS \"from_path!\", e.parent_column AS \"from_column!\",\n                      c.asset_path AS \"to_path!\", e.child_column AS \"to_column!\",\n                      e.lineage_kind AS \"kind!\"\n                 FROM unnest($2::text[], $3::bigint[], $4::uuid[])\n                        AS o(script_path, script_hash, job_id)\n                 JOIN dbt_column_edge e ON e.workspace_id = $1\n                                       AND e.script_path = o.script_path\n                                       AND e.job_id = o.job_id\n                                       -- `=` still, with the NULL-to-NULL case\n                                       -- spelled out and gated on the pin: a\n                                       -- version-less row's hash is NULL on both\n                                       -- sides, which `=` never matches, but\n                                       -- `IS NOT DISTINCT FROM` would cost the\n                                       -- equality its index bound everywhere else.\n                                       AND (e.script_hash = o.script_hash\n                                            OR ($5::text IS NOT NULL\n                                                AND o.script_hash IS NULL\n                                                AND e.script_hash IS NULL))\n                 JOIN dbt_node p ON p.workspace_id = e.workspace_id\n                                AND p.script_path = e.script_path\n                                AND p.script_hash IS NOT DISTINCT FROM e.script_hash\n                                AND p.job_id = e.job_id\n                                AND p.unique_id = e.parent_unique_id\n                 JOIN dbt_node c ON c.workspace_id = e.workspace_id\n                                AND c.script_path = e.script_path\n                                AND c.script_hash IS NOT DISTINCT FROM e.script_hash\n                                AND c.job_id = e.job_id\n                                AND c.unique_id = e.child_unique_id\n                WHERE e.lineage_kind IN ('copy', 'mod')\n                  AND p.asset_path IS NOT NULL AND c.asset_path IS NOT NULL",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "from_path!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "from_column!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "to_path!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "to_column!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "kind!",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray",
+        "Int8Array",
+        "UuidArray",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "55af8c19888ddc222a0ef2db04fac8ee7e664e64a51972327875b1138f80db5d"
+}

--- a/backend/.sqlx/query-58231bdfb04fe73a8a41601fcc3c77cdae5377120441229490e468d47112819d.json
+++ b/backend/.sqlx/query-58231bdfb04fe73a8a41601fcc3c77cdae5377120441229490e468d47112819d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms)\n         VALUES ($1, $2, $2, '{}', '{}')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "58231bdfb04fe73a8a41601fcc3c77cdae5377120441229490e468d47112819d"
+}

--- a/backend/.sqlx/query-5cbff3d68b684f794bf43ea981716bd03da56192754610d9b34d69e567bd1f10.json
+++ b/backend/.sqlx/query-5cbff3d68b684f794bf43ea981716bd03da56192754610d9b34d69e567bd1f10.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,\n                                      parent_unique_id, parent_column, child_unique_id,\n                                      child_column, lineage_kind)\n         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000',\n                 'source.q.' || $4, 'k', 'model.q.' || $5, 'k', 'copy')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5cbff3d68b684f794bf43ea981716bd03da56192754610d9b34d69e567bd1f10"
+}

--- a/backend/.sqlx/query-7334351af91382d5619ff437a253c2d1acc3cd857e089e8c6972fcd276094837.json
+++ b/backend/.sqlx/query-7334351af91382d5619ff437a253c2d1acc3cd857e089e8c6972fcd276094837.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,\n                                      parent_unique_id, parent_column, child_unique_id,\n                                      child_column, lineage_kind)\n         SELECT $1, $2, $3, '00000000-0000-0000-0000-000000000000',\n                'model.p.raw_orders', 'c' || i, 'model.p.orders', 'c' || i, 'copy'\n           FROM generate_series(1, 6000) i",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7334351af91382d5619ff437a253c2d1acc3cd857e089e8c6972fcd276094837"
+}

--- a/backend/.sqlx/query-895a4feb0b3cc01ad711ce0eff8eef4f68cc3ecaf680c55a94175f6dfc2e2912.json
+++ b/backend/.sqlx/query-895a4feb0b3cc01ad711ce0eff8eef4f68cc3ecaf680c55a94175f6dfc2e2912.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,\n                                      parent_unique_id, parent_column, child_unique_id,\n                                      child_column, lineage_kind)\n         VALUES ($1, $2, NULL, $3, 'model.p.draft_src', 'raw', 'model.p.draft', 'clean', 'mod')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "895a4feb0b3cc01ad711ce0eff8eef4f68cc3ecaf680c55a94175f6dfc2e2912"
+}

--- a/backend/.sqlx/query-9f0979110f86dffc7452d80ea0410ba39025d9c9787a71a9456241cf8a9b9d82.json
+++ b/backend/.sqlx/query-9f0979110f86dffc7452d80ea0410ba39025d9c9787a71a9456241cf8a9b9d82.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,\n                               resource_type, name, asset_path, tags)\n         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'model.p.raw_orders',\n                 'model', 'raw_orders', 'u/a/wh/analytics/raw_orders', '{}'),\n                ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'model.p.orders',\n                 'model', 'orders', 'u/a/wh/analytics/orders', '{}')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9f0979110f86dffc7452d80ea0410ba39025d9c9787a71a9456241cf8a9b9d82"
+}

--- a/backend/.sqlx/query-b9c200365ea426ebe01b2e67c378ca41990e4c5d49b5baaee41acfe409bb1c24.json
+++ b/backend/.sqlx/query-b9c200365ea426ebe01b2e67c378ca41990e4c5d49b5baaee41acfe409bb1c24.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,\n                               resource_type, name, asset_path, tags)\n         VALUES ($1, $2, $3, $4, 'model.p.raw_orders', 'model', 'raw_orders',\n                 'u/a/wh/analytics/raw_orders', '{}')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b9c200365ea426ebe01b2e67c378ca41990e4c5d49b5baaee41acfe409bb1c24"
+}

--- a/backend/.sqlx/query-c793b147014cb1b6e138aed1c2eb8b93b4a8383d8cf835a7d350056565669e7f.json
+++ b/backend/.sqlx/query-c793b147014cb1b6e138aed1c2eb8b93b4a8383d8cf835a7d350056565669e7f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,\n                                 resource_type, name, asset_path, raw_code, tags)\n           VALUES ($1, $2, NULL, $3, 'model.p.draft', 'model', 'draft',\n                   'u/a/wh/analytics/draft', 'select 3', '{}'),\n                  ($1, $2, NULL, $3, 'model.p.draft_src', 'model', 'draft_src',\n                   'u/a/wh/analytics/draft_src', 'select 4', '{}')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c793b147014cb1b6e138aed1c2eb8b93b4a8383d8cf835a7d350056565669e7f"
+}

--- a/backend/.sqlx/query-eb0df8f3f1d66dd7dfc9aedc7945989fae585115a24f19946a4d58257c93bbe2.json
+++ b/backend/.sqlx/query-eb0df8f3f1d66dd7dfc9aedc7945989fae585115a24f19946a4d58257c93bbe2.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT n.script_path AS \"script_path!\", n.script_hash, n.job_id AS \"job_id!\"\n                 FROM dbt_node n\n                WHERE n.workspace_id = $1 AND n.asset_path = ANY($2)\n                  -- The run's snapshot, or the deployed graph when that job stored\n                  -- none -- a build pins only if it wrote one.\n                  AND n.job_id = CASE WHEN $5::uuid IS NOT NULL AND EXISTS (\n                                        SELECT 1 FROM dbt_graph_snapshot g\n                                         WHERE g.workspace_id = $1 AND g.job_id = $5)\n                                      THEN $5::uuid\n                                      ELSE '00000000-0000-0000-0000-000000000000'::uuid END\n                  -- The gate, re-decided for every project the walk reaches. That\n                  -- is what resolving owners in a loop is for: being entitled to\n                  -- one project is not being entitled to the one that declares a\n                  -- relation it hands over.\n                  AND ( $6\n                        OR n.script_path = ANY($7)\n                        OR EXISTS ( SELECT 1 FROM unnest($8::text[]) AS pfx\n                                     WHERE n.script_path = pfx\n                                        OR left(n.script_path, length(pfx) + 1) = pfx || '/' ) )\n                  AND CASE\n                        -- Pinned: which version comes from a job this caller was\n                        -- already granted, so `script` does not decide THAT -- but\n                        -- it still decides whether the project may be read, the\n                        -- same second gate `script_visible` is on the graph. Being\n                        -- entitled to a run is not being entitled to the SQL\n                        -- behind it, and column lineage is that SQL's shape. A\n                        -- version-less row is exempt because it is an editor\n                        -- buffer, which has no `script` row to ask and reaches\n                        -- this only through the parse job that wrote it.\n                        --\n                        -- One project answers, so a pinned trace never crosses\n                        -- into another: neither does the graph it annotates.\n                        WHEN $4::text IS NOT NULL\n                          THEN n.script_path = $4 AND n.script_hash IS NOT DISTINCT FROM $3::bigint\n                               AND ($3::bigint IS NULL OR EXISTS (\n                                     SELECT 1 FROM script sc\n                                      WHERE sc.workspace_id = $1 AND sc.path = n.script_path\n                                        AND sc.hash = $3))\n                        -- A named version: the deployed one an editor is drawing.\n                        -- `script` is read under RLS, so this is the visibility\n                        -- check as well as the existence one. A hash names one\n                        -- script row, so this arm answers for one project too —\n                        -- and deliberately: a pin says which stored graph is on\n                        -- screen, and another project's live graph is not it.\n                        WHEN $3::bigint IS NOT NULL\n                          THEN n.script_hash = $3 AND EXISTS (\n                                 SELECT 1 FROM script sc\n                                  WHERE sc.workspace_id = $1 AND sc.path = n.script_path\n                                    AND sc.hash = $3)\n                        -- Otherwise the version deployed now: an older one's rows\n                        -- outlive it in `dbt_node` until the sweep, and describe a\n                        -- project that is no longer what runs. `language` narrows\n                        -- it the way the graph's own resolution does, so a path\n                        -- that has since become a script of another kind draws and\n                        -- explains the same version rather than disagreeing. Read\n                        -- under RLS, so a project the caller cannot see resolves\n                        -- to NULL and matches nothing.\n                        ELSE n.script_hash = (\n                               SELECT sc.hash FROM script sc\n                                WHERE sc.workspace_id = $1 AND sc.path = n.script_path\n                                  AND sc.language = 'dbt'\n                                  AND sc.deleted = false AND sc.archived = false\n                                ORDER BY sc.created_at DESC LIMIT 1)\n                      END",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "script_path!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "script_hash",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "job_id!",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray",
+        "Int8",
+        "Text",
+        "Uuid",
+        "Bool",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "eb0df8f3f1d66dd7dfc9aedc7945989fae585115a24f19946a4d58257c93bbe2"
+}

--- a/backend/.sqlx/query-f6de1512fa3e46883b32d56fd19ffe8aaf6dfe664c330ac8cea51a157a4fe52e.json
+++ b/backend/.sqlx/query-f6de1512fa3e46883b32d56fd19ffe8aaf6dfe664c330ac8cea51a157a4fe52e.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,\n                                      parent_unique_id, parent_column, child_unique_id,\n                                      child_column, lineage_kind)\n         VALUES ($1, $2, $3, $4, 'model.p.raw_orders', 'id', 'model.p.orders', 'order_id',\n                 'copy')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f6de1512fa3e46883b32d56fd19ffe8aaf6dfe664c330ac8cea51a157a4fe52e"
+}

--- a/backend/windmill-api-assets/src/lib.rs
+++ b/backend/windmill-api-assets/src/lib.rs
@@ -6,6 +6,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sqlx::Row;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use windmill_common::{
     assets::{parse_asset_trigger_ref, AssetKind, AssetUsageKind},
     db::UserDB,
@@ -13,7 +14,9 @@ use windmill_common::{
     utils::escape_ilike_pattern,
 };
 
-use windmill_api_auth::{build_scope_path_predicate, ApiAuthed};
+use windmill_api_auth::{
+    build_scope_path_filter, build_scope_path_predicate, ApiAuthed, ScopePathFilter,
+};
 
 // Partition-range backfill preview. The logic (producer resolution, range
 // enumeration, status join) is enterprise: the `private` build compiles the
@@ -33,6 +36,7 @@ pub fn workspaced_service() -> Router {
         .route("/list_by_usages", post(list_assets_by_usages))
         .route("/list_favorites", get(list_favorites))
         .route("/graph", get(asset_graph))
+        .route("/column_lineage", get(dbt_column_lineage))
         .route("/pipelines", get(list_pipeline_folders))
         .route("/partitions", get(list_partitions))
         .route("/partitions_in_range", get(list_partitions_in_range))
@@ -955,6 +959,442 @@ pub struct AssetGraphResponse {
 struct DbtLineageEdge {
     from_asset_path: String,
     to_asset_path: String,
+}
+
+/// One column-to-column edge, in the same terms: the two relations and the two
+/// columns, never dbt's node ids.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DbtColumnLineageEdge {
+    from_asset_path: String,
+    from_column: String,
+    to_asset_path: String,
+    to_column: String,
+    /// dbt's own word for how the value travelled: `copy` (passthrough), `mod`
+    /// (transformed), `scan` (read to produce the ROW rather than the value — a
+    /// join key, a predicate, a `group by`). Sent verbatim, including a kind
+    /// this engine version invented, because the renderer decides what a kind
+    /// means and the set is the engine's.
+    kind: String,
+}
+
+/// The dbt relations a view is tracing, and which stored graph to read them
+/// from.
+///
+/// Several relations, answered as one union, because ONE selection reaches
+/// several: a script's output column can be derived from columns of several dbt
+/// models, and a model's columns can be consumed by scripts that feed others.
+/// Asking per relation instead is a request per boundary plus the bookkeeping to
+/// stitch the answers together and decide which of them is still current — which
+/// is a cache, and is what taking them together exists to not need.
+pub struct ColumnLineageQuery {
+    /// The `dbt://` relations whose lineage to return.
+    pub asset_paths: Vec<String>,
+    /// The deployed version a view is drawing, when it is drawing one — the dbt
+    /// editor, which shows a single project as of a single deploy.
+    ///
+    /// A version-pinned answer is that version's project ALONE, the same as a
+    /// job-pinned one: the pin exists so the trace describes the stored graph on
+    /// screen, and another project's live graph is not part of it. Only the
+    /// unpinned answer crosses projects.
+    ///
+    /// A run's or an editor buffer's graph is NOT reachable from here: it pins
+    /// to a job, and that costs the job-read gate.
+    pub dbt_script_hash: Option<windmill_common::scripts::ScriptHash>,
+}
+
+impl ColumnLineageQuery {
+    /// Built from the raw pairs rather than deserialized as a struct, because
+    /// `asset_path` REPEATS and `serde_urlencoded` — what `Query` deserializes
+    /// with — reads no sequence from a repeated key. A GET rather than a POST
+    /// body carrying the list: the method decides a scoped token's action, so a
+    /// POST would ask `assets:write` for a read and refuse a read-only token
+    /// outright.
+    pub fn from_query_pairs(pairs: Vec<(String, String)>) -> windmill_common::error::Result<Self> {
+        let mut asset_paths: Vec<String> = Vec::new();
+        let mut dbt_script_hash = None;
+        for (key, value) in pairs {
+            match key.as_str() {
+                "asset_path" => asset_paths.push(value),
+                // Hex, like every other script-hash parameter, so a page can
+                // pass `job.script_hash` verbatim.
+                "dbt_script_hash" => {
+                    dbt_script_hash =
+                        Some(serde_json::from_value(Value::String(value)).map_err(|_| {
+                            windmill_common::error::Error::BadRequest(
+                                "dbt_script_hash is not a script hash".to_string(),
+                            )
+                        })?)
+                }
+                _ => {}
+            }
+        }
+        // REFUSED, not answered empty. A caller that named no relation — or
+        // misspelled the parameter — asked for something, and an empty component
+        // is what a relation with no lineage returns, so answering that way says
+        // "this has none" for a question that was never asked.
+        if asset_paths.is_empty() {
+            return Err(windmill_common::error::Error::BadRequest(
+                "at least one asset_path is required".to_string(),
+            ));
+        }
+        Ok(ColumnLineageQuery { asset_paths, dbt_script_hash })
+    }
+}
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct ColumnLineageResponse {
+    /// Direct (`copy` / `mod`) column edges of the component the asked-for
+    /// relations' columns sit in, in the terms the canvas draws. Empty when no
+    /// project involved asked for the analysis pass, which is the ordinary case.
+    edges: Vec<DbtColumnLineageEdge>,
+    /// The component reaches further than what is here: `edges` holds the part
+    /// nearest the asked-for relations. Said rather than silently cut, because a
+    /// trace that stops short is otherwise indistinguishable from one that ends.
+    truncated: bool,
+}
+
+/// How many edges one trace may carry back. The renderer draws a box per column,
+/// so a component past this is unreadable however it is served — a synthetic
+/// 3000-model project whose models share a column returns 58k direct edges and
+/// 7.3MB. Applied over the walk, which is the LAST filter, so what survives is
+/// the part nearest the selection rather than an arbitrary slice of it.
+const MAX_TRACE_EDGES: usize = 5_000;
+
+/// How many times one trace may discover a project it has not read yet. Each
+/// round costs a gate and a fetch, and a component crossing this many projects
+/// has already outgrown what the canvas can show; stopping says what the edge
+/// bound says.
+const MAX_OWNER_ROUNDS: usize = 8;
+
+/// How many edges one trace may HOLD while walking, as opposed to answer with.
+/// A project's edges arrive whole — the walk decides what is in the component,
+/// so a `LIMIT` on the fetch would cut an arbitrary set that need not even
+/// contain the asked-for relation — and a project is bounded at ingest by
+/// `MAX_COLUMN_EDGES`, which is 200k. Rounds are what this bounds: reading a
+/// second project's worth on top of an already outsized first one buys nothing,
+/// since the walk is going to stop at `MAX_TRACE_EDGES` regardless.
+const MAX_HELD_EDGES: usize = 100_000;
+
+/// A stored project graph: a deployed version, or one job's snapshot of it.
+/// `script_hash` is NULL for an editor buffer's parse, which names no version.
+type ProjectVersion = (String, Option<i64>, uuid::Uuid);
+
+async fn dbt_column_lineage(
+    authed: ApiAuthed,
+    Path(w_id): Path<String>,
+    Extension(user_db): Extension<UserDB>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> JsonResult<ColumnLineageResponse> {
+    // `None`: pinning to one run is job-scoped and this endpoint is authorized
+    // as `assets:read`. See `dbt_column_lineage_for`.
+    let q = ColumnLineageQuery::from_query_pairs(pairs)?;
+    dbt_column_lineage_for(&authed, &w_id, user_db, q, None).await
+}
+
+/// The column-level lineage the asked-for relations sit in, optionally as one
+/// run saw it.
+///
+/// AUTHORIZES NOTHING BY ITSELF, on the same contract as `asset_graph_for`:
+/// `assets:read` always, and the job-read gate for `Some(pinned)`, whose path
+/// and hash are then taken from that job's row rather than from the caller.
+///
+/// A column trace is transitive and a relation is not owned by one project, so
+/// the answer grows a project at a time: resolve who owns the relations reached
+/// so far, read their edges, walk, and repeat for the relations that walk newly
+/// reached. Every round re-applies the caller's gate to the projects it
+/// discovers — a relation being reachable from a project the caller may read
+/// says nothing about the project on the other side of it.
+pub async fn dbt_column_lineage_for(
+    authed: &ApiAuthed,
+    w_id: &str,
+    user_db: UserDB,
+    q: ColumnLineageQuery,
+    pinned: Option<PinnedRun>,
+) -> JsonResult<ColumnLineageResponse> {
+    // A column-level view is the shape of what the author WROTE, so it takes the
+    // model's own gate rather than the relation's.
+    let (scope_all, scope_exact, scope_prefix) =
+        match build_scope_path_filter(authed, "scripts", "read") {
+            ScopePathFilter::AllowAll => (true, Vec::new(), Vec::new()),
+            ScopePathFilter::Restricted { exact, prefix } => (false, exact, prefix),
+        };
+    let (pinned_path, script_hash) = match pinned.as_ref() {
+        // The job's own version, so a pin cannot name one project's run while
+        // claiming another's version — including when it names NONE, which is
+        // the editor buffer.
+        Some(p) => (Some(p.script_path.as_str()), p.script_hash),
+        None => (None, q.dbt_script_hash.map(|h| h.0)),
+    };
+    let pinned_job_id = pinned.as_ref().map(|p| p.job_id);
+
+    let seeds: BTreeSet<String> = q.asset_paths.into_iter().collect();
+    let mut tx = user_db.begin(authed).await?;
+
+    // Relations whose owners have been asked for, project graphs already read,
+    // and the edges they yielded. These are what end the loop: a round asks only
+    // about relations not asked about before and reads only projects not read
+    // before, so it stops as soon as one of the two runs out.
+    let mut asked: HashSet<String> = HashSet::new();
+    let mut read: HashSet<ProjectVersion> = HashSet::new();
+    let mut edges: Vec<DbtColumnLineageEdge> = Vec::new();
+    let mut answer: Vec<DbtColumnLineageEdge> = Vec::new();
+    let mut pending: Vec<String> = seeds.iter().cloned().collect();
+    let mut truncated = false;
+
+    for _ in 0..MAX_OWNER_ROUNDS {
+        if pending.is_empty() {
+            break;
+        }
+        // Which project version owns each of these relations, under this
+        // caller's access. Usually one row per relation; a relation a second
+        // project declares as a source has two, and each answers for its own
+        // lineage.
+        let owners = sqlx::query!(
+            r#"SELECT DISTINCT n.script_path AS "script_path!", n.script_hash, n.job_id AS "job_id!"
+                 FROM dbt_node n
+                WHERE n.workspace_id = $1 AND n.asset_path = ANY($2)
+                  -- The run's snapshot, or the deployed graph when that job stored
+                  -- none -- a build pins only if it wrote one.
+                  AND n.job_id = CASE WHEN $5::uuid IS NOT NULL AND EXISTS (
+                                        SELECT 1 FROM dbt_graph_snapshot g
+                                         WHERE g.workspace_id = $1 AND g.job_id = $5)
+                                      THEN $5::uuid
+                                      ELSE '00000000-0000-0000-0000-000000000000'::uuid END
+                  -- The gate, re-decided for every project the walk reaches. That
+                  -- is what resolving owners in a loop is for: being entitled to
+                  -- one project is not being entitled to the one that declares a
+                  -- relation it hands over.
+                  AND ( $6
+                        OR n.script_path = ANY($7)
+                        OR EXISTS ( SELECT 1 FROM unnest($8::text[]) AS pfx
+                                     WHERE n.script_path = pfx
+                                        OR left(n.script_path, length(pfx) + 1) = pfx || '/' ) )
+                  AND CASE
+                        -- Pinned: which version comes from a job this caller was
+                        -- already granted, so `script` does not decide THAT -- but
+                        -- it still decides whether the project may be read, the
+                        -- same second gate `script_visible` is on the graph. Being
+                        -- entitled to a run is not being entitled to the SQL
+                        -- behind it, and column lineage is that SQL's shape. A
+                        -- version-less row is exempt because it is an editor
+                        -- buffer, which has no `script` row to ask and reaches
+                        -- this only through the parse job that wrote it.
+                        --
+                        -- One project answers, so a pinned trace never crosses
+                        -- into another: neither does the graph it annotates.
+                        WHEN $4::text IS NOT NULL
+                          THEN n.script_path = $4 AND n.script_hash IS NOT DISTINCT FROM $3::bigint
+                               AND ($3::bigint IS NULL OR EXISTS (
+                                     SELECT 1 FROM script sc
+                                      WHERE sc.workspace_id = $1 AND sc.path = n.script_path
+                                        AND sc.hash = $3))
+                        -- A named version: the deployed one an editor is drawing.
+                        -- `script` is read under RLS, so this is the visibility
+                        -- check as well as the existence one. A hash names one
+                        -- script row, so this arm answers for one project too —
+                        -- and deliberately: a pin says which stored graph is on
+                        -- screen, and another project's live graph is not it.
+                        WHEN $3::bigint IS NOT NULL
+                          THEN n.script_hash = $3 AND EXISTS (
+                                 SELECT 1 FROM script sc
+                                  WHERE sc.workspace_id = $1 AND sc.path = n.script_path
+                                    AND sc.hash = $3)
+                        -- Otherwise the version deployed now: an older one's rows
+                        -- outlive it in `dbt_node` until the sweep, and describe a
+                        -- project that is no longer what runs. `language` narrows
+                        -- it the way the graph's own resolution does, so a path
+                        -- that has since become a script of another kind draws and
+                        -- explains the same version rather than disagreeing. Read
+                        -- under RLS, so a project the caller cannot see resolves
+                        -- to NULL and matches nothing.
+                        ELSE n.script_hash = (
+                               SELECT sc.hash FROM script sc
+                                WHERE sc.workspace_id = $1 AND sc.path = n.script_path
+                                  AND sc.language = 'dbt'
+                                  AND sc.deleted = false AND sc.archived = false
+                                ORDER BY sc.created_at DESC LIMIT 1)
+                      END"#,
+            w_id,
+            &pending[..],
+            script_hash,
+            pinned_path,
+            pinned_job_id,
+            scope_all,
+            &scope_exact[..],
+            &scope_prefix[..],
+        )
+        .fetch_all(&mut *tx)
+        .await?;
+        asked.extend(pending.drain(..));
+
+        let fresh: Vec<ProjectVersion> = owners
+            .into_iter()
+            .map(|o| (o.script_path, o.script_hash, o.job_id))
+            .filter(|k| read.insert(k.clone()))
+            .collect();
+        if fresh.is_empty() {
+            break;
+        }
+        let fresh_paths: Vec<String> = fresh.iter().map(|k| k.0.clone()).collect();
+        let fresh_hashes: Vec<Option<i64>> = fresh.iter().map(|k| k.1).collect();
+        let fresh_jobs: Vec<uuid::Uuid> = fresh.iter().map(|k| k.2).collect();
+
+        // DIRECT kinds only. `scan` -- the column was read to produce the ROW,
+        // not the value -- reaches every output column of its model, so it is
+        // most of a project's stored lineage and none of what a trace draws.
+        // It stays in the table for a later view to ask for.
+        let rows = sqlx::query!(
+            r#"SELECT p.asset_path AS "from_path!", e.parent_column AS "from_column!",
+                      c.asset_path AS "to_path!", e.child_column AS "to_column!",
+                      e.lineage_kind AS "kind!"
+                 FROM unnest($2::text[], $3::bigint[], $4::uuid[])
+                        AS o(script_path, script_hash, job_id)
+                 JOIN dbt_column_edge e ON e.workspace_id = $1
+                                       AND e.script_path = o.script_path
+                                       AND e.job_id = o.job_id
+                                       -- `=` still, with the NULL-to-NULL case
+                                       -- spelled out and gated on the pin: a
+                                       -- version-less row's hash is NULL on both
+                                       -- sides, which `=` never matches, but
+                                       -- `IS NOT DISTINCT FROM` would cost the
+                                       -- equality its index bound everywhere else.
+                                       AND (e.script_hash = o.script_hash
+                                            OR ($5::text IS NOT NULL
+                                                AND o.script_hash IS NULL
+                                                AND e.script_hash IS NULL))
+                 JOIN dbt_node p ON p.workspace_id = e.workspace_id
+                                AND p.script_path = e.script_path
+                                AND p.script_hash IS NOT DISTINCT FROM e.script_hash
+                                AND p.job_id = e.job_id
+                                AND p.unique_id = e.parent_unique_id
+                 JOIN dbt_node c ON c.workspace_id = e.workspace_id
+                                AND c.script_path = e.script_path
+                                AND c.script_hash IS NOT DISTINCT FROM e.script_hash
+                                AND c.job_id = e.job_id
+                                AND c.unique_id = e.child_unique_id
+                WHERE e.lineage_kind IN ('copy', 'mod')
+                  AND p.asset_path IS NOT NULL AND c.asset_path IS NOT NULL"#,
+            w_id,
+            &fresh_paths[..],
+            &fresh_hashes[..] as &[Option<i64>],
+            &fresh_jobs[..],
+            pinned_path,
+        )
+        .fetch_all(&mut *tx)
+        .await?;
+
+        edges.extend(rows.into_iter().map(|r| DbtColumnLineageEdge {
+            from_asset_path: r.from_path,
+            from_column: r.from_column,
+            to_asset_path: r.to_path,
+            to_column: r.to_column,
+            kind: r.kind,
+        }));
+        // Two projects can describe one relation, so the same edge can arrive
+        // twice. Sorted as well as deduplicated: the walk reads the incidence
+        // lists in this order, so the answer does not depend on which round a
+        // project was discovered in.
+        edges.sort();
+        edges.dedup();
+
+        let walked = component(&edges, &seeds);
+        answer = walked.edges;
+        truncated = walked.truncated;
+        if truncated {
+            break;
+        }
+        // The relations the walk newly reached. Their owners are the next round's
+        // question: this project declares them, and so may another.
+        pending = answer
+            .iter()
+            .flat_map(|e| [&e.from_asset_path, &e.to_asset_path])
+            .filter(|p| !asked.contains(*p))
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        // Stop discovering projects once the held set is outsized. The tail
+        // below reports what that leaves unresolved, and reports nothing when
+        // the walk had already reached everything.
+        if edges.len() >= MAX_HELD_EDGES {
+            break;
+        }
+    }
+    tx.commit().await?;
+    // Out of rounds with relations still unresolved: more of the component
+    // exists, which is what hitting the edge bound also means.
+    Ok(Json(ColumnLineageResponse {
+        truncated: truncated || !pending.is_empty(),
+        edges: answer,
+    }))
+}
+
+struct WalkedComponent {
+    edges: Vec<DbtColumnLineageEdge>,
+    truncated: bool,
+}
+
+/// The edges of the connected component the asked-for relations sit in, nearest
+/// first and at most `MAX_TRACE_EDGES` of them.
+///
+/// The canvas lays out the component of the selected relation's columns, so a
+/// project's other model families are edges nothing it draws can reach. Walked
+/// here rather than in SQL: a recursive CTE has no index to walk, so it rescans
+/// the whole edge set once per level — measured at 1.24s against 59ms for the
+/// query alone on a 3000-model project, for a walk that is microseconds over a
+/// map. Columns are keyed by relation, not by project, which is how the canvas
+/// keys them too: two projects describing one relation draw one node.
+///
+/// Breadth-first, so the bound cuts the far end of the trace rather than an
+/// arbitrary part of it.
+fn component(edges: &[DbtColumnLineageEdge], seeds: &BTreeSet<String>) -> WalkedComponent {
+    let mut incident: HashMap<(&str, &str), Vec<usize>> = HashMap::new();
+    for (i, e) in edges.iter().enumerate() {
+        incident
+            .entry((&e.from_asset_path, &e.from_column))
+            .or_default()
+            .push(i);
+        incident
+            .entry((&e.to_asset_path, &e.to_column))
+            .or_default()
+            .push(i);
+    }
+    let mut start: Vec<(&str, &str)> = incident
+        .keys()
+        .filter(|(path, _)| seeds.contains(*path))
+        .copied()
+        .collect();
+    start.sort();
+    let mut seen_node: HashSet<(&str, &str)> = start.iter().copied().collect();
+    let mut queue: VecDeque<(&str, &str)> = start.into();
+    let mut taken = vec![false; edges.len()];
+    let mut kept: Vec<usize> = Vec::new();
+    let mut truncated = false;
+    'walk: while let Some(node) = queue.pop_front() {
+        for &i in incident.get(&node).map(Vec::as_slice).unwrap_or_default() {
+            if std::mem::replace(&mut taken[i], true) {
+                continue;
+            }
+            if kept.len() == MAX_TRACE_EDGES {
+                truncated = true;
+                break 'walk;
+            }
+            kept.push(i);
+            let e = &edges[i];
+            let ends = [
+                (e.from_asset_path.as_str(), e.from_column.as_str()),
+                (e.to_asset_path.as_str(), e.to_column.as_str()),
+            ];
+            for end in ends {
+                if seen_node.insert(end) {
+                    queue.push_back(end);
+                }
+            }
+        }
+    }
+    // Back into edge order, so a response does not carry the walk's shape.
+    kept.sort_unstable();
+    WalkedComponent { edges: kept.into_iter().map(|i| edges[i].clone()).collect(), truncated }
 }
 
 async fn asset_graph(

--- a/backend/windmill-api-assets/tests/dbt_pinned_graph.rs
+++ b/backend/windmill-api-assets/tests/dbt_pinned_graph.rs
@@ -8,7 +8,9 @@
 //! whole dbt half, and every later fix in this area re-touched one of the two.
 
 use sqlx::{Pool, Postgres};
-use windmill_api_assets::{asset_graph_for, GraphQuery, PinnedRun};
+use windmill_api_assets::{
+    asset_graph_for, dbt_column_lineage_for, ColumnLineageQuery, GraphQuery, PinnedRun,
+};
 use windmill_api_auth::ApiAuthed;
 use windmill_common::db::UserDB;
 
@@ -76,6 +78,34 @@ async fn seed(db: &Pool<Postgres>, job: uuid::Uuid) {
                    'u/a/wh/analytics/orders', 'select 1', '{finance}', 'daily order facts',
                    '{"order_id": {"description": "natural key"}}'::jsonb,
                    '{"warn_after": {"count": 12, "period": "hour"}}'::jsonb)"#,
+        WS,
+        PATH,
+        HASH,
+        job
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    // The relation it reads, and the column edge between them.
+    sqlx::query!(
+        "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,
+                               resource_type, name, asset_path, tags)
+         VALUES ($1, $2, $3, $4, 'model.p.raw_orders', 'model', 'raw_orders',
+                 'u/a/wh/analytics/raw_orders', '{}')",
+        WS,
+        PATH,
+        HASH,
+        job
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,
+                                      parent_unique_id, parent_column, child_unique_id,
+                                      child_column, lineage_kind)
+         VALUES ($1, $2, $3, $4, 'model.p.raw_orders', 'id', 'model.p.orders', 'order_id',
+                 'copy')",
         WS,
         PATH,
         HASH,
@@ -365,7 +395,25 @@ async fn seed_editor_graph(db: &Pool<Postgres>, job: uuid::Uuid) {
         r#"INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,
                                  resource_type, name, asset_path, raw_code, tags)
            VALUES ($1, $2, NULL, $3, 'model.p.draft', 'model', 'draft',
-                   'u/a/wh/analytics/draft', 'select 3', '{}')"#,
+                   'u/a/wh/analytics/draft', 'select 3', '{}'),
+                  ($1, $2, NULL, $3, 'model.p.draft_src', 'model', 'draft_src',
+                   'u/a/wh/analytics/draft_src', 'select 4', '{}')"#,
+        WS,
+        PATH,
+        job
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    // A version-less row's `script_hash` is NULL on both sides of every join and
+    // every visibility check, and `= NULL` is never true — so the column edges
+    // need the same NULL arm the node query has, or a buffer parse renders its
+    // columns and none of their lineage.
+    sqlx::query!(
+        "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,
+                                      parent_unique_id, parent_column, child_unique_id,
+                                      child_column, lineage_kind)
+         VALUES ($1, $2, NULL, $3, 'model.p.draft_src', 'raw', 'model.p.draft', 'clean', 'mod')",
         WS,
         PATH,
         job
@@ -450,4 +498,445 @@ async fn an_editor_graph_renders_only_through_its_own_job(db: Pool<Postgres>) {
         !deployed_run.contains("u/a/wh/analytics/draft"),
         "nor of a run of the deployed version: {deployed_run}"
     );
+}
+
+async fn column_lineage_q(
+    db: &Pool<Postgres>,
+    authed: &ApiAuthed,
+    pairs: Vec<(String, String)>,
+    pinned: Option<PinnedRun>,
+) -> serde_json::Value {
+    let res = dbt_column_lineage_for(
+        authed,
+        WS,
+        UserDB::new(db.clone()),
+        ColumnLineageQuery::from_query_pairs(pairs).unwrap(),
+        pinned,
+    )
+    .await
+    .unwrap();
+    serde_json::to_value(&res.0).unwrap()
+}
+
+async fn column_lineage(
+    db: &Pool<Postgres>,
+    authed: &ApiAuthed,
+    asset_paths: &[&str],
+    pinned: Option<PinnedRun>,
+) -> serde_json::Value {
+    let pairs = asset_paths
+        .iter()
+        .map(|p| ("asset_path".to_string(), p.to_string()))
+        .collect();
+    column_lineage_q(db, authed, pairs, pinned).await
+}
+
+/// The buffer parse's own lineage, which is the case the versionless rows exist
+/// for. Its `script_hash` is NULL on both sides of every join and every
+/// visibility check, and `= NULL` is never true — so the versionless arm has to
+/// be written for it, or a parse renders its columns and none of their lineage.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn an_editor_buffers_column_lineage_answers_through_its_job(db: Pool<Postgres>) {
+    let parse = uuid::Uuid::from_u128(9);
+    seed(&db, uuid::Uuid::from_u128(7)).await;
+    seed_editor_graph(&db, parse).await;
+    let admin = ApiAuthed { is_admin: true, ..outsider() };
+
+    let pinned = PinnedRun { job_id: parse, script_path: PATH.to_string(), script_hash: None };
+    assert_eq!(
+        column_lineage(&db, &admin, &["u/a/wh/analytics/draft"], Some(pinned)).await["edges"],
+        serde_json::json!([{
+            "from_asset_path": "u/a/wh/analytics/draft_src",
+            "from_column": "raw",
+            "to_asset_path": "u/a/wh/analytics/draft",
+            "to_column": "clean",
+            "kind": "mod",
+        }]),
+    );
+    // Unpinned, the same relation resolves through the deployed version, which
+    // never heard of the buffer's models.
+    assert_eq!(
+        column_lineage(&db, &admin, &["u/a/wh/analytics/draft"], None).await["edges"],
+        serde_json::json!([]),
+        "a buffer's lineage is reachable only through the job that parsed it"
+    );
+}
+
+/// Being entitled to a RUN is not being entitled to the SQL behind it, and
+/// column lineage is that SQL's shape. The pinned graph draws the relations for
+/// a share-link viewer and redacts what the author wrote; the lineage is the
+/// second, and resolving the version from the job must not be mistaken for
+/// deciding that too.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn a_pinned_run_does_not_hand_over_the_projects_column_lineage(db: Pool<Postgres>) {
+    let job = uuid::Uuid::from_u128(7);
+    seed(&db, job).await;
+    let pinned =
+        || PinnedRun { job_id: job, script_path: PATH.to_string(), script_hash: Some(HASH) };
+
+    assert_eq!(
+        column_lineage(
+            &db,
+            &outsider(),
+            &["u/a/wh/analytics/orders"],
+            Some(pinned())
+        )
+        .await["edges"],
+        serde_json::json!([]),
+        "the run renders for them, its column-level shape does not"
+    );
+    assert_eq!(
+        column_lineage(
+            &db,
+            &ApiAuthed { is_admin: true, ..outsider() },
+            &["u/a/wh/analytics/orders"],
+            Some(pinned())
+        )
+        .await["edges"],
+        serde_json::json!([{
+            "from_asset_path": "u/a/wh/analytics/raw_orders",
+            "from_column": "id",
+            "to_asset_path": "u/a/wh/analytics/orders",
+            "to_column": "order_id",
+            "kind": "copy",
+        }]),
+        "while a reader of the project gets it"
+    );
+}
+
+/// The deployed version of the same two models, plus a `scan` edge beside the
+/// direct one: `seed`'s rows are a run's snapshot, and the unpinned answer is
+/// the version's own graph.
+async fn seed_deployed_orders(db: &Pool<Postgres>) {
+    sqlx::query!(
+        "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,
+                               resource_type, name, asset_path, tags)
+         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'model.p.raw_orders',
+                 'model', 'raw_orders', 'u/a/wh/analytics/raw_orders', '{}'),
+                ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'model.p.orders',
+                 'model', 'orders', 'u/a/wh/analytics/orders', '{}')",
+        WS,
+        PATH,
+        HASH,
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,
+                                      parent_unique_id, parent_column, child_unique_id,
+                                      child_column, lineage_kind)
+         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000',
+                 'model.p.raw_orders', 'id', 'model.p.orders', 'order_id', 'copy'),
+                ($1, $2, $3, '00000000-0000-0000-0000-000000000000',
+                 'model.p.raw_orders', 'status', 'model.p.orders', 'order_id', 'scan')",
+        WS,
+        PATH,
+        HASH,
+    )
+    .execute(db)
+    .await
+    .unwrap();
+}
+
+/// A column-level view is the shape of what the author WROTE, so it takes the
+/// script's own gate — the same one that keeps `raw_code` behind access to the
+/// project. `scan` says the column was read to produce the ROW rather than the
+/// value, so it reaches every output column of its model and is never served.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn column_lineage_takes_the_scripts_gate_and_only_the_direct_kinds(db: Pool<Postgres>) {
+    seed(&db, uuid::Uuid::from_u128(7)).await;
+    seed_deployed_orders(&db).await;
+
+    let admin = ApiAuthed { is_admin: true, ..outsider() };
+    assert_eq!(
+        column_lineage(&db, &admin, &["u/a/wh/analytics/orders"], None).await["edges"],
+        serde_json::json!([{
+            "from_asset_path": "u/a/wh/analytics/raw_orders",
+            "from_column": "id",
+            "to_asset_path": "u/a/wh/analytics/orders",
+            "to_column": "order_id",
+            "kind": "copy",
+        }]),
+        "the direct edge, and not the `scan` one beside it"
+    );
+    assert_eq!(
+        column_lineage(&db, &outsider(), &["u/a/wh/analytics/orders"], None).await["edges"],
+        serde_json::json!([]),
+        "and nothing at all for a caller who cannot read the project"
+    );
+}
+
+/// One project routinely holds model families that share no column, and the
+/// canvas lays out the connected component of the selected relation's columns.
+/// Answering with the project's other components sends edges nothing can draw.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn column_lineage_stops_at_the_selected_relations_component(db: Pool<Postgres>) {
+    let job = uuid::Uuid::from_u128(7);
+    seed(&db, job).await;
+    // A second family in the same project version, reaching neither of the two
+    // relations `seed` wired together.
+    sqlx::query!(
+        "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,
+                               resource_type, name, asset_path, tags)
+         VALUES ($1, $2, $3, $4, 'model.p.stock', 'model', 'stock',
+                 'u/a/wh/analytics/stock', '{}'),
+                ($1, $2, $3, $4, 'model.p.stock_daily', 'model', 'stock_daily',
+                 'u/a/wh/analytics/stock_daily', '{}')",
+        WS,
+        PATH,
+        HASH,
+        job
+    )
+    .execute(&db)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,
+                                      parent_unique_id, parent_column, child_unique_id,
+                                      child_column, lineage_kind)
+         VALUES ($1, $2, $3, $4, 'model.p.stock', 'sku', 'model.p.stock_daily', 'sku', 'copy')",
+        WS,
+        PATH,
+        HASH,
+        job
+    )
+    .execute(&db)
+    .await
+    .unwrap();
+
+    let admin = ApiAuthed { is_admin: true, ..outsider() };
+    let pinned =
+        || PinnedRun { job_id: job, script_path: PATH.to_string(), script_hash: Some(HASH) };
+    assert_eq!(
+        column_lineage(&db, &admin, &["u/a/wh/analytics/orders"], Some(pinned())).await["edges"],
+        serde_json::json!([{
+            "from_asset_path": "u/a/wh/analytics/raw_orders",
+            "from_column": "id",
+            "to_asset_path": "u/a/wh/analytics/orders",
+            "to_column": "order_id",
+            "kind": "copy",
+        }]),
+        "the orders family, and not the stock one beside it in the same project"
+    );
+    assert_eq!(
+        column_lineage(
+            &db,
+            &admin,
+            &["u/a/wh/analytics/stock_daily"],
+            Some(pinned())
+        )
+        .await["edges"],
+        serde_json::json!([{
+            "from_asset_path": "u/a/wh/analytics/stock",
+            "from_column": "sku",
+            "to_asset_path": "u/a/wh/analytics/stock_daily",
+            "to_column": "sku",
+            "kind": "copy",
+        }]),
+        "and the other way round — reached from the child end, which is upstream"
+    );
+}
+
+/// A deployed dbt project in `folder`, declaring `parent`'s relation as a source
+/// and deriving `child` from it. `orders → mart → secret_out` is three projects
+/// chained through two shared relations.
+async fn seed_neighbour_project(
+    db: &Pool<Postgres>,
+    folder: &str,
+    hash: i64,
+    parent: (&str, &str),
+    child: (&str, &str),
+) {
+    let path = format!("f/{folder}/proj");
+    sqlx::query!(
+        "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms)
+         VALUES ($1, $2, $2, '{}', '{}')",
+        WS,
+        folder
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "INSERT INTO script (workspace_id, hash, path, summary, description, content,
+                             created_by, language, lock)
+         VALUES ($1, $2, $3, '', '', 'profile: {}', 'test-user', 'dbt', '')",
+        WS,
+        hash,
+        path,
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "INSERT INTO dbt_node (workspace_id, script_path, script_hash, job_id, unique_id,
+                               resource_type, name, asset_path, tags)
+         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'source.q.' || $4,
+                 'source', $4, $5, '{}'),
+                ($1, $2, $3, '00000000-0000-0000-0000-000000000000', 'model.q.' || $6,
+                 'model', $6, $7, '{}')",
+        WS,
+        path,
+        hash,
+        parent.0,
+        parent.1,
+        child.0,
+        child.1,
+    )
+    .execute(db)
+    .await
+    .unwrap();
+    sqlx::query!(
+        "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,
+                                      parent_unique_id, parent_column, child_unique_id,
+                                      child_column, lineage_kind)
+         VALUES ($1, $2, $3, '00000000-0000-0000-0000-000000000000',
+                 'source.q.' || $4, 'k', 'model.q.' || $5, 'k', 'copy')",
+        WS,
+        path,
+        hash,
+        parent.0,
+        child.0,
+    )
+    .execute(db)
+    .await
+    .unwrap();
+}
+
+/// A trace crosses out of the project it started in, and the gate crosses with
+/// it.
+///
+/// A relation one project produces is another's source, so the component reaches
+/// edges the first project's owner set never named — that is what resolving
+/// owners to a fixpoint is for. The other half is that the caller's access has
+/// to be re-decided for each project discovered on the way: reaching a relation
+/// says nothing about who may read the project on the far side of it.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn column_lineage_crosses_projects_only_where_the_caller_may_read_them(db: Pool<Postgres>) {
+    seed(&db, uuid::Uuid::from_u128(7)).await;
+    seed_deployed_orders(&db).await;
+    seed_neighbour_project(
+        &db,
+        "mid",
+        43,
+        ("orders", "u/a/wh/analytics/orders"),
+        ("mart", "u/a/wh/analytics/mart"),
+    )
+    .await;
+    seed_neighbour_project(
+        &db,
+        "secret",
+        44,
+        ("mart", "u/a/wh/analytics/mart"),
+        ("secret_out", "u/a/wh/analytics/secret_out"),
+    )
+    .await;
+
+    let admin = ApiAuthed { is_admin: true, ..outsider() };
+    let reached = |body: &serde_json::Value| {
+        body["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["to_asset_path"].as_str().unwrap().to_string())
+            .collect::<std::collections::BTreeSet<_>>()
+    };
+
+    let all = column_lineage(&db, &admin, &["u/a/wh/analytics/orders"], None).await;
+    assert_eq!(
+        reached(&all),
+        [
+            "u/a/wh/analytics/mart",
+            "u/a/wh/analytics/orders",
+            "u/a/wh/analytics/secret_out"
+        ]
+        .map(String::from)
+        .into(),
+        "two projects out from the one asked about, not one: {all}"
+    );
+
+    // Granted the first two folders and not the third. The edges of the project
+    // they may read are theirs; the one beyond it is not, even though the
+    // relation joining them is in the answer.
+    let partial = ApiAuthed {
+        folders: vec![
+            ("private".to_string(), false, false),
+            ("mid".to_string(), false, false),
+        ],
+        ..outsider()
+    };
+    let some = column_lineage(&db, &partial, &["u/a/wh/analytics/orders"], None).await;
+    assert_eq!(
+        reached(&some),
+        ["u/a/wh/analytics/mart", "u/a/wh/analytics/orders"]
+            .map(String::from)
+            .into(),
+        "the trace stops where the caller's access does: {some}"
+    );
+
+    // The other half of the same gate, and the half that is hand-written SQL
+    // rather than RLS: a token scoped to one folder reaches the projects in it
+    // and no others, whatever its grants say.
+    let scoped = ApiAuthed {
+        is_admin: true,
+        scopes: Some(vec!["scripts:read:f/private/*".to_string()]),
+        ..outsider()
+    };
+    let scoped = column_lineage(&db, &scoped, &["u/a/wh/analytics/orders"], None).await;
+    assert_eq!(
+        reached(&scoped),
+        ["u/a/wh/analytics/orders"].map(String::from).into(),
+        "and where its scope does: {scoped}"
+    );
+
+    // A version pin answers for that version's project alone — the dbt editor,
+    // which draws one project as of one deploy. Crossing into `mid` here would
+    // annotate that canvas with relations it does not draw.
+    let pinned_version = column_lineage_q(
+        &db,
+        &admin,
+        vec![
+            (
+                "asset_path".to_string(),
+                "u/a/wh/analytics/orders".to_string(),
+            ),
+            ("dbt_script_hash".to_string(), format!("{:016x}", HASH)),
+        ],
+        None,
+    )
+    .await;
+    assert_eq!(
+        reached(&pinned_version),
+        ["u/a/wh/analytics/orders"].map(String::from).into(),
+        "a version pin does not cross into the project beside it: {pinned_version}"
+    );
+}
+
+/// The bound on the answer, and that hitting it is said rather than silently
+/// cut: a trace that stops reads exactly like one that ends.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn a_component_past_the_bound_is_cut_and_says_so(db: Pool<Postgres>) {
+    seed(&db, uuid::Uuid::from_u128(7)).await;
+    seed_deployed_orders(&db).await;
+    // One direct edge per column pair, more of them than a trace may carry.
+    sqlx::query!(
+        "INSERT INTO dbt_column_edge (workspace_id, script_path, script_hash, job_id,
+                                      parent_unique_id, parent_column, child_unique_id,
+                                      child_column, lineage_kind)
+         SELECT $1, $2, $3, '00000000-0000-0000-0000-000000000000',
+                'model.p.raw_orders', 'c' || i, 'model.p.orders', 'c' || i, 'copy'
+           FROM generate_series(1, 6000) i",
+        WS,
+        PATH,
+        HASH,
+    )
+    .execute(&db)
+    .await
+    .unwrap();
+
+    let admin = ApiAuthed { is_admin: true, ..outsider() };
+    let body = column_lineage(&db, &admin, &["u/a/wh/analytics/orders"], None).await;
+    assert_eq!(body["edges"].as_array().unwrap().len(), 5000);
+    assert_eq!(body["truncated"], serde_json::json!(true));
 }

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -24445,6 +24445,68 @@ paths:
               schema:
                 $ref: "#/components/schemas/AssetGraph"
 
+  /w/{workspace}/assets/column_lineage:
+    get:
+      summary: Column-level lineage of a set of dbt relations
+      description: >
+        The direct (`copy` / `mod`) column-to-column lineage the given relations'
+        columns sit in — the connected component around them, from the engine's
+        static analysis. Not their own edges, which would stop one hop out since
+        a column trace walks transitively, and not a whole project's, which
+        carries model families the selection cannot reach.
+
+        Several relations, answered as one union, because one selection reaches
+        several: a script's output column can derive from columns of several dbt
+        models. Unpinned, the component crosses projects — a relation one project
+        produces is another's source — and the caller's access is decided again
+        for every project it reaches, so a trace ends where their grants do. A
+        pinned answer, by version here or by job on the run route, is one
+        project's.
+
+        Its own endpoint rather than a field on the asset graph: the graph is
+        folder-wide and polled by a run page, while this is rendered for one
+        selection at a time. Empty for projects that did not opt into the
+        analysis pass (`column_lineage: true`), which is the ordinary case. The
+        indirect `scan` kind is stored but never served: it reaches every output
+        column of its model.
+      operationId: getDbtColumnLineage
+      tags:
+        - asset
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: asset_path
+          in: query
+          required: true
+          description: >
+            The `dbt://` relations whose lineage to return. Repeated, once per
+            relation, and answered as one union.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: dbt_script_hash
+          in: query
+          description: >
+            The deployed version a view is drawing, when it is drawing one — the
+            dbt editor, which shows a single project as of a single deploy. A
+            version-pinned answer is that version's project alone, the same as a
+            job-pinned one, and only the unpinned answer crosses projects: a pin
+            says which stored graph is on screen, and another project's live
+            graph is not part of it.
+
+            A run's or an editor buffer's own graph is not reachable here: that
+            pins to a job, and costs the job-read gate — see
+            `jobs/dbt_column_lineage/{id}`.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: the relations' column-level lineage
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DbtColumnLineage"
+
   /w/{workspace}/assets/macros:
     get:
       summary: List every workspace DuckDB macro (deployed `// macros` libraries)
@@ -24635,6 +24697,49 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AssetGraph"
+
+  /w/{workspace}/jobs/dbt_column_lineage/{id}:
+    get:
+      summary: Get relations' project column lineage as one run saw it
+      description: >
+        The same answer as `assets/column_lineage`, for the project version a
+        single job ran — including the dbt editor's parse of its own buffer,
+        whose graph belongs to that job and is reachable no other way. One
+        project answers here, the one the run is of, since the graph this
+        annotates is that project's too. Authorized through the job, the same
+        gate as `dbt_graph`. Reaching the run is not on its own enough to read
+        the project: a caller with no access to the script gets its relations and
+        `ref()` edges from `dbt_graph` and an empty answer here, exactly as that
+        endpoint redacts the model's SQL.
+      operationId: getDbtRunColumnLineage
+      tags:
+        - job
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: id
+          in: path
+          required: true
+          description: The job whose graph the lineage is read from
+          schema:
+            type: string
+            format: uuid
+        - name: asset_path
+          in: query
+          required: true
+          description: >
+            The `dbt://` relations whose lineage to return. Repeated, once per
+            relation, and answered as one union.
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: the relations' column-level lineage
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DbtColumnLineage"
 
   /w/{workspace}/jobs/run_progress/{id}:
     get:
@@ -26229,6 +26334,40 @@ components:
             drawn identically and the ambiguity would otherwise just move into
             the editor. Omitted for the unpinned workspace graph, which spans
             every project and so has no one time.
+    DbtColumnLineage:
+      type: object
+      description: >-
+        The direct column-to-column lineage the asked-for relations' columns sit
+        in — the connected component around them — in the terms the canvas draws:
+        relations and columns, never dbt's node ids.
+      required: [edges, truncated]
+      properties:
+        edges:
+          type: array
+          items:
+            type: object
+            required: [from_asset_path, from_column, to_asset_path, to_column, kind]
+            properties:
+              from_asset_path:
+                type: string
+              from_column:
+                type: string
+              to_asset_path:
+                type: string
+              to_column:
+                type: string
+              kind:
+                type: string
+                description: >-
+                  dbt's own word for how the value travelled — `copy`
+                  (passthrough) or `mod` (transformed). Not an enum: the engine
+                  treats the set as open.
+        truncated:
+          type: boolean
+          description: >-
+            The component reaches further than `edges`, which holds the part
+            nearest the asked-for relations. A trace that stops short is
+            otherwise indistinguishable from one that ends.
     DbtAssetProvenance:
       type: object
       description: >-

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -139,6 +139,7 @@ pub fn workspaced_service() -> Router {
         .route("/run_progress/{id}", get(get_run_progress))
         .route("/run_assets/{id}", get(list_run_assets))
         .route("/dbt_graph/{id}", get(get_dbt_run_graph))
+        .route("/dbt_column_lineage/{id}", get(get_dbt_run_column_lineage))
         .route("/dbt_resumable/{id}", get(get_dbt_resumable))
         .route(
             "/dbt_resumable_script/p/{*script_path}",
@@ -891,21 +892,27 @@ struct AssetProgress {
     error: Option<String>,
 }
 
-/// The asset graph as one run saw it. Pinning to a job needs the full job-read
-/// contract, so it lives on `require_job_read_access` here rather than as a
-/// parameter on `/assets/graph`. See docs/dbt-runtime.md.
-async fn get_dbt_run_graph(
-    authed: ApiAuthed,
-    OptViewToken(view_token): OptViewToken,
-    Extension(db): Extension<DB>,
-    Extension(user_db): Extension<UserDB>,
-    Path((w_id, job_id)): Path<(String, Uuid)>,
-    Query(q): Query<windmill_api_assets::GraphQuery>,
-) -> error::JsonResult<windmill_api_assets::AssetGraphResponse> {
+/// Which project version a dbt view pins to for this job, once the caller has
+/// been shown to be entitled to it.
+///
+/// `Ok(None)` is "answer unpinned", not a refusal: a job that stored no graph of
+/// its own — and one that has aged out of retention — is served the deployed
+/// version rather than an error, so a run page keeps drawing after the run is
+/// gone. Pinning needs the full job-read contract, which is why it lives on
+/// `require_job_read_access` here rather than as a parameter on `/assets/*`.
+/// See docs/dbt-runtime.md.
+async fn dbt_pinned_run(
+    authed: &ApiAuthed,
+    db: &DB,
+    user_db: &UserDB,
+    w_id: &str,
+    job_id: Uuid,
+    view_token: Option<&str>,
+) -> error::Result<Option<windmill_api_assets::PinnedRun>> {
     // The scope domain comes from the URL segment, so `/jobs` asks a scoped token
     // for `jobs:read` alone while the body returned is asset data. Both are
     // required: the job gate below reaches this run, this reaches assets at all.
-    check_scopes(&authed, || "assets:read".to_string())?;
+    check_scopes(authed, || "assets:read".to_string())?;
     let job = sqlx::query!(
         r#"SELECT created_by, runnable_path,
                 CASE WHEN kind = 'script' THEN runnable_id END AS script_hash,
@@ -918,40 +925,68 @@ async fn get_dbt_run_graph(
                            AND g.script_hash IS NULL) AS "editor_graph!"
            FROM v2_job WHERE id = $1 AND workspace_id = $2"#,
         job_id,
-        &w_id
+        w_id
     )
-    .fetch_optional(&db)
+    .fetch_optional(db)
     .await?;
-    // No such job: answer the unpinned graph rather than 404, so a run page whose
-    // job has aged out of retention still draws the deployed version instead of
-    // an error. Reachable only with `assets:read`, which is exactly what
-    // `/assets/graph` would have cost for the same answer.
+    // Unpinned rather than 404 for a job that is gone. Reachable only with
+    // `assets:read`, which is exactly what the unpinned route would have cost
+    // for the same answer.
     let Some(job) = job else {
-        return windmill_api_assets::asset_graph_for(&authed, &w_id, user_db, db, q, None).await;
+        return Ok(None);
     };
     require_job_read_access(
-        &db,
-        &user_db,
-        &authed,
-        &w_id,
+        db,
+        user_db,
+        authed,
+        w_id,
         &job_id,
         &job.created_by,
-        view_token.as_deref(),
+        view_token,
     )
     .await?;
     // A preview or flow job names no deployed version, so there is usually no
     // graph to pin to and the workspace one answers. The exception is a job that
     // parsed one itself, which is what the dbt editor's refresh is: its graph
     // belongs to that job alone and nothing else can reach it.
-    let pinned = job
+    Ok(job
         .runnable_path
         .filter(|_| job.script_hash.is_some() || job.editor_graph)
         .map(|path| windmill_api_assets::PinnedRun {
             job_id,
             script_path: path,
             script_hash: job.script_hash,
-        });
+        }))
+}
+
+/// The asset graph as one run saw it.
+async fn get_dbt_run_graph(
+    authed: ApiAuthed,
+    OptViewToken(view_token): OptViewToken,
+    Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
+    Path((w_id, job_id)): Path<(String, Uuid)>,
+    Query(q): Query<windmill_api_assets::GraphQuery>,
+) -> error::JsonResult<windmill_api_assets::AssetGraphResponse> {
+    let pinned =
+        dbt_pinned_run(&authed, &db, &user_db, &w_id, job_id, view_token.as_deref()).await?;
     windmill_api_assets::asset_graph_for(&authed, &w_id, user_db, db, q, pinned).await
+}
+
+/// The column lineage a set of relations sits in as one run saw it — the same
+/// pin as `get_dbt_run_graph`, for the trace drawn beside a node of that graph.
+async fn get_dbt_run_column_lineage(
+    authed: ApiAuthed,
+    OptViewToken(view_token): OptViewToken,
+    Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
+    Path((w_id, job_id)): Path<(String, Uuid)>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> error::JsonResult<windmill_api_assets::ColumnLineageResponse> {
+    let q = windmill_api_assets::ColumnLineageQuery::from_query_pairs(pairs)?;
+    let pinned =
+        dbt_pinned_run(&authed, &db, &user_db, &w_id, job_id, view_token.as_deref()).await?;
+    windmill_api_assets::dbt_column_lineage_for(&authed, &w_id, user_db, q, pinned).await
 }
 
 /// Whether a `dbt retry` submitted by this caller would resume THIS run.

--- a/docs/dbt-runtime.md
+++ b/docs/dbt-runtime.md
@@ -435,7 +435,9 @@ Two things make that safe rather than a widening:
   model set and its relations are already visible to them.
 - **`raw_code` is gated separately**, on an `EXISTS` against `script` in the
   authed transaction. The body of a model is the project's source code and stays
-  behind access to the project, whatever the shape query resolved.
+  behind access to the project, whatever the shape query resolved. `column_schema`
+  and the column trace behind `/jobs/dbt_column_lineage/{id}` take the same gate,
+  for the same reason: both are the shape of what the author wrote.
 
 The path and hash coming from the job row rather than the query also means a
 caller cannot pin one project's version while naming another's run.
@@ -1647,18 +1649,65 @@ table is `ref()` lineage. The typed column list lands in
 `dbt_node.column_schema`, beside `columns` rather than merged into it —
 `columns` stays what the author *declared*.
 
-**Stored now, served later.** This change lands the ingest and the storage; the
-endpoint that draws a column trace is a follow-up. What is user-visible today is
-`column_schema` — every column of a relation, typed and in the order the model
-emits them — which rides the asset graph the details pane already fetches, and
-replaces a panel that could only list the columns an author happened to document.
-The edges sit in `dbt_column_edge` waiting for their surface.
+Two things are user-visible. `column_schema` — every column of a relation, typed
+and in the order the model emits them — rides the asset graph the details pane
+already fetches, and replaces a panel that could only list the columns an author
+happened to document. The edges are served by an endpoint of their own,
+`assets/column_lineage`, which the pane asks for the selection it is drawing.
 
-`column_schema` is gated on being able to read the producing project, like the
-model's SQL: a column-level view is the shape of what the author wrote, one level
-finer than the `ref()` graph, which is ungated only because it draws relations the
-caller already sees. A share-link viewer entitled to a dbt run therefore gets its
+Both are gated on being able to read the producing project, like the model's SQL:
+a column-level view is the shape of what the author wrote, one level finer than
+the `ref()` graph, which is ungated only because it draws relations the caller
+already sees. A share-link viewer entitled to a dbt run therefore gets its
 relations and `ref()` edges, and neither the SQL nor the columns.
+
+**One request per selection, and the gate re-decided per project.** The endpoint
+takes every relation the view has reached and answers their union, because one
+selection reaches several — a script's output column can derive from columns of
+several models. Holding partial answers between selections instead was tried and
+is what a client cache is: it produced a wrong premise for a relation two projects
+describe, then staleness on redeploy, then a lost retry.
+
+The answer is the connected component around those relations, and that component
+does not stop at the project that owns them: a relation one project produces is
+another's source, so the walk resolves owners, reads their edges, walks, and
+repeats for the relations that walk newly reached. Resolving once — for the
+relations asked about — stops the trace at the first project boundary. The
+security half is that a project reached this way is a project the caller may not
+be entitled to, so the scope filter and the project's visibility are re-applied to
+every project the expansion discovers, not decided once for the first owner set.
+
+A PINNED answer is the exception and needs none of it, whether it names a job or
+a deployed version: the pin says which stored graph is on screen, and another
+project's live graph is not part of it, so it answers for that one project. The
+dbt editor pins by version on every selection and the run page pins by job; the
+pipeline page pins nothing, and is where the walk crosses projects.
+
+**The component is bounded, and says when it was cut.** The renderer draws a box
+per column, so a component past a few thousand edges is unreadable however it is
+served — a synthetic 3000-model project whose models share a column returns 58k
+direct edges and 7.3MB. The walk is breadth-first from the asked-for relations and
+stops at 5000 edges, so what survives is the part nearest the selection rather
+than an arbitrary slice, and `truncated` says so: a trace that stops short is
+otherwise indistinguishable from one that ends. The FETCH is not bounded the same
+way — a project's edges arrive whole, because the walk is what decides which of
+them are in the component, and a `LIMIT` would cut a set that need not contain
+the asked-for relation at all. What bounds it is the ingest's own cap per version
+plus a stop on discovering further projects once the held set is outsized.
+
+The walk is in Rust rather than a recursive CTE. `EXPLAIN ANALYZE` on that same
+project measured 1243ms against 59ms for the query alone: a CTE has no index to
+walk, so the recursive term rescans the doubled edge set once per level (11.7M
+rows), while the same walk over a map is microseconds.
+
+The two halves of a trace — dbt's and the pipeline's — meet at shared node ids. A
+DuckDB script's `// column x <- dbt://wh/s/model.col` mints the same
+`(dbt, path, column)` node dbt's own lineage does, so the producer graph the asset
+graph already carries and the dbt graph are MERGED rather than chosen between, and
+a trace crosses that boundary in either direction. What the browser cannot close
+in one request is a relation the server discovers whose columns are consumed by a
+script that writes into a third project: the producer half of that hop is the
+canvas's, not the server's, and the seeds were computed before the answer arrived.
 
 **The analysis pass takes the build's own `--full-refresh`.** `is_incremental()`
 branches on it, so an incremental model reading `{{ this }}` compiles its
@@ -1691,7 +1740,7 @@ the compile that produced it, and a run that re-ingests describes its own run.
 | `unique`/`not_null`/`accepted_values`/`relationships` | `data_tests` | exact 1:1 with the four `// data_test` kinds |
 | declared column metadata | `columns` on the asset node | descriptions only, from the manifest |
 | analyzed column schema | `column_schema` on the asset node | `dbt.node_columns.parquet`, opt-in |
-| column-to-column lineage | `dbt_column_edge` rows (no view yet) | `dbt.column_lineage.parquet`, opt-in |
+| column-to-column lineage | `dbt_column_edge` rows, drawn as a column trace | `dbt.column_lineage.parquet`, opt-in |
 | model `tags` | node badge | `tag` |
 | source freshness | `freshness` | `last_success_at` chip |
 | `run_results.json` | materialization records | `record_materialization` |

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -36,7 +36,8 @@
 		type ColumnLineage,
 		type PipelineAnnotations
 	} from './parsePipelineAnnotations'
-	import ColumnLineageTrace from './ColumnLineageTrace.svelte'
+	import ColumnTraceSection from './ColumnTraceSection.svelte'
+	import DbtColumnList from './DbtColumnList.svelte'
 	import { extractDraftMacros } from './resolveGraph'
 	import { assetColumnNodes, type ColumnLineageGraph } from './columnLineageGraph'
 	import SummaryPathDisplay from '$lib/components/SummaryPathDisplay.svelte'
@@ -156,6 +157,12 @@
 		// resolved graph). Drives the transitive column-lineage trace shown for a
 		// selected materialized asset.
 		selectionColumnGraph?: ColumnLineageGraph
+		/** That graph still being fetched — a dbt relation's lineage is a request
+		 *  of its own, so it arrives after the selection does. */
+		selectionColumnLoading?: boolean
+		/** The lineage reaches past what the graph holds: the API cut it at the
+		 *  part nearest the selection. */
+		selectionColumnTruncated?: boolean
 		/** dbt provenance of the selected relation, when a dbt project
 		 *  materializes it — carries the model's own SQL. */
 		selectionDbt?: DbtAssetProvenance
@@ -289,6 +296,8 @@
 		onScriptRemoved,
 		selectionProducers = [],
 		selectionColumnGraph,
+		selectionColumnLoading = false,
+		selectionColumnTruncated = false,
 		selectionDbt,
 		schemaCanEvolve = true,
 		selectionForkMaterialization = undefined,
@@ -445,6 +454,19 @@
 		const scripts = selectionProducers.filter((p) => p.kind === 'script')
 		return scripts.length === 1 ? `${scripts[0].path}__dbt/${file}` : file
 	})
+
+	// The two things a dbt relation can show besides its SQL, and what decides
+	// whether the panel opens at all for one that has none: the columns the model
+	// produces, and the trace they sit in. A share-link viewer gets neither —
+	// both are gated on reading the project, like the SQL.
+	let selectionDbtHasColumns = $derived(
+		!!selectionDbt?.column_schema?.length || Object.keys(selectionDbt?.columns ?? {}).length > 0
+	)
+	let selectionColumnNodes = $derived(
+		selection?.kind === 'asset' && selectionColumnGraph
+			? assetColumnNodes(selectionColumnGraph, selection.asset_kind, selection.path)
+			: []
+	)
 
 	// Bound from ScriptEditor — populated by inferAssets on every code
 	// change. Forwarded to the page so the canvas can re-derive write
@@ -1221,22 +1243,20 @@
 												</span>
 											</div>
 										{/if}
-										{#if selectionColumnGraph && assetColumnNodes(selectionColumnGraph, selection.asset_kind, selection.path).length > 0}
-											<div class="border-b shrink-0">
-												<ColumnLineageTrace
-													graph={selectionColumnGraph}
-													assetKind={selection.asset_kind}
-													assetPath={selection.path}
-													targetLabel={selection.path}
-												/>
-											</div>
-										{/if}
+										<ColumnTraceSection
+											graph={selectionColumnGraph}
+											assetKind={selection.asset_kind}
+											assetPath={selection.path}
+											targetLabel={selection.path}
+											loading={selectionColumnLoading}
+											truncated={selectionColumnTruncated}
+										/>
 										<div class="flex-1 min-h-0">
 											<DucklakeAssetPanel path={selection.path} {workspace} {schemaCanEvolve} />
 										</div>
 									</div>
 								{/key}
-							{:else if selectionDbt?.raw_code}
+							{:else if selectionDbt && (selectionDbt.raw_code || selectionDbtHasColumns || selectionColumnNodes.length > 0 || selectionColumnLoading)}
 								<!-- The transform behind the node. Read-only on purpose: dbt
 								     development is a local loop (`dbt run --select`, `dbt test`
 								     against a dev target), and a browser textarea over one file
@@ -1249,11 +1269,32 @@
 										<DbtIcon width={11} height={11} />
 										<span class="font-mono truncate">{dbtBundlePath ?? selectionDbt.unique_id}</span
 										>
-										<span class="ml-auto shrink-0 opacity-70">read-only · edit locally</span>
+										{#if selectionDbt.raw_code}
+											<span class="ml-auto shrink-0 opacity-70">read-only · edit locally</span>
+										{/if}
 									</div>
-									<div class="flex-1 min-h-0 overflow-auto">
-										<HighlightCode language="sql" code={selectionDbt.raw_code} />
-									</div>
+									<!-- Above the SQL rather than beside it: the columns are what
+									     the SQL below produces, so reading them in that order is
+									     the model's own shape. Same trace component the ducklake
+									     assets use — the graph is one graph across both. -->
+									{#if selectionDbtHasColumns}
+										<div class="border-b shrink-0 overflow-auto max-h-48 px-3 py-1.5">
+											<DbtColumnList dbt={selectionDbt} />
+										</div>
+									{/if}
+									<ColumnTraceSection
+										graph={selectionColumnGraph}
+										assetKind={selection.asset_kind}
+										assetPath={selection.path}
+										targetLabel={selectionDbt.unique_id}
+										loading={selectionColumnLoading}
+										truncated={selectionColumnTruncated}
+									/>
+									{#if selectionDbt.raw_code}
+										<div class="flex-1 min-h-0 overflow-auto">
+											<HighlightCode language="sql" code={selectionDbt.raw_code} />
+										</div>
+									{/if}
 								</div>
 							{:else}
 								<div class="p-3 text-xs text-secondary">

--- a/frontend/src/lib/components/assets/AssetGraph/ColumnTraceSection.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/ColumnTraceSection.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	// The column trace for one selected asset, plus the two things that are not
+	// the diagram: the lineage still being fetched, and an answer the API cut
+	// short. Both exist because a dbt project's half arrives in a request of its
+	// own — a project without the analysis pass and one whose answer has not
+	// landed yet are the same empty graph otherwise, and a trace that stops at a
+	// bound reads exactly like one that ends.
+	import type { AssetKind } from '$lib/gen'
+	import { Loader2 } from 'lucide-svelte'
+	import ColumnLineageTrace from './ColumnLineageTrace.svelte'
+	import { assetColumnNodes, type ColumnLineageGraph } from './columnLineageGraph'
+
+	let {
+		graph,
+		assetKind,
+		assetPath,
+		targetLabel,
+		loading = false,
+		truncated = false
+	}: {
+		graph?: ColumnLineageGraph
+		assetKind: AssetKind
+		assetPath: string
+		targetLabel?: string
+		loading?: boolean
+		truncated?: boolean
+	} = $props()
+
+	// The selected asset's own column nodes, which is what decides whether there
+	// is a trace to draw at all: a producer that declares no column lineage — or a
+	// dbt project that never asked for the analysis pass — has none.
+	let nodes = $derived(graph ? assetColumnNodes(graph, assetKind, assetPath) : [])
+</script>
+
+{#if loading && nodes.length === 0}
+	<div class="border-b shrink-0 flex items-center gap-2 px-3 py-1.5 text-2xs text-secondary">
+		<Loader2 size={12} class="animate-spin" />
+		Loading column lineage
+	</div>
+{:else if graph && nodes.length > 0}
+	<div class="border-b shrink-0 overflow-auto max-h-64">
+		<ColumnLineageTrace {graph} {assetKind} {assetPath} {targetLabel} />
+		{#if truncated}
+			<div class="px-3 pb-1.5 text-2xs text-tertiary">
+				Showing the part of the trace nearest this relation. The lineage reaches further than one
+				view can draw.
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/frontend/src/lib/components/assets/AssetGraph/DbtColumnList.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DbtColumnList.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	// A dbt relation's columns: the real ones where the analysis pass produced
+	// them — typed and in the order the model emits them — and the declared ones
+	// otherwise. The description comes from `columns` either way: that is the only
+	// place an author's prose lives, and a project documents a handful of forty.
+	import type { DbtAssetProvenance } from './types'
+
+	let { dbt }: { dbt: DbtAssetProvenance } = $props()
+
+	let columns = $derived(
+		dbt.column_schema?.length
+			? dbt.column_schema.map((c) => ({
+					name: c.name,
+					type: c.type,
+					description: dbt.columns?.[c.name] ?? ''
+				}))
+			: Object.entries(dbt.columns ?? {}).map(([name, description]) => ({
+					name,
+					type: undefined,
+					description
+				}))
+	)
+	let analyzed = $derived(!!dbt.column_schema?.length)
+</script>
+
+{#if columns.length > 0}
+	<div class="text-2xs">
+		<div class="text-tertiary mb-0.5">{analyzed ? 'columns' : 'columns declared'}</div>
+		<div class="flex flex-col gap-0.5">
+			{#each columns as col (col.name)}
+				<div class="flex gap-2">
+					<span class="font-mono text-primary shrink-0">{col.name}</span>
+					{#if col.type}
+						<span class="font-mono text-tertiary shrink-0">{col.type}</span>
+					{/if}
+					<span class="text-secondary truncate">{col.description}</span>
+				</div>
+			{/each}
+		</div>
+		<!-- `manifest.json` carries declared columns only, so without the analysis
+		     pass this list is what an author wrote down rather than what the model
+		     produces. -->
+		{#if !analyzed}
+			<div class="text-tertiary mt-0.5">
+				Declared metadata. Set `column_lineage: true` in the descriptor for the real column schema,
+				typed and in the order the model produces it.
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -17,7 +17,9 @@
 		AssetGraphResponse,
 		AssetGraphSelection,
 		NativeTriggerKind,
-		PipelineMode, DbtAssetProvenance } from './types'
+		PipelineMode,
+		DbtAssetProvenance
+	} from './types'
 	import type { AssetKind, Script, ScriptLang } from '$lib/gen'
 	import type { RunnableRunState, PipelineEvent } from './activeRunnables.svelte'
 	import type { PipelineOutputKind } from './pipelineTemplates'
@@ -76,6 +78,8 @@
 		localScriptsVersion,
 		selectionProducers = [],
 		selectionColumnGraph,
+		selectionColumnLoading = false,
+		selectionColumnTruncated = false,
 		selectionDbt,
 		schemaCanEvolve = true,
 		selectionForkMaterialization = undefined,
@@ -180,8 +184,13 @@
 		 * the selected node's source on live-reload. */
 		localScriptsVersion?: unknown
 		selectionProducers?: Array<{ kind: 'script' | 'flow'; path: string; unsaved?: boolean }>
-		/** Transitive column-lineage trace for a selected ducklake asset (route page). */
+		/** Transitive column-lineage trace for the selected asset (route page). */
 		selectionColumnGraph?: ColumnLineageGraph
+		/** That trace still being fetched — a dbt relation's is a request of its
+		 *  own, so it arrives after the selection does. */
+		selectionColumnLoading?: boolean
+		/** That trace cut at the part nearest the selection. */
+		selectionColumnTruncated?: boolean
 		/** dbt provenance of the selected relation — carries its SQL. */
 		selectionDbt?: DbtAssetProvenance
 		schemaCanEvolve?: boolean
@@ -514,6 +523,8 @@
 						selection={activeDraft ? undefined : editor.selection}
 						selectionProducers={activeDraft ? [] : selectionProducers}
 						{selectionColumnGraph}
+						{selectionColumnLoading}
+						{selectionColumnTruncated}
 						{selectionDbt}
 						{schemaCanEvolve}
 						{selectionForkMaterialization}

--- a/frontend/src/lib/components/assets/AssetGraph/columnLineageGraph.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/columnLineageGraph.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { AssetGraphResponse } from './types'
 import {
 	buildColumnGraph,
+	buildDbtColumnGraph,
 	colNodeId,
+	mergeColumnGraphs,
+	type ColumnLineageGraph,
 	traceColumn,
 	connectedComponent,
 	assetColumnNodes,
@@ -117,6 +120,79 @@ describe('buildColumnGraph', () => {
 		expect(g.up.has(STAGING_AMT)).toBe(false)
 		// ...but s2 still anchors daily.total ← staging.amt (staging.amt as a source).
 		expect(g.up.get(DAILY_TOTAL)).toEqual(new Set([STAGING_AMT]))
+	})
+})
+
+describe('buildDbtColumnGraph', () => {
+	it('takes the direct kinds and drops any other', () => {
+		// `scan` means the column was read to produce the ROW — a join key, a
+		// predicate, a `group by` — so it reaches every output column of its model
+		// and is not what a column trace means. The server filters it out; this
+		// filters again, because the kind set is the engine's and an unknown one
+		// must not become an edge the trace calls data flow.
+		const g = buildDbtColumnGraph([
+			{
+				from_asset_path: 'main/s/stg',
+				from_column: 'raw_name',
+				to_asset_path: 'main/s/mart',
+				to_column: 'clean_name',
+				kind: 'mod'
+			},
+			{
+				from_asset_path: 'main/s/stg',
+				from_column: 'id',
+				to_asset_path: 'main/s/mart',
+				to_column: 'id',
+				kind: 'copy'
+			},
+			{
+				from_asset_path: 'main/s/stg',
+				from_column: 'id',
+				to_asset_path: 'main/s/mart',
+				to_column: 'clean_name',
+				kind: 'scan'
+			}
+		])
+		expect(g.up.get(colNodeId('dbt', 'main/s/mart', 'clean_name'))).toEqual(
+			new Set([colNodeId('dbt', 'main/s/stg', 'raw_name')])
+		)
+		expect(g.up.get(colNodeId('dbt', 'main/s/mart', 'id'))).toEqual(
+			new Set([colNodeId('dbt', 'main/s/stg', 'id')])
+		)
+	})
+})
+
+describe('mergeColumnGraphs', () => {
+	it('chains a dbt column into what a producer derives from it', () => {
+		// The two halves arrive separately — the producer's from the asset graph,
+		// dbt's from its own request — and meet at the dbt node a `// column`
+		// annotation names. A trace has to cross that, or a dbt selection stops
+		// before the script consuming it.
+		const dbt = buildDbtColumnGraph([
+			{
+				from_asset_path: 'main/s/stg',
+				from_column: 'raw',
+				to_asset_path: 'main/s/mart',
+				to_column: 'clean',
+				kind: 'copy'
+			}
+		])
+		const producer: ColumnLineageGraph = {
+			nodes: new Map(),
+			up: new Map(),
+			down: new Map()
+		}
+		const src = colNodeId('dbt', 'main/s/mart', 'clean')
+		const out = colNodeId('ducklake', 'wh/report', 'total')
+		producer.nodes.set(src, { kind: 'dbt', path: 'main/s/mart', column: 'clean' })
+		producer.nodes.set(out, { kind: 'ducklake', path: 'wh/report', column: 'total' })
+		producer.up.set(out, new Set([src]))
+		producer.down.set(src, new Set([out]))
+
+		const merged = mergeColumnGraphs(dbt, producer)
+		expect(traceColumn(colNodeId('dbt', 'main/s/stg', 'raw'), merged)).toEqual(
+			new Set([colNodeId('dbt', 'main/s/stg', 'raw'), src, out])
+		)
 	})
 })
 

--- a/frontend/src/lib/components/assets/AssetGraph/columnLineageGraph.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/columnLineageGraph.ts
@@ -1,5 +1,10 @@
-import type { AssetKind } from '$lib/gen'
+import type { AssetKind, DbtColumnLineage } from '$lib/gen'
 import type { AssetGraphResponse } from './types'
+
+// One column-to-column edge of a dbt project's static analysis, as the API
+// serves it. Taken from the generated client rather than restated: unlike the
+// asset graph, this response is fetched through it.
+export type DbtColumnEdge = DbtColumnLineage['edges'][number]
 
 // A node in the column-level lineage graph: one column of one asset.
 export type ColumnNode = { kind: AssetKind; path: string; column: string }
@@ -22,6 +27,21 @@ export type ColumnLineageGraph = {
 	// sourceColumn → the output columns derived from it (walk downstream).
 	down: Map<ColumnNodeId, Set<ColumnNodeId>>
 }
+
+export const EMPTY_COLUMN_GRAPH: ColumnLineageGraph = {
+	nodes: new Map(),
+	up: new Map(),
+	down: new Map()
+}
+
+// Direct value flow, as dbt's static analysis labels it: `copy` passes a column
+// through, `mod` transforms it. The API serves only those two — the third kind,
+// `scan`, means the column was read to produce the ROW rather than the value (a
+// join key, a `where` predicate, a `group by`), so it reaches EVERY output
+// column of the model and would draw the diagram as a complete bipartite graph.
+// Filtered here as well so a kind the engine invents cannot silently become an
+// edge the trace claims is data flow.
+const DIRECT_DBT_LINEAGE = new Set(['copy', 'mod'])
 
 // Build the column graph from a resolved asset graph. A producer's
 // `column_lineage` describes the columns of the asset it materializes; that
@@ -86,6 +106,59 @@ export function buildColumnGraph(graph: AssetGraphResponse): ColumnLineageGraph 
 		}
 	}
 
+	return { nodes, up, down }
+}
+
+// The same graph, from dbt's own column lineage. dbt arrives already resolved to
+// two relations rather than anchored to a producer, and the API serves only the
+// direct kinds, so this is a straight edge list.
+export function buildDbtColumnGraph(edges: DbtColumnEdge[]): ColumnLineageGraph {
+	const nodes = new Map<ColumnNodeId, ColumnNode>()
+	const up = new Map<ColumnNodeId, Set<ColumnNodeId>>()
+	const down = new Map<ColumnNodeId, Set<ColumnNodeId>>()
+	const addNode = (n: ColumnNode): ColumnNodeId => {
+		const id = colNodeId(n.kind, n.path, n.column)
+		if (!nodes.has(id)) nodes.set(id, n)
+		return id
+	}
+	for (const e of edges) {
+		// Belt and braces: the API filters to `copy`/`mod`, and a kind an engine
+		// invents must not silently become an edge the trace calls data flow.
+		if (!DIRECT_DBT_LINEAGE.has(e.kind)) continue
+		const src = addNode({ kind: 'dbt', path: e.from_asset_path, column: e.from_column })
+		const out = addNode({ kind: 'dbt', path: e.to_asset_path, column: e.to_column })
+		if (src === out) continue
+		;(up.get(out) ?? up.set(out, new Set()).get(out)!).add(src)
+		;(down.get(src) ?? down.set(src, new Set()).get(src)!).add(out)
+	}
+	return { nodes, up, down }
+}
+
+// One graph out of several, so a trace crosses the boundary between them.
+//
+// The two halves reach each other through shared node ids: a producer's
+// `// column out <- dbt://wh/schema/model.col` puts a `('dbt', path, column)`
+// node in the producer graph under the same `colNodeId` the dbt lineage mints
+// for it, so the union chains a dbt model's columns into the script that
+// consumes them and on into what that script writes. Kept separate up to here
+// because they are fetched separately — the producer half rides on the asset
+// graph, the dbt half is asked for per selection.
+export function mergeColumnGraphs(...graphs: ColumnLineageGraph[]): ColumnLineageGraph {
+	const nodes = new Map<ColumnNodeId, ColumnNode>()
+	const up = new Map<ColumnNodeId, Set<ColumnNodeId>>()
+	const down = new Map<ColumnNodeId, Set<ColumnNodeId>>()
+	for (const g of graphs) {
+		for (const [id, n] of g.nodes) if (!nodes.has(id)) nodes.set(id, n)
+		for (const [dir, into] of [
+			[g.up, up],
+			[g.down, down]
+		] as const) {
+			for (const [id, adj] of dir) {
+				const target = into.get(id) ?? into.set(id, new Set()).get(id)!
+				for (const m of adj) target.add(m)
+			}
+		}
+	}
 	return { nodes, up, down }
 }
 

--- a/frontend/src/lib/components/assets/AssetGraph/dbtColumnLineage.svelte.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/dbtColumnLineage.svelte.ts
@@ -1,0 +1,120 @@
+import { AssetService, JobService, type DbtColumnLineage } from '$lib/gen'
+import {
+	buildDbtColumnGraph,
+	EMPTY_COLUMN_GRAPH,
+	type ColumnLineageGraph
+} from './columnLineageGraph'
+
+/** Which stored dbt graph a view is drawing. A job — a run's snapshot, or the
+ *  editor's parse of its own buffer — is asked through the job route, the only
+ *  way to reach a graph that names no deployed version; otherwise the deployed
+ *  version by hash, or the current one when there is no hash. */
+export type DbtGraphPin = { jobId?: string; scriptHash?: string | number }
+
+/** What a selection's dbt column lineage is doing right now. `loading` is
+ *  separate because a project still being fetched and one that never asked for
+ *  the analysis pass are the same empty graph otherwise. */
+export type DbtColumnLineageState = {
+	readonly graph: ColumnLineageGraph
+	readonly loading: boolean
+	/** The component reaches past what `graph` holds — the API cut it at the
+	 *  part nearest the selection. */
+	readonly truncated: boolean
+}
+
+function fetchLineage(
+	workspace: string,
+	assetPaths: string[],
+	pin: DbtGraphPin | undefined
+): Promise<DbtColumnLineage> {
+	return pin?.jobId
+		? JobService.getDbtRunColumnLineage({ workspace, id: pin.jobId, assetPath: assetPaths })
+		: AssetService.getDbtColumnLineage({
+				workspace,
+				assetPath: assetPaths,
+				dbtScriptHash: pin?.scriptHash != undefined ? String(pin.scriptHash) : undefined
+			})
+}
+
+/** Follow the selection, fetching the dbt column lineage it reaches.
+ *
+ *  One request per selection, whatever it reaches: the API takes every relation
+ *  at once and walks out from all of them, so there is no partial answer to hold
+ *  on to between selections and nothing to go stale behind a redeploy.
+ *
+ *  Per selection rather than off the graph response: the graph is folder-wide
+ *  and a run page polls it, while this is drawn for one selection. It also means
+ *  the request is never made for a project that did not opt into the analysis
+ *  pass — the pane simply never shows the section.
+ */
+export function useDbtColumnLineage(args: {
+	workspace: () => string | undefined
+	/** The dbt relations to expand. The selection itself when it is one; for a
+	 *  selection of another kind, every dbt relation its own lineage reaches —
+	 *  a ducklake table can be derived from several, and expanding only the
+	 *  first would leave the rest as leaves. */
+	assetPaths: () => string[]
+	/** The graph on screen, so the lineage describes the same project. */
+	pin?: () => DbtGraphPin | undefined
+}): DbtColumnLineageState {
+	let graph = $state<ColumnLineageGraph>(EMPTY_COLUMN_GRAPH)
+	let loading = $state(false)
+	let truncated = $state(false)
+
+	// The question the state in hand answers, and a counter deciding which answer
+	// is still wanted. Neither is a cache of edges: the API returns a whole
+	// component, so an answer is either the current selection's or nothing.
+	let asked: string | undefined = undefined
+	let latest = 0
+
+	$effect(() => {
+		const workspace = args.workspace()
+		const paths = [...new Set(args.assetPaths())].sort()
+		const pin = args.pin?.()
+		const question = JSON.stringify([workspace, pin?.jobId, pin?.scriptHash, paths])
+		// A selection re-derived from a graph that polled is the same question. Not
+		// asking it again is what keeps a run page from refetching a component's
+		// worth of edges every poll to redraw what is already on screen.
+		if (question === asked) return
+		asked = question
+		const id = ++latest
+		if (!workspace || paths.length === 0) {
+			graph = EMPTY_COLUMN_GRAPH
+			truncated = false
+			loading = false
+			return
+		}
+		loading = true
+		fetchLineage(workspace, paths, pin).then(
+			(r) => {
+				if (id !== latest) return
+				graph = buildDbtColumnGraph(r?.edges ?? [])
+				truncated = r?.truncated ?? false
+				loading = false
+			},
+			// Lineage annotates a graph that renders without it, so a failed fetch
+			// leaves that branch unexpanded rather than putting an error over the
+			// model. Not retried on its own: the effect reruns whenever the canvas
+			// does, and a failing endpoint would then be asked once per redraw.
+			// Selecting another node and back asks again.
+			() => {
+				if (id !== latest) return
+				graph = EMPTY_COLUMN_GRAPH
+				truncated = false
+				loading = false
+			}
+		)
+	})
+
+	return {
+		get graph() {
+			return graph
+		},
+		get loading() {
+			return loading
+		},
+		get truncated() {
+			return truncated
+		}
+	}
+}

--- a/frontend/src/lib/components/dbt/DbtEditor.svelte
+++ b/frontend/src/lib/components/dbt/DbtEditor.svelte
@@ -32,6 +32,15 @@
 		DbtAssetProvenance
 	} from '$lib/components/assets/AssetGraph/types'
 	import {
+		useDbtColumnLineage,
+		type DbtGraphPin
+	} from '$lib/components/assets/AssetGraph/dbtColumnLineage.svelte'
+	import {
+		EMPTY_COLUMN_GRAPH,
+		mergeColumnGraphs,
+		type ColumnLineageGraph
+	} from '$lib/components/assets/AssetGraph/columnLineageGraph'
+	import {
 		DBT_DESCRIPTOR,
 		DBT_MODULE_EXTENSIONS,
 		dbtDefaultContent,
@@ -223,6 +232,28 @@
 	// the deployed graph, which previews by version instead. Either way the rows
 	// come from the project whose SQL is displayed above them.
 	let selectedBuffer = $state<DbtPreviewBuffer | undefined>(undefined)
+	// Which graph the selection came from, so the lineage fetched below is the
+	// selected node's own project rather than whatever is deployed.
+	let selectionPin = $state<DbtGraphPin | undefined>(undefined)
+	// The selected model's column lineage, fetched on selection. Its own request
+	// rather than a field on the graph: only a project that opted into the
+	// analysis pass has any, and it is drawn for one model at a time.
+	const columnLineage = useDbtColumnLineage({
+		workspace: () => opWs,
+		assetPaths: () => {
+			const path = selectedDbt ? selectedAsset?.path : undefined
+			return path ? [path] : []
+		},
+		pin: () => selectionPin
+	})
+	// What the scripts around this project declare about its columns, off the
+	// same graph response the canvas drew. Merged rather than chosen between: a
+	// model's column and the ducklake column a script derives from it are one
+	// chain, and the trace has to cross that boundary.
+	let selectionProducerColumns = $state<ColumnLineageGraph>(EMPTY_COLUMN_GRAPH)
+	let selectionColumnGraph = $derived(
+		mergeColumnGraphs(columnLineage.graph, selectionProducerColumns)
+	)
 
 	let jobLoader: JobLoader | undefined = $state(undefined)
 	let testJob: any = $state(undefined)
@@ -525,10 +556,12 @@
 						testRunning={testIsLoading}
 						testResult={testJob?.result}
 						selection={graphSelection}
-						onSelect={(sel, dbt, buffer) => {
+						onSelect={(sel, dbt, buffer, pin, producerColumns) => {
 							graphSelection = sel
 							selectedDbt = dbt
 							selectedBuffer = buffer
+							selectionPin = pin
+							selectionProducerColumns = producerColumns
 						}}
 					/>
 				</Pane>
@@ -550,6 +583,9 @@
 							{args}
 							fileInBundle={!!selectedDbt.original_file_path &&
 								!!modules?.[selectedDbt.original_file_path]}
+							columnGraph={selectionColumnGraph}
+							columnLoading={columnLineage.loading}
+							columnTruncated={columnLineage.truncated}
 							onOpenFile={open}
 							onClose={() => (graphSelection = undefined)}
 						/>

--- a/frontend/src/lib/components/dbt/DbtModelDetails.svelte
+++ b/frontend/src/lib/components/dbt/DbtModelDetails.svelte
@@ -12,6 +12,9 @@
 	import { ClipboardCopy, Code2, FileCode2, Loader2, TableProperties, X } from 'lucide-svelte'
 	import { copyToClipboard } from '$lib/utils'
 	import type { DbtAssetProvenance } from '$lib/components/assets/AssetGraph/types'
+	import ColumnTraceSection from '$lib/components/assets/AssetGraph/ColumnTraceSection.svelte'
+	import DbtColumnList from '$lib/components/assets/AssetGraph/DbtColumnList.svelte'
+	import type { ColumnLineageGraph } from '$lib/components/assets/AssetGraph/columnLineageGraph'
 	import { previewDbtRows, type DbtPreview, type DbtPreviewBuffer } from './previewRows'
 	import { nodeSelector } from './parseDbtRun'
 
@@ -34,6 +37,12 @@
 		args,
 		/** Whether this model's file is in the bundle being edited. */
 		fileInBundle = false,
+		/** The project's column-level lineage, when the descriptor asked for it.
+		 *  Fetched for this relation against the same graph the canvas draws, so
+		 *  the trace and the nodes above it describe one parse. */
+		columnGraph,
+		columnLoading = false,
+		columnTruncated = false,
 		onOpenFile,
 		onClose
 	}: {
@@ -45,6 +54,9 @@
 		buffer?: DbtPreviewBuffer
 		args?: Record<string, unknown>
 		fileInBundle?: boolean
+		columnGraph?: ColumnLineageGraph
+		columnLoading?: boolean
+		columnTruncated?: boolean
 		onOpenFile?: (path: string) => void
 		onClose?: () => void
 	} = $props()
@@ -111,24 +123,9 @@
 		return typeof v === 'object' ? JSON.stringify(v) : String(v)
 	}
 
-	// The real columns where the analysis pass produced them — typed and in the
-	// order the model emits them — and the declared ones otherwise. The
-	// description comes from `columns` either way: that is the only place an
-	// author's prose lives, and a project documents a handful of forty.
-	let columns = $derived(
-		dbt.column_schema?.length
-			? dbt.column_schema.map((c) => ({
-					name: c.name,
-					type: c.type,
-					description: dbt.columns?.[c.name] ?? ''
-				}))
-			: Object.entries(dbt.columns ?? {}).map(([name, description]) => ({
-					name,
-					type: undefined,
-					description
-				}))
+	let hasColumns = $derived(
+		!!dbt.column_schema?.length || Object.keys(dbt.columns ?? {}).length > 0
 	)
-	let columnsAreAnalyzed = $derived(!!dbt.column_schema?.length)
 	// `dbt show` SELECTs from the node's own relation and the worker intersects
 	// the selector with `resource_type:model`, so offering it on a seed, snapshot
 	// or source only ever produces a failed job.
@@ -251,35 +248,9 @@
 			{/if}
 		</div>
 
-		{#if columns.length > 0 || (dbt.data_tests?.length ?? 0) > 0}
+		{#if hasColumns || (dbt.data_tests?.length ?? 0) > 0}
 			<div class="px-2 py-1.5 border-b flex flex-col gap-1.5">
-				{#if columns.length > 0}
-					<div class="text-2xs">
-						<div class="text-tertiary mb-0.5">
-							{columnsAreAnalyzed ? 'columns' : 'columns declared'}
-						</div>
-						<div class="flex flex-col gap-0.5">
-							{#each columns as col (col.name)}
-								<div class="flex gap-2">
-									<span class="font-mono text-primary shrink-0">{col.name}</span>
-									{#if col.type}
-										<span class="font-mono text-tertiary shrink-0">{col.type}</span>
-									{/if}
-									<span class="text-secondary truncate">{col.description}</span>
-								</div>
-							{/each}
-						</div>
-						<!-- `manifest.json` carries declared columns only, so without the
-						     analysis pass this list is what an author wrote down rather than
-						     what the model produces. -->
-						{#if !columnsAreAnalyzed}
-							<div class="text-tertiary mt-0.5">
-								Declared metadata. Set `column_lineage: true` in the descriptor for the real
-								column schema, typed and in the order the model produces it.
-							</div>
-						{/if}
-					</div>
-				{/if}
+				<DbtColumnList {dbt} />
 				{#if (dbt.data_tests?.length ?? 0) > 0}
 					<div class="text-2xs">
 						<div class="text-tertiary mb-0.5">tests</div>
@@ -294,6 +265,15 @@
 				{/if}
 			</div>
 		{/if}
+
+		<ColumnTraceSection
+			graph={columnGraph}
+			assetKind="dbt"
+			{assetPath}
+			targetLabel={dbt.unique_id}
+			loading={columnLoading}
+			truncated={columnTruncated}
+		/>
 
 		{#if showRows && preview}
 			{#if 'error' in preview}

--- a/frontend/src/lib/components/dbt/DbtModelGraph.svelte
+++ b/frontend/src/lib/components/dbt/DbtModelGraph.svelte
@@ -25,6 +25,12 @@
 		DbtAssetProvenance
 	} from '$lib/components/assets/AssetGraph/types'
 	import { useDbtRunStatus } from './runStatus.svelte'
+	import type { DbtGraphPin } from '$lib/components/assets/AssetGraph/dbtColumnLineage.svelte'
+	import {
+		buildColumnGraph,
+		EMPTY_COLUMN_GRAPH,
+		type ColumnLineageGraph
+	} from '$lib/components/assets/AssetGraph/columnLineageGraph'
 
 	let {
 		workspace,
@@ -80,7 +86,19 @@
 			 *  buffer rather than a deployed version — as submitted, not as the
 			 *  editor holds it now. Sent with the selection rather than exposed on
 			 *  its own so it can never disagree with the SQL the parent shows. */
-			buffer: DbtPreviewBuffer | undefined
+			buffer: DbtPreviewBuffer | undefined,
+			/** Which graph this node was taken from, so anything else fetched
+			 *  about it describes the same project: the editor's own parse job
+			 *  when the panel is pinned to one, else the deployed version. Sent
+			 *  with the selection for the same reason the buffer is — it must not
+			 *  be able to disagree with the node on screen. */
+			pin: DbtGraphPin,
+			/** Column lineage the CONSUMERS of this project declare — a script
+			 *  reading a model's column and writing a ducklake one. It comes off
+			 *  the same graph response, and the details pane merges it with the
+			 *  project's own so a trace crosses that boundary instead of ending
+			 *  at it. */
+			producerColumns: ColumnLineageGraph
 		) => void
 	} = $props()
 
@@ -364,6 +382,25 @@
 	// graph that actually came back.
 	let editorParsed = $derived(refreshJob != undefined && raw?.dbt_snapshot_job === refreshJob)
 
+	// Which stored graph is on screen. Anything the details pane fetches about a
+	// selected node asks for this one, so it cannot describe a node parsed from
+	// the buffer with the deployed version's answer.
+	let pin = $derived<DbtGraphPin>(
+		editorParsed && refreshJob ? { jobId: refreshJob } : { scriptHash: deployedHash }
+	)
+
+	// What the scripts around this project declare about its columns. Empty for
+	// the ordinary project nothing downstream annotates.
+	//
+	// A consumer is anchored here only by its `// materialize` target: this graph
+	// is fetched `asset_kinds=dbt` so the canvas is the project and nothing else,
+	// and `buildColumnGraph`'s other anchor is a ducklake WRITE EDGE, which that
+	// filter drops. So a script consuming a model and writing a ducklake table it
+	// never declared contributes no hop in this editor, while it does on the
+	// pipeline page, whose graph spans both kinds. Widening the request would put
+	// ducklake nodes on the dbt canvas, which is the opposite of what it is for.
+	let producerColumns = $derived(graph ? buildColumnGraph(graph) : EMPTY_COLUMN_GRAPH)
+
 	// `untrack`, because the effect that reloads the graph clears the selection
 	// through here: reading the graph to describe a selection would subscribe that
 	// effect to the very state its own fetch writes, and it would reload forever.
@@ -374,7 +411,9 @@
 				sel?.kind === 'asset'
 					? graph?.assets.find((a) => a.kind === sel.asset_kind && a.path === sel.path)?.dbt
 					: undefined,
-				editorParsed ? parsedBuffer : undefined
+				editorParsed ? parsedBuffer : undefined,
+				pin,
+				producerColumns
 			)
 		)
 	}
@@ -405,7 +444,6 @@
 		if (deployedHash != undefined) return 'as of last deploy'
 		return 'never parsed'
 	})
-
 </script>
 
 <div class="flex flex-col h-full min-h-0">
@@ -435,8 +473,8 @@
 
 	{#if refreshPending}
 		<div class="shrink-0 px-2 py-1.5 border-b text-2xs text-secondary">
-			Still parsing. A cold worker provisions the dbt engine before it starts; a project
-			pinned to a worker tag nothing serves waits here indefinitely.
+			Still parsing. A cold worker provisions the dbt engine before it starts; a project pinned to a
+			worker tag nothing serves waits here indefinitely.
 			<a
 				class="text-blue-500 hover:underline"
 				href="{base}/run/{refreshPending}?workspace={workspace}"

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -33,9 +33,13 @@
 	import MacroExplorerDrawer from '$lib/components/assets/AssetGraph/MacroExplorerDrawer.svelte'
 	import { parsePipelineAnnotations } from '$lib/components/assets/AssetGraph/parsePipelineAnnotations'
 	import {
+		assetColumnNodes,
 		buildColumnGraph,
-		type ColumnLineageGraph
+		connectedComponent,
+		EMPTY_COLUMN_GRAPH,
+		mergeColumnGraphs
 	} from '$lib/components/assets/AssetGraph/columnLineageGraph'
+	import { useDbtColumnLineage } from '$lib/components/assets/AssetGraph/dbtColumnLineage.svelte'
 	import { resolveGraph } from '$lib/components/assets/AssetGraph/resolveGraph'
 	import { normalizePipelineFolder } from '$lib/utils/pipelineFolder'
 	import { hideDbtRunnables } from '$lib/components/assets/AssetGraph/hideDbtRunnables'
@@ -1980,26 +1984,48 @@
 			?.dbt
 	})
 
-	// Empty graph reused when the trace isn't shown (no ducklake-asset selection,
-	// or a draft is actively edited) so the pane blanks out like the other
-	// selection overlays and `buildColumnGraph` doesn't run.
-	const EMPTY_COLUMN_GRAPH: ColumnLineageGraph = {
-		nodes: new Map(),
-		up: new Map(),
-		down: new Map()
-	}
 	// Pipeline-wide column-lineage graph, stitched across every producer's
 	// (inferred + annotated) `column_lineage` and the asset write-edges. Drives
 	// the transitive column trace in the details pane. Built from `displayGraph`
 	// — the exact graph the canvas renders — so the trace matches it: draft
-	// overlays in edit / show-drafts, deployed-only in plain View. Gated to a
-	// ducklake-asset selection so it isn't rebuilt on every editor keystroke when
-	// the trace UI isn't even shown.
-	let columnGraph = $derived(
-		pe.selection?.kind === 'asset' && pe.selection.asset_kind === 'ducklake'
+	// overlays in edit / show-drafts, deployed-only in plain View. Gated to the
+	// two asset kinds that can carry column lineage so it isn't rebuilt on every
+	// editor keystroke when the trace UI isn't even shown.
+	let producerColumnGraph = $derived(
+		pe.selection?.kind === 'asset' &&
+			(pe.selection.asset_kind === 'ducklake' || pe.selection.asset_kind === 'dbt')
 			? buildColumnGraph(displayGraph)
 			: EMPTY_COLUMN_GRAPH
 	)
+	// dbt's half comes from its own request instead: a project's static analysis
+	// is stored per relation and only exists if the descriptor asked for it, so
+	// the folder-wide graph does not carry it. A draft is never asked about —
+	// nothing has parsed it, so there is nothing to fetch.
+	//
+	// The relations to ask about are the selected one when it IS a dbt relation,
+	// and otherwise every dbt relation a producer feeding this selection names as
+	// a source — the boundary nodes above. Asking at all of them at once is what
+	// lets a ducklake selection trace back up the dbt projects that fed it, and
+	// why one selection is one request however many boundaries it crosses.
+	let dbtSeedPaths = $derived.by(() => {
+		const sel = pe.selection
+		if (pe.activeDraft || sel?.kind !== 'asset') return []
+		if (sel.asset_kind === 'dbt') return [sel.path]
+		const seeds = assetColumnNodes(producerColumnGraph, sel.asset_kind, sel.path)
+		const paths = new Set<string>()
+		for (const id of connectedComponent(seeds, producerColumnGraph)) {
+			const node = producerColumnGraph.nodes.get(id)
+			if (node?.kind === 'dbt') paths.add(node.path)
+		}
+		return [...paths]
+	})
+	const dbtColumnLineage = useDbtColumnLineage({
+		workspace: () => $workspaceStore,
+		assetPaths: () => dbtSeedPaths
+	})
+	// One graph across both, so a trace crosses the dbt/ducklake boundary in
+	// either direction rather than stopping at it.
+	let columnGraph = $derived(mergeColumnGraphs(producerColumnGraph, dbtColumnLineage.graph))
 
 	// Producer-side facts for the editor's live schema-contract diagnostics:
 	// which assets are muted (`on_schema_change=ignore`) and which `_current`
@@ -2602,6 +2628,8 @@
 				{selectionProducers}
 				{selectionDbt}
 				selectionColumnGraph={pe.activeDraft ? EMPTY_COLUMN_GRAPH : columnGraph}
+				selectionColumnLoading={dbtColumnLineage.loading}
+				selectionColumnTruncated={dbtColumnLineage.truncated}
 				{schemaCanEvolve}
 				{selectionForkMaterialization}
 				{schemaContractContext}


### PR DESCRIPTION
## Summary

Follow-up to #10977, which landed the ingest and storage for dbt column-level lineage. This is the surface: the endpoint that serves `dbt_column_edge`, and the views that draw a column trace from it.

`assets/column_lineage` answers the connected component a set of dbt relations' columns sit in. The details pane draws it beside the model's SQL — on the pipeline page, in the dbt editor, and for a run through `jobs/dbt_column_lineage/{id}` — merged with the producer-side column lineage the asset graph already carries, so one trace crosses the dbt/ducklake boundary in either direction.

Three things decided here rather than inherited:

**The unpinned component crosses projects, and the gate crosses with it.** A relation one project produces is another's source, so resolving owners once — for the relations asked about — stops the trace at the first boundary. Owners are resolved to a fixpoint instead: resolve who owns the relations reached so far, read their edges, walk, repeat. The security half is that a project reached that way is a project the caller may not be entitled to, so the `scripts:read` scope filter and the project's RLS visibility are re-applied to **every** project version the expansion discovers, not decided once for the first owner set. A pinned answer is the exception, by version or by job: the pin says which stored graph is on screen, and another project's live graph is not part of it.

**One request per selection, whatever it reaches.** The endpoint takes every relation at once and answers their union, so nothing is held between selections and there is no staleness, retry bookkeeping or per-click dedup to balance. It is a GET with a repeated `asset_path`, not a POST body: the HTTP method decides a scoped token's action, so a POST would ask `assets:write` for a read and refuse a read-only token outright.

**The answer is bounded, and says when it was cut.** A synthetic 3000-model project whose models share a column has 58k direct edges and returns 7.3MB, which no column diagram can draw. The walk is breadth-first from the asked-for relations and stops at 5000 edges, so what survives is the part nearest the selection rather than an arbitrary slice, and `truncated` says the trace stopped short rather than ended. The walk is in Rust, not a recursive CTE: `EXPLAIN ANALYZE` on that project measured 1243ms against 59ms for the query alone, because a CTE has no index to walk and rescans the doubled edge set once per level.

Also folds in the columns section the pipeline page's asset pane was missing, so `column_schema` — which #10977 ships on the same asset-graph response — is visible there and not only in the dbt editor.

## Changes

- **`assets/column_lineage`** (GET, repeated `asset_path`, optional `dbt_script_hash`) and **`jobs/dbt_column_lineage/{id}`** (behind `require_job_read_access`, via a shared `dbt_pinned_run` helper restored in `jobs.rs`). Response is `{edges, truncated}` in the canvas's terms — relations and columns, never dbt node ids. Only the direct kinds are served: a `scan` edge reaches every output column of its model.
- **Owner resolution to a fixpoint**, with the caller's gate re-applied per round, bounded by `MAX_OWNER_ROUNDS`. Termination is independent of that bound — a round asks only about relations not asked about before and reads only projects not read before.
- **`MAX_TRACE_EDGES` / `MAX_HELD_EDGES`.** The first bounds the answer, over the walk, which is the last filter. The second stops discovering further projects once the held set is outsized; the fetch itself is deliberately unbounded, because a `LIMIT` would cut an arbitrary set that need not contain the asked-for relation at all.
- **Frontend**: `buildDbtColumnGraph` / `mergeColumnGraphs` in `columnLineageGraph.ts`, a fetch-on-selection composable in `dbtColumnLineage.svelte.ts`, a shared `ColumnTraceSection` used by all three call sites, and the pipeline page's seed walk (every dbt relation the selection's own producer lineage reaches, asked about together).
- **`DbtColumnList`**, extracted from `DbtModelDetails` and used by the pipeline asset pane too.
- **Docs**: `docs/dbt-runtime.md` decision 14 updated — the endpoint exists, the cross-project rule and its pinned exception, the two bounds and why the fetch is not one of them.

## Test plan

- [x] `cargo test -p windmill-api-assets --test dbt_pinned_graph` — 11 tests. Six cover this change: the editor-buffer pin (the NULL-hash arm), the share-link gate on a pinned run, the `scan` exclusion plus the scope gate, component scoping within one project in both directions, the three-project chain under a partial folder grant / a path-scoped token / a version pin, and the edge bound with its `truncated` flag.
- [x] The cross-project test was written before the fix and confirmed to fail with the expansion capped at one round, reproducing the old "stops at the first boundary" answer.
- [x] `SQLX_OFFLINE=true cargo check --workspace --features all_sqlx_features`, and the assets crate with `--all-targets`.
- [x] `npm run check` — 0 errors; `vitest` over `AssetGraph/` — 299 pass, including new `buildDbtColumnGraph` / `mergeColumnGraphs` cases.
- [x] Exercised on a dev instance with two dbt projects (the second declaring the first's relation as a source) plus a DuckDB producer annotated `// column revenue_total <- dbt://…`: the trace spans `raw_orders.amount → orders.total → mart_daily.revenue → main/reports/daily.revenue_total` from either end; one request per selection and none on a graph refetch; the version-pinned and job-pinned arms each answer for their one project; an editor buffer's own edges are reachable only through its parse job; a malformed `dbt_script_hash` and a missing `asset_path` are both 400.
- [ ] Reviewer check worth doing on a real project: open a deployed dbt project with `column_lineage: true`, select a model, and confirm the trace follows a buffer re-parse rather than the deployed version after hitting Refresh.

## Screenshots

Pipeline page, dbt relation selected — the columns section (new here) above a trace that crosses from `raw_orders` in one project through `orders` into `mart_daily` in a second:

![pr-1-pipeline-dbt](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-column-lineage-view/1788854790421640474-pr-1-pipeline-dbt.png)

The same trace from a ducklake selection, scrolled to its far end: the dbt half and the producer half are one graph, so `main/reports/daily.revenue_total` sits on the same chain:

![pr-2-ducklake-boundary](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-column-lineage-view/1788854792461084519-pr-2-ducklake-boundary.png)

dbt editor, model details — the trace is pinned to the version the canvas drew, so it is that project's alone:

![pr-3-dbt-editor](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-column-lineage-view/1788854793623001728-pr-3-dbt-editor.png)

What a cut trace looks like — the nearest part survives and the notice says there is more (captured with the bound lowered, since the demo project is four edges wide):

![pr-4-truncated](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dbt-column-lineage-view/1788854795382952437-pr-4-truncated.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serves the stored `dbt_column_edge` data as a column trace drawn beside a model's SQL — in the dbt editor, on the pipeline page, and for runs — crossing projects and the dbt/ducklake boundary as one graph.

**New Features**
- Adds `assets/column_lineage`, a GET with a repeated `asset_path`, answering the connected component around the selected relations; a POST would require `assets:write` and break read-only tokens.
- Adds `jobs/dbt_column_lineage/{id}` for run-pinned graphs, behind `require_job_read_access`.
- Resolves relation owners to a fixpoint so the trace crosses projects, re-applying the caller's `scripts:read` scope and RLS for every project reached.
- Bounds the answer at 5000 edges and returns `truncated` when cut, walking breadth-first in Rust instead of a recursive CTE.
- Merges the dbt trace with existing producer-side lineage so the same chain shows from either side of the pipeline boundary.
- Shows the dbt columns section in the pipeline page asset pane, where it was previously missing.

<sup>Written for commit 76031c35fd309d917be0013b3d7f03a6f21f3262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

