### PR TITLE
fix: reduce php parser stack use in debug workers

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -108,6 +108,10 @@ debug = "line-tables-only"
 [profile.dev.package."*"]
 debug = false
 
+# The expression parser's fallback call chain exhausts worker stacks without optimization.
+[profile.dev.package.php-parser-rs]
+opt-level = 1
+
 [profile.release]
 lto = "thin"
 debug = "line-tables-only"

--- a/backend/tests/volume_tests.rs
+++ b/backend/tests/volume_tests.rs
@@ -555,6 +555,7 @@ export function main() {
 #[cfg(all(feature = "parquet", feature = "private", feature = "php"))]
 #[sqlx::test(fixtures("base"))]
 async fn test_php_volume_with_default_stack(db: Pool<Postgres>) -> anyhow::Result<()> {
+    // Nested calls exercise the parser's fallback chain; flattening them weakens this guard.
     let code = r#"<?php
 // volume: test-vol data
 

--- a/backend/tests/volume_tests.rs
+++ b/backend/tests/volume_tests.rs
@@ -537,6 +537,54 @@ fn test_asset_kind_volume_variant() {
 #[cfg(feature = "parquet")]
 #[sqlx::test(fixtures("base"))]
 async fn test_volume_sql_worker_e2e(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let code = r#"// volume: test-vol data
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+
+export function main() {
+    const content = readFileSync("data/hello.txt", "utf-8");
+    writeFileSync("data/output.txt", "written by sql worker");
+    return {
+        read_content: content,
+        output_exists: existsSync("data/output.txt"),
+    };
+}"#;
+    run_volume_sql_worker_e2e(db, ScriptLang::Bun, code).await
+}
+
+#[cfg(all(feature = "parquet", feature = "private", feature = "php"))]
+#[sqlx::test(fixtures("base"))]
+async fn test_php_volume_with_default_stack(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let code = r#"<?php
+// volume: test-vol data
+
+function main() {
+    $content = file_get_contents("data/hello.txt");
+    file_put_contents("data/output.txt", "written by sql worker");
+    return [
+        "read_content" => $content,
+        "output_exists" => in_array("output.txt", array_values(array_diff(scandir("data"), ['.', '..']))),
+    ];
+}"#;
+
+    // CI raises RUST_MIN_STACK; keep the worker at Tokio's default to catch regressions.
+    tokio::task::spawn_blocking(move || {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .thread_stack_size(2 * 1024 * 1024)
+            .enable_all()
+            .build()?
+            .block_on(run_volume_sql_worker_e2e(db, ScriptLang::Php, code))
+    })
+    .await?
+}
+
+#[cfg(feature = "parquet")]
+async fn run_volume_sql_worker_e2e(
+    db: Pool<Postgres>,
+    language: ScriptLang,
+    code: &str,
+) -> anyhow::Result<()> {
     initialize_tracing().await;
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
@@ -571,24 +619,11 @@ async fn test_volume_sql_worker_e2e(db: Pool<Postgres>) -> anyhow::Result<()> {
     std::fs::write(vol_dir.join("hello.txt"), b"hello from volume")?;
 
     // 3. Push the job and run with SQL-connected worker
-    let code = r#"// volume: test-vol data
-
-import { readFileSync, writeFileSync, existsSync } from "fs";
-
-export function main() {
-    const content = readFileSync("data/hello.txt", "utf-8");
-    writeFileSync("data/output.txt", "written by sql worker");
-    return {
-        read_content: content,
-        output_exists: existsSync("data/output.txt"),
-    };
-}"#;
-
     let job = JobPayload::Code(RawCode {
         hash: None,
         content: code.to_string(),
         path: None,
-        language: ScriptLang::Bun,
+        language,
         lock: None,
         cache_ttl: None,
         cache_ignore_s3_path: None,


### PR DESCRIPTION
## Summary

Reduce PHP parser stack usage in debug builds so a PHP job with a volume can execute on Tokio's default 2 MiB worker stack. The unoptimized expression parser's fallback call chain consumes most of the stack remaining beneath the worker's async polling frames.

## Changes

- Compile only `php-parser-rs` with `opt-level = 1` in the development profile. Release settings and the worker runtime stack size are unchanged.
- Add a real PHP-volume worker regression that explicitly uses 2 MiB worker threads, independently of CI's `RUST_MIN_STACK=4194304`.
- Share the existing Bun volume fixture and retain its read/write, backing-store synchronization, and lease-release assertions.

This is the immediate mitigation only. Moving CPU-heavy parsing off async worker threads and reducing shared worker polling frames are follow-up investigations, not implemented here. This does not establish a bound for arbitrarily nested PHP source.

## Test plan

- [x] Run the new PHP-volume regression with `private,parquet,php,quickjs`: passes on explicitly configured 2 MiB worker threads; real PHP subprocess completes and volume output is synchronized.
- [x] Override `profile.dev.package.php-parser-rs.opt-level=0` and run the same regression: reproduces `tokio-runtime-worker` stack overflow / SIGABRT.
- [x] Run the existing Bun SQL-worker volume test: passes.
- [x] `rustfmt --check --edition 2021 backend/tests/volume_tests.rs` and `git diff --check`.
- [x] Independent local review and cold Codex review: no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debug builds of the PHP expression parser now compile with optimization, so PHP volume jobs no longer crash with a stack overflow on Tokio's default 2 MiB worker stack.

- Optimizes only `php-parser-rs` via `opt-level = 1` in the dev profile; release builds and the worker runtime stack size are unchanged.
- Adds a PHP volume regression test that runs on explicitly configured 2 MiB worker threads, independent of CI's `RUST_MIN_STACK` override; the test code uses nested calls so the parser's fallback chain stays exercised.
- Reuses the existing Bun volume fixture and keeps its read/write, backing-store synchronization, and lease-release assertions.

<sup>Written for commit feffde23ac8526a9deb9d1207037c34925b4686c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

