### PR TITLE
fix: keep each dev server's session when worktrees share a host

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -79,6 +79,10 @@ const remoteUrl =
 		? `http://localhost:${process.env.BACKEND_PORT}`
 		: 'https://app.windmill.dev/')
 
+// Strip the upstream Domain so cookies are host-only: `Domain=localhost` is rejected
+// when the dev server is reached as 127.0.0.1 or over the network.
+const cookieDomain = ''
+
 // Browsers scope cookies by host, not port, so dev servers sharing a host (one per
 // worktree) would share one `token` and every login would sign the others out. Store the
 // session under a name tied to the backend that issued it, and forward only that one as
@@ -157,13 +161,13 @@ const config = {
 			'^/\\.well-known/.*': {
 				target: remoteUrl,
 				changeOrigin: true,
-				cookieDomainRewrite: 'localhost',
+				cookieDomainRewrite: cookieDomain,
 				configure: isolateAuthCookie
 			},
 			'^/api/w/[^/]+/s3_proxy/.*': {
 				target: remoteUrl,
 				changeOrigin: false, // Important for signature to be correct
-				cookieDomainRewrite: 'localhost',
+				cookieDomainRewrite: cookieDomain,
 				configure: (proxy, options) => {
 					isolateAuthCookie(proxy)
 					proxy.on('proxyReq', (proxyReq, req, res) => {
@@ -177,7 +181,7 @@ const config = {
 			'^/api/.*': {
 				target: remoteUrl,
 				changeOrigin: true,
-				cookieDomainRewrite: 'localhost',
+				cookieDomainRewrite: cookieDomain,
 				configure: isolateAuthCookie
 			},
 			'^/ws/.*': {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -79,7 +79,31 @@ const remoteUrl =
 		? `http://localhost:${process.env.BACKEND_PORT}`
 		: 'https://app.windmill.dev/')
 
-const cookieDomain = process.env.ISOLATE_DEV_AUTH === '1' ? '' : 'localhost'
+// Browsers scope cookies by host, not port, so dev servers sharing a host (one per
+// worktree) would share one `token` and every login would sign the others out. Store the
+// session under a name tied to the backend that issued it, and forward only that one as
+// `token`, the name the backend reads.
+const authCookie = `token_${new URL(remoteUrl).host.replace(/\W/g, '_')}`
+
+function isolateAuthCookie(proxy) {
+	proxy.on('proxyReq', (proxyReq, req) => {
+		const kept = []
+		let session
+		for (const cookie of (req.headers.cookie ?? '').split(/;\s*/)) {
+			if (cookie.startsWith(`${authCookie}=`)) session = cookie.slice(authCookie.length + 1)
+			else if (cookie && !cookie.startsWith('token=')) kept.push(cookie)
+		}
+		if (session !== undefined) kept.push(`token=${session}`)
+		if (kept.length) proxyReq.setHeader('cookie', kept.join('; '))
+		else proxyReq.removeHeader('cookie')
+	})
+	proxy.on('proxyRes', (proxyRes) => {
+		const setCookie = proxyRes.headers['set-cookie']
+		if (setCookie) {
+			proxyRes.headers['set-cookie'] = setCookie.map((c) => c.replace(/^token=/, `${authCookie}=`))
+		}
+	})
+}
 
 // Cross-origin isolation headers, scoped to mirror the production predicate —
 // see `needs_cross_origin_isolation` in backend/windmill-api/src/static_assets.rs
@@ -133,13 +157,15 @@ const config = {
 			'^/\\.well-known/.*': {
 				target: remoteUrl,
 				changeOrigin: true,
-				cookieDomainRewrite: cookieDomain
+				cookieDomainRewrite: 'localhost',
+				configure: isolateAuthCookie
 			},
 			'^/api/w/[^/]+/s3_proxy/.*': {
 				target: remoteUrl,
 				changeOrigin: false, // Important for signature to be correct
-				cookieDomainRewrite: cookieDomain,
+				cookieDomainRewrite: 'localhost',
 				configure: (proxy, options) => {
+					isolateAuthCookie(proxy)
 					proxy.on('proxyReq', (proxyReq, req, res) => {
 						// Prevent collapsing slashes during URL normalization
 						const originalPath = req.url
@@ -151,7 +177,8 @@ const config = {
 			'^/api/.*': {
 				target: remoteUrl,
 				changeOrigin: true,
-				cookieDomainRewrite: cookieDomain
+				cookieDomainRewrite: 'localhost',
+				configure: isolateAuthCookie
 			},
 			'^/ws/.*': {
 				target: process.env.REMOTE_LSP ?? process.env.REMOTE_EXTRA ?? 'https://app.windmill.dev',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -79,17 +79,19 @@ const remoteUrl =
 		? `http://localhost:${process.env.BACKEND_PORT}`
 		: 'https://app.windmill.dev/')
 
-// Strip the upstream Domain so cookies are host-only: `Domain=localhost` is rejected
-// when the dev server is reached as 127.0.0.1 or over the network.
-const cookieDomain = ''
-
 // Browsers scope cookies by host, not port, so dev servers sharing a host (one per
-// worktree) would share one `token` and every login would sign the others out. Store the
-// session under a name tied to the backend that issued it, and forward only that one as
-// `token`, the name the backend reads.
+// worktree) would share one `token` and each login would sign the others out. The session
+// is stored under a name tied to its backend and forwarded as `token`, the name the backend
+// reads. ISOLATE_DEV_AUTH=0 keeps the shared `token` for tools reading it across instances.
+const isolateDevAuth = process.env.ISOLATE_DEV_AUTH !== '0'
 const authCookie = `token_${new URL(remoteUrl).host.replace(/\W/g, '_')}`
 
+// Isolated cookies are host-only: `Domain=localhost` is rejected when the dev server is
+// reached as 127.0.0.1 or over the network.
+const cookieDomain = isolateDevAuth ? '' : 'localhost'
+
 function isolateAuthCookie(proxy) {
+	if (!isolateDevAuth) return
 	proxy.on('proxyReq', (proxyReq, req) => {
 		const kept = []
 		let session


### PR DESCRIPTION
## Summary

Browsers scope cookies by host, not by port. Dev servers reached on one host (several worktrees on different ports, via `localhost` or a Tailscale IP) all shared one `token` cookie. Logging into one therefore signed every other one out, because each worktree has its own database and the other session's token is not valid there.

The Vite proxy now stores the session under a name tied to the backend it proxies to, e.g. `token_localhost_8200`, and forwards it to the backend as `token`.

The name is keyed by the backend URL, not the frontend port. `dev-supervisor.mjs` starts vite on an internal port and rewrites `FRONTEND_PORT` to it, so a port-keyed name would change every time vite restarts after going idle.

`ISOLATE_DEV_AUTH` (#9576) targeted the same problem as an opt-in, but it only removed the cookie `Domain`, which does not separate ports. It is now on by default:

- **Default:** per-backend cookie names, and `Domain` is stripped so cookies are host-only. Session cookies from an upstream that sets a `Domain`, such as a backend with `COOKIE_DOMAIN`, now work when the dev server is opened on `127.0.0.1` or another host, not only on `localhost`.
- **`ISOLATE_DEV_AUTH=0`:** the previous behaviour, with one plain `token` shared by every dev server on the host and `Domain` rewritten to `localhost`. This is for tools that read that cookie across instances.

## Changes

- `frontend/vite.config.js`: a new `isolateAuthCookie` proxy hook on the `/api`, `s3_proxy` and `/.well-known` rules.
  - Responses: renames `Set-Cookie: token=` to the per-backend name.
  - Requests: forwards only that cookie, as `token`. A leftover shared `token` is dropped.
- `cookieDomainRewrite` is `''`, which strips `Domain`, when isolated, and `localhost` with `ISOLATE_DEV_AUTH=0`.

OAuth is unaffected. Providers send the browser back to frontend routes (`/user/login_callback/…`, `/oauth/callback/…`), which finish the login through `/api`. The OAuth `csrf`, guest-app and `mcp_oauth` cookies pass through the proxy unchanged.

## Test plan

- [x] Two dev servers from this branch, proxying to two different worktree backends, reached on both `100.88.12.12` and `localhost`. After logging into both (curl cookie jar, plus headless Chromium on the Tailscale IP), `whoami` through each still returns 200. Before, the second login replaced the first cookie.
- [x] A request carrying a leftover plain `token` and another backend's cookie still authenticates with this backend's session.
- [x] Logging out on one server clears only its cookie: `whoami` returns 401 there and still 200 on the other.
- [x] Against a stub upstream that sets `Domain=example.test`:
  - before the Domain change, the cookie was rejected on the Tailscale IP and the upstream received no cookie;
  - after it, the cookie is stored host-only and forwarded on both `localhost` and the Tailscale IP.
- [x] `ISOLATE_DEV_AUTH=0`: login sets a plain `token` and authenticates, the same as before this PR.
- [ ] Not exercised: an OAuth login end to end, which needs an EE build with a configured provider. It relies on the same proxied `Set-Cookie` and `/api` round-trip tested above.
- [ ] Not exercised: `/api/w/<ws>/s3_proxy/`. That route is only mounted with `private,parquet`. It calls the same hook as `/api`.

One-time effect: every dev server needs a fresh login after this change, because the old shared `token` cookie is ignored.

## Screenshots

No visible UI effect: this only changes the dev server's proxy config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
