### PR TITLE
fix: bundle deployed bun scripts whose only pin is on a dynamic import

### DIFF
--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -1019,7 +1019,8 @@ async fn test_bun_bundles_pinned_dynamic_import(db: Pool<Postgres>) -> anyhow::R
     std::fs::create_dir_all(&*windmill_worker::BUN_BUNDLE_CACHE_DIR)?;
 
     const PATH: &str = "f/pinned_dynamic_import/main";
-    // The nonce keys a bundle no earlier job cached, which would skip the build under test.
+    // Every `script` call draws its own nonce, so each job below misses every bundle cached before
+    // it, this test's included, and has to build one: a cached bundle skips the build under test.
     // 4.17.20 is not npm's `latest`, so a bundle that lost the pin cannot match by accident.
     let script = |body: &str| {
         format!(

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -990,9 +990,25 @@ export function main() { return [ns === isNumber, label, local()]; }"#
     Ok(())
 }
 
-/// Bundling a locked script resolves a pinned dynamic `import()` as written, which fails. Both the
-/// dependency job and a run that finds no cached bundle must still build it, from the version the
-/// lock pins.
+async fn bun_dependency_lock(db: &Pool<Postgres>, port: u16, path: &str, content: &str) -> String {
+    let deps = RunJob::from(JobPayload::RawScriptDependencies {
+        script_path: path.into(),
+        content: content.into(),
+        language: ScriptLang::Bun,
+    })
+    .run_until_complete(db, false, port)
+    .await
+    .json_result()
+    .unwrap();
+    let Some(lock) = deps["lock"].as_str() else {
+        panic!("the dependency job returned no lock: {deps}");
+    };
+    lock.to_string()
+}
+
+/// Bundling a locked script resolves a pinned dynamic `import()` as written. Where that fails, both
+/// the dependency job and a run that finds no cached bundle must still build it, from the version
+/// the lock pins; where bun tolerates the failure, the bundle must stay as written.
 #[sqlx::test(fixtures("base"))]
 async fn test_bun_bundles_pinned_dynamic_import(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;
@@ -1002,37 +1018,23 @@ async fn test_bun_bundles_pinned_dynamic_import(db: Pool<Postgres>) -> anyhow::R
     // The dependency job saves the script's bundle here; the server binary creates it at startup.
     std::fs::create_dir_all(&*windmill_worker::BUN_BUNDLE_CACHE_DIR)?;
 
+    const PATH: &str = "f/pinned_dynamic_import/main";
     // The nonce keys a bundle no earlier job cached, which would skip the build under test.
     // 4.17.20 is not npm's `latest`, so a bundle that lost the pin cannot match by accident.
-    let content = || {
+    let script = |body: &str| {
         format!(
-            r#"export async function main() {{
-  const m = await import("lodash@4.17.20");
-  return (m.default ?? m).VERSION;
-}}
-// {}"#,
+            "export async function main() {{\n  {body}\n}}\n// {}",
             Uuid::new_v4()
         )
     };
+    let import = r#"const m = await import("lodash@4.17.20"); return (m.default ?? m).VERSION;"#;
 
-    let deps = RunJob::from(JobPayload::RawScriptDependencies {
-        script_path: "f/pinned_dynamic_import/main".into(),
-        content: content(),
-        language: ScriptLang::Bun,
-    })
-    .run_until_complete(&db, false, port)
-    .await
-    .json_result()
-    .unwrap();
-    let Some(lock) = deps["lock"].as_str() else {
-        panic!("the dependency job returned no lock: {deps}");
-    };
-
+    let lock = bun_dependency_lock(&db, port, PATH, &script(import)).await;
     let result = RunJob::from(JobPayload::Code(RawCode {
-        content: content(),
-        path: Some("f/pinned_dynamic_import/main".into()),
+        content: script(import),
+        path: Some(PATH.into()),
         language: ScriptLang::Bun,
-        lock: Some(lock.into()),
+        lock: Some(lock),
         ..RawCode::default()
     }))
     .run_until_complete(&db, false, port)
@@ -1040,6 +1042,20 @@ async fn test_bun_bundles_pinned_dynamic_import(db: Pool<Postgres>) -> anyhow::R
     .json_result()
     .unwrap();
     assert_eq!(result, serde_json::json!("4.17.20"));
+
+    let tolerated = script(&format!("try {{ {import} }} catch {{ return null; }}"));
+    let lock = bun_dependency_lock(&db, port, PATH, &tolerated).await;
+    let (bundle, _) = windmill_worker::compute_bundle_local_and_remote_path(
+        &tolerated,
+        &lock,
+        PATH,
+        Some(&db),
+        "test-workspace",
+        &None,
+        None,
+    )
+    .await;
+    assert!(std::fs::read_to_string(bundle)?.contains("lodash@4.17.20"));
     Ok(())
 }
 

