### PR TITLE
fix: skip the deploy PR when the git sync push committed nothing

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -183,7 +183,7 @@ pub enum ObjectType {
     DatatableMigration,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28949/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28958/sync-script-to-git-repo-windmill";
 
 /// Hub script that applies a repository's state back into a workspace
 /// (the repo → Windmill / "pull" direction). Same script the UI runs from

--- a/integration_tests/test/git_sync_test.py
+++ b/integration_tests/test/git_sync_test.py
@@ -771,6 +771,69 @@ class TestGitSync(GitSyncTestBase):
             f"Expected folder-grouped branch name containing '{expected_folder_part}', got: {deploy_branch}",
         )
 
+    def _new_sync_job_results(self, seen: set, path: str) -> list:
+        """Results of the deploy callbacks not in `seen` that pushed `path`."""
+        results = []
+        for listed in self._client.get_completed_jobs(job_kinds="deploymentcallback"):
+            if listed["id"] in seen:
+                continue
+            job = self._client._client.get(
+                f"/api/w/{self._client._workspace}/jobs_u/get/{listed['id']}"
+            ).json()
+            items = (job.get("args") or {}).get("items") or []
+            if any(item.get("path") == path for item in items):
+                results.append(job.get("result"))
+        return results
+
+    def test_promotion_push_reports_whether_it_pushed(self):
+        """The push job's result says whether a commit was pushed, and the
+        PR-on-deploy hook relies on it: on `pushed: false` it skips, otherwise
+        it asks the host for a PR on the deploy branch, which for a push that
+        committed nothing was never created (GitHub: 422 "head invalid")."""
+        repo_name, _ = self._create_test_repo()
+        resource_path = self._setup_git_sync_resource(repo_name)
+
+        # Saving the config is itself a settings deploy, and it commits nothing:
+        # the repo has no wmill.yaml including settings, so none are pulled.
+        seen = {j["id"] for j in self._client.get_completed_jobs(job_kinds="deploymentcallback")}
+        self._configure_single_repo_sync(
+            resource_path,
+            include_type=["script", "settings"],
+            use_individual_branch=True,
+            group_by_folder=True,
+        )
+        self._wait_until(
+            lambda: self._new_sync_job_results(seen, "settings.yaml"),
+            timeout=90,
+            message="no push job for the settings deploy",
+        )
+        results = self._new_sync_job_results(seen, "settings.yaml")
+        self.assertEqual(
+            [(r or {}).get("pushed") for r in results],
+            [False],
+            f"a settings deploy that committed nothing must report pushed: false, got: {results}",
+        )
+
+        folder_name = unique_name("pushed")
+        self._create_folder(folder_name)
+        seen = {j["id"] for j in self._client.get_completed_jobs(job_kinds="deploymentcallback")}
+        script_path = f"f/{folder_name}/{unique_name('script')}"
+        self._client.create_script(
+            path=script_path,
+            content=ts_script("return 'pushed'"),
+            language="bun",
+        )
+        self._wait_until(
+            lambda: self._new_sync_job_results(seen, script_path),
+            timeout=90,
+            message=f"no push job for {script_path}",
+        )
+        results = self._new_sync_job_results(seen, script_path)
+        self.assertTrue(
+            all((r or {}).get("pushed") is True for r in results),
+            f"a deploy that committed must report pushed: true, got: {results}",
+        )
+
     # ──────────────────────────────────────────────────
     # Exclude path filtering
     # ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

With promotion mode and **Open a pull request for each deploy branch** on, a deploy whose push commits nothing still asks the git host for a PR on its `wm_deploy/**` branch. That branch was never pushed, so GitHub answers `422 Validation Failed` (`field: head, code: invalid`), and the error lands on the repo card as `open_pr_error`.

Settings deploys hit this most often, for three reasons:
- In promotion mode, settings.yaml only lands when the repo's wmill.yaml includes settings.
- Several settings writes never change settings.yaml at all (shared UI, protection rules, public app rate limit).
- Saving the git sync repository is itself a settings deploy. That includes turning the PR toggle on, so enabling the toggle is enough to trigger the error.

