### PR TITLE
feat: recognize `// volume:` mounts in PHP scripts

### DIFF
--- a/backend/windmill-api-scripts/src/asset_inference.rs
+++ b/backend/windmill-api-scripts/src/asset_inference.rs
@@ -86,13 +86,17 @@ fn comment_prefix(lang: &ScriptLang) -> Option<&'static str> {
 
 /// Mirror of the frontend `parseVolumeAnnotations` (infer.ts): `<prefix>
 /// volume: <path>` lines in the leading comment block, each an `rw` volume
-/// asset. Scanning stops at the first non-comment line (blank lines and the PHP
-/// open tag are skipped), exactly like the frontend.
+/// asset. Scanning stops at the first non-comment line; blank lines and PHP's
+/// opening tag line are skipped, exactly like the frontend.
 fn parse_volume_annotations(content: &str, prefix: &str) -> Vec<AssetWithAltAccessType> {
     let mut volumes = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed == "<?php" {
+        if trimmed.is_empty()
+            || trimmed
+                .get(..5)
+                .is_some_and(|p| p.eq_ignore_ascii_case("<?php"))
+        {
             continue;
         }
         let Some(after) = trimmed.strip_prefix(prefix) else {

--- a/backend/windmill-api-scripts/src/asset_inference.rs
+++ b/backend/windmill-api-scripts/src/asset_inference.rs
@@ -87,7 +87,8 @@ fn comment_prefix(lang: &ScriptLang) -> Option<&'static str> {
 /// Mirror of the frontend `parseVolumeAnnotations` (infer.ts): `<prefix>
 /// volume: <path>` lines in the leading comment block, each an `rw` volume
 /// asset. Scanning stops at the first non-comment line; blank lines and PHP's
-/// opening tag line are skipped, exactly like the frontend.
+/// opening tag line are skipped whole (the tag may carry code, so an annotation
+/// must sit on its own line below it), exactly like the frontend.
 fn parse_volume_annotations(content: &str, prefix: &str) -> Vec<AssetWithAltAccessType> {
     let mut volumes = Vec::new();
     for line in content.lines() {

--- a/backend/windmill-api-scripts/src/asset_inference.rs
+++ b/backend/windmill-api-scripts/src/asset_inference.rs
@@ -78,20 +78,21 @@ fn comment_prefix(lang: &ScriptLang) -> Option<&'static str> {
         | ScriptLang::Bun
         | ScriptLang::Bunnative
         | ScriptLang::Nativets
-        | ScriptLang::Go => Some("//"),
+        | ScriptLang::Go
+        | ScriptLang::Php => Some("//"),
         _ => None,
     }
 }
 
 /// Mirror of the frontend `parseVolumeAnnotations` (infer.ts): `<prefix>
 /// volume: <path>` lines in the leading comment block, each an `rw` volume
-/// asset. Scanning stops at the first non-comment line (blank lines are
-/// skipped), exactly like the frontend.
+/// asset. Scanning stops at the first non-comment line (blank lines and the PHP
+/// open tag are skipped), exactly like the frontend.
 fn parse_volume_annotations(content: &str, prefix: &str) -> Vec<AssetWithAltAccessType> {
     let mut volumes = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() {
+        if trimmed.is_empty() || trimmed == "<?php" {
             continue;
         }
         let Some(after) = trimmed.strip_prefix(prefix) else {
@@ -257,5 +258,14 @@ mod tests {
         assert_eq!(vols.len(), 1);
         assert_eq!(vols[0].path, "my_vol");
         assert_eq!(vols[0].access_type, Some(AssetUsageAccessType::RW));
+    }
+
+    #[test]
+    fn php_volume_annotations_survive_the_open_tag() {
+        let content = "<?php\n\n// volume: my_vol\nfunction main() {}\n";
+        let got = effective_script_assets(&ScriptLang::Php, content, None).unwrap();
+        let vols: Vec<_> = got.iter().filter(|a| a.kind == AssetKind::Volume).collect();
+        assert_eq!(vols.len(), 1);
+        assert_eq!(vols[0].path, "my_vol");
     }
 }

--- a/backend/windmill-worker-volumes/src/lib.rs
+++ b/backend/windmill-worker-volumes/src/lib.rs
@@ -179,11 +179,15 @@ pub fn interpolate_volume_name(
     result
 }
 
+/// Scans the leading comment block for `<prefix> volume: <name> <target>` lines,
+/// stopping at the first line that is neither blank nor a comment. A PHP script
+/// opens with `<?php`, which is not a comment, so it is skipped like a blank line;
+/// otherwise the block would end before reaching any annotation.
 pub fn parse_volume_annotations(content: &str, comment_prefix: &str) -> Vec<VolumeMount> {
     let mut volumes = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() {
+        if trimmed.is_empty() || trimmed == "<?php" {
             continue;
         }
         if !trimmed.starts_with(comment_prefix) {
@@ -223,6 +227,16 @@ mod tests {
     #[test]
     fn parse_typescript_single_volume() {
         let content = "// volume: mydata /tmp/data\nexport function main() {}";
+        let result = parse_volume_annotations(content, "//");
+        assert_eq!(
+            result,
+            vec![VolumeMount { name: "mydata".to_string(), target: "/tmp/data".to_string() }]
+        );
+    }
+
+    #[test]
+    fn parse_php_volume_after_open_tag() {
+        let content = "<?php\n\n// volume: mydata /tmp/data\nfunction main() {}";
         let result = parse_volume_annotations(content, "//");
         assert_eq!(
             result,

--- a/backend/windmill-worker-volumes/src/lib.rs
+++ b/backend/windmill-worker-volumes/src/lib.rs
@@ -179,15 +179,23 @@ pub fn interpolate_volume_name(
     result
 }
 
+/// PHP's opening tag, which is case-insensitive and may be followed by code.
+fn is_php_open_tag(trimmed_line: &str) -> bool {
+    trimmed_line
+        .get(..5)
+        .is_some_and(|p| p.eq_ignore_ascii_case("<?php"))
+}
+
 /// Scans the leading comment block for `<prefix> volume: <name> <target>` lines,
 /// stopping at the first line that is neither blank nor a comment. A PHP script
-/// opens with `<?php`, which is not a comment, so it is skipped like a blank line;
-/// otherwise the block would end before reaching any annotation.
+/// opens with `<?php`, which is not a comment, so that line is skipped like a blank
+/// one; otherwise the block would end before reaching any annotation. The whole line
+/// goes, since the tag may carry code (`<?php declare(strict_types=1);`).
 pub fn parse_volume_annotations(content: &str, comment_prefix: &str) -> Vec<VolumeMount> {
     let mut volumes = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed == "<?php" {
+        if trimmed.is_empty() || is_php_open_tag(trimmed) {
             continue;
         }
         if !trimmed.starts_with(comment_prefix) {
@@ -236,7 +244,8 @@ mod tests {
 
     #[test]
     fn parse_php_volume_after_open_tag() {
-        let content = "<?php\n\n// volume: mydata /tmp/data\nfunction main() {}";
+        let content =
+            "<?php declare(strict_types=1);\n\n// volume: mydata /tmp/data\nfunction main() {}";
         let result = parse_volume_annotations(content, "//");
         assert_eq!(
             result,

--- a/backend/windmill-worker-volumes/src/lib.rs
+++ b/backend/windmill-worker-volumes/src/lib.rs
@@ -190,7 +190,8 @@ fn is_php_open_tag(trimmed_line: &str) -> bool {
 /// stopping at the first line that is neither blank nor a comment. A PHP script
 /// opens with `<?php`, which is not a comment, so that line is skipped like a blank
 /// one; otherwise the block would end before reaching any annotation. The whole line
-/// goes, since the tag may carry code (`<?php declare(strict_types=1);`).
+/// goes, since the tag may carry code (`<?php declare(strict_types=1);`) — so an
+/// annotation must sit on its own line, below the opener.
 pub fn parse_volume_annotations(content: &str, comment_prefix: &str) -> Vec<VolumeMount> {
     let mut volumes = Vec::new();
     for line in content.lines() {

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -6412,7 +6412,8 @@ mount {{
             | ScriptLang::Bun
             | ScriptLang::Bunnative
             | ScriptLang::Nativets
-            | ScriptLang::Go => "//",
+            | ScriptLang::Go
+            | ScriptLang::Php => "//",
             _ => "",
         };
         let raw_mounts = windmill_worker_volumes::parse_volume_annotations(&code, comment_prefix);

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -428,6 +428,7 @@ function volumeCommentPrefix(language: string): string | undefined {
     case "bunnative":
     case "nativets":
     case "go":
+    case "php":
       return "//";
     default:
       return undefined;
@@ -435,11 +436,11 @@ function volumeCommentPrefix(language: string): string | undefined {
 }
 
 // `<prefix> volume: <path>` lines in the LEADING comment block, each an `rw`
-// volume asset. Scanning stops at the first non-comment line (blank lines
-// skipped). Exact mirror of frontend `parseVolumeAnnotations` (infer.ts) /
-// backend `parse_volume_annotations` (asset_inference.rs) — the wasm body parser
-// does NOT emit these, so the local graph must supplement them or a `volume:`
-// producer shows disconnected from its `// on volume://…` consumers.
+// volume asset. Scanning stops at the first non-comment line (blank lines and the
+// PHP open tag skipped). Exact mirror of frontend `parseVolumeAnnotations`
+// (infer.ts) / backend `parse_volume_annotations` (asset_inference.rs) — the wasm
+// body parser does NOT emit these, so the local graph must supplement them or a
+// `volume:` producer shows disconnected from its `// on volume://…` consumers.
 function parseVolumeAnnotations(
   content: string,
   prefix: string,
@@ -447,7 +448,7 @@ function parseVolumeAnnotations(
   const out: { kind: string; path: string; access_type: "rw" }[] = [];
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
-    if (trimmed === "") continue;
+    if (trimmed === "" || trimmed === "<?php") continue;
     if (!trimmed.startsWith(prefix)) break;
     const after = trimmed.slice(prefix.length).trim();
     const m = after.match(/^volume:\s*(\S+)/);

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -413,7 +413,13 @@ export function parseMuteAnnotations(content: string): {
 // Comment prefix for `volume:` annotations. Deliberately NOT `commentPrefix`
 // above (which returns `--` for SQL): volume annotations are only recognized for
 // the languages the backend/frontend recognize them for — mirrors
-// `asset_inference.rs:comment_prefix` and `infer.ts:getCommentPrefix` (SQL → none).
+// `asset_inference.rs:comment_prefix` and `infer.ts:getCommentPrefix` (SQL → none),
+// minus `php`. Those two recognize PHP, but a PHP script cannot reach this map: it
+// has no wasm asset parser, so `fallbackParse` handles it and that scan breaks on
+// the mandatory `<?php` opener, leaving `in_pipeline` false and the script dropped
+// as a non-member. Add `php` here together with PHP support in the pipeline
+// annotation scanners (backend `parse_pipeline_annotations` + its frontend mirror
+// + the header scans in this file), or the local graph desyncs from the deployed one.
 function volumeCommentPrefix(language: string): string | undefined {
   switch (language) {
     case "python3":

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -428,7 +428,6 @@ function volumeCommentPrefix(language: string): string | undefined {
     case "bunnative":
     case "nativets":
     case "go":
-    case "php":
       return "//";
     default:
       return undefined;
@@ -436,11 +435,11 @@ function volumeCommentPrefix(language: string): string | undefined {
 }
 
 // `<prefix> volume: <path>` lines in the LEADING comment block, each an `rw`
-// volume asset. Scanning stops at the first non-comment line (blank lines and the
-// PHP open tag skipped). Exact mirror of frontend `parseVolumeAnnotations`
-// (infer.ts) / backend `parse_volume_annotations` (asset_inference.rs) — the wasm
-// body parser does NOT emit these, so the local graph must supplement them or a
-// `volume:` producer shows disconnected from its `// on volume://…` consumers.
+// volume asset. Scanning stops at the first non-comment line (blank lines
+// skipped). Exact mirror of frontend `parseVolumeAnnotations` (infer.ts) /
+// backend `parse_volume_annotations` (asset_inference.rs) — the wasm body parser
+// does NOT emit these, so the local graph must supplement them or a `volume:`
+// producer shows disconnected from its `// on volume://…` consumers.
 function parseVolumeAnnotations(
   content: string,
   prefix: string,
@@ -448,7 +447,7 @@ function parseVolumeAnnotations(
   const out: { kind: string; path: string; access_type: "rw" }[] = [];
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
-    if (trimmed === "" || trimmed === "<?php") continue;
+    if (trimmed === "") continue;
     if (!trimmed.startsWith(prefix)) break;
     const after = trimmed.slice(prefix.length).trim();
     const m = after.match(/^volume:\s*(\S+)/);

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -205,13 +205,14 @@ export type PreparedAssetsSqlQuery =
 	| { error: string; columns?: undefined } // error message if preparation failed
 
 // Scans the leading comment block, stopping at the first line that is neither blank
-// nor a comment. A PHP script opens with `<?php`, which is not a comment, so it is
-// skipped like a blank line; otherwise the block would end before reaching any annotation.
+// nor a comment. A PHP script opens with `<?php`, which is not a comment, so that line
+// is skipped like a blank one; otherwise the block would end before reaching any
+// annotation. The whole line goes, since the tag may carry code (`<?php declare(…);`).
 function parseVolumeAnnotations(code: string, commentPrefix: string): AssetWithAccessType[] {
 	const volumes: AssetWithAccessType[] = []
 	for (const line of code.split('\n')) {
 		const trimmed = line.trim()
-		if (!trimmed || trimmed === '<?php') continue
+		if (!trimmed || trimmed.slice(0, 5).toLowerCase() === '<?php') continue
 		if (!trimmed.startsWith(commentPrefix)) break
 		const after = trimmed.slice(commentPrefix.length).trim()
 		const match = after.match(/^volume:\s*(\S+)/)

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -207,7 +207,8 @@ export type PreparedAssetsSqlQuery =
 // Scans the leading comment block, stopping at the first line that is neither blank
 // nor a comment. A PHP script opens with `<?php`, which is not a comment, so that line
 // is skipped like a blank one; otherwise the block would end before reaching any
-// annotation. The whole line goes, since the tag may carry code (`<?php declare(…);`).
+// annotation. The whole line goes, since the tag may carry code (`<?php declare(…);`) —
+// so an annotation must sit on its own line, below the opener.
 function parseVolumeAnnotations(code: string, commentPrefix: string): AssetWithAccessType[] {
 	const volumes: AssetWithAccessType[] = []
 	for (const line of code.split('\n')) {

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -204,11 +204,14 @@ export type PreparedAssetsSqlQuery =
 	| { columns: Record<string, string> } // e.g { id: "number", name: "text" }
 	| { error: string; columns?: undefined } // error message if preparation failed
 
+// Scans the leading comment block, stopping at the first line that is neither blank
+// nor a comment. A PHP script opens with `<?php`, which is not a comment, so it is
+// skipped like a blank line; otherwise the block would end before reaching any annotation.
 function parseVolumeAnnotations(code: string, commentPrefix: string): AssetWithAccessType[] {
 	const volumes: AssetWithAccessType[] = []
 	for (const line of code.split('\n')) {
 		const trimmed = line.trim()
-		if (!trimmed) continue
+		if (!trimmed || trimmed === '<?php') continue
 		if (!trimmed.startsWith(commentPrefix)) break
 		const after = trimmed.slice(commentPrefix.length).trim()
 		const match = after.match(/^volume:\s*(\S+)/)
@@ -233,6 +236,7 @@ function getCommentPrefix(language: SupportedLanguage | undefined): string | und
 		case 'bunnative':
 		case 'nativets':
 		case 'go':
+		case 'php':
 			return '//'
 		default:
 			return undefined


### PR DESCRIPTION
## Summary

Volume annotations were parsed for every language but PHP, so a PHP script could not mount a workspace volume. Two things stood in the way:

- PHP had no entry in the comment-prefix maps that decide which languages are scanned for `volume:` annotations.
- A PHP script opens with `<?php`, which is not a comment, so it ended the leading comment block the parsers scan before any annotation was reached.

The worker half was already plumbed: `run.php.config.proto` carries `{SHARED_MOUNT}` and its `cwd: "/tmp"` matches the fallback nsjail cwd used for relative volume targets, and `handle_php_job` already takes `shared_mount`. Only the parsing gate was missing.

## Changes

- Add `ScriptLang::Php` / `'php'` to the `//` comment-prefix group in the worker (`worker.rs`), the deploy-time asset inference (`asset_inference.rs`) and the editor's client-side inference (`infer.ts`).
- Skip PHP's opening tag while scanning the leading comment block, in all three `parse_volume_annotations` mirrors. Matched as a case-insensitive prefix over the whole line, so `<?php declare(strict_types=1);` works too.
- Two unit tests, one per backend parser, pinning that a `// volume:` line below the opener is still found.

Deliberately **not** changed: `cli/src/commands/pipeline/localGraph.ts`. Adding PHP there would be dead code — PHP has no wasm asset parser, so it goes through `fallbackParse`, whose own header scan stops at `<?php` and drops the script as a non-pipeline member before any volume asset is read. Making only the CLI PHP-aware would also put the local graph out of parity with the deployed one, whose `parse_pipeline_annotations` stops at `<?php` as well. PHP pipeline membership is a separate change spanning the backend parser, its wasm build, the frontend mirror and the CLI's three header scanners.

## Screenshots

Deployed PHP script with `// volume: php-vol /tmp/data`; the editor's assets panel now lists the volume as R/W:

![php-volume-asset](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/implement-volume-for-php/1788863881-php-volume-asset.png)

## Test plan

Exercised on a local worker built with `--features quickjs,php,parquet,private`, against a workspace with filesystem large-file storage and `volume_storage: primary`:

- [x] PHP job with `// volume: php-vol /tmp/data` mounts the volume (`mounted volume 'php-vol' at '/tmp/data'`) and writes into it
- [x] A second, separate PHP job reads the file back — `{"note": "hello from php volume", "files": ["from_bun.txt", "note.txt"]}` — so the write syncs to storage and re-downloads
- [x] Files land in the object store at `volumes/<workspace>/php-vol/`, and the volume's `size_bytes` / `file_count` update
- [x] Same volume shared with a Bun script: each language sees the other's files
- [x] `<?php declare(strict_types=1);` opener also mounts and writes
- [x] Deploying the PHP script records the volume in the `asset` table as `kind=volume, usage_access_type=rw`
- [x] Script editor shows `php-vol / Volume / R/W` in the assets panel
- [x] `cargo test -p windmill-worker-volumes`, `cargo test -p windmill-api-scripts --lib asset_inference`, `npm run check:fast` (4 pre-existing unrelated errors), `bun test test/pipeline_local_graph_unit.test.ts`

Note for reviewers: in a **debug** build the PHP + volume path needs slightly more stack than tokio's 2 MB default (it aborts with `tokio-runtime-worker has overflowed its stack`); it passes at 2.5 MB and at the `RUST_MIN_STACK=4194304` that CI already sets for backend tests. Debug futures are much larger than release ones, and the margin is ~25%, so this looks like the usual debug-build frame bloat rather than a release concern — flagging it so a reviewer running a plain `cargo run` isn't surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3FR7iS9nRhpFt615cnuQ7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
PHP scripts now support `// volume:` mounts, which previously failed because PHP wasn't in the comment-prefix maps and the `<?php` opener ended the leading comment block before annotations were read.

- Adds `ScriptLang::Php` to the `//` comment-prefix group in the worker, deploy-time asset inference, and editor client-side inference.
- Skips the PHP opening tag line during comment-block scanning in all three parsers, matching `<?php` case-insensitively as a prefix so `<?php declare(strict_types=1);` works too.
- Adds unit tests for the backend parsers pinning that annotations below the opener are found.
- Leaves the CLI local-graph scanner unchanged: PHP has no wasm asset parser, so PHP-aware CLI code would be dead and out of parity with the deployed pipeline parser.

<sup>Written for commit 7320ffc4ad77322fa3c40db5520f500315d1be5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



One adjacency worth knowing (pre-existing, not introduced here): `parse_php_imports` scans the lines after `// require:` with a single-token regex, so any multi-token comment placed *between* `// require:` and the package list truncates the dependency list. Put the `volume:` line before the `require:` block, as the annotations at the top of the default template already are.
