### PR TITLE
fix: serve instance env settings at the documented /settings/local path

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -113,6 +113,9 @@ async fn get_ruff_config_unauthed(Extension(db): Extension<DB>) -> error::Result
 pub fn global_service() -> Router {
     #[warn(unused_mut)]
     let r = Router::new()
+        // `/local` is the path in openapi.yaml, so every generated client (getLocal) calls it;
+        // `/envs` stays for callers that found the route in the code.
+        .route("/local", get(get_local_settings))
         .route("/envs", get(get_local_settings))
         .route(
             "/global/{key}",


### PR DESCRIPTION
## Summary
`openapi.yaml` documents the superadmin env-settings endpoint as `GET /settings/local` (`getLocal`), but the router only registers it as `/settings/envs` (renamed in #2314 without updating the spec). Every client generated from the spec, including the published TypeScript and Python SDKs and the TS client bundled into the nativets runtime, therefore gets a 404 from `getLocal`.

This registers the handler at `/settings/local` as well, which fixes all existing generated clients without regenerating or releasing them. `/settings/envs` is kept for anyone who calls it directly.

## Changes
- `windmill-api-settings`: `.route("/local", get(get_local_settings))` next to the existing `/envs` route, same handler and same superadmin check.

The committed `openapi-deref.*` bundles and generated clients already use `/settings/local`, so nothing needs regenerating.

## Test plan
- [x] As superadmin, `GET /api/settings/local` now returns 200 with the same body as `GET /api/settings/envs` (it returned 404 before).
- [x] Unauthenticated `GET /api/settings/local` and `/api/settings/envs` both return 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbLzVfFDZ9pjBGHSzCSrNZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the instance env settings endpoint so it's also served at `/settings/local` as documented in `openapi.yaml`, preventing 404s for clients generated from the spec. The existing `/envs` route stays for direct callers.

<sup>Written for commit 509427b516c15525091932fecce460da1d767174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

