### PR TITLE
fix: support gzip and zstd compression for OTLP export over gRPC

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -13622,6 +13622,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2 0.4.19",
  "http 1.5.0",
  "http-body 1.1.0",
@@ -13641,6 +13642,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -701,7 +701,7 @@ async-stream = "^0"
 opentelemetry = "0.30.0"
 tracing-opentelemetry = "0.31.0"
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio", "testing"] }
-opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "tls", "http-proto"] }
+opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "tls", "http-proto", "gzip-tonic", "zstd-tonic"] }
 opentelemetry-appender-tracing = "0.30.0"
 opentelemetry-semantic-conventions = { version = "0.30.0", features = ["semconv_experimental"] }
 opentelemetry-proto = { version = "0.30.0", features = ["with-serde", "gen-tonic"] }


### PR DESCRIPTION
## Summary
Setting `OTEL_EXPORTER_OTLP_COMPRESSION` (directly, or through the compression field of the OTEL instance setting, which `load_otel` mirrors into it) made the OTLP exporters fail to build over gRPC, the default protocol. `opentelemetry-otlp` is compiled without its gRPC compression features, so metrics and tracing were silently disabled:

```
Failed to build OTEL metric exporter: feature 'gzip-tonic' is required to use the compression algorithm 'gzip'
Failed to build OTEL span exporter: feature 'gzip-tonic' is required to use the compression algorithm 'gzip'
```

This enables `gzip-tonic` and `zstd-tonic`, the two algorithms the variable accepts. `flate2` and `zstd` are already in the dependency tree, so no new crates are added (the lockfile only gains the two edges from `tonic`). The HTTP exporter in 0.30 has no compression support and keeps ignoring the variable, as before.

## Changes
- `backend/Cargo.toml`: `opentelemetry-otlp` features += `gzip-tonic`, `zstd-tonic`.

## Test plan
- [x] Before (main): backend with `OTEL_METRICS_ENABLED=true`, `OTEL_TRACING_ENABLED=true`, gRPC endpoint and `OTEL_EXPORTER_OTLP_COMPRESSION=gzip` prints the two errors above and exports nothing.
- [x] After: same env, no build errors, and a local OpenTelemetry collector's gRPC receiver gets the metrics. Repeated with `zstd`: no errors, metrics received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbLzVfFDZ9pjBGHSzCSrNZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OTLP export over gRPC when compression is enabled, so setting `OTEL_EXPORTER_OTLP_COMPRESSION` no longer silently disables metrics and tracing.

- Adds `gzip-tonic` and `zstd-tonic` features to `opentelemetry-otlp`.
- `flate2` and `zstd` were already in the dependency tree, so no new crates are added.
- The HTTP exporter still ignores the compression variable, as before.

<sup>Written for commit 4bb3725602c38a5d355a5d3b98cd7ec13b97fa8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

