### PR TITLE
fix: stop a new AI session adopting a legacy sidebar chat

### DIFF
--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -38,7 +38,6 @@ import {
 import {
 	commitSessionWorkspace,
 	deleteSession as deleteSessionState,
-	ensureChatIdsSeeded,
 	getEffectiveWorkspaceId,
 	materializeTransient,
 	sessionState,
@@ -927,7 +926,6 @@ async function initRuntime(runtime: SessionRuntime, session: Session) {
 	// Restore linked files persisted for this session (live handles re-grant on send;
 	// snapshots restore directly). Non-transient sessions persist immediately.
 	await manager.attachedFiles.restore(session.id, !session.transient)
-	await ensureChatIdsSeeded(manager.historyManager)
 
 	// Keep the session record's chatId following the manager's active chat: a
 	// "/clear" rotation or a history switch would otherwise leave it pointing at

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -38,7 +38,6 @@ export function syncWorkspaceTo(workspaceId: string | undefined): void {
 }
 import { WorkspaceService } from '$lib/gen'
 import { sendUserToast } from '$lib/toast'
-import type HistoryManager from '$lib/components/copilot/chat/HistoryManager.svelte'
 import { onUserChange } from '$lib/userScopedStorage'
 
 // A destination the session preview can open as an editor: a workspace item
@@ -405,7 +404,7 @@ export function takeSessionAutoSend(sessionId: string): boolean {
 
 // Persist a session on a genuine user edit, promoting an in-memory-only
 // (transient) pending session to a durable IndexedDB record on first touch.
-// Non-touch writers (runtime chatId seeding via patchStoredSessionChatId, the
+// Non-touch writers (runtime chatId writes via patchStoredSessionChatId, the
 // unread watermark via putSession) persist directly, so an untouched draft
 // stays in memory and vanishes on reload.
 function persistTouched(s: Session): void {
@@ -1183,42 +1182,4 @@ async function patchStoredSessionChatId(s: Session, chatId: string): Promise<voi
 	} catch (e) {
 		console.error('Failed to persist session chat id', e)
 	}
-}
-
-let seedPromise: Promise<void> | undefined
-
-// One-shot pairing of the user's two most-recently-modified saved chats with
-// the two seeded sessions. Idempotent across all callers / SessionWrappers.
-export function ensureChatIdsSeeded(historyManager: HistoryManager): Promise<void> {
-	if (!seedPromise) {
-		seedPromise = (async () => {
-			try {
-				await historyManager.init()
-				// Read directly from storage so we see chats regardless of this manager's
-				// own session-scope filter (getPastChats would hide already-tagged ones).
-				const pastChats = historyManager.getAllSavedChats()
-				const untagged = pastChats
-					.filter((c) => !c.sessionId)
-					.sort((a, b) => b.lastModified - a.lastModified)
-				// Only seed pre-existing (persisted) sessions. Transient
-				// sessions are freshly created via the "+" button and must
-				// start with an empty chat — if the seed catches one (e.g. the
-				// user clicks "New session" before this one-shot runs), it
-				// would graft a previous discussion onto the new session.
-				const seedable = sessionState.sessions.filter((s) => !s.transient)
-				for (let i = 0; i < Math.min(seedable.length, untagged.length); i++) {
-					if (!seedable[i].chatId) {
-						const chatId = untagged[i].id
-						const sessionId = seedable[i].id
-						seedable[i].chatId = chatId
-						await historyManager.tagChatWithSession(chatId, sessionId)
-						void putSession(seedable[i])
-					}
-				}
-			} catch (e) {
-				console.error('Failed to seed chat ids from history', e)
-			}
-		})()
-	}
-	return seedPromise
 }

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -456,8 +456,8 @@ export async function putSession(s: Session): Promise<void> {
 	if (s.transient) return
 	// A record removed because its workspace is gone had its files and artifacts GC'd with
 	// it, so writing it back resurrects an empty husk. Callers reach here holding a
-	// reference captured before the delete — the chat-id seeder awaits mid-loop,
-	// find-then-write callers race the re-hydrate.
+	// reference captured before the delete: find-then-write callers race the
+	// re-hydrate, and any writer that awaits between the find and the write.
 	if (deletedSessionIds.has(s.id)) return
 	// Separately, keep a UI action (e.g. unarchive) from persisting into a workspace that
 	// has gone unavailable but not yet reconciled. `userWorkspaces` answers that only for
@@ -758,9 +758,9 @@ function isDiscardableDraft(s: Session): boolean {
 }
 
 // Somewhere empty to put the user, for a URL naming a session this browser
-// doesn't hold. Only `transient` makes "empty" trustworthy: chat seeding and
-// attached-file persistence both key off `!transient` and leave every field
-// below untouched, so a persisted session can hold a conversation regardless.
+// doesn't hold. Only `transient` makes "empty" trustworthy: a persisted session
+// can hold a conversation while every field below stays untouched — its chat and
+// attached files key off `!transient`, not off these.
 export function findEmptyLandingSession(): Session | undefined {
 	return sessionState.sessions.find(
 		(s) =>

--- a/frontend/src/lib/components/sessions/sessionState.test.ts
+++ b/frontend/src/lib/components/sessions/sessionState.test.ts
@@ -537,10 +537,10 @@ describe('findEmptyLandingSession — where an unresolvable session link lands',
 		}
 	})
 
-	it('passes over a persisted session, onto which chat seeding can graft a conversation', () => {
+	it('passes over a persisted session, which may hold a conversation', () => {
 		const restore = withTwoFamilies('forkA')
-		// ensureChatIdsSeeded assigns untagged legacy chats to `!transient` sessions
-		// and initRuntime loads them, without touching a field checked here.
+		// Persisted means touched: its chat can hold a conversation initRuntime
+		// reloads, without touching a field checked here.
 		const abandoned = session({
 			id: 'landing-abandoned',
 			name: 'session-910',

--- a/frontend/src/lib/components/sessions/sessionStateIndexedDb.test.ts
+++ b/frontend/src/lib/components/sessions/sessionStateIndexedDb.test.ts
@@ -534,8 +534,8 @@ describe('sessionState IndexedDB persistence', () => {
 		} as never)
 		await reconcileSessionsLifecycle()
 
-		// A caller that captured the session before the delete writes it back — what the
-		// chat-id seeder does when it resumes after awaiting mid-loop.
+		// A caller that captured the session before the delete writes it back — what any
+		// writer does when it resumes after awaiting between the find and the write.
 		doomed.chatId = 'chat-from-a-stale-reference'
 		await putSession(doomed)
 


### PR DESCRIPTION
## Summary

Clicking "Open in AI session" from an editor could open the new session on **someone else's
conversation** — the script in the preview tab was right, but the chat on the left was a
conversation held earlier in the docked sidebar chat.

`ensureChatIdsSeeded` was a one-shot migration from the original sessions PR (#9034): it paired
saved chats carrying no `sessionId` ("untagged") with sessions carrying no `chatId`, **by index in
two independently-sorted lists**, so conversations held before sessions shipped would still appear
under sessions. Two of its assumptions no longer hold:

- **"A session with no chat is an old session."** `openInSession` creates the session and then
  seeds its preview tab, and `setSessionTabs` → `persistTouched` strips `transient` — so by the
  time the sessions page inits the runtime, the brand-new hand-off session looks pre-existing.
  Being prepended to `sessionState.sessions`, it sits at index 0 and is first in line for the
  newest untagged chat, which `initRuntime` then loads into it.
- **"An untagged chat is a leftover from before sessions."** The docked sidebar chat still ships
  behind the beta opt-out, and only the session runtime calls `historyManager.setSessionId` — so
  every conversation held there today is written untagged and keeps feeding the migration.

That same PR had already patched this symptom once, by skipping `transient` sessions; the hand-off
slips past that clause because it persists its session before the seed runs.

Rather than tighten the heuristic again, this deletes it. Sessions and legacy chats are separate
things and pairing them by list position cannot be made correct. Pre-sessions conversations remain
in storage and reachable through the legacy chat's own History list.

## Changes

- Delete `ensureChatIdsSeeded` and its `seedPromise` one-shot from `sessionState.svelte.ts`, plus
  the now-unused `HistoryManager` type import.
- Drop its single call site from `initRuntime` in `sessionRuntime.svelte.ts`. A session still
  assigns and reloads its own `chatId` there, so nothing else changes.
- Update two comments that referenced the deleted migration: a test comment that justified itself
  by citing it (the behaviour it pins — recovery never lands on a persisted session — still holds,
  because such a session can hold a conversation of its own), and `persistTouched`'s note about
  non-touch writers.

**Users who already ran the seeding keep their pairing on disk**, and this deletion does not
repair it: a session that adopted a chat still loads it (`initRuntime`'s `if (session.chatId)`
branch), and because the seeding also stamped `sessionId` on that chat, it no longer appears in the
legacy chat's History. `/clear` in the affected session moves it onto a fresh chat. The deletion
stops new occurrences; it does not restore the pre-migration state.

## Screenshots

Before — hand-off from the script editor lands on a sidebar-chat conversation the user never had
in this session:

![grafted-chat-repro](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pending-session-open-chat-fix/1788943891-grafted-chat-repro.png)

After — same steps, same history: the session opens empty, on its own chat:

![after-fix-handoff-empty-chat](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pending-session-open-chat-fix/1788943894-after-fix-handoff-empty-chat.png)

## Test plan

Both preconditions matter: the bug needs an untagged chat in history **and** the one-shot unspent
in that page load (it ran at the first session runtime init), which is why visiting `/sessions`
first hides it.

- [ ] Hold a conversation in the docked sidebar chat (switch back to legacy chat), then switch
      sessions back on.
- [ ] Hard-reload a script editor page — don't open `/sessions` after the reload — and click
      "Open in AI session". The session opens empty, with the script in the preview tab.
- [ ] Reopen an existing session that has a conversation: it still loads its own chat.
- [ ] The sidebar conversation is still listed in the legacy chat's History.
- [ ] `npx vitest run src/lib/components/sessions/ src/lib/components/copilot/chat/HistoryManager.test.ts` — 324 pass.


Fixes WIN-2489