### PR TITLE
fix: keep an app's deployed policy on wmill push

### DIFF
--- a/cli/TESTING.md
+++ b/cli/TESTING.md
@@ -31,21 +31,25 @@ Examples: `sync_pull_push`, `dev_server`, `standalone_commands`
 
 ## Module mocks
 
-`mock.module` replaces a module for the **whole process**, and a stub cannot be taken
-back. Every test file's imports resolve before any `afterAll` runs, so a suite that binds
-a stub at import time keeps it however the file that installed it cleans up afterwards.
-An `afterAll` hand-back only reaches a consumer that imports dynamically, later.
+`mock.module` replaces a module for the **whole process**, and it does reach modules that
+were already imported — a stub one file installs lands on a consumer an earlier file
+loaded.
+
+Handing the module back in `afterAll` is not a reliable undo. Files do run one at a time
+(a root-level `afterAll` completes before the next file's body evaluates), so it looks
+like it should be — but stubbing `bundle.ts` and restoring it that way still left
+`raw_app_svelte_plugin_unit.test.ts` asserting against an empty bundle, green on Linux
+and red on Windows, where the `readdir` file order differs. Treat a stub as permanent for
+the run.
 
 So the rule is about what you stub, not how you clean up: **stub only a module no other
 in-process suite imports.** Check with `grep -rl "<exported fn>" test/` before reaching
 for one. A suite that drives the CLI through a spawned process is out of reach of a
 module mock and doesn't count.
 
-`raw_app_push_policy_unit.test.ts` stubs `gen/services.gen.ts` (nothing else in `test/`
-imports the three API functions it replaces) but deliberately does **not** stub
-`bundle.ts`: doing so made `raw_app_svelte_plugin_unit.test.ts` assert against an empty
-bundle whenever the runner reached the two files in that order — green on Linux, red on
-Windows, because the ordering is `readdir` order.
+`raw_app_push_policy_unit.test.ts` is the worked example: it stubs `gen/services.gen.ts`,
+which passes the rule because nothing else in `test/` imports the three API functions it
+replaces, and deliberately does not stub `bundle.ts`, which failed it.
 
 ## AI Benchmark Caveats
 

--- a/cli/TESTING.md
+++ b/cli/TESTING.md
@@ -29,6 +29,24 @@ binary and starts a shared backend instance.
 
 Examples: `sync_pull_push`, `dev_server`, `standalone_commands`
 
+## Module mocks
+
+`mock.module` replaces a module for the **whole process**, and a stub cannot be taken
+back. Every test file's imports resolve before any `afterAll` runs, so a suite that binds
+a stub at import time keeps it however the file that installed it cleans up afterwards.
+An `afterAll` hand-back only reaches a consumer that imports dynamically, later.
+
+So the rule is about what you stub, not how you clean up: **stub only a module no other
+in-process suite imports.** Check with `grep -rl "<exported fn>" test/` before reaching
+for one. A suite that drives the CLI through a spawned process is out of reach of a
+module mock and doesn't count.
+
+`raw_app_push_policy_unit.test.ts` stubs `gen/services.gen.ts` (nothing else in `test/`
+imports the three API functions it replaces) but deliberately does **not** stub
+`bundle.ts`: doing so made `raw_app_svelte_plugin_unit.test.ts` assert against an empty
+bundle whenever the runner reached the two files in that order — green on Linux, red on
+Windows, because the ordering is `readdir` order.
+
 ## AI Benchmark Caveats
 
 The repo-level benchmark CLI lives under `ai_evals/`, but it currently depends on

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -145,10 +145,6 @@ function statedExecutionMode(app: any): AppExecutionMode | undefined {
   return mode === "viewer" || mode === "publisher" ? mode : undefined;
 }
 
-export function executionModeFromAppFile(app: any): AppExecutionMode {
-  return statedExecutionMode(app) ?? "publisher";
-}
-
 /** The mode this push deploys under. A file that states one is authoritative, in
  * both directions. Otherwise the two open-access markers are all it says, so
  * their absence closes a deployed `anonymous`/`guest` app back down to
@@ -330,13 +326,14 @@ export function preserveOnBehalfOfFields(
   return { preserve_on_behalf_of: true };
 }
 
-/** The policy is written wholesale by the deploy, but only its triggerables and
- * access mode are derivable from the tracked files: everything else (run-as
- * identity, sandbox isolation, S3 rules) is carried over from the deployed
- * policy, or a push would silently reset it. The legacy `triggerables` still
- * grant execution — the backend folds them into `triggerables_v2` at run time —
- * so they are dropped rather than carried, otherwise a deployed app would keep
- * being able to run runnables this push removed. */
+/** The policy is written wholesale by the deploy, so the fields it does not
+ * derive from the tracked sources have to survive the trip. The policy builder
+ * has already recomputed what it can — the triggerables on both paths, plus the
+ * S3 rules on the low-code one, which `updateRawAppPolicy` has no equivalent of
+ * and so carries over. This sets the two left: the access mode, and the legacy
+ * `triggerables`, which still grant execution (the backend folds them into
+ * `triggerables_v2` at run time) and so are dropped rather than carried, or a
+ * deployed app would keep being able to run runnables this push removed. */
 export function finalizeDerivedPolicy(
   policy: Policy,
   executionMode: AppExecutionMode

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -119,9 +119,10 @@ export function isExecutionModeAnonymous(app: any) {
 export function isExecutionModeGuest(app: any) {
   return app?.["policy"]?.["execution_mode"] == "guest";
 }
-export type AppExecutionMode = "anonymous" | "guest" | "publisher";
+export type AppExecutionMode = "anonymous" | "guest" | "publisher" | "viewer";
 /** The access mode is the one policy field a tracked app keeps, as `public` (anonymous)
- * or `guests` (guest); the rest of the policy is regenerated on push. */
+ * or `guests` (guest); the rest of the policy is preserved from the deployed app on
+ * push (see `generatingPolicy`). */
 export function markAccessFromPolicy(app: any) {
   if (isExecutionModeAnonymous(app)) {
     app.public = true;
@@ -137,6 +138,21 @@ export function executionModeFromAppFile(app: any): AppExecutionMode {
     return "guest";
   }
   return "publisher";
+}
+
+/** The mode this push deploys under. The tracked file records only the two
+ * open-access markers, so their absence closes a deployed `anonymous`/`guest`
+ * app back down to `publisher`; a deployed mode the file cannot express
+ * (`viewer`) is not an access grant the markers revoke, so it carries over. */
+export function executionModeForPush(
+  localApp: any,
+  deployedPolicy: Policy | undefined,
+): AppExecutionMode {
+  const stated = executionModeFromAppFile(localApp);
+  if (stated !== "publisher") {
+    return stated;
+  }
+  return deployedPolicy?.execution_mode === "viewer" ? "viewer" : "publisher";
 }
 export async function pushApp(
   workspace: string,
@@ -161,12 +177,9 @@ export async function pushApp(
     //ignore
   }
 
-  let remoteOnBehalfOf: string | undefined;
-  let remoteOnBehalfOfEmail: string | undefined;
-  if (app?.policy) {
-    remoteOnBehalfOf = app.policy.on_behalf_of;
-    remoteOnBehalfOfEmail = app.policy.on_behalf_of_email;
-  }
+  // Captured before `markAccessFromPolicy` clears it below, which it does so the
+  // policy takes no part in the up-to-date comparison.
+  const deployedPolicy: Policy | undefined = app?.policy;
 
   markAccessFromPolicy(app);
   // console.log(app);
@@ -181,20 +194,19 @@ export async function pushApp(
   const localApp = (await yamlParseFile(path)) as AppFile;
 
   replaceInlineScripts(localApp.value, localPath, true);
-  await generatingPolicy(localApp, remotePath, executionModeFromAppFile(localApp));
+  await generatingPolicy(
+    localApp,
+    remotePath,
+    executionModeForPush(localApp, deployedPolicy),
+    deployedPolicy
+  );
 
-  const preserveFields: { preserve_on_behalf_of?: boolean } = {};
-  if (permissionedAsContext?.userIsAdminOrDeployer) {
-    if (app) {
-      if (localApp.policy && remoteOnBehalfOf) {
-        (localApp.policy as any).on_behalf_of = remoteOnBehalfOf;
-        (localApp.policy as any).on_behalf_of_email = remoteOnBehalfOfEmail;
-        preserveFields.preserve_on_behalf_of = true;
-        log.info(`Preserving ${remoteOnBehalfOfEmail ?? remoteOnBehalfOf} as permissioned_as for app ${remotePath}`);
-      }
-    }
-    // On create: backend applies folder defaults
-  }
+  // On create the backend applies folder defaults, so there is nothing to preserve.
+  const preserveFields = preserveOnBehalfOfFields(
+    remotePath,
+    localApp.policy,
+    permissionedAsContext
+  );
 
   // extra_perms goes through /acls/* — strip from the body so a perms-only
   // edit never bumps the app version (see applyExtraPermsDiff for details).
@@ -251,16 +263,50 @@ export async function pushApp(
 export async function generatingPolicy(
   app: any,
   path: string,
-  executionMode: AppExecutionMode
+  executionMode: AppExecutionMode,
+  deployedPolicy: Policy | undefined
 ) {
   log.info(colors.gray(`Generating fresh policy for app ${path}...`));
   try {
-    app.policy = await windmillUtils.updatePolicy(app.value, undefined);
-    app.policy.execution_mode = executionMode;
+    app.policy = await windmillUtils.updatePolicy(app.value, deployedPolicy);
+    finalizeDerivedPolicy(app.policy, executionMode);
   } catch (e) {
     log.error(colors.red(`Error generating policy for app ${path}: ${e}`));
     throw e;
   }
+}
+
+/** Claim the run-as identity the policy carries over from the deployed app.
+ * Without the flag the backend rewrites `on_behalf_of` to whoever is pushing,
+ * and it only honors the flag for an admin or a `wm_deployers` member — so a
+ * caller who is neither doesn't get to claim it here either. */
+export function preserveOnBehalfOfFields(
+  remotePath: string,
+  policy: Policy | undefined,
+  permissionedAsContext: PermissionedAsContext | undefined
+): { preserve_on_behalf_of?: boolean } {
+  if (!permissionedAsContext?.userIsAdminOrDeployer || !policy?.on_behalf_of) {
+    return {};
+  }
+  log.info(
+    `Preserving ${policy.on_behalf_of_email ?? policy.on_behalf_of} as permissioned_as for app ${remotePath}`
+  );
+  return { preserve_on_behalf_of: true };
+}
+
+/** The policy is written wholesale by the deploy, but only its triggerables and
+ * access mode are derivable from the tracked files: everything else (run-as
+ * identity, sandbox isolation, S3 rules) is carried over from the deployed
+ * policy, or a push would silently reset it. The legacy `triggerables` still
+ * grant execution — the backend folds them into `triggerables_v2` at run time —
+ * so they are dropped rather than carried, otherwise a deployed app would keep
+ * being able to run runnables this push removed. */
+export function finalizeDerivedPolicy(
+  policy: Policy,
+  executionMode: AppExecutionMode
+) {
+  policy.triggerables = undefined;
+  policy.execution_mode = executionMode;
 }
 
 async function list(opts: GlobalOptions & { includeDraftOnly?: boolean; json?: boolean }) {
@@ -425,14 +471,16 @@ async function push(
   if (isRawAppByName || hasRawAppYaml) {
     const { pushRawApp } = await import("./raw_apps.ts");
     const merged = await mergeConfigWithConfigFile(opts);
-    // Raw-app ownership preservation is not implemented on either push
-    // path: sync push hands pushRawApp no context either.
     await pushRawApp(
       workspace.workspaceId,
       remotePath,
       absoluteFilePath,
       undefined,
       merged.defaultTs,
+      await buildPermissionedAsContext(
+        workspace.workspaceId,
+        await readEffectiveSyncBehavior(opts, workspace),
+      ),
     );
     log.info(colors.bold.underline.green("Raw app pushed"));
   } else {

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -130,33 +130,36 @@ export function markAccessFromPolicy(app: any) {
     app.guests = true;
   }
 }
-export function executionModeFromAppFile(app: any): AppExecutionMode {
+/** The mode the tracked file states, or `undefined` when it states none — the
+ * normal case, since a pull writes only the two open-access markers. `viewer`
+ * and `publisher` have no marker of their own, so a file can only name them
+ * through a policy block it was hand-written with. */
+function statedExecutionMode(app: any): AppExecutionMode | undefined {
   if (app?.["public"] ?? isExecutionModeAnonymous(app)) {
     return "anonymous";
   }
   if (app?.["guests"] ?? isExecutionModeGuest(app)) {
     return "guest";
   }
-  // `viewer` has no marker of its own — a pull never writes one, since it is not
-  // an open-access mode. Read it where the other modes are read from anyway, so
-  // a file stating it is not deployed as the wider `publisher` (which runs the
-  // runnables as the app's identity rather than each viewer's).
-  if (app?.["policy"]?.["execution_mode"] == "viewer") {
-    return "viewer";
-  }
-  return "publisher";
+  const mode = app?.["policy"]?.["execution_mode"];
+  return mode === "viewer" || mode === "publisher" ? mode : undefined;
 }
 
-/** The mode this push deploys under. The tracked file normally records only the
- * two open-access markers, so their absence closes a deployed `anonymous`/`guest`
- * app back down to `publisher` — while a deployed `viewer` is not an access grant
- * those markers revoke, so it carries over. */
+export function executionModeFromAppFile(app: any): AppExecutionMode {
+  return statedExecutionMode(app) ?? "publisher";
+}
+
+/** The mode this push deploys under. A file that states one is authoritative, in
+ * both directions. Otherwise the two open-access markers are all it says, so
+ * their absence closes a deployed `anonymous`/`guest` app back down to
+ * `publisher` — while a deployed `viewer` is not a grant those markers revoke,
+ * so it carries over rather than widening to `publisher`. */
 export function executionModeForPush(
   localApp: any,
   deployedPolicy: Policy | undefined,
 ): AppExecutionMode {
-  const stated = executionModeFromAppFile(localApp);
-  if (stated !== "publisher") {
+  const stated = statedExecutionMode(localApp);
+  if (stated) {
     return stated;
   }
   return deployedPolicy?.execution_mode === "viewer" ? "viewer" : "publisher";

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -201,18 +201,17 @@ export async function pushApp(
   const localApp = (await yamlParseFile(path)) as AppFile;
 
   replaceInlineScripts(localApp.value, localPath, true);
-  await generatingPolicy(
-    localApp,
-    remotePath,
-    executionModeForPush(localApp, deployedPolicy),
-    deployedPolicy
-  );
-
   // On create the backend applies folder defaults, so there is nothing to preserve.
   const preserveFields = preserveOnBehalfOfFields(
     remotePath,
     deployedPolicy,
     permissionedAsContext
+  );
+  await generatingPolicy(
+    localApp,
+    remotePath,
+    executionModeForPush(localApp, deployedPolicy),
+    basePolicy(localApp, deployedPolicy, !!preserveFields.preserve_on_behalf_of)
   );
 
   // extra_perms goes through /acls/* — strip from the body so a perms-only
@@ -271,14 +270,11 @@ export async function generatingPolicy(
   app: any,
   path: string,
   executionMode: AppExecutionMode,
-  deployedPolicy: Policy | undefined
+  base: Policy | undefined
 ) {
   log.info(colors.gray(`Generating fresh policy for app ${path}...`));
   try {
-    app.policy = await windmillUtils.updatePolicy(
-      app.value,
-      basePolicy(app, deployedPolicy)
-    );
+    app.policy = await windmillUtils.updatePolicy(app.value, base);
     finalizeDerivedPolicy(app.policy, executionMode);
   } catch (e) {
     log.error(colors.red(`Error generating policy for app ${path}: ${e}`));
@@ -286,22 +282,23 @@ export async function generatingPolicy(
   }
 }
 
-/** What the regenerated policy starts from: the deployed one, so a push keeps
+/** What the regenerated policy starts from: the deployed policy, so a push keeps
  * settings the tracked file doesn't record. A first push has no deployed policy,
- * and then the file is the only thing that could state one — minus the run
- * identity, which is never the repo's to name. The backend rewrites an
- * unclaimed `on_behalf_of` to the pusher, but `wmill` is regularly pointed at
- * older servers, so never put one on the wire that no deploy vouched for. */
+ * and then the file is what states one.
+ *
+ * The run identity comes along only when `claimsOnBehalfOf` says this push is
+ * entitled to it — never from the file, and never from a pusher who may not
+ * preserve one. The backend rewrites an unclaimed `on_behalf_of` to the pusher,
+ * but `wmill` is regularly pointed at older servers, so the only identity that
+ * goes on the wire is one this push is allowed to deploy under. */
 export function basePolicy(
   localApp: any,
-  deployedPolicy: Policy | undefined
+  deployedPolicy: Policy | undefined,
+  claimsOnBehalfOf: boolean
 ): Policy | undefined {
-  if (deployedPolicy) {
-    return deployedPolicy;
-  }
-  const stated = localApp?.policy as Policy | undefined;
-  if (!stated) {
-    return undefined;
+  const stated = deployedPolicy ?? (localApp?.policy as Policy | undefined);
+  if (!stated || claimsOnBehalfOf) {
+    return stated;
   }
   const base: Policy = { ...stated };
   delete base.on_behalf_of;

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -204,7 +204,7 @@ export async function pushApp(
   // On create the backend applies folder defaults, so there is nothing to preserve.
   const preserveFields = preserveOnBehalfOfFields(
     remotePath,
-    localApp.policy,
+    deployedPolicy,
     permissionedAsContext
   );
 
@@ -268,7 +268,10 @@ export async function generatingPolicy(
 ) {
   log.info(colors.gray(`Generating fresh policy for app ${path}...`));
   try {
-    app.policy = await windmillUtils.updatePolicy(app.value, deployedPolicy);
+    app.policy = await windmillUtils.updatePolicy(
+      app.value,
+      basePolicy(app, deployedPolicy)
+    );
     finalizeDerivedPolicy(app.policy, executionMode);
   } catch (e) {
     log.error(colors.red(`Error generating policy for app ${path}: ${e}`));
@@ -276,20 +279,33 @@ export async function generatingPolicy(
   }
 }
 
-/** Claim the run-as identity the policy carries over from the deployed app.
- * Without the flag the backend rewrites `on_behalf_of` to whoever is pushing,
- * and it only honors the flag for an admin or a `wm_deployers` member — so a
- * caller who is neither doesn't get to claim it here either. */
+/** What the regenerated policy starts from: the deployed one, so a push keeps
+ * settings the tracked file doesn't record. A first push has no deployed policy,
+ * and then the file is the only thing that could state one. */
+export function basePolicy(
+  localApp: any,
+  deployedPolicy: Policy | undefined
+): Policy | undefined {
+  return deployedPolicy ?? localApp?.policy;
+}
+
+/** Claim the run-as identity the regenerated policy carries over from the
+ * deployed app. Only a deployed identity may be claimed, never one the tracked
+ * file states — a repo doesn't get to pick who an app runs as. Without the flag
+ * the backend rewrites `on_behalf_of` to whoever is pushing, and it only honors
+ * the flag for an admin or a `wm_deployers` member, so a caller who is neither
+ * doesn't get to claim it here either. */
 export function preserveOnBehalfOfFields(
   remotePath: string,
-  policy: Policy | undefined,
+  deployedPolicy: Policy | undefined,
   permissionedAsContext: PermissionedAsContext | undefined
 ): { preserve_on_behalf_of?: boolean } {
-  if (!permissionedAsContext?.userIsAdminOrDeployer || !policy?.on_behalf_of) {
+  const onBehalfOf = deployedPolicy?.on_behalf_of;
+  if (!permissionedAsContext?.userIsAdminOrDeployer || !onBehalfOf) {
     return {};
   }
   log.info(
-    `Preserving ${policy.on_behalf_of_email ?? policy.on_behalf_of} as permissioned_as for app ${remotePath}`
+    `Preserving ${deployedPolicy?.on_behalf_of_email ?? onBehalfOf} as permissioned_as for app ${remotePath}`
   );
   return { preserve_on_behalf_of: true };
 }

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -288,12 +288,25 @@ export async function generatingPolicy(
 
 /** What the regenerated policy starts from: the deployed one, so a push keeps
  * settings the tracked file doesn't record. A first push has no deployed policy,
- * and then the file is the only thing that could state one. */
+ * and then the file is the only thing that could state one — minus the run
+ * identity, which is never the repo's to name. The backend rewrites an
+ * unclaimed `on_behalf_of` to the pusher, but `wmill` is regularly pointed at
+ * older servers, so never put one on the wire that no deploy vouched for. */
 export function basePolicy(
   localApp: any,
   deployedPolicy: Policy | undefined
 ): Policy | undefined {
-  return deployedPolicy ?? localApp?.policy;
+  if (deployedPolicy) {
+    return deployedPolicy;
+  }
+  const stated = localApp?.policy as Policy | undefined;
+  if (!stated) {
+    return undefined;
+  }
+  const base: Policy = { ...stated };
+  delete base.on_behalf_of;
+  delete base.on_behalf_of_email;
+  return base;
 }
 
 /** Claim the run-as identity the regenerated policy carries over from the

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -137,13 +137,20 @@ export function executionModeFromAppFile(app: any): AppExecutionMode {
   if (app?.["guests"] ?? isExecutionModeGuest(app)) {
     return "guest";
   }
+  // `viewer` has no marker of its own — a pull never writes one, since it is not
+  // an open-access mode. Read it where the other modes are read from anyway, so
+  // a file stating it is not deployed as the wider `publisher` (which runs the
+  // runnables as the app's identity rather than each viewer's).
+  if (app?.["policy"]?.["execution_mode"] == "viewer") {
+    return "viewer";
+  }
   return "publisher";
 }
 
-/** The mode this push deploys under. The tracked file records only the two
- * open-access markers, so their absence closes a deployed `anonymous`/`guest`
- * app back down to `publisher`; a deployed mode the file cannot express
- * (`viewer`) is not an access grant the markers revoke, so it carries over. */
+/** The mode this push deploys under. The tracked file normally records only the
+ * two open-access markers, so their absence closes a deployed `anonymous`/`guest`
+ * app back down to `publisher` — while a deployed `viewer` is not an access grant
+ * those markers revoke, so it carries over. */
 export function executionModeForPush(
   localApp: any,
   deployedPolicy: Policy | undefined,
@@ -177,8 +184,8 @@ export async function pushApp(
     //ignore
   }
 
-  // Captured before `markAccessFromPolicy` clears it below, which it does so the
-  // policy takes no part in the up-to-date comparison.
+  // `app.policy` is cleared a few lines down, so capture it first: it is the
+  // base the regenerated policy is built on.
   const deployedPolicy: Policy | undefined = app?.policy;
 
   markAccessFromPolicy(app);

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -281,15 +281,11 @@ export async function generatingPolicy(
   }
 }
 
-/** What the regenerated policy starts from: the deployed policy, so a push keeps
- * settings the tracked file doesn't record. A first push has no deployed policy,
- * and then the file is what states one.
- *
- * The run identity comes along only when `claimsOnBehalfOf` says this push is
- * entitled to it — never from the file, and never from a pusher who may not
- * preserve one. The backend rewrites an unclaimed `on_behalf_of` to the pusher,
- * but `wmill` is regularly pointed at older servers, so the only identity that
- * goes on the wire is one this push is allowed to deploy under. */
+/** What the regenerated policy starts from: the deployed one, so a push keeps
+ * settings the tracked file doesn't record; on a first push, whatever the file
+ * states. The run identity rides along only when `claimsOnBehalfOf` — never
+ * from the file, never from a pusher who may not preserve one, since `wmill`
+ * is regularly pointed at servers older than the rewrite that would fix it. */
 export function basePolicy(
   localApp: any,
   deployedPolicy: Policy | undefined,

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -385,9 +385,8 @@ export async function pushRawApp(
   } catch {
     //ignore
   }
-  // Captured before it is cleared below, which it is so the policy takes no part
-  // in the up-to-date comparison. `raw_app.yaml` records none of it, so anything
-  // the deploy drawer set is only here.
+  // `app.policy` is cleared a few lines down, so capture it first. `raw_app.yaml`
+  // records none of the policy, so anything the deploy drawer set is only here.
   const deployedPolicy: Policy | undefined = app?.policy;
 
   markAccessFromPolicy(app);

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -32,6 +32,10 @@ import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
 import { buildPermissionedAsContext } from "../../core/permissioned_as.ts";
 import { createBundle, detectFrameworks } from "./bundle.ts";
 import { APP_BACKEND_FOLDER, RECORDINGS_FOLDER } from "./app_metadata.ts";
+import {
+  NEVER_DEPLOYED_DIRS,
+  NEVER_DEPLOYED_FILES,
+} from "../../utils/app_files.ts";
 import { writeIfChanged } from "../../utils/utils.ts";
 import { yamlOptions } from "../sync/sync.ts";
 import { applyExtraPermsDiff } from "../../core/extra_perms.ts";
@@ -324,13 +328,11 @@ async function collectAppFiles(
       const relativePath = basePath + entry.name;
 
       if (entry.isDirectory()) {
-        // Skip the runnables, node_modules, and sql_to_apply subfolders
+        // The backend folder deploys as `value.runnables`, not as a bundled
+        // file; the rest reach the server through no channel at all.
         if (
           entry.name === APP_BACKEND_FOLDER ||
-          entry.name === "node_modules" ||
-          entry.name === "dist" ||
-          entry.name === ".claude" ||
-          entry.name === "sql_to_apply"
+          NEVER_DEPLOYED_DIRS.has(entry.name)
         ) {
           continue;
         }
@@ -342,13 +344,11 @@ async function collectAppFiles(
         }
         await readDirRecursive(fullPath + SEP, relativePath + "/");
       } else if (entry.isFile()) {
-        // Skip generated/metadata files that shouldn't be part of the app
+        // `raw_app.yaml` deploys as the request's metadata rather than as a
+        // bundled file; the rest reach the server through no channel at all.
         if (
           entry.name === "raw_app.yaml" ||
-          entry.name === "package-lock.json" ||
-          entry.name === "DATATABLES.md" ||
-          entry.name === "AGENTS.md" ||
-          entry.name === "wmill.d.ts"
+          NEVER_DEPLOYED_FILES.has(entry.name)
         ) {
           continue;
         }

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -437,17 +437,21 @@ export async function pushRawApp(
 
   // Create a temporary app object for policy generation
   const appForPolicy = { ...localApp, runnables };
-  await generatingPolicy(
-    appForPolicy,
-    remotePath,
-    executionModeForPush(localApp, deployedPolicy),
-    deployedPolicy,
-  );
   // On create the backend applies folder defaults, so there is nothing to preserve.
   const preserveFields = preserveOnBehalfOfFields(
     remotePath,
     deployedPolicy,
     permissionedAsContext,
+  );
+  await generatingPolicy(
+    appForPolicy,
+    remotePath,
+    executionModeForPush(localApp, deployedPolicy),
+    basePolicy(
+      localApp,
+      deployedPolicy,
+      !!preserveFields.preserve_on_behalf_of,
+    ),
   );
 
   const files = await collectAppFiles(localPath);
@@ -553,14 +557,11 @@ export async function generatingPolicy(
   app: any,
   path: string,
   executionMode: AppExecutionMode,
-  deployedPolicy: Policy | undefined,
+  base: Policy | undefined,
 ) {
   log.info(colors.gray(`Generating fresh policy for app ${path}...`));
   try {
-    app.policy = await windmillUtils.updateRawAppPolicy(
-      app.runnables,
-      basePolicy(app, deployedPolicy),
-    );
+    app.policy = await windmillUtils.updateRawAppPolicy(app.runnables, base);
     finalizeDerivedPolicy(app.policy, executionMode);
   } catch (e) {
     log.error(colors.red(`Error generating policy for app ${path}: ${e}`));

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -20,6 +20,7 @@ import { deepEqual, readTextFile } from "../../utils/utils.ts";
 
 import {
   type AppExecutionMode,
+  basePolicy,
   executionModeForPush,
   finalizeDerivedPolicy,
   markAccessFromPolicy,
@@ -446,7 +447,7 @@ export async function pushRawApp(
   // On create the backend applies folder defaults, so there is nothing to preserve.
   const preserveFields = preserveOnBehalfOfFields(
     remotePath,
-    appForPolicy.policy,
+    deployedPolicy,
     permissionedAsContext,
   );
 
@@ -559,7 +560,7 @@ export async function generatingPolicy(
   try {
     app.policy = await windmillUtils.updateRawAppPolicy(
       app.runnables,
-      deployedPolicy,
+      basePolicy(app, deployedPolicy),
     );
     finalizeDerivedPolicy(app.policy, executionMode);
   } catch (e) {

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -1,6 +1,9 @@
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
-import { mergeConfigWithConfigFile } from "../../core/conf.ts";
+import {
+  mergeConfigWithConfigFile,
+  readEffectiveSyncBehavior,
+} from "../../core/conf.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
 import { sep as SEP } from "node:path";
@@ -17,11 +20,15 @@ import { deepEqual, readTextFile } from "../../utils/utils.ts";
 
 import {
   type AppExecutionMode,
-  executionModeFromAppFile,
+  executionModeForPush,
+  finalizeDerivedPolicy,
   markAccessFromPolicy,
+  preserveOnBehalfOfFields,
   replaceInlineScripts,
   repopulateFields,
 } from "./app.ts";
+import type { PermissionedAsContext } from "../../core/permissioned_as.ts";
+import { buildPermissionedAsContext } from "../../core/permissioned_as.ts";
 import { createBundle, detectFrameworks } from "./bundle.ts";
 import { APP_BACKEND_FOLDER, RECORDINGS_FOLDER } from "./app_metadata.ts";
 import { writeIfChanged } from "../../utils/utils.ts";
@@ -360,6 +367,7 @@ export async function pushRawApp(
   localPath: string,
   message?: string,
   defaultTs: "bun" | "deno" = "bun",
+  permissionedAsContext?: PermissionedAsContext,
 ): Promise<void> {
   if (alreadySynced.includes(localPath)) {
     return;
@@ -376,6 +384,11 @@ export async function pushRawApp(
   } catch {
     //ignore
   }
+  // Captured before it is cleared below, which it is so the policy takes no part
+  // in the up-to-date comparison. `raw_app.yaml` records none of it, so anything
+  // the deploy drawer set is only here.
+  const deployedPolicy: Policy | undefined = app?.policy;
+
   markAccessFromPolicy(app);
   // console.log(app);
   if (app) {
@@ -427,7 +440,14 @@ export async function pushRawApp(
   await generatingPolicy(
     appForPolicy,
     remotePath,
-    executionModeFromAppFile(localApp),
+    executionModeForPush(localApp, deployedPolicy),
+    deployedPolicy,
+  );
+  // On create the backend applies folder defaults, so there is nothing to preserve.
+  const preserveFields = preserveOnBehalfOfFields(
+    remotePath,
+    appForPolicy.policy,
+    permissionedAsContext,
   );
 
   const files = await collectAppFiles(localPath);
@@ -482,6 +502,7 @@ export async function pushRawApp(
             path: remotePath,
             summary: localApp.summary,
             policy: appForPolicy.policy,
+            ...preserveFields,
             deployment_message: message,
             // Preserve any user draft at this path (see backend skip_draft_deletion).
             skip_draft_deletion: true,
@@ -532,14 +553,15 @@ export async function generatingPolicy(
   app: any,
   path: string,
   executionMode: AppExecutionMode,
+  deployedPolicy: Policy | undefined,
 ) {
   log.info(colors.gray(`Generating fresh policy for app ${path}...`));
   try {
     app.policy = await windmillUtils.updateRawAppPolicy(
       app.runnables,
-      app.policy,
+      deployedPolicy,
     );
-    app.policy.execution_mode = executionMode;
+    finalizeDerivedPolicy(app.policy, executionMode);
   } catch (e) {
     log.error(colors.red(`Error generating policy for app ${path}: ${e}`));
     throw e;
@@ -564,6 +586,10 @@ async function pushRawAppCommand(
     filePath,
     undefined,
     merged.defaultTs,
+    await buildPermissionedAsContext(
+      workspace.workspaceId,
+      await readEffectiveSyncBehavior(opts, workspace),
+    ),
   );
   log.info(colors.bold.underline.green("Raw app pushed"));
 }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -152,6 +152,7 @@ import {
   generateAppLocksInternal,
   RECORDINGS_FOLDER,
 } from "../app/app_metadata.ts";
+import { deploysWithRawApp } from "../../utils/app_files.ts";
 import {
   isFlowPath,
   isAppPath,
@@ -2018,20 +2019,18 @@ export async function elementsToMap(
     }
 
     if (isRawAppFile(path)) {
-      // FSFSElement builds paths with the platform separator, while the checks
-      // below are written with "/": without normalizing, none of them match on
-      // Windows and the push collector's own exclusions become perpetual diffs.
+      // FSFSElement builds paths with the platform separator, while
+      // `deploysWithRawApp` is written with "/": without normalizing it matches
+      // nothing on Windows and the push collector's own exclusions become
+      // perpetual diffs.
       const suffix = path
         .split(getFolderSuffix("raw_app") + SEP)
         .pop()
         ?.replaceAll(SEP, "/");
-      if (
-        suffix?.startsWith("dist/") ||
-        suffix?.startsWith(RECORDINGS_FOLDER + "/") ||
-        suffix == "wmill.d.ts" ||
-        suffix == "package-lock.json" ||
-        suffix == "DATATABLES.md"
-      ) {
+      // A file no push sends is not a change to track. Listing it leaves it
+      // pending forever — nothing ever uploads it — and pushing it redeploys
+      // the whole app, reassigning its run-as user, to ship nothing.
+      if (suffix && !deploysWithRawApp(suffix)) {
         continue;
       }
     }
@@ -6142,7 +6141,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        { message: opts.message },
+                        { message: opts.message, permissionedAsContext },
                       );
                     } else {
                       // Flow folder doesn't exist locally — delete on server

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -6187,7 +6187,7 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        { message: opts.message },
+                        { message: opts.message, permissionedAsContext },
                       );
                     } else {
                       // App folder doesn't exist locally — delete on server
@@ -6233,7 +6233,11 @@ export async function push(
                         undefined,
                         opts.plainSecrets ?? false,
                         alreadySynced,
-                        { message: opts.message, defaultTs: opts.defaultTs },
+                        {
+                          message: opts.message,
+                          defaultTs: opts.defaultTs,
+                          permissionedAsContext,
+                        },
                       );
                     } else {
                       // The entire raw app folder was deleted locally,

--- a/cli/src/core/permissioned_as.ts
+++ b/cli/src/core/permissioned_as.ts
@@ -3,6 +3,7 @@ import * as log from "./log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import { Confirm } from "@cliffy/prompt/confirm";
 import { getTypeStrFromPath } from "../types.ts";
+import { extractFolderPath } from "../utils/resource_folders.ts";
 import { parseSyncBehavior } from "./conf.ts";
 
 export interface PermissionedAsContext {
@@ -89,6 +90,21 @@ function contentHasOnBehalfOf(content: string, typeStr: string): boolean {
   return false;
 }
 
+/** The app a changed file belongs to, or undefined when the file is not an
+ * app's. Any file in the folder redeploys the app and so rewrites its policy,
+ * so the owner changes once however many of the app's files moved — raw apps
+ * included: `raw_app.yaml` records no policy, so a push always reassigns. */
+function appOwnerChange(
+  path: string,
+  typeStr: string
+): { path: string; currentOwner: string } | undefined {
+  if (typeStr !== "app" && typeStr !== "raw_app") return undefined;
+  return {
+    path: extractFolderPath(path, typeStr) ?? path,
+    currentOwner: "(app policy owner)",
+  };
+}
+
 export async function preCheckPermissionedAs(
   changes: Change[],
   userEmail: string,
@@ -101,6 +117,11 @@ export async function preCheckPermissionedAs(
   if (userIsAdminOrDeployer) return;
 
   const wouldChangeItems: { path: string; currentOwner: string }[] = [];
+  const addItem = (item: { path: string; currentOwner: string }) => {
+    if (!wouldChangeItems.some((i) => i.path === item.path)) {
+      wouldChangeItems.push(item);
+    }
+  };
 
   for (const change of changes) {
     let typeStr: string;
@@ -130,11 +151,9 @@ export async function preCheckPermissionedAs(
         const label =
           typeStr === "script" ? "(script owner)" : "(flow owner)";
         wouldChangeItems.push({ path: change.path, currentOwner: label });
-      } else if (typeStr === "app") {
-        wouldChangeItems.push({
-          path: change.path,
-          currentOwner: "(app policy owner)",
-        });
+      } else {
+        const app = appOwnerChange(change.path, typeStr);
+        if (app) addItem(app);
       }
       continue;
     }
@@ -177,11 +196,9 @@ export async function preCheckPermissionedAs(
         }
       }
       continue;
-    } else if (typeStr === "app") {
-      wouldChangeItems.push({
-        path: change.path,
-        currentOwner: "(app policy owner)",
-      });
+    } else if (typeStr === "app" || typeStr === "raw_app") {
+      const app = appOwnerChange(change.path, typeStr);
+      if (app) addItem(app);
       continue;
     } else if (typeStr === "schedule") {
       const match = beforeContent.match(

--- a/cli/src/core/permissioned_as.ts
+++ b/cli/src/core/permissioned_as.ts
@@ -8,6 +8,7 @@ import {
   isAppFolderMetadataFile,
   isRawAppFolderMetadataFile,
 } from "../utils/resource_folders.ts";
+import { deploysWithRawApp } from "../utils/app_files.ts";
 import { parseSyncBehavior } from "./conf.ts";
 
 export interface PermissionedAsContext {
@@ -160,13 +161,17 @@ export async function preCheckPermissionedAs(
       continue;
     }
 
-    // An app is redeployed whole by any change to any of its files — added,
-    // edited or deleted alike — so its policy is rewritten regardless of what
-    // the file holds. Settled here, before the content the other kinds parse to
-    // find their owner, which an app has none of to parse.
+    // An app is redeployed whole by any change to any of the files it actually
+    // sends — added, edited or deleted alike — so its policy is rewritten
+    // regardless of what the file holds. Settled here, before the content the
+    // other kinds parse to find their owner, which an app has none of to parse.
     if (isAppTypeStr(typeStr)) {
-      const folder = appFolderOf(toPosix(change.path), typeStr);
-      if (!arrivingOrLeaving.has(folder)) {
+      const path = toPosix(change.path);
+      const folder = appFolderOf(path, typeStr);
+      if (
+        !arrivingOrLeaving.has(folder) &&
+        (typeStr === "app" || deploysWithRawApp(path.slice(folder.length)))
+      ) {
         addItem({ path: folder, currentOwner: "(app policy owner)" });
       }
       continue;

--- a/cli/src/core/permissioned_as.ts
+++ b/cli/src/core/permissioned_as.ts
@@ -94,14 +94,21 @@ function contentHasOnBehalfOf(content: string, typeStr: string): boolean {
   return false;
 }
 
-/** The app folder a changed file belongs to, or undefined when the file is not
- * an app's. Adding, editing or deleting any file in the folder redeploys the
- * whole app and so rewrites its policy, so the owner changes once however many
- * of the app's files moved — raw apps included: `raw_app.yaml` records no
- * policy, so a push always reassigns. */
-function appFolderOf(path: string, typeStr: string): string | undefined {
-  if (typeStr !== "app" && typeStr !== "raw_app") return undefined;
+type AppTypeStr = "app" | "raw_app";
+
+function isAppTypeStr(typeStr: string): typeStr is AppTypeStr {
+  return typeStr === "app" || typeStr === "raw_app";
+}
+
+/** The app folder a file belongs to. `isAppFolderMetadataFile` and its raw twin
+ * match a literal `/`, unlike `extractFolderPath` — so normalize before either,
+ * or a Windows path takes a different branch from the same file on Linux. */
+function appFolderOf(path: string, typeStr: AppTypeStr): string {
   return extractFolderPath(path, typeStr) ?? path;
+}
+
+function toPosix(path: string): string {
+  return path.replaceAll("\\", "/");
 }
 
 /** App folders whose own metadata file is being added or deleted, which is how a
@@ -111,19 +118,17 @@ function appsArrivingOrLeaving(changes: Change[]): Set<string> {
   const folders = new Set<string>();
   for (const change of changes) {
     if (change.name === "edited") continue;
-    if (
-      !isAppFolderMetadataFile(change.path) &&
-      !isRawAppFolderMetadataFile(change.path)
-    ) {
+    const path = toPosix(change.path);
+    if (!isAppFolderMetadataFile(path) && !isRawAppFolderMetadataFile(path)) {
       continue;
     }
-    let folder: string | undefined;
+    let typeStr: string;
     try {
-      folder = appFolderOf(change.path, getTypeStrFromPath(change.path));
+      typeStr = getTypeStrFromPath(path);
     } catch {
       continue;
     }
-    if (folder) folders.add(folder);
+    if (isAppTypeStr(typeStr)) folders.add(appFolderOf(path, typeStr));
   }
   return folders;
 }
@@ -146,12 +151,6 @@ export async function preCheckPermissionedAs(
     }
   };
   const arrivingOrLeaving = appsArrivingOrLeaving(changes);
-  const addAppOwnerChange = (path: string, typeStr: string) => {
-    const folder = appFolderOf(path, typeStr);
-    if (folder && !arrivingOrLeaving.has(folder)) {
-      addItem({ path: folder, currentOwner: "(app policy owner)" });
-    }
-  };
 
   for (const change of changes) {
     let typeStr: string;
@@ -161,9 +160,15 @@ export async function preCheckPermissionedAs(
       continue;
     }
 
-    // Deleting one of an app's files re-pushes the app, policy and all.
-    if (change.name === "deleted") {
-      addAppOwnerChange(change.path, typeStr);
+    // An app is redeployed whole by any change to any of its files — added,
+    // edited or deleted alike — so its policy is rewritten regardless of what
+    // the file holds. Settled here, before the content the other kinds parse to
+    // find their owner, which an app has none of to parse.
+    if (isAppTypeStr(typeStr)) {
+      const folder = appFolderOf(toPosix(change.path), typeStr);
+      if (!arrivingOrLeaving.has(folder)) {
+        addItem({ path: folder, currentOwner: "(app policy owner)" });
+      }
       continue;
     }
 
@@ -187,8 +192,6 @@ export async function preCheckPermissionedAs(
         const label =
           typeStr === "script" ? "(script owner)" : "(flow owner)";
         wouldChangeItems.push({ path: change.path, currentOwner: label });
-      } else {
-        addAppOwnerChange(change.path, typeStr);
       }
       continue;
     }
@@ -230,9 +233,6 @@ export async function preCheckPermissionedAs(
           });
         }
       }
-      continue;
-    } else if (typeStr === "app" || typeStr === "raw_app") {
-      addAppOwnerChange(change.path, typeStr);
       continue;
     } else if (typeStr === "schedule") {
       const match = beforeContent.match(

--- a/cli/src/core/permissioned_as.ts
+++ b/cli/src/core/permissioned_as.ts
@@ -3,7 +3,11 @@ import * as log from "./log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import { Confirm } from "@cliffy/prompt/confirm";
 import { getTypeStrFromPath } from "../types.ts";
-import { extractFolderPath } from "../utils/resource_folders.ts";
+import {
+  extractFolderPath,
+  isAppFolderMetadataFile,
+  isRawAppFolderMetadataFile,
+} from "../utils/resource_folders.ts";
 import { parseSyncBehavior } from "./conf.ts";
 
 export interface PermissionedAsContext {
@@ -90,19 +94,38 @@ function contentHasOnBehalfOf(content: string, typeStr: string): boolean {
   return false;
 }
 
-/** The app a changed file belongs to, or undefined when the file is not an
- * app's. Any file in the folder redeploys the app and so rewrites its policy,
- * so the owner changes once however many of the app's files moved — raw apps
- * included: `raw_app.yaml` records no policy, so a push always reassigns. */
-function appOwnerChange(
-  path: string,
-  typeStr: string
-): { path: string; currentOwner: string } | undefined {
+/** The app folder a changed file belongs to, or undefined when the file is not
+ * an app's. Adding, editing or deleting any file in the folder redeploys the
+ * whole app and so rewrites its policy, so the owner changes once however many
+ * of the app's files moved — raw apps included: `raw_app.yaml` records no
+ * policy, so a push always reassigns. */
+function appFolderOf(path: string, typeStr: string): string | undefined {
   if (typeStr !== "app" && typeStr !== "raw_app") return undefined;
-  return {
-    path: extractFolderPath(path, typeStr) ?? path,
-    currentOwner: "(app policy owner)",
-  };
+  return extractFolderPath(path, typeStr) ?? path;
+}
+
+/** App folders whose own metadata file is being added or deleted, which is how a
+ * whole app arrives or goes rather than being redeployed. Neither takes an owner
+ * over: a create has none yet, and a delete leaves none behind. */
+function appsArrivingOrLeaving(changes: Change[]): Set<string> {
+  const folders = new Set<string>();
+  for (const change of changes) {
+    if (change.name === "edited") continue;
+    if (
+      !isAppFolderMetadataFile(change.path) &&
+      !isRawAppFolderMetadataFile(change.path)
+    ) {
+      continue;
+    }
+    let folder: string | undefined;
+    try {
+      folder = appFolderOf(change.path, getTypeStrFromPath(change.path));
+    } catch {
+      continue;
+    }
+    if (folder) folders.add(folder);
+  }
+  return folders;
 }
 
 export async function preCheckPermissionedAs(
@@ -122,12 +145,25 @@ export async function preCheckPermissionedAs(
       wouldChangeItems.push(item);
     }
   };
+  const arrivingOrLeaving = appsArrivingOrLeaving(changes);
+  const addAppOwnerChange = (path: string, typeStr: string) => {
+    const folder = appFolderOf(path, typeStr);
+    if (folder && !arrivingOrLeaving.has(folder)) {
+      addItem({ path: folder, currentOwner: "(app policy owner)" });
+    }
+  };
 
   for (const change of changes) {
     let typeStr: string;
     try {
       typeStr = getTypeStrFromPath(change.path);
     } catch {
+      continue;
+    }
+
+    // Deleting one of an app's files re-pushes the app, policy and all.
+    if (change.name === "deleted") {
+      addAppOwnerChange(change.path, typeStr);
       continue;
     }
 
@@ -152,8 +188,7 @@ export async function preCheckPermissionedAs(
           typeStr === "script" ? "(script owner)" : "(flow owner)";
         wouldChangeItems.push({ path: change.path, currentOwner: label });
       } else {
-        const app = appOwnerChange(change.path, typeStr);
-        if (app) addItem(app);
+        addAppOwnerChange(change.path, typeStr);
       }
       continue;
     }
@@ -197,8 +232,7 @@ export async function preCheckPermissionedAs(
       }
       continue;
     } else if (typeStr === "app" || typeStr === "raw_app") {
-      const app = appOwnerChange(change.path, typeStr);
-      if (app) addItem(app);
+      addAppOwnerChange(change.path, typeStr);
       continue;
     } else if (typeStr === "schedule") {
       const match = beforeContent.match(

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -234,7 +234,7 @@ export async function pushObj(
     if (!rawAppName) {
       throw new Error(`Could not extract raw app name from path: ${p}`);
     }
-    await pushRawApp(workspace, rawAppName, buildFolderPath(rawAppName, "raw_app"), message, defaultTs);
+    await pushRawApp(workspace, rawAppName, buildFolderPath(rawAppName, "raw_app"), message, defaultTs, permissionedAsContext);
   } else if (typeEnding === "folder") {
     await pushFolder(workspace, p, befObj, newObj);
   } else if (typeEnding === "variable") {

--- a/cli/src/utils/app_files.ts
+++ b/cli/src/utils/app_files.ts
@@ -1,4 +1,7 @@
-import { RECORDINGS_FOLDER } from "../commands/app/app_metadata.ts";
+import {
+  APP_BACKEND_FOLDER,
+  RECORDINGS_FOLDER,
+} from "../commands/app/app_metadata.ts";
 
 /** Directories under a raw app that no push ever sends — dependencies, build
  * output, editor state, and SQL staged for a datatable migration. */
@@ -37,6 +40,12 @@ export function deploysWithRawApp(relativePath: string): boolean {
   if (segments.length === 0) return false;
   const name = segments[segments.length - 1];
   const dirs = segments.slice(0, -1);
+  // The backend folder deploys as runnables, a channel of its own: the two sets
+  // below describe the bundle, which `collectAppFiles` never walks into here, so
+  // applying them would strip a runnable whose file happens to share a name (a
+  // `backend/wmill.d.ts` is the runnable `wmill.d`). `loadRunnablesFromBackend`
+  // reads that folder's top level only, so nothing deeper deploys either way.
+  if (dirs[0] === APP_BACKEND_FOLDER) return dirs.length === 1;
   if (NEVER_DEPLOYED_FILES.has(name)) return false;
   if (dirs.some((d) => NEVER_DEPLOYED_DIRS.has(d))) return false;
   // Session recordings are written at the app root only, so an app with a

--- a/cli/src/utils/app_files.ts
+++ b/cli/src/utils/app_files.ts
@@ -1,0 +1,48 @@
+import { RECORDINGS_FOLDER } from "../commands/app/app_metadata.ts";
+
+/** Directories under a raw app that no push ever sends — dependencies, build
+ * output, editor state, and SQL staged for a datatable migration. */
+const NEVER_DEPLOYED_DIRS = new Set([
+  "node_modules",
+  "dist",
+  ".claude",
+  "sql_to_apply",
+]);
+
+/** Files under a raw app that no push ever sends: generated for the local
+ * toolchain, or documentation for whoever edits it. */
+const NEVER_DEPLOYED_FILES = new Set([
+  "package-lock.json",
+  "DATATABLES.md",
+  "AGENTS.md",
+  "wmill.d.ts",
+]);
+
+/**
+ * Whether a path under a raw app's folder reaches the server at all. The three
+ * channels a push sends are `raw_app.yaml` as metadata, the backend folder as
+ * runnables, and everything `collectAppFiles` bundles into `value.files` — so
+ * a path this rejects deploys nothing, and changing it is not a change to the
+ * app however much the sync diff lists it.
+ *
+ * `collectAppFiles` is the one that must not drift from this: it applies the
+ * same two sets, plus its own two exclusions for the paths that deploy through
+ * the other channels rather than the bundle.
+ *
+ * @param relativePath app-root-relative, with `/` separators (`/index.tsx`,
+ *   `sql_to_apply/a.sql`) — either way a leading slash is optional.
+ */
+export function deploysWithRawApp(relativePath: string): boolean {
+  const segments = relativePath.split("/").filter(Boolean);
+  if (segments.length === 0) return false;
+  const name = segments[segments.length - 1];
+  const dirs = segments.slice(0, -1);
+  if (NEVER_DEPLOYED_FILES.has(name)) return false;
+  if (dirs.some((d) => NEVER_DEPLOYED_DIRS.has(d))) return false;
+  // Session recordings are written at the app root only, so an app with a
+  // `recordings/` component folder of its own still ships it.
+  if (dirs[0] === RECORDINGS_FOLDER) return false;
+  return true;
+}
+
+export { NEVER_DEPLOYED_DIRS, NEVER_DEPLOYED_FILES };

--- a/cli/src/utils/app_files.ts
+++ b/cli/src/utils/app_files.ts
@@ -3,8 +3,7 @@ import {
   RECORDINGS_FOLDER,
 } from "../commands/app/app_metadata.ts";
 
-/** Directories under a raw app that no push ever sends — dependencies, build
- * output, editor state, and SQL staged for a datatable migration. */
+/** Directories under a raw app that no push sends. */
 const NEVER_DEPLOYED_DIRS = new Set([
   "node_modules",
   "dist",
@@ -12,8 +11,7 @@ const NEVER_DEPLOYED_DIRS = new Set([
   "sql_to_apply",
 ]);
 
-/** Files under a raw app that no push ever sends: generated for the local
- * toolchain, or documentation for whoever edits it. */
+/** Files under a raw app that no push sends. */
 const NEVER_DEPLOYED_FILES = new Set([
   "package-lock.json",
   "DATATABLES.md",
@@ -22,29 +20,22 @@ const NEVER_DEPLOYED_FILES = new Set([
 ]);
 
 /**
- * Whether a path under a raw app's folder reaches the server at all. The three
- * channels a push sends are `raw_app.yaml` as metadata, the backend folder as
- * runnables, and everything `collectAppFiles` bundles into `value.files` — so
- * a path this rejects deploys nothing, and changing it is not a change to the
- * app however much the sync diff lists it.
- *
- * `collectAppFiles` is the one that must not drift from this: it applies the
- * same two sets, plus its own two exclusions for the paths that deploy through
- * the other channels rather than the bundle.
- *
- * @param relativePath app-root-relative, with `/` separators (`/index.tsx`,
- *   `sql_to_apply/a.sql`) — either way a leading slash is optional.
+ * Whether an app-root-relative path (`/` separators, leading slash optional)
+ * reaches the server through any of a push's three channels: `raw_app.yaml` as
+ * metadata, the backend folder as runnables, the rest bundled by
+ * `collectAppFiles`. A path this rejects deploys nothing, so changing it is not
+ * a change to the app however much the sync diff lists it. `collectAppFiles`
+ * must not drift from this — it reads the same two sets.
  */
 export function deploysWithRawApp(relativePath: string): boolean {
   const segments = relativePath.split("/").filter(Boolean);
   if (segments.length === 0) return false;
   const name = segments[segments.length - 1];
   const dirs = segments.slice(0, -1);
-  // The backend folder deploys as runnables, a channel of its own: the two sets
-  // below describe the bundle, which `collectAppFiles` never walks into here, so
-  // applying them would strip a runnable whose file happens to share a name (a
-  // `backend/wmill.d.ts` is the runnable `wmill.d`). `loadRunnablesFromBackend`
-  // reads that folder's top level only, so nothing deeper deploys either way.
+  // The sets below describe the bundle, which never walks into the backend
+  // folder — applying them there would strip a runnable whose file shares a
+  // name (`backend/wmill.d.ts` is the runnable `wmill.d`). Depth 1 because
+  // `loadRunnablesFromBackend` reads that folder's top level only.
   if (dirs[0] === APP_BACKEND_FOLDER) return dirs.length === 1;
   if (NEVER_DEPLOYED_FILES.has(name)) return false;
   if (dirs.some((d) => NEVER_DEPLOYED_DIRS.has(d))) return false;

--- a/cli/test/app_access_mode_unit.test.ts
+++ b/cli/test/app_access_mode_unit.test.ts
@@ -14,7 +14,12 @@ test("the access mode survives the app.yaml round trip", async () => {
   expect(guest.guests).toBe(true);
   expect(guest.public).toBeUndefined();
   expect(executionModeFromAppFile(guest)).toBe("guest");
-  await generatingPolicy(guest, "u/test/app", executionModeFromAppFile(guest));
+  await generatingPolicy(
+    guest,
+    "u/test/app",
+    executionModeFromAppFile(guest),
+    undefined,
+  );
   expect(guest.policy.execution_mode).toBe("guest");
 
   const anonymous: any = { policy: { execution_mode: "anonymous" }, value: {} };

--- a/cli/test/app_access_mode_unit.test.ts
+++ b/cli/test/app_access_mode_unit.test.ts
@@ -44,4 +44,9 @@ test("viewer is never widened to publisher by a push", () => {
   // The open-access markers still win, in either direction.
   expect(executionModeForPush({ public: true }, { execution_mode: "viewer" })).toBe("anonymous");
   expect(executionModeForPush({}, { execution_mode: "anonymous" })).toBe("publisher");
+  // A stated mode is authoritative both ways: the carry-over is for a file that
+  // says nothing, so it must not pin a deployed app to `viewer` forever.
+  expect(
+    executionModeForPush({ policy: { execution_mode: "publisher" } }, { execution_mode: "viewer" })
+  ).toBe("publisher");
 });

--- a/cli/test/app_access_mode_unit.test.ts
+++ b/cli/test/app_access_mode_unit.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "bun:test";
 import {
   executionModeForPush,
-  executionModeFromAppFile,
   generatingPolicy,
   markAccessFromPolicy,
 } from "../src/commands/app/app.ts";
@@ -14,11 +13,11 @@ test("the access mode survives the app.yaml round trip", async () => {
   guest.policy = undefined;
   expect(guest.guests).toBe(true);
   expect(guest.public).toBeUndefined();
-  expect(executionModeFromAppFile(guest)).toBe("guest");
+  expect(executionModeForPush(guest, undefined)).toBe("guest");
   await generatingPolicy(
     guest,
     "u/test/app",
-    executionModeFromAppFile(guest),
+    executionModeForPush(guest, undefined),
     undefined,
   );
   expect(guest.policy.execution_mode).toBe("guest");
@@ -27,10 +26,10 @@ test("the access mode survives the app.yaml round trip", async () => {
   markAccessFromPolicy(anonymous);
   anonymous.policy = undefined;
   expect(anonymous.public).toBe(true);
-  expect(executionModeFromAppFile(anonymous)).toBe("anonymous");
+  expect(executionModeForPush(anonymous, undefined)).toBe("anonymous");
 
-  expect(executionModeFromAppFile({ policy: { execution_mode: "publisher" } })).toBe("publisher");
-  expect(executionModeFromAppFile({})).toBe("publisher");
+  expect(executionModeForPush({ policy: { execution_mode: "publisher" } }, undefined)).toBe("publisher");
+  expect(executionModeForPush({}, undefined)).toBe("publisher");
 });
 
 // `viewer` is the narrowest mode — each runnable runs as the viewer, not as the

--- a/cli/test/app_access_mode_unit.test.ts
+++ b/cli/test/app_access_mode_unit.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import {
+  executionModeForPush,
   executionModeFromAppFile,
   generatingPolicy,
   markAccessFromPolicy,
@@ -30,4 +31,17 @@ test("the access mode survives the app.yaml round trip", async () => {
 
   expect(executionModeFromAppFile({ policy: { execution_mode: "publisher" } })).toBe("publisher");
   expect(executionModeFromAppFile({})).toBe("publisher");
+});
+
+// `viewer` is the narrowest mode — each runnable runs as the viewer, not as the
+// app's identity — and the only one with no marker in the file, so both ways it
+// can reach a push must survive rather than widen to `publisher`.
+test("viewer is never widened to publisher by a push", () => {
+  // Carried over from the deployed app: a pull writes no marker for it.
+  expect(executionModeForPush({}, { execution_mode: "viewer" })).toBe("viewer");
+  // Stated by the file, which is all a first push has to go on.
+  expect(executionModeForPush({ policy: { execution_mode: "viewer" } }, undefined)).toBe("viewer");
+  // The open-access markers still win, in either direction.
+  expect(executionModeForPush({ public: true }, { execution_mode: "viewer" })).toBe("anonymous");
+  expect(executionModeForPush({}, { execution_mode: "anonymous" })).toBe("publisher");
 });

--- a/cli/test/precheck_permissioned_as_apps_unit.test.ts
+++ b/cli/test/precheck_permissioned_as_apps_unit.test.ts
@@ -116,11 +116,17 @@ test("a file the push never sends is not a change to the app", async () => {
   const sent = await precheck([change("f/test/myapp.raw_app/index.tsx")]);
   const meta = await precheck([change("f/test/myapp.raw_app/raw_app.yaml")]);
   const runnable = await precheck([change("f/test/myapp.raw_app/backend/a.ts")]);
+  // The runnable channel is not the bundle: the bundle's name exclusions don't
+  // reach into it, so a runnable file sharing one of those names still deploys.
+  const namesake = await precheck([
+    change("f/test/myapp.raw_app/backend/wmill.d.ts"),
+  ]);
 
   expect(artifacts).toBeUndefined();
   expect(sent).toContain("f/test/myapp.raw_app");
   expect(meta).toContain("f/test/myapp.raw_app");
   expect(runnable).toContain("f/test/myapp.raw_app");
+  expect(namesake).toContain("f/test/myapp.raw_app");
 });
 
 test("an app is listed once however many of its files changed", async () => {

--- a/cli/test/precheck_permissioned_as_apps_unit.test.ts
+++ b/cli/test/precheck_permissioned_as_apps_unit.test.ts
@@ -101,6 +101,28 @@ test("a Windows path classifies the same as its posix twin", async () => {
   expect(edited).toContain("f/test/myapp.raw_app");
 });
 
+// `collectAppFiles` never sends these, and the sync diff never stops listing
+// them (nothing uploads them, so they stay "added" forever) — so warning on one
+// would gate every push of a scaffolded app on the override flag.
+test("a file the push never sends is not a change to the app", async () => {
+  const artifacts = await precheck([
+    change("f/test/myapp.raw_app/AGENTS.md", "added"),
+    change("f/test/myapp.raw_app/sql_to_apply/a.sql", "added"),
+    change("f/test/myapp.raw_app/node_modules/dep/index.js", "added"),
+    change("f/test/myapp.raw_app/recordings/r.json", "added"),
+    change("f/test/myapp.raw_app/package-lock.json"),
+  ]);
+  // The three channels a push does send through: bundled file, metadata, runnable.
+  const sent = await precheck([change("f/test/myapp.raw_app/index.tsx")]);
+  const meta = await precheck([change("f/test/myapp.raw_app/raw_app.yaml")]);
+  const runnable = await precheck([change("f/test/myapp.raw_app/backend/a.ts")]);
+
+  expect(artifacts).toBeUndefined();
+  expect(sent).toContain("f/test/myapp.raw_app");
+  expect(meta).toContain("f/test/myapp.raw_app");
+  expect(runnable).toContain("f/test/myapp.raw_app");
+});
+
 test("an app is listed once however many of its files changed", async () => {
   const message = await precheck([
     change("f/test/myapp.raw_app/index.tsx"),

--- a/cli/test/precheck_permissioned_as_apps_unit.test.ts
+++ b/cli/test/precheck_permissioned_as_apps_unit.test.ts
@@ -111,6 +111,11 @@ test("a file the push never sends is not a change to the app", async () => {
     change("f/test/myapp.raw_app/node_modules/dep/index.js", "added"),
     change("f/test/myapp.raw_app/recordings/r.json", "added"),
     change("f/test/myapp.raw_app/package-lock.json"),
+    change("f/test/myapp.raw_app/wmill.d.ts"),
+    // Only the backend folder's *top level* is a runnable; nothing reads deeper,
+    // so the depth limit is what keeps a `backend/node_modules/` from becoming
+    // the perpetual diff this predicate exists to remove.
+    change("f/test/myapp.raw_app/backend/node_modules/dep/index.js", "added"),
   ]);
   // The three channels a push does send through: bundled file, metadata, runnable.
   const sent = await precheck([change("f/test/myapp.raw_app/index.tsx")]);

--- a/cli/test/precheck_permissioned_as_apps_unit.test.ts
+++ b/cli/test/precheck_permissioned_as_apps_unit.test.ts
@@ -9,7 +9,15 @@ import { preCheckPermissionedAs } from "../src/core/permissioned_as.ts";
 
 /** Non-interactive and without the override flag, the pre-check exits rather
  * than reassigning silently — so a thrown exit is the signal it fired. */
-async function precheck(paths: string[]): Promise<string | undefined> {
+type Shape = "edited" | "added" | "deleted";
+
+function change(path: string, name: Shape = "edited") {
+  return { name, path, before: "summary: x\n", content: "summary: x\n" };
+}
+
+async function precheck(
+  changes: ReturnType<typeof change>[],
+): Promise<string | undefined> {
   const exit = process.exit;
   let code: number | undefined;
   (process as any).exit = (c?: number) => {
@@ -20,13 +28,7 @@ async function precheck(paths: string[]): Promise<string | undefined> {
   const err = console.error;
   console.error = (...a: unknown[]) => void logged.push(a.join(" "));
   try {
-    await preCheckPermissionedAs(
-      paths.map((path) => ({ name: "edited" as const, path, before: "summary: x\n" })),
-      "pusher@corp",
-      false,
-      false,
-      false,
-    );
+    await preCheckPermissionedAs(changes, "pusher@corp", false, false, false);
   } catch (e) {
     if (!String(e).startsWith("Error: exit:")) throw e;
   } finally {
@@ -37,20 +39,46 @@ async function precheck(paths: string[]): Promise<string | undefined> {
 }
 
 test("a raw-app push warns the non-deployer it will take over the run-as user", async () => {
-  const message = await precheck(["f/test/myapp.raw_app/index.tsx"]);
+  const message = await precheck([change("f/test/myapp.raw_app/index.tsx")]);
 
   expect(message).toBeDefined();
   expect(message).toContain("f/test/myapp.raw_app");
   expect(message).toContain("pusher@corp");
 });
 
+// Deleting one file re-pushes the whole app rather than deleting it, so the
+// takeover happens there too.
+test("deleting one of an app's files warns like editing one", async () => {
+  const message = await precheck([
+    change("f/test/myapp.raw_app/gone.tsx", "deleted"),
+  ]);
+
+  expect(message).toContain("f/test/myapp.raw_app");
+});
+
+// The metadata file going with it means the app itself is created or removed —
+// neither takes an owner over.
+test("an app arriving or leaving whole is not a takeover", async () => {
+  const created = await precheck([
+    change("f/test/new.raw_app/raw_app.yaml", "added"),
+    change("f/test/new.raw_app/index.tsx", "added"),
+  ]);
+  const removed = await precheck([
+    change("f/test/old.raw_app/raw_app.yaml", "deleted"),
+    change("f/test/old.raw_app/index.tsx", "deleted"),
+  ]);
+
+  expect(created).toBeUndefined();
+  expect(removed).toBeUndefined();
+});
+
 test("an app is listed once however many of its files changed", async () => {
   const message = await precheck([
-    "f/test/myapp.raw_app/index.tsx",
-    "f/test/myapp.raw_app/raw_app.yaml",
-    "f/test/myapp.raw_app/backend/a.ts",
-    "f/test/low.app/app.yaml",
-    "f/test/low.app/inline.ts",
+    change("f/test/myapp.raw_app/index.tsx"),
+    change("f/test/myapp.raw_app/raw_app.yaml"),
+    change("f/test/myapp.raw_app/backend/a.ts"),
+    change("f/test/low.app/app.yaml"),
+    change("f/test/low.app/inline.ts"),
   ]);
 
   expect(message).toContain("2 item(s)");

--- a/cli/test/precheck_permissioned_as_apps_unit.test.ts
+++ b/cli/test/precheck_permissioned_as_apps_unit.test.ts
@@ -72,6 +72,35 @@ test("an app arriving or leaving whole is not a takeover", async () => {
   expect(removed).toBeUndefined();
 });
 
+// An app carries no owner in its files, so nothing about it depends on their
+// content — an empty one redeploys it exactly like any other.
+test("an empty file still counts as a change to the app", async () => {
+  const added = await precheck([
+    { name: "added", path: "f/test/myapp.raw_app/blank.ts", content: "" },
+  ]);
+  const edited = await precheck([
+    { name: "edited", path: "f/test/myapp.raw_app/blank.ts", before: "" },
+  ]);
+
+  expect(added).toContain("f/test/myapp.raw_app");
+  expect(edited).toContain("f/test/myapp.raw_app");
+});
+
+// `extractFolderPath` normalizes separators but the metadata predicates match a
+// literal `/`, so a Windows path must not take a different branch.
+test("a Windows path classifies the same as its posix twin", async () => {
+  const created = await precheck([
+    change("f\\test\\new.raw_app\\raw_app.yaml", "added"),
+    change("f\\test\\new.raw_app\\index.tsx", "added"),
+  ]);
+  const edited = await precheck([
+    change("f\\test\\myapp.raw_app\\index.tsx"),
+  ]);
+
+  expect(created).toBeUndefined();
+  expect(edited).toContain("f/test/myapp.raw_app");
+});
+
 test("an app is listed once however many of its files changed", async () => {
   const message = await precheck([
     change("f/test/myapp.raw_app/index.tsx"),

--- a/cli/test/precheck_permissioned_as_apps_unit.test.ts
+++ b/cli/test/precheck_permissioned_as_apps_unit.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The pre-check is what stops a push from silently reassigning an item's run-as
+ * user. Raw apps were missing from it, so the one kind whose file records no
+ * policy at all was also the one that changed owner without a word.
+ */
+
+import { expect, test } from "bun:test";
+import { preCheckPermissionedAs } from "../src/core/permissioned_as.ts";
+
+/** Non-interactive and without the override flag, the pre-check exits rather
+ * than reassigning silently — so a thrown exit is the signal it fired. */
+async function precheck(paths: string[]): Promise<string | undefined> {
+  const exit = process.exit;
+  let code: number | undefined;
+  (process as any).exit = (c?: number) => {
+    code = c;
+    throw new Error(`exit:${c}`);
+  };
+  const logged: string[] = [];
+  const err = console.error;
+  console.error = (...a: unknown[]) => void logged.push(a.join(" "));
+  try {
+    await preCheckPermissionedAs(
+      paths.map((path) => ({ name: "edited" as const, path, before: "summary: x\n" })),
+      "pusher@corp",
+      false,
+      false,
+      false,
+    );
+  } catch (e) {
+    if (!String(e).startsWith("Error: exit:")) throw e;
+  } finally {
+    (process as any).exit = exit;
+    console.error = err;
+  }
+  return code === undefined ? undefined : logged.join("\n");
+}
+
+test("a raw-app push warns the non-deployer it will take over the run-as user", async () => {
+  const message = await precheck(["f/test/myapp.raw_app/index.tsx"]);
+
+  expect(message).toBeDefined();
+  expect(message).toContain("f/test/myapp.raw_app");
+  expect(message).toContain("pusher@corp");
+});
+
+test("an app is listed once however many of its files changed", async () => {
+  const message = await precheck([
+    "f/test/myapp.raw_app/index.tsx",
+    "f/test/myapp.raw_app/raw_app.yaml",
+    "f/test/myapp.raw_app/backend/a.ts",
+    "f/test/low.app/app.yaml",
+    "f/test/low.app/inline.ts",
+  ]);
+
+  expect(message).toContain("2 item(s)");
+});

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `raw_app.yaml` records none of the policy but the access-mode markers, so a
+ * push that regenerated the whole policy reset the deploy drawer's settings —
+ * run-as identity, sandbox isolation — to the pushing user's. Pin that the
+ * deployed policy is carried over, and that the markers still close a deployed
+ * open app back down.
+ */
+
+import { beforeEach, expect, mock, test } from "bun:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let updateCalls: any[] = [];
+let deployedPolicy: any;
+
+mock.module("../gen/services.gen.ts", () => ({
+  getAppByPath: async () => ({
+    path: "f/test/raw",
+    summary: "raw",
+    value: { files: {}, runnables: {} },
+    policy: deployedPolicy,
+  }),
+  updateAppRaw: async (a: unknown) => {
+    updateCalls.push(a);
+  },
+}));
+
+const realBundle = await import("../src/commands/app/bundle.ts");
+mock.module("../src/commands/app/bundle.ts", () => ({
+  ...realBundle,
+  createBundle: async () => ({ js: "", css: "" }),
+}));
+
+const { pushRawApp } = await import("../src/commands/app/raw_apps.ts");
+
+const ADMIN = {
+  userCache: new Map(),
+  userIsAdminOrDeployer: true,
+  userEmail: "deployer@windmill.dev",
+};
+
+async function push(yamlTail: string, admin = true): Promise<any> {
+  updateCalls = [];
+  const dir = await mkdtemp(join(tmpdir(), "windmill_raw_push_"));
+  await writeFile(
+    join(dir, "raw_app.yaml"),
+    `summary: raw\nrunnables: {}\n${yamlTail}`,
+    "utf-8",
+  );
+  // Any file the remote doesn't have, so the push isn't short-circuited as
+  // up to date.
+  await writeFile(join(dir, "index.tsx"), "export default 1\n", "utf-8");
+  await pushRawApp("w", "f/test/raw", dir, undefined, "bun", admin ? ADMIN : undefined);
+  expect(updateCalls).toHaveLength(1);
+  return updateCalls[0].formData.app;
+}
+
+beforeEach(() => {
+  deployedPolicy = {
+    on_behalf_of: "u/svc",
+    on_behalf_of_email: "svc@corp",
+    sandbox: true,
+    frontend_sdk_scopes: ["jobs:run"],
+    execution_mode: "anonymous",
+    // Legacy v1 grants: the backend folds them into v2 at run time, so keeping
+    // them would keep granting runnables a push has removed.
+    triggerables: { "script/f/test/gone": {} },
+    triggerables_v2: { "a:script/f/test/gone": {} },
+  };
+});
+
+test("a raw-app push keeps the deployed run-as and sandbox settings", async () => {
+  const body = await push("public: true\n");
+
+  expect(body.policy.on_behalf_of).toBe("u/svc");
+  expect(body.policy.on_behalf_of_email).toBe("svc@corp");
+  expect(body.preserve_on_behalf_of).toBe(true);
+  expect(body.policy.sandbox).toBe(true);
+  expect(body.policy.frontend_sdk_scopes).toEqual(["jobs:run"]);
+  expect(body.policy.execution_mode).toBe("anonymous");
+  expect(body.policy.triggerables).toBeUndefined();
+  expect(body.policy.triggerables_v2).toEqual({});
+});
+
+test("a raw-app push without the marker closes an anonymous app back down", async () => {
+  const body = await push("");
+
+  expect(body.policy.execution_mode).toBe("publisher");
+  // Only the caller who may claim it gets the flag; everyone else deploys as
+  // themselves, which is what the backend enforces anyway.
+  expect((await push("", false)).preserve_on_behalf_of).toBeUndefined();
+});

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -103,10 +103,14 @@ test("a raw-app push without the marker closes an anonymous app back down", asyn
 
 test("a first raw-app push deploys the policy its file states", async () => {
   deployed = false;
-  const body = await push("policy:\n  sandbox: true\n  on_behalf_of: u/impostor\n");
+  const body = await push(
+    "policy:\n  sandbox: true\n  on_behalf_of: u/impostor\n  on_behalf_of_email: impostor@corp\n",
+  );
 
   expect(body.policy.sandbox).toBe(true);
-  // A repo doesn't get to pick who an app runs as: only a deployed identity is
-  // ever claimed, so the backend assigns the pushing user's here.
+  // A repo doesn't get to pick who an app runs as: the identity never reaches
+  // the wire, so no server can be talked into deploying under it.
+  expect(body.policy.on_behalf_of).toBeUndefined();
+  expect(body.policy.on_behalf_of_email).toBeUndefined();
   expect(body.preserve_on_behalf_of).toBeUndefined();
 });

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -6,7 +6,7 @@
  * file states, and that the markers still close a deployed open app back down.
  */
 
-import { beforeEach, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, expect, mock, test } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,7 +16,14 @@ let deployedPolicy: any;
 /** No app deployed at the path: `getAppByPath` 404s and the push creates one. */
 let deployed = true;
 
+// `mock.module` replaces the module for the whole process, so both are handed
+// back at the end — `raw_app_svelte_plugin_unit.test.ts` drives the real
+// `createBundle`, and would silently bundle nothing under the stub.
+const realServices = await import("../gen/services.gen.ts");
+const realBundle = await import("../src/commands/app/bundle.ts");
+
 mock.module("../gen/services.gen.ts", () => ({
+  ...realServices,
   getAppByPath: async () => {
     if (!deployed) throw new Error("not found");
     return {
@@ -34,11 +41,15 @@ mock.module("../gen/services.gen.ts", () => ({
   },
 }));
 
-const realBundle = await import("../src/commands/app/bundle.ts");
 mock.module("../src/commands/app/bundle.ts", () => ({
   ...realBundle,
   createBundle: async () => ({ js: "", css: "" }),
 }));
+
+afterAll(() => {
+  mock.module("../gen/services.gen.ts", () => realServices);
+  mock.module("../src/commands/app/bundle.ts", () => realBundle);
+});
 
 const { pushRawApp } = await import("../src/commands/app/raw_apps.ts");
 

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -16,13 +16,13 @@ let deployedPolicy: any;
 /** No app deployed at the path: `getAppByPath` 404s and the push creates one. */
 let deployed = true;
 
-// Only the API is stubbed, and it is handed back in `afterAll` — `mock.module`
-// replaces a module for the whole process. `bundle.ts` is deliberately NOT
-// stubbed: every test file's imports resolve before any `afterAll` runs, so a
-// stub there reaches `raw_app_svelte_plugin_unit.test.ts` whenever the test
-// runner reaches this file first, and that suite then asserts against a bundle
-// containing nothing. The real bundler runs instead, on the app each push
-// writes below.
+// Stub only what no other in-process suite imports (see "Module mocks" in
+// cli/TESTING.md): a `mock.module` stub is process-global and cannot be taken
+// back, since every file's imports resolve before any `afterAll` runs. These
+// three API functions qualify — nothing else in `test/` imports them. `bundle.ts`
+// did not: stubbing it made `raw_app_svelte_plugin_unit.test.ts` assert against
+// an empty bundle whenever the runner reached this file first, so the real
+// bundler runs instead, on the app each push writes below.
 const realServices = await import("../gen/services.gen.ts");
 
 mock.module("../gen/services.gen.ts", () => ({
@@ -44,6 +44,8 @@ mock.module("../gen/services.gen.ts", () => ({
   },
 }));
 
+// Reaches only a consumer that imports the module dynamically, after these
+// tests; the static importers above are already bound either way.
 afterAll(() => {
   mock.module("../gen/services.gen.ts", () => realServices);
 });

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -16,12 +16,11 @@ let deployedPolicy: any;
 /** No app deployed at the path: `getAppByPath` 404s and the push creates one. */
 let deployed = true;
 
-// Stub only what no other in-process suite imports (see "Module mocks" in
-// cli/TESTING.md): a `mock.module` stub is process-global and cannot be taken
-// back, since every file's imports resolve before any `afterAll` runs. These
-// three API functions qualify — nothing else in `test/` imports them. `bundle.ts`
-// did not: stubbing it made `raw_app_svelte_plugin_unit.test.ts` assert against
-// an empty bundle whenever the runner reached this file first, so the real
+// Stub only what no other in-process suite imports, and treat a stub as
+// permanent for the run (see "Module mocks" in cli/TESTING.md). These three API
+// functions qualify — nothing else in `test/` imports them. `bundle.ts` did not:
+// stubbing it left `raw_app_svelte_plugin_unit.test.ts` asserting against an
+// empty bundle, which an `afterAll` hand-back did not prevent. So the real
 // bundler runs instead, on the app each push writes below.
 const realServices = await import("../gen/services.gen.ts");
 
@@ -44,8 +43,8 @@ mock.module("../gen/services.gen.ts", () => ({
   },
 }));
 
-// Reaches only a consumer that imports the module dynamically, after these
-// tests; the static importers above are already bound either way.
+// Belt and braces: nothing else in-process calls these, and a hand-back is not
+// what makes that safe.
 afterAll(() => {
   mock.module("../gen/services.gen.ts", () => realServices);
 });

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -2,8 +2,8 @@
  * `raw_app.yaml` records none of the policy but the access-mode markers, so a
  * push that regenerated the whole policy reset the deploy drawer's settings —
  * run-as identity, sandbox isolation — to the pushing user's. Pin that the
- * deployed policy is carried over, and that the markers still close a deployed
- * open app back down.
+ * deployed policy is carried over, that a first push still starts from what the
+ * file states, and that the markers still close a deployed open app back down.
  */
 
 import { beforeEach, expect, mock, test } from "bun:test";
@@ -11,18 +11,26 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-let updateCalls: any[] = [];
+let calls: any[] = [];
 let deployedPolicy: any;
+/** No app deployed at the path: `getAppByPath` 404s and the push creates one. */
+let deployed = true;
 
 mock.module("../gen/services.gen.ts", () => ({
-  getAppByPath: async () => ({
-    path: "f/test/raw",
-    summary: "raw",
-    value: { files: {}, runnables: {} },
-    policy: deployedPolicy,
-  }),
+  getAppByPath: async () => {
+    if (!deployed) throw new Error("not found");
+    return {
+      path: "f/test/raw",
+      summary: "raw",
+      value: { files: {}, runnables: {} },
+      policy: deployedPolicy,
+    };
+  },
   updateAppRaw: async (a: unknown) => {
-    updateCalls.push(a);
+    calls.push(a);
+  },
+  createAppRaw: async (a: unknown) => {
+    calls.push(a);
   },
 }));
 
@@ -41,7 +49,7 @@ const ADMIN = {
 };
 
 async function push(yamlTail: string, admin = true): Promise<any> {
-  updateCalls = [];
+  calls = [];
   const dir = await mkdtemp(join(tmpdir(), "windmill_raw_push_"));
   await writeFile(
     join(dir, "raw_app.yaml"),
@@ -52,11 +60,12 @@ async function push(yamlTail: string, admin = true): Promise<any> {
   // up to date.
   await writeFile(join(dir, "index.tsx"), "export default 1\n", "utf-8");
   await pushRawApp("w", "f/test/raw", dir, undefined, "bun", admin ? ADMIN : undefined);
-  expect(updateCalls).toHaveLength(1);
-  return updateCalls[0].formData.app;
+  expect(calls).toHaveLength(1);
+  return calls[0].formData.app;
 }
 
 beforeEach(() => {
+  deployed = true;
   deployedPolicy = {
     on_behalf_of: "u/svc",
     on_behalf_of_email: "svc@corp",
@@ -90,4 +99,14 @@ test("a raw-app push without the marker closes an anonymous app back down", asyn
   // Only the caller who may claim it gets the flag; everyone else deploys as
   // themselves, which is what the backend enforces anyway.
   expect((await push("", false)).preserve_on_behalf_of).toBeUndefined();
+});
+
+test("a first raw-app push deploys the policy its file states", async () => {
+  deployed = false;
+  const body = await push("policy:\n  sandbox: true\n  on_behalf_of: u/impostor\n");
+
+  expect(body.policy.sandbox).toBe(true);
+  // A repo doesn't get to pick who an app runs as: only a deployed identity is
+  // ever claimed, so the backend assigns the pushing user's here.
+  expect(body.preserve_on_behalf_of).toBeUndefined();
 });

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -96,9 +96,18 @@ test("a raw-app push without the marker closes an anonymous app back down", asyn
   const body = await push("");
 
   expect(body.policy.execution_mode).toBe("publisher");
-  // Only the caller who may claim it gets the flag; everyone else deploys as
-  // themselves, which is what the backend enforces anyway.
-  expect((await push("", false)).preserve_on_behalf_of).toBeUndefined();
+});
+
+test("a push that may not claim the deployed identity doesn't send it", async () => {
+  const body = await push("", false);
+
+  expect(body.preserve_on_behalf_of).toBeUndefined();
+  // Not just the flag: the identity itself stays off the wire, so no server can
+  // deploy this push under it.
+  expect(body.policy.on_behalf_of).toBeUndefined();
+  expect(body.policy.on_behalf_of_email).toBeUndefined();
+  // Everything the pusher is entitled to carry over still comes along.
+  expect(body.policy.sandbox).toBe(true);
 });
 
 test("a first raw-app push deploys the policy its file states", async () => {

--- a/cli/test/raw_app_push_policy_unit.test.ts
+++ b/cli/test/raw_app_push_policy_unit.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterAll, beforeEach, expect, mock, test } from "bun:test";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -16,11 +16,14 @@ let deployedPolicy: any;
 /** No app deployed at the path: `getAppByPath` 404s and the push creates one. */
 let deployed = true;
 
-// `mock.module` replaces the module for the whole process, so both are handed
-// back at the end — `raw_app_svelte_plugin_unit.test.ts` drives the real
-// `createBundle`, and would silently bundle nothing under the stub.
+// Only the API is stubbed, and it is handed back in `afterAll` — `mock.module`
+// replaces a module for the whole process. `bundle.ts` is deliberately NOT
+// stubbed: every test file's imports resolve before any `afterAll` runs, so a
+// stub there reaches `raw_app_svelte_plugin_unit.test.ts` whenever the test
+// runner reaches this file first, and that suite then asserts against a bundle
+// containing nothing. The real bundler runs instead, on the app each push
+// writes below.
 const realServices = await import("../gen/services.gen.ts");
-const realBundle = await import("../src/commands/app/bundle.ts");
 
 mock.module("../gen/services.gen.ts", () => ({
   ...realServices,
@@ -41,14 +44,8 @@ mock.module("../gen/services.gen.ts", () => ({
   },
 }));
 
-mock.module("../src/commands/app/bundle.ts", () => ({
-  ...realBundle,
-  createBundle: async () => ({ js: "", css: "" }),
-}));
-
 afterAll(() => {
   mock.module("../gen/services.gen.ts", () => realServices);
-  mock.module("../src/commands/app/bundle.ts", () => realBundle);
 });
 
 const { pushRawApp } = await import("../src/commands/app/raw_apps.ts");
@@ -68,8 +65,16 @@ async function push(yamlTail: string, admin = true): Promise<any> {
     "utf-8",
   );
   // Any file the remote doesn't have, so the push isn't short-circuited as
-  // up to date.
+  // up to date. It is also the bundler's entry point, so it has to compile.
   await writeFile(join(dir, "index.tsx"), "export default 1\n", "utf-8");
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "app", private: true }),
+    "utf-8",
+  );
+  // `ensureNodeModules` only checks the directory is there; borrowing the CLI's
+  // own skips an npm install per push.
+  await symlink(join(process.cwd(), "node_modules"), join(dir, "node_modules"));
   await pushRawApp("w", "f/test/raw", dir, undefined, "bun", admin ? ADMIN : undefined);
   expect(calls).toHaveLength(1);
   return calls[0].formData.app;


### PR DESCRIPTION
## Summary

Fixes GIT-1001. Deploying a raw app through `wmill sync push` regenerated its whole policy from the runnables: `on_behalf_of` was reset to the pushing token's user, `sandbox` and `frontend_sdk_scopes` were dropped, and `execution_mode` was forced to `publisher`. `raw_app.yaml` records none of the policy, so a run-as user or sandbox setting configured in the deploy drawer produced no git-sync change and the next push silently wiped it.

The deployed policy is now the base the regenerated one is built on, so a push only rewrites what the tracked files actually describe and carries the rest forward.

The same bug applies to low-code apps for everything except `on_behalf_of` (which `pushApp` already preserved): `updatePolicy(value, undefined)` cannot emit `sandbox`, so it was dropped on every push there too. Both paths are fixed the same way.

**Left in draft deliberately:** this decides who an app runs as (`on_behalf_of`) and who may open it (`execution_mode`), so it wants a human look before going ready — even though it is CLI-only and the backend enforces both independently.

## Changes

Three named rules, shared by the low-code and raw-app push paths:

- **`basePolicy`** — what the regenerated policy starts from. The deployed policy, so a push keeps settings the tracked file doesn't record; on a first push there is none, so the file is what states one. The run identity comes along only when the push is entitled to claim it: never from the file (a repo doesn't get to name who an app runs as) and never from a pusher who is neither admin nor in `wm_deployers`. The backend already rewrites an unclaimed `on_behalf_of` to the pusher, but `wmill` is regularly pointed at older servers, so the identity is kept off the wire client-side too.
- **`executionModeForPush`** — the mode to deploy under. A file that states one is authoritative in both directions; otherwise the two open-access markers are all it says, so their absence still closes a deployed `anonymous`/`guest` app back down to `publisher`, while a deployed `viewer` (not a grant those markers revoke) carries over instead of widening.
- **`finalizeDerivedPolicy`** — sets the access mode and drops the legacy v1 `triggerables`, which still grant execution because the backend folds them into `triggerables_v2` at run time; carrying them would keep granting runnables the push removed.

`preCheckPermissionedAs` also gained a `raw_app` branch, so a pusher who is neither admin nor in `wm_deployers` is now told that the push will take over the app's run-as user instead of it happening silently — the warning low-code apps, scripts, flows, schedules and triggers already get. Apps are reported once by folder rather than once per changed file, which also de-noises the low-code listing. **This can newly fail a non-interactive push** that would previously have reassigned silently: the fix is `--accept-overriding-permissioned-as-with-self`, as for every other item type. Who this newly affects is worth being precise about, because the gate is not uniform across kinds:

| kind | flags a non-deployer |
| --- | --- |
| low-code app | always — any changed file in the folder |
| `*_trigger` | always, on edit |
| script | only with `has_on_behalf_of: true`, or an `on_behalf_of_email:` differing from the pusher |
| flow | only with `has_on_behalf_of: true` |
| schedule | only when the file's `email:` differs from the pusher |

Scripts, flows and schedules resolve a `currentOwner` and are gated on `currentOwner && currentOwner !== userEmail`, so an item carrying no custom owner never trips it. Raw apps now behave like low-code apps and triggers: unconditional.

So the newly-gated case is a `syncBehavior: v1` repo where a non-deployer pushes raw-app changes non-interactively, the same push carries no low-code app or trigger change, and its scripts/flows/schedules carry no differing owner. A repo that is only raw apps meets all three.

Plumbing: `pushRawApp` now sends `preserve_on_behalf_of` when the caller may claim the deployed identity (`pushApp` already did) and takes a `PermissionedAsContext`, which `sync push` and `wmill app push` both build the way they already did for low-code apps.

## What this does not fix

- **`on_behalf_of` is preserved only at `syncBehavior: v1` and above, and only for an admin or `wm_deployers` member.** `sandbox`, `frontend_sdk_scopes` and `execution_mode` are preserved unconditionally, but the run-as identity rides on `PermissionedAsContext`, which `buildPermissionedAsContext` returns as `undefined` below v1 — for every item type, not just apps. On a v0 repo the identity is still reassigned to the pusher, which is that contract working as documented. Verified: same push from a `wmill.yaml` with no `syncBehavior` line keeps `sandbox` and `viewer` but moves `on_behalf_of` from `u/svc` to the pusher.
- **The policy still isn't tracked in git.** Editing run-as or sandbox in the deploy drawer still produces no git-sync diff; this PR makes the next push non-destructive rather than making the repo the source of truth. Tracking it is a design decision (the policy names workspace-specific identities), not a bugfix.

## Test plan

- [x] `cli/test/raw_app_push_policy_unit.test.ts` pins the wire body: deployed run-as, sandbox and SDK scopes survive an update; the marker's absence closes an `anonymous` app down; a first push deploys the policy its file states without its identity; a push that may not claim the deployed identity sends neither the flag nor the identity, but still carries `sandbox`.
- [x] `cli/test/app_access_mode_unit.test.ts` pins both routes to `viewer`, that a file-stated `publisher` beats a deployed `viewer`, and that the open-access markers still win.
- [x] Full CLI unit suite (`UNIT_ONLY=1 bun test test/*_unit*.test.ts`): 1116 pass. Typecheck clean in the touched files.
- [x] End-to-end against a local backend. Reproduced the bug on `main`'s CLI first (`on_behalf_of` → the pusher, `sandbox` gone), then with the fix: `sync push` of a source change keeps `on_behalf_of: u/svc`, `sandbox: true`, `frontend_sdk_scopes` and the deployed mode.
- [x] Entitlement, both directions: a workspace member who is neither admin nor in `wm_deployers` pushes an app deployed as `u/admin` → app runs as the pusher, sandbox and scopes intact, no `Preserving …` line. Admin pushes the same app → identity kept.
- [x] Access mode round trip for both open modes: `anonymous`/`guest` remotely with no marker in the file closes to `publisher`; after a `sync pull` writes the marker, the next push keeps the mode. Removing `public: true` as the *only* change still closes the app down.
- [x] `viewer`, both directions: a file stating `publisher` moves a deployed `viewer` app back; a silent file leaves it on `viewer`.
- [x] Create path: a `raw_app.yaml` stating `sandbox: true` deploys sandboxed with the run-as assigned to the pusher; one naming `u/svc` does not deploy under it.
- [x] Re-pushing with no local change is still a no-op (no new app version).
- [x] Low-code app with `sandbox` + run-as set: a summary change pushed through `sync push` keeps both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


