### PR TITLE
fix: space the trailing AI settings cards

### DIFF
--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -614,6 +614,39 @@
 			</div>
 		</SettingCard>
 	{/if}
+
+	{#if promptScope === 'workspace'}
+		<!-- Recorded usage must be priced with the rates the chats actually ran under.
+		     A workspace on instance defaults has no rates of its own, so the effective
+		     ones come from copilotInfo rather than from this form's (empty) workspace
+		     config. -->
+		<AiUsagePanel
+			workspace={effectiveWorkspace}
+			modelPricing={usesInstanceAiConfig ? ($copilotInfo.modelPricing ?? {}) : modelPricing}
+		/>
+	{/if}
+
+	<!-- Below the usage it explains: the rates are read as a correction to what the
+	     table above already shows. Kept on its own `showWorkspaceOverrideEditor` gate so
+	     the instance scope, which has no usage panel, still edits rates. -->
+	{#if showWorkspaceOverrideEditor}
+		<ModelPricing {aiProviders} bind:modelPricing />
+	{/if}
+
+	{#if promptScope === 'workspace'}
+		<SettingCard
+			label="Hide AI sessions"
+			description="Hides AI sessions and every other AI assistant button (chat, code generation and completion, AI fix) from all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured above. This hides the assistant in the UI only; it does not restrict API access to the configured providers."
+		>
+			<Toggle
+				checked={copilotDisabled}
+				on:change={(e) => {
+					copilotDisabled = e.detail
+				}}
+				options={{ right: 'Hide AI sessions in this workspace' }}
+			/>
+		</SettingCard>
+	{/if}
 </div>
 
 <AIPromptsModal
@@ -623,39 +656,6 @@
 	hasChanges={hasPromptsChanges}
 	scope={promptScope}
 />
-
-{#if promptScope === 'workspace'}
-	<!-- Recorded usage must be priced with the rates the chats actually ran under.
-	     A workspace on instance defaults has no rates of its own, so the effective
-	     ones come from copilotInfo rather than from this form's (empty) workspace
-	     config. -->
-	<AiUsagePanel
-		workspace={effectiveWorkspace}
-		modelPricing={usesInstanceAiConfig ? ($copilotInfo.modelPricing ?? {}) : modelPricing}
-	/>
-{/if}
-
-<!-- Below the usage it explains: the rates are read as a correction to what the
-     table above already shows. Kept on its own `showWorkspaceOverrideEditor` gate so
-     the instance scope, which has no usage panel, still edits rates. -->
-{#if showWorkspaceOverrideEditor}
-	<ModelPricing {aiProviders} bind:modelPricing />
-{/if}
-
-{#if promptScope === 'workspace'}
-	<SettingCard
-		label="Hide AI sessions"
-		description="Hides AI sessions and every other AI assistant button (chat, code generation and completion, AI fix) from all members of this workspace. AI agent steps and the AI sandbox in flows are not affected and keep using the providers configured above. This hides the assistant in the UI only; it does not restrict API access to the configured providers."
-	>
-		<Toggle
-			checked={copilotDisabled}
-			on:change={(e) => {
-				copilotDisabled = e.detail
-			}}
-			options={{ right: 'Hide AI sessions in this workspace' }}
-		/>
-	</SettingCard>
-{/if}
 
 <!-- Not gated on `showWorkspaceOverrideEditor`: a workspace on instance defaults still has
      the hide toggle above to save. -->


### PR DESCRIPTION
## Summary

On the workspace **Windmill AI** settings tab, the AI usage, Model pricing and Hide AI sessions cards were stacked flush against each other with no gap, so the three `SettingCard` boxes read as one broken block.

`SettingCard` carries no outer margin by design — the vertical rhythm comes from the page container `<div class="flex flex-col gap-6 mt-4 pb-8">`. That container's closing tag sits in the middle of `AISettings.svelte`, and these three blocks were written after it, as top-level siblings of the component. Outside the flex column there is no `gap-6`, so they got 0px between them. Same cause on the instance AI settings, where Model pricing sat flush against Custom system prompts.

Moving the container's `</div>` down past the Hide AI sessions card puts all three back in the flex column. `AIPromptsModal` moves below the container instead.

## Changes

- `frontend/src/lib/components/workspaceSettings/AISettings.svelte`: extend the `flex flex-col gap-6` container to wrap `AiUsagePanel`, `ModelPricing` and the Hide AI sessions card; move `AIPromptsModal` after it. Markup only — no logic, props or conditions changed.

## Screenshots

Before — AI usage / Model pricing / Hide AI sessions touching (0px gaps):

![ai-settings-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/admin-sessions-settings-spacing/1788957707-ai-settings-before.png)

After — 24px between each, matching the cards above:

![ai-settings-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/admin-sessions-settings-spacing/1788957709-ai-settings-after.png)

## Test plan

- [x] Workspace settings → Windmill AI: measured card rects in the browser — AI usage ends 1666, Model pricing 1690–1804, Hide AI sessions starts 1828 (24px each, same as the cards above). Before the change: 447/447 and 561/561.
- [ ] Instance settings → Windmill AI: Model pricing is spaced from the card above it (same container, `promptScope="instance"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GHiwAKGrsaPVAXDJVxhDq