### PR TITLE
fix: bring back Publish to Hub for scripts

### DIFF
--- a/frontend/src/lib/components/common/table/ScriptRow.svelte
+++ b/frontend/src/lib/components/common/table/ScriptRow.svelte
@@ -55,7 +55,12 @@
 	import Popover from '$lib/components/Popover.svelte'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import { getDeployUiSettings } from '$lib/components/home/deploy_ui'
-	import { editInForkAllowed, editInForkLabel, onEditInForkClick } from '$lib/utils/editInFork'
+	import {
+		claimTab,
+		editInForkAllowed,
+		editInForkLabel,
+		onEditInForkClick
+	} from '$lib/utils/editInFork'
 	import EditInForkButton from './EditInForkButton.svelte'
 	import { isCloudHosted } from '$lib/cloud'
 
@@ -415,25 +420,27 @@
 						displayName: 'Publish to Hub',
 						icon: Globe2,
 						action: async () => {
-							const scriptData = await ScriptService.getScriptByPath({
-								workspace: $workspaceStore!,
-								path: script.path
-							})
-							window.open(
-								scriptToHubUrl(
-									scriptData.content,
-									scriptData.summary,
-									scriptData.description ?? '',
-									scriptData.kind,
-									scriptData.language,
-									scriptData.schema,
-									scriptData.lock ?? '',
-									$hubBaseUrlStore
-								).toString(),
-								'_blank'
-							)
+							// The row only carries metadata, so the code has to be fetched first; the tab is
+							// claimed before that, since Safari won't open one after an await.
+							const tab = claimTab()
+							try {
+								const fullScript = await ScriptService.getScriptByPath({
+									workspace: $workspaceStore!,
+									path: script.path
+								})
+								const url = scriptToHubUrl(fullScript, $hubBaseUrlStore).toString()
+								if (tab) {
+									tab.show(url)
+								} else if (!window.open(url)) {
+									sendUserToast('Allow popups to publish this script to the Hub', true)
+								}
+							} catch (e: any) {
+								tab?.discard()
+								sendUserToast(`Could not load ${script.path}: ${e?.body ?? e?.message ?? e}`, true)
+							}
 						},
