### PR TITLE
fix: bound list_jobs runtime and paginate runs on the sorted column

### DIFF
--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -585,6 +585,8 @@ pub fn list_completed_jobs_query(
     let mut sqlb = SqlBuilder::select_from("v2_job_completed")
         .fields(fields)
         .order_by(
+            // The runs page picks its pagination cursor column from this same rule
+            // (frontend/src/lib/components/runs/useJobsLoader.svelte.ts); change both together.
             if lq.completed_before.is_some()
                 || lq.completed_after.is_some()
                 || lq.success == Some(false)

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -4416,7 +4416,14 @@ async fn count_completed_jobs(
         ))
 }
 
-const LIST_JOBS_STATEMENT_TIMEOUT_SECS: u64 = 30;
+lazy_static::lazy_static! {
+    /// 0 keeps the connection-wide statement_timeout.
+    static ref LIST_JOBS_STATEMENT_TIMEOUT_SECS: u64 =
+        std::env::var("LIST_JOBS_STATEMENT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|x| x.parse().ok())
+            .unwrap_or(30);
+}
 
 async fn list_jobs(
     authed: ApiAuthed,
@@ -4537,22 +4544,25 @@ async fn list_jobs(
 
     // A client that gives up does not cancel its query, so without this bound every retry of a
     // slow filter stacks another scan running until the connection-wide 5min timeout.
-    sqlx::query(&format!(
-        "SET LOCAL statement_timeout = '{LIST_JOBS_STATEMENT_TIMEOUT_SECS}s'"
-    ))
-    .execute(&mut *tx)
-    .await?;
+    let timeout_secs = *LIST_JOBS_STATEMENT_TIMEOUT_SECS;
+    if timeout_secs > 0 {
+        sqlx::query(&format!("SET LOCAL statement_timeout = '{timeout_secs}s'"))
+            .execute(&mut *tx)
+            .await?;
+    }
 
     let jobs: Vec<UnifiedJob> = sqlx::query_as(&sql)
         .fetch_all(&mut *tx)
         .warn_after_seconds_with_sql(5, format!("list_jobs: {}", sql))
         .await
         .map_err(|e| match e {
-            sqlx::Error::Database(ref db_err) if db_err.code().as_deref() == Some("57014") => {
+            sqlx::Error::Database(ref db_err)
+                if timeout_secs > 0 && db_err.code().as_deref() == Some("57014") =>
+            {
                 Error::Generic(
                     StatusCode::BAD_REQUEST,
                     format!(
-                        "Listing jobs took more than {LIST_JOBS_STATEMENT_TIMEOUT_SECS}s and was stopped. Set a start date or narrow the filters."
+                        "Listing jobs took more than {timeout_secs}s and was stopped. Set a start date or narrow the filters."
                     ),
                 )
             }

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -4416,6 +4416,8 @@ async fn count_completed_jobs(
         ))
 }
 
+const LIST_JOBS_STATEMENT_TIMEOUT_SECS: u64 = 30;
+
 async fn list_jobs(
     authed: ApiAuthed,
     Extension(user_db): Extension<UserDB>,
@@ -4533,10 +4535,29 @@ async fn list_jobs(
     // tracing::info!("sql: {}", &sql);
     let mut tx: Transaction<'_, Postgres> = user_db.begin(&authed).await?;
 
+    // A client that gives up does not cancel its query, so without this bound every retry of a
+    // slow filter stacks another scan running until the connection-wide 5min timeout.
+    sqlx::query(&format!(
+        "SET LOCAL statement_timeout = '{LIST_JOBS_STATEMENT_TIMEOUT_SECS}s'"
+    ))
+    .execute(&mut *tx)
+    .await?;
+
     let jobs: Vec<UnifiedJob> = sqlx::query_as(&sql)
         .fetch_all(&mut *tx)
         .warn_after_seconds_with_sql(5, format!("list_jobs: {}", sql))
-        .await?;
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::Database(ref db_err) if db_err.code().as_deref() == Some("57014") => {
+                Error::Generic(
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "Listing jobs took more than {LIST_JOBS_STATEMENT_TIMEOUT_SECS}s and was stopped. Set a start date or narrow the filters."
+                    ),
+                )
+            }
+            e => e.into(),
+        })?;
     tx.commit().await?;
 
     Ok(Json(jobs.into_iter().map(From::from).collect()))

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -126,9 +126,14 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		let promise = loadJobsIntern(true)
 		if (perPage > 25) {
 			promise = CancelablePromiseUtils.onTimeout(promise, 4000, () => {
-				sendUserToast('Loading jobs is taking longer than expected...', 'warning', [
-					{ label: 'Stream by batches of 25', callback: () => restreamWithSmallBatches() }
-				])
+				const noStartDate = timeframe?.computeMinMax().minTs == null
+				sendUserToast(
+					(success == 'failure' || success == 'canceled') && noStartDate
+						? `Loading ${success == 'failure' ? 'failed' : 'canceled'} jobs with no start date scans the full job history. Set a time range to speed it up.`
+						: 'Loading jobs is taking longer than expected...',
+					'warning',
+					[{ label: 'Stream by batches of 25', callback: () => restreamWithSmallBatches() }]
+				)
 			})
 		}
 		promise = CancelablePromiseUtils.finallyDo(promise, () => {
@@ -191,21 +196,31 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		loadingExtra = false
 	}
 
+	// Mirrors when list_completed_jobs_query sorts by completed_at. A created_at cursor does not
+	// bound that index scan, so each batch would rescan from the newest job, and skip jobs created
+	// after the cursor but completed before it.
+	function sortsByCompletedAt(minTs: string | null): boolean {
+		return minTs != null || success == 'failure' || success == 'canceled'
+	}
+
 	function loadExtraJobsBatch(batchSize: number): CancelablePromise<void> {
 		if (!jobs || jobs.length === 0) {
 			lastFetchWentToEnd = true
 			return CancelablePromiseUtils.pure<void>(undefined as void)
 		}
 		const lastJob = jobs[jobs.length - 1]
-		const ts = lastJob.created_at
+		const minTs = timeframe?.computeMinMax().minTs ?? null
+		const byCompletedAt = lastJob.type === 'CompletedJob' && sortsByCompletedAt(minTs)
+		const ts = byCompletedAt ? lastJob.completed_at : lastJob.created_at
 		if (!ts) {
 			lastFetchWentToEnd = true
 			return CancelablePromiseUtils.pure<void>(undefined as void)
 		}
 		const cursorTs = new Date(new Date(ts).getTime() - 1).toISOString()
-		const minTs = timeframe?.computeMinMax().minTs ?? null
 		return CancelablePromiseUtils.map(
-			fetchJobs(null, minTs, undefined, cursorTs, batchSize),
+			byCompletedAt
+				? fetchJobs(cursorTs, minTs, undefined, undefined, batchSize)
+				: fetchJobs(null, minTs, undefined, cursorTs, batchSize),
 			(olderJobs) => {
 				jobs = updateWithNewJobs(olderJobs ?? [], jobs ?? [])
 				if (extendedJobs) {
@@ -289,7 +304,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		})
 		promise = CancelablePromiseUtils.catchErr(promise, (e) => {
 			if (e instanceof CancelError) return CancelablePromiseUtils.err(e)
-			sendUserToast('There was an issue loading jobs, see browser console for more details', true)
+			sendUserToast(`Could not load jobs: ${e.body ?? e.message}`, true)
 			console.error(e)
 			return CancelablePromiseUtils.pure<Job[]>([])
 		})
@@ -394,6 +409,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		overrideBatchSize?: number
 	): CancelablePromise<void> {
 		const { minTs, maxTs } = timeframe?.computeMinMax() ?? { minTs: null, maxTs: null }
+		listLoadedAt = new Date(Date.now() - 60_000).toISOString()
 		if (shouldGetCount) {
 			getCount()
 		}
@@ -529,6 +545,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 	}
 
 	let lastQueueTs: string | undefined = undefined
+	let listLoadedAt: string | null = null
 
 	async function syncer() {
 		if (loadingFetch) {
@@ -575,7 +592,10 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 					loading = true
 					let newJobs: Job[]
 					if (concurrencyKey == null || concurrencyKey === '') {
-						newJobs = await fetchJobs(maxTs, minTs ?? completedTs, queueTs)
+						// With no completed job to anchor on, each refresh would repeat the initial
+						// unbounded scan, possibly the one that just timed out. The margin on
+						// listLoadedAt absorbs clock skew between the browser and the database.
+						newJobs = await fetchJobs(maxTs, minTs ?? completedTs ?? listLoadedAt, queueTs)
 					} else {
 						// Obscured jobs have no ids, so we have to do the full request
 						extendedJobs = await fetchExtendedJobs(concurrencyKey, maxTs, minTs ?? completedTs)

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -75,6 +75,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 	let label = $derived(filters?.label ?? null)
 	let worker = $derived(filters?.worker ?? null)
 	let success = $derived(filters?.status ?? null)
+	let isQueueOnly = $derived(success == 'running' || success == 'suspended' || success == 'waiting')
 	let showSkipped = $derived(filters?.show_skipped ?? false)
 	let resolutionFilter = $derived(filters?.resolved ?? 'all')
 	let showSchedules = $derived(!filters?.job_trigger_kind?.includes('!schedule'))
@@ -199,8 +200,8 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 	// Mirrors when list_completed_jobs_query sorts by completed_at. A created_at cursor does not
 	// bound that index scan, so each batch would rescan from the newest job, and skip jobs created
 	// after the cursor but completed before it.
-	function sortsByCompletedAt(minTs: string | null): boolean {
-		return minTs != null || success == 'failure' || success == 'canceled'
+	function sortsByCompletedAt(minTs: string | null, maxTs: string | null): boolean {
+		return minTs != null || maxTs != null || success == 'failure' || success == 'canceled'
 	}
 
 	function loadExtraJobsBatch(batchSize: number): CancelablePromise<void> {
@@ -208,19 +209,24 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 			lastFetchWentToEnd = true
 			return CancelablePromiseUtils.pure<void>(undefined as void)
 		}
-		const lastJob = jobs[jobs.length - 1]
-		const minTs = timeframe?.computeMinMax().minTs ?? null
-		const byCompletedAt = lastJob.type === 'CompletedJob' && sortsByCompletedAt(minTs)
-		const ts = byCompletedAt ? lastJob.completed_at : lastJob.created_at
-		if (!ts) {
+		const { minTs, maxTs } = timeframe?.computeMinMax() ?? { minTs: null, maxTs: null }
+		const byCompletedAt =
+			jobs[jobs.length - 1].type === 'CompletedJob' && sortsByCompletedAt(minTs, maxTs)
+		const sortKey = (j: Job) =>
+			byCompletedAt ? (j.type === 'CompletedJob' ? j.completed_at : undefined) : j.created_at
+		const cursorTs = sortKey(jobs[jobs.length - 1])
+		if (!cursorTs) {
 			lastFetchWentToEnd = true
 			return CancelablePromiseUtils.pure<void>(undefined as void)
 		}
-		const cursorTs = new Date(new Date(ts).getTime() - 1).toISOString()
+		// The cursor is inclusive and keeps the API's microsecond precision, so jobs sharing the
+		// boundary timestamp (e.g. a bulk cancel) are refetched instead of skipped. Widening the page
+		// by the ones already listed leaves room for a full batch of new jobs.
+		const pageSize = batchSize + jobs.filter((j) => sortKey(j) === cursorTs).length
 		return CancelablePromiseUtils.map(
 			byCompletedAt
-				? fetchJobs(cursorTs, minTs, undefined, undefined, batchSize)
-				: fetchJobs(null, minTs, undefined, cursorTs, batchSize),
+				? fetchJobs(cursorTs, minTs, undefined, undefined, pageSize)
+				: fetchJobs(null, minTs, undefined, cursorTs, pageSize),
 			(olderJobs) => {
 				jobs = updateWithNewJobs(olderJobs ?? [], jobs ?? [])
 				if (extendedJobs) {
@@ -228,7 +234,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 					extendedJobs = extendedJobs
 				}
 				computeCompletedJobs()
-				lastFetchWentToEnd = (olderJobs?.length ?? 0) < batchSize
+				lastFetchWentToEnd = (olderJobs?.length ?? 0) < pageSize
 				loading = false
 			}
 		)
@@ -245,7 +251,6 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		loadingFetch = true
 		let scriptPathStart = folder == null || folder === '' ? undefined : `f/${folder}/`
 		let scriptPathExact = path == null || path === '' ? undefined : path
-		let isQueueOnly = success == 'running' || success == 'suspended' || success == 'waiting'
 		let isCompletedOnly = success == 'success' || success == 'failure' || success == 'canceled'
 		let promise = JobService.listJobs({
 			workspace: currentWorkspace,
@@ -593,9 +598,14 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 					let newJobs: Job[]
 					if (concurrencyKey == null || concurrencyKey === '') {
 						// With no completed job to anchor on, each refresh would repeat the initial
-						// unbounded scan, possibly the one that just timed out. The margin on
-						// listLoadedAt absorbs clock skew between the browser and the database.
-						newJobs = await fetchJobs(maxTs, minTs ?? completedTs ?? listLoadedAt, queueTs)
+						// unbounded scan of completed jobs, possibly the one that just timed out. Not for
+						// queue-only views: fetchJobs turns this into the queue's created_at bound, hiding
+						// older jobs that suspend or come due. The margin absorbs browser/database skew.
+						newJobs = await fetchJobs(
+							maxTs,
+							minTs ?? completedTs ?? (isQueueOnly ? null : listLoadedAt),
+							queueTs
+						)
 					} else {
 						// Obscured jobs have no ids, so we have to do the full request
 						extendedJobs = await fetchExtendedJobs(concurrencyKey, maxTs, minTs ?? completedTs)

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -18,6 +18,9 @@ import { CancelablePromiseUtils } from '$lib/cancelable-promise-utils'
 import type { Timeframe } from './timeframes'
 import { allowWildcards as _allowWildcards, type RunsFilterInstance } from './runsFilter'
 
+// windmill_common::utils::MAX_PER_PAGE: the server silently caps per_page at this value
+const MAX_PER_PAGE = 10000
+
 export function computeJobKinds(jobKindsCat: string | null): string {
 	if (jobKindsCat == 'all') {
 		return ''
@@ -219,14 +222,18 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 			lastFetchWentToEnd = true
 			return CancelablePromiseUtils.pure<void>(undefined as void)
 		}
-		// The cursor is inclusive and keeps the API's microsecond precision, so jobs sharing the
-		// boundary timestamp (e.g. a bulk cancel) are refetched instead of skipped. Widening the page
-		// by the ones already listed leaves room for a full batch of new jobs.
-		const pageSize = batchSize + jobs.filter((j) => sortKey(j) === cursorTs).length
+		// Inclusive cursor at the API's microsecond precision: jobs sharing the boundary timestamp (e.g.
+		// a bulk cancel) are refetched rather than skipped, and the page grows by those already listed,
+		// up to the server's MAX_PER_PAGE. Once the listed part of the group fills that cap, the cursor
+		// steps just below the group, dropping its remainder instead of ending the list early.
+		const tied = jobs.filter((j) => sortKey(j) === cursorTs).length
+		const stepOver = tied >= MAX_PER_PAGE
+		const cursor = stepOver ? new Date(new Date(cursorTs).getTime() - 1).toISOString() : cursorTs
+		const pageSize = stepOver ? batchSize : Math.min(batchSize + tied, MAX_PER_PAGE)
 		return CancelablePromiseUtils.map(
 			byCompletedAt
-				? fetchJobs(cursorTs, minTs, undefined, undefined, pageSize)
-				: fetchJobs(null, minTs, undefined, cursorTs, pageSize),
+				? fetchJobs(cursor, minTs, undefined, undefined, pageSize)
+				: fetchJobs(null, minTs, undefined, cursor, pageSize),
 			(olderJobs) => {
 				jobs = updateWithNewJobs(olderJobs ?? [], jobs ?? [])
 				if (extendedJobs) {
@@ -414,7 +421,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		overrideBatchSize?: number
 	): CancelablePromise<void> {
 		const { minTs, maxTs } = timeframe?.computeMinMax() ?? { minTs: null, maxTs: null }
-		listLoadedAt = new Date(Date.now() - 60_000).toISOString()
+		listLoadedAt = new Date(Date.now() - 5 * 60_000).toISOString()
 		if (shouldGetCount) {
 			getCount()
 		}


### PR DESCRIPTION
## Summary

Filtering the runs page by failed (or canceled) status for one runnable, with no start date, can scan the whole retention window. The page made that worse in three ways:

- **Abandoned requests keep running.** A request the browser gives up on does not cancel its query, which keeps going until the connection-wide 5min `statement_timeout`. Every retry stacks another concurrent scan.
- **Batches rescan from the top.** Extra batches paginated with a `created_before` cursor while the backend sorts these views by `completed_at` (failure/canceled status, or any time bound). A `created_at` bound does not limit a `completed_at` index scan, so each batch restarted from the newest failure. It also skipped jobs created after the cursor but completed before it.
- **Empty lists refresh unbounded.** With no completed job to anchor on, every auto-refresh re-ran the same unbounded query, including after it had just failed.

Measured locally on a seeded workspace (2M jobs, 59.5k failures, `script_path_exact` + `status=failure`, pages touched per request):

| Runnable in the filter | per_page 1000 | per_page 25 | per_page 1 |
|---|---|---|---|
| runs every 30s, 20 failures | 60k | 260k | 36k |
| runs every min, fails 50% | 244k | 0.4k | 10 |

With the old `created_before` cursor, "stream 1 by 1" re-walked the failures on every batch (batch 6: 76k pages, batch 11: 141k).

This PR bounds the damage and fixes pagination. It does not make the first unbounded load fast; that needs an index covering path and status together, which is a separate change.

## Changes

- **`list_jobs` timeout** (`windmill-api/src/jobs.rs`): `SET LOCAL statement_timeout` in the transaction the handler already opens, 30s by default. New env var `LIST_JOBS_STATEMENT_TIMEOUT_SECS` overrides it; `0` keeps the connection-wide timeout. A `57014` cancel is returned as a 400 with an actionable message ("Listing jobs took more than 30s and was stopped. Set a start date or narrow the filters."). SQL errors were already 400s; only the body changes.
- **Batch cursor** (`useJobsLoader.svelte.ts`):
  - Extra batches now use the column the backend sorts on: `completed_before` whenever `list_completed_jobs_query` sorts by `completed_at`, `created_before` otherwise.
  - The cursor is the job's exact microsecond timestamp, sent inclusively. The page is widened by the boundary-timestamp jobs already listed, so ties (e.g. a bulk cancel, which shares one `completed_at`) are refetched rather than skipped. The same applies to the `created_at` cursor, which had the same tie skip.
  - The widened page is capped at the server's `MAX_PER_PAGE` (10,000). Once the listed part of a tie group fills that cap, the cursor steps just below the group, dropping its remainder instead of ending the list early. A proper `(completed_at, id)` keyset cursor would remove this limit but needs a new API parameter.
- **Auto-refresh bound:** when the list has no completed job to anchor on, the refresh bounds completed jobs by the list's load time (minus 5 minutes for clock skew). Queue-only views (running/suspended/waiting) are unchanged, because their refresh reuses that value as the queue `created_at` bound.
- **Toasts:** the error toast shows the backend message instead of "see browser console". The 4s slow-load toast for failed/canceled with no start date says a time range is what speeds it up.
- **Pointer comment:** `list_completed_jobs_query`'s `ORDER BY` rule now points to the frontend code that mirrors it.

## Test plan

Run against a local instance with the seeded workspace above.

- [x] `list_jobs` under a forced lock wait stops at 30.0s with HTTP 400 and the message. A request abandoned after 3s still had its query waiting at ~11s, and it was gone by ~35s instead of running to 5min.
- [x] Failure filter, 5 per page: "Load next 5 jobs" sends `completed_before` set to the 5th row's `completed_at`. The 10 listed rows match SQL order by `completed_at` desc.
- [x] 12 jobs canceled with identical `completed_at` plus 3 older ones, canceled filter, 5 per page: follow-up requests carry the same exact cursor at `per_page` 10 and 15. All 15 jobs are listed once; the old `-1ms` cursor dropped 7.
- [x] 10,500 jobs canceled with identical `completed_at` plus 5 older ones, 1000 per page: pages widen 2000 → 9005, then are capped at 10,000, then the cursor steps just below the group and the 5 older jobs load. The list ends at 10,008 jobs instead of stopping early.
- [x] Server-only instance with `LIST_JOBS_STATEMENT_TIMEOUT_SECS=5`: a forced lock wait returns the 400 at 5.0s ("more than 5s"). The default instance still answers the same request in ~0.1s unlocked.
- [x] Suspended view: refresh requests carry no `created_after_queue`, as before.
- [x] End-date-only range (`max_ts`): later batches use a `completed_before` cursor.
- [x] Forced timeout in the UI: slow-load toast at 4s, error toast at 30s, and the next refresh sends a `completed_after` bound derived from the load time.
- `npm run check:fast`: no errors in the changed file (4 pre-existing errors elsewhere). The backend builds.

No automated tests: exercising the timeout needs a query slower than 30s, and the cursor logic lives in a composable with no test harness.

## Screenshots

Slow first load with a failure filter and no start date:

![runs-slow-load-toast](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/list-jobs-timeout-cursor/1789061567-runs-slow-load-toast.png)

Load stopped by the 30s timeout:

![runs-timeout-error-toast](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/list-jobs-timeout-cursor/1789061569-runs-timeout-error-toast.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRqFF6xk1A41AcF6NsTDNS
