### PR TITLE
fix(frontend): recompute dataflow edges when selecting a step

### DIFF
--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -989,6 +989,9 @@
 		// FlowRunStatus instead.
 		flowJob
 		suspendStatus
+		// Dataflow edges hang off the selected step. Selection is otherwise xyflow's own state,
+		// so it only rebuilds the graph while those edges are shown.
+		if ($useDataflow) selectedId
 
 		const collapsedGroupIds = new Set(
 			allGroups


### PR DESCRIPTION
## Summary
With the **Dataflow** toggle on in a flow run's graph, clicking a different step did not redraw the dataflow edges: they stayed on whichever step was selected when the toggle was turned on.

The dataflow edges are built by `graphBuilder` around the selected step, but the `graph` derivation in `FlowGraphV2` reads `selectedId` only inside `untrack`, so a selection change never rebuilt the graph. On a running flow the poll's `flowJob` tick rebuilds it anyway, which hid the bug; on a finished run nothing else changes, so the edges froze.

## Changes
- `FlowGraphV2.svelte`: the `graph` derivation depends on `selectedId` while `$useDataflow` is on. With the toggle off, selection stays xyflow's own state and does not rebuild the graph, as before.

## Test plan
- [x] Created a flow `a → b → c` (`b` reads `results.a`, `c` reads `results.b` and `flow_input.x`), ran it to completion, opened the run page, turned on Dataflow and clicked `a`, `b`, `c` in turn, recording the `dep-*` edges after each click:
  - with the fix: `a` → `Input→a`, `a→b`; `b` → `a→b`, `b→c`; `c` → `Input→c`, `b→c`
  - without it (line removed): all three clicks show `Input→a`, `a→b`
- [x] `npm run check:fast`: no errors in the changed file
- [x] Cold-context `local-review`: good to merge, no findings
- Local Codex review skipped: the `codex` CLI is not installed on this machine

## Screenshots
Run page, Dataflow on, step `c` selected.

Before: edges still drawn around `a`
![before-selected-c](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dataflow-recompute-on-click/1789056288-before-selected-c.png)

After: edges drawn around `c`
![after-selected-c](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dataflow-recompute-on-click/1789056290-after-selected-c.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk3d9DpuPuV8C8nKSeGCqC