### PR TITLE
fix: ignore comments and continuations in python lockfiles

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -2512,34 +2512,40 @@ pub fn split_python_requirements<T: AsRef<str>>(requirements: T) -> Vec<String> 
         .collect()
 }
 
-/// Byte offset of the comment marker in a requirements-file line, per pip's rule: a `#`
-/// either at the start of the line or preceded by whitespace. A `#` anywhere else belongs
-/// to the requirement itself (`pkg @ https://host/pkg.whl#sha256=...`).
+/// Byte offset of the comment marker, per pip's rule: a `#` at line start or preceded by
+/// whitespace. A `#` elsewhere belongs to the requirement (`pkg @ https://h/p.whl#sha256=…`).
 fn requirement_comment_start(line: &str) -> Option<usize> {
     line.char_indices()
         .find(|(i, c)| *c == '#' && (*i == 0 || line[..*i].ends_with(char::is_whitespace)))
         .map(|(i, _)| i)
 }
 
-/// The installable requirement carried by one lockfile line, or `None` when the line has
-/// none (comment, `-r`/`-e`/`--flag` directive, or blank).
+/// The installable requirement carried by one lockfile line, or `None` for a comment, a
+/// `-r`/`-e`/`--flag` directive, or a blank.
 ///
-/// Windmill installs a lockfile one entry at a time, passing each to `uv pip install` as an
-/// argument. Requirements-file syntax that every file-level parser absorbs — comments, and
-/// `\` continuations — is therefore an unparseable package name here, so it has to be
-/// stripped rather than left for uv. Comments arrive indented from `uv pip compile`'s
-/// annotations (`    # via httpx`) and continuations from its `--generate-hashes` output.
+/// Windmill installs a lockfile one entry at a time as a `uv pip install` argument, so
+/// requirements-file syntax a file-level parser would absorb is an unparseable package name
+/// here and has to be stripped first.
 pub fn requirement_from_lockfile_line(line: &str) -> Option<&str> {
     let requirement = match requirement_comment_start(line) {
         Some(i) => &line[..i],
         None => line,
     }
     .trim()
-    // The continued lines are the `--hash=` ones, already dropped as flags.
+    // Continuations are stripped, not joined: right for `--generate-hashes` locks, whose
+    // continued lines are `--hash=` flags this function drops, but a lock continuing onto a
+    // marker or extra would lose it.
     .trim_end_matches('\\')
     .trim_end();
 
     (!requirement.is_empty() && !requirement.starts_with('-')).then_some(requirement)
+}
+
+/// Whether a lockfile line continues onto the next one. The continued lines reach the
+/// installer as entries of their own rather than being joined, so a caller that cares what
+/// they carried — `--hash=` pins, for a `--generate-hashes` lock — has to say so itself.
+pub fn lockfile_line_has_continuation(line: &str) -> bool {
+    line.trim_end().ends_with('\\')
 }
 
 #[derive(Eq, PartialEq, Clone, Copy, Default, Debug)]
@@ -2660,9 +2666,10 @@ mod tests {
         ids.iter().map(|s| s.to_string()).collect()
     }
 
