### PR TITLE
fix: keep pinned import versions of imported scripts in bun lockfiles

### DIFF
--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -731,6 +731,46 @@ export function main() {
     Ok(())
 }
 
+/// A pinned import in a script the entry imports must keep its version in the generated lock,
+/// the same as a pinned import in the entry itself.
+#[sqlx::test(fixtures("base"))]
+async fn test_bun_lockfile_keeps_pin_of_imported_script(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    sqlx::query(
+        "INSERT INTO script (workspace_id, created_by, content, schema, summary, description, path, hash, language, lock)
+         VALUES ('test-workspace', 'test-user', $1, '{}', '', '', 'f/system/pinned_module', 12350, 'bun', '')",
+    )
+    .bind(
+        r#"
+import _ from "lodash@4.17.20";
+export function helper() { return _.VERSION; }
+"#,
+    )
+    .execute(&db)
+    .await?;
+
+    let result = RunJob::from(JobPayload::RawScriptDependencies {
+        script_path: "f/system/pinned_consumer".into(),
+        content: r#"
+import { helper } from "/f/system/pinned_module";
+export function main() { return helper(); }
+"#
+        .into(),
+        language: ScriptLang::Bun,
+    })
+    .run_until_complete(&db, false, port)
+    .await
+    .json_result()
+    .unwrap();
+
+    let lock = result["lock"].as_str().unwrap_or_default();
+    assert!(lock.contains(r#""lodash": "4.17.20""#), "{result}");
+    Ok(())
+}
+
 // ============================================================================
 // Deeply Nested Import Tests
 // ============================================================================

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -731,46 +731,6 @@ export function main() {
     Ok(())
 }
 
-/// A pinned import in a script the entry imports must keep its version in the generated lock,
-/// the same as a pinned import in the entry itself.
-#[sqlx::test(fixtures("base"))]
-async fn test_bun_lockfile_keeps_pin_of_imported_script(db: Pool<Postgres>) -> anyhow::Result<()> {
-    initialize_tracing().await;
-    let server = ApiServer::start(db.clone()).await?;
-    let port = server.addr.port();
-
-    sqlx::query(
-        "INSERT INTO script (workspace_id, created_by, content, schema, summary, description, path, hash, language, lock)
-         VALUES ('test-workspace', 'test-user', $1, '{}', '', '', 'f/system/pinned_module', 12350, 'bun', '')",
-    )
-    .bind(
-        r#"
-import _ from "lodash@4.17.20";
-export function helper() { return _.VERSION; }
-"#,
-    )
-    .execute(&db)
-    .await?;
-
-    let result = RunJob::from(JobPayload::RawScriptDependencies {
-        script_path: "f/system/pinned_consumer".into(),
-        content: r#"
-import { helper } from "/f/system/pinned_module";
-export function main() { return helper(); }
-"#
-        .into(),
-        language: ScriptLang::Bun,
-    })
-    .run_until_complete(&db, false, port)
-    .await
-    .json_result()
-    .unwrap();
-
-    let lock = result["lock"].as_str().unwrap_or_default();
-    assert!(lock.contains(r#""lodash": "4.17.20""#), "{result}");
-    Ok(())
-}
-
 // ============================================================================
 // Deeply Nested Import Tests
 // ============================================================================

--- a/backend/tests/script_modules.rs
+++ b/backend/tests/script_modules.rs
@@ -159,3 +159,58 @@ export function main(name: string) {
     assert_eq!(result, json!("hello world"));
     Ok(())
 }
+
+/// A multi-file script run without a lock is bundled by the lockfile build. A pinned import in
+/// a workspace script it imports must be installed at that version and still resolve at run time.
+#[sqlx::test(fixtures("base"))]
+async fn test_bun_module_imports_pinned_workspace_script(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    sqlx::query(
+        "INSERT INTO script (workspace_id, created_by, content, schema, summary, description, path, hash, language, lock)
+         VALUES ('test-workspace', 'test-user', $1, '{}', '', '', 'f/system/pinned_module', 12350, 'bun', '')",
+    )
+    .bind(
+        r#"
+import _ from "lodash@4.17.20";
+export function lodashVersion() { return _.VERSION; }
+"#,
+    )
+    .execute(&db)
+    .await?;
+
+    let mut modules = HashMap::new();
+    modules.insert(
+        "helper.ts".to_string(),
+        ScriptModule {
+            content: "export function label(v: string) { return v; }\n".to_string(),
+            language: ScriptLang::Bun,
+            lock: None,
+        },
+    );
+
+    let job = JobPayload::Code(RawCode {
+        content: r#"
+import { lodashVersion } from "/f/system/pinned_module";
+import { label } from "./helper.ts";
+export function main() { return label(lodashVersion()); }
+"#
+        .to_owned(),
+        path: Some("f/system/my_script".to_string()),
+        language: ScriptLang::Bun,
+        modules: Some(modules),
+        tag: None,
+        ..RawCode::default()
+    });
+
+    let result = RunJob::from(job)
+        .run_until_complete(&db, false, port)
+        .await
+        .json_result()
+        .unwrap();
+
+    assert_eq!(result, json!("4.17.20"));
+    Ok(())
+}

--- a/backend/windmill-worker/loader.bun.js
+++ b/backend/windmill-worker/loader.bun.js
@@ -106,8 +106,8 @@ const p = {
       const hash = TEMP_SCRIPT_REFS?.[normalized];
 
       const url = (isRelative
-        ? `${base_internal_url}/api/w/${w_id}/scripts/raw_unpinned/p/${file_path}/../${args.path}${endExt}`
-        : `${base_internal_url}/api/w/${w_id}/scripts/raw_unpinned/p/${args.path}${endExt}`
+        ? `${base_internal_url}/api/w/${w_id}/scripts/RAW_GET_ENDPOINT/p/${file_path}/../${args.path}${endExt}`
+        : `${base_internal_url}/api/w/${w_id}/scripts/RAW_GET_ENDPOINT/p/${args.path}${endExt}`
       ) + (hash ? `?temp_script_hash=${hash}` : "");
       const file = isRelative
         ? resolve("./" + file_path + "/../" + args.path + ".url")


### PR DESCRIPTION
## Summary

Server-side lockfile generation for Bun scripts (dependency jobs on create/edit, and the relative-import relock cascade) dropped `pkg@version` pins that live in a script the entry file imports. Given

```ts
// u/admin/pin_module
import * as wmill from "windmill-client@1.795.0"
export function helper() { return typeof wmill }

// u/admin/pin_consumer
import { helper } from "/u/admin/pin_module"
export function main() { return helper() }
```

`pin_consumer` locked `"windmill-client": "latest"`, while the same pin in the entry file locked `1.795.0`. Every redeploy of an imported script then relocked its importers to `latest`.

**Root cause.** The lock-generation build fetches imported scripts through the relative-import loader (`loader.bun.js`). The loader's endpoint is a `RAW_GET_ENDPOINT` placeholder:
- `gen_bun_lockfile` fills it with `raw`, so pins stay intact.
- `build_loader` fills it with `raw_unpinned`, so pins are stripped for execution.

A later change hardcoded `raw_unpinned` in `loader.bun.js` (7024404bb3), which made the `raw` substitution a no-op. The lockfile builder then saw bare specifiers and defaulted them to `latest`. The Windows loader kept the placeholder and was never affected.

## Changes

- **`backend/windmill-worker/loader.bun.js`:** restore the `RAW_GET_ENDPOINT` placeholder. Lock generation fetches imported scripts from `raw` again. Execution keeps `raw_unpinned` via `build_loader`.
- **`backend/tests/script_modules.rs`:** one regression test. A multi-file script run without a lock imports a deployed script pinning `lodash@4.17.20` and must return `4.17.20`.
  - It goes through `gen_bun_lockfile`, the same function dependency jobs use, so it guards the stored-lock case from the report.
  - It also covers the one run path where the lockfile build's output is executed.

**No runtime strip is needed.** An unlocked multi-file run executes the lockfile build's bundle, which now carries the imported script's specifier verbatim (`from "lodash@4.17.20"`). That bundle only becomes the runtime entry on paths that run bun with `-i --prefer-offline`, and install-fallback resolves the pinned specifier from the cache the job's `bun install` just filled. The test pins that this keeps working.

Existing locks that already drifted to `latest` are not rewritten by this change. They pick up the pin on their next relock, which happens on a redeploy of the script or of anything it imports.

Out of scope, pre-existing: a local module file (as opposed to the entry) that imports a workspace script without the `.ts` extension fails the build with `Unrecognized import`. The loader only appends `.ts` for `main.ts` and fetched scripts.

## Test plan

- [x] New test passes. With the loader back on `raw_unpinned` it fails with `"4.18.1"`: the lock resolves `latest`.
- [x] Existing bun relative-import, nested-import, loader-builder and module tests pass.
- [x] Live instance, the issue's repro: `pin_direct`, `pin_module` and `pin_consumer` all lock `windmill-client` `1.795.0`. Redeploying `pin_module` pinned to `1.796.0` cascades a relock that moves `pin_consumer` to `1.796.0`. The deployed `pin_consumer` still runs.
- [x] Live instance, multi-file preview (entry imports a deployed script pinning `lodash@4.17.20`, plus a local `helper.ts` module) returns `4.17.20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores pinned import versions (e.g. `lodash@4.17.20`) in Bun lockfiles generated server-side for scripts that import other deployed scripts. Previously the importer's lock dropped those pins and resolved `latest`, so every redeploy relocked the importer to `latest`.

- The relative-import loader now keeps the `RAW_GET_ENDPOINT` placeholder; lock generation fills it with `raw` to preserve pins, while execution still uses `raw_unpinned`.
- Adds a regression test proving an unlocked multi-file run imports a pinned workspace script at its pinned version.
- Existing locks that already drifted to `latest` are not rewritten and will pick up the pin on their next relock.

<sup>Written for commit 036003ee01fbd67b33d54ff8d737b57e6c16c1fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

