### PR TITLE
feat: remove the viewer login status badge from public apps

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -33969,12 +33969,6 @@ components:
             the app bundle so `windmill-client` calls run as the viewer. Must
             be a subset of the server's curated allowlist (jobs:run, jobs:read,
             users:read, resources:read, variables:read).
-        hide_login_status:
-          type: boolean
-          description: >
-            When true, the app's public and custom URLs do not show the viewer's
-            login status (the user they are signed in as, or that they are
-            signed out) in the top-left corner. Absent or false shows it.
 
     ListableApp:
       type: object

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -521,9 +521,6 @@ pub struct Policy {
     /// `FRONTEND_SDK_ALLOWED_SCOPES`; absent means no credential (the default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frontend_sdk_scopes: Option<Vec<String>>,
-    /// Display only: hides the viewer's login status badge on the public viewer.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hide_login_status: Option<bool>,
 }
 
 impl Policy {
@@ -4583,7 +4580,6 @@ async fn upload_s3_file_from_app(
             allowed_s3_keys: None,
             sandbox: None,
             frontend_sdk_scopes: None,
-            hide_login_status: None,
         })
     } else {
         let policy_o = sqlx::query_scalar!(
@@ -4999,7 +4995,6 @@ async fn get_on_behalf_authed_from_app(
             allowed_s3_keys: Some(force_allowed_s3_keys),
             sandbox: None,
             frontend_sdk_scopes: None,
-            hide_login_status: None,
         }
     } else {
         // TODO: improve db query to not return uneeded fields
@@ -5024,7 +5019,6 @@ async fn get_on_behalf_authed_from_app(
                 allowed_s3_keys: None,
                 sandbox: None,
                 frontend_sdk_scopes: None,
-                hide_login_status: None,
             })
     };
 

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -1283,10 +1283,6 @@ is, a different one moves it there and archives the old path"),
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true — an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
-                                },
-                                "hide_login_status": {
-                                        "type": "boolean",
-                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 }
@@ -1402,10 +1398,6 @@ is, a different one moves it there and archives the old path"),
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true — an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
-                                },
-                                "hide_login_status": {
-                                        "type": "boolean",
-                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 },

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -649,24 +649,6 @@
 				</div>
 			{/if}
 		</div>
-
-		<div class="mt-4">
-			<Toggle
-				options={{ right: "Show the viewer's login status" }}
-				checked={!policy.hide_login_status}
-				on:change={(e) => {
-					policy.hide_login_status = e.detail ? undefined : true
-					if (savedApp && !newApp) {
-						setPublishState(e.detail ? 'Login status shown' : 'Login status hidden')
-					}
-				}}
-				disabled={!savedApp}
-			/>
-			<div class="text-xs text-secondary mt-1">
-				The public and custom URLs show who the viewer is signed in as, or that they are signed out,
-				in the top-left corner.
-			</div>
-		</div>
 	</div>
 	<Alert type="info" title="Only latest deployed app is publicly available">
 		You will still need to deploy the app to make visible the latest changes

--- a/frontend/src/lib/components/apps/editor/PublicApp.svelte
+++ b/frontend/src/lib/components/apps/editor/PublicApp.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { User, UserRoundX } from 'lucide-svelte'
 	import { applyDarkModeVariant } from '$lib/darkModeVariant'
 	import { enterpriseLicense, userStore } from '$lib/stores'
 	import { base } from '$app/paths'
@@ -48,7 +47,7 @@
 		/**
 		 * In-workspace rendering (`/apps/get`, `/app_embed`): keep exact parity
 		 * with the pre-sandbox member viewer — no "Powered by Windmill" badge, no
-		 * user overlay, no HTML-result approval gate, column flex wrapper.
+		 * HTML-result approval gate, column flex wrapper.
 		 */
 		inWorkspace?: boolean
 		hideRefreshBar?: boolean