--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -990,6 +990,59 @@ export function main() { return [ns === isNumber, label, local()]; }"#
     Ok(())
 }
 
+/// Bundling a locked script resolves a pinned dynamic `import()` as written, which fails. Both the
+/// dependency job and a run that finds no cached bundle must still build it, from the version the
+/// lock pins.
+#[sqlx::test(fixtures("base"))]
+async fn test_bun_bundles_pinned_dynamic_import(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    // The dependency job saves the script's bundle here; the server binary creates it at startup.
+    std::fs::create_dir_all(&*windmill_worker::BUN_BUNDLE_CACHE_DIR)?;
+
+    // The nonce keys a bundle no earlier job cached, which would skip the build under test.
+    // 4.17.20 is not npm's `latest`, so a bundle that lost the pin cannot match by accident.
+    let content = || {
+        format!(
+            r#"export async function main() {{
+  const m = await import("lodash@4.17.20");
+  return (m.default ?? m).VERSION;
+}}
+// {}"#,
+            Uuid::new_v4()
+        )
+    };
+
+    let deps = RunJob::from(JobPayload::RawScriptDependencies {
+        script_path: "f/pinned_dynamic_import/main".into(),
+        content: content(),
+        language: ScriptLang::Bun,
+    })
+    .run_until_complete(&db, false, port)
+    .await
+    .json_result()
+    .unwrap();
+    let Some(lock) = deps["lock"].as_str() else {
+        panic!("the dependency job returned no lock: {deps}");
+    };
+
+    let result = RunJob::from(JobPayload::Code(RawCode {
+        content: content(),
+        path: Some("f/pinned_dynamic_import/main".into()),
+        language: ScriptLang::Bun,
+        lock: Some(lock.into()),
+        ..RawCode::default()
+    }))
+    .run_until_complete(&db, false, port)
+    .await
+    .json_result()
+    .unwrap();
+    assert_eq!(result, serde_json::json!("4.17.20"));
+    Ok(())
+}
+
 #[sqlx::test(fixtures("base", "bun_edge_cases"))]
 async fn test_bun_shared_imports_both_styles(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1175,7 +1175,14 @@ async fn generate_bun_bundle_unpinning_dynamic_imports(
         occupancy_metrics,
     )
     .await;
-    if !matches!(built, Err(error::Error::ExitStatus(..))) {
+    // Without a job, a failed build comes back as an `ExecutionErr`; with one, that variant is a
+    // cancellation or timeout, which must not be retried.
+    let build_failed = match &built {
+        Err(error::Error::ExitStatus(..)) => true,
+        Err(_) => db.is_none(),
+        Ok(()) => false,
+    };
+    if !build_failed {
         return built;
     }
     let Some(unpinned) = read_file_content(&format!("{job_dir}/main.ts"))

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1146,11 +1146,11 @@ pub async fn generate_bun_bundle(
     Ok(())
 }
 
-/// [`generate_bun_bundle`], built once more with the pins dropped from the dynamic `import()`
+/// [`generate_bun_bundle`], built once more with the version pins dropped from the import
 /// specifiers of `main.ts` if it fails. The lockfile pins those versions, but bun fails on a
 /// pinned specifier except where it tolerates a failed import (in a `try`, under a `.catch`, in
 /// dead code). Such a script builds as written and must keep that bundle, so only failures retry.
-async fn generate_bun_bundle_unpinning_dynamic_imports(
+async fn generate_bun_bundle_unpinning_imports(
     job_dir: &str,
     w_id: &str,
     job_id: &Uuid,
@@ -1201,7 +1201,7 @@ async fn generate_bun_bundle_unpinning_dynamic_imports(
         append_logs(
             job_id,
             w_id,
-            "\nbundling again with the dynamic imports' versions taken from the lockfile\n",
+            "\nbundling again with the imports' versions taken from the lockfile\n",
             db,
         )
         .await;
@@ -1380,7 +1380,7 @@ pub async fn prebundle_bun_script(
 
     let common_bun_proc_envs: HashMap<String, String> = get_common_bun_proc_envs(None).await;
 
-    generate_bun_bundle_unpinning_dynamic_imports(
+    generate_bun_bundle_unpinning_imports(
         job_dir,
         w_id,
         job_id,
@@ -2277,7 +2277,7 @@ try {{
 
     if !codebase.is_some() && !has_bundle_cache {
         if build_cache {
-            generate_bun_bundle_unpinning_dynamic_imports(
+            generate_bun_bundle_unpinning_imports(
                 job_dir,
                 &job.workspace_id,
                 &job.id,

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1146,6 +1146,74 @@ pub async fn generate_bun_bundle(
     Ok(())
 }
 
+/// [`generate_bun_bundle`], built once more with the pins dropped from the dynamic `import()`
+/// specifiers of `main.ts` if it fails. The lockfile pins those versions, but bun fails on a
+/// pinned specifier except where it tolerates a failed import (in a `try`, under a `.catch`, in
+/// dead code). Such a script builds as written and must keep that bundle, so only failures retry.
+async fn generate_bun_bundle_unpinning_dynamic_imports(
+    job_dir: &str,
+    w_id: &str,
+    job_id: &Uuid,
+    worker_name: &str,
+    db: Option<&Connection>,
+    timeout: Option<i32>,
+    mem_peak: &mut i32,
+    canceled_by: &mut Option<CanceledBy>,
+    common_bun_proc_envs: &HashMap<String, String>,
+    occupancy_metrics: &mut Option<&mut OccupancyMetrics>,
+) -> Result<()> {
+    let built = generate_bun_bundle(
+        job_dir,
+        w_id,
+        job_id,
+        worker_name,
+        db,
+        timeout,
+        mem_peak,
+        canceled_by,
+        common_bun_proc_envs,
+        occupancy_metrics,
+    )
+    .await;
+    if !matches!(built, Err(error::Error::ExitStatus(..))) {
+        return built;
+    }
+    let Some(unpinned) = read_file_content(&format!("{job_dir}/main.ts"))
+        .await
+        .ok()
+        .and_then(|main| {
+            remove_pinned_import_specifiers(&main)
+                .ok()
+                .filter(|u| *u != main)
+        })
+    else {
+        return built;
+    };
+    write_file(job_dir, "main.ts", &unpinned)?;
+    if let Some(db) = db {
+        append_logs(
+            job_id,
+            w_id,
+            "\nbundling again with the dynamic imports' versions taken from the lockfile\n",
+            db,
+        )
+        .await;
+    }
+    generate_bun_bundle(
+        job_dir,
+        w_id,
+        job_id,
+        worker_name,
+        db,
+        timeout,
+        mem_peak,
+        canceled_by,
+        common_bun_proc_envs,
+        occupancy_metrics,
+    )
+    .await
+}
+
 struct PulledCodebase {
     is_esm: bool,
 }
@@ -1305,7 +1373,7 @@ pub async fn prebundle_bun_script(
 
     let common_bun_proc_envs: HashMap<String, String> = get_common_bun_proc_envs(None).await;
 
-    generate_bun_bundle(
+    generate_bun_bundle_unpinning_dynamic_imports(
         job_dir,
         w_id,
         job_id,
@@ -2202,7 +2270,7 @@ try {{
 
     if !codebase.is_some() && !has_bundle_cache {
         if build_cache {
-            generate_bun_bundle(
+            generate_bun_bundle_unpinning_dynamic_imports(
                 job_dir,
                 &job.workspace_id,
                 &job.id,


### PR DESCRIPTION
## Summary

Deploying a Bun script whose only use of a pinned package is a dynamic import fails, although its lockfile generates fine:

```ts
export async function main() {
  const m = await import("lodash@4.17.20");
  return (m.default ?? m).VERSION;
}
```

The dependency job installs `lodash@4.17.20`, then fails on the bundle it builds right after (`error: Could not resolve: "lodash@4.17.20"` … `Non-zero exit status for bun build: 1`). The script is left with `lock_error_logs`. A run that finds no cached bundle builds the same bundle again in `handle_bun_job` and fails the same way. A preview works, because `bun -i` auto-installs the pinned specifier.

Both deploy-time bundling paths (`prebundle_bun_script` and the `build_cache` build in `handle_bun_job`) bundle `remove_pinned_imports(code)`. That only unpins the specifiers of static imports, so a dynamic `import("pkg@1.2.3")` reaches `Bun.build` with its pin, and bun cannot resolve it from `node_modules`. This has been broken since the deploy-time bundle cache landed.

## Fix

Both paths now bundle through `generate_bun_bundle_unpinning_imports`. It builds `main.ts` exactly as today. If that build fails, and `remove_pinned_import_specifiers` (#11083) changes `main.ts`, it rewrites `main.ts` with those version pins dropped and builds once more. That function rewrites only the specifier literals (`import`/`export … from` sources and `import()` arguments) and leaves other text alone. `main.ts` has already been through `remove_pinned_imports` on these paths, so what the retry unpins there is the dynamic imports. The lockfile already pins those versions, so the bundle resolves the pinned version from `node_modules` and nothing is fetched at run time.

The one path where `main.ts` still has static pins is a `//native` run that finds no cached bundle: `handle_bun_job` builds it from the raw source. On main, a native script with a pinned static import fails that build (`Could not resolve: "is-number@6.0.0"`), although its dependency job's prebundle succeeds. The retry drops those static pins too, so that run now builds. This also only happens on a build that already failed. One difference to be aware of: a string in that native script equal to the pinned specifier keeps its pin in the retried bundle, whereas the dependency job's prebundle (`remove_pinned_imports`) rewrites it.

**Why a retry rather than always unpinning.** Bun (1.3.11) tolerates an unresolvable specifier in some places, and the pinned import then builds fine today:

| pinned `import("lodash@4.17.20")` | `Bun.build` today |
|---|---|
| plain `await import(…)` | fails |
| inside `try {}` | builds |
| `.catch(…)` / `.then(ok, err)` | builds |
| dead code (`if (false)`) | builds |

Such a script deploys today and keeps its pinned import in the bundle, so it fetches the package at run time. Unpinning every dynamic import up front would change its bundle. Retrying only after a failed build leaves every script that bundles today with the same input, byte for byte.

**Which of the two cases this fixes: dynamic `import()` only, not `require()`.** `require` is an ordinary binding that a script can shadow, and bun does not resolve a shadowed call, so unpinning a `require("pkg@1.2.3")` argument could rewrite the script's own data. `remove_pinned_import_specifiers` leaves `require` alone, so a script whose only pin is on a `require` still fails to deploy, as before.

**When a retry happens.** With a job, only after a normal non-zero exit (`Error::ExitStatus`), never after a cancellation, timeout or log-size kill, which surface as `ExecutionErr`. Without a job (the `windmill cache` hub pre-caching step calls `prebundle_bun_script` with no `db`), `generate_bun_bundle` reports a failed build as `ExecutionErr`, and nothing can cancel it, so any failure retries there.

**Unchanged:** `remove_pinned_imports`, the `raw_unpinned` endpoint (so a pinned dynamic import inside an *imported* script still fails), and non-bundled runs. The dedicated `//native` worker's bundle (`start_worker`) is also left alone: this fix stays confined to the deploy-time bundle paths, so that worker can still fail on such a script.

## Test plan

- [x] **Repro on a local instance.** Before: deploying the script above fails with `Could not resolve: "lodash@4.17.20"`. After: the dependency job logs that first failure, then `bundling again with the imports' versions taken from the lockfile`, and succeeds with a lock pinning `lodash 4.17.20`. `run_wait_result` returns `"4.17.20"` from the cached bundle, which inlines lodash (`__toESM(require_lodash())`, no pinned specifier left). With that cached bundle deleted, the next run rebuilds through `build_cache` the same way and returns `"4.17.20"`.
- [x] **Scripts that deploy today are unaffected.** I deployed 16 scripts on main and on this branch and compared the cached bundles byte for byte:

  | script | main | this branch |
  |---|---|---|
  | static pin | deploys | identical bundle, lock, result |
  | static + dynamic import of the same pin | deploys | identical |
  | `require` + static import of the same pin | deploys | identical |
  | shadowed `require("is-number@6.0.0")` | deploys | identical, still returns `"is-number@6.0.0"` |
  | string equal to a statically imported specifier | deploys | identical |
  | string equal to a specifier, no import | deploys | identical |
  | pinned dynamic import in `try` / under `.catch` / in dead code | deploys | identical, no retry |
  | pinned dynamic import (plain, `/fp` subpath, scoped, `//nodejs`) | fails | deploys and runs the pinned version |
  | pinned dynamic import + shadowed `require` + matching string | fails | deploys; the `require` data and the string keep their pin |
  | plain `require("is-number@6.0.0")` | fails | fails (not fixed, see above) |

  Only the scripts that failed on main took the retry.
- [x] **Regression test.** `test_bun_bundles_pinned_dynamic_import` runs the dependency job, then a locked run that finds no cached bundle, then the dependency job of a script whose pinned import sits in a `try`. It fails on main at the dependency job. With only the prebundle fixed, it fails at the run. Against a variant that always unpins up front, it fails at the `try` script, whose bundle must keep `lodash@4.17.20`. It passes here, including from an empty `WINDMILL_DIR`, the way CI starts. All 36 `bun_jobs` tests pass.
- [x] **`//native` run path.** A throwaway test (not committed), built with `deno_core`, runs a native script with a pinned static import through its dependency job, then a locked native run that misses the cache. On main the run fails at `bun build`. Here it returns `[true, "is-number@6.0.0"]`.
- [x] **No-`db` path.** A throwaway test (not committed) mirrored the `windmill cache` sequence (`prepare_job_dir`, `install_bun_lockfile`, then `prebundle_bun_script` with `db: None`). It prebundled the pinned script, and the cached bundle inlines lodash. With the no-`db` arm disabled, it fails with `bun build exited with non-zero status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EH42obCk6WJnc7N4Fa25JH
