### PR TITLE
fix: show preview runs by default

### DIFF
--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -299,7 +299,7 @@
 			hasNullParent:
 				filters.val.path != undefined ||
 				filters.val.path != undefined ||
-				filters.val.job_kinds != 'all'
+				(filters.val.job_kinds != undefined && filters.val.job_kinds != 'all')
 					? true
 					: undefined,
 			label: filters.val.label || undefined,
@@ -688,8 +688,8 @@
 				<ToggleButtonGroup
 					tabListClass="hidden xl:flex"
 					bind:selected={
-						() => filters.val.job_kinds ?? 'runs',
-						(v) => (v === 'runs' ? delete filters.val.job_kinds : (filters.val.job_kinds = v))
+						() => filters.val.job_kinds ?? 'all',
+						(v) => (v === 'all' ? delete filters.val.job_kinds : (filters.val.job_kinds = v))
 					}
 				>
 					{#snippet children({ item })}

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -287,7 +287,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 						? false
 						: undefined,
 			// isFlowStep: jobKindsCat != 'all' ? false : undefined,
-			hasNullParent: jobKindsCat != 'all' ? true : undefined,
+			hasNullParent: jobKindsCat != null && jobKindsCat != 'all' ? true : undefined,
 			label: label == null || label === '' ? undefined : label,
 			tag: tag == null || tag === '' ? undefined : tag,
 			worker: worker == null || worker === '' ? undefined : worker,

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -22,7 +22,7 @@ import { allowWildcards as _allowWildcards, type RunsFilterInstance } from './ru
 const MAX_PER_PAGE = 10000
 
 export function computeJobKinds(jobKindsCat: string | null): string {
-	if (jobKindsCat == 'all') {
+	if (jobKindsCat == null || jobKindsCat == 'all') {
 		return ''
 	} else if (jobKindsCat == 'dependencies') {
 		let kinds: CompletedJob['job_kind'][] = ['dependencies', 'flowdependencies', 'appdependencies']
@@ -34,10 +34,6 @@ export function computeJobKinds(jobKindsCat: string | null): string {
 		let kinds: CompletedJob['job_kind'][] = ['deploymentcallback']
 		return kinds.join(',')
 	} else {
-		// Default mirrors the explicit 'runs' category — top-level scripts, flows,
-		// and single-step flows. flowscript/flownode/appscript are intermediate
-		// flow children with non-null parent_job, and the loader pairs this with
-		// hasNullParent: true, so they would never match here anyway.
 		let kinds: CompletedJob['job_kind'][] = ['script', 'flow', 'singlestepflow']
 		return kinds.join(',')
 	}


### PR DESCRIPTION
## Problem

The Runs page says it shows all past executions, including previews, but a bare `/runs` page behaved like the `Runs` filter. Preview jobs only appeared after selecting `All` or `Previews`, which made preview runs look missing when no `job_kinds` filter was applied.

Closes #10019.

## Fix

- Treat a missing `job_kinds` filter the same as `All` when computing job kinds.
- Keep `hasNullParent` unset for the unfiltered view so preview jobs are not excluded.
- Make the top-level toggle show `All` as the selected default and clear the query param when `All` is selected.

## Validation

- `npm run generate-backend-client`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run check`

## Risks

Low. This only changes the Runs page's unfiltered/default behavior; explicit `Runs`, `Previews`, `Deps`, `Sync`, and `All` filters still map to their existing filter values.

## UI verification

I could not exercise the page in a browser in this environment because no Windmill backend/frontend dev instance was running. The frontend type check passed after generating the API client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Runs page so preview runs show by default on a bare `/runs` page instead of only after selecting `All` or `Previews`.

- Treats a missing `job_kinds` filter as `All` in both the page toggle and the jobs loader, and leaves `hasNullParent` unset for the unfiltered view.
- Sets the default toggle to `All` and clears the query param when `All` is selected.
- Explicit `Runs`, `Previews`, `Deps`, `Sync`, and `All` filters keep their existing behavior.
- Closes #10019.

<sup>Written for commit cd240bf95ae55f58ad497734c02836be7d13a58b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/11105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

