### PR TITLE
feat: set OTEL resource attributes from the instance settings

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -732,6 +732,8 @@ struct OtelSetting {
     otel_exporter_otlp_protocol: Option<String>,
     #[serde(default, deserialize_with = "empty_as_none")]
     otel_exporter_otlp_compression: Option<String>,
+    #[serde(default, deserialize_with = "empty_as_none")]
+    otel_resource_attributes: Option<String>,
 }
 
 pub async fn load_otel(db: &DB) {
@@ -786,6 +788,15 @@ pub async fn load_otel(db: &DB) {
                 if let Some(compression) = o.otel_exporter_otlp_compression {
                     unsafe {
                         std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION", compression);
+                    }
+                }
+                if let Some(resource_attributes) = o.otel_resource_attributes {
+                    let merged = windmill_common::tracing_init::merge_otel_resource_attributes(
+                        &resource_attributes,
+                        std::env::var("OTEL_RESOURCE_ATTRIBUTES").ok().as_deref(),
+                    );
+                    unsafe {
+                        std::env::set_var("OTEL_RESOURCE_ATTRIBUTES", merged);
                     }
                 }
                 println!("OTEL settings loaded: tracing ({tracing_enabled}), logs ({logs_enabled}), metrics ({metrics_enabled}), endpoint ({:?}), headers defined: ({})",

--- a/backend/tests/otel.rs
+++ b/backend/tests/otel.rs
@@ -745,3 +745,22 @@ fn test_otlp_resource_dedicated_overrides_win() {
         Some(windmill_common::utils::GIT_VERSION)
     );
 }
+
+#[test]
+#[serial_test::serial]
+fn test_otlp_resource_setting_attributes_keep_pod_attributes() {
+    let merged = windmill_common::tracing_init::merge_otel_resource_attributes(
+        "team=platform,region=eu-west-1",
+        Some("k8s.pod.uid=abc-123,region=us-east-1"),
+    );
+    std::env::set_var("OTEL_RESOURCE_ATTRIBUTES", merged);
+    let attrs = resource_attrs();
+    std::env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
+
+    assert_eq!(
+        attrs.get("k8s.pod.uid").map(String::as_str),
+        Some("abc-123")
+    );
+    assert_eq!(attrs.get("team").map(String::as_str), Some("platform"));
+    assert_eq!(attrs.get("region").map(String::as_str), Some("us-east-1"));
+}

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -631,6 +631,8 @@ pub struct OtelSettings {
     pub otel_exporter_otlp_protocol: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub otel_exporter_otlp_compression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub otel_resource_attributes: Option<String>,
 }
 
 /// Per-language HTTP request tracing proxy configuration.

--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -48,6 +48,17 @@ pub const VERBOSE_TARGET: &str = "windmill_verbose";
 /// when `OTEL_JOB_LOGS=true`. Stripped before forwarding to the tracing layer.
 pub const OTEL_PREFIX: &str = "OTEL: ";
 
+/// Combines the instance setting's resource attributes with the `OTEL_RESOURCE_ATTRIBUTES` the
+/// process started with, which a deployment sets per pod (e.g. `k8s.pod.uid` from the downward
+/// API). Overwriting it would drop those; the env's pairs go last because the SDK keeps the last
+/// value of a duplicate key, so the pod's own value wins.
+pub fn merge_otel_resource_attributes(from_setting: &str, from_env: Option<&str>) -> String {
+    match from_env.map(str::trim).filter(|v| !v.is_empty()) {
+        Some(from_env) => format!("{from_setting},{from_env}"),
+        None => from_setting.to_string(),
+    }
+}
+
 /// Creates a Targets filter that optionally filters out verbose logs when quiet mode is enabled.
 fn create_targets_filter(default_env_filter: LevelFilter) -> Targets {
     let targets =

--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -694,6 +694,26 @@
 									<option value="http/protobuf">http/protobuf</option>
 								</select>
 							</div>
+							<div class="flex flex-col gap-1">
+								<label
+									for="OTEL_RESOURCE_ATTRIBUTES"
+									class="block text-xs font-semibold text-emphasis">Resource attributes</label
+								>
+								<TextInput
+									inputProps={{
+										type: 'text',
+										placeholder: 'team=platform,region=eu-west-1',
+										id: 'OTEL_RESOURCE_ATTRIBUTES',
+										disabled: !$enterpriseLicense
+									}}
+									bind:value={$values[setting.key].otel_resource_attributes}
+								/>
+								<span class="text-2xs font-normal text-secondary">
+									Added to everything Windmill exports, alongside the OTEL_RESOURCE_ATTRIBUTES env
+									var, which wins on a shared key. Windmill's own service.name, service.version,
+									host.name and deployment.environment take precedence over both.
+								</span>
+							</div>
 						{/if}
 					</div>
 				{:else if setting.fieldType == 'otel_tracing_proxy'}


### PR DESCRIPTION
## Summary
`OTEL_RESOURCE_ATTRIBUTES` is honored since #10974, but only as an env var on each process. Instances that configure OpenTelemetry from the instance settings (endpoint, headers, protocol) had no way to set it there. This adds a "Resource attributes" field to the OTEL setting, applied like the other OTEL fields: `load_otel` writes it into `OTEL_RESOURCE_ATTRIBUTES` before tracing starts.

Unlike those single-value fields, the setting is merged with the env var the process started with instead of replacing it. A deployment injects per-pod attributes (e.g. `k8s.pod.uid` from the Kubernetes downward API) that an instance-wide setting cannot express, and overwriting the env var would drop them. On a shared key the env var wins. Windmill's own `service.name`, `service.version`, `host.name` and `deployment.environment*` keep precedence over both, as #10974 defined.

## Changes
- `OtelSettings` (`instance_config.rs`): new `otel_resource_attributes` field. The settings page's bulk save round-trips through this struct, so without it the key is silently dropped on save.
- `load_otel` (`monitor.rs`): merges the setting into `OTEL_RESOURCE_ATTRIBUTES` through the new `tracing_init::merge_otel_resource_attributes`.
- Instance settings, OTEL section: new "Resource attributes" input.
- `tests/otel.rs`: regression test through the real resource builder: a pod-injected attribute survives the setting, and the pod's value wins a shared key.

## Test plan
- [x] `cargo test --features quickjs,private,enterprise,otel --test otel -- test_otlp_resource`: 3 passed
- [x] E2E against a local OpenTelemetry collector (debug exporter, OTLP over `http/protobuf`). Backend started with `OTEL_RESOURCE_ATTRIBUTES=k8s.pod.uid=abc-123,region=us-east-1` in its environment and the setting set to `team=platform,region=eu-west-1`. The exported resource carries `k8s.pod.uid=abc-123`, `team=platform` and `region=us-east-1`, with `service.name`, `host.name` and `deployment.environment.name` unchanged.
- [x] Saved the field from the settings page: the value persists in `global_settings.otel` and shows again after a reload.
- [x] `npm run check:fast`: no new errors

## Screenshots
![otel-resource-attributes-setting](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/datadog-otlp-ingest-endpoint/1789051419-otel-resource-attributes-setting.png)

Related: metrics temporality (`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, needed by delta-only OTLP intakes) is handled separately in WIN-2494.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbLzVfFDZ9pjBGHSzCSrNZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Resource attributes field to the OpenTelemetry instance settings so instances can set `OTEL_RESOURCE_ATTRIBUTES` without relying on a per-process env var. The setting is merged with the env var the process started with; on a shared key the env var wins, and Windmill's own `service.name`, `service.version`, `host.name`, and `deployment.environment*` attributes keep precedence over both.

**Details**
- The setting round-trips through the settings page's bulk save so the value isn't dropped on save.
- A regression test confirms a pod-injected attribute survives the merge and wins a shared key.

<sup>Written for commit 971f50993d6f57dd4c018d1320106a9ec075040e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

