### PR TITLE
fix(dbt): stop dbt sending anonymous usage stats from workers

### DIFF
--- a/backend/windmill-worker/src/dbt_executor.rs
+++ b/backend/windmill-worker/src/dbt_executor.rs
@@ -2271,7 +2271,11 @@ pub(crate) fn dbt_command(p: &PreparedProject, args: &[&str]) -> Command {
         .envs(PROXY_ENVS.clone())
         .env("PATH", PATH_ENV.as_str())
         .env("TZ", TZ_ENV.as_str())
-        .env("GIT_PATH", GIT_PATH.as_str());
+        .env("GIT_PATH", GIT_PATH.as_str())
+        // dbt reports anonymous usage to dbt Labs from every invocation unless told
+        // not to, and a project's `flags:` block cannot override the variable. Set
+        // before the project's environment so a descriptor can still opt back in.
+        .env("DBT_SEND_ANONYMOUS_USAGE_STATS", "false");
     // Both environments belong to the child. Under a sandbox they reach it through
     // the jail profile instead: set here, they would reach the dynamic loader that
     // execs nsjail itself, so an `LD_PRELOAD` from the project would run as the


### PR DESCRIPTION
## Summary
By default, dbt reports anonymous usage to dbt Labs on every invocation, so every dbt job phase on a Windmill worker (`deps`, `parse` in the deploy lock job, `build`/`run`, `show`, `ls`, the column-index pass) opened an outbound connection:

- dbt-core 1.x connects to `fishtownanalytics.sinter-collect.com`.
- Fusion connects to `p.vx.dbt.com`.

Windmill never disabled it. That is telemetry about the customer's runs leaving their workers, and a stray connection on instances that restrict outbound traffic.

This sets `DBT_SEND_ANONYMOUS_USAGE_STATS=false` in `dbt_command`, which launches every dbt invocation that runs a project. The only other launch of a dbt binary is Fusion's one-off `dbt --version` probe at install time (`fusion_version`). Behind the same CONNECT logger, that probe opens no connections, so it is left as is.

## Changes
- `dbt_command` (`backend/windmill-worker/src/dbt_executor.rs`) sets `DBT_SEND_ANONYMOUS_USAGE_STATS=false` alongside the other environment Windmill controls.
- The variable is set before the project's environment is applied, so a descriptor can still opt back in with `env: {DBT_SEND_ANONYMOUS_USAGE_STATS: "true"}`. This holds with and without the nsjail sandbox: unsandboxed, the later `.envs()` call overrides it; sandboxed, it reaches the child through `keep_env`, and nsjail applies the project's `envar:` lines on top.
- A project's `dbt_project.yml` `flags: send_anonymous_usage_stats: true` cannot turn stats back on, because the environment variable takes precedence over project flags on both dbt-core and Fusion.

No test is added. Nothing constructs a `PreparedProject` in unit tests today, and building one (provisioned engine, rendered profile, sandbox fields) to assert a single environment variable would be setup without value. The checks below were run against a live instance instead.

## Test plan
- [x] Real dbt jobs on a local instance (default `dbt-core-1x` engine, Postgres warehouse). The descriptor's `env` routed HTTP(S) through a local CONNECT logger:
  - Default: the deploy lock job (`dbt parse`) and the run (`dbt build`) both succeeded, and the logger saw **no** connections.
  - Descriptor sets `DBT_SEND_ANONYMOUS_USAGE_STATS: "true"`: both jobs connected to `fishtownanalytics.sinter-collect.com`. This confirms the opt-in works and that the logger was in the traffic path.
- [x] dbt directly (outside Windmill) behind the same logger:
  - dbt-core 1.12.4: `sinter-collect.com` without the variable, nothing with it.
  - Fusion 2.0.0-preview.218: `p.vx.dbt.com` without the variable, nothing with it.
  - Both engines still send nothing when the project sets `flags: send_anonymous_usage_stats: true`.
- [x] Sandboxed precedence, checked with nsjail directly: `keep_env: true` (as in `run.dbt.config.proto`), with the launcher setting `false` and an `envar:` line setting `true`. The child sees a single `DBT_SEND_ANONYMOUS_USAGE_STATS=true` entry, which Python and `sh` both read, so the descriptor's opt-in survives the jail. Without the `envar:` line, the child reads `false`.
- [ ] Not exercised: a full dbt job on a sandboxed worker, and the `dbt-core-2x` engine inside Windmill. Fusion's startup version check (`public.cdn.getdbt.com`, disabled separately by `DBT_DISABLE_VERSION_CHECK`) is not usage reporting, and this PR leaves it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJZKmyRJZWUmSS7H1vV6Hs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dbt from sending anonymous usage stats from Windmill workers. Sets `DBT_SEND_ANONYMOUS_USAGE_STATS=false` in `dbt_command`, while allowing job descriptors to opt back in via a project env; a project's `flags:` cannot override it.

<sup>Written for commit c156c95d8e18cc9c70c49fa885a61417e8c4708f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


