### PR TITLE
feat: let apps hide the viewer login status on public urls

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -33958,6 +33958,12 @@ components:
             the app bundle so `windmill-client` calls run as the viewer. Must
             be a subset of the server's curated allowlist (jobs:run, jobs:read,
             users:read, resources:read, variables:read).
+        hide_login_status:
+          type: boolean
+          description: >
+            When true, the app's public and custom URLs do not show the viewer's
+            login status (the user they are signed in as, or that they are
+            signed out) in the top-left corner. Absent or false shows it.
 
     ListableApp:
       type: object

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -521,6 +521,9 @@ pub struct Policy {
     /// `FRONTEND_SDK_ALLOWED_SCOPES`; absent means no credential (the default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frontend_sdk_scopes: Option<Vec<String>>,
+    /// Display only: hides the viewer's login status badge on the public viewer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hide_login_status: Option<bool>,
 }
 
 impl Policy {
@@ -4580,6 +4583,7 @@ async fn upload_s3_file_from_app(
             allowed_s3_keys: None,
             sandbox: None,
             frontend_sdk_scopes: None,
+            hide_login_status: None,
         })
     } else {
         let policy_o = sqlx::query_scalar!(
@@ -4995,6 +4999,7 @@ async fn get_on_behalf_authed_from_app(
             allowed_s3_keys: Some(force_allowed_s3_keys),
             sandbox: None,
             frontend_sdk_scopes: None,
+            hide_login_status: None,
         }
     } else {
         // TODO: improve db query to not return uneeded fields
@@ -5019,6 +5024,7 @@ async fn get_on_behalf_authed_from_app(
                 allowed_s3_keys: None,
                 sandbox: None,
                 frontend_sdk_scopes: None,
+                hide_login_status: None,
             })
     };
 

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -1265,7 +1265,7 @@ is, a different one moves it there and archives the old path"),
                                 },
                                 "execution_mode": {
                                         "type": "string",
-                                        "description": "Who the app's runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Either way `anonymous`, which makes the app publicly executable, is never assumed. Possible values: viewer, publisher, anonymous"
+                                        "description": "Who may open the app, and who its runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Neither `anonymous`, which makes the app publicly executable, nor `guest`, which opens it to anyone the identity provider authenticates, is ever assumed. A guest is only admitted where the workspace also has `guest_access_enabled`, which is checked when the session is minted and again on every guest request. Possible values: viewer, publisher, guest, anonymous"
                                 },
                                 "on_behalf_of": {
                                         "type": "string"
@@ -1283,6 +1283,10 @@ is, a different one moves it there and archives the old path"),
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true — an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
+                                },
+                                "hide_login_status": {
+                                        "type": "boolean",
+                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 }
@@ -1380,7 +1384,7 @@ is, a different one moves it there and archives the old path"),
                                 },
                                 "execution_mode": {
                                         "type": "string",
-                                        "description": "Who the app's runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Either way `anonymous`, which makes the app publicly executable, is never assumed. Possible values: viewer, publisher, anonymous"
+                                        "description": "Who may open the app, and who its runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Neither `anonymous`, which makes the app publicly executable, nor `guest`, which opens it to anyone the identity provider authenticates, is ever assumed. A guest is only admitted where the workspace also has `guest_access_enabled`, which is checked when the session is minted and again on every guest request. Possible values: viewer, publisher, guest, anonymous"
                                 },
                                 "on_behalf_of": {
                                         "type": "string"
@@ -1398,6 +1402,10 @@ is, a different one moves it there and archives the old path"),
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true — an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
+                                },
+                                "hide_login_status": {
+                                        "type": "boolean",
+                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 },

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -649,6 +649,24 @@
 				</div>
 			{/if}
 		</div>
+
+		<div class="mt-4">
+			<Toggle
+				options={{ right: "Show the viewer's login status" }}
+				checked={!policy.hide_login_status}
+				on:change={(e) => {
+					policy.hide_login_status = e.detail ? undefined : true
+					if (savedApp && !newApp) {
+						setPublishState(e.detail ? 'Login status shown' : 'Login status hidden')
+					}
+				}}
+				disabled={!savedApp}
+			/>
+			<div class="text-xs text-secondary mt-1">
+				The public and custom URLs show who the viewer is signed in as, or that they are signed out,
+				in the top-left corner.
+			</div>
+		</div>
 	</div>
 	<Alert type="info" title="Only latest deployed app is publicly available">
 		You will still need to deploy the app to make visible the latest changes

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -651,20 +651,19 @@
 		</div>
 
 		<div class="mt-4">
