### PR TITLE
fix: refuse cross-site GET requests that run Hub scripts

### DIFF
--- a/backend/tests/jobs_cross_site_get.rs
+++ b/backend/tests/jobs_cross_site_get.rs
@@ -1,184 +1,138 @@
-//! Regression test for cross-site GET CSRF on the job-run endpoints.
+//! Regression test for cross-site GET CSRF on the job-run endpoints that can run a Hub script.
 //!
-//! Seven GET handlers under `/api/w/:workspace/jobs` queue and run a script or flow.
-//! The session cookie is `SameSite=Lax`, so a browser attaches it to a cross-site
-//! top-level GET navigation, and nothing in the request path looked at `Origin`,
-//! `Referer` or `Sec-Fetch-*`: an attacker page could make a logged-in browser execute
-//! any deployed runnable with arguments of its choosing. CORS hides the response but
-//! not the side effect.
+//! `run_wait_result/p/{path}` and `run_and_stream/p/{path}` answer GET and, for a `hub/` path,
+//! run any public Hub script. The session cookie is `SameSite=Lax`, so a browser attaches it
+//! to a cross-site top-level GET navigation, and an argument written `$var:<path>` or
+//! `$res:<path>` is resolved as the caller: an attacker page could make a logged-in browser
+//! run a generic Hub script and hand it the victim's secrets. CORS hides the response but not
+//! the side effect.
 //!
-//! `CrossSiteGetGuard` refuses a cross-site GET that authenticates on the session cookie
-//! alone. A request carrying its own credential is allowed, which is what keeps the webhook
-//! URLs working: a cross-origin `EventSource` cannot set headers, so `?token=` is its only
-//! way to reach `run_and_stream`, and a `Lax` cookie never rides an `EventSource` anyway.
-//! The one case that does regress is deliberate: a signed-in user clicking a `?token=` link
-//! from another site is refused, because `extract_token` gives the cookie precedence and so
-//! exempting the parameter would let `?token=junk` reinstate the whole vector.
+//! `CrossSiteGetGuard` refuses such a request. Workspace scripts are deliberately not refused,
+//! since they only run code the workspace's own members deployed. A request carrying its own
+//! credential is allowed; the one case that regresses is a signed-in user clicking a `?token=`
+//! Hub-script link from another site, because `extract_token` gives the cookie precedence and
+//! exempting the parameter would let `?token=junk` reinstate the vector.
 //!
 //! This test pins down:
-//!   - every one of the seven GETs rejects a cross-site cookie request (the core fix),
-//!   - the cookie outranks a `token` query parameter in `extract_token`, so appending a
-//!     junk one does not buy a pass,
-//!   - the `Referer` fallback, which is what covers an instance served over plain http:
-//!     no `Sec-Fetch-*` header is emitted there, so without it the guard would be inert,
-//!   - no over-blocking: same-origin, `none`, a header-less client, a bearer token, a real
-//!     `?token=`, a `Referer` matching either `Host` or `X-Forwarded-Host`, and POST on the
-//!     same route all get through.
+//!   - both endpoints refuse a cross-site cookie GET to a Hub script (the core fix), whether
+//!     `Sec-Fetch-Site` says so or, with no such header (plain http), a cross-host `Referer`,
+//!   - a junk `token` query parameter does not buy a pass,
+//!   - the scope: the same request to a workspace script is not refused,
+//!   - a Hub-script request with its own credential (bearer, or `?token=` and no cookie), or
+//!     sent as a POST, gets through.
 //!
-//! The runnables are deliberately absent from the fixture. The guard is an extractor, so
-//! it answers before the handler looks anything up, and every request that gets past it
-//! fails as not-found instead — which isolates the guard without a worker or a deploy.
+//! No runnable exists and no Hub is contacted. A request that gets past the guard fails as
+//! not-found on a workspace path, and on the non-numeric version in `hub/x/...` for a Hub
+//! path, which is rejected while resolving the runnable, before any call to the Hub.
 
 use reqwest::StatusCode;
 use sqlx::{Pool, Postgres};
 use windmill_test_utils::*;
 
