### PR TITLE
fix(ai-agent): label the save-as-agent form fields per the guidelines

### DIFF
--- a/frontend/src/lib/components/flows/content/AgentResourceBar.svelte
+++ b/frontend/src/lib/components/flows/content/AgentResourceBar.svelte
@@ -3,7 +3,8 @@
 	import Alert from '$lib/components/common/alert/Alert.svelte'
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 	import Path from '$lib/components/Path.svelte'
-	import TextInput from '$lib/components/text_input/TextInput.svelte'
+	import Label from '$lib/components/Label.svelte'
+	import autosize from '$lib/autosize'
 	import { ResourceService, type InputTransform, type Resource } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
@@ -609,27 +610,29 @@
 		<div class="flex flex-col gap-4">
 			<p class="text-xs text-secondary">
 				Save this AI agent's configuration and tools as a reusable resource. Other flows can then
-				link to it, updates propagate automatically, and it gains a dataset of eval cases of its
-				own.
+				link to it, and updates propagate automatically.
 			</p>
-			<Path
-				bind:path={newPath}
-				bind:error={pathError}
-				initialPath=""
-				namePlaceholder="my_agent"
-				kind="resource"
-				workspaceOverride={ws}
-			/>
-			<label class="flex flex-col gap-1 text-xs">
-				<span class="text-secondary">Description</span>
-				<TextInput
-					bind:value={description}
-					inputProps={{ placeholder: 'What this agent does' }}
+			<Label label="Path">
+				<Path
+					bind:path={newPath}
+					bind:error={pathError}
+					initialPath=""
+					namePlaceholder="my_agent"
+					kind="resource"
+					workspaceOverride={ws}
 					size="sm"
 				/>
-			</label>
+			</Label>
+			<Label label="Description">
+				<textarea
+					bind:value={description}
+					use:autosize
+					rows="3"
+					placeholder="What this agent does"
+				></textarea>
+			</Label>
 			{#if providerSaveError}
-				<p class="text-xs text-red-600 dark:text-red-400">
+				<p class="text-2xs text-red-600 dark:text-red-400">
 					{providerSaveError}
 				</p>
 			{/if}


### PR DESCRIPTION
## Summary

The "Save as reusable agent" drawer did not follow `frontend/brand-guidelines.md` → Layout → Form, which sets the order **Label → Description → Input → Validation** and a label style of `text-xs font-semibold text-emphasis`.

## Screenshots

![drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-save-agent-drawer/1789134973-drawer.png)

## Changes

- The path input had no label at all. It now uses `<Label label="Path">`, which is the convention everywhere else a `Path` appears in a form — `AddScorer.svelte`, `ResourceForm.svelte`, `AppConnectInner.svelte` — and passes `size="sm"` to match the sibling drawer.
- The description was a single-line `TextInput`, too small for what it asks for. It is now a `textarea` with `use:autosize` at three rows, as used for the resource description in `AppConnectInner` and in `ContextualVariableEditor`.
- Its label was `text-secondary`, which is the guidelines' *description* style, so the label and the blurb above it rendered identically. `<Label>` applies the emphasis style.
- The provider validation message was `text-xs`; the guidelines put validation at `text-2xs`. The red stays, since that is a feedback colour.
- Dropped "and it gains a dataset of eval cases of its own" from the blurb. It raised a concept the drawer does nothing with, and the remaining two sentences say what saving does.

## Test plan

- [x] Opened the drawer on a flow with an AI agent step on a local instance and confirmed both labels render, the description accepts multiple lines and grows, and the blurb reads as intended.
- [x] `npm run check:fast` reports no errors in the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the save-as-agent drawer form to match the form field guidelines in `frontend/brand-guidelines.md`.

- Adds a label to the path input, which previously had none, and sets its size to match the sibling drawer.
- Replaces the single-line description input with an autosizing textarea at three rows.
- Corrects the description label to use the emphasis style instead of `text-secondary`.
- Shrinks the provider validation message to `text-2xs` per the guidelines.
- Removes the sentence about gaining eval cases from the blurb since the drawer does nothing with that concept.

<sup>Written for commit 94bccf0a1f53cf3680bcb4356b47d8b68f04475f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