+			<!-- Applied by the deploy rather than `setPublishState`: that call claims the
+			     app's run-as identity and republishes the editor's triggerables, too much
+			     for a display setting. -->
 			<Toggle
 				options={{ right: "Show the viewer's login status" }}
 				checked={!policy.hide_login_status}
 				on:change={(e) => {
 					policy.hide_login_status = e.detail ? undefined : true
-					if (savedApp && !newApp) {
-						setPublishState(e.detail ? 'Login status shown' : 'Login status hidden')
-					}
 				}}
-				disabled={!savedApp}
 			/>
 			<div class="text-xs text-secondary mt-1">
 				The public and custom URLs show who the viewer is signed in as, or that they are signed out,
-				in the top-left corner.
+				in the top-left corner. Applies on the next deploy.
 			</div>
 		</div>
 	</div>

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -651,19 +651,20 @@
 		</div>
 
 		<div class="mt-4">
-			<!-- Applied by the deploy rather than `setPublishState`: that call claims the
-			     app's run-as identity and republishes the editor's triggerables, too much
-			     for a display setting. -->
 			<Toggle
 				options={{ right: "Show the viewer's login status" }}
 				checked={!policy.hide_login_status}
 				on:change={(e) => {
 					policy.hide_login_status = e.detail ? undefined : true
+					if (savedApp && !newApp) {
+						setPublishState(e.detail ? 'Login status shown' : 'Login status hidden')
+					}
 				}}
+				disabled={!savedApp}
 			/>
 			<div class="text-xs text-secondary mt-1">
 				The public and custom URLs show who the viewer is signed in as, or that they are signed out,
-				in the top-left corner. Applies on the next deploy.
+				in the top-left corner.
 			</div>
 		</div>
 	</div>

--- a/frontend/src/lib/components/apps/editor/PublicApp.svelte
+++ b/frontend/src/lib/components/apps/editor/PublicApp.svelte
@@ -56,6 +56,10 @@
 	// Use workspace from props or from app.workspace_id (for custom path responses)
 	let effectiveWorkspace = $derived(workspace ?? app?.workspace_id)
 
+	// The setting lives on the app, so the badge waits for it while loading
+	// instead of flashing on an app that hides it.
+	let showLoginStatus = $derived(app ? !app.policy?.hide_login_status : notExists || noPermission)
+
 	// On the public surfaces (untrusted distribution) runnable-authored html/svg needs
 	// the viewer's approval before it renders, unless the app sandbox isolates it. The
 	// in-workspace viewer renders it verbatim. See getAppMarkupTrust.
@@ -116,13 +120,15 @@
 		<div class="flex gap-1 items-center"><User size={14} />{child}</div>
 	{/snippet}
 
