### PR TITLE
fix: refetch an unparseable hub script cache entry instead of panicking

### DIFF
--- a/backend/windmill-common/src/scripts.rs
+++ b/backend/windmill-common/src/scripts.rs
@@ -250,23 +250,37 @@ pub async fn get_full_hub_script_by_path(
     let version = path_iterator
         .next()
         .ok_or_else(|| Error::internal_err(format!("expected hub path to have version number")))?;
+    // A cache entry that cannot be read or parsed counts as a miss rather than an error:
+    // a truncated write leaves a file that exists but deserializes to nothing, and refetching
+    // it is always preferable to failing the job push it was read for.
     let cache_path = format!("{}/{version}", *HUB_CACHE_DIR);
-    let script;
-    if tokio::fs::metadata(&cache_path).await.is_err() {
-        script = get_full_hub_script_by_path_inner(path, http_client, db).await?;
-        if let Err(e) = crate::worker::write_file(
-            &HUB_CACHE_DIR,
-            &version,
-            &serde_json::to_string(&script).map_err(to_anyhow)?,
-        ) {
-            tracing::error!("failed to write hub script {path} to cache: {e}");
-        } else {
-            tracing::info!("wrote hub script {path} to cache");
+    let cached = match tokio::fs::read_to_string(&cache_path).await {
+        Ok(content) => serde_json::from_str::<HubScript>(&content)
+            .inspect_err(|e| {
+                tracing::error!("hub script cache at {cache_path} is unparseable, refetching: {e}")
+            })
+            .ok(),
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::error!("hub script cache at {cache_path} is unreadable, refetching: {e}");
+            }
+            None
         }
-    } else {
-        let cache_content = tokio::fs::read_to_string(cache_path).await?;
-        script = serde_json::from_str(&cache_content).unwrap();
+    };
+    if let Some(script) = cached {
         tracing::info!("read hub script {path} from cache");
+        return Ok(script);
+    }
+
+    let script = get_full_hub_script_by_path_inner(path, http_client, db).await?;
+    if let Err(e) = crate::worker::write_file(
+        &HUB_CACHE_DIR,
+        &version,
+        &serde_json::to_string(&script).map_err(to_anyhow)?,
+    ) {
+        tracing::error!("failed to write hub script {path} to cache: {e}");
+    } else {
+        tracing::info!("wrote hub script {path} to cache");
     }
     Ok(script)
 }


### PR DESCRIPTION
## Summary

`get_full_hub_script_by_path` checked the hub script cache with `tokio::fs::metadata` and, on a
hit, did `serde_json::from_str(&cache_content).unwrap()`. A cache entry that exists but is
truncated or unreadable therefore panicked the request instead of being refetched.

`write_file` truncates with `File::create` and then `write_all`, with no temp-and-rename, so a
process killed mid-write leaves a strict prefix of the JSON on disk — a real window, not a
hypothetical one. This function runs on the **API server** at job-push time for every `hub/`
script path (`script_path_to_payload`, and again in `push` for `JobPayload::ScriptHub`), so the
blast radius is a bodyless 500 on any job launched by hub path, with the cache file sitting
right there on disk looking fine.

## Changes

- Read the cache entry directly instead of `metadata` + read, and treat an unparseable entry as
  a miss: log and refetch, which also rewrites the entry and repairs it.
- Treat an unreadable entry (anything other than `NotFound`) as a miss too, with its own log
  line. Previously that surfaced through `?` as a 500.
- No change to the hit path's result, the miss path, or the non-fatal handling of a failed
  cache write. The hit path is now one syscall cheaper.

## Test plan

Exercised against a running server, driving `POST /jobs/run/p/hub/28184/...`:

- [x] Valid cache entry → served from cache, file not rewritten
- [x] Truncated entry (`{"content":"trunc`) → `is unparseable, refetching`, refetched, entry
      repaired, job runs. On `main` this panics inside the request.
- [x] Absent entry → fetched from the hub and written back
- [x] Unreadable entry (`chmod 000`) → `is unreadable, refetching`, refetch succeeds, push
      returns 201. On `main` this returns 500.

No test committed: exercising this needs the `HUB_CACHE_DIR` lazy global overridden *and* a hub
HTTP stub, which is the elaborate-fixture-for-a-trivial-assertion case `AGENTS.md` says to leave
out. `scripts.rs` has no `mod tests` and nothing in `backend/tests/` touches the hub cache, so no
existing assertion is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kpsfAAaL94fGaqb7tQPFZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `get_full_hub_script_by_path` so a truncated or unreadable hub script cache entry is refetched instead of panicking the request or returning a 500.

<sup>Written for commit 8aeb85f09a63ed207d154a77e9184cf1dc85a9e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