@@ -56,10 +55,6 @@
 
 	// Use workspace from props or from app.workspace_id (for custom path responses)
 	let effectiveWorkspace = $derived(workspace ?? app?.workspace_id)
-
-	// The setting lives on the app, so the badge waits for it while loading
-	// instead of flashing on an app that hides it.
-	let showLoginStatus = $derived(app ? !app.policy?.hide_login_status : notExists || noPermission)
 
 	// On the public surfaces (untrusted distribution) runnable-authored html/svg needs
 	// the viewer's approval before it renders, unless the app sandbox isolates it. The
@@ -116,20 +111,6 @@
 			>Powered by &nbsp;<WindmillIcon />&nbsp;Windmill</a
 		>
 	</div>
-
-	{#snippet userInfo(child)}
-		<div class="flex gap-1 items-center"><User size={14} />{child}</div>
-	{/snippet}
-
-	{#if showLoginStatus}
-		<div class="z-50 text-2xs text-primary absolute top-3 left-2"
-			>{#if $userStore}
-				{@render userInfo($userStore.username)}
-			{:else if globalUser}
-				{@render userInfo(globalUser.email)}
-			{:else}<UserRoundX size={14} />{/if}
-		</div>
-	{/if}
 {/if}
 
 {#if notExists}

--- a/frontend/src/lib/components/apps/editor/PublicApp.svelte
+++ b/frontend/src/lib/components/apps/editor/PublicApp.svelte
@@ -8,7 +8,7 @@
 	import Alert from '$lib/components/common/alert/Alert.svelte'
 	import Skeleton from '$lib/components/common/skeleton/Skeleton.svelte'
 	import WindmillIcon from '$lib/components/icons/WindmillIcon.svelte'
-	import { getContext, onMount, setContext } from 'svelte'
+	import { getContext, setContext } from 'svelte'
 	import {
 		EMBED_NAV_CONTEXT_KEY,
 		IS_APP_PUBLIC_CONTEXT_KEY,
@@ -92,12 +92,12 @@
 		// console.log(user)
 	}
 
-	onMount(() => {
-		// this is to avoid loading global user if the userStore is set at loading
-		setTimeout(() => {
-			if ($userStore) return
+	// Only the no-access page reads it, to tell a signed-in non-member which
+	// workspace the app belongs to.
+	$effect(() => {
+		if (noPermission && !guestAppPath && !$userStore && !globalUser) {
 			loadGlobalUser()
-		}, 2000)
+		}
 	})
 </script>
 

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -1290,10 +1290,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true \u2014 an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
-                                },
-                                "hide_login_status": {
-                                        "type": "boolean",
-                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 }
@@ -1409,10 +1405,6 @@ export const mcpEndpointTools: EndpointTool[] = [
                                                 "type": "string"
                                         },
                                         "description": "Raw apps: author-declared scopes for the frontend SDK token. Takes effect only when `sandbox` is also true \u2014 an unsandboxed bundle runs with the viewer's own session, so no token is advertised or minted for it and this list stays inert. On a sandboxed app a non-empty list lets viewers mint (after consenting) a short-lived token carrying their own identity restricted to these scopes, handed to the app bundle so `windmill-client` calls run as the viewer. Must be a subset of the server's curated allowlist (jobs:run, jobs:read, users:read, resources:read, variables:read).\n"
-                                },
-                                "hide_login_status": {
-                                        "type": "boolean",
-                                        "description": "When true, the app's public and custom URLs do not show the viewer's login status (the user they are signed in as, or that they are signed out) in the top-left corner. Absent or false shows it.\n"
                                 }
                         }
                 },


### PR DESCRIPTION
## Summary

Public and custom app URLs showed the viewer's login status in the top-left corner: the username (or global email) of whoever was signed in, or a crossed-out user icon when signed out. #11089 added a per-app toggle to hide it. This PR removes the badge entirely instead, and with it that toggle and the `hide_login_status` policy field, so no public app surface shows it anymore.

#11089 is not in any release tag yet, so the field never shipped in a released API.

## Changes

- `PublicApp.svelte`: drop the top-left login status badge (and its `userInfo` snippet, the `showLoginStatus` derived value and the lucide `User`/`UserRoundX` imports).
- `PublicApp.svelte`: the badge was the only thing that read `globalUser` on an app that loads, but a 2s timer still called `globalWhoami` on every public view without a workspace session (a wasted 401 for every logged-out visitor). It is now fetched by an `$effect` only when the no-access page can show it: `noPermission`, no guest path, no workspace user. That page uses it to tell a signed-in non-member which workspace the app belongs to.
- `AppEditorHeaderDeploy.svelte`: remove the "Show the viewer's login status" toggle from the deploy panel's public URL section.
- `apps.rs`: remove `hide_login_status` from `Policy` and its three struct literals.
- `openapi.yaml`: remove the `hide_login_status` property from `Policy`; MCP endpoint tools regenerated (`auto_generated_endpoints.rs`, `mcpEndpointTools.ts`), and the regenerated diff touches only that property.

An app deployed while #11089 was on `main` can have `"hide_login_status": true` in its stored policy. No migration is needed for it: `Policy` does not deny unknown fields, nothing reads the key any more, and the next deploy re-serializes the policy through `Policy`, which drops it.

## Test plan

- [x] Backend rebuilt cleanly under `cargo watch` (`--features quickjs`).
- [x] `cargo check -p windmill-api --features parquet` passes, which compiles the `#[cfg(feature = "parquet")]` `Policy` literal in `upload_s3_file_from_app`.
- [x] `npm run generate-backend-client` after the OpenAPI change: `hide_login_status` is gone from `src/lib/gen/types.gen.ts` (gitignored, so no diff).
- [x] `npm run check` (full, with `NODE_OPTIONS=--max-old-space-size=8192`, since the default 4 GB heap runs out of memory): 2 errors, both in the untouched `tutorials/Tutorial.svelte`. The only hit in a touched file is the existing `state_referenced_locally` warning on the unchanged `setContext(IS_APP_PUBLIC_CONTEXT_KEY, !inWorkspace)` line.
- [x] Created an anonymous low-code app and opened its public URL while signed in as admin: the app renders and there is no badge (no `admin` username, no user icon, no top-left overlay element).
- [x] Signed out, the same public URL renders the app with no badge and no crossed-out user icon.
- [x] Signed out, a members-only (`publisher`) app's public URL shows the "This app requires read access" sign-in screen with no badge.
- [x] Opened a non-existent public URL (`/public/admins/000…`): "Not found" renders with no badge.
- [x] App editor → Deploy → Public access: the section goes straight from "Use a custom URL" to the "Only latest deployed app is publicly available" notice; no login status toggle.
- [x] Planted `"hide_login_status": true` in the app's stored policy via SQL: the public app still loads (200), and an update through `POST /apps/update` succeeds and drops the key from the stored policy.
- [x] Logged-out public app view: the network log has only the workspace `/api/w/admins/users/whoami` (from the user-store loader), and no global `/api/users/whoami` request anymore.
- [ ] Not exercised end to end: the "You are logged in but are not a member of the workspace …" message. On this build a signed-in non-member (planted via SQL) is stopped by `PublicAppFrame` at the embed-token step on both `/public/…` and `/app_embed/…` ("You are signed in, but this app is not open to you"), so `PublicApp`'s branch never renders for them. The effect's condition mirrors exactly what that branch reads.

## Screenshots

Public app URL, signed in as admin (the badge used to sit over the app title):

![remove-login-status-public-app](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/remove-app-login-status/1789126171-remove-login-status-public-app.png)

Deploy panel, public access section (the toggle used to sit under "Use a custom URL"):

![remove-login-status-deploy-panel](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/remove-app-login-status/1789126173-remove-login-status-deploy-panel.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXbCbgjgBgdg7t68VGWQnZ