The completion hook `maybe_open_git_sync_deploy_pr` already skips PR creation when the push reports `pushed: false`, but that check has never fired. Every sync hub script from 28786 (the version PR-on-deploy shipped with) through 28949 computes `{ pushed }` in `inner()` and then drops it in `main()`, so the job result is always `null`.

windmill-integrations#193 fixed `main()`, and the fix is published as hub 28958. This PR pins it. Compared with 28949, 28958 only changes how the result is returned and uses the same windmill-cli 1.802.1. It also reports `sha`, `branch` and `rebased`, which nothing on main reads.

This is the first time that skip is actually live, which changes two things users can see:
- Redeploying an unchanged item no longer retries a PR that failed earlier.
- An existing `open_pr_error` stays on the card until the next deploy that commits and opens its PR.

#10096 sets this constant to the same value as part of WIN-2051. The two edits to that line are identical, so either merge order applies cleanly. This PR lets the fix ship without waiting for that feature.

## Changes

- `LATEST_GIT_SYNC_SCRIPT_PATH` now points to hub/28958 instead of hub/28949.
  - Repos pinned to an explicit `script_path` keep their pin. Their repo card already offers to switch them to latest.
  - `GIT_SYNC_PULL_SCRIPT_PATH` and `gitInitRepo` stay at 28948. The newer pull script only adds result fields that #10096 uses.
- New git sync e2e test, `test_promotion_push_reports_whether_it_pushed`, pins the result the PR hook reads:
  - An empty promotion push (the settings deploy that saving the config triggers) must report `pushed: false`.
  - A push that commits must report `pushed: true`.
  - Any change to `workspaces.rs` runs the git-sync e2e workflow, so a future pin to a script that drops the result fails here.

The CLI is unchanged. `gitSyncIncludePattern` gives settings and key the script pattern (`settings.yaml.*`), which looks wrong but has no effect: `ignoreF` lets those files bypass path filters whenever their include flag is set, and when the flag is off the export doesn't contain them.

## Test plan

- [x] Before/after e2e on an EE build.
  - Setup: a local GitLab stand-in (git smart-HTTP plus `/api/v4`) that answers a PR on a missing branch with GitHub's 422 body. Promotion mode with group by folder, settings in the repo's include types, and a repo wmill.yaml without `includeSettings`.
  - hub 28949: turning the PR toggle on produced a settings push with result `null`, then a PR request for `wm_deploy/admins/settings.yaml`, a 422 head invalid, and `open_pr_error` on the card.
  - hub 28958: the same steps produced result `{"pushed": false}`, no PR request, and no `open_pr_error`.
- [x] PRs still open for pushes that commit: a script deploy (`wm_deploy/admins/f__promo`) and a settings deploy with `includeSettings: true` both opened their PR.
- [x] The new test fails with the repo pinned to hub 28949 (`[None] != [False]`) and passes on 28958.
- [x] Full git sync e2e suite passes locally: 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVDyzszjbvSssMN6HpnZZw


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deploy PR hook so it skips opening a PR when the git sync push committed nothing, instead of asking the host for a PR on a branch that was never pushed and surfacing GitHub's 422 "head invalid" as `open_pr_error`.

- Bumps `LATEST_GIT_SYNC_SCRIPT_PATH` to `hub/28958`; the push job now returns whether it pushed, since the old script always returned `null` and the skip never fired. Only `pushed` is read; `GIT_SYNC_PULL_SCRIPT_PATH` stays at 28948.
- Repos pinned to an explicit `script_path` keep their pin — their card already offers switching to latest.
- Adds `test_promotion_push_reports_whether_it_pushed`: an empty settings push must report `pushed: false` and a committing script push `pushed: true`, so a future pin that drops the result fails CI.
- Side effects: redeploying an unchanged item no longer retries a previously failed PR, and an existing `open_pr_error` stays until the next deploy that commits and opens its PR.
- The constant bump is the same edit planned for WIN-2051, so whichever merges first applies cleanly.

<sup>Written for commit 9930f5494b2e072f87a5ff9537e96cc5d1eee52a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

