### PR TITLE
perf: reduce shared worker debug polling frames

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -108,6 +108,10 @@ debug = "line-tables-only"
 [profile.dev.package."*"]
 debug = false
 
+# The expression parser's fallback call chain exhausts worker stacks without optimization.
+[profile.dev.package.php-parser-rs]
+opt-level = 1
+
 [profile.release]
 lto = "thin"
 debug = "line-tables-only"

--- a/backend/tests/agent_workers.rs
+++ b/backend/tests/agent_workers.rs
@@ -293,6 +293,7 @@ async fn test_agent_worker_volume_e2e(db: Pool<Postgres>) -> anyhow::Result<()> 
     let lfs_config = json!({
         "type": "FilesystemStorage",
         "root_path": storage_root,
+        "volume_storage": "primary",
         "public_resource": null,
         "advanced_permissions": null
     });
@@ -306,7 +307,11 @@ async fn test_agent_worker_volume_e2e(db: Pool<Postgres>) -> anyhow::Result<()> 
     .await?;
 
     // 2. Pre-populate the volume with a file
-    let vol_dir = storage_dir.path().join("volumes").join("test-vol");
+    let vol_dir = storage_dir
+        .path()
+        .join("volumes")
+        .join("test-workspace")
+        .join("test-vol");
     std::fs::create_dir_all(&vol_dir)?;
     std::fs::write(vol_dir.join("hello.txt"), b"hello from volume")?;
 
@@ -343,6 +348,7 @@ async fn test_agent_worker_volume_e2e(db: Pool<Postgres>) -> anyhow::Result<()> 
     // 4. GET /file/* — download the existing file
     let resp = http
         .get(format!("{vol_base}/file/hello.txt"))
+        .query(&[("worker_name", "test-worker-1")])
         .send()
         .await?;
     assert!(
@@ -360,6 +366,7 @@ async fn test_agent_worker_volume_e2e(db: Pool<Postgres>) -> anyhow::Result<()> 
     // 5. PUT /file/* — upload a new file
     let resp = http
         .put(format!("{vol_base}/file/output.txt"))
+        .query(&[("worker_name", "test-worker-1")])
         .body(b"written by agent worker".to_vec())
         .send()
         .await?;
@@ -533,6 +540,7 @@ async fn test_agent_worker_volume_release(db: Pool<Postgres>) -> anyhow::Result<
     let lfs_config = json!({
         "type": "FilesystemStorage",
         "root_path": storage_root,
+        "volume_storage": "primary",
         "public_resource": null,
         "advanced_permissions": null
     });

--- a/backend/tests/agent_workers.rs
+++ b/backend/tests/agent_workers.rs
@@ -432,7 +432,8 @@ async fn test_agent_worker_volume_http_worker_e2e(db: Pool<Postgres>) -> anyhow:
         "type": "FilesystemStorage",
         "root_path": storage_root,
         "public_resource": null,
-        "advanced_permissions": null
+        "advanced_permissions": null,
+        "volume_storage": "primary"
     });
 
     sqlx::query!(
@@ -444,20 +445,24 @@ async fn test_agent_worker_volume_http_worker_e2e(db: Pool<Postgres>) -> anyhow:
     .await?;
 
     // 2. Pre-populate the volume with a file
-    let vol_dir = storage_dir.path().join("volumes").join("test-vol");
+    let vol_dir = storage_dir
+        .path()
+        .join("volumes")
+        .join("test-workspace")
+        .join("test-vol");
     std::fs::create_dir_all(&vol_dir)?;
     std::fs::write(vol_dir.join("hello.txt"), b"hello from volume")?;
 
     // 3. Push the job, then run worker with HTTP connection (bun tag)
-    let code = r#"// volume: test-vol /tmp/data
+    let code = r#"// volume: test-vol data
 import { readFileSync, writeFileSync, existsSync } from "fs";
 
 export function main() {
-    const content = readFileSync("/tmp/data/hello.txt", "utf-8");
-    writeFileSync("/tmp/data/output.txt", "written by agent worker");
+    const content = readFileSync("data/hello.txt", "utf-8");
+    writeFileSync("data/output.txt", "written by agent worker");
     return {
         read_content: content,
-        output_exists: existsSync("/tmp/data/output.txt"),
+        output_exists: existsSync("data/output.txt"),
     };
 }"#;
 

--- a/backend/tests/volume_tests.rs
+++ b/backend/tests/volume_tests.rs
@@ -549,7 +549,7 @@ export function main() {
         output_exists: existsSync("data/output.txt"),
     };
 }"#;
