### PR TITLE
feat: background and wait_seconds for run_script, skip preprocessor

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -4479,8 +4479,10 @@ describe('global AI tools', () => {
 		const deployedForm = statuses.find((s) => s.runForm)?.runForm
 		expect(deployedForm.submitted).toBe(true)
 		expect(deployedForm.schema).toBeUndefined()
+		// skipPreprocessor: the form fills the main input schema, so a preprocessor would take
+		// these arguments for a webhook body and run main on its output instead.
 		expect(JobService.runScriptByPath).toHaveBeenCalledWith(
-			expect.objectContaining({ requestBody: { name: 'Ada' } })
+			expect.objectContaining({ requestBody: { name: 'Ada' }, skipPreprocessor: true })
 		)
 	})
 
@@ -4664,6 +4666,27 @@ describe('global AI tools', () => {
 		const persisted = statuses.filter((s) => s.parameters !== undefined).at(-1)?.parameters
 		expect(persisted).toEqual({ reason: 'WINDMILL_TOO_BIG' })
 		expect(JSON.stringify(statuses)).not.toContain(huge)
+	})
+
+	// A dropped pass-through fails silently: the argument is accepted and ignored, and the
+	// run just waits out the default budget.
+	it('run_script detaches on background and on wait_seconds', async () => {
+		vi.mocked(ScriptService.getScriptByPath).mockResolvedValue({
+			path: 'f/scripts/slow',
+			schema: { properties: { name: { type: 'string' } } }
+		} as any)
+
+		// wait_seconds 0 detaches the same way, so one run of each pins both lines.
+		for (const detachArg of [{ background: true }, { wait_seconds: 0 }]) {
+			const onJobDetached = vi.fn()
+			await callGlobalTool(
+				'run_script',
+				{ path: 'f/scripts/slow', args: { name: 'Ada' }, ...detachArg },
+				{ ...toolCallbacks, onJobStarted: vi.fn(), onJobDetached }
+			)
+
+			expect(onJobDetached).toHaveBeenCalledWith('job-script-by-path')
+		}
 	})
 
 	// A schema with no fields still opens a form: an empty one is still the Run button, and
@@ -5112,7 +5135,8 @@ describe('global AI tools', () => {
 				locked: 'fixed',
 				doc: bytes,
 				token: '$var:u/ada/prod_api_key'
-			}
+			},
+			skipPreprocessor: true
 		})
 		expect(result).toContain('does not declare force_delete')
 		expect(result).toContain('<file: 3 KB>')