-						hide: $disableHubStore
+						// Operators can't write scripts, so they have nothing to publish.
+						hide: $disableHubStore || $userStore?.operator
 					},
 					{
 						displayName: script.archived ? 'Unarchive' : 'Archive',

--- a/frontend/src/lib/components/common/table/ScriptRow.svelte
+++ b/frontend/src/lib/components/common/table/ScriptRow.svelte
@@ -9,7 +9,14 @@
 	import type ShareModal from '$lib/components/ShareModal.svelte'
 
 	import { ScriptService, type Script } from '$lib/gen'
-	import { userStore, userWorkspaces, workspaceStore } from '$lib/stores'
+	import {
+		disableHubStore,
+		hubBaseUrlStore,
+		userStore,
+		userWorkspaces,
+		workspaceStore
+	} from '$lib/stores'
+	import { scriptToHubUrl } from '$lib/hub'
 	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 
 	import { createEventDispatcher } from 'svelte'
@@ -32,6 +39,7 @@
 		FolderOpen,
 		ChevronUpSquare,
 		GitFork,
+		Globe2,
 		List,
 		Pen,
 		Shield,
@@ -402,6 +410,30 @@
 						action: () => {
 							copyToClipboard(script.path)
 						}
+					},
+					{
+						displayName: 'Publish to Hub',
+						icon: Globe2,
+						action: async () => {
+							const scriptData = await ScriptService.getScriptByPath({
+								workspace: $workspaceStore!,
+								path: script.path
+							})
+							window.open(
+								scriptToHubUrl(
+									scriptData.content,
+									scriptData.summary,
+									scriptData.description ?? '',
+									scriptData.kind,
+									scriptData.language,
+									scriptData.schema,
+									scriptData.lock ?? '',
+									$hubBaseUrlStore
+								).toString(),
+								'_blank'
+							)
+						},
+						hide: $disableHubStore
 					},
 					{
 						displayName: script.archived ? 'Unarchive' : 'Archive',

--- a/frontend/src/lib/hub.ts
+++ b/frontend/src/lib/hub.ts
@@ -1,5 +1,7 @@
-import { AppService, FlowService } from './gen'
+import type { Schema } from './common'
+import { AppService, FlowService, type Script } from './gen'
 import hubPathsData from './hubPaths.json'
+import { encodeState } from './utils'
 import {
 	replacePlaceholderForSignatureScriptTemplate,
 	SIGNATURE_TEMPLATE_FLOW_HUB_ID,
@@ -16,6 +18,26 @@ export const HubScript = {
 export const HubFlow = {
 	SIGNATURE_TEMPLATE: SIGNATURE_TEMPLATE_FLOW_HUB_ID
 } as const
+
+/**
+ * The Hub's script submission form, prefilled with this script. The Hub decodes the
+ * hash, so the code never reaches its server until the user submits. Flows and apps
+ * reach the Hub inside a project, published from a folder, so only scripts have this.
+ */
+export function scriptToHubUrl(
+	content: string,
+	summary: string,
+	description: string,
+	kind: Script['kind'],
+	language: Script['language'],
+	schema: Schema | any,
+	lock: string | undefined,
+	hubBaseUrl: string
+): URL {
+	const url = new URL(hubBaseUrl + '/scripts/add')
+	url.hash = encodeState({ content, summary, description, kind, language, schema, lock })
+	return url
+}
 
 export function replaceScriptPlaceholderWithItsValues(id: string, content: string) {
 	switch (id) {

--- a/frontend/src/lib/hub.ts
+++ b/frontend/src/lib/hub.ts
@@ -1,4 +1,3 @@
-import type { Schema } from './common'
 import { AppService, FlowService, type Script } from './gen'
 import hubPathsData from './hubPaths.json'
 import { encodeState } from './utils'
@@ -25,17 +24,23 @@ export const HubFlow = {
  * reach the Hub inside a project, published from a folder, so only scripts have this.
  */
 export function scriptToHubUrl(
-	content: string,
-	summary: string,
-	description: string,
-	kind: Script['kind'],
-	language: Script['language'],
-	schema: Schema | any,
-	lock: string | undefined,
+	script: Pick<
+		Script,
+		'content' | 'summary' | 'description' | 'kind' | 'language' | 'schema' | 'lock'
+	>,
 	hubBaseUrl: string
 ): URL {
+	const { content, summary, kind, language, schema } = script
 	const url = new URL(hubBaseUrl + '/scripts/add')
-	url.hash = encodeState({ content, summary, description, kind, language, schema, lock })
+	url.hash = encodeState({
+		content,
+		summary,
+		description: script.description ?? '',
+		kind,
+		language,
+		schema,
+		lock: script.lock ?? ''
+	})
 	return url
 }
 

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -22,7 +22,14 @@
 	} from '$lib/utils'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import ShareModal from '$lib/components/ShareModal.svelte'
-	import { enterpriseLicense, userStore, userWorkspaces, workspaceStore } from '$lib/stores'
+	import {
+		disableHubStore,
+		enterpriseLicense,
+		hubBaseUrlStore,
+		userStore,
+		userWorkspaces,
+		workspaceStore
+	} from '$lib/stores'
 	import { isDeployable, ALL_DEPLOYABLE } from '$lib/utils_deployable'
 	import AIFormAssistant from '$lib/components/copilot/AIFormAssistant.svelte'
 
@@ -59,6 +66,7 @@
 		Eye,
 		FolderOpen,
 		GitFork,
+		Globe2,
 		History,
 		Loader2,
 		Pen,
@@ -71,6 +79,7 @@
 		ChevronDown,
 		ChevronRight
 	} from 'lucide-svelte'
+	import { scriptToHubUrl } from '$lib/hub'
 	import SharedBadge from '$lib/components/SharedBadge.svelte'
 	import Popover from '$lib/components/Popover.svelte'
 	import ScriptVersionHistory from '$lib/components/ScriptVersionHistory.svelte'
@@ -615,6 +624,29 @@
 				Icon: ChevronUpSquare,
 				onclick: () => {
 					deploymentDrawer?.openDrawer(script?.path ?? '', 'script')
+				}
+			})
+		}
+
+		if (!$disableHubStore) {
+			menuItems.push({
+				label: 'Publish to Hub',
+				Icon: Globe2,
+				onclick: () => {
+					if (!script) return
+					window.open(
+						scriptToHubUrl(
+							script.content,
+							script.summary,
+							script.description ?? '',
+							script.kind,
+							script.language,
+							script.schema,
+							script.lock ?? '',
+							$hubBaseUrlStore
+						).toString(),
+						'_blank'
+					)
 				}
 			})
 		}

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -634,19 +634,7 @@
 				Icon: Globe2,
 				onclick: () => {
 					if (!script) return
-					window.open(
-						scriptToHubUrl(
-							script.content,
-							script.summary,
-							script.description ?? '',
-							script.kind,
-							script.language,
-							script.schema,
-							script.lock ?? '',
-							$hubBaseUrlStore
-						).toString(),
-						'_blank'
-					)
+					window.open(scriptToHubUrl(script, $hubBaseUrlStore).toString(), '_blank', 'noopener')
 				}
 			})
 		}


### PR DESCRIPTION
## What does this PR do?

Brings back **Publish to Hub** for single scripts, on the script detail page and in the script list row menu.

#10310 removed every per-item entry point so that publishing goes through Folders → Publish to Hub. That flow publishes a whole folder as a project and needs a workspace admin, which left no way to share a single script — the main thing private hubs are used for.

- `scriptToHubUrl(script, hubBaseUrl)` is back in `lib/hub.ts`. It opens `<hub>/scripts/add` on whichever Hub the instance is configured to use, with the script in the URL hash. The Hub still decodes that hash, so no Hub change is needed.
- The row menu has to fetch the script first, so it claims the tab inside the click (`claimTab()`, as `editInFork` does) — Safari refuses `window.open` after an `await`. A failed fetch closes the tab with a toast; a blocked popup says so.
- Hidden from operators, who can't write scripts (the detail page's menu already returned nothing for them), and when the instance's **Disable Hub** setting is on.
- The detail page opens the Hub with `noopener`.
- Flows and apps stay project-only: the raw app button and the flow/app helpers are not restored.

The menu items reuse the existing menu design, so no new UI to screenshot.

**Testing:** `svelte-check` reports no errors or warnings in the three changed files (the two remaining errors in the frontend are in `tutorials/Tutorial.svelte`). Not clicked in a running instance.

## Related issue

Reverses the script part of #10310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)