### PR TITLE
perf: index the FK columns that cascade on workspace delete

### DIFF
--- a/backend/migrations/20260909163047_workspace_delete_cascade_indexes.down.sql
+++ b/backend/migrations/20260909163047_workspace_delete_cascade_indexes.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS index_app_version_on_app_id;
+
+DROP INDEX IF EXISTS index_app_script_on_app;
+
+DROP INDEX IF EXISTS index_workspace_runnable_dependencies_on_app_path;
+
+DROP INDEX IF EXISTS index_workspace_runnable_dependencies_on_flow_path;

--- a/backend/migrations/20260909163047_workspace_delete_cascade_indexes.up.sql
+++ b/backend/migrations/20260909163047_workspace_delete_cascade_indexes.up.sql
@@ -1,0 +1,32 @@
+-- The FK columns that cascade when a workspace's apps and flows are deleted. Unindexed,
+-- Postgres seq-scans the whole child table once per deleted parent row, making a workspace
+-- delete cost O(apps and flows deleted x rows in the instance). Fork deletion is where that
+-- bites: a fork clones its parent's apps, flows and entire app version history.
+--
+-- The workspace_runnable_dependencies pair are partial because the table's check constraint
+-- makes app_path and flow_path mutually exclusive, halving each index -- the cascade's
+-- equality on the path proves the predicate. The table's existing path indexes are partial on
+-- script_hash, which the cascade does not constrain, so they cannot serve it.
+--
+-- Dropped before built: a failed concurrent build leaves an invalid index that IF NOT EXISTS
+-- would accept forever, unused by the planner yet still maintained on every write.
+--
+-- No statement separators outside the statements below, comments included: the CONCURRENTLY
+-- rewrite in windmill-api/src/db.rs splits the file on them and would run comment text as SQL.
+DROP INDEX IF EXISTS index_app_version_on_app_id;
+
+CREATE INDEX index_app_version_on_app_id ON app_version (app_id);
+
+DROP INDEX IF EXISTS index_app_script_on_app;
+
+CREATE INDEX index_app_script_on_app ON app_script (app);
+
+DROP INDEX IF EXISTS index_workspace_runnable_dependencies_on_app_path;
+
+CREATE INDEX index_workspace_runnable_dependencies_on_app_path
+    ON workspace_runnable_dependencies (app_path, workspace_id) WHERE app_path IS NOT NULL;
+
+DROP INDEX IF EXISTS index_workspace_runnable_dependencies_on_flow_path;
+
+CREATE INDEX index_workspace_runnable_dependencies_on_flow_path
+    ON workspace_runnable_dependencies (flow_path, workspace_id) WHERE flow_path IS NOT NULL;

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -108,6 +108,9 @@ lazy_static::lazy_static! {
                     (20260826214706, include_str!(
                         "../../migrations/20260826214706_queue_suspended_drop_legacy_index.up.sql"
                     ).replace("DROP INDEX", "DROP INDEX CONCURRENTLY")),
+                    (20260909163047, include_str!(
+                        "../../migrations/20260909163047_workspace_delete_cascade_indexes.up.sql"
+                    ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY").replace("DROP INDEX", "DROP INDEX CONCURRENTLY")),
                     ].into_iter().collect();
 }
 


### PR DESCRIPTION
## Summary

Deleting a workspace fork from the UI is very slow, and degrades further with each fork deleted — slow enough that the request can outlive a proxy timeout and appear to have done nothing.

The cost is entirely in the FK cascades out of `app` and `flow`. Three of them have no usable index on the referencing side, so Postgres seq-scans the whole child table **once per deleted parent row**:

| constraint | referencing column | index before |
|---|---|---|
| `app_version_flow_id_fkey` | `app_version.app_id` | none |
| `app_script_app_fkey` | `app_script.app` | none |
| `fk_workspace_runnable_dependencies_app_path` | `workspace_runnable_dependencies (app_path, workspace_id)` | only partial on `script_hash`, which the cascade doesn't constrain |
| `flow_workspace_runnables_workspace_id_flow_path_fkey` | `workspace_runnable_dependencies (flow_path, workspace_id)` | same |

So deleting a workspace costs `O(apps and flows deleted × rows in the whole instance)` instead of `O(rows the workspace owns)`. That is also why it degrades with use: forking clones every app and flow of the parent — along with the parent's **entire app version history** — into those same child tables, so each fork created makes the next delete slower.

`EXPLAIN ANALYZE` of `DELETE FROM app WHERE workspace_id = $1` for a 300-app fork, before:

```
Delete on app  (actual time=1.085..1.085 rows=0)      <- the 300 app rows themselves: 1.1 ms
Trigger for constraint app_version_flow_id_fkey:              time=4746.193 calls=300
Trigger for constraint app_script_app_fkey:                   time=1163.155 calls=300
Trigger for constraint fk_workspace_runnable_dependencies_..: time=2871.237 calls=300
```

## Changes

- New migration `20260909163047_workspace_delete_cascade_indexes` adding the four missing FK indexes: `app_version (app_id)`, `app_script (app)`, and a partial index each for `workspace_runnable_dependencies (app_path, workspace_id)` and `(flow_path, workspace_id)`. The last two are partial because the table's check constraint makes the two path columns mutually exclusive, which halves each index; the cascade's equality on the path proves the predicate, so the planner still uses them.
- Registered in `OVERRIDDEN_MIGRATIONS` (`backend/windmill-api/src/db.rs`) so the statements run as `CREATE INDEX CONCURRENTLY` outside a transaction — no `ACCESS EXCLUSIVE` lock on these tables during an upgrade.
- Each index is dropped immediately before it is built. A concurrent build interrupted mid-migration (restart, deadlock, dropped connection) leaves an *invalid* index behind, which `IF NOT EXISTS` would accept forever — recording the migration as applied while the index is never used by the planner and still maintained on every write. The drop makes the retry self-healing.

No test added: the migration is itself the pin for these indexes, and a test asserting an index exists would guard nothing a future change could plausibly break.

## Measurements

Same fork, same data, same instance — 300 apps / 301 flows, 618k `app_version`, 123k `app_script`, 360k `workspace_runnable_dependencies` rows. End-to-end `DELETE /api/workspaces/delete/{workspace}`:

| | before | after |
|---|---|---|
| whole request | **8.92s** | **0.84s** |
| `DELETE FROM app` | 6994 ms | 567 ms |
| `DELETE FROM flow` | 1806 ms | 162 ms |

The remaining time is proportional to the rows the fork actually owns, not to the size of the instance.

## Test plan

- [x] Migration applies at server startup through the `CONCURRENTLY` rewrite; all four statements logged as `Executing:` / `Done:`, and all four indexes come out `indisvalid` / `indisready`.
- [x] Simulated the naive `;` splitter in `db.rs` against the rewritten file to confirm every fragment is a well-formed statement and the header comment is skipped (this caught a semicolon in an early draft of the comment).
- [x] `cargo sqlx migrate revert` then `cargo sqlx migrate run` — 4 indexes → 0 → 4.
- [x] Before/after on identical data, measured with `pg_stat_statements` and `EXPLAIN ANALYZE` trigger timings (table above).
- [x] Deleted a fork through the real UI (sidebar → Delete forked workspace → Remove): completed, landed on the parent workspace, sidebar showed "0 forks", parent workspace and its rows intact.

## Follow-ups found, not in this PR

- `clone_apps` (`backend/windmill-api-workspaces/src/workspaces.rs`) copies **every** `app_version` of the parent, one `INSERT ... RETURNING` round-trip per row, inside the fork transaction — ~30s for 309k versions in the repro above, and it adds a full second copy of that history to the table each time. Only the S3 bundles were ever narrowed to the latest version; the rows were not. This is the bigger lever for anyone who forks often.
- `token`, `capture`, `input`, `raw_app` and `flow_node` reference `workspace(id)` without an index on `workspace_id`, so `DELETE FROM workspace` seq-scans each one once (~43ms total at 200k rows apiece — real, but ~0.5% of the problem here).
- `raw_app_pkey` is `btree(path)` with no `workspace_id`, so `clone_raw_apps` fails with `duplicate key value violates unique constraint "raw_app_pkey"` when forking a workspace that holds any legacy raw app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtSL61CGQqtLc28AT2h75d