-    run_volume_sql_worker_e2e(db, ScriptLang::Bun, code).await
+    run_volume_with_default_stack(db, ScriptLang::Bun, code).await
 }
 
 #[cfg(all(feature = "parquet", feature = "private", feature = "php"))]
@@ -568,6 +568,15 @@ function main() {
     ];
 }"#;
 
+    run_volume_with_default_stack(db, ScriptLang::Php, code).await
+}
+
+#[cfg(feature = "parquet")]
+async fn run_volume_with_default_stack(
+    db: Pool<Postgres>,
+    language: ScriptLang,
+    code: &'static str,
+) -> anyhow::Result<()> {
     // CI raises RUST_MIN_STACK; keep the worker at Tokio's default to catch regressions.
     tokio::task::spawn_blocking(move || {
         tokio::runtime::Builder::new_multi_thread()
@@ -575,7 +584,7 @@ function main() {
             .thread_stack_size(2 * 1024 * 1024)
             .enable_all()
             .build()?
-            .block_on(run_volume_sql_worker_e2e(db, ScriptLang::Php, code))
+            .block_on(run_volume_sql_worker_e2e(db, language, code))
     })
     .await?
 }

--- a/backend/tests/volume_tests.rs
+++ b/backend/tests/volume_tests.rs
@@ -555,6 +555,7 @@ export function main() {
 #[cfg(all(feature = "parquet", feature = "private", feature = "php"))]
 #[sqlx::test(fixtures("base"))]
 async fn test_php_volume_with_default_stack(db: Pool<Postgres>) -> anyhow::Result<()> {
+    // Nested calls exercise the parser's fallback chain; flattening them weakens this guard.
     let code = r#"<?php
 // volume: test-vol data
 

--- a/backend/tests/volume_tests.rs
+++ b/backend/tests/volume_tests.rs
@@ -537,6 +537,54 @@ fn test_asset_kind_volume_variant() {
 #[cfg(feature = "parquet")]
 #[sqlx::test(fixtures("base"))]
 async fn test_volume_sql_worker_e2e(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let code = r#"// volume: test-vol data
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+
+export function main() {
+    const content = readFileSync("data/hello.txt", "utf-8");
+    writeFileSync("data/output.txt", "written by sql worker");
+    return {
+        read_content: content,
+        output_exists: existsSync("data/output.txt"),
+    };
+}"#;
+    run_volume_sql_worker_e2e(db, ScriptLang::Bun, code).await
+}
+
+#[cfg(all(feature = "parquet", feature = "private", feature = "php"))]
+#[sqlx::test(fixtures("base"))]
+async fn test_php_volume_with_default_stack(db: Pool<Postgres>) -> anyhow::Result<()> {
+    let code = r#"<?php
+// volume: test-vol data
+
+function main() {
+    $content = file_get_contents("data/hello.txt");
+    file_put_contents("data/output.txt", "written by sql worker");
+    return [
+        "read_content" => $content,
+        "output_exists" => in_array("output.txt", array_values(array_diff(scandir("data"), ['.', '..']))),
+    ];
+}"#;
+
+    // CI raises RUST_MIN_STACK; keep the worker at Tokio's default to catch regressions.
+    tokio::task::spawn_blocking(move || {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .thread_stack_size(2 * 1024 * 1024)
+            .enable_all()
+            .build()?
+            .block_on(run_volume_sql_worker_e2e(db, ScriptLang::Php, code))
+    })
+    .await?
+}
+
+#[cfg(feature = "parquet")]
+async fn run_volume_sql_worker_e2e(
+    db: Pool<Postgres>,
+    language: ScriptLang,
+    code: &str,
+) -> anyhow::Result<()> {
     initialize_tracing().await;
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
@@ -571,24 +619,11 @@ async fn test_volume_sql_worker_e2e(db: Pool<Postgres>) -> anyhow::Result<()> {
     std::fs::write(vol_dir.join("hello.txt"), b"hello from volume")?;
 
     // 3. Push the job and run with SQL-connected worker
-    let code = r#"// volume: test-vol data
-
-import { readFileSync, writeFileSync, existsSync } from "fs";
-
-export function main() {
-    const content = readFileSync("data/hello.txt", "utf-8");
-    writeFileSync("data/output.txt", "written by sql worker");
-    return {
-        read_content: content,
-        output_exists: existsSync("data/output.txt"),
-    };
-}"#;
-
     let job = JobPayload::Code(RawCode {
         hash: None,
         content: code.to_string(),
         path: None,
-        language: ScriptLang::Bun,
+        language,
         lock: None,
         cache_ttl: None,
         cache_ignore_s3_path: None,

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -3091,16 +3091,16 @@ async fn test_php_job(db: Pool<Postgres>) -> anyhow::Result<()> {
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
 
-    let content = r#"
+    let content = r#"// schema_validation
 <?php
 
-function main(string $name): string {
-    return "hello " . $name;
+function main(string $name, string $prefix = "hello "): string {
+    return $prefix . $name;
 }
 "#
     .to_owned();
 
-    let result = RunJob::from(JobPayload::Code(RawCode {
+    let code = RawCode {
         hash: None,
         content,
         path: None,
@@ -3114,14 +3114,24 @@ function main(string $name): string {
         debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
         modules: None,
         tag: None,
-    }))
-    .arg("name", json!("world"))
-    .run_until_complete(&db, false, port)
-    .await
-    .json_result()
-    .unwrap();
+    };
+    let completed = RunJob::from(JobPayload::Code(code.clone()))
+        .arg("name", json!("world"))
+        .run_until_complete(&db, false, port)
+        .await;
 
-    assert_eq!(result, serde_json::json!("hello world"));
+    assert!(completed.success, "{:?}", completed.result);
+    assert_eq!(
+        completed.json_result().unwrap(),
+        serde_json::json!("hello world")
+    );
+
+    let invalid = RunJob::from(JobPayload::Code(code))
+        .arg("name", json!(42))
+        .run_until_complete(&db, false, port)
+        .await;
+    // PHP coerces numbers to strings; rejection proves inferred validation ran.
+    assert!(!invalid.success, "{:?}", invalid.result);
     Ok(())
 }
 

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -3132,6 +3132,10 @@ function main(string $name, string $prefix = "hello "): string {
         .await;
     // PHP coerces numbers to strings; rejection proves inferred validation ran.
     assert!(!invalid.success, "{:?}", invalid.result);
+    assert!(invalid.json_result().unwrap()["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("Argument `name` should be a string"));
     Ok(())
 }
 

--- a/backend/windmill-worker/src/ai/utils.rs
+++ b/backend/windmill-worker/src/ai/utils.rs
@@ -26,11 +26,11 @@ use windmill_queue::{flow_status::get_step_of_flow_status, MiniPulledJob};
 
 use crate::parse_sig_of_lang;
 
-pub fn parse_raw_script_schema(
+pub async fn parse_raw_script_schema(
     content: &str,
     language: &ScriptLang,
 ) -> Result<Box<RawValue>, Error> {
-    let main_arg_signature = parse_sig_of_lang(content, Some(&language), None)?
+    let main_arg_signature = parse_sig_of_lang(content, Some(&language), None).await?
         .ok_or_else(|| Error::BadConfig(format!(
             "Cannot parse signature for language {:?}. The language parser may not be enabled in this build.",
             language

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -621,7 +621,7 @@ pub async fn handle_ai_agent_job(
                     (schema, input_transforms, derived_description)
                 }
                 FlowModuleValue::RawScript { content, language, input_transforms, .. } => {
-                    let schema = Some(parse_raw_script_schema(&content, &language)?);
+                    let schema = Some(parse_raw_script_schema(&content, &language).await?);
                     (schema, input_transforms, None)
                 }
                 FlowModuleValue::AIAgent { input_transforms, .. } => {

--- a/backend/windmill-worker/src/php_executor.rs
+++ b/backend/windmill-worker/src/php_executor.rs
@@ -54,7 +54,17 @@ async fn parse_php_signature_with_slot(
     main_override: Option<String>,
     slot: &'static tokio::sync::Semaphore,
 ) -> Result<MainArgSignature> {
-    let permit = slot.acquire().await.map_err(to_anyhow)?;
+    let acquire = slot.acquire();
+    tokio::pin!(acquire);
+    // Retain the acquisition across the warning to preserve its FIFO queue position.
+    let permit = tokio::select! {
+        permit = &mut acquire => permit,
+        _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {
+            tracing::warn!("Waiting over a second for PHP signature parser capacity");
+            acquire.await
+        }
+    }
+    .map_err(to_anyhow)?;
     let code = code.to_owned();
     tokio::task::spawn_blocking(move || {
         // Parsing walks the entire AST. Keep its stack off async workers and retain

--- a/backend/windmill-worker/src/php_executor.rs
+++ b/backend/windmill-worker/src/php_executor.rs
@@ -14,7 +14,7 @@ use windmill_common::{
 };
 use windmill_queue::MiniPulledJob;
 
-use windmill_parser::Typ;
+use windmill_parser::{MainArgSignature, Typ};
 use windmill_queue::{append_logs, CanceledBy};
 
 use crate::{
@@ -39,6 +39,33 @@ lazy_static::lazy_static! {
 }
 
 const COMPOSER_LOCK_SPLIT: &str = "\nLOCK\n";
+
+static PHP_PARSER_SLOT: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(1);
+
+pub(crate) async fn parse_php_signature(
+    code: &str,
+    main_override: Option<String>,
+) -> Result<MainArgSignature> {
+    parse_php_signature_with_slot(code, main_override, &PHP_PARSER_SLOT).await
+}
+
+async fn parse_php_signature_with_slot(
+    code: &str,
+    main_override: Option<String>,
+    slot: &'static tokio::sync::Semaphore,
+) -> Result<MainArgSignature> {
+    let permit = slot.acquire().await.map_err(to_anyhow)?;
+    let code = code.to_owned();
+    tokio::task::spawn_blocking(move || {
+        // Parsing walks the entire AST. Keep its stack off async workers and retain
+        // the process-wide CPU limit even if the awaiting job is cancelled.
+        let _permit = permit;
+        windmill_parser_php::parse_php_signature(&code, main_override)
+    })
+    .await
+    .map_err(|e| error::Error::internal_err(format!("PHP signature parsing task failed: {e}")))?
+    .map_err(Into::into)
+}
 
 pub fn parse_php_imports(code: &str) -> anyhow::Result<Option<String>> {
     let find_requirements = code
@@ -333,11 +360,9 @@ pub async fn handle_php_job(
     let main_override = job.script_entrypoint_override.as_deref();
 
     let write_wrapper_f = async {
-        let args = windmill_parser_php::parse_php_signature(
-            inner_content,
-            main_override.map(ToString::to_string),
-        )?
-        .args;
+        let args = parse_php_signature(inner_content, main_override.map(ToString::to_string))
+            .await?
+            .args;
 
         let args_to_include = args
             .iter()
@@ -490,4 +515,52 @@ try {{
     )
     .await?;
     read_result(job_dir, None).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_php_signature_with_slot;
+
+    #[test]
+    fn cancelled_parse_retains_slot_until_blocking_work_finishes() {
+        static SLOT: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(1);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let blocker = runtime.spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.recv();
+        });
+
+        runtime.block_on(async {
+            started_rx.await.unwrap();
+            let parse = tokio::spawn(parse_php_signature_with_slot(
+                "<?php function main() {}",
+                None,
+                &SLOT,
+            ));
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                while SLOT.available_permits() != 0 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .unwrap();
+
+            parse.abort();
+            assert!(parse.await.unwrap_err().is_cancelled());
+            assert!(SLOT.try_acquire().is_err());
+
+            release_tx.send(()).unwrap();
+            blocker.await.unwrap();
+            let _permit = tokio::time::timeout(std::time::Duration::from_secs(5), SLOT.acquire())
+                .await
+                .unwrap()
+                .unwrap();
+        });
+    }
 }

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -3867,7 +3867,8 @@ pub async fn run_worker(
                     let job_result = windmill_common::log_context::with_log_context(
                         log_ctx,
                         async {
-                            let result = handle_queued_job(
+                            // Keep large job-phase futures boxed to limit debug polling frames.
+                            let result = Box::pin(handle_queued_job(
                                 arc_job.clone(),
                                 raw_code,
                                 raw_lock,
@@ -3888,7 +3889,7 @@ pub async fn run_worker(
                                 flow_runners,
                                 #[cfg(feature = "benchmark")]
                                 &mut bench,
-                            )
+                            ))
                             .await;
                             record_job_span_status(&result);
                             result
@@ -5527,7 +5528,7 @@ async fn handle_code_execution_job(
     .await?;
 
     let language = language.clone();
-    let result = run_language_executor(
+    let result = Box::pin(run_language_executor(
         job,
         conn,
         client,
@@ -5552,7 +5553,7 @@ async fn handle_code_execution_job(
         &modules,
         false,
         in_pipeline,
-    )
+    ))
     .await;
     record_declared_warehouse_write(job, conn, code, &result).await;
     result
@@ -6466,7 +6467,7 @@ mount {{
         .await;
 
         if let Connection::Sql(db) = conn {
-            volume_setup = crate::volume_oss::setup_volumes_sql_worker(
+            volume_setup = Box::pin(crate::volume_oss::setup_volumes_sql_worker(
                 &volume_mounts,
                 db,
                 &job.workspace_id,
@@ -6479,10 +6480,10 @@ mount {{
                 language,
                 &mut envs,
                 &mut shared_mount,
-            )
+            ))
             .await?;
         } else if let Connection::Http(http) = conn {
-            volume_setup = crate::volume_oss::setup_volumes_http_worker(
+            volume_setup = Box::pin(crate::volume_oss::setup_volumes_http_worker(
                 &volume_mounts,
                 http,
                 &job.workspace_id,
@@ -6495,7 +6496,7 @@ mount {{
                 language,
                 &mut envs,
                 &mut shared_mount,
-            )
+            ))
             .await?;
         }
     }
@@ -6991,7 +6992,7 @@ mount {{
 
         if let Some(ref vol_client) = volume_setup.client {
             if let Connection::Sql(db) = conn {
-                crate::volume_oss::sync_volumes_sql_worker(
+                Box::pin(crate::volume_oss::sync_volumes_sql_worker(
                     &volume_setup.states,
                     &volume_setup.writable,
                     vol_client,
@@ -7001,13 +7002,13 @@ mount {{
                     worker_name,
                     conn,
                     result.is_ok(),
-                )
+                ))
                 .await;
             }
         }
 
         if let Connection::Http(http) = conn {
-            crate::volume_oss::sync_volumes_http_worker(
+            Box::pin(crate::volume_oss::sync_volumes_http_worker(
                 &volume_setup.states,
                 &volume_setup.writable,
                 http,
@@ -7016,7 +7017,7 @@ mount {{
                 worker_name,
                 conn,
                 result.is_ok(),
-            )
+            ))
             .await;
         }
 

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -5159,7 +5159,7 @@ async fn try_validate_schema(
                             code,
                             language,
                             job.script_entrypoint_override.clone(),
-                        )? {
+                        ).await? {
                             Ok(Some(schema_validator_from_main_arg_sig(&sig)))
                         } else {
                             Err(anyhow!("Job was expected to validate the arguments schema, but no schema was provided and couldn't be inferred from the script for language `{language:?}`. Try removing schema validation for this job").into())
@@ -7051,7 +7051,7 @@ mount {{
     result
 }
 
-pub fn parse_sig_of_lang(
+pub async fn parse_sig_of_lang(
     code: &str,
     language: Option<&ScriptLang>,
     main_override: Option<String>,
@@ -7086,10 +7086,9 @@ pub fn parse_sig_of_lang(
             ScriptLang::DuckDb => Some(windmill_parser_sql::parse_duckdb_sig(code)?),
             ScriptLang::OracleDB => Some(windmill_parser_sql::parse_oracledb_sig(code)?),
             #[cfg(feature = "php")]
-            ScriptLang::Php => Some(windmill_parser_php::parse_php_signature(
-                code,
-                main_override,
-            )?),
+            ScriptLang::Php => {
+                Some(crate::php_executor::parse_php_signature(code, main_override).await?)
+            }
             #[cfg(not(feature = "php"))]
             ScriptLang::Php => None,
             #[cfg(feature = "rust")]


### PR DESCRIPTION
## Summary

Reduce shared debug worker polling frames by boxing six large awaited job phases. Execution remains in the same task: this does not change cancellation, task ownership, volume lease lifetimes, or completion ordering.

Stage 3, stacked on #11027 (`fix/php-parser-offload`). Stage 1 (#11025) is already merged.

## Changes

- Box the queued-job handler at the worker loop and the language dispatcher at code execution.
- Box SQL/HTTP volume setup and sync futures, matching the existing boxed language executors.
- Run the existing Bun volume regression on explicit 2 MiB worker threads, reusing the PHP regression's runtime harness.
- Refresh the HTTP worker volume fixture to enable volume storage and use the current workspace namespace. Use a job-relative mount to avoid a shared `/tmp/data` path.

Measured with `-Zemit-stack-sizes`, debug optimization level 0, `private,php,parquet,windmill-object-store/private`:

| Poll frame | Before (bytes) | After (bytes) |
| --- | ---: | ---: |
| `run_worker` | 305,176 | 237,368 |
| `handle_queued_job` | 182,824 | 173,688 |
| `handle_code_execution_job` | 80,744 | 25,928 |
| `run_language_executor` | 194,632 | 177,032 |
| Total of these frames | 763,376 | 614,016 |

That is about 146 KiB / 20% less across these shared frames. These are compiler-emitted frame sizes for the stated build, not a measured full-stack high-water mark or a guarantee for every feature/compiler combination. Boxing shrinks embedded future state and temporary frames; it does not sever the synchronous poll call chain. No general spawned-job lifecycle rewrite or broad profile optimization is included.

## Test plan

- [x] All 24 volume tests pass, including real Bun and PHP execution on explicitly configured 2 MiB worker threads, sync-back, and lease release.
- [x] Real HTTP-connected Bun worker volume test passes with `private,parquet,php,quickjs,enterprise,agent_worker_server`; also passes when run with `RUST_MIN_STACK=2097152`.
- [x] Actual standalone worker on an isolated test database and 2 MiB threads: nested parallel Bun branches and Bash execution succeed.
- [x] Cancel a running Bun job with a volume and verify cancellation plus released database lease.
- [x] Compare compiler-emitted polling frames before and after.
- [x] Local review and cold Codex review: no findings.
- [x] `rustfmt` and `git diff --check`.

No SQL query, migration, EE source, public HTTP schema, or frontend changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces shared worker debug polling frames by boxing six large awaited job phases. Execution stays in the same task, so cancellation, task ownership, volume lease lifetimes, and completion ordering are unchanged.

- Boxes the queued-job handler, language dispatcher, and SQL/HTTP volume setup and sync futures.
- Refreshes volume test fixtures: enables volume storage, adds worker name query params, and uses workspace-scoped, job-relative mounts.
- Runs Bun and PHP volume regressions on explicit 2 MiB worker threads.

<sup>Written for commit d3f456339baec2b6588cf1d6003e66a86b5ab223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

