### PR TITLE
feat: link from the public run view to the authenticated run page

### DIFF
--- a/frontend/src/routes/public_run/[workspace]/[id]/+page.svelte
+++ b/frontend/src/routes/public_run/[workspace]/[id]/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/state'
 	import { onDestroy, untrack } from 'svelte'
-	import { Globe } from 'lucide-svelte'
+	import { ArrowRight, Globe } from 'lucide-svelte'
+	import { base } from '$lib/base'
 	import type { Job } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { setViewToken } from '$lib/viewToken'
 	import { setLicense } from '$lib/enterpriseUtils'
 	import { applyDarkModeVariant } from '$lib/darkModeVariant'
 	import { displayDate, isNotFlow, truncateRev } from '$lib/utils'
-	import { Alert, Badge, Skeleton } from '$lib/components/common'
+	import { Alert, Badge, Button, Skeleton } from '$lib/components/common'
 	import DisplayResult from '$lib/components/DisplayResult.svelte'
 	import FlowStatusViewer from '$lib/components/FlowStatusViewer.svelte'
 	import JobArgs from '$lib/components/JobArgs.svelte'
@@ -106,12 +107,20 @@
 
 <div class="min-h-screen bg-surface">
 	<div class="border-b bg-surface-secondary">
-		<div class="max-w-7xl mx-auto w-full px-4 py-3 flex items-center gap-3">
+		<div class="max-w-7xl mx-auto w-full px-4 py-3 flex flex-wrap items-center gap-3">
 			<WindmillIcon height="20px" width="20px" />
 			<span class="text-sm font-semibold text-primary">Run {truncateRev(jobId, 8)}</span>
 			<Badge color="blue" small>
 				<span class="flex items-center gap-1"><Globe size={12} /> Public read-only view</span>
 			</Badge>
+			<Button
+				unifiedSize="sm"
+				endIcon={{ icon: ArrowRight }}
+				wrapperClasses="ml-auto"
+				href={`${base}/run/${jobId}?workspace=${encodeURIComponent(workspace)}`}
+			>
+				Open full view
+			</Button>
 		</div>
 	</div>
 


### PR DESCRIPTION
## Summary

The public read-only run view (`/public_run/{workspace}/{id}`) had no way out. A workspace member who lands on a shared link had to reconstruct the `/run/{id}?workspace=…` URL by hand before they could retry a failed job, cancel it, or open the script. This adds an **Open full view** link to the header bar.

Closes WIN-2488.

## Changes

- `frontend/src/routes/public_run/[workspace]/[id]/+page.svelte`: an **Open full view** `<Button href>` at the right of the header bar, after the "Public read-only view" badge, pointing at `${base}/run/${jobId}?workspace=${encodeURIComponent(workspace)}` in the same tab.
- Same file: the header row is now `flex-wrap`, so the added button wraps to a second line on a phone instead of pushing the bar past the viewport.

The view token is dropped when the public page unmounts, so the run page loads under normal auth.

## Screenshots

_(pending — see comment)_

## Test plan

- [x] Signed in: the link lands on `/run/{id}?workspace={ws}` with the full toolbar (Run again, Edit, View script), no console errors.
- [x] Signed out: it redirects to `/user/login?rd=%2Frun%2F…%3Fworkspace%3D…`, so logging in returns the visitor to the run.
- [x] At 375px wide the header wraps and `document.documentElement.scrollWidth` (370) stays under the viewport width.
- [x] `npm run check:fast` — the 4 errors it reports are pre-existing on `main` (`projects/import/+page@(root).svelte`, `hubProject.ts`), none in the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xBcJ5EB5uhwqWysHbG4w6