@@ -5201,7 +5225,8 @@ describe('global AI tools', () => {
 		expect(JobService.runScriptByPath).toHaveBeenCalledWith({
 			workspace: WORKSPACE,
 			path: 'f/scripts/greet',
-			requestBody: { name: 'Grace' }
+			requestBody: { name: 'Grace' },
+			skipPreprocessor: true
 		})
 		// The model must not assume its proposal is what ran.
 		expect(result).toContain('Ran with arguments: {"name":"Grace"}')

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -907,7 +907,9 @@ const testRunScriptToolDef = createToolDef(
 
 const runScriptSchema = z.object({
 	path: z.string().describe('Workspace path of the deployed script to run.'),
-	args: testRunArgsSchema
+	args: testRunArgsSchema,
+	background: backgroundArgSchema,
+	wait_seconds: waitSecondsArgSchema
 })
 
 const runScriptToolDef = createToolDef(
@@ -5762,8 +5764,18 @@ async function runDeployedScript(
 			// Bypassable like a test run: the posture is the user's standing answer, and a form
 			// it parks on is a card nobody is watching.
 			autoAcceptable: true,
+			background: args.background,
+			detachAfterMs: waitSecondsToDetachMs(args.wait_seconds),
 			startJob: (submitted) =>
-				JobService.runScriptByPath({ workspace, path: args.path, requestBody: submitted })
+				JobService.runScriptByPath({
+					workspace,
+					path: args.path,
+					requestBody: submitted,
+					// As the script's own run page does: the form fills the main input schema, and a
+					// preprocessor would take these arguments for a webhook body and hand the script
+					// its own output instead.
+					skipPreprocessor: true
+				})
 		},
 		ctx
 	)


### PR DESCRIPTION
## Summary

The global AI chat's `run_script` tool (the deployed, run-for-real one) was the only
job-starting tool in global mode without the `background` / `wait_seconds` arguments its
five siblings carry, and it started its job without `skipPreprocessor`.

Both are one-line gaps in an existing path, fixed here together.

**Detaching.** `background` / `wait_seconds` are declared on exactly the tools where
detaching is live — global mode, where `AIChatManager` wires `onJobStarted`.
`test_run_script`, `test_run_flow`, `test_run_step`, `test_run_app_runnable` and
`exec_datatable_sql` all carry both; `run_script` carried neither. The tool def is
`strict: false`, so a model generalising from the siblings could send `background: true`
and get neither the behaviour nor an error. Deployed runs are also where the long jobs
actually live (deploys, backfills, big queries), which is what that argument is for.
No new plumbing: `FormRunSpec` already declared `background` / `detachAfterMs` and
`runThroughForm` already forwarded both to `executeTestRun`.

**Preprocessor.** `runScriptByPath` defaults to running the script's preprocessor. On a
deployed script that has one, the backend (`WebhookArgs::to_args_from_runnable`) wraps the
submitted arguments as `{ event: { kind: "webhook", body, headers, query } }` and feeds
`main` the preprocessor's output instead. The chat's argument form is built from the
script's *main* input schema, so those arguments were silently discarded and the run was
wrong. The script's own run page already passes `skipPreprocessor: true`; this matches it.

## Changes

- `runScriptSchema` gains `background` and `wait_seconds`, reusing the shared
  `backgroundArgSchema` / `waitSecondsArgSchema` rather than new wording.
- `runDeployedScript` passes `background` and `waitSecondsToDetachMs(args.wait_seconds)`
  into the `runThroughForm` spec, as `testRunScriptByPath` already did.
- `runDeployedScript` passes `skipPreprocessor: true` to `JobService.runScriptByPath`.
- One new test pinning both detach pass-throughs; three existing assertions extended to
  pin `skipPreprocessor`.

## Screenshots

No new UI: the diff changes a model-facing tool schema and one request flag, and the
argument form the user sees is unchanged. What does change is timing — an existing card
state and jobs-tray entry are now reached as soon as the job starts, instead of after the
15s default budget.

Asked to run the deployed script "in the background", the model passes `background: true`;
the turn continues about a second after Run rather than holding for 15s, and the job keeps
running in the tray (here at 25s of a 90s run, with the reply already delivered):

![background-run-card](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/add-run-script-background-wait-args/1789130683-background-run-card.png)

## Test plan

- [x] `frontend`: `npx vitest run src/lib/components/copilot/chat/global/core.test.ts` — 240/240 pass.
- [x] New test proved able to fail: with the `runDeployedScript` pass-through reverted it fails on the `onJobDetached` spy.
- [x] `npm run check:fast` — no new type errors (6 pre-existing, unrelated files).
- [x] `background: true` on a 60s deployed script detaches in 24ms instead of holding the turn.
- [x] `wait_seconds: 60` on a 25s deployed script holds the turn 25.4s and returns the result inline.
- [x] Control: same script, 18s, no detach arguments — detaches at 15.3s, the default budget.
- [x] Driven through the real chat UI against a deployed 90s script: the model sent `background: true`, the turn continued ~1s after Run, and the job stayed in the tray (screenshot above).
- [x] Deployed script with a preprocessor: the job's pushed args are `{"name": "Ada"}`. Without `skipPreprocessor` the same call pushes `{"event": {"kind": "webhook", "body": {...}, "headers": {...}}}`.

## Reviews

Both local reviewers (branch-diff-reviewer, and the cold Codex pass at `xhigh`) returned
"Good to merge" with no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YS9n9Mq5CER6bApudfKMdi
