### PR TITLE
fix: stop uv pip compile emitting lockfile annotations

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -324,6 +324,11 @@ pub async fn uv_pip_compile(
             "compile",
             "-q",
             "--no-header",
+            // Windmill installs a lockfile one entry at a time, so an annotated lock is a
+            // lock whose every other line is an unparseable package name. Not emitting the
+            // annotations keeps that out of the stored lockfile rather than relying on the
+            // reader to strip them.
+            "--no-annotate",
             file,
             "--strip-extras",
             "-o",

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -324,10 +324,10 @@ pub async fn uv_pip_compile(
             "compile",
             "-q",
             "--no-header",
-            // Windmill installs a lockfile one entry at a time, so an annotated lock is a
-            // lock whose every other line is an unparseable package name. Not emitting the
-            // annotations keeps that out of the stored lockfile rather than relying on the
-            // reader to strip them.
+            // The `#`-line filter applied to the output below only catches whole-line
+            // annotations, and uv's annotation style is configurable: `[pip]
+            // annotation-style = "line"` in the worker HOME's uv.toml emits them inline
+            // ("anyio==4.15.1  # via httpx"), which that filter keeps.
             "--no-annotate",
             file,
             "--strip-extras",


### PR DESCRIPTION
## Summary

`uv pip compile` annotates each resolved package with the `# via <pkg>` comments naming what pulled it in. Windmill installs a lockfile one entry at a time as a `uv pip install` argument, so those lines reach the installer as unparseable package names:

```
error: Failed to parse: `    # via httpx`
  Caused by: Expected package name starting with an alphanumeric character, found `#`
```

The reader half of WIN-2487 already landed on main in #11035 (`requirement_from_lockfile_line`), covering lockfiles that arrive already annotated — deployed from the CLI or git-sync. This is the source-side half: pass `--no-annotate` so lockfiles Windmill generates itself never carry annotations.

**This is not only belt-and-braces.** `uv_pip_compile` already drops whole-line comments from uv's output before storing the lockfile, so under uv's default `split` annotation style the stored result is unchanged. But uv's annotation style is configurable, and it is read from the worker's own `HOME` — `child_cmd` sets `HOME` explicitly, so `env_clear()` does not block `$HOME/.config/uv/uv.toml`. With `[pip] annotation-style = "line"`, uv emits annotations **inline**:

```
anyio==4.15.1             # via httpx
certifi==2026.7.22        # via httpcore, httpx
```

The whole-line filter keeps every one of those lines verbatim, and they land in the stored lockfile. `--no-annotate` overrides the config and the output is clean either way. Verified both directions against uv 0.11.24, the version the Dockerfiles pin.

## Changes

- `backend/windmill-worker/src/python_executor.rs`: add `--no-annotate` to the `uv pip compile` argument vector in `uv_pip_compile`, with a comment recording what the filter below cannot catch.

The existing `#`-line post-filter stays: it is the only thing stripping any non-annotation comment uv might emit, and removing it would be a behaviour change with no upside on a path whose failure mode is a hard job failure.

## Test plan

No test ships with this. The only seam a Rust test could reach is `args.contains("--no-annotate")`, which pins the diff rather than any behaviour; the behaviour that matters is already guarded by `test_requirement_from_lockfile_line` (#11035), which covers the lockfiles this flag cannot reach. Verified by running it instead, on a local backend built with `--features quickjs,python`:

- [x] **The flag reaches uv.** Deployed a `pandas` script with no lockfile so the dependency job ran a real `uv pip compile`. The raw `requirements.txt` uv wrote into the job dir (`KEEP_JOB_DIR=true`) is annotation-free before Windmill's post-filter ever sees it — previously it held the `    # via pandas` lines. Stored lockfile: `# py: 3.12` header intact, four pins, no annotations.
- [x] **The `annotation-style = "line"` gap is real.** With that config in `$HOME/.config/uv/uv.toml` and no flag, uv emits inline annotations and the whole-line filter strips none of them; with the flag, output is clean.
- [x] **Annotated lockfiles from outside still install.** Deployed a script whose lockfile is verbatim `uv pip compile` output (split-style annotations, including `# via -r requirements.in`). Job succeeded, returned `"0.28.1"`, exactly the 7 real packages installed.
- [x] **The failure this guards against is real.** Rebuilt the same backend with #11035 and this flag both reverted, ran the same annotated lockfile, and got `Failed to parse: '    # via httpx'` for every annotation line.
- [x] **No relock cascade.** Stored lockfile is byte-identical to what main stores under the default annotation style, so `pip_resolution_cache` rows (whose `req_hash` does not include this flag) and `lock_hash` dependency-change detection stay stable across a mixed-version worker fleet.
- [x] `cargo check`, `cargo test -p windmill-common --lib` (555 passed), `cargo test -p windmill-worker --lib` (225 passed), `rustfmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)