-const RUN_GETS: [&str; 7] = [
+const HUB_GETS: [&str; 2] = [
+    "run_wait_result/p/hub/x/absent",
+    "run_and_stream/p/hub/x/absent",
+];
+const WORKSPACE_GETS: [&str; 2] = [
     "run_wait_result/p/u/test-user/absent",
-    "run_wait_result/f/u/test-user/absent",
-    "run_wait_result/fv/999",
     "run_and_stream/p/u/test-user/absent",
-    "run_and_stream/f/u/test-user/absent",
-    "run_and_stream/fv/999",
-    "run_and_stream/h/000000000000000f",
 ];
 
+async fn send(req: reqwest::RequestBuilder) -> anyhow::Result<(StatusCode, String)> {
+    let resp = req.send().await?;
+    let status = resp.status();
+    Ok((status, resp.text().await?))
+}
+
 #[sqlx::test(fixtures("base"))]
-async fn test_cross_site_get_cannot_run_jobs(db: Pool<Postgres>) -> anyhow::Result<()> {
+async fn test_cross_site_get_cannot_run_hub_scripts(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;
 
     let server = ApiServer::start(db.clone()).await?;
-    let origin = format!("http://localhost:{}", server.addr.port());
-    let base = format!("{origin}/api/w/test-workspace/jobs");
+    let base = format!(
+        "http://localhost:{}/api/w/test-workspace/jobs",
+        server.addr.port()
+    );
     let client = reqwest::Client::new();
-
-    // ---- CORE REGRESSION: every job-queuing GET refuses a cross-site cookie request.
-    for path in RUN_GETS {
-        let resp = client
+    let cookie_get = |path: &str| {
+        client
             .get(format!("{base}/{path}"))
             .header("Cookie", "token=SECRET_TOKEN")
-            .header("Sec-Fetch-Site", "cross-site")
-            .send()
-            .await?;
+    };
+
+    // ---- CORE REGRESSION: a cross-site cookie GET cannot run a Hub script.
+    for path in HUB_GETS {
+        let refused = [
+            (
+                "Sec-Fetch-Site: cross-site",
+                cookie_get(path).header("Sec-Fetch-Site", "cross-site"),
+            ),
+            // Plain http gets no `Sec-Fetch-*` at all, so `Referer` is the only signal left.
+            (
+                "cross-host Referer with no Sec-Fetch-Site",
+                cookie_get(path).header("Referer", "http://attacker.example/page"),
+            ),
+            // The cookie outranks a `token` query parameter when authenticating.
+            (
+                "junk ?token= next to the cookie",
+                client
+                    .get(format!("{base}/{path}?token=junk"))
+                    .header("Cookie", "token=SECRET_TOKEN")
+                    .header("Sec-Fetch-Site", "cross-site"),
+            ),
+        ];
+        for (name, req) in refused {
+            let (status, body) = send(req).await?;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "{path} [{name}] must be refused: {body}"
+            );
+        }
+    }
+
+    // ---- Scope: the same request to a workspace script is not refused.
+    for path in WORKSPACE_GETS {
+        let (status, body) = send(cookie_get(path).header("Sec-Fetch-Site", "cross-site")).await?;
         assert_eq!(
-            resp.status(),
-            StatusCode::FORBIDDEN,
-            "{path} must reject a cross-site GET authenticated by the session cookie"
+            status,
+            StatusCode::NOT_FOUND,
+            "{path} is a workspace script and must reach the handler: {body}"
         );
     }
 
-    // A junk `token` query parameter is not an explicit credential: the cookie is what
-    // authenticates the request, so the guard must still fire.
-    let resp = client
-        .get(format!("{base}/{}?token=junk", RUN_GETS[0]))
-        .header("Cookie", "token=SECRET_TOKEN")
-        .header("Sec-Fetch-Site", "cross-site")
-        .send()
-        .await?;
-    assert_eq!(
-        resp.status(),
-        StatusCode::FORBIDDEN,
-        "a junk `token` query parameter must not bypass the guard"
-    );
-
-    // An instance served over plain http gets no `Sec-Fetch-*` header at all — Fetch
-    // Metadata rides only on potentially trustworthy URLs — while the cookie still
-    // arrives, so `Referer` is the only signal left there.
-    let resp = client
-        .get(format!("{base}/{}", RUN_GETS[0]))
-        .header("Cookie", "token=SECRET_TOKEN")
-        .header("Referer", "http://attacker.example/page")
-        .send()
-        .await?;
-    assert_eq!(
-        resp.status(),
-        StatusCode::FORBIDDEN,
-        "a cross-host Referer must stand in for a missing Sec-Fetch-Site"
-    );
-
-    // ---- No over-blocking. Each of these authenticates, so a 404 for the absent
-    //      runnable is the expected "got past the guard" answer.
-    let allowed: [(&str, reqwest::RequestBuilder); 8] = [
-        (
-            "same-origin",
-            client
-                .get(format!("{base}/{}", RUN_GETS[0]))
-                .header("Cookie", "token=SECRET_TOKEN")
-                .header("Sec-Fetch-Site", "same-origin"),
-        ),
-        (
-            "direct navigation (none)",
-            client
-                .get(format!("{base}/{}", RUN_GETS[0]))
-                .header("Cookie", "token=SECRET_TOKEN")
-                .header("Sec-Fetch-Site", "none"),
-        ),
-        (
-            "non-browser client (no Sec-Fetch-Site)",
-            client
-                .get(format!("{base}/{}", RUN_GETS[0]))
-                .header("Cookie", "token=SECRET_TOKEN"),
-        ),
+    // ---- A Hub-script request that carries its own credential, or is a POST, gets through.
+    let hub = HUB_GETS[1];
+    let allowed = [
         (
             "cross-origin bearer token",
             client
-                .get(format!("{base}/{}", RUN_GETS[0]))
+                .get(format!("{base}/{hub}"))
                 .header("Authorization", "Bearer SECRET_TOKEN")
                 .header("Sec-Fetch-Site", "cross-site"),
         ),
         (
-            "cross-origin webhook URL carrying ?token=",
+            "cross-origin ?token= with no cookie",
             client
-                .get(format!("{base}/{}?token=SECRET_TOKEN", RUN_GETS[0]))
+                .get(format!("{base}/{hub}?token=SECRET_TOKEN"))
                 .header("Sec-Fetch-Site", "cross-site"),
         ),
         (
-            "same-host Referer",
+            "POST with the cookie",
             client
-                .get(format!("{base}/{}", RUN_GETS[0]))
+                .post(format!("{base}/{hub}"))
                 .header("Cookie", "token=SECRET_TOKEN")
-                .header("Referer", format!("{origin}/apps")),
-        ),
-        (
-            "Sec-Fetch-Site outranks a cross-host Referer",
-            client
-                .get(format!("{base}/{}", RUN_GETS[0]))
-                .header("Cookie", "token=SECRET_TOKEN")
-                .header("Sec-Fetch-Site", "same-origin")
-                .header("Referer", "http://attacker.example/page"),
-        ),
-        (
-            "Referer matching X-Forwarded-Host but not Host",
-            client
-                .get(format!("{base}/{}", RUN_GETS[0]))
-                .header("Cookie", "token=SECRET_TOKEN")
-                .header("X-Forwarded-Host", "windmill.example, proxy.internal")
-                .header("Referer", "https://windmill.example/apps"),
+                .header("Sec-Fetch-Site", "cross-site")
+                .json(&serde_json::json!({})),
         ),
     ];
     for (name, req) in allowed {
-        let resp = req.send().await?;
-        assert_eq!(
-            resp.status(),
-            StatusCode::NOT_FOUND,
-            "{name} must reach the handler"
+        let (status, body) = send(req).await?;
+        assert!(
+            body.contains("Invalid hub script version"),
+            "{name} must get past the guard to runnable resolution (got {status}): {body}"
         );
     }
-
-    // POST is not the CSRF vector — a `SameSite=Lax` cookie is not sent on one — and the
-    // stream routes serve both methods off the same handler.
-    let resp = client
-        .post(format!("{base}/{}", RUN_GETS[3]))
-        .header("Cookie", "token=SECRET_TOKEN")
-        .header("Sec-Fetch-Site", "cross-site")
-        .json(&serde_json::json!({}))
-        .send()
-        .await?;
-    assert_eq!(
-        resp.status(),
-        StatusCode::NOT_FOUND,
-        "a cross-site POST must reach the handler"
-    );
 
     Ok(())
 }

--- a/backend/tests/jobs_cross_site_get.rs
+++ b/backend/tests/jobs_cross_site_get.rs
@@ -1,0 +1,184 @@
+//! Regression test for cross-site GET CSRF on the job-run endpoints.
+//!
+//! Seven GET handlers under `/api/w/:workspace/jobs` queue and run a script or flow.
+//! The session cookie is `SameSite=Lax`, so a browser attaches it to a cross-site
+//! top-level GET navigation, and nothing in the request path looked at `Origin`,
+//! `Referer` or `Sec-Fetch-*`: an attacker page could make a logged-in browser execute
+//! any deployed runnable with arguments of its choosing. CORS hides the response but
+//! not the side effect.
+//!
+//! `CrossSiteGetGuard` refuses a cross-site GET that authenticates on the session cookie
+//! alone. A request carrying its own credential is allowed, which is what keeps the webhook
+//! URLs working: a cross-origin `EventSource` cannot set headers, so `?token=` is its only
+//! way to reach `run_and_stream`, and a `Lax` cookie never rides an `EventSource` anyway.
+//! The one case that does regress is deliberate: a signed-in user clicking a `?token=` link
+//! from another site is refused, because `extract_token` gives the cookie precedence and so
+//! exempting the parameter would let `?token=junk` reinstate the whole vector.
+//!
+//! This test pins down:
+//!   - every one of the seven GETs rejects a cross-site cookie request (the core fix),
+//!   - the cookie outranks a `token` query parameter in `extract_token`, so appending a
+//!     junk one does not buy a pass,
+//!   - the `Referer` fallback, which is what covers an instance served over plain http:
+//!     no `Sec-Fetch-*` header is emitted there, so without it the guard would be inert,
+//!   - no over-blocking: same-origin, `none`, a header-less client, a bearer token, a real
+//!     `?token=`, a `Referer` matching either `Host` or `X-Forwarded-Host`, and POST on the
+//!     same route all get through.
+//!
+//! The runnables are deliberately absent from the fixture. The guard is an extractor, so
+//! it answers before the handler looks anything up, and every request that gets past it
+//! fails as not-found instead — which isolates the guard without a worker or a deploy.
+
+use reqwest::StatusCode;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+const RUN_GETS: [&str; 7] = [
+    "run_wait_result/p/u/test-user/absent",
+    "run_wait_result/f/u/test-user/absent",
+    "run_wait_result/fv/999",
+    "run_and_stream/p/u/test-user/absent",
+    "run_and_stream/f/u/test-user/absent",
+    "run_and_stream/fv/999",
+    "run_and_stream/h/000000000000000f",
+];
+
+#[sqlx::test(fixtures("base"))]
+async fn test_cross_site_get_cannot_run_jobs(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let origin = format!("http://localhost:{}", server.addr.port());
+    let base = format!("{origin}/api/w/test-workspace/jobs");
+    let client = reqwest::Client::new();
+
+    // ---- CORE REGRESSION: every job-queuing GET refuses a cross-site cookie request.
+    for path in RUN_GETS {
+        let resp = client
+            .get(format!("{base}/{path}"))
+            .header("Cookie", "token=SECRET_TOKEN")
+            .header("Sec-Fetch-Site", "cross-site")
+            .send()
+            .await?;
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "{path} must reject a cross-site GET authenticated by the session cookie"
+        );
+    }
+
+    // A junk `token` query parameter is not an explicit credential: the cookie is what
+    // authenticates the request, so the guard must still fire.
+    let resp = client
+        .get(format!("{base}/{}?token=junk", RUN_GETS[0]))
+        .header("Cookie", "token=SECRET_TOKEN")
+        .header("Sec-Fetch-Site", "cross-site")
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a junk `token` query parameter must not bypass the guard"
+    );
+
+    // An instance served over plain http gets no `Sec-Fetch-*` header at all — Fetch
+    // Metadata rides only on potentially trustworthy URLs — while the cookie still
+    // arrives, so `Referer` is the only signal left there.
+    let resp = client
+        .get(format!("{base}/{}", RUN_GETS[0]))
+        .header("Cookie", "token=SECRET_TOKEN")
+        .header("Referer", "http://attacker.example/page")
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a cross-host Referer must stand in for a missing Sec-Fetch-Site"
+    );
+
+    // ---- No over-blocking. Each of these authenticates, so a 404 for the absent
+    //      runnable is the expected "got past the guard" answer.
+    let allowed: [(&str, reqwest::RequestBuilder); 8] = [
+        (
+            "same-origin",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Cookie", "token=SECRET_TOKEN")
+                .header("Sec-Fetch-Site", "same-origin"),
+        ),
+        (
+            "direct navigation (none)",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Cookie", "token=SECRET_TOKEN")
+                .header("Sec-Fetch-Site", "none"),
+        ),
+        (
+            "non-browser client (no Sec-Fetch-Site)",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Cookie", "token=SECRET_TOKEN"),
+        ),
+        (
+            "cross-origin bearer token",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Authorization", "Bearer SECRET_TOKEN")
+                .header("Sec-Fetch-Site", "cross-site"),
+        ),
+        (
+            "cross-origin webhook URL carrying ?token=",
+            client
+                .get(format!("{base}/{}?token=SECRET_TOKEN", RUN_GETS[0]))
+                .header("Sec-Fetch-Site", "cross-site"),
+        ),
+        (
+            "same-host Referer",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Cookie", "token=SECRET_TOKEN")
+                .header("Referer", format!("{origin}/apps")),
+        ),
+        (
+            "Sec-Fetch-Site outranks a cross-host Referer",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Cookie", "token=SECRET_TOKEN")
+                .header("Sec-Fetch-Site", "same-origin")
+                .header("Referer", "http://attacker.example/page"),
+        ),
+        (
+            "Referer matching X-Forwarded-Host but not Host",
+            client
+                .get(format!("{base}/{}", RUN_GETS[0]))
+                .header("Cookie", "token=SECRET_TOKEN")
+                .header("X-Forwarded-Host", "windmill.example, proxy.internal")
+                .header("Referer", "https://windmill.example/apps"),
+        ),
+    ];
+    for (name, req) in allowed {
+        let resp = req.send().await?;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "{name} must reach the handler"
+        );
+    }
+
+    // POST is not the CSRF vector — a `SameSite=Lax` cookie is not sent on one — and the
+    // stream routes serve both methods off the same handler.
+    let resp = client
+        .post(format!("{base}/{}", RUN_GETS[3]))
+        .header("Cookie", "token=SECRET_TOKEN")
+        .header("Sec-Fetch-Site", "cross-site")
+        .json(&serde_json::json!({}))
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "a cross-site POST must reach the handler"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api/src/csrf.rs
+++ b/backend/windmill-api/src/csrf.rs
@@ -13,34 +13,70 @@ use url::Url;
 use windmill_common::error::Error;
 use windmill_common::users::COOKIE_NAME;
 
-/// Refuses a cross-site GET that would queue a job on the strength of the session cookie
-/// alone. Belongs on every GET handler that runs a script or a flow.
+use crate::triggers::trigger_helpers::RunnableId;
+
+/// Whether a request is a cross-site GET authenticating on the session cookie alone, for the
+/// GET handlers that can run a Hub script to refuse one with [`Self::refuse_hub_script`].
 ///
 /// The cookie is `SameSite=Lax`, so browsers attach it to cross-site top-level GET
-/// navigations: a GET that runs a job lets any page make a logged-in browser execute a
-/// deployed runnable with arguments of its choosing.
+/// navigations. A `hub/` path runs any public Hub script, and an argument written
+/// `$var:<path>` or `$res:<path>` is resolved as the caller before the script sees it: such a
+/// GET lets any page pick a generic Hub script and hand it the victim's secrets, which the job
+/// can then send anywhere. Workspace scripts and flows are deliberately not refused — they
+/// only run code the workspace's own members deployed.
 ///
 /// The cookie is the only ambient credential. A bearer header is explicit, and so is the
-/// `token` query parameter the webhook URLs carry — a cross-origin `EventSource` has no
-/// other way to authenticate, since it cannot set headers. The checks below run in
-/// `extract_token`'s order, header before cookie, because that is the order it resolves
-/// them in: a request carrying both a cookie and `token=` authenticates on the cookie and
-/// is therefore still ambient, which is also why a valid `token=` link opened cross-site
-/// while signed in is refused.
-pub struct CrossSiteGetGuard;
+/// `token` query parameter the webhook URLs carry — a cross-origin `EventSource` has no other
+/// way to authenticate, since it cannot set headers. The checks run in `extract_token`'s
+/// order, header before cookie, because that is the order it resolves them in: a request
+/// carrying both a cookie and `token=` authenticates on the cookie and is therefore still
+/// ambient, which is also why a valid `token=` link opened cross-site while signed in is
+/// refused.
+pub struct CrossSiteGetGuard(Option<CrossSite>);
+
+impl CrossSiteGetGuard {
+    pub fn refuse_hub_script(
+        &self,
+        runnable_id: &RunnableId,
+    ) -> windmill_common::error::Result<()> {
+        let (Some(signal), RunnableId::HubScript(_)) = (&self.0, runnable_id) else {
+            return Ok(());
+        };
+        // The `Referer` leg is the one that can misfire, on a request that really was
+        // same-host: it compares against the hosts the backend can see, and a proxy that
+        // rewrites `Host` without setting `X-Forwarded-Host` leaves none of them matching
+        // what the browser addressed. Name the comparison so that shows up as a
+        // misconfiguration rather than as an unexplained 403.
+        if let CrossSite::RefererMismatch { referer, instance_hosts } = signal {
+            tracing::warn!(
+                referer_host = %referer,
+                ?instance_hosts,
+                "refusing a cross-site GET Hub script run inferred from Referer; if the request \
+                 was same-host, set `X-Forwarded-Host` on the proxy or configure `BASE_URL`"
+            );
+        }
+        Err(Error::PermissionDenied(
+            "a cross-site GET request cannot run a Hub script with the session cookie, which takes \
+             precedence over a `token` query parameter: pass the token in the `Authorization` \
+             header, or open the link from the instance itself or from a browser with no Windmill \
+             session"
+                .to_string(),
+        ))
+    }
+}
 
 impl<S: Send + Sync> FromRequestParts<S> for CrossSiteGetGuard {
-    type Rejection = Error;
+    type Rejection = std::convert::Infallible;
 
     async fn from_request_parts(
         parts: &mut Parts,
         state: &S,
     ) -> std::result::Result<Self, Self::Rejection> {
         if parts.method != Method::GET {
-            return Ok(CrossSiteGetGuard);
+            return Ok(CrossSiteGetGuard(None));
         }
         let Some(signal) = cross_site_signal(parts) else {
-            return Ok(CrossSiteGetGuard);
+            return Ok(CrossSiteGetGuard(None));
         };
 
         let has_bearer = parts
@@ -49,43 +85,20 @@ impl<S: Send + Sync> FromRequestParts<S> for CrossSiteGetGuard {
             .and_then(|v| v.to_str().ok())
             .is_some_and(|v| v.starts_with("Bearer "));
         if has_bearer {
-            return Ok(CrossSiteGetGuard);
+            return Ok(CrossSiteGetGuard(None));
         }
 
         let has_session_cookie =
             Extension::<tower_cookies::Cookies>::from_request_parts(parts, state)
                 .await
                 .is_ok_and(|Extension(cookies)| cookies.get(COOKIE_NAME).is_some());
-        if has_session_cookie {
-            // The `Referer` leg is the one that can misfire, on a request that really was
-            // same-host: it compares against the hosts the backend can see, and a proxy
-            // that rewrites `Host` without setting `X-Forwarded-Host` leaves none of them
-            // matching what the browser addressed. Name the comparison so that shows up as
-            // a misconfiguration rather than as an unexplained 403.
-            if let CrossSite::RefererMismatch { referer } = &signal {
-                tracing::warn!(
-                    referer_host = %referer,
-                    instance_hosts = ?instance_hosts(parts).collect::<Vec<_>>(),
-                    "refusing a cross-site GET job run inferred from Referer; if the request was \
-                     same-host, set `X-Forwarded-Host` on the proxy or configure `BASE_URL`"
-                );
-            }
-            return Err(Error::PermissionDenied(
-                "a cross-site GET request cannot run a job with the session cookie, which takes \
-                 precedence over a `token` query parameter: pass the token in the `Authorization` \
-                 header, or open the link from the instance itself or from a browser with no \
-                 Windmill session"
-                    .to_string(),
-            ));
-        }
-
-        Ok(CrossSiteGetGuard)
+        Ok(CrossSiteGetGuard(has_session_cookie.then_some(signal)))
     }
 }
 
 enum CrossSite {
     Declared,
-    RefererMismatch { referer: String },
+    RefererMismatch { referer: String, instance_hosts: Vec<String> },
 }
 
 fn cross_site_signal(parts: &Parts) -> Option<CrossSite> {
@@ -107,8 +120,11 @@ fn cross_site_signal(parts: &Parts) -> Option<CrossSite> {
     // reads as not cross-site, matching how `Sec-Fetch-Site: none` (a bookmark, a typed
     // URL) is treated.
     let referer = referer_host(parts)?;
-    (!instance_hosts(parts).any(|host| host.eq_ignore_ascii_case(&referer)))
-        .then_some(CrossSite::RefererMismatch { referer })
+    let instance_hosts: Vec<String> = instance_hosts(parts).collect();
+    (!instance_hosts
+        .iter()
+        .any(|host| host.eq_ignore_ascii_case(&referer)))
+    .then_some(CrossSite::RefererMismatch { referer, instance_hosts })
 }
 
 /// Every host a legitimate same-host request can name. `Host` alone is not enough: a
@@ -160,7 +176,58 @@ fn host_of(value: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::host_of;
+    use super::{cross_site_signal, host_of, CrossSite};
+    use axum::http::{request::Parts, Request};
+
+    fn parts(headers: &[(&str, &str)]) -> Parts {
+        let mut req = Request::get("/api/w/ws/jobs/run_wait_result/p/hub/1/x");
+        for (name, value) in headers {
+            req = req.header(*name, *value);
+        }
+        req.body(()).unwrap().into_parts().0
+    }
+
+    #[test]
+    fn sec_fetch_site_decides_when_present() {
+        let declared = |site| cross_site_signal(&parts(&[("sec-fetch-site", site)]));
+        assert!(matches!(declared("cross-site"), Some(CrossSite::Declared)));
+        for site in ["same-origin", "same-site", "none"] {
+            assert!(declared(site).is_none(), "{site} is not cross-site");
+        }
+        // The header outranks a `Referer` that disagrees with it.
+        let with_referer = parts(&[
+            ("sec-fetch-site", "same-origin"),
+            ("host", "windmill.example"),
+            ("referer", "https://attacker.example/page"),
+        ]);
+        assert!(cross_site_signal(&with_referer).is_none());
+    }
+
+    #[test]
+    fn referer_stands_in_when_sec_fetch_site_is_absent() {
+        let signal = |headers: &[(&str, &str)]| cross_site_signal(&parts(headers));
+        assert!(matches!(
+            signal(&[
+                ("host", "windmill.example"),
+                ("referer", "https://attacker.example/p")
+            ]),
+            Some(CrossSite::RefererMismatch { .. })
+        ));
+        // Ports differ between the frontend and the API, and do not make a request cross-site.
+        assert!(signal(&[
+            ("host", "windmill.example:8000"),
+            ("referer", "http://windmill.example:3000/apps"),
+        ])
+        .is_none());
+        // A proxy that rewrote `Host` but forwarded the public name.
+        assert!(signal(&[
+            ("host", "windmill-server.internal"),
+            ("x-forwarded-host", "windmill.example"),
+            ("referer", "https://windmill.example/apps"),
+        ])
+        .is_none());
+        assert!(signal(&[("host", "windmill.example")]).is_none());
+    }
 
     #[test]
     fn host_of_strips_port_brackets_and_proxy_chain() {

--- a/backend/windmill-api/src/csrf.rs
+++ b/backend/windmill-api/src/csrf.rs
@@ -15,15 +15,20 @@ use windmill_common::users::COOKIE_NAME;
 
 use crate::triggers::trigger_helpers::RunnableId;
 
-/// Whether a request is a cross-site GET authenticating on the session cookie alone, for the
-/// GET handlers that can run a Hub script to refuse one with [`Self::refuse_hub_script`].
+/// Whether a request is a cross-site GET authenticating on the session cookie alone. A GET
+/// handler that runs a script by path resolves it through [`Self::script_runnable`], which
+/// refuses a Hub script on such a request.
 ///
 /// The cookie is `SameSite=Lax`, so browsers attach it to cross-site top-level GET
 /// navigations. A `hub/` path runs any public Hub script, and an argument written
 /// `$var:<path>` or `$res:<path>` is resolved as the caller before the script sees it: such a
 /// GET lets any page pick a generic Hub script and hand it the victim's secrets, which the job
-/// can then send anywhere. Workspace scripts and flows are deliberately not refused — they
-/// only run code the workspace's own members deployed.
+/// can then send anywhere.
+///
+/// Workspace scripts and flows are not refused, by choice, so that GET links to them keep
+/// working. That is a scope decision, not a safety property: they still take attacker-chosen
+/// arguments, `$var:` and `$res:` included, resolved as the victim. What bounds the exposure
+/// is that the attacker needs a runnable path and can only run code the workspace deployed.
 ///
 /// The cookie is the only ambient credential. A bearer header is explicit, and so is the
 /// `token` query parameter the webhook URLs carry — a cross-origin `EventSource` has no other
@@ -35,12 +40,10 @@ use crate::triggers::trigger_helpers::RunnableId;
 pub struct CrossSiteGetGuard(Option<CrossSite>);
 
 impl CrossSiteGetGuard {
-    pub fn refuse_hub_script(
-        &self,
-        runnable_id: &RunnableId,
-    ) -> windmill_common::error::Result<()> {
-        let (Some(signal), RunnableId::HubScript(_)) = (&self.0, runnable_id) else {
-            return Ok(());
+    pub fn script_runnable(&self, script_path: &str) -> windmill_common::error::Result<RunnableId> {
+        let runnable_id = RunnableId::from_script_path(script_path);
+        let (Some(signal), RunnableId::HubScript(_)) = (&self.0, &runnable_id) else {
+            return Ok(runnable_id);
         };
         // The `Referer` leg is the one that can misfire, on a request that really was
         // same-host: it compares against the hosts the backend can see, and a proxy that

--- a/backend/windmill-api/src/csrf.rs
+++ b/backend/windmill-api/src/csrf.rs
@@ -36,9 +36,12 @@ impl<S: Send + Sync> FromRequestParts<S> for CrossSiteGetGuard {
         parts: &mut Parts,
         state: &S,
     ) -> std::result::Result<Self, Self::Rejection> {
-        if parts.method != Method::GET || !is_cross_site(parts) {
+        if parts.method != Method::GET {
             return Ok(CrossSiteGetGuard);
         }
+        let Some(signal) = cross_site_signal(parts) else {
+            return Ok(CrossSiteGetGuard);
+        };
 
         let has_bearer = parts
             .headers
@@ -54,6 +57,19 @@ impl<S: Send + Sync> FromRequestParts<S> for CrossSiteGetGuard {
                 .await
                 .is_ok_and(|Extension(cookies)| cookies.get(COOKIE_NAME).is_some());
         if has_session_cookie {
+            // The `Referer` leg is the one that can misfire, on a request that really was
+            // same-host: it compares against the hosts the backend can see, and a proxy
+            // that rewrites `Host` without setting `X-Forwarded-Host` leaves none of them
+            // matching what the browser addressed. Name the comparison so that shows up as
+            // a misconfiguration rather than as an unexplained 403.
+            if let CrossSite::RefererMismatch { referer } = &signal {
+                tracing::warn!(
+                    referer_host = %referer,
+                    instance_hosts = ?instance_hosts(parts).collect::<Vec<_>>(),
+                    "refusing a cross-site GET job run inferred from Referer; if the request was \
+                     same-host, set `X-Forwarded-Host` on the proxy or configure `BASE_URL`"
+                );
+            }
             return Err(Error::PermissionDenied(
                 "a cross-site GET request cannot run a job with the session cookie, which takes \
                  precedence over a `token` query parameter: pass the token in the `Authorization` \
@@ -67,21 +83,32 @@ impl<S: Send + Sync> FromRequestParts<S> for CrossSiteGetGuard {
     }
 }
 
-fn is_cross_site(parts: &Parts) -> bool {
+enum CrossSite {
+    Declared,
+    RefererMismatch { referer: String },
+}
+
+fn cross_site_signal(parts: &Parts) -> Option<CrossSite> {
     if let Some(site) = parts.headers.get("sec-fetch-site") {
-        return site.as_bytes().eq_ignore_ascii_case(b"cross-site");
+        return site
+            .as_bytes()
+            .eq_ignore_ascii_case(b"cross-site")
+            .then_some(CrossSite::Declared);
     }
-    // Fetch Metadata is attached only to potentially trustworthy URLs, so an instance
-    // served over plain http never receives `Sec-Fetch-Site` (nor does Safari before
-    // 16.4) while the cookie, not being `Secure` there either, still arrives. `Referer`
-    // is the only other thing a top-level GET navigation carries — `Origin` is not sent
-    // on one — and a page can suppress it, so this leg narrows the window on those
-    // deployments rather than closing it. An absent `Referer` reads as not cross-site,
-    // matching how `Sec-Fetch-Site: none` (a bookmark, a typed URL) is treated.
-    let Some(referer) = referer_host(parts) else {
-        return false;
-    };
-    !instance_hosts(parts).any(|host| host.eq_ignore_ascii_case(&referer))
+    // Fetch Metadata rides only on potentially trustworthy URLs, so an instance served
+    // over plain http never receives `Sec-Fetch-Site` (nor does Safari before 16.4) while
+    // the cookie, not being `Secure` there either, still arrives. `Referer` is the only
+    // other thing a top-level GET navigation carries — `Origin` is not sent on one — so it
+    // is all that is left there, and it is weak: the default `strict-origin-when-cross-
+    // origin` policy already drops `Referer` on an https-to-http downgrade, so an https
+    // attacker page pointing a victim at a plain-http instance sends neither header. This
+    // leg catches an http-served attacker page and pre-16.4 Safari on https; the guard is
+    // load-bearing on https and best-effort at best on plain http. An absent `Referer`
+    // reads as not cross-site, matching how `Sec-Fetch-Site: none` (a bookmark, a typed
+    // URL) is treated.
+    let referer = referer_host(parts)?;
+    (!instance_hosts(parts).any(|host| host.eq_ignore_ascii_case(&referer)))
+        .then_some(CrossSite::RefererMismatch { referer })
 }
 
 /// Every host a legitimate same-host request can name. `Host` alone is not enough: a
@@ -116,14 +143,39 @@ fn request_host(parts: &Parts) -> Option<String> {
 }
 
 fn header_host(parts: &Parts, name: impl header::AsHeaderName) -> Option<String> {
-    // The value is `host[:port]`, where `host` may be a bracketed IPv6 literal, and a
-    // chain of proxies appends to `X-Forwarded-Host` so only the first entry is the one
-    // the browser addressed. Let the URL parser split the port rather than hand-rolling
-    // the bracket rules.
-    let host = parts.headers.get(name)?.to_str().ok()?;
-    let host = host.split(',').next()?.trim();
+    host_of(parts.headers.get(name)?.to_str().ok()?)
+}
+
+/// The host in a `Host`-shaped header value: `host[:port]`, where `host` may be a bracketed
+/// IPv6 literal, and where a chain of proxies appends to `X-Forwarded-Host` so only the
+/// first entry is the one the browser addressed. The port is split off by the URL parser
+/// rather than by hand-rolling the bracket rules.
+fn host_of(value: &str) -> Option<String> {
+    let host = value.split(',').next()?.trim();
     Url::parse(&format!("http://{host}"))
         .ok()?
         .host_str()
         .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::host_of;
+
+    #[test]
+    fn host_of_strips_port_brackets_and_proxy_chain() {
+        assert_eq!(host_of("windmill.example"), Some("windmill.example".into()));
+        assert_eq!(
+            host_of("windmill.example:8000"),
+            Some("windmill.example".into())
+        );
+        assert_eq!(host_of("[::1]:8000"), Some("[::1]".into()));
+        assert_eq!(host_of("[::1]"), Some("[::1]".into()));
+        assert_eq!(
+            host_of("windmill.example, proxy.internal"),
+            Some("windmill.example".into())
+        );
+        assert_eq!(host_of(""), None);
+        assert_eq!(host_of("not a host"), None);
+    }
 }

--- a/backend/windmill-api/src/csrf.rs
+++ b/backend/windmill-api/src/csrf.rs
@@ -1,0 +1,129 @@
+/*
+ * Author: Ruben Fiszel
+ * Copyright: Windmill Labs, Inc 2022
+ * This file and its contents are licensed under the AGPLv3 License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-AGPL for a copy of the license.
+ */
+
+use axum::extract::FromRequestParts;
+use axum::http::{header, request::Parts, Method};
+use axum::Extension;
+use url::Url;
+use windmill_common::error::Error;
+use windmill_common::users::COOKIE_NAME;
+
+/// Refuses a cross-site GET that would queue a job on the strength of the session cookie
+/// alone. Belongs on every GET handler that runs a script or a flow.
+///
+/// The cookie is `SameSite=Lax`, so browsers attach it to cross-site top-level GET
+/// navigations: a GET that runs a job lets any page make a logged-in browser execute a
+/// deployed runnable with arguments of its choosing.
+///
+/// The cookie is the only ambient credential. A bearer header is explicit, and so is the
+/// `token` query parameter the webhook URLs carry — a cross-origin `EventSource` has no
+/// other way to authenticate, since it cannot set headers. The checks below run in
+/// `extract_token`'s order, header before cookie, because that is the order it resolves
+/// them in: a request carrying both a cookie and `token=` authenticates on the cookie and
+/// is therefore still ambient, which is also why a valid `token=` link opened cross-site
+/// while signed in is refused.
+pub struct CrossSiteGetGuard;
+
+impl<S: Send + Sync> FromRequestParts<S> for CrossSiteGetGuard {
+    type Rejection = Error;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &S,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        if parts.method != Method::GET || !is_cross_site(parts) {
+            return Ok(CrossSiteGetGuard);
+        }
+
+        let has_bearer = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.starts_with("Bearer "));
+        if has_bearer {
+            return Ok(CrossSiteGetGuard);
+        }
+
+        let has_session_cookie =
+            Extension::<tower_cookies::Cookies>::from_request_parts(parts, state)
+                .await
+                .is_ok_and(|Extension(cookies)| cookies.get(COOKIE_NAME).is_some());
+        if has_session_cookie {
+            return Err(Error::PermissionDenied(
+                "a cross-site GET request cannot run a job with the session cookie, which takes \
+                 precedence over a `token` query parameter: pass the token in the `Authorization` \
+                 header, or open the link from the instance itself or from a browser with no \
+                 Windmill session"
+                    .to_string(),
+            ));
+        }
+
+        Ok(CrossSiteGetGuard)
+    }
+}
+
+fn is_cross_site(parts: &Parts) -> bool {
+    if let Some(site) = parts.headers.get("sec-fetch-site") {
+        return site.as_bytes().eq_ignore_ascii_case(b"cross-site");
+    }
+    // Fetch Metadata is attached only to potentially trustworthy URLs, so an instance
+    // served over plain http never receives `Sec-Fetch-Site` (nor does Safari before
+    // 16.4) while the cookie, not being `Secure` there either, still arrives. `Referer`
+    // is the only other thing a top-level GET navigation carries — `Origin` is not sent
+    // on one — and a page can suppress it, so this leg narrows the window on those
+    // deployments rather than closing it. An absent `Referer` reads as not cross-site,
+    // matching how `Sec-Fetch-Site: none` (a bookmark, a typed URL) is treated.
+    let Some(referer) = referer_host(parts) else {
+        return false;
+    };
+    !instance_hosts(parts).any(|host| host.eq_ignore_ascii_case(&referer))
+}
+
+/// Every host a legitimate same-host request can name. `Host` alone is not enough: a
+/// reverse proxy that forwards without preserving it (nginx `proxy_pass` with no
+/// `proxy_set_header Host $host`) hands the backend the upstream's name, which no browser
+/// `Referer` will ever match. None of these is browser-settable on a navigation — a
+/// navigation carries no custom headers, and `BASE_URL` is instance config — so widening
+/// the accepted set costs nothing.
+fn instance_hosts(parts: &Parts) -> impl Iterator<Item = String> {
+    let base_url = windmill_common::BASE_URL.load();
+    [
+        request_host(parts),
+        header_host(parts, "x-forwarded-host"),
+        Url::parse(base_url.as_str())
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_owned)),
+    ]
+    .into_iter()
+    .flatten()
+}
+
+fn referer_host(parts: &Parts) -> Option<String> {
+    let referer = parts.headers.get(header::REFERER)?.to_str().ok()?;
+    Url::parse(referer).ok()?.host_str().map(str::to_owned)
+}
+
+fn request_host(parts: &Parts) -> Option<String> {
+    if let Some(host) = parts.uri.host() {
+        return Some(host.to_owned());
+    }
+    header_host(parts, header::HOST)
+}
+
+fn header_host(parts: &Parts, name: impl header::AsHeaderName) -> Option<String> {
+    // The value is `host[:port]`, where `host` may be a bracketed IPv6 literal, and a
+    // chain of proxies appends to `X-Forwarded-Host` so only the first entry is the one
+    // the browser addressed. Let the URL parser split the port rather than hand-rolling
+    // the bracket rules.
+    let host = parts.headers.get(name)?.to_str().ok()?;
+    let host = host.split(',').next()?.trim();
+    Url::parse(&format!("http://{host}"))
+        .ok()?
+        .host_str()
+        .map(str::to_owned)
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -73,6 +73,7 @@ use crate::{
     args::{self, RawWebhookArgs},
     auth::{OptTokened, Tokened},
     concurrency_groups::join_concurrency_key,
+    csrf::CrossSiteGetGuard,
     db::{ApiAuthed, DB},
     triggers::trigger_helpers::RunnableId,
     users::{
@@ -7416,6 +7417,7 @@ async fn log_job_view(
 }
 
 pub async fn run_wait_result_job_by_path_get(
+    _: CrossSiteGetGuard,
     method: hyper::http::Method,
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,
@@ -7522,6 +7524,7 @@ pub async fn run_wait_result_job_by_path_get(
 }
 
 pub async fn run_wait_result_flow_by_path_get(
+    _: CrossSiteGetGuard,
     method: hyper::http::Method,
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,
@@ -7820,6 +7823,7 @@ pub async fn run_wait_result_flow_by_path(
 }
 
 pub async fn stream_flow_by_path(
+    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -7842,6 +7846,7 @@ pub async fn stream_flow_by_path(
 }
 
 pub async fn stream_flow_by_version(
+    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -7864,6 +7869,7 @@ pub async fn stream_flow_by_version(
 }
 
 pub async fn stream_script_by_path(
+    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -7886,6 +7892,7 @@ pub async fn stream_script_by_path(
 }
 
 pub async fn stream_script_by_hash(
+    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -8078,6 +8085,7 @@ pub async fn run_wait_result_flow_by_path_internal(
 }
 
 pub async fn run_wait_result_flow_by_version_get(
+    _: CrossSiteGetGuard,
     method: hyper::http::Method,
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7417,7 +7417,7 @@ async fn log_job_view(
 }
 
 pub async fn run_wait_result_job_by_path_get(
-    _: CrossSiteGetGuard,
+    cross_site: CrossSiteGetGuard,
     method: hyper::http::Method,
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,
@@ -7430,6 +7430,7 @@ pub async fn run_wait_result_job_by_path_get(
     check_license_key_valid().await?;
 
     let script_path = script_path.to_path();
+    cross_site.refuse_hub_script(&RunnableId::from_script_path(script_path))?;
     check_scopes(&authed, || format!("jobs:run:scripts:{script_path}"))?;
 
     if method == http::Method::HEAD {
@@ -7524,7 +7525,6 @@ pub async fn run_wait_result_job_by_path_get(
 }
 
 pub async fn run_wait_result_flow_by_path_get(
-    _: CrossSiteGetGuard,
     method: hyper::http::Method,
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,
@@ -7823,7 +7823,6 @@ pub async fn run_wait_result_flow_by_path(
 }
 
 pub async fn stream_flow_by_path(
-    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -7846,7 +7845,6 @@ pub async fn stream_flow_by_path(
 }
 
 pub async fn stream_flow_by_version(
-    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -7869,7 +7867,7 @@ pub async fn stream_flow_by_version(
 }
 
 pub async fn stream_script_by_path(
-    _: CrossSiteGetGuard,
+    cross_site: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -7878,12 +7876,14 @@ pub async fn stream_script_by_path(
     method: hyper::http::Method,
     args: RawWebhookArgs,
 ) -> error::Result<Response> {
+    let runnable_id = RunnableId::from_script_path(script_path.to_path());
+    cross_site.refuse_hub_script(&runnable_id)?;
     stream_job(
         authed,
         db,
         user_db,
         w_id,
-        RunnableId::from_script_path(script_path.to_path()),
+        runnable_id,
         args,
         run_query,
         method == http::Method::GET,
@@ -7892,7 +7892,6 @@ pub async fn stream_script_by_path(
 }
 
 pub async fn stream_script_by_hash(
-    _: CrossSiteGetGuard,
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
@@ -8085,7 +8084,6 @@ pub async fn run_wait_result_flow_by_path_internal(
 }
 
 pub async fn run_wait_result_flow_by_version_get(
-    _: CrossSiteGetGuard,
     method: hyper::http::Method,
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7430,7 +7430,7 @@ pub async fn run_wait_result_job_by_path_get(
     check_license_key_valid().await?;
 
     let script_path = script_path.to_path();
-    cross_site.refuse_hub_script(&RunnableId::from_script_path(script_path))?;
+    let runnable_id = cross_site.script_runnable(script_path)?;
     check_scopes(&authed, || format!("jobs:run:scripts:{script_path}"))?;
 
     if method == http::Method::HEAD {
@@ -7443,12 +7443,7 @@ pub async fn run_wait_result_job_by_path_get(
     args.body = args::Body::HashMap(payload_as_args);
 
     let args = args
-        .to_args_from_runnable(
-            &db,
-            &w_id,
-            RunnableId::from_script_path(script_path),
-            run_query.skip_preprocessor,
-        )
+        .to_args_from_runnable(&db, &w_id, runnable_id, run_query.skip_preprocessor)
         .await?;
 
     check_queue_too_long(&db, QUEUE_LIMIT_WAIT_RESULT.or(run_query.queue_limit)).await?;
@@ -7876,8 +7871,7 @@ pub async fn stream_script_by_path(
     method: hyper::http::Method,
     args: RawWebhookArgs,
 ) -> error::Result<Response> {
-    let runnable_id = RunnableId::from_script_path(script_path.to_path());
-    cross_site.refuse_hub_script(&runnable_id)?;
+    let runnable_id = cross_site.script_runnable(script_path.to_path())?;
     stream_job(
         authed,
         db,

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -80,6 +80,7 @@ pub mod azure_proxy_ee;
 mod azure_proxy_oss;
 mod capture;
 mod concurrency_groups;
+mod csrf;
 mod db;
 mod db_health;
 mod dbt;


### PR DESCRIPTION
## Summary

`run_wait_result/p/{path}` and `run_and_stream/p/{path}` answer GET, and for a `hub/` path
they run **any public Hub script**. Two properties make that exploitable as CSRF:

- The session cookie is `SameSite=Lax`, so a browser attaches it to a cross-site top-level
  GET navigation, and nothing in the request path looked at `Origin`, `Referer` or
  `Sec-Fetch-*`.
- An argument written `$var:<path>` or `$res:<path>` is resolved by the worker **as the
  caller** before the script sees it (`windmill-worker/src/common.rs`), whatever the
  argument's type.

So an attacker page can make a logged-in user's browser run a generic Hub script (an HTTP
request, a SQL query, …) with arguments like `$var:f/prod/stripe_key` or
`$res:f/prod/postgres`, and the job itself sends the secret out or acts with the
credential. CORS hides the response from the attacker page, but it doesn't need it. All the
attacker needs is the workspace id; no script has to exist in the workspace.

This adds `CrossSiteGetGuard`: those two handlers refuse a cross-site GET that targets a Hub
script and authenticates on the session cookie alone. The check happens before the Hub
script is fetched or any job is pushed.

**Scope, deliberately:** workspace scripts, flows, flow versions and script hashes are **not**
refused, so GET links to them keep working. That is a scope decision, not a safety property:
they still take attacker-chosen arguments. See *Known limits* for what that leaves.

**Left in draft:** this is an auth path, so it wants a human look before it goes ready.

## Changes

- New `backend/windmill-api/src/csrf.rs` holding `CrossSiteGetGuard`. It is an extractor
  that records whether the request is a cross-site GET with no `Authorization: Bearer`
  header and a session cookie. Handlers resolve a script path through
  `script_runnable(path)`, which returns the `RunnableId` and answers 403 instead when the
  target is a Hub script on such a request, so getting the id is the check.
- Cross-site is read from `Sec-Fetch-Site` when present, with a `Referer` fallback when it
  is not (see *Known limits*). The fallback compares the `Referer` host against `Host`,
  `X-Forwarded-Host` and the configured `BASE_URL`, and logs the comparison when it refuses,
  so a proxy that rewrites `Host` reads as a misconfiguration rather than an unexplained 403.
- Wired into `run_wait_result_job_by_path_get` and `stream_script_by_path` in `jobs.rs`, the
  only two of the GET run handlers that can reach a Hub script (`RunnableId::from_script_path`
  is the only place a `HubScript` is built; flows have no Hub variant).
- Regression test `backend/tests/jobs_cross_site_get.rs`, plus unit tests for the
  cross-site detection and the `Host`-header parsing.

## Deliberate trade-off

A signed-in user who clicks a `?token=` link **to a Hub script from another site** gets a
403. `extract_token` resolves header → cookie → query, so the cookie is what authenticates
such a request; exempting the mere presence of a `token` parameter would let `?token=junk`
reinstate the whole vector. The rejection message names the alternatives. Cross-origin
`EventSource`/`fetch` with `?token=` are unaffected: a `Lax` cookie never rides those.

## Known limits

- **Workspace runnables are still reachable this way.** A cross-site GET can still run a
  workspace script or flow as the victim, with attacker-chosen arguments, including
  `$var:`/`$res:` references. The damage depends on what the workspace's scripts do; one
  whose argument reaches the network can still leak a secret. The attacker also needs the
  paths, so the sharpest case is an insider (e.g. a member who can't read secrets) sending an
  admin a link.
- **The guard is load-bearing on https, best-effort at best on plain http.** Fetch Metadata
  rides only on potentially-trustworthy URLs, so an instance served over plain `http` gets no
  `Sec-Fetch-*` header while the cookie — not `Secure` there either — still arrives; Safari
  also shipped `SameSite` long before Fetch Metadata (16.4). The `Referer` fallback covers
  some of that, but the default `strict-origin-when-cross-origin` policy drops `Referer` on
  an https-to-http downgrade.
- An attacker controlling a sibling subdomain sends `Sec-Fetch-Site: same-site` and passes,
  most concretely on an instance configured with `COOKIE_DOMAIN`.
- `route_job` (`triggers/http/handler.rs`) resolves the caller through the same cookie, but
  HTTP route triggers point at workspace runnables, so under this scope they are out of it.

## Test plan

- [x] `cargo test --features quickjs --test jobs_cross_site_get` and the `csrf` unit tests pass.
- [x] On a running instance, with a real Hub script (`hub/28359/helper/random_integer`):
      cookie + `Sec-Fetch-Site: cross-site` → 403 on both endpoints; cookie + cross-host
      `Referer` with no `Sec-Fetch-Site` → 403; bearer token, same-origin cookie, and
      `?token=` without a cookie each create the job. The refused requests create none.
      (That dev instance had no worker on the `nativets` tag, so the Hub jobs queued but
      never ran; the guard's decision is what was under test.)
- [x] Workspace script, flow and flow version with cookie + `Sec-Fetch-Site: cross-site` →
      200 and the job runs.
- [x] Real browser (Playwright): signed in on `localhost`, then from a page served on
      `127.0.0.1` (a different site), a link to the Hub script → 403, and a link to a
      workspace script → runs.
- [x] The diagnostic `WARN` fires only on the `Referer` leg, naming the referer host and the
      hosts it compared against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V51NZ7yeRzbJCsq5n4tzd

