### PR TITLE
fix(cli): stop sync push from resetting an app's run-as, sandbox and execution mode

### DIFF
--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -119,9 +119,14 @@ export function isExecutionModeAnonymous(app: any) {
 export function isExecutionModeGuest(app: any) {
   return app?.["policy"]?.["execution_mode"] == "guest";
 }
-export type AppExecutionMode = "anonymous" | "guest" | "publisher";
+export type AppExecutionMode =
+  | "anonymous"
+  | "guest"
+  | "publisher"
+  | "viewer";
 /** The access mode is the one policy field a tracked app keeps, as `public` (anonymous)
- * or `guests` (guest); the rest of the policy is regenerated on push. */
+ * or `guests` (guest); the rest is carried over from the deployed policy on push
+ * (see {@link deployedPolicyBase}). */
 export function markAccessFromPolicy(app: any) {
   if (isExecutionModeAnonymous(app)) {
     app.public = true;
@@ -129,14 +134,41 @@ export function markAccessFromPolicy(app: any) {
     app.guests = true;
   }
 }
-export function executionModeFromAppFile(app: any): AppExecutionMode {
+export function executionModeFromAppFile(
+  app: any,
+  deployedPolicy?: Policy,
+): AppExecutionMode {
   if (app?.["public"] ?? isExecutionModeAnonymous(app)) {
     return "anonymous";
   }
   if (app?.["guests"] ?? isExecutionModeGuest(app)) {
     return "guest";
   }
+  // `public`/`guests` are the only modes the file records, so "neither" covers
+  // both publisher and viewer: keep the deployed one rather than demoting a
+  // viewer app to publisher on every push.
+  if (deployedPolicy?.execution_mode === "viewer") {
+    return "viewer";
+  }
   return "publisher";
+}
+
+/**
+ * What a push's regenerated policy starts from. The app file states only the
+ * access mode, so regenerating from the local sources alone silently drops every
+ * other policy field the deployed app carries — its run-as identity, sandbox
+ * isolation, SDK scopes. Anything the file does state still wins.
+ *
+ * Legacy `triggerables` are dropped: the backend folds them into
+ * `triggerables_v2` on read, so carrying them over would keep granting runnables
+ * this deploy no longer contains.
+ */
+export function deployedPolicyBase(
+  deployedPolicy: Policy | undefined,
+  localPolicy: Policy | undefined,
+): Policy {
+  const { triggerables: _legacy, ...deployed } = deployedPolicy ?? {};
+  return { ...deployed, ...(localPolicy ?? {}) } as Policy;
 }
 export async function pushApp(
   workspace: string,
@@ -161,12 +193,9 @@ export async function pushApp(
     //ignore
   }
 
-  let remoteOnBehalfOf: string | undefined;
-  let remoteOnBehalfOfEmail: string | undefined;
-  if (app?.policy) {
-    remoteOnBehalfOf = app.policy.on_behalf_of;
-    remoteOnBehalfOfEmail = app.policy.on_behalf_of_email;
-  }
+  const remotePolicy = app?.policy as Policy | undefined;
+  const remoteOnBehalfOf = remotePolicy?.on_behalf_of;
+  const remoteOnBehalfOfEmail = remotePolicy?.on_behalf_of_email;
 
   markAccessFromPolicy(app);
   // console.log(app);
@@ -181,7 +210,11 @@ export async function pushApp(
   const localApp = (await yamlParseFile(path)) as AppFile;
 
   replaceInlineScripts(localApp.value, localPath, true);
-  await generatingPolicy(localApp, remotePath, executionModeFromAppFile(localApp));
+  // Read the mode off the file before the deployed policy is merged in, so
+  // dropping `public` from app.yaml still demotes the app.
+  const executionMode = executionModeFromAppFile(localApp, remotePolicy);
+  localApp.policy = deployedPolicyBase(remotePolicy, localApp.policy);
+  await generatingPolicy(localApp, remotePath, executionMode);
 
   const preserveFields: { preserve_on_behalf_of?: boolean } = {};
   if (permissionedAsContext?.userIsAdminOrDeployer) {
@@ -255,7 +288,7 @@ export async function generatingPolicy(
 ) {
   log.info(colors.gray(`Generating fresh policy for app ${path}...`));
   try {
-    app.policy = await windmillUtils.updatePolicy(app.value, undefined);
+    app.policy = await windmillUtils.updatePolicy(app.value, app.policy);
     app.policy.execution_mode = executionMode;
   } catch (e) {
     log.error(colors.red(`Error generating policy for app ${path}: ${e}`));
@@ -425,14 +458,16 @@ async function push(
   if (isRawAppByName || hasRawAppYaml) {
     const { pushRawApp } = await import("./raw_apps.ts");
     const merged = await mergeConfigWithConfigFile(opts);
-    // Raw-app ownership preservation is not implemented on either push
-    // path: sync push hands pushRawApp no context either.
     await pushRawApp(
       workspace.workspaceId,
       remotePath,
       absoluteFilePath,
       undefined,
       merged.defaultTs,
+      await buildPermissionedAsContext(
+        workspace.workspaceId,
+        await readEffectiveSyncBehavior(opts, workspace),
+      ),
     );
     log.info(colors.bold.underline.green("Raw app pushed"));
   } else {

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -144,31 +144,59 @@ export function executionModeFromAppFile(
   if (app?.["guests"] ?? isExecutionModeGuest(app)) {
     return "guest";
   }
-  // `public`/`guests` are the only modes the file records, so "neither" covers
-  // both publisher and viewer: keep the deployed one rather than demoting a
-  // viewer app to publisher on every push.
-  if (deployedPolicy?.execution_mode === "viewer") {
+  // A pull records the mode as `public`/`guests` and nothing else, so a file
+  // saying neither may still be a viewer app: honour an explicit `viewer`, and
+  // otherwise keep the deployed mode rather than demoting one on every push. A
+  // file stating `publisher` does not demote a deployed viewer — that block is
+  // vestigial (only older pulls wrote it), and viewer is the stricter of the
+  // two, running each viewer's own identity instead of the publisher's.
+  if (
+    app?.["policy"]?.["execution_mode"] === "viewer" ||
+    deployedPolicy?.execution_mode === "viewer"
+  ) {
     return "viewer";
   }
   return "publisher";
 }
 
+/** The policy fields a deploy derives from the app it is deploying. Carrying one
+ * over from either side would leave a grant keyed to sources this deploy just
+ * replaced: legacy `triggerables` are folded into `triggerables_v2` on read, and
+ * `s3_inputs` / `allowed_s3_keys` are what the backend enforces S3 access
+ * against. A low-code deploy recomputes these; a raw one produces none of them.
+ * `triggerables_v2` is not listed because both deploys overwrite it outright. */
+const DERIVED_POLICY_FIELDS = [
+  "triggerables",
+  "s3_inputs",
+  "allowed_s3_keys",
+] as const;
+
 /**
  * What a push's regenerated policy starts from. The app file states only the
  * access mode, so regenerating from the local sources alone silently drops every
- * other policy field the deployed app carries — its run-as identity, sandbox
- * isolation, SDK scopes. Anything the file does state still wins.
+ * other policy field the deployed app carries — its sandbox isolation, SDK
+ * scopes. Anything else the file does state still wins.
  *
- * Legacy `triggerables` are dropped: the backend folds them into
- * `triggerables_v2` on read, so carrying them over would keep granting runnables
- * this deploy no longer contains.
+ * The run-as identity is never taken from the file: the deployed policy owns it,
+ * and a push claims a different one only through `preserve_on_behalf_of`. Older
+ * pulls wrote the whole policy into the app file, so repos still carry
+ * `on_behalf_of` keys — a stale one, or an explicit `null`, would otherwise
+ * re-permission the app from checked-in content.
  */
 export function deployedPolicyBase(
   deployedPolicy: Policy | undefined,
   localPolicy: Policy | undefined,
 ): Policy {
-  const { triggerables: _legacy, ...deployed } = deployedPolicy ?? {};
-  return { ...deployed, ...(localPolicy ?? {}) } as Policy;
+  const {
+    on_behalf_of: _obo,
+    on_behalf_of_email: _oboEmail,
+    ...local
+  } = localPolicy ?? {};
+  const base: Record<string, any> = { ...(deployedPolicy ?? {}), ...local };
+  for (const field of DERIVED_POLICY_FIELDS) {
+    delete base[field];
+  }
+  return base as Policy;
 }
 export async function pushApp(
   workspace: string,

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -1,6 +1,9 @@
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
-import { mergeConfigWithConfigFile } from "../../core/conf.ts";
+import {
+  mergeConfigWithConfigFile,
+  readEffectiveSyncBehavior,
+} from "../../core/conf.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
 import { sep as SEP } from "node:path";
@@ -13,10 +16,15 @@ import path from "node:path";
 import { readdir } from "node:fs/promises";
 
 import { GlobalOptions, isSuperset } from "../../types.ts";
+import {
+  buildPermissionedAsContext,
+  type PermissionedAsContext,
+} from "../../core/permissioned_as.ts";
 import { deepEqual, readTextFile } from "../../utils/utils.ts";
 
 import {
   type AppExecutionMode,
+  deployedPolicyBase,
   executionModeFromAppFile,
   markAccessFromPolicy,
   replaceInlineScripts,
@@ -360,6 +368,7 @@ export async function pushRawApp(
   localPath: string,
   message?: string,
   defaultTs: "bun" | "deno" = "bun",
+  permissionedAsContext?: PermissionedAsContext,
 ): Promise<void> {
   if (alreadySynced.includes(localPath)) {
     return;
@@ -376,6 +385,8 @@ export async function pushRawApp(
   } catch {
     //ignore
   }
+
+  const remotePolicy = app?.policy as Policy | undefined;
   markAccessFromPolicy(app);
   // console.log(app);
   if (app) {
@@ -423,12 +434,32 @@ export async function pushRawApp(
   repopulateFields(runnables);
 
   // Create a temporary app object for policy generation
-  const appForPolicy = { ...localApp, runnables };
+  const appForPolicy = {
+    ...localApp,
+    runnables,
+    policy: deployedPolicyBase(remotePolicy, localApp.policy),
+  };
   await generatingPolicy(
     appForPolicy,
     remotePath,
-    executionModeFromAppFile(localApp),
+    executionModeFromAppFile(localApp, remotePolicy),
   );
+
+  // Submitting a policy is how the backend reads a claim on the app's execution
+  // identity; without the flag it rewrites on_behalf_of to whoever ran the push.
+  const preserveFields: { preserve_on_behalf_of?: boolean } = {};
+  if (
+    permissionedAsContext?.userIsAdminOrDeployer &&
+    appForPolicy.policy.on_behalf_of
+  ) {
+    preserveFields.preserve_on_behalf_of = true;
+    log.info(
+      `Preserving ${
+        appForPolicy.policy.on_behalf_of_email ??
+          appForPolicy.policy.on_behalf_of
+      } as permissioned_as for app ${remotePath}`,
+    );
+  }
 
   const files = await collectAppFiles(localPath);
   async function createBundleRaw() {
@@ -483,6 +514,7 @@ export async function pushRawApp(
             summary: localApp.summary,
             policy: appForPolicy.policy,
             deployment_message: message,
+            ...preserveFields,
             // Preserve any user draft at this path (see backend skip_draft_deletion).
             skip_draft_deletion: true,
             ...(localApp.custom_path
@@ -505,6 +537,7 @@ export async function pushRawApp(
           summary: localApp.summary,
           policy: appForPolicy.policy,
           deployment_message: message,
+          ...preserveFields,
           // Preserve any user draft at this path (see backend skip_draft_deletion).
           skip_draft_deletion: true,
           ...(localApp.custom_path
@@ -564,6 +597,10 @@ async function pushRawAppCommand(
     filePath,
     undefined,
     merged.defaultTs,
+    await buildPermissionedAsContext(
+      workspace.workspaceId,
+      await readEffectiveSyncBehavior(opts, workspace),
+    ),
   );
   log.info(colors.bold.underline.green("Raw app pushed"));
 }

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -447,16 +447,14 @@ export async function pushRawApp(
 
   // Submitting a policy is how the backend reads a claim on the app's execution
   // identity; without the flag it rewrites on_behalf_of to whoever ran the push.
+  // Only ever claims the deployed identity — on create the backend applies the
+  // folder default instead, as on the low-code path.
   const preserveFields: { preserve_on_behalf_of?: boolean } = {};
-  if (
-    permissionedAsContext?.userIsAdminOrDeployer &&
-    appForPolicy.policy.on_behalf_of
-  ) {
+  if (permissionedAsContext?.userIsAdminOrDeployer && remotePolicy?.on_behalf_of) {
     preserveFields.preserve_on_behalf_of = true;
     log.info(
       `Preserving ${
-        appForPolicy.policy.on_behalf_of_email ??
-          appForPolicy.policy.on_behalf_of
+        remotePolicy.on_behalf_of_email ?? remotePolicy.on_behalf_of
       } as permissioned_as for app ${remotePath}`,
     );
   }
@@ -537,7 +535,6 @@ export async function pushRawApp(
           summary: localApp.summary,
           policy: appForPolicy.policy,
           deployment_message: message,
-          ...preserveFields,
           // Preserve any user draft at this path (see backend skip_draft_deletion).
           skip_draft_deletion: true,
           ...(localApp.custom_path

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -6142,7 +6142,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        { message: opts.message },
+                        { message: opts.message, permissionedAsContext },
                       );
                     } else {
                       // Flow folder doesn't exist locally — delete on server
@@ -6187,7 +6187,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        { message: opts.message },
+                        { message: opts.message, permissionedAsContext },
                       );
                     } else {
                       // App folder doesn't exist locally — delete on server
@@ -6233,7 +6233,11 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        { message: opts.message, defaultTs: opts.defaultTs },
+                        {
+                          message: opts.message,
+                          defaultTs: opts.defaultTs,
+                          permissionedAsContext,
+                        },
                       );
                     } else {
                       // The entire raw app folder was deleted locally,

--- a/cli/src/core/permissioned_as.ts
+++ b/cli/src/core/permissioned_as.ts
@@ -130,7 +130,7 @@ export async function preCheckPermissionedAs(
         const label =
           typeStr === "script" ? "(script owner)" : "(flow owner)";
         wouldChangeItems.push({ path: change.path, currentOwner: label });
-      } else if (typeStr === "app") {
+      } else if (typeStr === "app" || typeStr === "raw_app") {
         wouldChangeItems.push({
           path: change.path,
           currentOwner: "(app policy owner)",
@@ -177,7 +177,7 @@ export async function preCheckPermissionedAs(
         }
       }
       continue;
-    } else if (typeStr === "app") {
+    } else if (typeStr === "app" || typeStr === "raw_app") {
       wouldChangeItems.push({
         path: change.path,
         currentOwner: "(app policy owner)",

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -234,7 +234,7 @@ export async function pushObj(
     if (!rawAppName) {
       throw new Error(`Could not extract raw app name from path: ${p}`);
     }
-    await pushRawApp(workspace, rawAppName, buildFolderPath(rawAppName, "raw_app"), message, defaultTs);
+    await pushRawApp(workspace, rawAppName, buildFolderPath(rawAppName, "raw_app"), message, defaultTs, permissionedAsContext);
   } else if (typeEnding === "folder") {
     await pushFolder(workspace, p, befObj, newObj);
   } else if (typeEnding === "variable") {

--- a/cli/test/app_access_mode_unit.test.ts
+++ b/cli/test/app_access_mode_unit.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+  deployedPolicyBase,
   executionModeFromAppFile,
   generatingPolicy,
   markAccessFromPolicy,
@@ -25,4 +26,60 @@ test("the access mode survives the app.yaml round trip", async () => {
 
   expect(executionModeFromAppFile({ policy: { execution_mode: "publisher" } })).toBe("publisher");
   expect(executionModeFromAppFile({})).toBe("publisher");
+});
+
+// `viewer` has no representation in the app file, so a push that read the mode
+// off the file alone demoted every viewer app to publisher — running the
+// publisher's identity for viewers instead of each viewer's own.
+test("a deployed viewer mode is not demoted by a file that cannot express it", () => {
+  expect(executionModeFromAppFile({}, { execution_mode: "viewer" } as any)).toBe("viewer");
+  expect(executionModeFromAppFile({ policy: { execution_mode: "viewer" } })).toBe("viewer");
+  // Widening still has to come from the file, and dropping `public` still demotes.
+  expect(executionModeFromAppFile({}, { execution_mode: "anonymous" } as any)).toBe("publisher");
+  expect(
+    executionModeFromAppFile({ public: true }, { execution_mode: "viewer" } as any),
+  ).toBe("anonymous");
+});
+
+// A push regenerates the policy, so whatever `deployedPolicyBase` does not carry
+// over is dropped from the deployed app. Older pulls wrote the whole policy into
+// the app file, so repos still ship `on_behalf_of` keys — letting one win would
+// hand the app's execution identity to checked-in content, which is what
+// `preserve_on_behalf_of` exists to prevent.
+test("deployedPolicyBase: the file never sets the run-as identity", () => {
+  const deployed: any = {
+    on_behalf_of: "u/svc",
+    on_behalf_of_email: "svc@corp",
+    sandbox: true,
+  };
+  for (
+    const local of [
+      undefined,
+      { on_behalf_of: null, on_behalf_of_email: null },
+      { on_behalf_of: "u/stale", on_behalf_of_email: "stale@corp" },
+    ] as any[]
+  ) {
+    expect(deployedPolicyBase(deployed, local)).toMatchObject({
+      on_behalf_of: "u/svc",
+      on_behalf_of_email: "svc@corp",
+      sandbox: true,
+    });
+  }
+});
+
+// Grants keyed to the sources a deploy replaces must not survive it, from either
+// side of the merge: the backend folds legacy `triggerables` into
+// `triggerables_v2` on read and enforces S3 access against `s3_inputs`.
+test("deployedPolicyBase: derived grants are never carried over", () => {
+  const stale: any = {
+    triggerables: { "gone:script/f/gone": {} },
+    s3_inputs: [{ allowed_resources: ["u/gone"] }],
+    allowed_s3_keys: [{ s3_path: "gone" }],
+  };
+  for (const [deployed, local] of [[stale, undefined], [{}, stale]] as any[]) {
+    const base = deployedPolicyBase(deployed, local) as any;
+    expect(base.triggerables).toBeUndefined();
+    expect(base.s3_inputs).toBeUndefined();
+    expect(base.allowed_s3_keys).toBeUndefined();
+  }
 });

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -812,14 +812,39 @@ syncBehavior: v1`, "utf-8");
       expect(pushResult2.code).toEqual(0);
       await waitForDeploymentJobs(backend);
 
-      const getResp = await backend.apiRequest!(
-        `/api/w/${backend.workspace}/apps/get/p/f/test/policy_app`
-      );
-      expect(getResp.status).toEqual(200);
-      const policy = (await getResp.json()).policy;
+      async function readPolicy() {
+        const resp = await backend.apiRequest!(
+          `/api/w/${backend.workspace}/apps/get/p/f/test/policy_app`
+        );
+        expect(resp.status).toEqual(200);
+        return (await resp.json()).policy;
+      }
+      const policy = await readPolicy();
       expect(policy.on_behalf_of).toEqual("u/svc");
       expect(policy.on_behalf_of_email).toEqual("svc@windmill.dev");
       expect(policy.sandbox).toEqual(true);
       expect(policy.execution_mode).toEqual("viewer");
+
+      // The carry-over must not make the access mode sticky in the widening
+      // direction: `public: true` promotes, and dropping it demotes again.
+      const yamlPath = path.join(appDir, "raw_app.yaml");
+      const baseYaml = await readFileContent(yamlPath);
+      await writeFile(yamlPath, `${baseYaml}public: true\n`, "utf-8");
+      expect((await backend.runCLICommand(
+        ["sync", "push", "--yes"], tempDir, "raw_app_policy_test"
+      )).code).toEqual(0);
+      await waitForDeploymentJobs(backend);
+      expect(await readPolicy()).toMatchObject({ execution_mode: "anonymous" });
+
+      await writeFile(yamlPath, baseYaml, "utf-8");
+      expect((await backend.runCLICommand(
+        ["sync", "push", "--yes"], tempDir, "raw_app_policy_test"
+      )).code).toEqual(0);
+      await waitForDeploymentJobs(backend);
+      expect(await readPolicy()).toMatchObject({
+        execution_mode: "publisher",
+        sandbox: true,
+        on_behalf_of: "u/svc",
+      });
     });
 });

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -746,3 +746,80 @@ excludes: []`, "utf-8");
       expect(lowercased).toEqual([]);
     });
 });
+
+test("Raw App: push preserves the deployed policy's run-as, sandbox and execution mode", async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      const testWorkspace = {
+        remote: backend.baseUrl,
+        workspaceId: backend.workspace,
+        name: "raw_app_policy_test",
+        token: backend.token
+      };
+      await addWorkspace(testWorkspace, { force: true, configDir: backend.testConfigDir });
+
+      // syncBehavior v1 is what enables ownership preservation on update.
+      await writeFile(`${tempDir}/wmill.yaml`, `defaultTs: bun
+includes:
+  - "**"
+excludes: []
+syncBehavior: v1`, "utf-8");
+
+      const appDir = path.join(tempDir, "f", "test", "policy_app.raw_app");
+      await mkdir(path.join(tempDir, "f", "test"), { recursive: true });
+      await createRawAppOnDisk(appDir);
+
+      const pushResult1 = await backend.runCLICommand(
+        ["sync", "push", "--yes"],
+        tempDir, "raw_app_policy_test"
+      );
+      expect(pushResult1.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
+
+      // Stand in for the deploy drawer: give the app a run-as identity that is
+      // not the pushing user, sandbox isolation and a non-default mode. None of
+      // it is recorded in raw_app.yaml, so only the deployed policy carries it.
+      const setPolicy = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/apps/update/f/test/policy_app`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            policy: {
+              on_behalf_of: "u/svc",
+              on_behalf_of_email: "svc@windmill.dev",
+              sandbox: true,
+              execution_mode: "viewer",
+              triggerables_v2: {},
+            },
+            preserve_on_behalf_of: true,
+          }),
+        }
+      );
+      expect(setPolicy.status).toEqual(200);
+
+      // Edit a source file so the app is not up to date and gets redeployed.
+      const appTsxPath = path.join(appDir, "App.tsx");
+      await writeFile(
+        appTsxPath,
+        (await readFileContent(appTsxPath)).replace("hello world", "hello again"),
+        "utf-8"
+      );
+
+      const pushResult2 = await backend.runCLICommand(
+        ["sync", "push", "--yes"],
+        tempDir, "raw_app_policy_test"
+      );
+      expect(pushResult2.code).toEqual(0);
+      await waitForDeploymentJobs(backend);
+
+      const getResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/apps/get/p/f/test/policy_app`
+      );
+      expect(getResp.status).toEqual(200);
+      const policy = (await getResp.json()).policy;
+      expect(policy.on_behalf_of).toEqual("u/svc");
+      expect(policy.on_behalf_of_email).toEqual("svc@windmill.dev");
+      expect(policy.sandbox).toEqual(true);
+      expect(policy.execution_mode).toEqual("viewer");
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #11046.

`wmill sync push` regenerated a raw app's policy from the local sources alone. `raw_app.yaml` records only the access mode (`public` / `guests`), so everything else the deployed policy carried was lost on every push: `on_behalf_of` was rewritten to whoever ran the push, `sandbox` and `frontend_sdk_scopes` disappeared, and a `viewer` app was demoted to `publisher`. A CI job pushing with an admin token silently re-permissioned every raw app it touched, and since the policy is not in `raw_app.yaml`, git sync recorded no change to hint at it.

The regenerated policy now starts from the deployed one, so the fields nothing local states carry over, and the push sends `preserve_on_behalf_of` the way the low-code path already did.

Low-code apps went through the same regeneration and lost `sandbox` too, so both paths now share one helper. It drops the legacy `triggerables` map rather than carrying it forward — the backend folds that map into `triggerables_v2` on read, so preserving it would keep granting runnables the deploy no longer contains.

Separately, the deletion-driven re-push (a file removed inside a flow / app / raw-app folder re-pushes the whole item) reached `pushObj` without the permissioned-as context, so it reset ownership even where the normal path preserved it. That path is hit routinely for raw apps, since the server-generated `.lock` files show up as local deletions.

## Changes

- `deployedPolicyBase(deployed, local)` in `cli/src/commands/app/app.ts`: the base a push's regenerated policy starts from — deployed fields first, anything the app file states wins, legacy `triggerables` dropped.
- `executionModeFromAppFile` takes the deployed policy: "neither `public` nor `guests`" now keeps a deployed `viewer` mode instead of always meaning `publisher`. Dropping `public` from the file still demotes the app — the mode is read off the file before the deployed policy is merged in.
- `pushRawApp` accepts a `PermissionedAsContext` and sends `preserve_on_behalf_of` when the pusher is an admin or `wm_deployers` member; both `wmill sync push` and `wmill app push` now pass it.
- `pushApp` (low-code) uses the same base, so `sandbox` survives a push.
- The three deletion-driven `pushObj` re-pushes in `sync.ts` (flow, app, raw app) now pass `permissionedAsContext`.
- Regression test in `cli/test/raw_app_sync.test.ts`: plant a run-as identity, `sandbox` and `viewer` on a deployed raw app, edit a source file, push, assert all three survive.

## Review status

Two CI review rounds; round 2 is clean (Codex "Good to merge", Claude nit-only, nit dismissed in a comment with reasoning).

**Left in draft: this is permission logic** — it decides whose `on_behalf_of` an app is deployed under and which execution mode it lands in, so it wants a human look before ready even with a clean round. Everything else about the change is self-contained (CLI-only, no backend, no API surface, no migration).

## Test plan

- [x] `bun test test/raw_app_sync.test.ts` — 8 pass; the new test fails on the pre-fix code (`on_behalf_of` comes back as the pushing user).
- [x] `bun test test/app_access_mode_unit.test.ts test/app_policy_bundle_unit.test.ts test/deploy_on_behalf_of_unit.test.ts test/folder_default_permissioned_as.test.ts test/pull_on_behalf_of_marker.test.ts test/app_inline_script_delete.test.ts test/sync_pull_push.test.ts test/gitsync_promotion.test.ts test/datatable_settings_sync.test.ts` — all green.
- [x] Manual, against a live instance: pushed a raw app, set `on_behalf_of: u/svc` + `sandbox: true` + `execution_mode: viewer` + `frontend_sdk_scopes` on the deployed policy, edited a source file, pushed again — reproduced the reset on the pre-fix code, and all four fields preserved after.
- [x] Manual counter-cases on both raw and low-code apps: adding `public: true` to the app file still promotes to `anonymous`, and removing it still demotes to `publisher` while keeping `sandbox` and the run-as identity; a planted legacy `triggerables` entry is dropped rather than carried forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