-	<div class="z-50 text-2xs text-primary absolute top-3 left-2"
-		>{#if $userStore}
-			{@render userInfo($userStore.username)}
-		{:else if globalUser}
-			{@render userInfo(globalUser.email)}
-		{:else}<UserRoundX size={14} />{/if}
-	</div>
+	{#if showLoginStatus}
+		<div class="z-50 text-2xs text-primary absolute top-3 left-2"
+			>{#if $userStore}
+				{@render userInfo($userStore.username)}
+			{:else if globalUser}
+				{@render userInfo(globalUser.email)}
+			{:else}<UserRoundX size={14} />{/if}
+		</div>
+	{/if}
 {/if}
 
 {#if notExists}

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -1272,7 +1272,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                                 },
                                 "execution_mode": {
                                         "type": "string",
-                                        "description": "Who the app's runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Either way `anonymous`, which makes the app publicly executable, is never assumed. Possible values: viewer, publisher, anonymous"
+                                        "description": "Who may open the app, and who its runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Neither `anonymous`, which makes the app publicly executable, nor `guest`, which opens it to anyone the identity provider authenticates, is ever assumed. A guest is only admitted where the workspace also has `guest_access_enabled`, which is checked when the session is minted and again on every guest request. Possible values: viewer, publisher, guest, anonymous"
                                 },
                                 "on_behalf_of": {
                                         "type": "string"
@@ -1290,6 +1290,10 @@ export const mcpEndpointTools: EndpointTool[] = [
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true \u2014 an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
+                                },
+                                "hide_login_status": {
+                                        "type": "boolean",
+                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 }
@@ -1387,7 +1391,7 @@ export const mcpEndpointTools: EndpointTool[] = [
                                 },
                                 "execution_mode": {
                                         "type": "string",
-                                        "description": "Who the app's runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Either way `anonymous`, which makes the app publicly executable, is never assumed. Possible values: viewer, publisher, anonymous"
+                                        "description": "Who may open the app, and who its runnables execute as. Optional, and what omitting it means depends on the operation: creating an app defaults it to `publisher` (runs on behalf of the app's publisher and requires an authenticated viewer), while updating one keeps the mode the app is already deployed under. Neither `anonymous`, which makes the app publicly executable, nor `guest`, which opens it to anyone the identity provider authenticates, is ever assumed. A guest is only admitted where the workspace also has `guest_access_enabled`, which is checked when the session is minted and again on every guest request. Possible values: viewer, publisher, guest, anonymous"
                                 },
                                 "on_behalf_of": {
                                         "type": "string"
@@ -1405,6 +1409,10 @@ export const mcpEndpointTools: EndpointTool[] = [
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true \u2014 an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
+                                },
+                                "hide_login_status": {
+                                        "type": "boolean",
+                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 },


### PR DESCRIPTION
## Summary

Raw and low-code apps opened from their public (secret) URL or custom URL show a badge in the top-left corner: the username the viewer is signed in as, or a crossed-out user icon when they are signed out. The badge sits on top of the app's own content, which gets in the way for apps embedded in another product. This PR makes it a per-app setting, **on by default**, so existing apps are unchanged.

The setting is an optional `hide_login_status` field on the app `Policy`, toggled from the deploy drawer's Access section, which both editors share.

Why the policy and not the app `value`: raw-app values are rebuilt as `{ files, runnables, data }` in several deploy paths (CLI push, `rawAppDeploy.ts`, AI chat merges), and each would silently drop a new key. Policy fields such as `sandbox` already survive all of them: `updatePolicy` / `updateRawAppPolicy` spread the current policy, and the CLI push starts from the deployed one (`basePolicy`). Both public endpoints return the stored policy, including the EE custom-path one and the sandboxed iframe viewer.

The toggle saves the way its neighbours in the drawer do (sandbox, access mode, frontend API scopes). For a deployed app it persists on change through `setPublishState`, with no new app version. For a not-yet-deployed app it rides along with the first deploy. One side effect comes from that shared path and is not new here: `setPublishState` sends the whole in-editor policy without `preserve_on_behalf_of`, so the person who flips any of these toggles becomes the app's run-as identity.

## Changes
- **Backend:** `Policy.hide_login_status: Option<bool>`, skipped when absent. Updated the three existing `Policy { .. }` literals.
- **OpenAPI:** documented the field on the `Policy` schema. Regenerated the MCP tool schemas (`auto_generated_endpoints.rs`, `mcpEndpointTools.ts`) from the spec. This also brings in the spec's current `execution_mode` description, which the generated files had fallen behind on.
- **`AppEditorHeaderDeploy.svelte`:** new "Show the viewer's login status" toggle in the Access section. Turning it back on removes the field instead of storing `false`.
- **`PublicApp.svelte`:** the badge renders only when the loaded app does not hide it. While the app is still loading the badge waits, so it never flashes on an app that hides it. The not-found and no-permission states keep it as before.

## Not covered
- **Git sync promotion:** like `sandbox`, the field is carried over by CLI pushes to an existing app, but it is not written to `app.yaml` / `raw_app.yaml`. A git-sync promotion that creates the app in another workspace starts with the default (badge shown).
- **Custom URLs (`/a/...`) are EE only** and weren't exercised on this CE build. They render through the same `PublicApp` and their endpoint returns the same stored policy.
- **No telemetry:** a display toggle whose default stays on answers no product question.

## Test plan
Run against this worktree's dev instance with one public low-code app and one public raw app:
- [x] By default both public pages show the badge: `admin` when signed in, the crossed-out icon when signed out.
- [x] Low-code: turning the toggle off shows a "Login status hidden" toast. The policy immediately has `hide_login_status: true`, with no new version and `execution_mode` unchanged. The badge is gone for signed-in and signed-out visitors, and a MutationObserver installed before navigation confirms it never appeared during load. Reopening the editor shows the toggle off, and a later full deploy keeps it.
- [x] Raw app: same flow from the raw editor's drawer, plus a real raw deploy (new version, flag kept). The badge is gone and the app still renders.
- [x] Sandboxed raw app, where the viewer renders in the opaque iframe: the badge shows by default, and with the flag set it is absent from every frame.
- [x] Turning the setting back on ("Login status shown") removes the field from the stored policy, and a signed-out visitor sees the crossed-out icon again.
- [x] `npm run check`: 2 errors, both in `Tutorial.svelte`, which this PR doesn't touch. The backend compiles in the dev pane (`cargo run --features quickjs`).

## Screenshots

Deploy drawer, Access section:

![badge_drawer_toggle](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/user-logged-status-toggle/1789123616-badge_drawer_toggle.png)

Low-code app public URL, before (the badge overlaps the app's own top-left text) and after:

![badge_lc_before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/user-logged-status-toggle/1789123617-badge_lc_before.png)
![badge_lc_after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/user-logged-status-toggle/1789123618-badge_lc_after.png)

Raw app public URL, before and after:

![badge_raw_before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/user-logged-status-toggle/1789123619-badge_raw_before.png)
![badge_raw_after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/user-logged-status-toggle/1789123620-badge_raw_after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTWrfHeqcFMH8qWdsP6kEr