+    /// Fixtures are verbatim `uv pip compile` output (uv 0.11.28): split and inline
+    /// annotation styles, and `--generate-hashes`.
     #[test]
     fn test_requirement_from_lockfile_line() {
-        // `uv pip compile` annotations: indented, and sometimes wrapping over several lines.
         assert_eq!(requirement_from_lockfile_line("    # via httpx"), None);
         assert_eq!(requirement_from_lockfile_line("    # via"), None);
         assert_eq!(requirement_from_lockfile_line("    #   anyio"), None);
@@ -2670,7 +2677,6 @@ mod tests {
             requirement_from_lockfile_line("    # via -r .tmp/requirements.in"),
             None
         );
-        // `--generate-hashes` output: the pin continues onto its `--hash=` lines.
         assert_eq!(
             requirement_from_lockfile_line("anyio==4.15.1 \\"),
             Some("anyio==4.15.1")
@@ -2681,7 +2687,6 @@ mod tests {
             ),
             None
         );
-        // Our own lockfile header, directives, blanks.
         assert_eq!(requirement_from_lockfile_line("# py: 3.11"), None);
         assert_eq!(requirement_from_lockfile_line("-r other.txt"), None);
         assert_eq!(
@@ -2689,7 +2694,6 @@ mod tests {
             None
         );
         assert_eq!(requirement_from_lockfile_line("   "), None);
-        // Requirements, with and without a trailing comment.
         assert_eq!(
             requirement_from_lockfile_line("httpx==0.27.0"),
             Some("httpx==0.27.0")
@@ -2703,6 +2707,9 @@ mod tests {
             requirement_from_lockfile_line("wmill @ https://h/wmill.whl#sha256=abc"),
             Some("wmill @ https://h/wmill.whl#sha256=abc")
         );
+
+        assert!(lockfile_line_has_continuation("anyio==4.15.1 \\"));
+        assert!(!lockfile_line_has_continuation("anyio==4.15.1"));
     }
 
     #[test]

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -2512,6 +2512,36 @@ pub fn split_python_requirements<T: AsRef<str>>(requirements: T) -> Vec<String> 
         .collect()
 }
 
+/// Byte offset of the comment marker in a requirements-file line, per pip's rule: a `#`
+/// either at the start of the line or preceded by whitespace. A `#` anywhere else belongs
+/// to the requirement itself (`pkg @ https://host/pkg.whl#sha256=...`).
+fn requirement_comment_start(line: &str) -> Option<usize> {
+    line.char_indices()
+        .find(|(i, c)| *c == '#' && (*i == 0 || line[..*i].ends_with(char::is_whitespace)))
+        .map(|(i, _)| i)
+}
+
+/// The installable requirement carried by one lockfile line, or `None` when the line has
+/// none (comment, `-r`/`-e`/`--flag` directive, or blank).
+///
+/// Windmill installs a lockfile one entry at a time, passing each to `uv pip install` as an
+/// argument. Requirements-file syntax that every file-level parser absorbs — comments, and
+/// `\` continuations — is therefore an unparseable package name here, so it has to be
+/// stripped rather than left for uv. Comments arrive indented from `uv pip compile`'s
+/// annotations (`    # via httpx`) and continuations from its `--generate-hashes` output.
+pub fn requirement_from_lockfile_line(line: &str) -> Option<&str> {
+    let requirement = match requirement_comment_start(line) {
+        Some(i) => &line[..i],
+        None => line,
+    }
+    .trim()
+    // The continued lines are the `--hash=` ones, already dropped as flags.
+    .trim_end_matches('\\')
+    .trim_end();
+
+    (!requirement.is_empty() && !requirement.starts_with('-')).then_some(requirement)
+}
+
 #[derive(Eq, PartialEq, Clone, Copy, Default, Debug)]
 #[repr(u32)]
 pub enum PyVAlias {
@@ -2628,6 +2658,51 @@ mod tests {
     /// A workspace id chain: the workspace itself, then its fork ancestors nearest-first.
     fn chain(ids: &[&str]) -> Vec<String> {
         ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_requirement_from_lockfile_line() {
+        // `uv pip compile` annotations: indented, and sometimes wrapping over several lines.
+        assert_eq!(requirement_from_lockfile_line("    # via httpx"), None);
+        assert_eq!(requirement_from_lockfile_line("    # via"), None);
+        assert_eq!(requirement_from_lockfile_line("    #   anyio"), None);
+        assert_eq!(
+            requirement_from_lockfile_line("    # via -r .tmp/requirements.in"),
+            None
+        );
+        // `--generate-hashes` output: the pin continues onto its `--hash=` lines.
+        assert_eq!(
+            requirement_from_lockfile_line("anyio==4.15.1 \\"),
+            Some("anyio==4.15.1")
+        );
+        assert_eq!(
+            requirement_from_lockfile_line(
+                "    --hash=sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7 \\"
+            ),
+            None
+        );
+        // Our own lockfile header, directives, blanks.
+        assert_eq!(requirement_from_lockfile_line("# py: 3.11"), None);
+        assert_eq!(requirement_from_lockfile_line("-r other.txt"), None);
+        assert_eq!(
+            requirement_from_lockfile_line("--index-url https://x"),
+            None
+        );
+        assert_eq!(requirement_from_lockfile_line("   "), None);
+        // Requirements, with and without a trailing comment.
+        assert_eq!(
+            requirement_from_lockfile_line("httpx==0.27.0"),
+            Some("httpx==0.27.0")
+        );
+        assert_eq!(
+            requirement_from_lockfile_line("httpx==0.27.0  # via -r requirements.in"),
+            Some("httpx==0.27.0")
+        );
+        // A `#` not preceded by whitespace is part of the requirement, not a comment.
+        assert_eq!(
+            requirement_from_lockfile_line("wmill @ https://h/wmill.whl#sha256=abc"),
+            Some("wmill @ https://h/wmill.whl#sha256=abc")
+        );
     }
 
     #[test]

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -37,9 +37,9 @@ use windmill_common::{
     scripts::ScriptLang,
     utils::calculate_hash,
     worker::{
-        copy_dir_recursively, is_allowed_file_location, pad_string, requirement_from_lockfile_line,
-        split_python_requirements, write_file, Connection, PyVAlias, PythonAnnotations,
-        WORKER_CONFIG,
+        copy_dir_recursively, is_allowed_file_location, lockfile_line_has_continuation, pad_string,
+        requirement_from_lockfile_line, split_python_requirements, write_file, Connection,
+        PyVAlias, PythonAnnotations, WORKER_CONFIG,
     },
 };
 
@@ -2521,6 +2521,22 @@ pub async fn handle_python_reqs(
     // Find out if there is already cached dependencies
     // If so, skip them
     let mut in_cache = vec![];
+    // Packages are installed one `uv pip install <req>` at a time, so the `--hash=` lines a
+    // `--generate-hashes` lock continues onto are never passed to uv. Say so: the lock asks
+    // for hash pinning and does not get it.
+    if requirements
+        .iter()
+        .any(|r| lockfile_line_has_continuation(r))
+    {
+        tracing::warn!(workspace_id = %w_id, job_id = %job_id, "lockfile carries hash pins that are not enforced");
+        append_logs(
+            job_id,
+            w_id,
+            "\n[!] lockfile uses `--hash=` pinning, which Windmill does not enforce: packages are resolved by version only\n".to_string(),
+            conn,
+        )
+        .await;
+    }
     for req in &requirements {
         let Some(req) = requirement_from_lockfile_line(req) else {
             continue;

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -37,8 +37,9 @@ use windmill_common::{
     scripts::ScriptLang,
     utils::calculate_hash,
     worker::{
-        copy_dir_recursively, is_allowed_file_location, pad_string, split_python_requirements,
-        write_file, Connection, PyVAlias, PythonAnnotations, WORKER_CONFIG,
+        copy_dir_recursively, is_allowed_file_location, pad_string, requirement_from_lockfile_line,
+        split_python_requirements, write_file, Connection, PyVAlias, PythonAnnotations,
+        WORKER_CONFIG,
     },
 };
 
@@ -227,9 +228,9 @@ fn filter_pip_local_dependencies(lines: Vec<String>) -> (Vec<String>, Vec<String
 /// `(kept, ignored)`. A line is ignored when it is not a `#` comment and matches any of
 /// `compiled_deps`. Kept separate from config/regex loading so it can be unit-tested.
 fn filter_lines_by_deps(lines: Vec<String>, compiled_deps: &[Regex]) -> (Vec<String>, Vec<String>) {
-    let (ignored, kept): (Vec<String>, Vec<String>) = lines
-        .into_iter()
-        .partition(|s| !s.starts_with('#') && compiled_deps.iter().any(|dep| dep.is_match(s)));
+    let (ignored, kept): (Vec<String>, Vec<String>) = lines.into_iter().partition(|s| {
+        !s.trim_start().starts_with('#') && compiled_deps.iter().any(|dep| dep.is_match(s))
+    });
 
     (kept, ignored)
 }
@@ -2521,10 +2522,9 @@ pub async fn handle_python_reqs(
     // If so, skip them
     let mut in_cache = vec![];
     for req in &requirements {
-        // Ignore python version annotation backed into lockfile
-        if req.starts_with('#') || req.starts_with('-') || req.trim().is_empty() {
+        let Some(req) = requirement_from_lockfile_line(req) else {
             continue;
-        }
+        };
         let py_prefix = &py_version.to_cache_dir(false);
 
         let venv_p = format!(

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -2521,18 +2521,15 @@ pub async fn handle_python_reqs(
     // Find out if there is already cached dependencies
     // If so, skip them
     let mut in_cache = vec![];
-    // Packages are installed one `uv pip install <req>` at a time, so the `--hash=` lines a
-    // `--generate-hashes` lock continues onto are never passed to uv. Say so: the lock asks
-    // for hash pinning and does not get it.
     if requirements
         .iter()
         .any(|r| lockfile_line_has_continuation(r))
     {
-        tracing::warn!(workspace_id = %w_id, job_id = %job_id, "lockfile carries hash pins that are not enforced");
+        tracing::warn!(workspace_id = %w_id, job_id = %job_id, "lockfile continues entries across lines; the continued lines are dropped");
         append_logs(
             job_id,
             w_id,
-            "\n[!] lockfile uses `--hash=` pinning, which Windmill does not enforce: packages are resolved by version only\n".to_string(),
+            "\n[!] lockfile continues entries across lines and the continued lines are dropped: `--hash=` pins, extras and markers written that way do not apply\n".to_string(),
             conn,
         )
         .await;


### PR DESCRIPTION
## Summary

A Python `.lock` that Windmill did not generate — one produced by running `uv pip compile`
locally and committed alongside the script — carries requirements-file syntax that Windmill's
installer treated as package names.

Windmill installs a lockfile one entry at a time, passing each line to `uv pip install` as an
argument, so anything a file-level parser would absorb has to be stripped first. Two shapes were
not:

- **Annotations.** `uv pip compile` indents them, and the guard that skipped comments matched
  only a `#` in column 0:

  ```
  error: Failed to parse: `    # via httpx`
    Caused by: Expected package name starting with an alphanumeric character, found `#`
  ```

- **Continuations.** `uv pip compile --generate-hashes` writes `anyio==4.15.1 \` followed by
  indented `--hash=` lines. The `--hash=` lines were already dropped as flags, but the pin kept
  its trailing backslash:

  ```
  error: Failed to parse: `anyio==4.15.1 \`
    Caused by: Trailing `\` is not allowed
  ```

Such a lock reaches the database untouched: a non-empty `lock` supplied on deploy is stored
verbatim and skips the dependency job entirely, so nothing sanitizes it on the way in.
Windmill's own resolver is unaffected — `uv_pip_compile` has always filtered `#` lines out of
uv's output before storing, which was confirmed against a live instance while diagnosing this.

## Changes

- `windmill-common/src/worker.rs`: add `requirement_from_lockfile_line`, returning the
  installable requirement carried by a lockfile line, or `None` for a comment, a
  `-r`/`-e`/`--flag` directive, or a blank. Comment detection follows pip's rule — a `#` at line
  start or preceded by whitespace — so `pkg @ https://host/x.whl#sha256=…` survives while a
  trailing `foo==1.0  # via bar` is trimmed. A trailing `\` continuation is stripped.
- `windmill-worker/src/python_executor.rs`: `handle_python_reqs` uses it in place of the
  `starts_with('#')` guard. This is the single choke point for every install path — deployed
  scripts, previews, ansible, and the dependency job's cache prefill all reach uv through it.
- `windmill-worker/src/python_executor.rs`: give `filter_lines_by_deps` the matching
  `trim_start`, so its documented behaviour ("`#` comment lines are always kept") also holds for
  indented ones.
- `windmill-worker/src/python_executor.rs`: log a warning when a lock carries `--hash=` pins.
  Installs are one `uv pip install <req>` at a time, so the hashes are never passed to uv — a
  `--generate-hashes` lock used to fail loudly on its trailing `\` and would otherwise now
  succeed with its integrity control silently dropped.

## Test plan

- [x] Unit test in `windmill-common` pins the rule against real uv output: split annotations
      (`# via`, wrapped `#   anyio`), inline annotations, `--generate-hashes` continuations and
      their `--hash=` lines, the `# py:` header, directives, blanks, and the URL-fragment case
      that must *not* be read as a comment.
- [x] End to end on a local instance (`--features quickjs,python`), deploying scripts whose
      stored lock carries each shape verbatim and running them:
      - Split + inline annotations → job succeeds, only the real pins install.
      - Verbatim `uv pip compile --generate-hashes` output (uv 0.11.28) → job succeeds,
        `anyio==4.15.1`, `idna==3.19`, `typing-extensions==4.16.0` install and nothing else.
      - With the guard reverted to its previous form, the annotation failure reproduces exactly
        as reported, one `Failed to parse` per annotation line.
- [x] Verified the resolver side is not the source: a script deployed without a lock (the path
      `wmill generate-metadata` triggers) stores `# py: 3.12` plus bare pins and no annotations,
      even with uv left to annotate by default.
- [x] `cargo test -p windmill-common --lib worker::tests::` (37 passed);
      `cargo check -p windmill-worker --features python` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python lockfile installs for lockfiles generated by `uv pip compile`. Indented `# via` annotations and trailing `\` continuation markers were passed to `uv pip install` as package names and failed; they are now stripped before install.

Lockfile lines are parsed with pip's comment rule: a `#` at line start or preceded by whitespace starts a comment, so inline annotations are trimmed while URL fragments like `pkg.whl#sha256=...` are preserved. Directives and blank lines remain ignored. The fix applies to every path that installs Python requirements, including deployed scripts, previews, ansible, and dependency cache prefill; resolver-generated lockfiles are unaffected.

**Notes**
- A lockfile with continued lines now logs a warning that the continued lines are dropped, since their contents (`--hash=` pins, extras, markers) cannot be enforced when packages are installed one at a time.

<sup>Written for commit fae4718b77e16db46cf26ce3b18b31972fb41a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

