### PR TITLE
fix: flow editor opens Settings instead of the clicked node

### DIFF
--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -734,11 +734,9 @@
 		return false
 	}
 
-	// Clear SvelteFlow's internal selection by creating new nodes array
 	function clearFlowSelection() {
-		// xyflow owns `selected` on the objects it was handed, and drops it only when it sees a
-		// node it does not recognise. Serving the cached mapping back would hand it the very
-		// object it marked selected, so the clear has to go through fresh objects.
+		// Resetting the cache and reassigning `nodes` hands xyflow objects it has not seen, the
+		// only lever on its selection available from our own array.
 		offsetNodeCache = new WeakMap<Node, Node>()
 		nodes = nodes.map((node) => {
 			if (node.selected) {
@@ -1410,7 +1408,7 @@
 				/>
 
 				<!-- SelectionTool for handling selection changes and filtering -->
-				<SelectionTool {selectionManager} clearGraphSelection={clearFlowSelection} />
+				<SelectionTool {selectionManager} />
 
 				{#if leftHeader}
 					<div class="absolute top-2 left-2 z-10">

--- a/frontend/src/lib/components/graph/SelectionTool.svelte
+++ b/frontend/src/lib/components/graph/SelectionTool.svelte
@@ -4,15 +4,17 @@
 	import type { SelectionManager } from './selectionUtils.svelte'
 	interface Props {
 		selectionManager: SelectionManager
-		clearGraphSelection: () => void
 	}
 
-	let { selectionManager, clearGraphSelection }: Props = $props()
+	let { selectionManager }: Props = $props()
 
-	untrack(() => selectionManager).setClearGraphSelection(untrack(() => clearGraphSelection))
-
-	// Get store to access selectionRect
 	const store = useStore()
+
+	// Clear through xyflow's store, never by handing it fresh node objects: replacing them
+	// re-creates every node's DOM, and a click whose node is rebuilt between pointerdown and
+	// release retargets to the pane, which clears the selection that same gesture just made.
+	// While xyflow holds a selection, useOnSelectionChange below re-broadcasts it over ours.
+	untrack(() => selectionManager).setClearGraphSelection(() => store.unselectNodesAndEdges())
 
 	// Handle selection changes from SvelteFlow
 	useOnSelectionChange(({ nodes: selectedNodes, edges: _selectedEdges }) => {

--- a/frontend/src/lib/components/graph/graphContext.ts
+++ b/frontend/src/lib/components/graph/graphContext.ts
@@ -12,6 +12,8 @@ export type GraphContext = {
 	showAssets: Writable<boolean | undefined>
 	noteManager?: NoteManager
 	moveManager?: MoveManager
+	/** Clears xyflow's selection by replacing every node object, so only for callers that rebuild
+	 *  the graph anyway. A selection change must use `selectionManager` instead. */
 	clearFlowSelection?: () => void
 	yOffset?: number
 	diffManager: FlowDiffManager


### PR DESCRIPTION
## Summary

Clicking a node in the flow editor sometimes selected it and then immediately showed the **Settings** panel instead. Reported as: add a flow, add an AI agent step, click Input — Settings opens.

`SelectionManager.selectId()` clears xyflow's own selection before setting ours. That clear was wired to `clearFlowSelection()`, which resets `offsetNodeCache` and reassigns `nodes` — handing xyflow node objects it does not recognise, which is what makes it drop its `selected` flag, but which also makes it re-create **every node's DOM**: 126 elements on a 25-node flow, on every selection.

Graph nodes select on `pointerdown` (`VirtualItemWrapper.svelte:55`). A `click` is dispatched on the closest common ancestor of its pointerdown and pointerup targets, so when the release lands inside that teardown gap the browser hit-tests to the pane, the click addresses the pane, and `onpaneclick` clears the selection back to the `settings` sentinel. It is a race, which is why it felt random — a longer press or a busier machine lands you in the gap.

The fix clears through xyflow's own API, so no node object changes identity and there is no gap to fall into.

## Changes

- `SelectionTool.svelte` registers `() => store.unselectNodesAndEdges()` with the `SelectionManager` instead of `clearFlowSelection`, and the `clearGraphSelection` prop that threaded it down is gone.
- `clearFlowSelection` is unchanged in behaviour and keeps its two group-creation callers, which rebuild the graph anyway; `graphContext.ts` now documents that contract where a new consumer wires from.

## Screenshots

Same steps both times — new flow, add an AI Agent step, click Input — with the CPU throttled 8× to widen the race window so it fires deterministically.

Before — nothing selected, Settings opens:

![before-fix-settings](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/flow-editor-mis-click-selection/1789036265-before-fix-settings.png)

After — Input selected, Flow Input opens:

![after-fix-flow-input](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/flow-editor-mis-click-selection/1789036268-after-fix-flow-input.png)

## Test plan

Throttling the CPU 8× (DevTools → Performance → CPU) makes the original bug fire 3/3 instead of intermittently.

- [ ] New flow → add an AI Agent step → click Input: the Flow Input panel opens (3/3 under 8× throttle; DOM churn drops from `removed 17` to `removed 0 added 1`)
- [ ] Click a step, then the graph's Settings toolbar button: Settings opens and no node stays outlined
- [ ] Click a step, then Input: Flow Input opens. Press Escape: back to Settings
- [ ] Meta+drag a marquee over two steps: "Multiple Selection"; Escape clears it; a single click replaces it; the Settings button still works from a multi-selection
- [ ] Marquee two contiguous steps → Actions → Create group: the group node appears, nothing stays selected, and clicking Input afterwards works
- [ ] Selection survives graph churn: an agent's tool nodes landing, a running flow's status polls, expanding a subflow — then clicking Input still opens Flow Input

Also checked on a completed run's graph, where `SelectionTool` still mounts. `npm run check:fast` reports 4 errors, all pre-existing (`EditableTextarea.svelte`, `hubProject.ts`, `projects/import`), none in the touched files.

Not addressed here, pre-existing: after multi-selecting and deleting, the right panel still names a deleted step. Reproduces identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7caEKonPr2DmvsWRR6bCK