### PR TITLE
feat(cli): sync extra_perms for variables in sync pull/push

### DIFF
--- a/backend/windmill-api-groups/src/granular_acls.rs
+++ b/backend/windmill-api-groups/src/granular_acls.rs
@@ -318,6 +318,19 @@ async fn add_granular_acl(
             )
             .await?
         }
+        "variable" => {
+            handle_deployment_metadata(
+                &authed.email,
+                &authed.username,
+                &db,
+                &w_id,
+                DeployedObject::Variable { path: path.to_string(), parent_path: None },
+                Some(format!("Variable '{}' changed permissions", path)),
+                true,
+                None,
+            )
+            .await?
+        }
         _ => (),
     }
 
@@ -523,6 +536,19 @@ async fn remove_granular_acl(
                     &w_id,
                     DeployedObject::Flow { path: path.to_string(), parent_path: None, version: 0 },
                     Some(format!("Flow '{}' changed permissions", path)),
+                    true,
+                    None,
+                )
+                .await?
+            }
+            "variable" => {
+                handle_deployment_metadata(
+                    &authed.email,
+                    &authed.username,
+                    &db,
+                    &w_id,
+                    DeployedObject::Variable { path: path.to_string(), parent_path: None },
+                    Some(format!("Variable '{}' changed permissions", path)),
                     true,
                     None,
                 )

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -346,7 +346,7 @@ pub(crate) struct ArchiveQueryParams {
     default_ts: Option<String>,
     /// Settings format version: "v1" (default) returns legacy flat format, "v2" returns grouped format
     settings_version: Option<String>,
-    /// Opt-in: include `extra_perms` on flow / script / app rows. Default `false`
+    /// Opt-in: include `extra_perms` on flow / script / app / variable rows. Default `false`
     /// so cross-workspace tarball imports do not carry over ACLs referring to
     /// identities that may not exist in the target workspace. `wmill sync pull`
     /// passes `true` to surface ACLs in the git-tracked yaml.

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -365,8 +365,8 @@ pub(crate) struct ArchiveQueryParams {
 ///                      pre-existing serialization for folders and groups so
 ///                      no customer sees a one-time noisy diff on upgrade.
 /// * `KeepIfNonEmpty` — keep when there is at least one entry, drop when `{}`
-///                      or null. New surface for flow / script / app, which
-///                      never carried ACLs in source before this change.
+///                      or null. Used for flow / script / app / variable, which
+///                      never carried ACLs in source before granular-ACL sync.
 #[derive(Clone, Copy)]
 pub enum ExtraPermsBehavior {
     Drop,
@@ -1002,8 +1002,7 @@ pub(crate) async fn tarball_workspace(
                     Error::internal_err(format!("Error decrypting variable {}: {}", var.path, e))
                 })?);
             }
-            let var_str =
-                &to_string_without_metadata(&var, ExtraPermsBehavior::Drop, None).unwrap();
+            let var_str = &to_string_without_metadata(&var, new_kinds_extra_perms, None).unwrap();
             archive
                 .write_to_archive(&var_str, &format!("{}.variable.json", var.path))
                 .await?;

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -665,7 +665,7 @@ pub(crate) async fn tarball_workspace(
         check_scopes(&authed, || "variables:read".to_string())?;
     }
 
-    // Opt-in behavior for surfacing per-resource ACLs on flow/app rows.
+    // Opt-in behavior for surfacing per-resource ACLs on flow/script/app/variable rows.
     // Folder and group rows have always carried `extra_perms` in source and
     // continue to do so unconditionally (`KeepEvenEmpty`) so existing
     // customer git repos see no one-time noisy diff.

--- a/cli/src/commands/sync/pull.ts
+++ b/cli/src/commands/sync/pull.ts
@@ -104,7 +104,7 @@ export async function downloadZip(
   // from v1 the on-behalf-of address is stripped below, so the tarball sends the
   // `has_on_behalf_of` marker instead and never resolves an address.
   // `preserve_extra_perms=true` opts the tarball into surfacing granular ACLs
-  // on flow / script / app rows. Default-off on the server protects cross-
+  // on flow / script / app / variable rows. Default-off on the server protects cross-
   // workspace tarball imports from carrying ACLs that reference identities
   // missing in the target workspace; the CLI sync flow explicitly wants them.
   const baseParams = `&plain_secret=${plainSecrets ?? false

--- a/cli/src/commands/variable/variable.ts
+++ b/cli/src/commands/variable/variable.ts
@@ -98,10 +98,7 @@ export interface VariableFile {
   description: string;
   account?: number;
   is_oauth?: boolean;
-  // Mirrors granular ACLs on the variable path. Omitted from variable.yaml when
-  // no perms are set. The CLI applies diffs through /acls/add and /acls/remove
-  // (see applyExtraPermsDiff) — never through update_variable — so a perm-only
-  // change never rewrites the variable value.
+  // Mirrors granular ACLs on the variable path; omitted when no perms are set.
   extra_perms?: Record<string, boolean>;
 }
 
@@ -158,10 +155,9 @@ export async function pushVariable(
     log.debug(`Variable ${remotePath} does not exist on remote`);
   }
 
-  // extra_perms is synced independently via /acls/* (see applyExtraPermsDiff)
-  // so a perm-only edit never rewrites the variable value. Strip the field from
-  // the body that goes to update_variable / create_variable and treat it as a
-  // separate step both for the up-to-date short-circuit and after the write.
+  // extra_perms must stay out of the update_variable / create_variable body and
+  // go through /acls/* instead, so a perm-only edit never rewrites the value —
+  // which for a secret would mean re-storing pulled ciphertext.
   const { extra_perms: localPerms, ...localVariableBody } = localVariable;
 
   if (variable) {
@@ -207,14 +203,9 @@ export async function pushVariable(
     });
   }
 
-  // Independent of whether the variable body changed, sync extra_perms via
-  // /acls/*. Self-contained log line + non-fatal failures.
-  //
-  // No refetch is needed: extra_perms is item-specific and additive on top of
-  // folder perms — folder perms are never merged onto item.extra_perms, and a
-  // freshly created variable starts with `{}`. Since the request body sent to
-  // update_variable / create_variable doesn't carry extra_perms, the value read
-  // in the initial getVariable above is also the post-write value.
+  // The getVariable read above is still authoritative for the remote perms: no
+  // write since then carried extra_perms, and a created variable starts at `{}`
+  // because folder perms are never merged into item.extra_perms.
   await applyExtraPermsDiff(
     workspace,
     "variable",

--- a/cli/src/commands/variable/variable.ts
+++ b/cli/src/commands/variable/variable.ts
@@ -19,6 +19,7 @@ import { sep as SEP } from "node:path";
 
 import * as wmill from "../../../gen/services.gen.ts";
 import { ListableVariable } from "../../../gen/types.gen.ts";
+import { applyExtraPermsDiff } from "../../core/extra_perms.ts";
 
 async function list(opts: GlobalOptions & { json?: boolean }) {
   if (opts.json) log.setSilent(true);
@@ -97,6 +98,11 @@ export interface VariableFile {
   description: string;
   account?: number;
   is_oauth?: boolean;
+  // Mirrors granular ACLs on the variable path. Omitted from variable.yaml when
+  // no perms are set. The CLI applies diffs through /acls/add and /acls/remove
+  // (see applyExtraPermsDiff) — never through update_variable — so a perm-only
+  // change never rewrites the variable value.
+  extra_perms?: Record<string, boolean>;
 }
 
 /**
@@ -152,37 +158,42 @@ export async function pushVariable(
     log.debug(`Variable ${remotePath} does not exist on remote`);
   }
 
+  // extra_perms is synced independently via /acls/* (see applyExtraPermsDiff)
+  // so a perm-only edit never rewrites the variable value. Strip the field from
+  // the body that goes to update_variable / create_variable and treat it as a
+  // separate step both for the up-to-date short-circuit and after the write.
+  const { extra_perms: localPerms, ...localVariableBody } = localVariable;
+
   if (variable) {
-    if (isSuperset(localVariable, variable)) {
+    if (isSuperset(localVariableBody, variable)) {
       log.debug(`Variable ${remotePath} is up-to-date`);
-      return;
-    }
+    } else {
+      log.debug(`Variable ${remotePath} is not up-to-date, updating`);
 
-    log.debug(`Variable ${remotePath} is not up-to-date, updating`);
-
-    // Apply is_secret only when it differs from the remote (the value is always
-    // sent, so the server allows the flag change). Upgrades (non-secret->secret)
-    // always apply; downgrades only when explicitly allowed (single-file push) —
-    // see allowSecretDowngrade. `undefined` leaves the flag untouched.
-    let nextIsSecret: boolean | undefined = undefined;
-    if (localVariable.is_secret !== variable.is_secret) {
-      if (localVariable.is_secret) {
-        nextIsSecret = true;
-      } else if (allowSecretDowngrade) {
-        nextIsSecret = false;
+      // Apply is_secret only when it differs from the remote (the value is always
+      // sent, so the server allows the flag change). Upgrades (non-secret->secret)
+      // always apply; downgrades only when explicitly allowed (single-file push) —
+      // see allowSecretDowngrade. `undefined` leaves the flag untouched.
+      let nextIsSecret: boolean | undefined = undefined;
+      if (localVariableBody.is_secret !== variable.is_secret) {
+        if (localVariableBody.is_secret) {
+          nextIsSecret = true;
+        } else if (allowSecretDowngrade) {
+          nextIsSecret = false;
+        }
       }
-    }
 
-    await wmill.updateVariable({
-      workspace,
-      path: remotePath.replaceAll(SEP, "/"),
-      alreadyEncrypted: !plainSecrets,
-      requestBody: {
-        ...localVariable,
-        is_secret: nextIsSecret,
-        ...(wsSpecific !== undefined ? { ws_specific: wsSpecific } : {}),
-      },
-    });
+      await wmill.updateVariable({
+        workspace,
+        path: remotePath.replaceAll(SEP, "/"),
+        alreadyEncrypted: !plainSecrets,
+        requestBody: {
+          ...localVariableBody,
+          is_secret: nextIsSecret,
+          ...(wsSpecific !== undefined ? { ws_specific: wsSpecific } : {}),
+        },
+      });
+    }
   } else {
     log.info(colors.yellow.bold(`Creating new variable ${remotePath}...`));
     await wmill.createVariable({
@@ -190,11 +201,27 @@ export async function pushVariable(
       alreadyEncrypted: !plainSecrets,
       requestBody: {
         path: remotePath.replaceAll(SEP, "/"),
-        ...localVariable,
+        ...localVariableBody,
         ...(wsSpecific !== undefined ? { ws_specific: wsSpecific } : {}),
       },
     });
   }
+
+  // Independent of whether the variable body changed, sync extra_perms via
+  // /acls/*. Self-contained log line + non-fatal failures.
+  //
+  // No refetch is needed: extra_perms is item-specific and additive on top of
+  // folder perms — folder perms are never merged onto item.extra_perms, and a
+  // freshly created variable starts with `{}`. Since the request body sent to
+  // update_variable / create_variable doesn't carry extra_perms, the value read
+  // in the initial getVariable above is also the post-write value.
+  await applyExtraPermsDiff(
+    workspace,
+    "variable",
+    remotePath.replaceAll(SEP, "/"),
+    localPerms,
+    (variable as any)?.extra_perms,
+  );
 }
 
 async function push(

--- a/cli/test/variable_resource_push.test.ts
+++ b/cli/test/variable_resource_push.test.ts
@@ -413,23 +413,40 @@ describe("variable", () => {
       expect(pulled).toContain("extra_perms:");
       expect(pulled).toContain("g/all: true");
 
-      // Demote the grant to read-only, leaving the rest of the spec untouched:
-      // the perms diff must go through /acls/* without rewriting the variable.
+      const readVariable = async () => {
+        const resp = await backend.apiRequest!(
+          `/api/w/${backend.workspace}/variables/get/${varPath}`
+        );
+        expect(resp.status).toEqual(200);
+        return resp.json();
+      };
+      const before = await readVariable();
+
+      // Demote the grant, then drop it entirely. Each push edits only
+      // extra_perms, so it must reach the variable through /acls/* — an
+      // unchanged edited_at is what proves the row was never rewritten.
       await writeFile(specFile, pulled.replace("g/all: true", "g/all: false"), "utf-8");
+      expect(
+        (await backend.runCLICommand(["sync", "push", "--yes"], tempDir)).code
+      ).toEqual(0);
 
-      const pushResult = await backend.runCLICommand(
-        ["sync", "push", "--yes"],
-        tempDir
-      );
-      expect(pushResult.code).toEqual(0);
-
-      const getResp = await backend.apiRequest!(
-        `/api/w/${backend.workspace}/variables/get/${varPath}`
-      );
-      expect(getResp.status).toEqual(200);
-      const varData = await getResp.json();
+      let varData = await readVariable();
       expect(varData.extra_perms).toEqual({ "g/all": false });
+
+      // `extra_perms: {}` is a revoke; an absent key would mean "no opinion".
+      await writeFile(
+        specFile,
+        pulled.replace("extra_perms:\n  g/all: true\n", "extra_perms: {}\n"),
+        "utf-8"
+      );
+      expect(
+        (await backend.runCLICommand(["sync", "push", "--yes"], tempDir)).code
+      ).toEqual(0);
+
+      varData = await readVariable();
+      expect(varData.extra_perms).toEqual({});
       expect(varData.value).toBe("perm_value");
+      expect(varData.edited_at).toBe(before.edited_at);
     });
   });
 });

--- a/cli/test/variable_resource_push.test.ts
+++ b/cli/test/variable_resource_push.test.ts
@@ -361,6 +361,77 @@ describe("variable", () => {
       expect(content).toContain("is_secret: false");
     });
   });
+
+  test("extra_perms round-trips through pull and is applied via /acls/*", async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      await setupWorkspaceProfile(backend);
+
+      const uniqueId = Date.now();
+      const varPath = `f/test/perm_var_${uniqueId}`;
+
+      const createResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/variables/create`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            path: varPath,
+            value: "perm_value",
+            is_secret: false,
+            description: "Variable with granular ACLs",
+          }),
+        }
+      );
+      expect(createResp.status).toBeLessThan(300);
+      await createResp.text();
+
+      const aclResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/acls/add/variable/${varPath}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ owner: "g/all", write: true }),
+        }
+      );
+      expect(aclResp.status).toBeLessThan(300);
+      await aclResp.text();
+
+      await writeFile(
+        join(tempDir, "wmill.yaml"),
+        `defaultTs: bun\nincludes:\n  - "${varPath}**"\nexcludes: []\n`,
+        "utf-8"
+      );
+
+      const pullResult = await backend.runCLICommand(
+        ["sync", "pull", "--yes"],
+        tempDir
+      );
+      expect(pullResult.code).toEqual(0);
+
+      const specFile = join(tempDir, `${varPath}.variable.yaml`);
+      const pulled = await readFile(specFile, "utf-8");
+      expect(pulled).toContain("extra_perms:");
+      expect(pulled).toContain("g/all: true");
+
+      // Demote the grant to read-only, leaving the rest of the spec untouched:
+      // the perms diff must go through /acls/* without rewriting the variable.
+      await writeFile(specFile, pulled.replace("g/all: true", "g/all: false"), "utf-8");
+
+      const pushResult = await backend.runCLICommand(
+        ["sync", "push", "--yes"],
+        tempDir
+      );
+      expect(pushResult.code).toEqual(0);
+
+      const getResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/variables/get/${varPath}`
+      );
+      expect(getResp.status).toEqual(200);
+      const varData = await getResp.json();
+      expect(varData.extra_perms).toEqual({ "g/all": false });
+      expect(varData.value).toBe("perm_value");
+    });
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`extra_perms` (granular ACLs) already round-trip through `wmill sync` for flows, scripts, apps and raw apps. Variables were the gap: the tarball export dropped the field unconditionally, and the CLI never reconciled it on push. This closes both halves for variables, following the same pattern as flows.

The `variable` kind was already accepted by the granular-ACL endpoints, so no new API surface is introduced.

## Changes

- **Export**: `workspaces_export.rs` now passes `new_kinds_extra_perms` for variables instead of a hardcoded `ExtraPermsBehavior::Drop`, so `?preserve_extra_perms=true` (what `sync pull` sends) surfaces variable ACLs. Default-off is unchanged, so cross-workspace tarball imports still carry no ACLs, and a variable with empty perms still emits no `extra_perms` key — no one-time noisy diff on upgrade.
- **Push**: `VariableFile` gains `extra_perms`, and `pushVariable` strips it from the `update_variable` / `create_variable` body and reconciles it through `applyExtraPermsDiff` (`/acls/add` + `/acls/remove`). A perms-only yaml edit therefore never rewrites the variable — which for a secret would mean re-storing pulled ciphertext. An absent `extra_perms` key still means "no opinion" and leaves remote ACLs alone.
- **Git-sync write-back**: `granular_acls.rs` dispatched `handle_deployment_metadata` for `folder`/`app`/`raw_app`/`script`/`flow` but not `variable`. Without it the CLI becomes authoritative in one direction only: an ACL granted on a variable in the UI never reaches the repo, and the next `sync push` computes its revoke set from the stale local map and silently drops that grant. Both handlers now dispatch `DeployedObject::Variable`.

## Test plan

- [x] `cli/test/variable_resource_push.test.ts` — new integration test: pull surfaces `extra_perms`, a perms-only yaml edit reaches the variable through `/acls/*`, and `value` is untouched. Verified it fails on the pre-change tree and passes after. Full file: 12/12 pass.
- [x] Manual, against the running instance: pull writes `extra_perms` for a variable with ACLs and omits it for one without; push applies grants, demotions and revokes; `extra_perms: {}` revokes all; an omitted key is a no-op; a new variable is created with its ACLs; single-file `wmill variable push` behaves the same. `edited_at` and the stored (cipher)text are unchanged by a perms-only push, and a secret still decrypts afterwards.
- [x] Tarball default-off checked directly: no `preserve_extra_perms` → no `extra_perms` in the variable JSON; `preserve_extra_perms=true` → present when non-empty, absent when `{}`.
- [x] Git-sync dispatch exercised on an EE build (`--features quickjs,private,enterprise`) with git-sync configured: a variable ACL add and a remove each enqueue a sync job carrying `path_type: "variable"` and the expected commit message; a resource ACL add enqueues nothing (negative control).
- [x] `cargo check --features quickjs,private,enterprise` clean; `rustfmt --check` clean; CLI typecheck error count unchanged from main.

## Note on draft status

Left in draft: it touches a permission path (`granular_acls.rs`) and adds a git-sync trigger, so it wants a human look before ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Variables now round-trip `extra_perms` through `wmill sync pull/push`, closing the gap where variable ACLs were dropped on export and never reconciled on push. Flows, scripts, apps, and raw apps already supported this; variables now follow the same pattern.

**Changes**
- Tarball export preserves `extra_perms` for variables when `preserve_extra_perms=true`; default-off is unchanged so cross-workspace imports still strip ACLs.
- `VariableFile` gains `extra_perms`; push applies it via `/acls/*` instead of the update/create body, so a perms-only edit never rewrites the variable value (important for secrets).
- An omitted `extra_perms` key means no opinion and leaves remote ACLs untouched; `extra_perms: {}` revokes all.
- Git-sync now dispatches a sync job when variable ACLs change via the UI, keeping the repo authoritative for the next push.
- New CLI test pins the no-rewrite invariant (`edited_at` unchanged) and the revoke path through `/acls/*`.

<sup>Written for commit 866ae3f5b9304f1daf8c062804fa83b25e79dc9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

